### PR TITLE
test: a suite's cleanup must not outlive its own test (rf2-e8kc)

### DIFF
--- a/implementation/adapters/reagent-slim/test/re_frame/adapter/reagent_slim_strict_mode_dom_cljs_test.cljs
+++ b/implementation/adapters/reagent-slim/test/re_frame/adapter/reagent_slim_strict_mode_dom_cljs_test.cljs
@@ -242,10 +242,17 @@
                     (is (= 0 (watch-count upstream))
                         (str "upstream watch count returned to baseline 0 after the genuine "
                              "unmount (clean teardown); got " (watch-count upstream)))
-                    (cleanup!)
-                    (done!)))
+                    nil))
+                ;; Reports; it does NOT finish. `done` hands
+                ;; `cljs.test/run-block` a continuation that runs the WHOLE
+                ;; remainder of the run synchronously, so a rejection handler
+                ;; downstream of the step that finished the row claims whatever
+                ;; a LATER namespace throws, prints it against this row's
+                ;; label, and fires `done` a second time (rf2-e8kc).
                 (.catch
                   (fn [err]
                     (is false (str "StrictMode double-mount scenario threw: " (pr-str err)))
-                    (cleanup!)
-                    (done!))))))))))
+                    nil))
+                ;; Both arms cleaned up identically, so it rides the single
+                ;; trailing step: written once, run once per path.
+                (.then (fn [_] (cleanup!) (done!))))))))))

--- a/implementation/adapters/reagent-slim/test/re_frame/adapter/reagent_slim_synthetic_event_frame_dom_cljs_test.cljs
+++ b/implementation/adapters/reagent-slim/test/re_frame/adapter/reagent_slim_synthetic_event_frame_dom_cljs_test.cljs
@@ -173,12 +173,23 @@
                                  (str "a real synthetic click on the injected `#(dispatch …)` "
                                       "button dispatched successfully AFTER the render boundary "
                                       "— app-db advanced to {:n 1}"))
-                             (finalize!)))
+                             nil))
+                    ;; Reports; it does NOT finalize. `done` hands
+                    ;; `cljs.test/run-block` a continuation that runs the WHOLE
+                    ;; remainder of the run synchronously, so a rejection
+                    ;; handler downstream of the step that finished the row
+                    ;; claims whatever a LATER namespace throws and prints it
+                    ;; against this row's label (rf2-e8kc). The CAS inside
+                    ;; `finalize!` swallowed the second `done`; it could not
+                    ;; swallow the misattributed failure.
                     (.catch (fn [e]
                               (is false
                                   (str "injected dispatch never advanced the render frame: "
                                        (pr-str (ex-message e))))
-                              (finalize!)))))))
+                              nil))
+                    ;; THE single finalizer, on the single trailing step —
+                    ;; both arms reach it, and nothing follows it.
+                    (.then (fn [_] (finalize!)))))))
           (catch :default e
             (is false (str "reagent-slim synthetic-event proof threw: " (pr-str e)))
             (finalize!)))))))

--- a/implementation/adapters/reagent/test/re_frame/form_3_lifecycle_dom_cljs_test.cljs
+++ b/implementation/adapters/reagent/test/re_frame/form_3_lifecycle_dom_cljs_test.cljs
@@ -219,10 +219,20 @@
                   cleanup! (fn []
                              (try (act-fn #(rdc/unmount root-a)) (catch :default _ nil))
                              (try (act-fn #(rdc/unmount root-b)) (catch :default _ nil)))
-                  fail! (fn [err]
-                          (is false (str "Form-3 isolation fixture threw: " (pr-str err)))
-                          (cleanup!)
-                          (done!))]
+                  ;; Reports; it does NOT finish. `done` hands
+                  ;; `cljs.test/run-block` a continuation that runs the WHOLE
+                  ;; remainder of the run synchronously, so a rejection handler
+                  ;; downstream of the step that finished the row claims
+                  ;; whatever a LATER namespace throws, prints it against this
+                  ;; row's label, and fires `done` a second time (rf2-e8kc).
+                  ;; The CAS in `done!` swallows that second call; it cannot
+                  ;; swallow the misattributed `is false`.
+                  report! (fn [err]
+                            (is false (str "Form-3 isolation fixture threw: " (pr-str err)))
+                            nil)
+                  ;; The SYNCHRONOUS terminal path only — a throw before the
+                  ;; chain exists has no trailing step to finish on.
+                  fail! (fn [err] (report! err) (cleanup!) (done!))]
               (set! (.-IS_REACT_ACT_ENVIRONMENT js/globalThis) true)
               (try
                 (act-fn #(rdc/render root-a
@@ -301,9 +311,11 @@
                         (is (= 3 (count (filter #(= :render-release (:phase %))
                                                 @events)))
                             "each Reagent-owned render reaction releases exactly once")
-                        (cleanup!)
-                        (done!)))
-                    (.catch fail!))
+                        nil))
+                    (.catch report!)
+                    ;; Both arms cleaned up identically, so it rides the single
+                    ;; trailing step: written once, run once per path.
+                    (.then (fn [_] (cleanup!) (done!))))
                 (catch :default e (fail! e))))))))))
 
 (deftest keyed-provider-retarget-remounts-the-locked-capture
@@ -326,10 +338,13 @@
                   root (rdc/create-root (.createElement js/document "div"))
                   cleanup! #(try (act-fn (fn [] (rdc/unmount root)))
                                  (catch :default _ nil))
-                  fail! (fn [err]
-                          (is false (str "Form-3 retarget fixture threw: " (pr-str err)))
-                          (cleanup!)
-                          (done!))]
+                  ;; Reports; it does NOT finish — as above, and for the same
+                  ;; reason (rf2-e8kc).
+                  report! (fn [err]
+                            (is false (str "Form-3 retarget fixture threw: " (pr-str err)))
+                            nil)
+                  ;; The SYNCHRONOUS terminal path only.
+                  fail! (fn [err] (report! err) (cleanup!) (done!))]
               (set! (.-IS_REACT_ACT_ENVIRONMENT js/globalThis) true)
               (try
                 (act-fn #(rdc/render root (retarget-tree frame-a view)))
@@ -389,9 +404,11 @@
                       (fn [_]
                         (is (= {} (cache-state frame-b))
                             "final B unmount restores B's exact baseline")
-                        (cleanup!)
-                        (done!)))
-                    (.catch fail!))
+                        nil))
+                    (.catch report!)
+                    ;; Both arms cleaned up identically, so it rides the single
+                    ;; trailing step: written once, run once per path.
+                    (.then (fn [_] (cleanup!) (done!))))
                 (catch :default e (fail! e))))))))))
 
 (deftest strict-mode-replay-preserves-render-ownership
@@ -418,10 +435,12 @@
                   tree [rf/frame-provider {:frame frame-a}
                         [klass :strict-one]]
                   cleanup! #(try (rdc/unmount root) (catch :default _ nil))
-                  fail! (fn [err]
-                          (is false (str "Form-3 StrictMode fixture threw: " (pr-str err)))
-                          (cleanup!)
-                          (done!))]
+                  ;; Reports; it does NOT finish — as above, and for the same
+                  ;; reason (rf2-e8kc). This row has no synchronous terminal
+                  ;; path, so the chain's tail is the row's only exit.
+                  report! (fn [err]
+                            (is false (str "Form-3 StrictMode fixture threw: " (pr-str err)))
+                            nil)]
               (set! (.-IS_REACT_ACT_ENVIRONMENT js/globalThis) true)
               ;; The four-arity stock-Reagent renderer installs StrictMode
               ;; outside its two internal bridge components. An authored
@@ -474,9 +493,11 @@
                             "Reagent destroys the retained render owner exactly once")
                         (is (= {} (cache-state frame-a))
                             "real unmount restores the exact cache baseline"))
-                      (cleanup!)
-                      (done!)))
-                  (.catch fail!)))))))))
+                      nil))
+                  (.catch report!)
+                  ;; Both arms cleaned up identically, so it rides the single
+                  ;; trailing step: written once, run once per path.
+                  (.then (fn [_] (cleanup!) (done!)))))))))))
 
 ;; ---------------------------------------------------------------------------
 ;; rf2-rjjry + rf2-ynved — the exceptional imperative-subscription recipe must be
