### PR TITLE
test(resources): pin the :rf.mutation/execute unregistered-id refusal — the guard was real, the test could not fail (rf2-06lp)

### DIFF
--- a/implementation/resources/test/re_frame/resources_mutation_cljs_test.cljc
+++ b/implementation/resources/test/re_frame/resources_mutation_cljs_test.cljc
@@ -310,7 +310,7 @@
               "the refusal NAMES the mutation id the caller typed")
           (is (= :fix-registration (:recovery data))
               "and carries the catalogued recovery disposition"))
-        (is (str/includes? (ex-message (:exception rec)) ":m/nope")
+        (is (str/includes? (str (some-> (:exception rec) ex-message)) ":m/nope")
             "the human message names the id too")))))
 
 (deftest execute-registered-under-another-kind-still-refuses

--- a/implementation/resources/test/re_frame/resources_mutation_cljs_test.cljc
+++ b/implementation/resources/test/re_frame/resources_mutation_cljs_test.cljc
@@ -167,6 +167,23 @@
          (finally (trace-tooling/unregister-listener! k)))
     @seen))
 
+(defn- record-error-records!
+  "Run `body-fn` with an `:errors` listener installed; return the vector of
+  every always-on error record fanned during it (capture order).
+
+  The `:errors` stream — not stdout, not the dev trace — is where a framework
+  REFUSAL is legible: per Spec 009 §Observability channels the runtime ships no
+  default console sink, so a category that fans a record here is loud in dev
+  AND in a production build, while a category that fans nothing is invisible
+  everywhere. Sibling of `record-mutation-traces!` above (rf2-06lp)."
+  [body-fn]
+  (let [seen (atom [])
+        k    ::error-record-recorder]
+    (rf/register-listener! :errors k (fn [rec] (swap! seen conj rec)))
+    (try (body-fn)
+         (finally (rf/unregister-listener! :errors k)))
+    @seen))
+
 (defn- save-article-spec
   ([] (save-article-spec {}))
   ([overrides]
@@ -251,11 +268,89 @@
     (is (nil? (:invalidate-timing (rf/mutation-meta :m/default))))
     (rf/clear-mutation :m/default)))
 
