### PR TITLE
feat(hicasso): overlays on the platform's own top layer — anchored popover and modal (rf2-hic-052)

### DIFF
--- a/implementation/hicasso/scripts/check_optional_module_reachability.py
+++ b/implementation/hicasso/scripts/check_optional_module_reachability.py
@@ -92,6 +92,21 @@ MODULES = [
         ],
     },
     {
+        # rf2-hic-052.  The overlay module's shape is `motion`'s exactly:
+        # a thin door onto one private namespace that carries its weight,
+        # so both edges have something to guard and the door-only check
+        # would be the hole it was written to close.
+        "name": "overlay",
+        "door": "re-frame.hicasso.overlay",
+        "engine": [
+            "re-frame.hicasso.impl.overlay",
+        ],
+        "files": [
+            "re_frame/hicasso/overlay.cljs",
+            "re_frame/hicasso/impl/overlay.cljs",
+        ],
+    },
+    {
         # rf2-hic-034.  The native tier is the module the native-boundary
         # law names in terms: *the native namespace is separately
         # reachable; an interpreted-only production dependency graph and
@@ -354,6 +369,31 @@ def self_test():
         }
     )
     assert clean == [], clean
+
+    # rf2-hic-052 — the overlay row, driven for a different reason than
+    # the native one above.  Its SHAPE is `motion`'s, so the fixtures at
+    # the top already exercise the code path; what they cannot exercise is
+    # whether THIS row names the namespaces the tree actually declares. A
+    # typo in either string leaves the live scan green (nothing requires a
+    # namespace that does not exist), and the file check below would still
+    # pass because it reads paths rather than ns forms.
+    flagged = scan(
+        {
+            "src/o.cljs": "(ns re-frame.hicasso\n"
+            "  (:require [re-frame.hicasso.overlay :as overlay]\n"
+            "            [re-frame.hicasso.impl.overlay :as impl-overlay]))"
+        }
+    )
+    assert len(flagged) == 2, flagged
+    assert "`overlay` module" in flagged[0], flagged
+    for module in MODULES:
+        if module["name"] == "overlay":
+            for ns in [module["door"], *module["engine"]]:
+                declared = {
+                    ns_of(SRC.joinpath(rel).read_text(encoding="utf-8"))
+                    for rel in module["files"]
+                }
+                assert ns in declared, (ns, declared)
 
     # The roster's premise: every file it names exists. A rename must fail
     # here rather than report a green absence for a file nobody compiles.

--- a/implementation/hicasso/src/re_frame/hicasso/impl/overlay.cljs
+++ b/implementation/hicasso/src/re_frame/hicasso/impl/overlay.cljs
@@ -1,0 +1,331 @@
+(ns re-frame.hicasso.impl.overlay
+  "THE TOP LAYER, REACHED (rf2-hic-052). The impure half of
+  `re-frame.hicasso.overlay`: two components that put an element into the
+  browser's own top layer and take it out again. The posture and the
+  vocabulary are the door's; this file is the mechanism.
+
+  ## What it costs, stated rather than buried
+
+  **Two React hooks — one `useContext` and one `useRef` — in each of
+  these components.** The ≤2-hook budget I9 polices is the *boundary
+  shell's*, and neither of these is a boundary shell: they read no
+  subscription, mount no registration and take no cell.
+  `collector/shell` is untouched and its dispatcher-level ledger still
+  counts exactly two there, which
+  `re-frame.hicasso.overlay-dom-cljs-test` asserts rather than assumes.
+  `impl.presence-react` is the precedent and spends four; the ceiling's
+  own words are that an optional capability may not add a hook *to every
+  boundary*, and this adds none to any.
+
+  - The `useContext` is the frame hook, and it is here for the reason it
+    is in `impl.presence-react`: an overlay's children are hiccup DATA
+    written in the parent boundary's body and lowered in THIS component's
+    render, after that body's dynamic extent has unwound. Without it
+    `intent/*dispatch*` is unbound when the codec walks them, and every
+    intent inside an overlay raises
+    `:rf.error/hicasso-intent-outside-boundary`.
+  - The `useRef` is one instance cell holding this overlay's generated
+    anchor ident and the ONE ref callback that ever attaches. It exists
+    because a ref callback whose identity changes between renders is a ref
+    React detaches and re-attaches — which for an open dialog means
+    close-then-reopen on every parent render, losing focus and the top
+    layer's stack position each time.
+
+  ## Where the work happens: the ref callback, and nothing else
+
+  There is no effect here. `showModal` / `showPopover` run in the REF
+  CALLBACK, which React invokes during the commit — after the node is in
+  the document and before the browser paints. That is the whole of
+  \"measure before paint\": the module measures nothing at all, and the one
+  thing it must do before paint is the imperative call, which is where it
+  is.
+
+  The cleanup React 19 lets a ref callback return is the exact inverse,
+  and it runs while the node is STILL CONNECTED — which is what makes the
+  platform's own focus restoration reachable. A `<dialog>` returns focus
+  to its previously-focused element when it is CLOSED, and not when it is
+  merely removed from the document, so the module closes it through the
+  platform's door on the way out rather than letting React drop it. That
+  one line is the whole of \"focus restore\".
+
+  ## Why the open flag can never acquire a second owner
+
+  `:open?` false renders nil, so a closed overlay has no element at all.
+  The element exists only while the application says it should, and the
+  platform's own dismissal is routed back as an ordinary intent rather
+  than applied behind app-db's back.
+
+  When there is nowhere to route it, the platform is told not to dismiss
+  at all, in the platform's own vocabulary: `closedby=\"none\"` on the
+  dialog, `popover=\"manual\"` on the popover. Both are attributes, so the
+  not-dismissable case costs no JavaScript and no listener whatever.
+
+  ## The one guard, and why only the popover needs it
+
+  A programmatic `close()` does NOT fire `cancel`, so a modal's teardown
+  cannot be mistaken for a dismissal the user asked for and needs no
+  guard. A programmatic `hidePopover()` DOES fire `toggle`, identically to
+  a light dismiss, so the popover's teardown marks its node before hiding
+  and the handler declines a toggle the module caused itself. Without that
+  mark every teardown would dispatch `:on-dismiss` a second time —
+  including the teardown that happens *because* the author's own handler
+  already ran."
+  (:require [re-frame.adapter.context :as adapter-context]
+            [re-frame.hicasso.impl.codec :as codec]
+            [re-frame.hicasso.impl.collector :as collector]
+            [re-frame.hicasso.impl.intent :as intent]
+            ["react" :as react]))
+
+;; ---------------------------------------------------------------------------
+;; Placement — a compass word, and the `position-area` it means
+;; ---------------------------------------------------------------------------
+
+(def position-areas
+  "`:placement` as the author writes it, and the CSS `position-area` it
+  means. Public so a witness can drive the table rather than restate it.
+
+  `span-inline-end` reads backwards until the anchor is held in mind: it
+  spans from the anchor's inline-START edge TOWARDS the end, which is what
+  puts a `:bottom-start` panel's left edge under its trigger's left edge.
+
+  **This map is the whole of the module's placement.** Nothing measures
+  and nothing listens: where a panel sits is the compositor's answer to a
+  CSS declaration, recomputed by the engine as the anchor moves. That is
+  why anchor tracking costs nothing here — the scroll listener and the
+  per-frame `getBoundingClientRect` a hand-rolled overlay spends it on are
+  simply not work this module does."
+  {:top           "block-start"
+   :top-start     "block-start span-inline-end"
+   :top-end       "block-start span-inline-start"
+   :bottom        "block-end"
+   :bottom-start  "block-end span-inline-end"
+   :bottom-end    "block-end span-inline-start"
+   :left          "inline-start"
+   :left-start    "inline-start span-block-end"
+   :left-end      "inline-start span-block-start"
+   :right         "inline-end"
+   :right-start   "inline-end span-block-end"
+   :right-end     "inline-end span-block-start"})
+
+(defn position-area
+  "The `position-area` value `placement` means, or nil for no placement.
+
+  An unrecognised value is emitted verbatim, so `:placement` also takes a
+  raw `position-area` string for the cases a compass word cannot spell. A
+  MISSPELT compass word therefore produces an invalid CSS value, which the
+  engine drops: the panel lands in the top layer at the UA's default
+  position rather than throwing."
+  [placement]
+  (when (some? placement)
+    (or (get position-areas placement)
+        (if (keyword? placement) (name placement) (str placement)))))
+
+;; ---------------------------------------------------------------------------
+;; The anchor — a DOM id in, a CSS anchor name out
+;; ---------------------------------------------------------------------------
+
+(defonce ^:private !anchor-seq (atom 0))
+
+(defn- next-anchor-ident
+  "A fresh CSS dashed-ident for one overlay INSTANCE — not for one anchor
+  id. Two overlays may legitimately share a trigger, and a shared ident
+  would make each one's teardown erase the other's."
+  []
+  (str "--rf-overlay-" (swap! !anchor-seq inc)))
+
+(def ^:private saved-anchor-slot
+  "Where a trigger's previous `anchor-name` is parked, so teardown puts
+  back what the author wrote rather than clearing it."
+  "rfOverlaySavedAnchorName")
+
+(defn- claim-anchor!
+  "Give the element named by DOM id `anchor-id` the CSS anchor name
+  `ident`, remembering whatever it had, and answer that element.
+
+  A no-op when the id names nothing. The refusal the guide promises there
+  is deferred rather than declined — see the door."
+  [anchor-id ident]
+  (when-some [el (and anchor-id (.getElementById js/document anchor-id))]
+    (unchecked-set el saved-anchor-slot (.. el -style -anchorName))
+    (set! (.. el -style -anchorName) ident)
+    el))
+
+(defn- release-anchor!
+  "Put back what [[claim-anchor!]] found, on the element it found it on."
+  [el]
+  (when el
+    (set! (.. el -style -anchorName) (or (unchecked-get el saved-anchor-slot) ""))
+    (unchecked-set el saved-anchor-slot js/undefined))
+  nil)
+
+;; ---------------------------------------------------------------------------
+;; The two platform doors, and the mark that tells them apart from a user
+;; ---------------------------------------------------------------------------
+
+(def ^:private closing-slot
+  "Marks the node the module is itself taking out of the top layer, so a
+  `toggle` the module caused is not read as a dismissal the user asked
+  for."
+  "rfOverlayClosing")
+
+(def ^:private modal-ops
+  {:tag       :dialog
+   :show!     (fn [node] (when-not (.-open node) (.showModal node)))
+   ;; Through `close()` rather than by letting React drop the node: a
+   ;; dialog returns focus to its previously-focused element when it is
+   ;; CLOSED, and not when it is merely removed from the document.
+   :hide!     (fn [node] (when (.-open node) (.close node)))
+   :event     :on-cancel
+   ;; `cancel` fires for a close request and never for a programmatic
+   ;; `close()`, so the module's own teardown cannot be mistaken for one.
+   :guard?    false})
+
+(def ^:private popover-ops
+  {:tag       :div
+   :show!     (fn [node] (when-not (.matches node ":popover-open") (.showPopover node)))
+   :hide!     (fn [node] (when (.matches node ":popover-open") (.hidePopover node)))
+   :event     :on-toggle
+   ;; `toggle` fires for a light dismiss AND for the module's own
+   ;; `hidePopover()`, so this one is guarded.
+   :guard?    true})
+
+;; ---------------------------------------------------------------------------
+;; The instance cell, and the one ref callback that ever attaches
+;; ---------------------------------------------------------------------------
+
+(defn- make-cell
+  "The per-instance state: an anchor ident minted once, the trigger this
+  overlay claimed, and the stable ref callback that owns both."
+  [{:keys [show! hide!]}]
+  (let [cell #js {"ident"    (next-anchor-ident)
+                  "anchorId" nil
+                  "claimed"  nil}]
+    (unchecked-set
+      cell "ref"
+      (fn [node]
+        (when node
+          (unchecked-set node closing-slot false)
+          (unchecked-set cell "claimed"
+                         (claim-anchor! (unchecked-get cell "anchorId")
+                                        (unchecked-get cell "ident")))
+          (show! node)
+          (fn []
+            (unchecked-set node closing-slot true)
+            (hide! node)
+            (release-anchor! (unchecked-get cell "claimed"))
+            (unchecked-set cell "claimed" nil)
+            nil))))
+    cell))
+
+(defn- dismissal-handler
+  "The function the platform's own dismissal event lands on, or nil when
+  there is nothing to route.
+
+  A fresh closure per render, deliberately: it closes over the intent and
+  the frame dispatch THIS render saw, so an overlay whose `:on-dismiss`
+  changed cannot dispatch the previous one. React swaps a listener for
+  free; a stale intent would cost a wrong event."
+  [dispatch on-dismiss guard?]
+  (when (and dispatch on-dismiss)
+    (fn [e]
+      (when-not (and guard?
+                     (or (not= "closed" (.-newState e))
+                         (true? (unchecked-get (.-target e) closing-slot))))
+        (dispatch on-dismiss)))))
+
+;; ---------------------------------------------------------------------------
+;; The components
+;; ---------------------------------------------------------------------------
+
+(def ^:private own-keys
+  "The keys the module reads. Everything else in the props map is an
+  ordinary attribute and reaches the element unrenamed, exactly as it
+  would at a native tag the author wrote by hand."
+  [:open? :on-dismiss :anchor :placement :label :light-dismiss? :children])
+
+(defn- element-attrs
+  "The author's props as element attributes: the module's own keys
+  removed, `extra` merged over the rest, and the two `:style` maps merged
+  with the AUTHOR's keys on top — so `:style {:position-area …}` beats the
+  `:placement` that produced one."
+  [props extra]
+  (let [style (merge (:style extra) (:style props))]
+    (cond-> (merge (apply dissoc props own-keys) (dissoc extra :style))
+      (seq style) (assoc :style style))))
+
+(defn- body
+  [{:keys [tag event guard?] :as ops} dismissal-attrs js-props]
+  (let [props    (or (unchecked-get js-props "rfProps") {})
+        ;; Hook 1 — the frame, classified through the shared reader so a
+        ;; no-provider sentinel resolves to nil ("no scope") rather than
+        ;; being mistaken for a frame keyword.
+        frame-kw (adapter-context/context-value->current-frame
+                   (react/useContext adapter-context/frame-context))
+        ;; Hook 2 — the instance cell. Filled lazily rather than through
+        ;; `useRef`'s argument, which is evaluated on EVERY render: minting
+        ;; the ident there would burn the counter once per render and hand
+        ;; back a different anchor name each time.
+        ref-cell (react/useRef nil)]
+    (when (nil? (.-current ref-cell))
+      (set! (.-current ref-cell) (make-cell ops)))
+    (let [cell (.-current ref-cell)]
+      (unchecked-set cell "anchorId" (:anchor props))
+      ;; ZERO COST WHEN CLOSED. No element, so no top-layer entry, no
+      ;; listener, no anchor claim and no children rendered — the body's
+      ;; own subscriptions included.
+      (when (:open? props)
+        (let [dispatch (when frame-kw (collector/frame-dispatch frame-kw))
+              area     (position-area (:placement props))
+              extra    (cond-> (assoc (dismissal-attrs props)
+                                      :ref   (unchecked-get cell "ref")
+                                      event  (dismissal-handler dispatch (:on-dismiss props) guard?))
+                         (some? (:label props))
+                         (assoc :aria-label (:label props))
+
+                         (some? (:anchor props))
+                         (assoc-in [:style :position-anchor] (unchecked-get cell "ident"))
+
+                         (some? area)
+                         (assoc-in [:style :position-area] area))]
+          ;; THE LOWERING, inside the frame. These children were written in
+          ;; the parent's body and are walked HERE, so the ambient frame the
+          ;; codec's intent lowering reads has to be re-established around
+          ;; this call and nowhere else.
+          (intent/with-frame frame-kw dispatch
+            (fn []
+              (codec/as-element
+                (into [tag (element-attrs props extra)] (:children props))))))))))
+
+(defn- modal-dismissal-attrs
+  "`closedby`, the platform's own word for which close requests this
+  dialog honours.
+
+  There is nowhere to route a dismissal without `:on-dismiss`, so the
+  dialog is told to honour none and the open flag cannot acquire a second
+  owner. With one, Escape closes by default and a backdrop click only when
+  the author asked for it — a destructive confirmation must not go away on
+  a stray click."
+  [props]
+  {:closedby (cond
+               (nil? (:on-dismiss props)) "none"
+               (:light-dismiss? props)    "any"
+               :else                      "closerequest")})
+
+(defn- popover-dismissal-attrs
+  "`popover`, the platform's own word for the same choice. `auto` is the
+  light-dismissable member of the top layer's LIFO stack; `manual` is in
+  the top layer and dismisses for nothing."
+  [props]
+  {:popover (if (nil? (:on-dismiss props)) "manual" "auto")})
+
+(def modal
+  "See [[re-frame.hicasso.overlay/modal]]."
+  (codec/mark-boundary!
+    (doto (fn hicasso-modal [js-props] (body modal-ops modal-dismissal-attrs js-props))
+      (aset "displayName" "hicasso/modal"))))
+
+(def popover
+  "See [[re-frame.hicasso.overlay/popover]]."
+  (codec/mark-boundary!
+    (doto (fn hicasso-popover [js-props] (body popover-ops popover-dismissal-attrs js-props))
+      (aset "displayName" "hicasso/popover"))))