@@ -656,10 +677,15 @@
                   tree  [rf/frame-provider {:frame frame-a} [klass :strict-gauge]]
                   rc    (fn [] (ref-count (cache-state frame-a) gauge-query))
                   cleanup! #(try (rdc/unmount root) (catch :default _ nil))
-                  fail! (fn [err]
-                          (is false (str "gauge StrictMode fixture threw: " (pr-str err)))
-                          (cleanup!)
-                          (done!))]
+                  ;; Reports and RELEASES; it does NOT finish — as above, and
+                  ;; for the same reason (rf2-e8kc). `cleanup!` stays HERE
+                  ;; rather than riding the tail: the success path unmounts the
+                  ;; root in-chain as a step under test, so only the failure
+                  ;; arm can still have a mounted root to drop.
+                  report! (fn [err]
+                            (is false (str "gauge StrictMode fixture threw: " (pr-str err)))
+                            (cleanup!)
+                            nil)]
               (set! (.-IS_REACT_ACT_ENVIRONMENT js/globalThis) true)
               (-> (js/Promise.resolve (act-fn #(rdc/render root tree nil true)))
                   (.then (fn [_] (settle-macrotasks 3)))
@@ -684,5 +710,7 @@
                     (fn [_]
                       (is (zero? (rc))
                           "the real unmount returns the shared reaction to zero")
-                      (done!)))
-                  (.catch fail!)))))))))
+                      nil))
+                  (.catch report!)
+                  ;; The single `done`, with nothing after it.
+                  (.then (fn [_] (done!)))))))))))

--- a/implementation/adapters/reagent/test/re_frame/frame_provider_context_dom_cljs_test.cljs
+++ b/implementation/adapters/reagent/test/re_frame/frame_provider_context_dom_cljs_test.cljs
@@ -772,13 +772,21 @@
                            "remount — the re-seeding :initial-events [[:rf/set-db "
                            "{:n 999}]] was RE-RECORDED but NOT replayed (got "
                            (pr-str (rf/app-db-value target)) ")"))
-                  (cleanup!)
-                  (done!)))
+                  nil))
+              ;; Reports; it does NOT finish. `done` hands `cljs.test/run-block`
+              ;; a continuation that runs the WHOLE remainder of the run
+              ;; synchronously, so a rejection handler downstream of the step
+              ;; that finished the row claims whatever a LATER namespace throws,
+              ;; prints it against this row's label, and fires `done` a second
+              ;; time (rf2-e8kc). The CAS in `done!` swallows that second call;
+              ;; it cannot swallow the misattributed `is false`.
               (.catch
                 (fn [err]
                   (is false (str "scenario-6-frame-root threw: " (pr-str err)))
-                  (cleanup!)
-                  (done!)))))))))
+                  nil))
+              ;; Both arms cleaned up identically, so it rides the single
+              ;; trailing step: written once, run once per path.
+              (.then (fn [_] (cleanup!) (done!)))))))))
 
 ;; ---- Scenario 6 (frame-root): genuine unmount LEAVES the frame live -------
 ;;
@@ -824,25 +832,35 @@
                   (is (= {:n 3} (rf/app-db-value target)) ":initial-events seeded app-db")
                   ;; Genuine unmount — frame-root does NOT destroy.
                   (js/Promise.resolve (act-fn (fn [] (.unmount root))))))
+              ;; AWAITED rather than fired-and-forgotten. A bare `js/setTimeout`
+              ;; returns a NUMBER, so this step used to settle the chain
+              ;; immediately and the assertions below ran OFF THE END of it —
+              ;; where the handler could not see a throw, and a throw would have
+              ;; left `done!` uncalled and hung the lane with no diagnostic at
+              ;; all. The same double-macrotask window, expressed as a promise
+              ;; the chain can wait on (rf2-e8kc).
               (.then
                 (fn [_]
-                  (js/setTimeout
-                    (fn []
+                  (js/Promise.
+                    (fn [resolve _]
                       (js/setTimeout
-                        (fn []
-                          (is (some? (frame/frame target))
-                              "genuine unmount LEFT the frame live (frame-root has no destroy-on-unmount)")
-                          (is (= {:n 3} (rf/app-db-value target))
-                              "durable app-db survived the unmount intact")
-                          (cleanup!)
-                          (done!))
-                        4))
-                    4)))
+                        (fn [] (js/setTimeout (fn [] (resolve nil)) 4))
+                        4)))))
+              (.then
+                (fn [_]
+                  (is (some? (frame/frame target))
+                      "genuine unmount LEFT the frame live (frame-root has no destroy-on-unmount)")
+                  (is (= {:n 3} (rf/app-db-value target))
+                      "durable app-db survived the unmount intact")
+                  nil))
+              ;; Reports; it does NOT finish — as above (rf2-e8kc).
               (.catch
                 (fn [err]
                   (is false (str "frame-root genuine-unmount scenario threw: " (pr-str err)))
-                  (cleanup!)
-                  (done!)))))))))
+                  nil))
+              ;; Both arms cleaned up identically, so it rides the single
+              ;; trailing step: written once, run once per path.
+              (.then (fn [_] (cleanup!) (done!)))))))))
 
 ;; ---- Scenario 6 (frame-root): a DISCARDED render creates NO frame ---------
 ;;
@@ -925,25 +943,32 @@
           (do (is true "act() not reachable; discarded-render scenario skipped")
               (done!))
           (-> (js/Promise.resolve (act-fn (fn [] (.render root boundary))))
+              ;; AWAITED rather than fired-and-forgotten, for the reason given
+              ;; on the genuine-unmount scenario above: a bare `js/setTimeout`
+              ;; returns a NUMBER, so the assertion below used to run off the
+              ;; end of a chain that had already settled (rf2-e8kc).
               (.then
                 (fn [_]
-                  (js/setTimeout
-                    (fn []
-                      (is (nil? (frame/frame target))
-                          (str "GHOST-FRAME FIX: an aborted (never-committed) render "
-                               "created NO frame under " (pr-str target)
-                               " (frame-root ensures at commit, not during render)"))
-                      (cleanup!)
-                      (done!))
-                    8)))
+                  (js/Promise. (fn [resolve _] (js/setTimeout (fn [] (resolve nil)) 8)))))
+              (.then
+                (fn [_]
+                  (is (nil? (frame/frame target))
+                      (str "GHOST-FRAME FIX: an aborted (never-committed) render "
+                           "created NO frame under " (pr-str target)
+                           " (frame-root ensures at commit, not during render)"))
+                  nil))
               (.catch
                 (fn [_err]
                   ;; A thrown render may reject the act() thenable depending on the
                   ;; error-boundary timing; the invariant still holds — no frame.
+                  ;; This arm ASSERTS rather than merely reports, and it still
+                  ;; does not finish: the single `done!` is on the tail below.
                   (is (nil? (frame/frame target))
                       "aborted render created NO frame (error path)")
-                  (cleanup!)
-                  (done!)))))))))
+                  nil))
+              ;; Both arms cleaned up identically, so it rides the single
+              ;; trailing step: written once, run once per path.
+              (.then (fn [_] (cleanup!) (done!)))))))))
 
 ;; ---- Scenario 7: concurrent rendering / suspense + act --------------------
 ;;
@@ -1004,9 +1029,19 @@
                 mount-node (make-mount-node!)
                 root       (rdc/create-root mount-node)
                 finish     (fn [] (teardown-and-done! root done))