-(deftest execute-unregistered-is-loud
-  (testing "EP-0003 §Mutations — :rf.mutation/execute on an unregistered
-            mutation never reaches the transport"
-    (rf/dispatch-sync [:rf.mutation/execute {:mutation :m/nope :params {} :instance :i1}])
-    (is (nil? @last-managed-args))))
+(deftest execute-unregistered-refuses-and-names-the-id
+  ;; rf2-06lp. This test was previously named `execute-unregistered-is-loud`
+  ;; and asserted ONLY `(nil? @last-managed-args)` — a claim a SILENT NO-OP
+  ;; satisfies exactly as well as a refusal does. It therefore could not have
+  ;; caught the regression it was named for, and a reader who met the symptom
+  ;; in an app (no instance, no request, `:idle` afterwards — byte-identical to
+  ;; "nobody asked") had no gate telling them the runtime HAD refused. The
+  ;; refusal is real: `mreg/require-mutation-spec!` runs as the FIRST statement
+  ;; of `execute-handler`, so the id lookup fails before any instance row,
+  ;; work-ledger row, optimistic patch or transport lowering exists.
+  ;;
+  ;; The granularity line sits EARLIER than rf2-04tx's (a foreign top-level
+  ;; effect key is refused at the router's final-effects boundary, after the
+  ;; handler has run) and for the same reason rf2-04tx drew one at all: the
+  ;; hazard is partial success disguised as success. For a mutation that hazard
+  ;; is a DURABLE instance row — an instance minted and left at `:pending` with
+  ;; no request behind it would be a write that reports itself in flight
+  ;; forever. Refusing before the mint is what makes "nothing was minted" a
+  ;; truthful reading rather than a half-built one.
+  (testing "EP-0003 §Mutations — an unregistered mutation id REFUSES"
+    (let [recs (record-error-records!
+                 #(rf/dispatch-sync [:rf.mutation/execute
+                                     {:mutation :m/nope :params {} :instance :i1}]))
+          rec  (first (filterv #(= :rf.error/handler-exception (:error %)) recs))]
+      (testing "the event ABORTED — nothing minted, nothing sent"
+        (is (nil? @last-managed-args) "no write reached the transport")
+        (is (nil? (instance :i1)) "no instance row was minted")
+        (is (nil? (mutation-record :i1)) "no work-ledger row was written"))
+      (testing "and the refusal is READABLE — the runtime did not stay silent"
+        ;; Read off the always-on `:errors` axis, not stderr: per Spec 009
+        ;; §Observability channels the framework ships NO default console sink,
+        ;; so this listener is where a refusal is legible in dev AND prod.
+        (is (some? rec)
+            ":rf.mutation/execute fanned an always-on error record")
+        (is (= :rf.mutation/execute (:event-id rec)))
+        (let [data (ex-data (:exception rec))]
+          (is (= :rf.error/mutation-not-registered (:rf.error/id data))
+              "the canonical catalogued category, not a bare host throw")
+          (is (= :m/nope (:mutation-id data))
+              "the refusal NAMES the mutation id the caller typed")
+          (is (= :fix-registration (:recovery data))
+              "and carries the catalogued recovery disposition"))
+        (is (str/includes? (ex-message (:exception rec)) ":m/nope")
+            "the human message names the id too")))))
+
+(deftest execute-registered-under-another-kind-still-refuses
+  ;; rf2-06lp, the identity half of the guard. `require-mutation-spec!` keys on
+  ;; the `:mutation` REGISTRAR KIND, not on "is this keyword registered
+  ;; somewhere" — a resource id reads as a perfectly well-formed keyword and
+  ;; resolves in a sibling registrar, so a guard that widened to any known id
+  ;; would sail straight past here and lower a resource's fetch as a write.
+  (rf/reg-resource :r/article
+                   {:scope :rf.scope/global
+                    :params-schema [:map [:slug :string]]
+                    :tags (fn [{:keys [slug]} _] #{[:article slug]})}
+                   (fn [{:keys [slug]} _] {:request {:method :get :url (str "/a/" slug)}}))
+  (testing "a RESOURCE id passed as :mutation refuses like any unknown id"
+    (let [recs (record-error-records!
+                 #(rf/dispatch-sync [:rf.mutation/execute
+                                     {:mutation :r/article :params {:slug "w"}
+                                      :instance :i/wrong-kind}]))
+          rec  (first (filterv #(= :rf.error/handler-exception (:error %)) recs))]
+      (is (nil? @last-managed-args) "no write reached the transport")
+      (is (nil? (instance :i/wrong-kind)) "no instance row was minted")
+      (is (= :rf.error/mutation-not-registered
+             (:rf.error/id (ex-data (:exception rec))))
+          "the mutation registrar, not the resource one, decides")
+      (is (= :r/article (:mutation-id (ex-data (:exception rec))))))))
+
+(deftest execute-registered-mutation-is-not-refused
+  ;; rf2-06lp, the OTHER direction — the direction a guard is almost never
+  ;; tested for. A REGISTERED id must run exactly as before: instance minted,
+  ;; write lowered, and the always-on `:errors` axis SILENT. An over-eager
+  ;; guard shows up here as a spurious record on an otherwise-working write,
+  ;; which no other assertion in this suite would notice.
+  (rf/reg-mutation :m/save (save-article-spec) save-article-request)
+  (let [recs (record-error-records!
+               #(rf/dispatch-sync [:rf.mutation/execute
+                                   {:mutation :m/save :params {:slug "w"}
+                                    :instance :i/ok}]))]
+    (is (= [] recs) "a registered mutation raises NO error record")
+    (is (= :pending (:status (instance :i/ok))) "the instance row was minted")
+    (is (some? @last-managed-args) "and the write reached the transport")))
 
 ;; ===========================================================================
 ;; 2. execute mints an instance + lowers the write (runtime-owned addressing)


### PR DESCRIPTION
Closes rf2-06lp.

## The premise did not hold — and what did

rf2-06lp reported that `[:rf.mutation/execute {:mutation <unregistered> …}]` is a **silent no-op**: no instance, no request, no error, `:idle` afterwards. It asked that execute "FAIL LOUD … the artefact's own `ex-info` with a canonical `:rf.error/id`, naming the mutation id."

**That refusal already exists and already fires.** `mreg/require-mutation-spec!` is the **first statement** of `execute-handler` (`mutation_events.cljc:1182`) and throws `:rf.error/mutation-not-registered` — naming the id, carrying `:recovery :fix-registration`, catalogued at `spec/009-Instrumentation.md:2079`. The event **aborts**; that is *why* there is no instance and no request. `require-resource-spec!` is its exact symmetric twin on the read path (the bead asked me to check it), used at four `:rf.resource/*` event handlers, the route integration, and the subscription — so the read path has no hole either. It is, however, equally untested: nothing in the corpus asserts `:rf.error/resource-not-registered` — filed as **rf2-w67y**, since its home is a different suite file.

Reproduced on the JVM lane, `:errors` listener attached, stdout/stderr bound:

```
INSTANCE       => nil
MANAGED-ARGS   => nil
PASSIVE-READ   => {:settled? false :status :idle …}
ERROR-RECORDS  => [{:error :rf.error/handler-exception
                    :event-id :rf.mutation/execute
                    :ex-msg "no mutation is registered under :m/never-registered — call
                             rf/reg-mutation before :rf.mutation/execute. Per Spec 016
                             §Mutations. [:rf.error/mutation-not-registered]"
                    :ex-data-id :rf.error/mutation-not-registered}]
STDOUT         => ""
STDERR         => ""
```

So the runtime refused, loudly, in the exact shape asked for. **What was actually missing was a test that could tell the difference** — and, separately, a channel the finder could see it on.

## The real defect this PR fixes: a test that could not fail

`execute-unregistered-is-loud` asserted exactly one thing:

```clojure
(rf/dispatch-sync [:rf.mutation/execute {:mutation :m/nope :params {} :instance :i1}])
(is (nil? @last-managed-args))
```

A **silent no-op satisfies that claim exactly as well as a refusal does**. The test was named for a regression it structurally could not catch — the fail-open class this programme has been deleting, sitting in the gate rather than in the runtime. This PR replaces it with three tests that pin the refusal, its identity basis, and its restraint.

## Where I drew the granularity line, and how it compares to rf2-04tx

rf2-04tx ruled **Option C: refuse** for a foreign top-level effect key — abort in-band at the **router's final-effects boundary**, nothing commits — because *partial success disguised as success* violates Conventions §No silent swallow.

**The same law governs here, and the line is drawn strictly earlier: before the mint, not at the commit.** rf2-04tx's boundary is necessarily late — a malformed effect map is only knowable after the handler has produced one. A mutation's id is knowable on the first line. And the hazard is worse if you wait: rf2-04tx's failure mode is a `:db` value that must not install, whereas a mutation refused *after* `mint-instance-id` would leave a **durable instance row stuck at `:pending` with no request behind it** — a write that reports itself in flight forever, readable by every `[:rf/mutation …]` sub, surviving into epoch export. Refusing before the mint is what makes "nothing was minted" a *truthful* reading rather than a half-built one.

I deliberately did **not** extend it further, and this is the judgement call in the PR:

- **No instance is minted to carry the failure.** The bead argues the passive read "cannot tell a write the runtime cannot perform from a write nobody asked for". True — but a settled `:error` instance would make a *source defect* look like a *runtime failure of a real mutation*, complete with a retry affordance for a mutation that does not exist. An unregistered id is fixable only by editing code. The repo's own precedent agrees one registrar up: dispatching an unregistered **event** id (`:rf.error/no-such-handler`) mints no event record either — it refuses and reports on the error axis.
- **No new mechanism, no new id, no nag.** The missing-registration mechanism already exists and the execute path already uses it. `:rf.warning/registration-collision` in `registrar.cljc` is a *re*-registration concern (its `collision?` keys on source provenance, so a hot reload stays silent) and is not the neighbouring case here. **No id was minted; no catalogue row was added.**

## Reproduce-then-fix evidence

**Sabotage A — the bead's exact feared behaviour.** An early silent bail in `execute-handler` (`(if (nil? (mreg/mutation-meta mutation)) {} …)`), reproducing the report byte for byte:

```
INSTANCE      => nil
MANAGED-ARGS  => nil
PASSIVE-READ  => {:settled? false :status :idle …}
ERROR-RECORDS => []          <-- no error on ANY channel
STDOUT        => ""
STDERR        => ""
```

- The **old test, run verbatim** against that sabotage: `EXIT=0` — **green**. It could not have caught this.
- The **new tests** against the same sabotage: `EXIT=1`, 7 failures + 1 error. The assertions that still passed are precisely the old test's whole content ("no write reached the transport", "no instance row was minted", "no work-ledger row was written") — which is the point.

**Sabotage B — the too-eager direction, and the identity direction in one edit.** `require-mutation-spec!` widened from the `:mutation` registrar **kind** to "is this keyword registered anywhere" (`(:rf/resource (registrar/lookup :resource mutation-id))`) — correct shape, wrong identity. `EXIT=1`, and both new guards fired:

- `execute-registered-mutation-is-not-refused` red — a **registered** `:m/save` now raised a spurious `:rf.error/mutation-not-registered`, minted no instance and sent nothing.
- `execute-registered-under-another-kind-still-refuses` red — `:r/article` (a *resource*) sailed through and the runtime **lowered a resource's GET as a mutation write**: `{:request {:method :get :url "/a/w"}}` reached the transport under a `:pending` instance row with `:mutation/id :r/article`.

**Restore verified by hashing the bytes, not `git diff`.** `mutation_events.cljc` = `c30ec6e6cdf931daefef2cbef75b2fc13100d94dde8bb8ace0a4adb86589e8b2` before sabotage A and after restore. After both restores `git diff --name-only` names **only** the test file; both source files are git-clean. **No runtime source is changed by this PR.**

## Quality gates

Every gate run alone, nothing appended, exit code captured on one line in one shell.

| gate | command | captured exit |
|---|---|---|
| resources JVM artefact suite (owns `implementation/resources/test/**`) | `clojure -M:test` in `implementation/resources` | **`EXIT=0`** — Ran 814 tests, 7252 assertions, 0 failures 0 errors |
| CLJS node lane (`.cljc` test compiles into `:node-test`; `resources/test` is on `:source-paths`, `cljs-test$` ns-regexp matches) | `npm run test:cljs` in `implementation` | **`EXIT=0`** — Ran 13525 tests, 68199 assertions, 0 failures 0 errors |
| fast-PR spine (JVM tier = `implementation/core` + `implementation/resources`; node tier) | `sh scripts/test-fast-pr.sh` | **`EXIT=0` — `PASS fast PR spine`** |
| sabotage A, new tests | `clojure -M:test -n re-frame.resources-mutation-cljs-test` | **`EXIT=1`** (7 failures, 1 error) |
| sabotage A, old test verbatim | `clojure -M:test -n <witness ns>` | **`EXIT=0`** (green — the hole) |
| sabotage B, new tests | `clojure -M:test -n re-frame.resources-mutation-cljs-test` | **`EXIT=1`** |

Counts are the ones I measured on this branch, not quoted from memory. `*.exit` artefacts were deleted between runs.

**`python scripts/check_fast_pr_gap.py --list` — 97 required checks the spine does not decide.** For this diff none of them covers the changed path: every browser lane (`cljs-browser`, `-prod-elision`, `-schemas-boundary-prod`, `cljs-ui-g13`), the bundle-isolation / perf-bundle / schemas-bundle gates, the adapter + ui + tenant-switcher testbed smokes, the Story/Xray browser gates, mcp-conformance, the tool JVM suites, and several steps *inside* jobs the spine does run (the EP-0036 donor-boundary `git grep` inside `jvm-freehand`, `test:ui-isolation` and `build:hicasso-release` inside the `cljs` job). **No browser lane is nominated and none is needed**: this PR changes no runtime source and makes no DOM claim, and the assertion it adds is `.cljc` that runs on both the JVM and node lanes above.

## Fences

- **No `spec/**` change.** `:rf.error/mutation-not-registered` is already catalogued (`009:2079`) and its row already describes exactly what the code does, including the interceptor-trap capture. Nothing to add.
- **No new public export, no new error/warning/complaint id, no catalogue row.**
- **No hot-zone file touched** (`shadow-cljs.edn`, `deps.edn`, `spec/**`, `.github/workflows/**` all untouched).
- Scope fence respected: no file under `implementation/hicasso/` was edited.

## Filed, not fixed here: rf2-fu75

Verifying this surfaced one genuine gap, and it is **core-owned, framework-wide, and hot-zone** — so I stopped and filed it rather than widening this PR. Four controls, same lane, stdout/stderr bound:

| dispatched | stdout | stderr | `:errors` record |
|---|---|---|---|
| unregistered mutation id | `""` | `""` | `:rf.error/handler-exception` |
| a plain handler that throws | `""` | `""` | `:rf.error/handler-exception` |
| a foreign top-level effect key (rf2-04tx's own refusal) | `""` | `""` | `:rf.error/effect-map-shape` |
| an unregistered **event** id | `""` | `""` | `:rf.error/no-such-handler` |

The silence is not mutation-specific. **Every** framework refusal is invisible to a developer with no listener attached — including a typo in an event id. And `spec/009` §Observability channels #5 claims the shortfall is covered ("a re-frame2 event handler that throws in production still surfaces [at `window.onerror`]"), which the code contradicts: the router *captures* into `:rf/interceptor-error` rather than re-throwing (`router.cljc:1004`, in terms), so nothing escapes `dispatch` or `dispatch-sync`. That is what cost rf2-06lp's finder four browser runs — not a missing guard. It wants a ruling on `implementation/core` + `spec/009`, sequentially.