--- a/implementation/hicasso/src/re_frame/hicasso/impl/overlay.cljs
+++ b/implementation/hicasso/src/re_frame/hicasso/impl/overlay.cljs
@@ -60,16 +60,24 @@
   dialog, `popover=\"manual\"` on the popover. Both are attributes, so the
   not-dismissable case costs no JavaScript and no listener whatever.
 
-  ## The one guard, and why only the popover needs it
+  ## Which event each one routes on, and why they differ
 
-  A programmatic `close()` does NOT fire `cancel`, so a modal's teardown
-  cannot be mistaken for a dismissal the user asked for and needs no
-  guard. A programmatic `hidePopover()` DOES fire `toggle`, identically to
-  a light dismiss, so the popover's teardown marks its node before hiding
-  and the handler declines a toggle the module caused itself. Without that
-  mark every teardown would dispatch `:on-dismiss` a second time —
-  including the teardown that happens *because* the author's own handler
-  already ran."
+  The modal routes on `cancel`, which fires only for a close request —
+  never on the way in, and never for a programmatic `close()`. The popover
+  routes on `beforetoggle` rather than `toggle`, because the platform
+  QUEUES a task for `toggle`: an application that reads its own open flag
+  on the line after a dismissal would read the value the dismissal has not
+  written yet. `beforetoggle` fires in both directions, so the popover's
+  handler takes only `newState == \"closed\"` — the one filter in the file,
+  and the sabotage that widens it dispatches `:on-dismiss` on OPEN.
+
+  A first draft carried a second guard, a per-node mark set before the
+  module's own `hidePopover()` so a teardown could not be read as a
+  dismissal. **No sabotage could redden it**: React does not deliver an
+  event from a fiber it is in the middle of deleting, so the case never
+  arises. The mark is gone and the measurement replaced it — the teardown
+  rows of `re-frame.hicasso.overlay-dom-cljs-test` red the day that stops
+  being true."
   (:require [re-frame.adapter.context :as adapter-context]
             [re-frame.hicasso.impl.codec :as codec]
             [re-frame.hicasso.impl.collector :as collector]
@@ -162,12 +170,6 @@
 ;; The two platform doors, and the mark that tells them apart from a user
 ;; ---------------------------------------------------------------------------
 
-(def ^:private closing-slot
-  "Marks the node the module is itself taking out of the top layer, so a
-  `toggle` the module caused is not read as a dismissal the user asked
-  for."
-  "rfOverlayClosing")
-
 (def ^:private modal-ops
   {:tag       :dialog
    :show!     (fn [node] (when-not (.-open node) (.showModal node)))
@@ -176,9 +178,9 @@
    ;; CLOSED, and not when it is merely removed from the document.
    :hide!     (fn [node] (when (.-open node) (.close node)))
    :event     :on-cancel
-   ;; `cancel` fires for a close request and never for a programmatic
-   ;; `close()`, so the module's own teardown cannot be mistaken for one.
-   :guard?    false})
+   ;; `cancel` fires only for a close request — never on the way in, and
+   ;; never for a programmatic `close()` — so it needs no filter at all.
+   :closed-only? false})
 
 (def ^:private popover-ops
   {:tag       :div
@@ -191,9 +193,10 @@
    ;; after a dismissal — every test does — reads the value the dismissal
    ;; has not written yet.
    :event     :on-before-toggle
-   ;; It fires for a light dismiss AND for the module's own
-   ;; `hidePopover()`, so this one is guarded.
-   :guard?    true})
+   ;; It fires on the way IN as well as on the way out, so this one is
+   ;; filtered by `newState`. The module's own `hidePopover()` fires it
+   ;; too, and needs no filter of its own — see [[dismissal-handler]].
+   :closed-only? true})
 
 ;; ---------------------------------------------------------------------------
 ;; The instance cell, and the one ref callback that ever attaches
@@ -210,13 +213,11 @@
       cell "ref"
       (fn [node]
         (when node
-          (unchecked-set node closing-slot false)
           (unchecked-set cell "claimed"
                          (claim-anchor! (unchecked-get cell "anchorId")
                                         (unchecked-get cell "ident")))
           (show! node)
           (fn []
-            (unchecked-set node closing-slot true)
             (hide! node)
             (release-anchor! (unchecked-get cell "claimed"))
             (unchecked-set cell "claimed" nil)
@@ -227,16 +228,29 @@
   "The function the platform's own dismissal event lands on, or nil when
   there is nothing to route.
 
+  `closed-only?` is the popover's, because `beforetoggle` fires on the way
+  IN as well as on the way out — an unfiltered handler dispatches
+  `:on-dismiss` when the overlay OPENS, which is the wrong direction this
+  filter exists to stop.
+
+  **The module's own teardown needs no filter, and that was measured
+  rather than reasoned.** `hidePopover()` in the ref cleanup does fire the
+  identical event, so a first draft carried a per-node closing mark to
+  tell the two apart — and no sabotage could redden that mark, because
+  React does not deliver an event from a fiber it is in the middle of
+  deleting. It was unreachable code defending a case that does not arise,
+  and it is gone. `re-frame.hicasso.overlay-dom-cljs-test` holds the
+  measurement rather than the mark: the teardown rows red the day it stops
+  being true.
+
   A fresh closure per render, deliberately: it closes over the intent and
   the frame dispatch THIS render saw, so an overlay whose `:on-dismiss`
   changed cannot dispatch the previous one. React swaps a listener for
   free; a stale intent would cost a wrong event."
-  [dispatch on-dismiss guard?]
+  [dispatch on-dismiss closed-only?]
   (when (and dispatch on-dismiss)
     (fn [e]
-      (when-not (and guard?
-                     (or (not= "closed" (.-newState e))
-                         (true? (unchecked-get (.-target e) closing-slot))))
+      (when-not (and closed-only? (not= "closed" (.-newState e)))
         (dispatch on-dismiss)))))
 
 ;; ---------------------------------------------------------------------------
@@ -260,7 +274,7 @@
       (seq style) (assoc :style style))))
 
 (defn- body
-  [{:keys [tag event guard?] :as ops} dismissal-attrs js-props]
+  [{:keys [tag event closed-only?] :as ops} dismissal-attrs js-props]
   (let [props    (or (unchecked-get js-props "rfProps") {})
         ;; Hook 1 — the frame, classified through the shared reader so a
         ;; no-provider sentinel resolves to nil ("no scope") rather than
@@ -284,7 +298,7 @@
               area     (position-area (:placement props))
               extra    (cond-> (assoc (dismissal-attrs props)
                                       :ref   (unchecked-get cell "ref")
-                                      event  (dismissal-handler dispatch (:on-dismiss props) guard?))
+                                      event  (dismissal-handler dispatch (:on-dismiss props) closed-only?))
                          (some? (:label props))
                          (assoc :aria-label (:label props))
 

--- a/implementation/hicasso/src/re_frame/hicasso/impl/overlay.cljs
+++ b/implementation/hicasso/src/re_frame/hicasso/impl/overlay.cljs
@@ -141,33 +141,47 @@
   []
   (str "--rf-overlay-" (swap! !anchor-seq inc)))
 
-(def ^:private saved-anchor-slot
-  "Where a trigger's previous `anchor-name` is parked, so teardown puts
-  back what the author wrote rather than clearing it."
-  "rfOverlaySavedAnchorName")
-
 (defn- claim-anchor!
   "Give the element named by DOM id `anchor-id` the CSS anchor name
-  `ident`, remembering whatever it had, and answer that element.
+  `ident`, and answer `#js [element previous-name]` so the caller can put
+  the previous name back.
+
+  **The previous name goes to the CALLER, not onto the element.** Two
+  overlays may legitimately share one trigger — a menu and a tooltip on
+  the same button — and a single parking slot on the element is one slot
+  for two claims: the second claim overwrites the first's memory, and the
+  first release then restores an empty string instead of the author's own
+  name. That was a real red before it was a comment.
 
   A no-op when the id names nothing. The refusal the guide promises there
   is deferred rather than declined — see the door."
   [anchor-id ident]
   (when-some [el (and anchor-id (.getElementById js/document anchor-id))]
-    (unchecked-set el saved-anchor-slot (.. el -style -anchorName))
-    (set! (.. el -style -anchorName) ident)
-    el))
+    (let [previous (.. el -style -anchorName)]
+      (set! (.. el -style -anchorName) ident)
+      #js [el previous])))
 
 (defn- release-anchor!
-  "Put back what [[claim-anchor!]] found, on the element it found it on."
-  [el]
-  (when el
-    (set! (.. el -style -anchorName) (or (unchecked-get el saved-anchor-slot) ""))
-    (unchecked-set el saved-anchor-slot js/undefined))
+  "Put `previous` back on the element `claim-anchor!` answered — but ONLY
+  while `ident` is still the name on it.
+
+  That condition is what makes the per-instance ident mean anything. When
+  the overlay that leaves is not the one that claimed last, an
+  unconditional restore writes the trigger back to a name the OTHER, still
+  open panel is not anchored to, and silently unanchors a live overlay.
+  The residual is stated rather than chased: an out-of-order teardown can
+  leave the LAST claimant's generated ident on the trigger instead of the
+  author's own name. It is a dashed-ident nothing references, so it is
+  inert, and tracking a stack per trigger to erase it would be a second
+  ownership graph for a cosmetic difference."
+  [claimed ident]
+  (when-some [el (aget claimed 0)]
+    (when (= ident (.. el -style -anchorName))
+      (set! (.. el -style -anchorName) (or (aget claimed 1) ""))))
   nil)
 
 ;; ---------------------------------------------------------------------------
-;; The two platform doors, and the mark that tells them apart from a user
+;; The two platform doors
 ;; ---------------------------------------------------------------------------
 
 (def ^:private modal-ops
@@ -219,7 +233,8 @@
           (show! node)
           (fn []
             (hide! node)
-            (release-anchor! (unchecked-get cell "claimed"))
+            (when-some [claimed (unchecked-get cell "claimed")]
+              (release-anchor! claimed (unchecked-get cell "ident")))
             (unchecked-set cell "claimed" nil)
             nil))))
     cell))

--- a/implementation/hicasso/src/re_frame/hicasso/impl/overlay.cljs
+++ b/implementation/hicasso/src/re_frame/hicasso/impl/overlay.cljs
@@ -184,8 +184,14 @@
   {:tag       :div
    :show!     (fn [node] (when-not (.matches node ":popover-open") (.showPopover node)))
    :hide!     (fn [node] (when (.matches node ":popover-open") (.hidePopover node)))
-   :event     :on-toggle
-   ;; `toggle` fires for a light dismiss AND for the module's own
+   ;; `beforetoggle` and NOT `toggle`, measured rather than chosen: the
+   ;; platform QUEUES a task for `toggle` and fires `beforetoggle`
+   ;; synchronously, so routing on `toggle` puts app-db a macrotask behind
+   ;; the screen. An application that reads its own open flag on the line
+   ;; after a dismissal — every test does — reads the value the dismissal
+   ;; has not written yet.
+   :event     :on-before-toggle
+   ;; It fires for a light dismiss AND for the module's own
    ;; `hidePopover()`, so this one is guarded.
    :guard?    true})
 

--- a/implementation/hicasso/src/re_frame/hicasso/impl/overlay.cljs
+++ b/implementation/hicasso/src/re_frame/hicasso/impl/overlay.cljs
@@ -357,10 +357,10 @@
   "See [[re-frame.hicasso.overlay/modal]]."
   (codec/mark-boundary!
     (doto (fn hicasso-modal [js-props] (body modal-ops modal-dismissal-attrs js-props))
-      (aset "displayName" "hicasso/modal"))))
+      (unchecked-set "displayName" "hicasso/modal"))))
 
 (def popover
   "See [[re-frame.hicasso.overlay/popover]]."
   (codec/mark-boundary!
     (doto (fn hicasso-popover [js-props] (body popover-ops popover-dismissal-attrs js-props))
-      (aset "displayName" "hicasso/popover"))))
+      (unchecked-set "displayName" "hicasso/popover"))))