-                fail!      (fn [e]
+                ;; Reports; it does NOT finish. `finish` closes over `done`, so
+                ;; calling it from a rejection handler downstream of the step
+                ;; that already called it claims a LATER namespace's throw as
+                ;; this row's and fires `done` a second time (rf2-e8kc). A
+                ;; closure is invisible to a scanner looking for a literal
+                ;; `(done)` or for a helper that TAKES `done`; it finishes the
+                ;; row just the same.
+                report!    (fn [e]
                              (is false (str "scenario-7 threw: " (pr-str e)))
-                             (finish))]
+                             nil)
+                ;; The SYNCHRONOUS terminal path only — a throw before the
+                ;; chain exists has no trailing step to finish on.
+                fail!      (fn [e] (report! e) (finish))]
             (try
               ;; Render 1 — wrap the call in act() so pending React work
               ;; commits before we read the observed-* atoms.
@@ -1033,9 +1068,12 @@
                       (is (some #{2} @observed-values)
                           (str "post-dispatch re-render observes the incremented value n=2; got "
                                (pr-str @observed-values)))
-                      ;; SOURCE fix (rf2-vp3m9): await the deferred teardown.
-                      (finish)))
-                  (.catch fail!))
+                      nil))
+                  (.catch report!)
+                  ;; SOURCE fix (rf2-vp3m9): await the deferred teardown. The
+                  ;; single exit, on the single trailing step, with nothing
+                  ;; after it.
+                  (.then (fn [_] (finish))))
               (catch :default e
                 (fail! e)))))))))
 

--- a/implementation/adapters/reagent/test/re_frame/views_synthetic_event_frame_dom_cljs_test.cljs
+++ b/implementation/adapters/reagent/test/re_frame/views_synthetic_event_frame_dom_cljs_test.cljs
@@ -232,12 +232,23 @@
                                  (str "a real synthetic click on the injected `#(dispatch …)` "
                                       "button dispatched successfully AFTER the render boundary "
                                       "— app-db advanced to {:n 1}"))
-                             (finalize!)))
+                             nil))
+                    ;; Reports; it does NOT finalize. `done` hands
+                    ;; `cljs.test/run-block` a continuation that runs the WHOLE
+                    ;; remainder of the run synchronously, so a rejection
+                    ;; handler downstream of the step that finished the row
+                    ;; claims whatever a LATER namespace throws and prints it
+                    ;; against this row's label (rf2-e8kc). The CAS inside
+                    ;; `finalize!` swallowed the second `done`; it could not
+                    ;; swallow the misattributed failure.
                     (.catch (fn [e]
                               (is false
                                   (str "injected dispatch never advanced the render frame: "
                                        (pr-str (ex-message e))))
-                              (finalize!)))))))
+                              nil))
+                    ;; THE single finalizer, on the single trailing step —
+                    ;; both arms reach it, and nothing follows it.
+                    (.then (fn [_] (finalize!)))))))
           (catch :default e
             (is false (str "synthetic-event proof threw: " (pr-str e)))
             (finalize!)))))))

--- a/implementation/hicasso/test/re_frame/hicasso/native_abi_dom_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/native_abi_dom_cljs_test.cljs
@@ -209,6 +209,12 @@
                    " | residue " (pr-str (inventory/residue))))
     nil))
 
+;; Teardown is NOT hoisted onto those trailing steps in the `mount-live!`
+;; rows: the rejection arm never had the handle at all, because `mount-live!`
+;; resolves WITH it, so the two arms were never writing the same release.
+;; `a-lazy-head-suspends-and-then-names-its-own-component` is the one row
+;; that holds its handle before the wait, and it hoists — it says so there.
+
 ;; ---------------------------------------------------------------------------
 ;; 1. The outward bridge
 ;; ---------------------------------------------------------------------------
@@ -249,10 +255,7 @@
                 (support/teardown-census! handle)
                 nil))
             (.catch (report-failure! "outward bridge"))
-            ;; The single `done`, on the single trailing step, with nothing
-            ;; after it. Teardown is NOT hoisted onto it: the rejection arm
-            ;; never had the handle at all — `mount-live!` resolves WITH it —
-            ;; so the two arms were never writing the same release.
+            ;; The single `done`, with nothing after it.
             (.then (fn [_] (done))))))))
 
 (deftest two-frames-are-two-cells-across-the-bridge
@@ -294,10 +297,7 @@
                 (support/teardown-census! b)
                 nil))
             (.catch (report-failure! "two frames across the bridge"))
-            ;; The single `done`, on the single trailing step, with nothing
-            ;; after it. Teardown is NOT hoisted onto it: the rejection arm
-            ;; never had the handle at all — `mount-live!` resolves WITH it —
-            ;; so the two arms were never writing the same release.
+            ;; The single `done`, with nothing after it.
             (.then (fn [_] (done))))))))
 
 (deftest the-views-memo-wrapper-survives-the-bridge
@@ -341,10 +341,7 @@
                 (support/teardown-census! handle)
                 nil))
             (.catch (report-failure! "memo across the bridge"))
-            ;; The single `done`, on the single trailing step, with nothing
-            ;; after it. Teardown is NOT hoisted onto it: the rejection arm
-            ;; never had the handle at all — `mount-live!` resolves WITH it —
-            ;; so the two arms were never writing the same release.
+            ;; The single `done`, with nothing after it.
             (.then (fn [_] (done))))))))
 
 ;; ---------------------------------------------------------------------------
@@ -393,10 +390,7 @@
                 (support/teardown-census! handle)
                 nil))
             (.catch (report-failure! "inward door"))
-            ;; The single `done`, on the single trailing step, with nothing
-            ;; after it. Teardown is NOT hoisted onto it: the rejection arm
-            ;; never had the handle at all — `mount-live!` resolves WITH it —
-            ;; so the two arms were never writing the same release.
+            ;; The single `done`, with nothing after it.
             (.then (fn [_] (done))))))))
 
 ;; ---------------------------------------------------------------------------
@@ -440,10 +434,7 @@
                 (support/teardown-census! handle)
                 nil))
             (.catch (report-failure! "memo across a re-render"))
-            ;; The single `done`, on the single trailing step, with nothing
-            ;; after it. Teardown is NOT hoisted onto it: the rejection arm
-            ;; never had the handle at all — `mount-live!` resolves WITH it —
-            ;; so the two arms were never writing the same release.
+            ;; The single `done`, with nothing after it.
             (.then (fn [_] (done))))))))
 
 (deftest a-fresh-mint-replaces-the-subtree-and-that-is-the-hmr-contract
@@ -486,10 +477,7 @@
                 (support/teardown-census! handle)
                 nil))
             (.catch (report-failure! "fresh mint"))
-            ;; The single `done`, on the single trailing step, with nothing
-            ;; after it. Teardown is NOT hoisted onto it: the rejection arm
-            ;; never had the handle at all — `mount-live!` resolves WITH it —
-            ;; so the two arms were never writing the same release.
+            ;; The single `done`, with nothing after it.
             (.then (fn [_] (done))))))))
 
 (deftest strict-modes-double-mount-crosses-the-bridge-exactly-once
@@ -515,10 +503,7 @@
                 (support/teardown-census! handle)
                 nil))
             (.catch (report-failure! "strict mode"))
-            ;; The single `done`, on the single trailing step, with nothing
-            ;; after it. Teardown is NOT hoisted onto it: the rejection arm
-            ;; never had the handle at all — `mount-live!` resolves WITH it —
-            ;; so the two arms were never writing the same release.
+            ;; The single `done`, with nothing after it.
             (.then (fn [_] (done))))))))
 
 (deftest a-ref-reaches-a-real-dom-node-through-the-memo-helper
@@ -628,10 +613,7 @@
                 (exercised! :bridge/teardown)
                 nil))
             (.catch (report-failure! "teardown"))
-            ;; The single `done`, on the single trailing step, with nothing
-            ;; after it. Teardown is NOT hoisted onto it: the rejection arm
-            ;; never had the handle at all — `mount-live!` resolves WITH it —
-            ;; so the two arms were never writing the same release.
+            ;; The single `done`, with nothing after it.
             (.then (fn [_] (done))))))))
 
 (deftest the-declared-population-was-actually-exercised

--- a/implementation/hicasso/test/re_frame/hicasso/native_abi_dom_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/native_abi_dom_cljs_test.cljs
@@ -192,13 +192,22 @@
                                    {:residue (inventory/residue)})))
                  handle)))))
 
-(defn- fail-and-finish!
-  [done label handle]
+(defn- report-failure!
+  "Reports a rejection against `label`; it does NOT finish the row.
+
+  `done` hands `cljs.test/run-block` a continuation that runs the WHOLE
+  remainder of the run synchronously, so a `.catch` sitting downstream of the
+  step that finished the row claims whatever a LATER namespace throws, prints
+  it against this row's label, and calls `done` a SECOND time — re-forcing
+  `run-block`'s unrealized delay and re-running the offending namespace, which
+  `run-browser-tests.cjs` promotes to a fatal console match (rf2-e8kc). Every
+  chain below therefore reports here and finishes on a single trailing step,
+  with nothing after it."
+  [label]
   (fn [e]
     (is false (str label " — " (.-message e)
                    " | residue " (pr-str (inventory/residue))))
-    (when handle (mount/release! handle))
-    (done)))
+    nil))
 
 ;; ---------------------------------------------------------------------------
 ;; 1. The outward bridge
@@ -238,8 +247,13 @@
 
                 (exercised! :bridge/outward)
                 (support/teardown-census! handle)
-                (done)))
-            (.catch (fail-and-finish! done "outward bridge" nil)))))))
+                nil))
+            (.catch (report-failure! "outward bridge"))
+            ;; The single `done`, on the single trailing step, with nothing
+            ;; after it. Teardown is NOT hoisted onto it: the rejection arm
+            ;; never had the handle at all — `mount-live!` resolves WITH it —
+            ;; so the two arms were never writing the same release.
+            (.then (fn [_] (done))))))))
 
 (deftest two-frames-are-two-cells-across-the-bridge
   (async done
@@ -278,8 +292,13 @@
                 (exercised! :bridge/two-frames)
                 (support/teardown-census! a)
                 (support/teardown-census! b)
-                (done)))
-            (.catch (fail-and-finish! done "two frames across the bridge" nil)))))))
+                nil))
+            (.catch (report-failure! "two frames across the bridge"))
+            ;; The single `done`, on the single trailing step, with nothing
+            ;; after it. Teardown is NOT hoisted onto it: the rejection arm
+            ;; never had the handle at all — `mount-live!` resolves WITH it —
+            ;; so the two arms were never writing the same release.
+            (.then (fn [_] (done))))))))
 
 (deftest the-views-memo-wrapper-survives-the-bridge
   (async done
@@ -320,8 +339,13 @@
 
                 (exercised! :bridge/memo-bail-out)
                 (support/teardown-census! handle)
-                (done)))
-            (.catch (fail-and-finish! done "memo across the bridge" nil)))))))
+                nil))
+            (.catch (report-failure! "memo across the bridge"))
+            ;; The single `done`, on the single trailing step, with nothing
+            ;; after it. Teardown is NOT hoisted onto it: the rejection arm
+            ;; never had the handle at all — `mount-live!` resolves WITH it —
+            ;; so the two arms were never writing the same release.
+            (.then (fn [_] (done))))))))
 
 ;; ---------------------------------------------------------------------------
 ;; 2. The inward door
@@ -367,8 +391,13 @@
 
                 (exercised! :bridge/inward)
                 (support/teardown-census! handle)
-                (done)))
-            (.catch (fail-and-finish! done "inward door" nil)))))))
+                nil))
+            (.catch (report-failure! "inward door"))
+            ;; The single `done`, on the single trailing step, with nothing
+            ;; after it. Teardown is NOT hoisted onto it: the rejection arm
+            ;; never had the handle at all — `mount-live!` resolves WITH it —
+            ;; so the two arms were never writing the same release.
+            (.then (fn [_] (done))))))))
 
 ;; ---------------------------------------------------------------------------
 ;; 3. The helpers, across a second render and a remount
@@ -409,8 +438,13 @@
 
                 (exercised! :helper/memo-across-a-re-render)
                 (support/teardown-census! handle)
-                (done)))
-            (.catch (fail-and-finish! done "memo across a re-render" nil)))))))
+                nil))
+            (.catch (report-failure! "memo across a re-render"))
+            ;; The single `done`, on the single trailing step, with nothing
+            ;; after it. Teardown is NOT hoisted onto it: the rejection arm
+            ;; never had the handle at all — `mount-live!` resolves WITH it —
+            ;; so the two arms were never writing the same release.
+            (.then (fn [_] (done))))))))
 
 (deftest a-fresh-mint-replaces-the-subtree-and-that-is-the-hmr-contract
   (async done
@@ -450,8 +484,13 @@
 
                 (exercised! :helper/fresh-mint-remounts)
                 (support/teardown-census! handle)
-                (done)))
-            (.catch (fail-and-finish! done "fresh mint" nil)))))))
+                nil))
+            (.catch (report-failure! "fresh mint"))
+            ;; The single `done`, on the single trailing step, with nothing
+            ;; after it. Teardown is NOT hoisted onto it: the rejection arm
+            ;; never had the handle at all — `mount-live!` resolves WITH it —
+            ;; so the two arms were never writing the same release.
+            (.then (fn [_] (done))))))))
 
 (deftest strict-modes-double-mount-crosses-the-bridge-exactly-once
   (async done
@@ -474,8 +513,13 @@
 
                 (exercised! :bridge/strict-mode)
                 (support/teardown-census! handle)
-                (done)))
-            (.catch (fail-and-finish! done "strict mode" nil)))))))
+                nil))
+            (.catch (report-failure! "strict mode"))
+            ;; The single `done`, on the single trailing step, with nothing
+            ;; after it. Teardown is NOT hoisted onto it: the rejection arm
+            ;; never had the handle at all — `mount-live!` resolves WITH it —
+            ;; so the two arms were never writing the same release.
+            (.then (fn [_] (done))))))))
 
 (deftest a-ref-reaches-a-real-dom-node-through-the-memo-helper
   (async done
@@ -547,9 +591,14 @@
                     (is (= "client-only" (unchecked-get marker-0 "server"))))
 
                   (exercised! :helper/lazy-arrival)
-                  (mount/release! handle)
-                  (done)))
-              (.catch (fail-and-finish! done "lazy arrival" handle))))))))
+                  nil))
+              (.catch (report-failure! "lazy arrival"))
+              ;; Unlike the `mount-live!` rows, THIS row holds its handle in
+              ;; the enclosing `let` rather than receiving it from the promise,
+              ;; so both arms really did release the same one — and the release
+              ;; rides the single trailing step: written once, run once per
+              ;; path, with the single `done` behind it.
+              (.then (fn [_] (mount/release! handle) (done)))))))))
 
 ;; ---------------------------------------------------------------------------
 ;; 4. Teardown, and the roster
@@ -577,8 +626,13 @@
                     (is (= support/released census))))
 
                 (exercised! :bridge/teardown)
-                (done)))
-            (.catch (fail-and-finish! done "teardown" nil)))))))
+                nil))
+            (.catch (report-failure! "teardown"))
+            ;; The single `done`, on the single trailing step, with nothing
+            ;; after it. Teardown is NOT hoisted onto it: the rejection arm
+            ;; never had the handle at all — `mount-live!` resolves WITH it —
+            ;; so the two arms were never writing the same release.
+            (.then (fn [_] (done))))))))
 
 (deftest the-declared-population-was-actually-exercised
   (if-not (mount/browser?)

--- a/implementation/hicasso/test/re_frame/hicasso/native_hooks_dom_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/native_hooks_dom_cljs_test.cljs
@@ -241,6 +241,12 @@
     (when handle (mount/release! handle))
     nil))
 
+;; Teardown is NOT hoisted onto those trailing steps anywhere in this file,
+;; and the reason is one reason: in the success arm it IS the assertion —
+;; `(is (= support/released (teardown! handle)))` — while the rejection arm
+;; never had the handle at all, because `mount-live!` resolves WITH it. The
+;; two arms were never writing the same release, so there is nothing to hoist.
+
 (defn- teardown!
   "Unmount, read the census while it is still exact, then finish the
   release. The order is the load-bearing part: `mount/release!` calls
@@ -317,11 +323,7 @@
                   (is (= support/released (teardown! handle))))
                 nil))
             (.catch (report-failure! "W1 mounted read" nil))
-            ;; The single `done`, on the single trailing step, with nothing
-            ;; after it. Teardown is NOT hoisted onto it: it is an ASSERTION
-            ;; under test in the success arm — the census must read
-            ;; `support/released` — and the rejection arm never had the
-            ;; handle, which `mount-live!` resolves WITH.
+            ;; The single `done`, with nothing after it.
             (.then (fn [_] (done))))))))
 
 ;; ---------------------------------------------------------------------------