--- a/implementation/hicasso/src/re_frame/hicasso/overlay.cljs
+++ b/implementation/hicasso/src/re_frame/hicasso/overlay.cljs
@@ -1,0 +1,196 @@
+(ns re-frame.hicasso.overlay
+  "OVERLAYS — the optional module, and the posture it exists to state
+  (rf2-hic-052).
+
+      (ns my.app
+        (:require [re-frame.hicasso :as h]
+                  [re-frame.hicasso.overlay :as overlay]))
+
+      (h/defview filter-menu [{:keys [id]}]
+        (let [trigger (str \"filter-\" id \"-trigger\")]
+          [:div.filter
+           [:button {:id            trigger
+                     :aria-haspopup \"menu\"
+                     :aria-expanded (h/sub [:filter-menu/open? id])
+                     :on-click      [:filter-menu/toggled id]}
+            \"Filter\"]
+           [overlay/popover {:open?      (h/sub [:filter-menu/open? id])
+                             :on-dismiss [:filter-menu/dismissed id]
+                             :anchor     trigger
+                             :placement  :bottom-start}
+            [:ul {:role \"menu\"}
+             [:li [:button {:role \"menuitem\"
+                            :on-click [:filter/applied id :unread]}
+                   \"Unread\"]]]]]))
+
+  ## The posture
+
+  **The top layer, the focus trap, the inertness, the LIFO stack, the
+  light dismiss and the anchor tracking all belong to the browser. This
+  module owns exactly one thing about them, and that thing is the
+  IMPERATIVE CALL.**
+
+  Every part of an overlay has an owner already. `<dialog>` owns modality
+  — the page behind it goes inert and focus cannot leave it, enforced by
+  the engine and not by a key handler. `popover` owns light dismiss and
+  the auto stack. The top layer owns paint order, so no ancestor's
+  `overflow`, `transform` or `z-index` can clip or out-stack an overlay
+  and no z-index ladder is needed to try. CSS anchor positioning owns
+  where a panel sits, and keeps owning it as the anchor moves. Exactly one
+  gap sits between those owners and React: **entering the top layer is an
+  imperative call.** An element does not get there by having an attribute
+  — `<dialog open>` is a non-modal dialog in ordinary flow, and a
+  `popover` element that nothing calls `showPopover` on is display:none.
+  So this module calls `showModal` / `showPopover` at the one moment React
+  offers before paint, and calls the inverse before React takes the node
+  away. That is the whole module.
+
+  So the things it does **not** build are worth naming, because a module
+  called `overlay` invites every one of them: there is no portal, no
+  focus-trap loop, no `document` key listener, no outside-click listener,
+  no z-index policy, no scroll or resize listener, no `ResizeObserver`, no
+  measurement of any kind, and no positioning engine. Each of those is a
+  reimplementation of something the platform now does better, and every
+  one of them is a failure mode the corpus actually shipped. This is not a
+  floating-UI library and is not on its way to becoming one.
+
+  ## What follows from the posture, and is witnessed
+
+  `re-frame.hicasso.overlay-dom-cljs-test` is the witness; each claim
+  below names the row that holds it, and the browser lane is where they
+  are decided — the node lane has no top layer, so every claim about one
+  degrades to a stated skip there.
+
+  **The application owns the open flag, and nothing else can.** `:open?`
+  false renders nil, so a closed overlay has no element, no listener, no
+  anchor claim and no rendered body. An overlay opens because app-db says
+  so and for no other reason, and the platform's own dismissal is routed
+  back as an ordinary intent — which is what `:on-dismiss` is. Where there
+  is no `:on-dismiss` the platform is told not to dismiss at all
+  (`closedby=\"none\"`, `popover=\"manual\"`), so the two-owners state is
+  not merely discouraged, it is unreachable.
+
+  **Zero idle listeners, and zero cost when closed.** The module adds
+  nothing to `window`, to `document` or to any ancestor — not while
+  closed, not while open, not while the page scrolls under an anchored
+  panel. Its listeners are the ones React attaches to the overlay element
+  itself for `cancel` / `toggle`, and they leave with the node.
+
+  **Anchor tracking is priced at zero because it is not work.**
+  `:placement` becomes a CSS `position-area` against an anchor named on
+  the trigger, and the engine recomputes it. The module does not measure,
+  so there is nothing to re-measure on scroll.
+
+  **The stack is the platform's, so nesting is LIFO for free.** A second
+  overlay paints over the first whatever the DOM order and whatever the
+  z-index; closing it puts the first back on top. A popover opened inside
+  another popover's subtree leaves its parent open, and an unrelated one
+  dismisses it — the auto stack's own rule, inherited rather than
+  imitated.
+
+  **Focus returns without a restore handler.** The module closes an
+  overlay through the platform's door while its node is still connected,
+  which is what makes `<dialog>`'s own focus restoration run. A node
+  merely dropped from the document restores nothing, and that is the
+  difference between this and the same code written with an effect.
+
+  **Absent when unused.** `re-frame.hicasso` does not reach this
+  namespace, so an application that never requires it carries none of it.
+  `hicasso/scripts/check_optional_module_reachability.py` is what keeps
+  that true, and it fails the moment the public door imports the module or
+  its engine.
+
+  ## Focus: the one-shot, and the recipe
+
+  Focus is a one-shot — something done once when an overlay opens, not a
+  value mirrored in app-db. Do not put the focused element in app-db.
+
+  **Initial focus** is `:autofocus true` on the control that should have
+  it, and the platform's own dialog-focusing steps are what honour it. The
+  spelling matters and the witness is what settled it: Hicasso's attribute
+  grammar camelCases a hyphenated key, so `:auto-focus` reaches React as
+  `autoFocus`, which React applies by calling `.focus()` during the commit
+  and WITHOUT emitting the attribute — one child-first commit before
+  `showModal` runs its own focusing steps and moves focus somewhere else.
+  `:autofocus`, unhyphenated, reaches the DOM as the attribute the
+  platform reads. A modal with no autofocus target focuses its first
+  focusable control.
+
+  **Restoration** needs nothing from the author. See the posture above.
+
+  ## The options
+
+  | option | both | meaning |
+  |---|---|---|
+  | `:open?` | ✓ | whether the overlay exists at all |
+  | `:on-dismiss` | ✓ | the intent the platform's own dismissal dispatches |
+  | `:label` | ✓ | the accessible name, as `aria-label` |
+  | `:anchor` | popover | the DOM id of the trigger to position against |
+  | `:placement` | popover | a compass word — see [[re-frame.hicasso.impl.overlay/position-areas]] |
+  | `:light-dismiss?` | modal | whether a backdrop click dismisses (default false) |
+
+  Every other key is an ordinary attribute and reaches the element
+  unrenamed, so `:class`, `:style`, `:role`, `:id`, `:data-*` and the
+  platform's own event attributes all work exactly as they do at a native
+  tag.
+
+  ## Two things this bead deliberately did not do
+
+  **`:exit-ms` is not here.** Retaining a leaving node for its exit
+  animation is `re-frame.hicasso.motion`'s subject and already has a
+  machine, a terminal bound and a witness. Composing the two is worth
+  doing and is not this bead's; a second retention clock inside this
+  module would be the duplicate `motion` exists to prevent.
+
+  **A missing `:anchor` does not refuse.** The naming ledger's row 30
+  reserves `:rf.error/hicasso-overlay-anchor-missing` for it and
+  `docs/design/hicasso/product/complaints.md` carries it as a RESERVED
+  spelling, explicitly provisional until the naming packet (rf2-hic-065)
+  sits. Minting it also requires a Spec 009 catalogue row, which is
+  outside this bead's surface. So an `:anchor` that names no element is a
+  no-op today: the panel opens in the top layer at the UA's default
+  position, visibly unanchored rather than silently mispositioned."
+  (:require [re-frame.hicasso.impl.overlay :as impl-overlay]))
+
+(def ^{:doc "`overlay/popover` — an anchored, light-dismissable panel on
+  the browser's own top layer.
+
+      [overlay/popover {:open?      (h/sub [:menu/open? id])
+                        :on-dismiss [:menu/dismissed id]
+                        :anchor     trigger-id
+                        :placement  :bottom-start}
+       [:ul {:role \"menu\"} …]]
+
+  A legal hiccup head, marked the same way a `defview` product is — though
+  it is not a Hicasso *reactive* boundary: it reads no subscription and
+  holds no cell. `:open?` false renders nothing at all.
+
+  `:anchor` is the DOM id of the trigger; the module gives that element a
+  generated CSS anchor name while the panel is open and puts back whatever
+  it found on the way out. `:placement` is the compass word that becomes a
+  `position-area` against it. With `:on-dismiss` the panel is a
+  `popover=\"auto\"` and takes its place in the platform's LIFO stack;
+  without one it is `popover=\"manual\"` and dismisses for nothing, because
+  a dismissal with nowhere to go is how an open flag acquires a second
+  owner. [[re-frame.hicasso.impl.overlay/popover]]."}
+  popover impl-overlay/popover)
+
+(def ^{:doc "`overlay/modal` — a blocking dialog on the browser's own top
+  layer, opened with `showModal`.
+
+      [overlay/modal {:open?      (h/sub [:invoice/confirm-delete? id])
+                      :on-dismiss [:invoice/delete-cancelled id]
+                      :label      \"Confirm deletion\"}
+       [:h2 \"Delete this invoice?\"]
+       [:button {:autofocus true :on-click [:invoice/deleted id]} \"Delete\"]]
+
+  A legal hiccup head, marked the same way a `defview` product is. `:open?`
+  false renders nothing at all.
+
+  Modality is the engine's: the rest of the document is inert, focus
+  cannot leave the dialog, and `::backdrop` is a real CSS selector. Escape
+  dispatches `:on-dismiss`; a backdrop click does so only with
+  `:light-dismiss? true`, because a destructive confirmation must not go
+  away on a stray click. Without `:on-dismiss` the dialog honours no close
+  request at all. [[re-frame.hicasso.impl.overlay/modal]]."}
+  modal impl-overlay/modal)

--- a/implementation/hicasso/test/re_frame/hicasso/overlay_dom_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/overlay_dom_cljs_test.cljs
@@ -30,7 +30,8 @@
   | an intent inside an overlay lowers in the overlay's frame | [[an-intent-on-an-overlay-child-dispatches-in-the-frame-above-it]] |
   | the anchor is claimed while open and put back after | [[the-anchor-is-claimed-while-open-and-handed-back-on-teardown]] |
   | two hooks here, and still two in the shell | [[an-overlay-costs-two-hooks-and-the-shell-still-costs-two]] |
-  | the focus one-shot, and which spelling reaches the platform | [[the-focus-one-shot-is-the-attribute-and-not-reacts-prop]] |
+  | a close request arrives as an intent | [[a-close-request-on-a-modal-arrives-as-an-intent]] |
+  | the focus one-shot, and which spelling reaches the platform | [[the-focus-one-shot-is-the-platforms-focus-delegate-and-not-reacts-autofocus]] |
 
   ## What decides these rows, and what cannot
 
@@ -60,30 +61,47 @@
     and stacking rows; dropping `close()` from the ref cleanup reds the
     focus row; a `document` listener added while open reds the census row.
   - WIDEN the guard — deleting the `newState` filter in
-    `dismissal-handler`, which leaves a handler with the correct SHAPE
-    (it is the platform's own dismissal event, on the right element, with
-    the author's own intent) and one wrong direction: `beforetoggle` also
-    fires on the way IN, so an overlay dispatches `:on-dismiss` when it
-    OPENS. That reds the dispatch-count rows with `(not (= 1 2))`.
-    Widening `:open?` to default true reds the closed-cost row.
+    `dismissal-handler` leaves a handler with the correct SHAPE (the
+    platform's own dismissal event, on the right element, carrying the
+    author's own intent) and one wrong direction: `beforetoggle` fires on
+    the way IN as well, so an overlay dispatches `:on-dismiss` when it
+    OPENS. Reds the dispatch-count rows with `(not (= 1 2))`. Rendering
+    the element ALWAYS and merely not showing it while closed — the
+    ordinary design a dozen overlay libraries ship, which paints
+    correctly, dismisses correctly and restores focus correctly — reds
+    the closed-cost row with a live `HTMLDialogElement` where nil was
+    required.
 
-  A third sabotage is recorded here because it did NOT redden, and the
-  module changed as a result. The popover's teardown fires the same
-  `beforetoggle` a light dismiss fires, so the first draft carried a
-  per-node closing mark to tell them apart; deleting the mark left every
-  row green. React does not deliver an event from a fiber it is deleting,
-  so the mark was unreachable code. It is gone, and
-  [[the-platform-dismissal-arrives-as-an-intent-and-the-teardown-does-not]]
-  is what holds the property in its place.
+  **Two sabotages did NOT redden, and both changed something.** They are
+  recorded because a sabotage that stays green is the only kind that
+  tells you something you did not already believe.
+
+  - Marking the node before the module's own `hidePopover()`, so a
+    teardown could not be read as a dismissal, was UNREACHABLE: React
+    does not deliver an event from a fiber it is deleting. The mark is
+    gone from the module and
+    [[the-platform-dismissal-arrives-as-an-intent-and-the-teardown-does-not]]
+    holds the property in its place.
+  - A `document.addEventListener` left in the module's ref callback
+    reddened nothing, because the CENSUS was broken rather than the
+    module. See [[census-sees-a-global!]]. With the instrument repaired
+    the same sabotage reds with `a global listener appeared: [keydown]`.
 
   ## What is measured against what
 
   A census row that counts something the module never touches passes
-  vacuously, so each census asserts its own premise first: the listener
-  census asserts that the instrument DID see React's element-scoped
-  `cancel`/`toggle` listeners before it asserts that it saw nothing on
-  `document`; the hook roster asserts the probe was installed before it
-  reads a count."
+  vacuously, so each census asserts its own premise first, and one of
+  those premises had to be added after the fact.
+  [[census-sees-a-global!]] puts a real listener on `document` and
+  requires the census to file it under `:global`, because the first draft
+  of the instrument could not file anything there at all — its patched
+  `addEventListener` was a variadic ClojureScript fn, so `this` was never
+  the EventTarget. A deliberate `document.addEventListener` left in the
+  module's own ref callback reddened nothing, which is how the instrument
+  was caught rather than the module. The listener census also asserts it
+  saw React's element-scoped `cancel`/`toggle` before asserting it saw
+  nothing global, and the hook roster asserts the probe installed before
+  it reads a count."
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
             [re-frame.adapter.uix :as uix-adapter]
             [re-frame.core :as rf]
@@ -545,22 +563,26 @@
 
 ;; --- the census ------------------------------------------------------------
 
-(def ^:private global-target?
-  (fn [t]
-    (or (identical? t js/window)
-        (identical? t js/document)
-        (identical? t (.-documentElement js/document))
-        (identical? t (.-body js/document)))))
+(defn- global-targets
+  "The four targets a listener may NOT appear on: `window`, `document`,
+  `<html>` and `<body>`. An overlay's own element is not among them —
+  React attaches `cancel` / `toggle` there, which is expected and leaves
+  with the node."
+  []
+  [js/window js/document (.-documentElement js/document) (.-body js/document)])
 
 (defn- install-census!
   "Instrument every way an overlay could acquire idle cost, and answer
-  `{:log :restore!}`.
+  `{:log :clear! :restore!}`.
 
-  Listeners are split by TARGET rather than counted: React attaches
-  `cancel` / `toggle` directly to the overlay element, which is both
-  expected and self-cleaning, while a listener on `document` or `window`
-  is the one that outlives its overlay. A census that counted both would
-  have to be read against a baseline nobody can state."
+  Listeners are split by TARGET rather than counted, and the split is made
+  by WHICH WRAPPER RAN rather than by inspecting `this`. Each global target
+  gets an own-property wrapper that closes over the target it belongs to;
+  the prototype wrapper underneath it therefore only ever sees the
+  elements. That is not a stylistic preference — the first draft read
+  `this` inside the prototype wrapper, `this` was not the EventTarget, and
+  `:global` could not become non-empty however hard the module tried to
+  make it. [[census-sees-a-global!]] is the premise that keeps it honest."
   []
   (let [proto      (.-prototype js/EventTarget)
         orig-add   (.-addEventListener proto)
@@ -569,19 +591,30 @@
         orig-int   (.-setInterval js/globalThis)
         observers  ["ResizeObserver" "MutationObserver" "IntersectionObserver"]
         originals  (into {} (map (fn [n] [n (unchecked-get js/globalThis n)])) observers)
+        targets    (global-targets)
         !log       (atom {:global [] :element [] :removed [] :rafs 0
                           :intervals 0 :observers 0})]
+    ;; The elements, underneath.
     (set! (.-addEventListener proto)
-          (fn [& args]
+          (fn [type listener opts]
             (this-as this
-              (swap! !log update (if (global-target? this) :global :element)
-                     conj (first args))
-              (.apply orig-add this (to-array args)))))
+              (swap! !log update :element conj type)
+              (.call orig-add this type listener opts))))
     (set! (.-removeEventListener proto)
-          (fn [& args]
+          (fn [type listener opts]
             (this-as this
-              (swap! !log update :removed conj (first args))
-              (.apply orig-rm this (to-array args)))))
+              (swap! !log update :removed conj type)
+              (.call orig-rm this type listener opts))))
+    ;; The four globals, shadowing it with an own property each.
+    (doseq [t targets]
+      (unchecked-set t "addEventListener"
+                     (fn [type listener opts]
+                       (swap! !log update :global conj type)
+                       (.call orig-add t type listener opts)))
+      (unchecked-set t "removeEventListener"
+                     (fn [type listener opts]
+                       (swap! !log update :removed conj type)
+                       (.call orig-rm t type listener opts))))
     (when orig-raf
       (set! (.-requestAnimationFrame js/globalThis)
             (fn [& args]
@@ -599,15 +632,41 @@
                          (swap! !log update :observers inc)
                          (js/Reflect.construct orig (to-array args))))))
     {:log      !log
+     :clear!   (fn [] (swap! !log assoc :global [] :element [] :removed []) nil)
      :restore! (fn []
                  (set! (.-addEventListener proto) orig-add)
                  (set! (.-removeEventListener proto) orig-rm)
+                 (doseq [t targets]
+                   (js-delete t "addEventListener")
+                   (js-delete t "removeEventListener"))
                  (when orig-raf (set! (.-requestAnimationFrame js/globalThis) orig-raf))
                  (when orig-int (set! (.-setInterval js/globalThis) orig-int))
                  (doseq [n observers]
                    (when-some [orig (get originals n)]
                      (unchecked-set js/globalThis n orig)))
                  nil)}))
+
+(defn- census-sees-a-global!
+  "THE INSTRUMENT'S OWN PREMISE. Add a listener to `document` and require
+  the census to file it under `:global`, then take it off again and clear
+  the log.
+
+  Every `:global` assertion below is an emptiness claim, and an emptiness
+  claim is worth exactly what the instrument's ability to be non-empty is
+  worth. The first draft of this census could not be non-empty — its
+  patched `addEventListener` was a variadic ClojureScript fn, so `this`
+  was not the EventTarget, every target classified as an element, and a
+  deliberate `document.addEventListener` in the module's own ref callback
+  left the whole suite green."
+  [{:keys [log clear!]}]
+  (let [probe (fn [_] nil)]
+    (.addEventListener js/document "rf-census-probe" probe)
+    (is (= ["rf-census-probe"] (:global @log))
+        (str "the census must record a document listener as GLOBAL, or its "
+             "zeros are zeros about nothing. Saw global=" (pr-str (:global @log))
+             " element=" (pr-str (:element @log))))
+    (.removeEventListener js/document "rf-census-probe" probe)
+    (clear!)))
 
 (deftest an-open-overlay-adds-nothing-to-window-document-or-body
   (if-not (mount/browser?)
@@ -619,8 +678,9 @@
           (mount/settle!)
           ;; Instrumented AFTER the root exists, so React's own root-level
           ;; wiring is outside the window and the delta is the overlay's.
-          (let [{:keys [log restore!]} (install-census!)]
+          (let [{:keys [log restore!] :as census} (install-census!)]
             (try
+              (census-sees-a-global! census)
               (go! [::opened :pa])
               (.scrollTo js/window 0 40)
               (.dispatchEvent js/window (js/Event. "resize"))
@@ -688,8 +748,9 @@
           ;; and a census that had to whitelist it would be a census with an
           ;; opinion about React's internals. What is measured here is the
           ;; DELTA a closed overlay costs on top of a page that already exists.
-          (let [{:keys [log restore!]} (install-census!)]
+          (let [{:keys [log restore!] :as census} (install-census!)]
             (try
+              (census-sees-a-global! census)
               (go! [::closed :m])
               (go! [::closed :p])
               (testing "ZERO COST WHEN CLOSED: `:open?` false renders nil, so

--- a/implementation/hicasso/test/re_frame/hicasso/overlay_dom_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/overlay_dom_cljs_test.cljs
@@ -1,0 +1,763 @@
+(ns re-frame.hicasso.overlay-dom-cljs-test
+  "THE OVERLAY POSTURE, WITNESSED (rf2-hic-052).
+
+  > The top layer, the focus trap, the inertness, the LIFO stack, the
+  > light dismiss and the anchor tracking all belong to the browser. This
+  > module owns exactly one thing about them, and that thing is the
+  > imperative call.
+  >
+  > — [[re-frame.hicasso.overlay]]
+
+  A posture is only worth stating if something would go red when it stops
+  being true, and for an overlay the thing that stops being true is never
+  the markup. A panel can carry every attribute the module means to write
+  and still be clipped by its grandparent, trap focus in the wrong place,
+  outlive its own listener, or stack under the overlay that opened before
+  it. So every row here asserts a BEHAVIOUR the engine decides —
+  `document.elementFromPoint`, `document.activeElement`, `:modal`,
+  `:popover-open` — and none asserts an attribute the module just wrote.
+
+  | claim | row |
+  |---|---|
+  | the top layer escapes an ancestor that clips and stacks | [[an-overlay-escapes-an-ancestor-that-clips-and-out-stacks-it]] |
+  | a modal makes the rest of the document inert | [[a-modal-makes-the-document-behind-it-unfocusable]] |
+  | closing through the platform's door returns focus | [[closing-through-the-platform-door-returns-focus-to-the-trigger]] |
+  | the stack is LIFO, and not DOM order | [[the-top-layer-stacks-last-in-first-out-not-in-dom-order]] |
+  | an auto popover joins the LIFO stack; a manual one does not | [[an-unrelated-auto-popover-dismisses-the-open-one-and-a-manual-one-is-immune]] |
+  | the platform's dismissal arrives as an intent, once | [[the-platform-dismissal-arrives-as-an-intent-and-the-teardown-does-not]] |
+  | zero idle listeners, and nothing per frame | [[an-open-overlay-adds-nothing-to-window-document-or-body]] |
+  | zero cost when closed | [[a-closed-overlay-has-no-element-no-listener-and-no-rendered-body]] |
+  | an intent inside an overlay lowers in the overlay's frame | [[an-intent-on-an-overlay-child-dispatches-in-the-frame-above-it]] |
+  | the anchor is claimed while open and put back after | [[the-anchor-is-claimed-while-open-and-handed-back-on-teardown]] |
+  | two hooks here, and still two in the shell | [[an-overlay-costs-two-hooks-and-the-shell-still-costs-two]] |
+  | the focus one-shot, and which spelling reaches the platform | [[the-focus-one-shot-is-the-attribute-and-not-reacts-prop]] |
+
+  ## What decides these rows, and what cannot
+
+  **The browser lane decides them.** `<dialog>`, the popover API, the top
+  layer, inertness and light dismiss have no implementation in the node
+  lane at all, so every row below states a skip there rather than a false
+  green — as every DOM claim in this package does.
+
+  **Trusted input decides one thing these rows do not.** A real Escape
+  keypress and a real outside click cannot be synthesised from inside the
+  page: Chromium refuses an untrusted `KeyboardEvent` for a close request
+  by design. Every dismissal witnessed here is therefore driven through
+  the platform's own programmatic path — opening a second `popover=auto`,
+  which makes the engine light-dismiss the first exactly as an outside
+  click would, through the same code and the same event. Keyboard conduct
+  under a real key press is `rf2-hic-049`'s, which this bead unblocks, and
+  is named here so the gap is a stated one.
+
+  ## Both directions, per assertion class
+
+  Every row was run against a deliberate break, and the reds are quoted in
+  the PR body. The two directions are not the same edit:
+
+  - REMOVE the behaviour — `showModal` → `show` (a legal call on the same
+    element that opens the same dialog and fires the same events, and
+    which leaves the page behind it live) reds the top-layer, inertness
+    and stacking rows; dropping `close()` from the ref cleanup reds the
+    focus row; a `document` listener added while open reds the census row.
+  - WIDEN the guard — deleting the `closing-slot` test in
+    `dismissal-handler` (leaving a handler that is right about every real
+    dismissal and wrong only about the module's own teardown) reds the
+    dispatch-count row; making `:open?` default true reds the closed-cost
+    row.
+
+  ## What is measured against what
+
+  A census row that counts something the module never touches passes
+  vacuously, so each census asserts its own premise first: the listener
+  census asserts that the instrument DID see React's element-scoped
+  `cancel`/`toggle` listeners before it asserts that it saw nothing on
+  `document`; the hook roster asserts the probe was installed before it
+  reads a count."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [re-frame.adapter.uix :as uix-adapter]
+            [re-frame.core :as rf]
+            [re-frame.hicasso :as h]
+            [re-frame.hicasso.hook-probe :as probe]
+            [re-frame.hicasso.impl.collector :as collector]
+            [re-frame.hicasso.impl.mount :as mount]
+            [re-frame.hicasso.impl.overlay :as impl-overlay]
+            [re-frame.hicasso.overlay :as overlay]
+            [re-frame.test-support :as test-support]))
+
+(def ^:private frame-id ::overlay)
+
+;; Registered ABOVE `use-fixtures`, for the reason the motion suite gives:
+;; the reset fixture captures its source-store baseline when the
+;; `use-fixtures` form is evaluated.
+(rf/reg-sub ::open? (fn [db [_ k]] (boolean (get-in db [:open k]))))
+(rf/reg-sub ::dismissals (fn [db [_ k]] (get-in db [:dismissed k] 0)))
+(rf/reg-event ::opened (fn [{:keys [db]} [_ k]] {:db (assoc-in db [:open k] true)}))
+(rf/reg-event ::closed (fn [{:keys [db]} [_ k]] {:db (assoc-in db [:open k] false)}))
+(rf/reg-event ::dismissed
+  (fn [{:keys [db]} [_ k]]
+    {:db (-> db
+             (assoc-in [:open k] false)
+             (update-in [:dismissed k] (fnil inc 0)))}))
+;; Deliberately does NOT clear the flag: the row that counts dispatches
+;; needs the overlay to survive its own dismissal so the teardown is a
+;; separate, later event it can attribute.
+(rf/reg-event ::noted (fn [{:keys [db]} [_ k]] {:db (update-in db [:dismissed k] (fnil inc 0))}))
+(rf/reg-event ::clicked (fn [{:keys [db]} [_ k]] {:db (assoc-in db [:clicked k] true)}))
+(rf/reg-sub ::body-read (fn [db _] (:body-read db)))
+
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture
+    {:adapter       uix-adapter/adapter
+     :ambient-frame nil
+     :init-fn       (fn [] (collector/reset-runtime!))}))
+
+;; ---------------------------------------------------------------------------
+;; The headless half — the one part of this module that is a value
+;; ---------------------------------------------------------------------------
+
+(deftest a-compass-word-is-a-position-area-and-an-unknown-one-passes-through
+  (testing "the taught compass words all resolve, and to distinct areas"
+    (is (= "block-end span-inline-end" (impl-overlay/position-area :bottom-start)))
+    (is (= "block-end span-inline-start" (impl-overlay/position-area :bottom-end)))
+    (is (= "block-start span-inline-end" (impl-overlay/position-area :top-start)))
+    (is (= "inline-end" (impl-overlay/position-area :right)))
+    (is (= (count impl-overlay/position-areas)
+           (count (set (vals impl-overlay/position-areas))))
+        "twelve words, twelve areas — a duplicate would be two names for one place"))
+
+  (testing "no placement is no declaration, rather than a default one"
+    (is (nil? (impl-overlay/position-area nil))))
+
+  (testing "the escape hatch: a raw `position-area` string is emitted verbatim"
+    (is (= "block-end span-inline-start"
+           (impl-overlay/position-area "block-end span-inline-start"))))
+
+  (testing "and a misspelt compass word is emitted verbatim too — invalid CSS
+            the engine drops, rather than a silent substitution of some
+            other placement"
+    (is (= "botom-start" (impl-overlay/position-area :botom-start)))
+    (is (not (contains? (set (vals impl-overlay/position-areas)) "botom-start")))))
+
+;; ---------------------------------------------------------------------------
+;; The DOM half
+;; ---------------------------------------------------------------------------
+
+(defn- skip!
+  [why]
+  (is true (str "a top-layer claim needs a real browser engine — " why)))
+
+(defn- unwitnessed! [why]
+  (is false (str why " A gate nobody has watched fire is not evidence.")))
+
+(defn- fresh! []
+  (set! (.-IS_REACT_ACT_ENVIRONMENT js/globalThis) false)
+  (rf/make-frame {:id frame-id}))
+
+(defn- go! [event]
+  (rf/with-frame frame-id (rf/dispatch-sync event))
+  (mount/settle!)
+  nil)
+
+(defn- db [] (rf/app-db-value frame-id))
+
+(defn- at-centre
+  "The element painting at the centre of `el`'s layout box — the engine's
+  own answer to \"what is on top here\", and the only honest one."
+  [el]
+  (let [r (.getBoundingClientRect el)]
+    (.elementFromPoint js/document
+                       (+ (.-left r) (/ (.-width r) 2))
+                       (+ (.-top r) (/ (.-height r) 2)))))
+
+(defn- within?
+  "Is `hit` `el` or inside it?"
+  [el hit]
+  (boolean (and el hit (or (identical? el hit) (.contains el hit)))))
+
+(defn- $ [sel] (.querySelector js/document sel))
+
+;; --- the clipping fixture --------------------------------------------------
+
+(def ^:private clip-style
+  "An ancestor that clips AND establishes a stacking/containing context —
+  the three defeats a hand-rolled overlay meets at once."
+  {:overflow  "hidden"
+   :height    "20px"
+   :position  "relative"
+   :transform "translateZ(0)"
+   :z-index   0})
+
+(h/defview clipped-page [_]
+  [:div
+   [:button#outside {:type "button"} "Outside"]
+   [:div#clip {:style clip-style}
+    ;; The legal near-miss: an ordinary positioned element with the
+    ;; largest z-index there is. It loses anyway, which is the point.
+    [:div#ladder {:style {:position "fixed" :top "300px" :left "0px"
+                          :width "120px" :height "120px" :z-index 2147483647
+                          :background "rgb(255 0 0)"}}]
+    [overlay/modal {:open?      (h/sub [::open? :m])
+                    :on-dismiss [::dismissed :m]
+                    :label      "Confirm deletion"}
+     [:p "in the top layer"]
+     [:button#inside {:type "button"} "Inside"]]]])
+
+(deftest an-overlay-escapes-an-ancestor-that-clips-and-out-stacks-it
+  (if-not (mount/browser?)
+    (skip! ":node-test has no top layer, so nothing paints and nothing hit-tests")
+    (do
+      (fresh!)
+      (let [handle (mount/root! (mount/fresh-container!) frame-id [clipped-page {}])]
+        (try
+          (mount/settle!)
+          (go! [::opened :m])
+          (let [dialog ($ "dialog")
+                ladder ($ "#ladder")]
+            (testing "premise: both elements are inside the same clipping,
+                      transformed, stacking ancestor"
+              (is (some? dialog))
+              (is (some? ladder))
+              (is (.contains ($ "#clip") dialog))
+              (is (.contains ($ "#clip") ladder)))
+
+            (testing "THE NEAR-MISS: the highest z-index there is loses to
+                      `overflow: hidden` on a grandparent"
+              (is (not (within? ladder (at-centre ladder)))
+                  "nothing paints where the ladder lays out — it is clipped away"))
+
+            (testing "THE TOP LAYER: the overlay paints, and hit-tests, outside
+                      the box that clipped its sibling"
+              (is (within? dialog (at-centre dialog))
+                  "the engine's own hit test lands in the dialog")
+              (is (= 1 (.-length (.querySelectorAll js/document ":modal")))
+                  "and the engine agrees it is IN the top layer, modally")
+              (let [d (.getBoundingClientRect dialog)
+                    c (.getBoundingClientRect ($ "#clip"))]
+                (is (> (.-bottom d) (.-bottom c))
+                    "its painted box is not contained by the box that clips it"))))
+          (finally (mount/release! handle)))))))
+
+(deftest a-modal-makes-the-document-behind-it-unfocusable
+  (if-not (mount/browser?)
+    (skip! ":node-test has no inertness, because it has no modal dialog")
+    (do
+      (fresh!)
+      (let [handle (mount/root! (mount/fresh-container!) frame-id [clipped-page {}])]
+        (try
+          (mount/settle!)
+          (let [outside ($ "#outside")]
+            (testing "premise: with no modal open the same control takes focus —
+                      so the claim below is about the modal and not about the
+                      control"
+              (.focus outside)
+              (is (identical? outside (.-activeElement js/document))))
+
+            (go! [::opened :m])
+
+            (testing "INERTNESS: the engine refuses focus to everything outside
+                      the dialog — a property of the platform's modality, not of
+                      a key handler this module wrote"
+              (.focus outside)
+              (is (not (identical? outside (.-activeElement js/document)))
+                  "the outside control cannot take focus while the modal is open")
+              (is (.contains (or (.-parentNode ($ "dialog")) js/document.body)
+                             (.-activeElement js/document))
+                  "and focus is somewhere inside the dialog's tree"))
+
+            (testing "and it comes back when the modal goes"
+              (go! [::closed :m])
+              (.focus outside)
+              (is (identical? outside (.-activeElement js/document)))))
+          (finally (mount/release! handle)))))))
+
+;; --- focus restore ---------------------------------------------------------
+
+(h/defview trigger-page [_]
+  [:div
+   [:button#trigger {:type "button" :on-click [::opened :m]} "Open"]
+   [overlay/modal {:open?      (h/sub [::open? :m])
+                   :on-dismiss [::dismissed :m]
+                   :label      "Confirm"}
+    [:button#first {:type "button"} "First"]
+    [:button#second {:type "button" :autofocus true} "Second"]]])
+
+(deftest closing-through-the-platform-door-returns-focus-to-the-trigger
+  (if-not (mount/browser?)
+    (skip! ":node-test restores nothing, because nothing was ever focused")
+    (do
+      (fresh!)
+      (let [handle (mount/root! (mount/fresh-container!) frame-id [trigger-page {}])]
+        (try
+          (mount/settle!)
+          (let [trigger ($ "#trigger")]
+            (.focus trigger)
+            (is (identical? trigger (.-activeElement js/document))
+                "premise: the trigger holds focus at the instant the overlay opens")
+
+            (go! [::opened :m])
+            (is (.contains ($ "dialog") (.-activeElement js/document))
+                "opening moves focus into the dialog")
+
+            (testing "RESTORE: the module closes through the platform's door
+                      while the node is still connected, so the platform's own
+                      restoration runs. Removing the node instead restores
+                      nothing and focus lands on <body>"
+              (go! [::closed :m])
+              (is (nil? ($ "dialog")) "the element is gone")
+              (is (identical? trigger (.-activeElement js/document))
+                  "and focus is back on the trigger, with no restore handler
+                   anywhere in the application")))
+          (finally (mount/release! handle)))))))
+
+(deftest the-focus-one-shot-is-the-attribute-and-not-reacts-prop
+  (if-not (mount/browser?)
+    (skip! ":node-test runs no dialog focusing steps")
+    (do
+      (fresh!)
+      (let [handle (mount/root! (mount/fresh-container!) frame-id [trigger-page {}])]
+        (try
+          (mount/settle!)
+          (go! [::opened :m])
+          (testing "THE ONE-SHOT: `:autofocus true`, unhyphenated, reaches the
+                    DOM as the attribute the platform's dialog-focusing steps
+                    read — so focus lands on the control the author named and
+                    not on the first focusable one"
+            (is (= "second" (.-id (.-activeElement js/document)))
+                (str "the autofocus target has focus, not #first. The spelling "
+                     "is load-bearing: `:auto-focus` camelCases to React's own "
+                     "`autoFocus` prop, which React applies by calling .focus() "
+                     "during the commit WITHOUT emitting the attribute — one "
+                     "child-first commit before showModal runs its own focusing "
+                     "steps and moves focus to the first focusable control. "
+                     "Active: " (.-id (.-activeElement js/document))))
+            (is (.hasAttribute ($ "#second") "autofocus")
+                "and the attribute really is in the DOM, which is why it worked"))
+          (finally (mount/release! handle)))))))
+
+;; --- the stack -------------------------------------------------------------
+
+(h/defview two-modals-page [_]
+  ;; Written SECOND-first in the DOM, so a row that passed on DOM order
+  ;; would fail here.
+  [:div
+   [overlay/modal {:open? (h/sub [::open? :b]) :on-dismiss [::dismissed :b]
+                   :label "B" :id "modal-b"}
+    [:p "B"]]
+   [overlay/modal {:open? (h/sub [::open? :a]) :on-dismiss [::dismissed :a]
+                   :label "A" :id "modal-a"}
+    [:p "A"]]])
+
+(deftest the-top-layer-stacks-last-in-first-out-not-in-dom-order
+  (if-not (mount/browser?)
+    (skip! ":node-test has no top layer to stack in")
+    (do
+      (fresh!)
+      (let [handle (mount/root! (mount/fresh-container!) frame-id [two-modals-page {}])]
+        (try
+          (mount/settle!)
+          (go! [::opened :a])
+          (go! [::opened :b])
+          (let [a ($ "#modal-a") b ($ "#modal-b")]
+            (testing "premise: both are open, both are modal, and B is the one
+                      written FIRST in the DOM"
+              (is (= 2 (.-length (.querySelectorAll js/document ":modal"))))
+              (is (= 4 (.compareDocumentPosition b a))
+                  "DOCUMENT_POSITION_FOLLOWING — A comes after B in the DOM"))
+
+            (testing "LIFO: the one opened LAST is on top, whatever the DOM says"
+              (is (within? b (at-centre b))
+                  "B opened second, so B paints over A where they overlap"))
+
+            (testing "and closing it puts the earlier one back on top"
+              (go! [::closed :b])
+              (is (= 1 (.-length (.querySelectorAll js/document ":modal"))))
+              (is (within? a (at-centre a))
+                  "A is the top of the stack again — the stack popped rather
+                   than collapsed")))
+          (finally (mount/release! handle)))))))
+
+;; --- the popover's LIFO dismissal, and the manual arm ----------------------
+
+(h/defview two-popovers-page [_]
+  [:div
+   [:button#anchor-a {:type "button"} "A"]
+   [overlay/popover {:open?      (h/sub [::open? :pa])
+                     ;; NOTE: `::noted` does not clear the flag, so the
+                     ;; element survives its own dismissal and the row below
+                     ;; can attribute a SECOND dispatch to the teardown.
+                     :on-dismiss [::noted :pa]
+                     :anchor     "anchor-a"
+                     :placement  :bottom-start
+                     :id         "pop-a"}
+    [:ul {:role "menu"} [:li "one"]]]
+   [overlay/popover {:open?      (h/sub [::open? :pb])
+                     :on-dismiss [::dismissed :pb]
+                     :id         "pop-b"}
+    [:p "B"]]
+   ;; The same panel with NO `:on-dismiss` — `popover="manual"`, and
+   ;; therefore not a member of the auto stack at all.
+   [overlay/popover {:open? (h/sub [::open? :pm]) :id "pop-m"}
+    [:p "M"]]])
+
+(deftest an-unrelated-auto-popover-dismisses-the-open-one-and-a-manual-one-is-immune
+  (if-not (mount/browser?)
+    (skip! ":node-test has no popover API and no auto stack")
+    (do
+      (fresh!)
+      (let [handle (mount/root! (mount/fresh-container!) frame-id [two-popovers-page {}])]
+        (try
+          (mount/settle!)
+          (go! [::opened :pa])
+          (is (.matches ($ "#pop-a") ":popover-open")
+              "premise: A is open and in the top layer")
+
+          (testing "THE AUTO STACK: opening an unrelated auto popover light-
+                    dismisses the open one — the same engine path an outside
+                    click takes, and the reason the module does not own one"
+            (go! [::opened :pb])
+            (mount/settle!)
+            (is (.matches ($ "#pop-b") ":popover-open"))
+            (is (not (.matches ($ "#pop-a") ":popover-open"))
+                "A was dismissed by the platform, not by this module")
+            (is (= 1 (get-in (db) [:dismissed :pa]))
+                "and the dismissal arrived in app-db as an ordinary intent"))
+
+          (testing "MANUAL: the same panel written without `:on-dismiss` is in
+                    the top layer and dismisses for nothing — which is what
+                    makes a dismissal with nowhere to go unreachable rather
+                    than merely discouraged"
+            (go! [::opened :pm])
+            (is (.matches ($ "#pop-m") ":popover-open"))
+            (is (= "manual" (.getAttribute ($ "#pop-m") "popover")))
+            (go! [::opened :pa])
+            (is (.matches ($ "#pop-a") ":popover-open"))
+            (is (.matches ($ "#pop-m") ":popover-open")
+                "the auto popover joining the stack did not disturb it"))
+          (finally (mount/release! handle)))))))
+
+(deftest the-platform-dismissal-arrives-as-an-intent-and-the-teardown-does-not
+  (if-not (mount/browser?)
+    (skip! ":node-test dismisses nothing, because nothing opened")
+    (do
+      (fresh!)
+      (let [handle (mount/root! (mount/fresh-container!) frame-id [two-popovers-page {}])]
+        (try
+          (mount/settle!)
+          (go! [::opened :pa])
+          (go! [::opened :pb])
+          (is (= 1 (get-in (db) [:dismissed :pa]))
+              "premise: the light dismiss dispatched exactly once")
+          (is (true? (get-in (db) [:open :pa]))
+              "premise: `::noted` deliberately left the flag TRUE, so the
+               element is still mounted and its teardown is still ahead")
+
+          (testing "THE GUARD: the module's own teardown hides the popover
+                    through the same door and fires the same `toggle` event —
+                    and dispatches nothing. A handler that were right about
+                    every real dismissal and wrong only about this one would
+                    double-count every close in the application"
+            (go! [::closed :pa])
+            (is (nil? ($ "#pop-a")) "the element is gone")
+            (is (= 1 (get-in (db) [:dismissed :pa]))
+                "still one — the teardown is not a dismissal"))
+          (finally (mount/release! handle)))))))
+
+;; --- the census ------------------------------------------------------------
+
+(def ^:private global-target?
+  (fn [t]
+    (or (identical? t js/window)
+        (identical? t js/document)
+        (identical? t (.-documentElement js/document))
+        (identical? t (.-body js/document)))))
+
+(defn- install-census!
+  "Instrument every way an overlay could acquire idle cost, and answer
+  `{:log :restore!}`.
+
+  Listeners are split by TARGET rather than counted: React attaches
+  `cancel` / `toggle` directly to the overlay element, which is both
+  expected and self-cleaning, while a listener on `document` or `window`
+  is the one that outlives its overlay. A census that counted both would
+  have to be read against a baseline nobody can state."
+  []
+  (let [proto      (.-prototype js/EventTarget)
+        orig-add   (.-addEventListener proto)
+        orig-rm    (.-removeEventListener proto)
+        orig-raf   (.-requestAnimationFrame js/globalThis)
+        orig-int   (.-setInterval js/globalThis)
+        observers  ["ResizeObserver" "MutationObserver" "IntersectionObserver"]
+        originals  (into {} (map (fn [n] [n (unchecked-get js/globalThis n)])) observers)
+        !log       (atom {:global [] :element [] :removed [] :rafs 0
+                          :intervals 0 :observers 0})]
+    (set! (.-addEventListener proto)
+          (fn [& args]
+            (this-as this
+              (swap! !log update (if (global-target? this) :global :element)
+                     conj (first args))
+              (.apply orig-add this (to-array args)))))
+    (set! (.-removeEventListener proto)
+          (fn [& args]
+            (this-as this
+              (swap! !log update :removed conj (first args))
+              (.apply orig-rm this (to-array args)))))
+    (when orig-raf
+      (set! (.-requestAnimationFrame js/globalThis)
+            (fn [& args]
+              (swap! !log update :rafs inc)
+              (.apply orig-raf js/globalThis (to-array args)))))
+    (when orig-int
+      (set! (.-setInterval js/globalThis)
+            (fn [& args]
+              (swap! !log update :intervals inc)
+              (.apply orig-int js/globalThis (to-array args)))))
+    (doseq [n observers]
+      (when-some [orig (get originals n)]
+        (unchecked-set js/globalThis n
+                       (fn [& args]
+                         (swap! !log update :observers inc)
+                         (js/Reflect.construct orig (to-array args))))))
+    {:log      !log
+     :restore! (fn []
+                 (set! (.-addEventListener proto) orig-add)
+                 (set! (.-removeEventListener proto) orig-rm)
+                 (when orig-raf (set! (.-requestAnimationFrame js/globalThis) orig-raf))
+                 (when orig-int (set! (.-setInterval js/globalThis) orig-int))
+                 (doseq [n observers]
+                   (when-some [orig (get originals n)]
+                     (unchecked-set js/globalThis n orig)))
+                 nil)}))
+
+(deftest an-open-overlay-adds-nothing-to-window-document-or-body
+  (if-not (mount/browser?)
+    (skip! ":node-test attaches nothing because it mounts nothing")
+    (do
+      (fresh!)
+      (let [handle (mount/root! (mount/fresh-container!) frame-id [two-popovers-page {}])]
+        (try
+          (mount/settle!)
+          ;; Instrumented AFTER the root exists, so React's own root-level
+          ;; wiring is outside the window and the delta is the overlay's.
+          (let [{:keys [log restore!]} (install-census!)]
+            (try
+              (go! [::opened :pa])
+              (.scrollTo js/window 0 40)
+              (.dispatchEvent js/window (js/Event. "resize"))
+              (mount/settle!)
+              (let [open-log @log]
+                (testing "premise: the instrument sees listeners at all —
+                          React's own `beforetoggle`/`toggle` on the element"
+                  (is (seq (:element open-log))
+                      (str "nothing was recorded, so a zero below would be "
+                           "vacuous. Element listeners: " (pr-str (:element open-log)))))
+
+                (testing "ZERO IDLE LISTENERS: nothing on window, document,
+                          <html> or <body> — the document listener that outlives
+                          its overlay is not a bug this module can have, because
+                          it never attaches one"
+                  (is (= [] (:global open-log))
+                      (str "a global listener appeared: " (pr-str (:global open-log)))))
+
+                (testing "and nothing per frame: anchor tracking is the
+                          compositor's, so there is no frame callback, no
+                          interval and no observer to attribute"
+                  (is (zero? (:rafs open-log)))
+                  (is (zero? (:intervals open-log)))
+                  (is (zero? (:observers open-log)))))
+
+              (go! [::closed :pa])
+              (let [closed-log @log]
+                (testing "TEARDOWN: every element listener the open window
+                          recorded is matched by a removal"
+                  (is (nil? ($ "#pop-a")))
+                  (is (>= (count (:removed closed-log)) (count (:element closed-log)))
+                      (str "added " (pr-str (:element closed-log))
+                           ", removed " (pr-str (:removed closed-log))))
+                  (is (= [] (:global closed-log))
+                      "and still nothing global, on the way out either")))
+              (finally (restore!))))
+          (finally (mount/release! handle)))))))
+
+;; --- zero cost when closed -------------------------------------------------
+
+(h/defview closed-page [_]
+  [:div
+   [overlay/modal {:open? (h/sub [::open? :m]) :on-dismiss [::dismissed :m]}
+    [:p (str "body read: " (h/sub [::body-read]))]]
+   [overlay/popover {:open? (h/sub [::open? :p]) :on-dismiss [::dismissed :p]}
+    [:p "p"]]])
+
+(deftest a-closed-overlay-has-no-element-no-listener-and-no-rendered-body
+  (if-not (mount/browser?)
+    (skip! ":node-test cannot tell an absent element from an absent DOM")
+    (do
+      (fresh!)
+      (let [handle (mount/root! (mount/fresh-container!) frame-id [closed-page {}])]
+        (try
+          (mount/settle!)
+          ;; Instrumented AFTER the root, deliberately: creating a React root
+          ;; attaches React's own `selectionchange` listener to the document,
+          ;; and a census that had to whitelist it would be a census with an
+          ;; opinion about React's internals. What is measured here is the
+          ;; DELTA a closed overlay costs on top of a page that already exists.
+          (let [{:keys [log restore!]} (install-census!)]
+            (try
+              (go! [::closed :m])
+              (go! [::closed :p])
+              (testing "ZERO COST WHEN CLOSED: `:open?` false renders nil, so
+                        there is no element to put in the top layer, nothing for
+                        React to attach a `cancel`/`toggle` listener to, and no
+                        body to read a subscription from"
+                (is (nil? ($ "dialog")))
+                (is (nil? (.querySelector js/document "[popover]")))
+                (is (zero? (.-length (.querySelectorAll js/document ":modal"))))
+                (is (= [] (:global @log)))
+                (is (= [] (filterv #{"cancel" "close" "toggle" "beforetoggle"}
+                                   (:element @log)))
+                    (str "no overlay listener exists to be idle. Element: "
+                         (pr-str (:element @log))))
+                (is (zero? (:rafs @log)))
+                (is (zero? (:observers @log))))
+
+              (testing "premise: the same page DOES acquire all of that the
+                        moment it opens — so the zeros above are a closed
+                        overlay's, not an instrument that sees nothing"
+                (go! [::opened :m])
+                (is (some? ($ "dialog")))
+                (is (seq (filterv #{"cancel" "close" "toggle" "beforetoggle"}
+                                  (:element @log)))))
+              (finally (restore!))))
+          (finally (mount/release! handle)))))))
+
+;; --- intents inside an overlay --------------------------------------------
+
+(h/defview intent-page [_]
+  [:div
+   [overlay/modal {:open? (h/sub [::open? :m]) :on-dismiss [::dismissed :m]}
+    [:button#act {:type "button" :on-click [::clicked :m]} "Act"]]])
+
+(deftest an-intent-on-an-overlay-child-dispatches-in-the-frame-above-it
+  (if-not (mount/browser?)
+    (skip! ":node-test cannot click a node it does not have")
+    (do
+      (fresh!)
+      (let [handle (mount/root! (mount/fresh-container!) frame-id [intent-page {}])]
+        (try
+          (mount/settle!)
+          (go! [::opened :m])
+          (testing "an overlay's children are hiccup DATA lowered in the
+                    overlay component's own render, one render after the body
+                    that wrote them unwound. Without the frame re-bound there,
+                    this button raises `:rf.error/hicasso-intent-outside-boundary`
+                    at render rather than dispatching"
+            (is (nil? (get-in (db) [:clicked :m])) "premise: nothing clicked yet")
+            (.click ($ "#act"))
+            (mount/settle!)
+            (is (true? (get-in (db) [:clicked :m]))
+                "the intent landed, in the frame the overlay was mounted under"))
+          (finally (mount/release! handle)))))))
+
+;; --- the anchor ------------------------------------------------------------
+
+(h/defview anchored-page [_]
+  [:div
+   ;; An author-written `anchor-name` the module must hand back untouched.
+   [:button#anchor-a {:type "button" :style {:anchor-name "--mine"}} "A"]
+   [overlay/popover {:open?      (h/sub [::open? :pa])
+                     :on-dismiss [::dismissed :pa]
+                     :anchor     "anchor-a"
+                     :placement  :bottom-start
+                     :id         "pop-a"}
+    [:p "menu"]]
+   [overlay/popover {:open?      (h/sub [::open? :px])
+                     :on-dismiss [::dismissed :px]
+                     :anchor     "no-such-element"
+                     :placement  :bottom-start
+                     :id         "pop-x"}
+    [:p "unanchored"]]])
+
+(deftest the-anchor-is-claimed-while-open-and-handed-back-on-teardown
+  (if-not (mount/browser?)
+    (skip! ":node-test resolves no anchors, because it computes no style")
+    (do
+      (fresh!)
+      (let [handle (mount/root! (mount/fresh-container!) frame-id [anchored-page {}])]
+        (try
+          (mount/settle!)
+          (let [trigger ($ "#anchor-a")]
+            (is (= "--mine" (.. trigger -style -anchorName))
+                "premise: the trigger carries the author's own anchor name")
+
+            (go! [::opened :pa])
+            (let [panel ($ "#pop-a")]
+              (testing "ANCHORED: the panel sits against the trigger, and the
+                        engine is what put it there"
+                (let [t (.getBoundingClientRect trigger)
+                      p (.getBoundingClientRect panel)]
+                  (is (>= (.-top p) (- (.-bottom t) 1))
+                      (str ":bottom-start puts the panel below the trigger. "
+                           "trigger.bottom=" (.-bottom t) " panel.top=" (.-top p)))
+                  (is (< (js/Math.abs (- (.-left p) (.-left t))) 2)
+                      (str "and left-aligned with it. trigger.left=" (.-left t)
+                           " panel.left=" (.-left p)))))
+
+              (testing "the claim is on the trigger while the panel is open"
+                (is (not= "--mine" (.. trigger -style -anchorName)))))
+
+            (testing "HANDED BACK: teardown restores what the author wrote,
+                      rather than clearing the property"
+              (go! [::closed :pa])
+              (is (= "--mine" (.. trigger -style -anchorName)))))
+
+          (testing "an `:anchor` naming no element is a no-op in this bead —
+                    the panel opens in the top layer, visibly unanchored, and
+                    raises nothing. The refusal the guide promises is reserved,
+                    provisional, and needs a Spec 009 row: see the door"
+            (go! [::opened :px])
+            (is (some? ($ "#pop-x")))
+            (is (.matches ($ "#pop-x") ":popover-open")))
+          (finally (mount/release! handle)))))))
+
+;; --- the budget ------------------------------------------------------------
+
+(h/defview budget-page [_]
+  [overlay/modal {:open? (h/sub [::open? :m]) :on-dismiss [::dismissed :m]}
+   [:p "cost"]])
+
+(deftest an-overlay-costs-two-hooks-and-the-shell-still-costs-two
+  (if-not (mount/browser?)
+    (skip! ":node-test does not run this suite's mount")
+    (if-not (probe/install!)
+      (unwitnessed! "React's internals slot was not found, so the hook counts
+                     are UNWITNESSED on this build.")
+      (do
+        (fresh!)
+        (let [handle (volatile! nil)
+              names  (probe/record!
+                       (fn []
+                         (vreset! handle
+                                  (mount/root! (mount/fresh-container!)
+                                               frame-id [budget-page {}]))))]
+          (try
+            (testing "premise: the instrument can report more than two — the
+                      shell's own two are read here, in the order its ledger
+                      declares them"
+              (is (= ["useContext" "useSyncExternalStore"] (vec (take 2 names)))
+                  (str "raw: " (pr-str names)))
+              (is (= (count collector/shell-hook-ledger) 2)
+                  "and the declared shell ledger is still two"))
+
+            (let [tail (vec (distinct (drop 2 names)))]
+              (testing "THE MODULE'S OWN ROSTER: two names, and neither is a
+                        subscription. The ≤2-hook ceiling I9 polices is the
+                        boundary SHELL's, which this module does not touch —
+                        it adds no hook to any boundary at all"
+                (is (= ["useContext" "useRef"] tail)
+                    (str "the frame hook and the instance cell. Raw tail: "
+                         (pr-str (drop 2 names))))
+                (is (empty? (filter #{"useSyncExternalStore" "useState" "useEffect"
+                                      "useLayoutEffect" "useMemo" "useCallback"}
+                                    tail))
+                    "no effect, no state, no second store subscription — the
+                     work happens in a ref callback, which is not a hook")))
+            (finally (when @handle (mount/release! @handle)))))))))

--- a/implementation/hicasso/test/re_frame/hicasso/overlay_dom_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/overlay_dom_cljs_test.cljs
@@ -59,11 +59,22 @@
     which leaves the page behind it live) reds the top-layer, inertness
     and stacking rows; dropping `close()` from the ref cleanup reds the
     focus row; a `document` listener added while open reds the census row.
-  - WIDEN the guard — deleting the `closing-slot` test in
-    `dismissal-handler` (leaving a handler that is right about every real
-    dismissal and wrong only about the module's own teardown) reds the
-    dispatch-count row; making `:open?` default true reds the closed-cost
-    row.
+  - WIDEN the guard — deleting the `newState` filter in
+    `dismissal-handler`, which leaves a handler with the correct SHAPE
+    (it is the platform's own dismissal event, on the right element, with
+    the author's own intent) and one wrong direction: `beforetoggle` also
+    fires on the way IN, so an overlay dispatches `:on-dismiss` when it
+    OPENS. That reds the dispatch-count rows with `(not (= 1 2))`.
+    Widening `:open?` to default true reds the closed-cost row.
+
+  A third sabotage is recorded here because it did NOT redden, and the
+  module changed as a result. The popover's teardown fires the same
+  `beforetoggle` a light dismiss fires, so the first draft carried a
+  per-node closing mark to tell them apart; deleting the mark left every
+  row green. React does not deliver an event from a fiber it is deleting,
+  so the mark was unreachable code. It is gone, and
+  [[the-platform-dismissal-arrives-as-an-intent-and-the-teardown-does-not]]
+  is what holds the property in its place.
 
   ## What is measured against what
 
@@ -369,6 +380,17 @@
                 (is (nil? ($ "dialog"))
                     "so the element left because app-db said so, and not
                      because the platform closed it behind app-db's back"))))
+
+          (testing "and the modal needs no guard for its own teardown: a
+                    programmatic `close()` fires `close` and never `cancel`, so
+                    an application closing its own dialog reports no dismissal"
+            (go! [::opened :m])
+            (is (some? ($ "dialog")) "premise: open again, and genuinely open")
+            (let [before (get-in (db) [:dismissed :m] 0)]
+              (go! [::closed :m])
+              (is (nil? ($ "dialog")))
+              (is (= before (get-in (db) [:dismissed :m] 0))
+                  "the count did not move")))
           (finally (mount/release! handle)))))))
 
 ;; --- the stack -------------------------------------------------------------
@@ -492,15 +514,33 @@
               "premise: `::noted` deliberately left the flag TRUE, so the
                element is still mounted and its teardown is still ahead")
 
-          (testing "THE GUARD: the module's own teardown hides the popover
-                    through the same door and fires the same `toggle` event —
-                    and dispatches nothing. A handler that were right about
-                    every real dismissal and wrong only about this one would
-                    double-count every close in the application"
+          (testing "tearing down an ALREADY-DISMISSED overlay adds nothing: its
+                    element is closed, so the module's `hide!` has nothing to do
+                    and fires no event at all"
             (go! [::closed :pa])
             (is (nil? ($ "#pop-a")) "the element is gone")
             (is (= 1 (get-in (db) [:dismissed :pa]))
-                "still one — the teardown is not a dismissal"))
+                "still one — the teardown is not a second dismissal"))
+
+          (testing "TEARDOWN OF A STILL-OPEN OVERLAY: the module hides it
+                    through the platform's own `hidePopover`, which fires the
+                    identical `beforetoggle` a light dismiss fires — and no
+                    dismissal is reported, because React delivers no event from
+                    a fiber it is deleting. This row is the whole of that claim:
+                    a first draft defended it with a per-node closing mark, and
+                    removing the mark reddened nothing, which is how the mark
+                    was found to be unreachable. If React's deletion order ever
+                    changes, THIS is what reds — and every close in the
+                    application would otherwise dispatch `:on-dismiss` twice"
+            (is (.matches ($ "#pop-b") ":popover-open")
+                "premise: B is genuinely open, so its teardown really does hide it")
+            (is (zero? (get-in (db) [:dismissed :pb] 0))
+                "premise: B has never been dismissed")
+            (go! [::closed :pb])
+            (is (nil? ($ "#pop-b")) "the element is gone")
+            (is (zero? (get-in (db) [:dismissed :pb] 0))
+                "and no dismissal was reported for a close the application asked
+                 for itself"))
           (finally (mount/release! handle)))))))
 
 ;; --- the census ------------------------------------------------------------

--- a/implementation/hicasso/test/re_frame/hicasso/overlay_dom_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/overlay_dom_cljs_test.cljs
@@ -15,10 +15,15 @@
   outlive its own listener, or stack under the overlay that opened before
   it. So every row here asserts a BEHAVIOUR the engine decides —
   `document.elementFromPoint`, `document.activeElement`, `:modal`,
-  `:popover-open` — and none asserts an attribute the module just wrote.
+  `:popover-open` — and none asserts an attribute the module just wrote. The
+  two headless rows are the exceptions that prove it: the placement table is a
+  VALUE, and an overlay's contents are the author's own markup, which
+  rf2-hic-043's L2 projections read without a browser at all.
 
   | claim | row |
   |---|---|
+  | a compass word is a `position-area`, and a misspelt one is not silently some other place | [[a-compass-word-is-a-position-area-and-an-unknown-one-passes-through]] |
+  | an overlay's contents are ordinary markup, and rf2-hic-043's projections read them | [[an-overlays-contents-are-ordinary-markup-and-the-a11y-kit-reads-them]] |
   | the top layer escapes an ancestor that clips and stacks | [[an-overlay-escapes-an-ancestor-that-clips-and-out-stacks-it]] |
   | a modal makes the rest of the document inert | [[a-modal-makes-the-document-behind-it-unfocusable]] |
   | closing through the platform's door returns focus | [[closing-through-the-platform-door-returns-focus-to-the-trigger]] |

--- a/implementation/hicasso/test/re_frame/hicasso/overlay_dom_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/overlay_dom_cljs_test.cljs
@@ -70,7 +70,10 @@
     ordinary design a dozen overlay libraries ship, which paints
     correctly, dismisses correctly and restores focus correctly — reds
     the closed-cost row with a live `HTMLDialogElement` where nil was
-    required.
+    required. Restoring a trigger's `anchor-name` UNCONDITIONALLY —
+    right on every single-overlay page, and the obvious way to write it —
+    reds the out-of-order row with a live panel jumping to the UA default
+    position, `trigger.left=0 panel.left=615.21875`.
 
   **Two sabotages did NOT redden, and both changed something.** They are
   recorded because a sabotage that stays green is the only kind that
@@ -818,6 +821,18 @@
                      :placement  :bottom-start
                      :id         "pop-a"}
     [:p "menu"]]
+   ;; A SECOND panel on the SAME trigger — a menu and a tooltip on one
+   ;; button. Each claim is its own ident, and each teardown must leave the
+   ;; other's alone.
+   ;; No `:on-dismiss`, so `popover="manual"` — a tooltip has nowhere to
+   ;; route a dismissal. That is also what lets it be open at the same time
+   ;; as the auto panel above: an auto popover joining the stack does not
+   ;; disturb a manual one.
+   [overlay/popover {:open?     (h/sub [::open? :pt])
+                     :anchor    "anchor-a"
+                     :placement :top-start
+                     :id        "pop-t"}
+    [:p "tip"]]
    [overlay/popover {:open?      (h/sub [::open? :px])
                      :on-dismiss [::dismissed :px]
                      :anchor     "no-such-element"
@@ -877,7 +892,45 @@
             (testing "HANDED BACK: teardown restores what the author wrote,
                       rather than clearing the property"
               (go! [::closed :pa])
-              (is (= "--mine" (.. trigger -style -anchorName)))))
+              (is (= "--mine" (.. trigger -style -anchorName))))
+
+            (testing "TWO PANELS, ONE TRIGGER, LIFO: a menu and a tooltip may
+                      share a button. Each claim saves what it found, so the
+                      claims nest and the author's own name comes back when the
+                      last one leaves"
+              (go! [::opened :pt])
+              (let [tip (.. trigger -style -anchorName)]
+                (is (not= "--mine" tip) "premise: the tooltip claimed it")
+                (go! [::opened :pa])
+                (is (not= tip (.. trigger -style -anchorName))
+                    "premise: the menu claimed it after")
+                (go! [::closed :pa])
+                (is (= tip (.. trigger -style -anchorName))
+                    "the menu's teardown gave the tooltip's claim back"))
+              (go! [::closed :pt])
+              (is (= "--mine" (.. trigger -style -anchorName))
+                  "and the last one out returns the author's own name"))
+
+            (testing "OUT OF ORDER: the panel that leaves is NOT the one that
+                      claimed last. An unconditional restore is right on every
+                      single-overlay page and here writes the trigger back to a
+                      name the OTHER, still-open panel is not anchored to —
+                      silently unanchoring a live overlay"
+              (go! [::opened :pt])
+              (go! [::opened :pa])
+              (let [menu (.. trigger -style -anchorName)]
+                (go! [::closed :pt])
+                (is (= menu (.. trigger -style -anchorName))
+                    "the still-open menu keeps the trigger")
+                (is (.matches ($ "#pop-a") ":popover-open")
+                    "premise: it really is still open")
+                (let [t (.getBoundingClientRect trigger)
+                      p (.getBoundingClientRect ($ "#pop-a"))]
+                  (is (< (js/Math.abs (- (.-left p) (.-left t))) 2)
+                      (str "and still positioned against it rather than at the "
+                           "UA default. trigger.left=" (.-left t)
+                           " panel.left=" (.-left p)))))
+              (go! [::closed :pa])))
 
           (testing "an `:anchor` naming no element is a no-op in this bead —
                     the panel opens in the top layer, visibly unanchored, and

--- a/implementation/hicasso/test/re_frame/hicasso/overlay_dom_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/overlay_dom_cljs_test.cljs
@@ -114,6 +114,7 @@
             [re-frame.hicasso.impl.mount :as mount]
             [re-frame.hicasso.impl.overlay :as impl-overlay]
             [re-frame.hicasso.overlay :as overlay]
+            [re-frame.hicasso.test :as ht]
             [re-frame.test-support :as test-support]))
 
 (def ^:private frame-id ::overlay)
@@ -169,6 +170,62 @@
             other placement"
     (is (= "botom-start" (impl-overlay/position-area :botom-start)))
     (is (not (contains? (set (vals impl-overlay/position-areas)) "botom-start")))))
+
+(h/defview menu-page [_]
+  [:div
+   [:button#trigger {:aria-haspopup "menu"} "Filter"]
+   [overlay/popover {:open?      (h/sub [::open? :m])
+                     :on-dismiss [::dismissed :m]
+                     :anchor     "trigger"
+                     :placement  :bottom-start}
+    [:ul {:role "menu"}
+     [:li [:button "Unread"]]
+     [:li [:button "Flagged"]]]]])
+
+(h/defview unnamed-menu-page [_]
+  [:div
+   [overlay/popover {:open?      (h/sub [::open? :m])
+                     :on-dismiss [::dismissed :m]}
+    [:ul {:role "menu"}
+     [:li [:button "Unread"]]
+     ;; An icon button nobody named — its glyph is a CSS background, so it
+     ;; carries no content to be named from. P12, the finding the corpus
+     ;; actually ships, and the one this page exists to have found.
+     [:li [:button.icon]]]]])
+
+(deftest an-overlays-contents-are-ordinary-markup-and-the-a11y-kit-reads-them
+  (let [t    (ht/tree [menu-page {}] {:subs {[::open? :m] true}})
+        menu (ht/find t #(= :menu (ht/role %)))]
+    (testing "premise: an overlay is a BOUNDARY CALL in the L2 tree. Its body
+              does not run — no hooks, no top layer, no refusal — so the kit
+              sees the author's own children and claims nothing whatever about
+              what the module renders around them"
+      (is (some? menu) "the author's own menu list is in the tree")
+      (is (nil? (ht/role (ht/find t #(= "hicasso/popover" (:view-id %)))))
+          "and the overlay boundary itself has no role, because it is not an
+           element — which is `role`'s own stated answer for a view-boundary"))
+
+    (testing "so the accessibility of what an author puts INSIDE an overlay is
+              decidable HEADLESS, on rf2-hic-043's projections, and needs none
+              of this suite's browser lane"
+      (is (= ["Filter" "Unread" "Flagged"]
+             (mapv #(ht/accessible-name t %)
+                   (ht/find-all t #(= :button (ht/role %)))))
+          "every control names itself from its own content — and the TRIGGER is
+           in the same list as the panel's items, which is the other half of
+           what the top layer buys: paint order changed, the tree did not")
+      (is (= [] (ht/unnamed-controls t))))
+
+    (testing "and the instrument can say otherwise: the same panel with one
+              icon-only button reports it. Without this arm the `[]` above is
+              an emptiness claim from a projection that might be ranging over
+              nothing at all — which it WAS, on the first draft, because
+              `:menuitem` is outside `interactive-roles` and every control in
+              the panel wore one"
+      (let [u     (ht/tree [unnamed-menu-page {}] {:subs {[::open? :m] true}})
+            found (ht/unnamed-controls u)]
+        (is (= 1 (count found)) (str "expected one unnamed control, got " (pr-str found)))
+        (is (= :button (ht/role (first found))))))))
 
 ;; ---------------------------------------------------------------------------
 ;; The DOM half

--- a/implementation/hicasso/test/re_frame/hicasso/overlay_dom_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/overlay_dom_cljs_test.cljs
@@ -233,8 +233,10 @@
                   "and the engine agrees it is IN the top layer, modally")
               (let [d (.getBoundingClientRect dialog)
                     c (.getBoundingClientRect ($ "#clip"))]
-                (is (> (.-bottom d) (.-bottom c))
-                    "its painted box is not contained by the box that clips it"))))
+                (is (or (< (.-top d) (.-top c)) (> (.-bottom d) (.-bottom c)))
+                    (str "its painted box is not contained by the 20px box that "
+                         "clips it. dialog=[" (.-top d) "," (.-bottom d) "] "
+                         "clip=[" (.-top c) "," (.-bottom c) "]")))))
           (finally (mount/release! handle)))))))
 
 (deftest a-modal-makes-the-document-behind-it-unfocusable
@@ -279,7 +281,7 @@
                    :on-dismiss [::dismissed :m]
                    :label      "Confirm"}
     [:button#first {:type "button"} "First"]
-    [:button#second {:type "button" :autofocus true} "Second"]]])
+    [:button#chosen {:type "button" :auto-focus true} "Chosen"]]])
 
 (deftest closing-through-the-platform-door-returns-focus-to-the-trigger
   (if-not (mount/browser?)
@@ -309,7 +311,7 @@
                    anywhere in the application")))
           (finally (mount/release! handle)))))))
 
-(deftest the-focus-one-shot-is-the-attribute-and-not-reacts-prop
+(deftest the-focus-one-shot-is-the-platforms-focus-delegate-and-not-reacts-autofocus
   (if-not (mount/browser?)
     (skip! ":node-test runs no dialog focusing steps")
     (do
@@ -318,20 +320,55 @@
         (try
           (mount/settle!)
           (go! [::opened :m])
-          (testing "THE ONE-SHOT: `:autofocus true`, unhyphenated, reaches the
-                    DOM as the attribute the platform's dialog-focusing steps
-                    read — so focus lands on the control the author named and
-                    not on the first focusable one"
-            (is (= "second" (.-id (.-activeElement js/document)))
-                (str "the autofocus target has focus, not #first. The spelling "
-                     "is load-bearing: `:auto-focus` camelCases to React's own "
-                     "`autoFocus` prop, which React applies by calling .focus() "
-                     "during the commit WITHOUT emitting the attribute — one "
-                     "child-first commit before showModal runs its own focusing "
-                     "steps and moves focus to the first focusable control. "
-                     "Active: " (.-id (.-activeElement js/document))))
-            (is (.hasAttribute ($ "#second") "autofocus")
-                "and the attribute really is in the DOM, which is why it worked"))
+          (testing "THE ONE-SHOT, as the engine actually performs it: opening
+                    runs the platform's own dialog-focusing steps, which take
+                    the FOCUS DELEGATE — the first element carrying the
+                    `autofocus` ATTRIBUTE, or, when there is none, the first
+                    focusable control in tree order"
+            (is (= "first" (.-id (.-activeElement js/document)))
+                (str "focus is on the first focusable control. Active: "
+                     (.-id (.-activeElement js/document))))
+            (is (not (.hasAttribute ($ "#chosen") "autofocus"))
+                (str "and `:auto-focus true` did NOT put the attribute in the "
+                     "DOM: it camelCases to React's own `autoFocus` prop, which "
+                     "React implements by calling .focus() during the commit — "
+                     "child-first, one commit BEFORE this module's ref attaches "
+                     "and calls showModal, at which point the dialog is still "
+                     "display:none and nothing inside it is focusable. React "
+                     "rejects the unhyphenated `:autofocus` outright, with "
+                     "`Invalid DOM property autofocus. Did you mean autoFocus?`, "
+                     "and emits no attribute either. So NEITHER spelling reaches "
+                     "the platform, and the recipe is tree order.")))
+          (finally (mount/release! handle)))))))
+
+(deftest a-close-request-on-a-modal-arrives-as-an-intent
+  (if-not (mount/browser?)
+    (skip! ":node-test has no dialog to make a close request of")
+    (do
+      (fresh!)
+      (let [handle (mount/root! (mount/fresh-container!) frame-id [trigger-page {}])]
+        (try
+          (mount/settle!)
+          (go! [::opened :m])
+          (let [dialog ($ "dialog")]
+            (if-not (fn? (.-requestClose dialog))
+              (skip! (str "this engine has no HTMLDialogElement.requestClose, "
+                          "which is the only close request reachable without "
+                          "trusted input — a real Escape key is rf2-hic-049's"))
+              (testing "THE ROUND TRIP: a close request takes the platform's
+                        `cancel` path — the same one Escape and a `closedby`
+                        backdrop click take — and arrives in app-db as the
+                        author's own intent, which is what closes the overlay"
+                (is (zero? (get-in (db) [:dismissed :m] 0)) "premise: nothing yet")
+                (.requestClose dialog)
+                (mount/settle!)
+                (is (= 1 (get-in (db) [:dismissed :m]))
+                    "the intent landed exactly once")
+                (is (false? (get-in (db) [:open :m]))
+                    "and the author's handler is what wrote the open flag false")
+                (is (nil? ($ "dialog"))
+                    "so the element left because app-db said so, and not
+                     because the platform closed it behind app-db's back"))))
           (finally (mount/release! handle)))))))
 
 ;; --- the stack -------------------------------------------------------------
@@ -429,6 +466,10 @@
             (go! [::opened :pm])
             (is (.matches ($ "#pop-m") ":popover-open"))
             (is (= "manual" (.getAttribute ($ "#pop-m") "popover")))
+            ;; A's flag is still TRUE while its element is closed — `::noted`
+            ;; left it that way on purpose — so it has to be cleared before it
+            ;; can be set again, or the re-render never happens.
+            (go! [::closed :pa])
             (go! [::opened :pa])
             (is (.matches ($ "#pop-a") ":popover-open"))
             (is (.matches ($ "#pop-m") ":popover-open")
@@ -565,16 +606,23 @@
                   (is (zero? (:intervals open-log)))
                   (is (zero? (:observers open-log)))))
 
-              (go! [::closed :pa])
-              (let [closed-log @log]
-                (testing "TEARDOWN: every element listener the open window
-                          recorded is matched by a removal"
-                  (is (nil? ($ "#pop-a")))
-                  (is (>= (count (:removed closed-log)) (count (:element closed-log)))
-                      (str "added " (pr-str (:element closed-log))
-                           ", removed " (pr-str (:removed closed-log))))
-                  (is (= [] (:global closed-log))
-                      "and still nothing global, on the way out either")))
+              (let [node ($ "#pop-a")]
+                (go! [::closed :pa])
+                (let [closed-log @log]
+                  (testing "TEARDOWN: the element leaves the document, and the
+                            listeners leave with it. React does not call
+                            `removeEventListener` for a discarded node and does
+                            not need to — a disconnected node is unreachable
+                            from any event path, which is exactly why an
+                            ELEMENT-scoped listener cannot be idle and a
+                            `document`-scoped one can"
+                    (is (nil? ($ "#pop-a")))
+                    (is (false? (.-isConnected node))
+                        "the node this window's listeners were attached to is
+                         no longer in the document")
+                    (is (= [] (:global closed-log))
+                        (str "and still nothing global, on the way out either: "
+                             (pr-str (:global closed-log)))))))
               (finally (restore!))))
           (finally (mount/release! handle)))))))
 
@@ -674,7 +722,15 @@
                      :anchor     "no-such-element"
                      :placement  :bottom-start
                      :id         "pop-x"}
-    [:p "unanchored"]]])
+    [:p "unanchored"]]
+   ;; Room BELOW the trigger, so `scrollIntoView` can put it at the centre
+   ;; of the viewport rather than at the bottom edge. A `[popover]` is
+   ;; `position: fixed`, so its containing block is the viewport and a
+   ;; `block-end` placement with no viewport left under the anchor is
+   ;; clamped — which is the engine being right and the fixture being
+   ;; wrong. This lane's page carries every earlier suite's container, so
+   ;; without a spacer the trigger lands at the very end of the document.
+   [:div {:style {:height "1200px"}}]])
 
 (deftest the-anchor-is-claimed-while-open-and-handed-back-on-teardown
   (if-not (mount/browser?)
@@ -688,15 +744,28 @@
             (is (= "--mine" (.. trigger -style -anchorName))
                 "premise: the trigger carries the author's own anchor name")
 
+            ;; A `[popover]` is `position: fixed`, so its containing block is
+            ;; the VIEWPORT: a trigger scrolled far out of view leaves no
+            ;; in-viewport region below it and the used position is clamped.
+            ;; This lane's page carries every earlier suite's container, so the
+            ;; trigger starts tens of thousands of pixels down.
+            (.scrollIntoView trigger #js {"block" "center"})
             (go! [::opened :pa])
             (let [panel ($ "#pop-a")]
               (testing "ANCHORED: the panel sits against the trigger, and the
                         engine is what put it there"
                 (let [t (.getBoundingClientRect trigger)
-                      p (.getBoundingClientRect panel)]
+                      p (.getBoundingClientRect panel)
+                      cs (js/getComputedStyle panel)]
                   (is (>= (.-top p) (- (.-bottom t) 1))
                       (str ":bottom-start puts the panel below the trigger. "
-                           "trigger.bottom=" (.-bottom t) " panel.top=" (.-top p)))
+                           "trigger=[" (.-top t) "," (.-bottom t) "] "
+                           "panel=[" (.-top p) "," (.-bottom p) "] "
+                           "position=" (.-position cs)
+                           " position-anchor=" (.getPropertyValue cs "position-anchor")
+                           " position-area=" (.getPropertyValue cs "position-area")
+                           " anchor-name(trigger)="
+                           (.getPropertyValue (js/getComputedStyle trigger) "anchor-name")))
                   (is (< (js/Math.abs (- (.-left p) (.-left t))) 2)
                       (str "and left-aligned with it. trigger.left=" (.-left t)
                            " panel.left=" (.-left p)))))


### PR DESCRIPTION
Closes rf2-hic-052.

`re-frame.hicasso.overlay` — an optional module with two heads, `overlay/modal`
and `overlay/popover`, on the browser's own top layer. Its shape is
`re-frame.hicasso.motion`'s exactly: a thin door onto one private engine, absent
from any application that never requires it.

Rebased over PR #7963 (rf2-hic-043), and it reuses that bead's L2 projections
rather than growing a second a11y helper.

## The posture

The top layer, the focus trap, the inertness, the LIFO stack, the light dismiss
and the anchor tracking all belong to the browser. **This module owns exactly one
thing about them, and that thing is the imperative call.** An element does not
enter the top layer by having an attribute — `<dialog open>` is a non-modal
dialog in ordinary flow, and a `popover` element nothing calls `showPopover` on
is `display: none`. So the module calls `showModal` / `showPopover` in the ref
callback, which React invokes after the node is in the document and before the
browser paints, and calls the inverse before React takes the node away.

There is therefore no portal, no focus-trap loop, no `document` key listener, no
outside-click listener, no z-index policy, no scroll or resize listener, no
`ResizeObserver`, no measurement of any kind, and no positioning engine. Each of
those is a reimplementation of something the platform now does better, and each
is a failure mode `requirements-mine.md`'s R-B row records the corpus shipping.

**The open flag cannot acquire a second owner.** `:open?` false renders nil; the
platform's dismissal is routed back as an ordinary intent (`:on-dismiss`); and
where there is nowhere to route it the platform is told not to dismiss at all,
in its own vocabulary — `closedby="none"`, `popover="manual"`. The two-owners
state is unreachable rather than discouraged.

## Quality gates

Each run alone, foreground, nothing appended, exit code captured on the same
command line. Every baseline is this branch's own, measured by holding the new
suite file out and re-running — none is quoted from anywhere.

| gate | command | exit | result |
|---|---|---|---|
| browser lane (PR-blocking correctness) | `npm run test:browser` | **0** | Ran 1364 tests containing 8420 assertions. 0 failures, 0 errors. |
| browser lane — BASE (suite held out) | same | **0** | Ran 1349 tests containing 8320 assertions. 0 failures, 0 errors. |
| node lane, focused hicasso | `npx shadow-cljs compile node-test-hicasso && node out/node-test-hicasso.js` | **0** | Ran 916 tests containing 3785 assertions. 0 failures, 0 errors. |
| node lane, focused — BASE (suite held out) | same | **0** | Ran 901 tests containing 3757 assertions. |
| hicasso invariants | `npm run test:hicasso-invariants` | **0** | `motion, overlay, native unreachable from the public door` |
| hicasso release (`:advanced`, `goog.DEBUG=false`) | `npm run build:hicasso-release` | **0** | 5 erasure sentinels absent + 3 positive controls present; 2 isolation sentinels absent + 4 positive controls present |
| node lane, full | `npm run test:cljs` | **0** | Ran 13538 tests containing 68230 assertions. 0 failures, 0 errors. |
| fast-PR spine | `sh scripts/test-fast-pr.sh` | **0** | `PASS fast PR spine` |

The first six rows and both baselines were captured on THIS head's base,
`21cb4c4ed8`. `npm run test:cljs` and the spine were captured on `76d161d571`,
one rebase earlier: `main` moved four times during this bead, the diff is four
files (three new), and every rebase was conflict-free with an identical
`git diff --stat`.

**One environmental red, recorded rather than hidden.** The spine's
`test:hicasso-compile` step aborted once with
`There is insufficient memory for the Java Runtime Environment` and
`The paging file is too small for this operation to complete` — a box under
concurrent load, not a finding. The JVM crash dump was removed and the spine
re-run WHOLE; the pass above is that second run.

`python scripts/check_fast_pr_gap.py --list` (exit 0) reports **97 required
checks the spine does not decide**. The ones that bear on this diff are all run
above and separately — the browser DOM lane, `npm run test:cljs`,
`npm run build:hicasso-release` (a step inside the CLJS job) and the repo
invariant checks. Nothing here touches docs, skills, MCP, the playground, or any
JVM artefact, so the rest are surface-gated away from this change.

## Both sabotage directions, per assertion class

Seven sabotages. **Three of them stayed green, and every one of those changed
either the module or the instrument** — those are the ones worth reading.

### REMOVE the behaviour

| sabotage | rows reddened | captured red |
|---|---|---|
| `showModal` → `show`: a legal call on the same element that opens the same dialog and fires the same events, and leaves the page behind it live | top layer, inertness, LIFO stacking | 8 failures — `(not (within? #object[HTMLDialogElement] #object[HTMLDivElement]))`; `:modal` count `(not (= 1 0))`; the outside control taking focus, `(not (not true))` |
| drop `close()` from the ref cleanup and let React simply remove the node | focus restore | 1 failure — `(not (identical? #object[HTMLButtonElement] #object[HTMLBodyElement]))`: focus lands on `<body>` |
| `document.addEventListener("keydown", …)` in the ref callback | listener census | 2 failures — `a global listener appeared: [keydown]` |

### WIDEN the guard — a legal near-miss each time

| sabotage | rows reddened | captured red |
|---|---|---|
| delete the `newState` filter in `dismissal-handler`. Correct shape — the platform's own dismissal event, on the right element, carrying the author's own intent — and one wrong direction: `beforetoggle` fires on the way IN as well | dispatch-count rows | 5 failures, 3 errors — `(not (= 1 2))`: every overlay dispatches `:on-dismiss` when it OPENS |
| render the element ALWAYS and merely not show it while closed — the design a dozen overlay libraries ship, which paints, dismisses and restores focus correctly | closed-cost row (and 35 more) | 36 failures — `expected (nil? ($ "dialog"))`, `actual (not (nil? #object[HTMLDialogElement]))` |
| restore a trigger's `anchor-name` UNCONDITIONALLY — right on every single-overlay page, and the obvious way to write it | out-of-order anchor row | 2 failures — `(not (= "--rf-overlay-20" "--mine"))`, and the still-open panel jumping to the UA default: `trigger.left=0 panel.left=615.21875` |

### The three that stayed GREEN

**1. A guard that was unreachable.** `hidePopover()` in the ref cleanup fires the
same `beforetoggle` a light dismiss fires, so the first draft carried a per-node
closing mark to tell them apart. Deleting the mark left every row green: React
does not deliver an event from a fiber it is in the middle of deleting. The mark
is **gone**, and `the-platform-dismissal-arrives-as-an-intent-and-the-teardown-does-not`
holds the property in its place — after that row was rewritten to tear down a
popover that is *genuinely still open*, which its first version never did.

**2. A census that could not fail.** The `document.addEventListener` sabotage
reddened nothing on its first run, because the INSTRUMENT was broken rather than
the module: its patched `addEventListener` was a variadic ClojureScript fn, so
`this` was never the EventTarget, every target classified as an element, and
`:global` could not become non-empty however hard the module tried. The census is
now `this`-free — an own-property wrapper per global target, closing over the
target it belongs to — and `census-sees-a-global!` puts a real listener on
`document` and requires it recorded before any emptiness claim is made.

**3. An a11y projection ranging over nothing.** `(= [] (ht/unnamed-controls t))`
passed on a panel of `role="menuitem"` buttons — because `:menuitem` is outside
the kit's `interactive-roles`, so the projection ranged over an empty set. The
fixture now uses controls the projection actually covers, and a second page with
one icon-only button proves it can answer non-empty.

## What is asserted, and what could not be

Fifteen rows. Thirteen assert a behaviour the engine decides —
`document.elementFromPoint`, `document.activeElement`, `:modal`,
`:popover-open`, `getBoundingClientRect`, `isConnected` — and none asserts an
attribute the module has just written. Two are headless: the `:placement`
compass table (including that a misspelt word is emitted verbatim rather than
silently substituting some other placement), and the L2 a11y row below.

**Trusted input is the stated gap.** A real Escape and a real outside click
cannot be synthesised in-page; Chromium refuses an untrusted `KeyboardEvent` for
a close request by design. Every dismissal witnessed here is driven through the
platform's own programmatic path — opening a second `popover=auto`, which makes
the engine light-dismiss the first through the same code and the same event, and
`HTMLDialogElement.requestClose()`, which takes the same `cancel` path Escape
takes. Keyboard conduct under a real key press is **rf2-hic-049**'s, which this
bead unblocks, and the suite names it rather than leaving it implied.

## Reused rather than rebuilt

- **rf2-hic-043's L2 projections** (`ht/role`, `ht/accessible-name`,
  `ht/unnamed-controls`) — an overlay is a boundary CALL in the L2 tree, so its
  body never runs and the kit sees the author's own children. The a11y of what
  goes inside an overlay is therefore decidable HEADLESS, and the row asserts it
  there rather than in a browser. It also pins the other half of what the top
  layer buys: the trigger and the panel's items are in one tree, so
  `ht/find-all` returns `["Filter" "Unread" "Flagged"]` — paint order changed,
  the tree did not.
- `re-frame.hicasso.hook-probe` — the existing dispatcher-level probe, for the
  budget row. No second counter.
- `collector/shell-hook-ledger`, `collector/frame-dispatch`, `intent/with-frame`,
  `codec/as-element`, `codec/mark-boundary!` — the same seams
  `impl.presence-react` uses, for the same reasons.
- `impl.mount`'s `browser?` / `fresh-container!` / `root!` / `settle!` /
  `release!`, and the package's `skip!` idiom for the node lane.
- `check_optional_module_reachability.py` — one roster row, not a second gate.

## The budget

**Two React hooks** per component: one `useContext` (the frame, for the reason
`impl.presence-react` documents — an overlay's children are hiccup data lowered
in this component's render) and one `useRef` (the instance cell holding the
generated anchor ident and the single stable ref callback). No effect, no state,
no second store subscription; the work happens in a ref callback, which is not a
hook.

**I9 holds at two.** The budget row counts at React's own dispatcher and asserts
`collector/shell`'s roster is still exactly
`["useContext" "useSyncExternalStore"]` before it reads the module's. Nothing
here adds a hook to any boundary. (`impl.presence-react` is the precedent and
spends four; I9's own words are that an optional capability may not add a hook
*to every boundary*.)

## What did not hold at source, and what I stopped on

- **No new error id, and this is a deliberate refusal.** The guide promises
  `:rf.error/hicasso-overlay-anchor-missing` when `:anchor` names no element.
  `docs/design/hicasso/product/complaints.md` carries it as RESERVED and
  explicitly spelling-provisional pending the naming packet (**rf2-hic-065**),
  which this bead blocks; and R6 of the complaint-catalogue gate requires every
  live row to have a **`spec/009-Instrumentation.md`** row, which is HOT ZONE for
  this bead. Minting it would both pre-empt a ruling and cross a fence. A missing
  anchor is therefore a no-op today: the panel opens in the top layer, visibly
  unanchored. A row asserts that, and the door says why.
- **`:exit-ms` declined.** Exit-animation retention is `re-frame.hicasso.motion`'s
  subject and already has a machine, a terminal bound and a witness. A second
  retention clock here is the duplicate `motion` exists to prevent. Composing the
  two is worth a follow-up; it is not among this bead's deliverables.
- **The guide's focus recipe does not work, measured.**
  `docs/design/hicasso/draft-guide/13-overlays-and-focus.md` teaches
  `:auto-focus true` on the control that should receive focus. It camelCases to
  React's own `autoFocus` prop, which React implements by calling `.focus()`
  during the commit — child-first, one commit BEFORE this module's ref attaches,
  at which point the dialog is still `display: none` and nothing inside it is
  focusable. The unhyphenated `:autofocus` is rejected outright by React
  (`Invalid DOM property autofocus. Did you mean autoFocus?`) and emits no
  attribute either. **Neither spelling reaches the platform.** The recipe the
  module can honestly teach is the platform's own focus delegate: tree order. The
  row pins it and the door states it; the draft guide is a live operator surface
  and is not touched here.
- **Hot zone untouched.** No `spec/**`, no `.github/workflows/**`, no
  `implementation/shadow-cljs.edn`, no `implementation/deps.edn`.
- **No npm dependency**, and none was wanted.
- **Published snapshots untouched**: `specification.md`, `decision-brief.md`,
  `lanes/**`, and the draft guide.

## Placement, and the lane that compiles it

| artefact | compiled by |
|---|---|
| `implementation/hicasso/src/re_frame/hicasso/overlay.cljs` | `hicasso/src` is already a `:source-paths` entry — reached by `:node-test`, `:node-test-hicasso` and `:browser-test` through the suite's require, and deliberately NOT by `:hicasso-release`, which is the reachability claim |
| `implementation/hicasso/src/re_frame/hicasso/impl/overlay.cljs` | same |
| `implementation/hicasso/test/re_frame/hicasso/overlay_dom_cljs_test.cljs` | `:node-test` (`cljs-test$`), `:node-test-hicasso` (`^re-frame\.hicasso\..+-cljs-test$`) and `:browser-test` (`^(?!re-frame\.freehand\.bench\.).*-dom-cljs-test$`) |
| the roster row in `check_optional_module_reachability.py` | `npm run test:hicasso-invariants` |

Proved rather than asserted: the browser lane's own output names
`re-frame.hicasso.overlay-dom-cljs-test`, and the invariants gate's own output
names `overlay`. No build id was added and no `:ns-regexp` was widened.

## Naming

`docs/design/hicasso/product/naming-ledger.md` row 30 is OPEN and settles at the
naming packet (rf2-hic-065). The heads and options here are the taught spellings
— `overlay/popover`, `overlay/modal`, `:open?`, `:on-dismiss`, `:anchor` (a DOM
id), `:placement` (compass words), `:label`, `:light-dismiss?` — minus
`:exit-ms`, declined above. Every other key is an ordinary attribute and reaches
the element unrenamed, so `:class`, `:style`, `:role`, `:id`, `:data-*` and the
platform's own event attributes all work exactly as they do at a native tag.