@@ -365,11 +367,7 @@
                 (is (= support/released (teardown! handle)))
                 nil))
             (.catch (report-failure! "W2 selective wake" nil))
-            ;; The single `done`, on the single trailing step, with nothing
-            ;; after it. Teardown is NOT hoisted onto it: it is an ASSERTION
-            ;; under test in the success arm — the census must read
-            ;; `support/released` — and the rejection arm never had the
-            ;; handle, which `mount-live!` resolves WITH.
+            ;; The single `done`, with nothing after it.
             (.then (fn [_] (done))))))))
 
 ;; ---------------------------------------------------------------------------
@@ -438,11 +436,7 @@
                   (is (= support/released (teardown! handle)))
                   nil)))
             (.catch (report-failure! "W3 no re-subscribe" nil))
-            ;; The single `done`, on the single trailing step, with nothing
-            ;; after it. Teardown is NOT hoisted onto it: it is an ASSERTION
-            ;; under test in the success arm — the census must read
-            ;; `support/released` — and the rejection arm never had the
-            ;; handle, which `mount-live!` resolves WITH.
+            ;; The single `done`, with nothing after it.
             (.then (fn [_] (done))))))))
 
 ;; ---------------------------------------------------------------------------
@@ -500,11 +494,7 @@
                                       (inventory/residue))))
                              nil)))))
             (.catch (report-failure! "W4 StrictMode" nil))
-            ;; The single `done`, on the single trailing step, with nothing
-            ;; after it. Teardown is NOT hoisted onto it: it is an ASSERTION
-            ;; under test in the success arm — the census must read
-            ;; `support/released` — and the rejection arm never had the
-            ;; handle, which `mount-live!` resolves WITH.
+            ;; The single `done`, with nothing after it.
             (.then (fn [_] (done))))))))
 
 ;; ---------------------------------------------------------------------------
@@ -554,11 +544,7 @@
                   (mount/release! (assoc a :root nil))
                   nil)))
             (.catch (report-failure! "W5 frame isolation" nil))
-            ;; The single `done`, on the single trailing step, with nothing
-            ;; after it. Teardown is NOT hoisted onto it: it is an ASSERTION
-            ;; under test in the success arm — the census must read
-            ;; `support/released` — and the rejection arm never had the
-            ;; handle, which `mount-live!` resolves WITH.
+            ;; The single `done`, with nothing after it.
             (.then (fn [_] (done))))))))
 
 ;; ---------------------------------------------------------------------------
@@ -711,11 +697,7 @@
                 (is (= support/released (teardown! handle)))
                 nil))
             (.catch (report-failure! "W7 transition" nil))
-            ;; The single `done`, on the single trailing step, with nothing
-            ;; after it. Teardown is NOT hoisted onto it: it is an ASSERTION
-            ;; under test in the success arm — the census must read
-            ;; `support/released` — and the rejection arm never had the
-            ;; handle, which `mount-live!` resolves WITH.
+            ;; The single `done`, with nothing after it.
             (.then (fn [_] (done))))))))
 
 ;; ---------------------------------------------------------------------------

--- a/implementation/hicasso/test/re_frame/hicasso/native_hooks_dom_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/native_hooks_dom_cljs_test.cljs
@@ -222,13 +222,24 @@
 
 (defn- skip! [why] (is true (str "a native-hook claim needs a real React DOM — " why)))
 
-(defn- fail-and-finish!
-  [done label handle]
+(defn- report-failure!
+  "Reports a rejection against `label`, releasing `handle` when this row's
+  rejection arm has one; it does NOT finish the row.
+
+  `done` hands `cljs.test/run-block` a continuation that runs the WHOLE
+  remainder of the run synchronously, so a `.catch` sitting downstream of the
+  step that finished the row claims whatever a LATER namespace throws, prints
+  it against this row's label, and calls `done` a SECOND time — re-forcing
+  `run-block`'s unrealized delay and re-running the offending namespace, which
+  `run-browser-tests.cjs` promotes to a fatal console match (rf2-e8kc). Every
+  chain below therefore reports here and finishes on a single trailing step,
+  with nothing after it."
+  [label handle]
   (fn [e]
     (is false (str label " — " (.-message e)
                    " | residue " (pr-str (inventory/residue))))
     (when handle (mount/release! handle))
-    (done)))
+    nil))
 
 (defn- teardown!
   "Unmount, read the census while it is still exact, then finish the
@@ -304,8 +315,14 @@
                 (exercised! :hooks/mounted-read)
                 (testing "teardown releases every membership the mount took"
                   (is (= support/released (teardown! handle))))
-                (done)))
-            (.catch (fail-and-finish! done "W1 mounted read" nil)))))))
+                nil))
+            (.catch (report-failure! "W1 mounted read" nil))
+            ;; The single `done`, on the single trailing step, with nothing
+            ;; after it. Teardown is NOT hoisted onto it: it is an ASSERTION
+            ;; under test in the success arm — the census must read
+            ;; `support/released` — and the rejection arm never had the
+            ;; handle, which `mount-live!` resolves WITH.
+            (.then (fn [_] (done))))))))
 
 ;; ---------------------------------------------------------------------------
 ;; W2. A write wakes its readers and nobody else
@@ -346,8 +363,14 @@
 
                 (exercised! :hooks/selective-wake)
                 (is (= support/released (teardown! handle)))
-                (done)))
-            (.catch (fail-and-finish! done "W2 selective wake" nil)))))))
+                nil))
+            (.catch (report-failure! "W2 selective wake" nil))
+            ;; The single `done`, on the single trailing step, with nothing
+            ;; after it. Teardown is NOT hoisted onto it: it is an ASSERTION
+            ;; under test in the success arm — the census must read
+            ;; `support/released` — and the rejection arm never had the
+            ;; handle, which `mount-live!` resolves WITH.
+            (.then (fn [_] (done))))))))
 
 ;; ---------------------------------------------------------------------------
 ;; W3. THE characteristic failure: a re-render that changed no read
@@ -413,8 +436,14 @@
 
                   (exercised! :hooks/no-resubscribe)
                   (is (= support/released (teardown! handle)))
-                  (done))))
-            (.catch (fail-and-finish! done "W3 no re-subscribe" nil)))))))
+                  nil)))
+            (.catch (report-failure! "W3 no re-subscribe" nil))
+            ;; The single `done`, on the single trailing step, with nothing
+            ;; after it. Teardown is NOT hoisted onto it: it is an ASSERTION
+            ;; under test in the success arm — the census must read
+            ;; `support/released` — and the rejection arm never had the
+            ;; handle, which `mount-live!` resolves WITH.
+            (.then (fn [_] (done))))))))
 
 ;; ---------------------------------------------------------------------------
 ;; W4. StrictMode's double mount, and exact teardown
@@ -469,8 +498,14 @@
                                (is (= {:cells 0 :cell-refs 0 :boundaries 0
                                        :edges 0 :entries 0}
                                       (inventory/residue))))
-                             (done))))))
-            (.catch (fail-and-finish! done "W4 StrictMode" nil)))))))
+                             nil)))))
+            (.catch (report-failure! "W4 StrictMode" nil))
+            ;; The single `done`, on the single trailing step, with nothing
+            ;; after it. Teardown is NOT hoisted onto it: it is an ASSERTION
+            ;; under test in the success arm — the census must read
+            ;; `support/released` — and the rejection arm never had the
+            ;; handle, which `mount-live!` resolves WITH.
+            (.then (fn [_] (done))))))))
 
 ;; ---------------------------------------------------------------------------
 ;; W5. Frames are isolated contexts — on this side of the fence too
@@ -517,8 +552,14 @@
                   (mount/unmount! a)
                   (is (= support/released (teardown! b)))
                   (mount/release! (assoc a :root nil))
-                  (done))))
-            (.catch (fail-and-finish! done "W5 frame isolation" nil)))))))
+                  nil)))
+            (.catch (report-failure! "W5 frame isolation" nil))
+            ;; The single `done`, on the single trailing step, with nothing
+            ;; after it. Teardown is NOT hoisted onto it: it is an ASSERTION
+            ;; under test in the success arm — the census must read
+            ;; `support/released` — and the rejection arm never had the
+            ;; handle, which `mount-live!` resolves WITH.
+            (.then (fn [_] (done))))))))
 
 ;; ---------------------------------------------------------------------------
 ;; W6. `use-frame`, both halves of the incarnation rule
@@ -610,9 +651,25 @@
 
                             (exercised! :hooks/incarnation)
                             (is (= support/released (teardown! handle)))
-                            (done)))
-                        (.catch (fail-and-finish! done "W6 incarnation" handle)))))))
-            (.catch (fail-and-finish! done "W6 incarnation" nil)))))))
+                            nil))
+                        ;; The inner chain now finishes NOTHING — it is
+                        ;; returned into the outer one below, whose single
+                        ;; trailing step is this row's only exit. Its own
+                        ;; diagnostic is kept rather than folded into the
+                        ;; outer one, because only this arm can say the
+                        ;; reincarnation never landed.
+                        ;;
+                        ;; Its `handle` release stays here rather than riding
+                        ;; the tail: the success arm's `teardown!` is an
+                        ;; ASSERTION under test — the census must read
+                        ;; `support/released` — so the failure arm does
+                        ;; strictly less, not the same thing.
+                        (.catch (report-failure! "W6 incarnation" handle)))))))
+            (.catch (report-failure! "W6 incarnation" nil))
+            ;; The single `done`, on the single trailing step, with nothing
+            ;; after it. Both of the inner chain's arms reach it, because the
+            ;; inner chain is returned into this one.
+            (.then (fn [_] (done))))))))
 
 ;; ---------------------------------------------------------------------------
 ;; W7. The external-store ceiling, measured
@@ -652,8 +709,14 @@
 
                 (exercised! :hooks/transition)
                 (is (= support/released (teardown! handle)))
-                (done)))
-            (.catch (fail-and-finish! done "W7 transition" nil)))))))
+                nil))
+            (.catch (report-failure! "W7 transition" nil))
+            ;; The single `done`, on the single trailing step, with nothing
+            ;; after it. Teardown is NOT hoisted onto it: it is an ASSERTION
+            ;; under test in the success arm — the census must read
+            ;; `support/released` — and the rejection arm never had the
+            ;; handle, which `mount-live!` resolves WITH.
+            (.then (fn [_] (done))))))))
 
 ;; ---------------------------------------------------------------------------
 ;; The roster

--- a/implementation/machines/test/re_frame/machine_view_unmount_teardown_mounted_dom_cljs_test.cljs
+++ b/implementation/machines/test/re_frame/machine_view_unmount_teardown_mounted_dom_cljs_test.cljs
@@ -145,10 +145,18 @@
               traces     (atom [])
               root       (rdc/create-root (.createElement js/document "div"))
               cleanup!   (fn [] (try (act-fn #(rdc/unmount root)) (catch :default _ nil)))
-              fail!      (fn [err]
+              ;; Reports; it does NOT finish. `done` hands `cljs.test/run-block`
+              ;; a continuation that runs the WHOLE remainder of the run
+              ;; synchronously, so a rejection handler downstream of the step
+              ;; that finished the row claims whatever a LATER namespace throws,
+              ;; prints it against this row's label, and fires `done` a second
+              ;; time (rf2-e8kc). The chain's single `done` sits at its tail.
+              report!    (fn [err]
                            (is false (str "mounted bare-unmount fixture threw: " (pr-str err)))
-                           (cleanup!)
-                           (done!))]
+                           nil)
+              ;; The SYNCHRONOUS terminal path only — a throw before the chain
+              ;; exists has no trailing step to finish on.
+              fail!      (fn [err] (report! err) (cleanup!) (done!))]
           (set! (.-IS_REACT_ACT_ENVIRONMENT js/globalThis) true)
           (try
             (rf/reg-machine machine-id
@@ -211,9 +219,11 @@
                       (is (empty? (filterv #(= :rf.machine (:op-type %)) @traces))
                           "NO :op-type :rf.machine trace fired — the real unmount
                            touched nothing in the machine runtime")
-                      (cleanup!)
-                      (done!)))
-                  (.catch fail!)))
+                      nil))
+                  (.catch report!)
+                  ;; Both arms cleaned up identically, so it rides the single
+                  ;; trailing step: written once, run once per path.
+                  (.then (fn [_] (cleanup!) (done!)))))
             (catch :default e (fail! e))))))))
 
 ;; ===========================================================================
@@ -239,10 +249,13 @@
               traces     (atom [])
               root       (rdc/create-root (.createElement js/document "div"))
               cleanup!   (fn [] (try (act-fn #(rdc/unmount root)) (catch :default _ nil)))
-              fail!      (fn [err]
+              ;; Reports; it does NOT finish — as in fixture A above, and for
+              ;; the same reason (rf2-e8kc).
+              report!    (fn [err]
                            (is false (str "mounted explicit-destroy fixture threw: " (pr-str err)))
-                           (cleanup!)
-                           (done!))]
+                           nil)
+              ;; The SYNCHRONOUS terminal path only.
+              fail!      (fn [err] (report! err) (cleanup!) (done!))]
           (set! (.-IS_REACT_ACT_ENVIRONMENT js/globalThis) true)
           (try
             ;; Stub `:rf.resource/release-owner` (stands in for the resources
@@ -310,6 +323,11 @@
                          destroy: the two teardowns are independent")
                     (is (zero? (count (ops-of @traces lifecycle-destroyed)))
                         "still zero registrar-channel destroys after the unmount")
-                    (done!)))
-                (.catch fail!))
+                    nil))
+                ;; The defensive `cleanup!` stays on the failure arm rather
+                ;; than riding the tail: the success path unmounted the root
+                ;; above as a step UNDER TEST, and a second unmount there
+                ;; would be teardown this row never asked for.
+                (.catch (fn [err] (report! err) (cleanup!) nil))
+                (.then (fn [_] (done!))))
             (catch :default e (fail! e))))))))

--- a/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/port_to_build_test.cljs
+++ b/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/port_to_build_test.cljs
@@ -198,6 +198,20 @@
               (let [edn (tu/extract-edn result)]
                 (is (true? (:ok? edn)))
                 (is (= :my-app (:build-id edn)) "explicit build wins over port"))
-              (done)))
-          (.finally (fn [] (set! probe/resolve-build-by-port orig)))
-          (.then (fn [_] (done)))))))
+              nil))
+          ;; Reports; it does NOT finish. `done` hands `cljs.test/run-block` a
+          ;; continuation that runs the WHOLE remainder of the run
+          ;; synchronously, so anything downstream of the step that finished
+          ;; the row claims a LATER namespace's throw as this row's and fires
+          ;; `done` a second time (rf2-e8kc). Here the second `done` was
+          ;; unconditional — the trailing `.then` ran it on every green pass —
+          ;; while a REJECTION reached neither, because `.finally` re-throws
+          ;; and the row simply timed out with no diagnostic at all.
+          (.catch (fn [e]
+                    (is false (str "explicit-build discovery rejected: " e))
+                    nil))
+          ;; The stub restore, and the single `done` with nothing after it.
+          ;; Both arms reach this step, which is what `.finally` was for.
+          (.then (fn [_]
+                   (set! probe/resolve-build-by-port orig)
+                   (done)))))))

--- a/tools/story/test/re_frame/story/ui/a11y_stale_settlement_cljs_test.cljs
+++ b/tools/story/test/re_frame/story/ui/a11y_stale_settlement_cljs_test.cljs
@@ -181,10 +181,18 @@
                         served to :rf.assert/a11y as a verdict")
                    (is (= :idle (a11y/status-for frame-id))
                        "a frame with no slot reads :idle, NOT :done")
-                   (done)))
+                   nil))
+          ;; Reports; it does NOT finish. `done` hands `cljs.test/run-block` a
+          ;; continuation that runs the WHOLE remainder of the run
+          ;; synchronously, so a rejection handler downstream of the step that
+          ;; finished the row claims whatever a LATER namespace throws, prints
+          ;; it against this row's label, and fires `done` a second time
+          ;; (rf2-e8kc).
           (.catch (fn [e]
                     (is false (str "settling after teardown threw: " e))
-                    (done)))))))
+                    nil))
+          ;; The single `done`, with nothing after it.
+          (.then (fn [_] (done)))))))
 
 (deftest stale-settlement-does-not-clobber-the-replacement-run
   (testing "THE OTHER WAY TO LOSE THE SLOT: run A parks on its scan, a


### PR DESCRIPTION
Closes rf2-e8kc. The closure-over-`done` class **outside** `implementation/freehand`.

`cljs.test/run-block` hands `done` a continuation that runs the **whole remainder of
the run** synchronously. A rejection handler sitting downstream of the step that called
`done` therefore claims whatever a **later namespace** throws as this row's failure,
prints it against this row's label, and calls `done` a **second** time — re-forcing
`run-block`'s unrealized `Delay` and re-running the offending namespace. The cure is
positional: the handler goes **upstream**, reports and returns `nil`; exactly one
`done` sits at the tail with nothing after it.

## The count — re-derived, and it holds; one claim beside it does not

The bead's per-file census is **exact on this branch's base** (`3cb092d5b6`):
**32 chains in 10 files**, file for file. Re-derived independently, with a real
Clojure reader (strings, character literals, regex literals, `#?` reader conditionals,
`#_` discard, metadata, tagged literals, `##NaN`) rather than a line matcher, and a
structural walk that recovers chains from `->`/`some->` threading forms, from nested
`(.catch (.then p f) g)` interop, and from a top-level `defn` that HOSTS a chain
because it takes `done` as a parameter.

It reproduces **every** landmark the campaign has published, which is what says the
agreement is about the method and not a coincidence:

| commit | freehand, literal signature | landmark |
|---|---|---|
| `1662f3cc8e` (rf2-qpns) | **184 / 46** | the campaign's "pre-repair 184 / 46" — exact |
| `2f33b56649` (rf2-d2xz, #7955) | **100 / 38** | the campaign's "100 on main / 38" — exact |
| `195a7cb1d0` (rf2-o0n1's base) | **55 / 29** | #7968's "55 in 29 files" — exact |
| `195a7cb1d0`, closure signature | **60 / 31** | #7968's "55 + 5 = 60 chains, 31 files" — exact |

**WHAT DID NOT HOLD.** The bead says the two `hicasso/native_*` files are "**ALSO the
only two the LITERAL signature still sees** (17 chains)". They are not the only two.
On this base the literal signature sees **19 chains in 4 files** — the same 17, plus
`tools/story/…/a11y_stale_settlement_cljs_test.cljs` (1) and
`tools/re-frame2-pair-mcp/…/port_to_build_test.cljs` (1), both plain literal `(done)`
rows that the bead filed under the closure class.

The part that matters is unaffected, and is in fact **stronger** than the bead states.
The 17 in the two `native_*` files really are **ONE set, not two** — but not because
they are counted twice under two different shapes. They are **literal-class rows**,
seen by rf2-fyba's original signature; they appear in the closure census only because
the closure signature **subsumes** the literal one. Repairing them once closes both,
exactly as the bead predicts.

So the 32 decompose as **19 literal-class + 13 genuinely closure-only**:

| file | chains | class |
|---|---|---|
| `implementation/hicasso/…/native_abi_dom_cljs_test.cljs` | 9 | literal |
| `implementation/hicasso/…/native_hooks_dom_cljs_test.cljs` | 8 | literal |
| `tools/story/…/a11y_stale_settlement_cljs_test.cljs` | 1 | literal |
| `tools/re-frame2-pair-mcp/…/port_to_build_test.cljs` | 1 | literal |
| `implementation/adapters/reagent/…/form_3_lifecycle_dom_cljs_test.cljs` | 4 | closure (`done!`) |
| `implementation/adapters/reagent/…/frame_provider_context_dom_cljs_test.cljs` | 4 | closure (`done!` ×3, `finish`) |
| `implementation/adapters/reagent/…/views_synthetic_event_frame_dom_cljs_test.cljs` | 1 | closure (`finalize!`) |
| `implementation/adapters/reagent-slim/…/reagent_slim_strict_mode_dom_cljs_test.cljs` | 1 | closure (`done!`) |
| `implementation/adapters/reagent-slim/…/reagent_slim_synthetic_event_frame_dom_cljs_test.cljs` | 1 | closure (`finalize!`) |
| `implementation/machines/…/machine_view_unmount_teardown_mounted_dom_cljs_test.cljs` | 2 | closure (`done!`) |

All 32 are repaired here. **All three censuses now read ZERO over the whole repository**
— `implementation/`, `tools/`, `examples/`, `testbeds/` — not merely over the files
this PR touches.

## The CAS guard is not a cure

Six of the thirteen closure-only chains close over a **CAS-guarded** finisher
(`(fn [] (when (compare-and-set! done? false true) (done)))`, or `finalize!`'s
equivalent). The guard does swallow the second `done`, so `FATAL_CONSOLE_RE` never
fires on them — and that is precisely why they survived three signature sweeps. It
cannot swallow the misattributed `(is false …)`, which is the thing that reds the
lane, against the wrong row, naming a suite that did nothing wrong. The guards are
left in place where a row genuinely has two mutually exclusive terminal paths (a
synchronous `try`/`catch` beside the chain); they are no longer load-bearing.

## Per-chain dispositions — 13 hoisted, 18 left in place, 1 with nothing to hoist

Teardown was **not** hoisted mechanically.

**Hoisted onto the single trailing step**, because both arms already wrote it
identically — written once, still run once per path:

- `cleanup!` in `form_3_lifecycle`'s `outer-capture`, `keyed-provider-retarget` and
  `strict-mode-replay`; in `frame_provider_context`'s three scenario-6 rows; in
  `reagent_slim_strict_mode`; and in `machines`' bare-unmount fixture — 8 chains
- `finalize!`, THE single guaranteed finalizer, in both synthetic-event proofs
  (stock Reagent and reagent-slim) — 2 chains
- `finish` (`teardown-and-done! root done`) in `frame_provider_context`'s scenario-7
  — 1 chain
- `(mount/release! handle)` in `native_abi`'s `a-lazy-head-suspends-…` — 1 chain. This
  is the ONE row in that file that holds its handle in the enclosing `let` rather than
  receiving it from the promise, so both arms genuinely had the same handle to drop.
- the `.finally` stub restore in `port_to_build` — 1 chain; the tail is what `.finally`
  was for, and both arms reach it

**Left in place, each for a source-located reason:**

- **`support/teardown-census!` across `native_abi`'s eight `mount-live!` rows** — the
  rejection arm never had the handle at all: `mount-live!` **resolves WITH** it, so a
  rejection is precisely the case where no handle was ever handed out. The two arms
  were never writing the same release. (The old `fail-and-finish!` took a `handle`
  parameter and every one of these eight passed `nil`, which is the same fact stated
  in the source already.)
- **`teardown!` across all eight of `native_hooks`' rows** — the same, and stronger:
  in every row the success arm's teardown **IS the assertion**,
  `(is (= support/released (teardown! handle)))`. Hoisting it would move a claim under
  test onto a step that runs on the failure path too.
- **W6's inner chain keeps its own `handle` release AND its own diagnostic** — the
  success arm asserts the census, the failure arm can only drop the handle, which is
  strictly less; and only that arm can say the reincarnation never landed. `run-async`
  was **not** adopted anywhere, precisely because its generic message would replace
  each row's own diagnostic.
- **`cleanup!` in `form_3_lifecycle`'s `gauge-owner-balances-under-strict-mode` and in
  `machines`' explicit-destroy fixture** — both success paths unmount the root
  **in-chain, as a step under test**. A second unmount on the tail would be teardown
  the row never asked for; only the failure arm can still have a mounted root to drop.

**Nothing to hoist:** `tools/story`'s `no-throw-and-no-resurrection` has no teardown at
all — its two arms differed only in the `(done)` this PR removes from one of them.

## Two second-order defects, fixed and named separately

**A bare timer carrying assertions off the end of the chain.**
`scenario-6-frame-root-genuine-unmount-leaves-frame-live` and
`scenario-6-frame-root-discarded-render-creates-no-frame` each returned a bare
`js/setTimeout` from a chain step. That returns a **number**, so the chain settled
immediately and the assertions ran **off the end of it**: the `.catch` could not see a
throw there, and a throw would have left `done!` uncalled and **hung the lane with no
diagnostic at all**. Neither was an instance of the misattribution — the chain had
already settled before `done!` ever ran. Both timers are now awaited as promises, which
puts the assertions upstream of the handler and the single `done!` at the tail. The
file's own scenario-6 StrictMode row already used exactly that promise-wrapped
double-macrotask idiom; these two now match it.

**An unconditional double-`done` on the green path.** `port_to_build`'s
`discover-app-explicit-build-wins-over-port` called `(done)` in its `.then` **and**
again in a trailing `.then` after a `.finally`, so **every green pass fired `done`
twice** — not only when a foreign throw arrived. The mirror image was worse: on a
rejection, `.finally` re-throws, so **neither** `done` ran and the row timed out with
no diagnostic. It had no rejection handler at all. This is the one place in the PR
where an assertion was **added** (see the inventory below).

## The assertion inventory

`(is ` occurrences across the 10 changed files: **367 before, 368 after**, and
per-file identical except for the one deliberate addition — the rejection diagnostic
`port_to_build`'s chain never had. Zero `deftest` added or removed anywhere. No
assertion was weakened, moved between arms, or deleted.

## Prove it — the reproduction control

A throwaway namespace
`re-frame.hicasso.native-abi-dom-cljs-test-rf2-e8kc-control-dom-cljs-test` — a **prefix
extension** of the target, and `shadow.test/test-vars-block` `sort-by`s the ns symbol,
so nothing can run between the two (the neighbours on either side are
`motion-presence-dom-cljs-test` and `native-hooks-dom-cljs-test`). It pairs a
**fn-form** `:each` fixture with an `async` row, which selects `cljs.test`'s `:sync`
strategy, wraps the row in `disable-async`, and throws the bare String
`"Async tests require fixtures to be specified as maps.  Testing aborted."`
**synchronously** inside whichever `done` continuation is running.

| run | tree | captured exit | claims | double-`done` |
|---|---|---|---|---|
| **A** reproduce | the ten files reverted to base, control present | **1** | **2** — `teardown —  \| residue {...}` and `lazy arrival —  \| residue {...}`, both `native-abi`'s OWN diagnostics printed under `FAIL in (rf2-e8kc-control-row)`, against the CONTROL's test name | **yes** |
| **C** repaired | the shipped tree, control present | **1** | **0** | **no** |

Run A's console, verbatim:

```
Testing re-frame.hicasso.native-abi-dom-cljs-test
Testing re-frame.hicasso.native-abi-dom-cljs-test-rf2-e8kc-control-dom-cljs-test

FAIL in (rf2-e8kc-control-row) (:)
teardown —  | residue {:cells 0, :cell-refs 0, :boundaries 0, :edges 0, :entries 0}
expected: false
  actual: false

FAIL in (rf2-e8kc-control-row) (:)
lazy arrival —  | residue {:cells 0, :cell-refs 0, :boundaries 0, :edges 0, :entries 0}
expected: false
  actual: false
WARNING: Async test called done more than one time.
```

Run C's last line is the honest end state — the throw escapes as an unhandled page
error, **attributed to nobody**:

```
Testing re-frame.hicasso.native-abi-dom-cljs-test
Testing re-frame.hicasso.native-abi-dom-cljs-test-rf2-e8kc-control-dom-cljs-test
[browser:pageerror] Async tests require fixtures to be specified as maps.  Testing aborted.
```

**Where the escaping claim landed: nowhere.** Every earlier batch watched the throw hand
off to the next still-defective handler one frame down. This one does not, and the
reason is measurable rather than lucky — after the repair all three censuses read zero
over the WHOLE repository, so there is no downstream handler left to claim it. Neither
run reaches a summary, because the control aborts the run by design; that is why exit 1
is the *expected* value for both, and why a green aggregate would have proved nothing.

**The control is deleted, and the restore is verified by hashing the bytes**, not by
`git diff`. `sha256sum -c` over all ten files is **OK, exit 0**, both immediately before the probe
and again after the control was deleted — and once more after the rebase onto
`origin/main`. The control is absent from disk and from `git ls-files`, and
`git status --untracked-files=all` is empty.

**A duplicate `done` is NOT invisible to the browser gate.**
`implementation/scripts/run-browser-tests.cjs:194` matches
`/Async test called done more than one time/` as `FATAL_CONSOLE_RE`, and
`:269` cross-checks that regex against the wording in the **installed** `cljs.test`, so
it cannot silently rot. A grep over `implementation/`, `tools/`, `spec/` and `docs/`
finds no docstring still claiming otherwise — #7964 dropped the last copy.

## Quality gates

Each run alone, foreground to completion, output redirected, exit code captured on the
same command line into its own `.exit` file. **Every number below is the captured one.**

| gate | captured exit | result |
|---|---|---|
| `npm run test:browser` — **shipped tree** | **0** | `Ran 1341 tests containing 8275 assertions. 0 failures, 0 errors.` |
| `npm run test:browser` — **base, same machine** | **0** | `Ran 1341 tests containing 8275 assertions. 0 failures, 0 errors.` |
| `npm run test:cljs` (`:node-test`) — shipped tree | **0** | `Ran 13476 tests containing 67997 assertions. 0 failures, 0 errors.` |
| `npm test` in `tools/re-frame2-pair-mcp` — shipped tree | **0** | `Ran 1224 tests containing 4440 assertions. 0 failures, 0 errors.` |
| `npm run test:browser` — run A (control, ten files reverted) | **1** | reproduction: two misattributed claims + double-`done`, no summary |
| `npm run test:browser` — run C (control, repaired) | **1** | zero claims, zero double-`done`, honest page error |
| `python scripts/check_fast_pr_gap.py --list` | **0** | 97 required checks the fast-PR spine does not decide |

**The baseline is measured, not remembered.** 1341 / 8275 on the base and 1341 / 8275 on
this branch, from the same checkout minutes apart — **the count did not move**, which
the 367-for-367 browser-lane assertion inventory predicts. (The one added `is` is in
`port_to_build_test.cljs`, which the browser lane does not run.)

One run was discarded and re-run WHOLE: a first attempt at the final shipped-tree browser
gate died with `EADDRINUSE 127.0.0.1:8021` — an `http-server` left listening by run C,
which aborts by design and never reaches the runner's shutdown. Environmental, not a
result. The stale listener was killed and the gate re-run from the top; the **0** above
is that whole re-run.

**Lane coverage, checked rather than assumed.** `:browser-test`'s ns-regexp is
`^(?!re-frame\.freehand\.bench\.).*-dom-cljs-test$`, so it decides 8 of the 10 files.
The other two: `tools/story/…/a11y_stale_settlement_cljs_test.cljs` is a `-cljs-test`, not
a `-dom-` one, and rides `:node-test` (`../tools/story/test` is on that build's
source-paths and `cljs-test$` matches) — `npm run test:cljs`, run above; and
`tools/re-frame2-pair-mcp/…/port_to_build_test.cljs` rides the tool's own `:server-test`
build (`-test$`) — `npm test` in that directory, run above.

`scripts/check_fast_pr_gap.py --list` names 97 required checks this spine does not decide.
The one that decides most of this change is `cljs-browser`
(`CLJS (shadow-cljs :browser-test, headless Chromium)` → `npm run test:browser`), run
above four times; the touched namespaces are also compiled and run by
`CLJS (shadow-cljs :node-test)`, and the MCP tool by its own lane. `clj-kondo` and
`splint` reach `implementation/`; CI pins clj-kondo 2026.04.15 and a differently-versioned
local binary proves nothing, so those are left to CI. Every other required job is
surface-gated off a diff that changes 10 CLJS test files and nothing else.

## What remains

Nothing of rf2-e8kc's scope. All three censuses read **zero** repo-wide.
