### PR TITLE
feat(migration): the corpus census — the reporter, before shadow comparison (rf2-hic-055)

### DIFF
--- a/migration/reagent-to-hicasso/codemod/README.md
+++ b/migration/reagent-to-hicasso/codemod/README.md
@@ -1,4 +1,4 @@
-# The Reagent `[:>]` → Hicasso migration codemod (the fixer)
+# The Reagent → Hicasso migration reporter, and the `[:>]` fixer
 
 A source-text tool that reads a consumer's Reagent `.cljs` namespaces and repairs
 the props dialect at every foreign crossing, so that a codebase whose `[:> …]`
@@ -28,6 +28,51 @@ clojure -M:run --report out.edn src/           # choose where the report goes
 The exit code is `0` for any run that completed and `1` only when a file could
 not be read or written. **A migration tool that fails a build because a
 consumer's code needs a human decision is a tool that gets run once.**
+
+## The report has two halves, and they answer different questions
+
+Everything below this section is about the **fixer**, whose population is the
+`[:>]`-family crossing. That population is not a Reagent codebase, and the
+difference is not small. Run over this repository's own 81-file example corpus
+the fixer reports **zero entries** — the corpus crosses into React nowhere — and
+a migrator reading that report sees eighty-one files that are not mentioned.
+
+So the same run also produces a **census**, under `:census` in the report, whose
+population is the **Reagent API call site**: `r/atom`, `r/with-let`,
+`r/create-class`, `r/as-element`, `r/cursor`, `r/reactify-component`, root
+mounting, and the rest of the roster in
+`src/re_frame/migration/hicasso/census.clj`. On that same corpus it reports
+**62 sites across 28 files**, one of them the `with-let` whose teardown no
+mechanical edit can carry.
+
+| Half | Population | Addressed at | Verdicts |
+|---|---|---|---|
+| fixer (`:entries`) | `[:>]`-family crossing sites | the site | rewrote / refused, in the classes below |
+| census (`:census`) | Reagent API call sites | the call | `:mechanical`, `:human-decision`, `:runtime-blocker` |
+
+*(4 columns; 2 body rows.)*
+
+**They are different estimands and neither is a denominator for the other.** The
+report names both, and the census summary always emits all three verdict
+buckets — including `:mechanical 0`, which is a measurement rather than an
+omission: every mechanical rewrite this tool family knows is a W-rule, and every
+W-rule sits at a crossing.
+
+**What the census cannot resolve, it reports.** `#?(:cljs [reagent.core :as r])`
+is the only legal way to require Reagent from a `.cljc` file and the reader
+binds nothing for it, so before the census such a file was silently a file with
+no Reagent in it — W4 and W5 dead, every API in it unnamed, and the report
+non-empty enough (`:>` needs no alias) that nothing looked wrong. It is now
+`:unresolved-reagent-require` at the `ns` form, with every qualified
+roster-named call in the file reported as `:unresolved-alias`. Three files under
+`examples/capabilities/ssr/` are real instances; so is every namespace of a
+project that vendors Reagent under an inlined name.
+
+**What it cannot name, it does not count.** A Form-2 component is a `defn`
+returning a `fn` and nothing else marks it; a structural test for that would
+report every higher-order function in the corpus. The `r/atom` such a component
+closes over is on the roster, and the shape itself is left uncounted and said
+so. A confident wrong number is worse than a stated silence.
 
 ## The two laws
 
@@ -184,6 +229,18 @@ plain `let`/`fn`/`apply`, with no Reagent left in it — and asserts the capture
 semantics directly, running the design's stated shape alongside to show the
 amendment is load-bearing. `shared_rule_test.clj` asserts that the slot rule
 this tool asks is the shared one and not a copy.
+
+`census_test.clj` gates the census on **both** ways a census fails — answering
+nothing, and answering too much. The second control is not decoration: it caught
+two live over-reports while the namespace was being written. An `ns` DOCSTRING
+discussing `reagent.ratom/run!` in prose made five clean example files read as
+five migration blockers, and `clojure.core`'s `(atom nil)`, one line above the
+`rdc/render` that is the genuine finding in the SSR examples, read as a second
+finding. A third defect surfaced from the other direction, by cross-checking the
+census against the text it is supposed to outperform: `^:cljstyle/ignore (ns …)`
+was not being read as an `ns` form at all, so **the whole file's aliases went
+unbound** — W4 and W5 dead in it, every Reagent API in it unnamed, and nothing
+looking wrong.
 
 ## One dependency, deliberately
 

--- a/migration/reagent-to-hicasso/codemod/src/re_frame/migration/hicasso/census.clj
+++ b/migration/reagent-to-hicasso/codemod/src/re_frame/migration/hicasso/census.clj
@@ -1,0 +1,358 @@
+(ns re-frame.migration.hicasso.census
+  "The corpus census — the REPORTER's second half, and the one that
+  answers *what is in this codebase* rather than *what can I fix*.
+
+  ## Why there are two halves at all
+
+  The fixer next door has a report, and it is exhaustive over its own
+  population: every `[:>]`, `[:r>]`, `[:f>]` and `(r/adapt-react-class …)`
+  head the tool reached. That population is a **crossing**. It is not a
+  Reagent codebase.
+
+  A file whose whole Reagent surface is
+
+      (defn counter []
+        (let [n (r/atom 0)]
+          (fn [] [:div {:on-click #(swap! n inc)} @n])))
+
+  contains no crossing, so the fixer walks it and reports NOTHING — not
+  \"clean\", not \"nothing to do\": nothing. A migrator reading that report
+  sees a file that is not mentioned, and a file that is not mentioned is
+  the one shape a report must never make ambiguous. Reagent's local
+  reactive cell is the single most common thing a Hicasso migration has to
+  answer for, and it was invisible.
+
+  So the census walks the same files for the **Reagent API surface**, and
+  the two halves partition the question rather than the population:
+
+  | Half | Estimand | Addressed by |
+  |---|---|---|
+  | fixer (`:entries`) | `[:>]`-family crossing SITES | site line/col |
+  | census (`:census`) | Reagent API CALL SITES | call line/col |
+
+  *(3 columns; 2 body rows.)*
+
+  They are different estimands and both are named, so neither is a
+  denominator for the other. A `(r/atom …)` inside a crossing's props is
+  one crossing site to the fixer and one call site here; the numbers are
+  not double-counted because they are not the same count.
+
+  ## The law this file exists to obey
+
+  **What cannot be resolved is REPORTED, never skipped.** [[ns-context]]
+  answers `#{}` for a require the reader cannot read, and the common one
+  is not exotic — `#?(:cljs [reagent.core :as r])` is the ONLY legal way
+  to require Reagent from a `.cljc` file. Before this namespace, such a
+  file was silently a file with no Reagent in it: every `r/atom`,
+  `r/as-element` and `(r/partial …)` in it invisible, W4 and W5 dead, and
+  the report non-empty enough (the `:>` head needs no alias) that nobody
+  would suspect a hole. That is a census that cannot fail, which is a
+  census that cannot be believed.
+
+  It is now `:unresolved-reagent-require`, at the `ns` form's own line, and
+  every roster-named call in such a file is `:unresolved-alias` with the
+  symbol it could not bind. The FIXER's blindness is unchanged and
+  deliberate — a fixer that starts rewriting `.cljc` files it previously
+  could not see is a behaviour change, and this is a reporter — so the
+  census's job is to make the hole loud, not to paper over it.
+
+  ## What it does not guess
+
+  A Form-2 component is a `defn` returning a `fn`, and nothing else marks
+  it. There is no roster to consult, and a structural test would report
+  every higher-order function in the corpus as a migration blocker. The
+  census names what it can name: the `r/atom` a Form-2 almost always
+  closes over is on the roster, and the shape it cannot name it does not
+  count. A confident wrong number is worse than a stated silence."
+  (:require [clojure.string :as str]
+            [re-frame.migration.hicasso.rewrite :as rw]
+            [rewrite-clj.parser :as p]
+            [rewrite-clj.zip :as z]))
+
+;; ---------------------------------------------------------------------------
+;; The roster
+;; ---------------------------------------------------------------------------
+
+(def surface
+  "Reagent's public API, and what a Hicasso migration owes each entry.
+
+  One row per callable. The `:class` is what the report says; the
+  `:verdict` is the migrator's triage bucket, and the three buckets are
+  the ones the migration page already teaches — **mechanical**, **human
+  decision**, **runtime blocker**.
+
+  Nothing here is `:mechanical`. That is a FINDING, not an omission: every
+  mechanical rewrite the tool family knows lives in the fixer's W1–W6, and
+  those all sit at a crossing. Outside a crossing, Reagent's API asks for a
+  state-ownership or lifecycle decision that no source reader can make.
+  [[summarise]] therefore emits `:mechanical 0` explicitly rather than
+  leaving the key absent, so an empty bucket reads as a measurement."
+  '{atom                      {:class :local-reactive-cell     :verdict :runtime-blocker}
+    cursor                    {:class :derived-cell            :verdict :runtime-blocker}
+    track                     {:class :derived-cell            :verdict :runtime-blocker}
+    track!                    {:class :derived-cell            :verdict :runtime-blocker}
+    reaction                  {:class :derived-cell            :verdict :runtime-blocker}
+    make-reaction             {:class :derived-cell            :verdict :runtime-blocker}
+    run!                      {:class :derived-cell            :verdict :runtime-blocker}
+    with-let                  {:class :with-let                :verdict :human-decision}
+    create-class              {:class :lifecycle-class         :verdict :runtime-blocker}
+    as-element                {:class :as-element              :verdict :runtime-blocker}
+    reactify-component        {:class :outward-bridge          :verdict :human-decision}
+    adapt-react-class         {:class :adapt-react-class       :verdict :human-decision}
+    create-element            {:class :react-create-element    :verdict :human-decision}
+    merge-props               {:class :props-helper            :verdict :human-decision}
+    partial                   {:class :reagent-partial         :verdict :human-decision}
+    dom-node                  {:class :component-introspection :verdict :runtime-blocker}
+    current-component         {:class :component-introspection :verdict :runtime-blocker}
+    props                     {:class :component-introspection :verdict :runtime-blocker}
+    children                  {:class :component-introspection :verdict :runtime-blocker}
+    argv                      {:class :component-introspection :verdict :runtime-blocker}
+    state                     {:class :component-introspection :verdict :runtime-blocker}
+    state-atom                {:class :component-introspection :verdict :runtime-blocker}
+    set-state                 {:class :component-introspection :verdict :runtime-blocker}
+    replace-state             {:class :component-introspection :verdict :runtime-blocker}
+    force-update              {:class :render-control          :verdict :human-decision}
+    force-update-all          {:class :render-control          :verdict :human-decision}
+    flush                     {:class :render-control          :verdict :human-decision}
+    next-tick                 {:class :render-control          :verdict :human-decision}
+    after-render              {:class :render-control          :verdict :human-decision}
+    render                    {:class :root-mount              :verdict :human-decision}
+    unmount-component-at-node {:class :root-mount              :verdict :human-decision}
+    create-root               {:class :root-mount              :verdict :human-decision}
+    hydrate-root              {:class :root-mount              :verdict :human-decision}})
+
+(def ^:private notes
+  "One recovery sentence per class, in the migrator's vocabulary. The
+  report's fourth property (§7.4) is that a refusal names the fix, and a
+  census entry is a refusal with a wider fence than the fixer's."
+  {:local-reactive-cell
+   (str "Reagent's local reactive cell. Hicasso has NO view-local state tier at all, so this "
+        "is not a syntax change: decide where the fact lives — an app-db address, the forms "
+        "module's draft, or inside a declared native host if it is genuinely widget mechanics "
+        "and not an application fact.")
+
+   :derived-cell
+   (str "A Reagent derived cell — `cursor`, `track`, `reaction`, `run!`. In Hicasso a derived "
+        "value is a layered subscription, registered once and read at the point of use. Port "
+        "the derivation to a `sub`; a cell created inside render has no home here.")
+
+   :with-let
+   (str "`r/with-let` gives a render body a once-per-mount binding and a `finally` teardown. "
+        "The binding half is an ordinary `let`. The TEARDOWN half is the part that needs a "
+        "decision — durable state belongs outside render, so the cleanup becomes an unmount "
+        "event or a declared host's release path, and it will not survive a mechanical edit.")
+
+   :lifecycle-class
+   (str "A form-3 component. React lifecycle is React's, not Hicasso's: port it to callback "
+        "refs, or to a named native component that owns its own lifecycle behind a declared "
+        "host.")
+
+   :as-element
+   (str "`r/as-element` lowers Hiccup for a foreign caller. Hicasso's counterpart is "
+        "`h/as-element` under a declared `:render` callback contract — and the closure usually "
+        "runs OUTSIDE the owner's render window, when the library calls it, so this is not a "
+        "text substitution.")
+
+   :outward-bridge
+   (str "`r/reactify-component` hands a Reagent component to React. The counterpart is "
+        "`h/as-component`, the outward bridge. Check what the foreign side does with the props "
+        "it passes: the two bridges do not convert them alike.")
+
+   :adapt-react-class
+   (str "`r/adapt-react-class` outside a Hiccup head position — bound to a name, or passed on. "
+        "W5 can only take the INLINE head form; a bound one changes the conversion regime of "
+        "every call site at once, including call sites this run never saw.")
+
+   :react-create-element
+   (str "`r/create-element` builds a React element directly. Hicasso's raw crossing is `[:> …]`, "
+        "and a repeated one graduates to a declared host — but the props dialect differs, so "
+        "read the crossing's rules before respelling this.")
+
+   :props-helper
+   (str "`r/merge-props` merges under Reagent's own class/style rules. Hicasso composes classes "
+        "under its own accepted spellings; check the merged result rather than assuming the two "
+        "rules agree.")
+
+   :reagent-partial
+   (str "`r/partial` is `clojure.core/partial` plus the marker that made Reagent treat the "
+        "result as a value rather than a callback. Outside a crossing that marker buys nothing, "
+        "so plain `partial` is usually right — but confirm nothing downstream tests for it.")
+
+   :component-introspection
+   (str "This reads or writes the CURRENTLY-RENDERING Reagent component — its props, children, "
+        "argv, replaceable state, or its DOM node. Hicasso has no such ambient component "
+        "object. Pass the value in as data, or own the node from a declared native host.")
+
+   :render-control
+   (str "This drives Reagent's own render scheduler. Hicasso commits on its own clock and "
+        "exposes no equivalent lever; a migration that needed one is usually a migration with a "
+        "read still living outside the frame.")
+
+   :root-mount
+   (str "Root mounting. Hicasso mounts its own root; this call is boot ceremony and is replaced "
+        "wholesale rather than edited.")
+
+   :unresolved-reagent-require
+   (str "This file's `ns` form NAMES a Reagent namespace, and the reader could not bind a "
+        "single symbol to it — a reader-conditional require (`#?(:cljs [reagent.core :as r])`), "
+        "the only legal way to require Reagent from a `.cljc` file, is the usual cause. EVERY "
+        "TOOL IN THIS FAMILY IS PARTIALLY BLIND IN THIS FILE: `r/partial` is not wrapped (W4), "
+        "`(r/adapt-react-class …)` is not respelled (W5), and Reagent API inside a crossing is "
+        "not named. Read this file by hand, or move the require out of the reader conditional "
+        "and re-run.")
+
+   :unresolved-alias
+   (str "A call whose NAME is on the Reagent roster, in a file whose Reagent require the reader "
+        "could not bind. It is reported rather than classified because the tool cannot tell "
+        "whether this symbol is Reagent's or something else's — which is exactly why it is "
+        "here and not silently absent.")})
+
+;; ---------------------------------------------------------------------------
+;; The walk
+;; ---------------------------------------------------------------------------
+
+(defn- head-symbol
+  "This node's head, when it is a call through a symbol."
+  [nd]
+  (when (rw/list-node? nd)
+    (let [h (rw/sexpr-safe (rw/element-at nd 0))]
+      (when (symbol? h) h))))
+
+(defn- roster-name
+  "The roster key this node's head spells, whether or not it resolves."
+  [nd]
+  (when-let [h (head-symbol nd)]
+    (let [k (symbol (name h))]
+      (when (contains? surface k) k))))
+
+(defn- entry
+  [{:keys [class verdict]} file line col form detail]
+  (cond-> {:class   class
+           :verdict verdict
+           :file    file
+           :line    line
+           :col     col
+           :form    form
+           :note    (get notes class)}
+    detail (assoc :detail detail)))
+
+(defn scan
+  "Every Reagent API call site in one source string.
+
+  Returns `{:entries [...] :reagent? bool :unresolved? bool}`.
+  `:reagent?` is whether the file names a Reagent namespace at all, which
+  is what lets the summary distinguish *scanned and clean* from *scanned
+  and irrelevant* — the fixer's report already carries `:sites-left-alone`
+  for the same reason."
+  [source file]
+  (let [root        (p/parse-string-all source)
+        ctx         (rw/ns-context root)
+        reagent?    (rw/names-reagent? root)
+        unresolved? (and reagent? (empty? (into (:aliases ctx) (:referred ctx))))
+        excerpt     (fn [loc] (let [s (z/string loc)]
+                                (if (> (count s) 200) (str (subs s 0 200) " …") s)))
+        ns-node?    rw/ns-form?]
+    (loop [loc     (z/of-string source {:track-position? true})
+           entries []]
+      (if (z/end? loc)
+        {:entries entries :reagent? reagent? :unresolved? unresolved?}
+        (let [nd         (z/node loc)
+              k          (roster-name nd)
+              [line col] (when (or k (and unresolved? (ns-node? nd))) (z/position loc))]
+          (recur
+           (z/next loc)
+           (cond
+             ;; The `ns` form of a file that names Reagent and binds
+             ;; nothing to it. Reported at the form itself, so the fix is
+             ;; where the line number points.
+             (and unresolved? (ns-node? nd))
+             (conj entries (entry {:class   :unresolved-reagent-require
+                                   :verdict :runtime-blocker}
+                                  file line col (excerpt loc) nil))
+
+             (nil? k) entries
+
+             ;; Resolved: this really is Reagent's, through a symbol the
+             ;; `ns` form binds.
+             (rw/reagent-call? nd k ctx)
+             (conj entries (entry (get surface k) file line col (excerpt loc) {:api (str k)}))
+
+             ;; Unresolvable, in a file we KNOW reaches for Reagent.
+             ;; Reported, never skipped — the tool cannot tell whose symbol
+             ;; this is, and saying so is the whole point.
+             ;;
+             ;; QUALIFIED HEADS ONLY. The thing that could not be bound is
+             ;; an ALIAS, so a call with no alias to bind is not evidence
+             ;; of it: `(atom nil)` is `clojure.core/atom`, and the SSR
+             ;; examples in this repository have one on the line above the
+             ;; `rdc/render` that IS the finding. Reporting both makes the
+             ;; real one harder to see, which is the only thing a census
+             ;; owes anybody.
+             (and unresolved? (namespace (head-symbol nd)))
+             (conj entries (entry {:class   :unresolved-alias
+                                   :verdict :runtime-blocker}
+                                  file line col (excerpt loc)
+                                  {:api    (str k)
+                                   :symbol (str (head-symbol nd))}))
+
+             :else entries)))))))
+
+;; ---------------------------------------------------------------------------
+;; The summary
+;; ---------------------------------------------------------------------------
+
+(def verdicts
+  "Every bucket, always emitted. A count that can only appear when it is
+  non-zero is a count nobody can tell from a bug."
+  [:mechanical :human-decision :runtime-blocker])
+
+(defn summarise
+  "The census half of the report artefact."
+  [{:keys [entries files-scanned files-with-reagent files-unresolved]}]
+  {:estimand "Reagent API call sites, addressed at the CALL. The fixer's `:entries` count `[:>]`-family crossing SITES; the two are different populations and neither is a denominator for the other."
+   :files-scanned      files-scanned
+   :files-with-reagent files-with-reagent
+   :files-unresolved   files-unresolved
+   :files-clean        (- files-with-reagent
+                          (count (into #{} (map :file) entries)))
+   :entries            (count entries)
+   :by-verdict         (into (sorted-map)
+                             (for [v verdicts]
+                               [v (count (filter #(= v (:verdict %)) entries))]))
+   :by-class           (into (sorted-map)
+                             (for [[k v] (group-by :class entries)] [k (count v)]))})
+
+(defn build
+  "Assemble the census section from the per-file scans."
+  [scans]
+  (let [entries (vec (mapcat :entries scans))]
+    {:summary (summarise {:entries            entries
+                          :files-scanned      (count scans)
+                          :files-with-reagent (count (filter :reagent? scans))
+                          :files-unresolved   (count (filter :unresolved? scans))})
+     :entries (vec (sort-by (juxt #(str (:file %)) #(or (:line %) 0) #(or (:col %) 0)
+                                  #(str (:class %)))
+                            entries))}))
+
+(defn print-lines
+  "One line per entry, the shape the fixer's report already prints."
+  [entries]
+  (doseq [{:keys [file line col class verdict detail]} entries]
+    (println (format "%s:%s:%s  %-26s %-16s %s"
+                     (or file "-") (or line "-") (or col "-")
+                     (name class) (name verdict)
+                     (or (:api detail) (:symbol detail) "")))))
+
+(defn scan-string
+  "Programmatic entry point over one source string."
+  ([s] (scan-string s nil))
+  ([s file] (scan s (some-> file str))))
+
+(defn describe
+  "A one-line human summary, for the CLI tail."
+  [{:keys [summary]}]
+  (str (:entries summary) " Reagent API call site(s) across "
+       (:files-with-reagent summary) " file(s) that name Reagent"
+       (when (pos? (:files-unresolved summary))
+         (str "; " (:files-unresolved summary) " file(s) UNRESOLVED"))
+       " — " (str/join ", " (for [[k v] (:by-verdict summary)] (str v " " (name k))))))

--- a/migration/reagent-to-hicasso/codemod/src/re_frame/migration/hicasso/census.clj
+++ b/migration/reagent-to-hicasso/codemod/src/re_frame/migration/hicasso/census.clj
@@ -252,20 +252,24 @@
         excerpt     (fn [loc] (let [s (z/string loc)]
                                 (if (> (count s) 200) (str (subs s 0 200) " …") s)))
         ns-node?    rw/ns-form?]
-    (loop [loc     (z/of-string source {:track-position? true})
-           entries []]
+    (loop [loc      (z/of-string source {:track-position? true})
+           entries  []
+           ns-said? false]
       (if (z/end? loc)
         {:entries entries :reagent? reagent? :unresolved? unresolved?}
         (let [nd         (z/node loc)
               k          (roster-name nd)
-              [line col] (when (or k (and unresolved? (ns-node? nd))) (z/position loc))]
+              ns-here?   (and unresolved? (not ns-said?) (ns-node? nd))
+              [line col] (when (or k ns-here?) (z/position loc))]
           (recur
            (z/next loc)
            (cond
              ;; The `ns` form of a file that names Reagent and binds
              ;; nothing to it. Reported at the form itself, so the fix is
-             ;; where the line number points.
-             (and unresolved? (ns-node? nd))
+             ;; where the line number points. Once per file: `ns-form?`
+             ;; sees through metadata, so `^:cljstyle/ignore (ns …)`
+             ;; matches at the meta node AND at the list inside it.
+             ns-here?
              (conj entries (entry {:class   :unresolved-reagent-require
                                    :verdict :runtime-blocker}
                                   file line col (excerpt loc) nil))
@@ -295,7 +299,8 @@
                                   {:api    (str k)
                                    :symbol (str (head-symbol nd))}))
 
-             :else entries)))))))
+             :else entries)
+           (or ns-said? ns-here?)))))))
 
 ;; ---------------------------------------------------------------------------
 ;; The summary

--- a/migration/reagent-to-hicasso/codemod/src/re_frame/migration/hicasso/codemod.clj
+++ b/migration/reagent-to-hicasso/codemod/src/re_frame/migration/hicasso/codemod.clj
@@ -32,6 +32,7 @@
   one level down."
   (:require [clojure.java.io :as io]
             [clojure.string :as str]
+            [re-frame.migration.hicasso.census :as census]
             [re-frame.migration.hicasso.report :as report]
             [re-frame.migration.hicasso.rewrite :as rw]
             [rewrite-clj.node :as n]
@@ -269,9 +270,14 @@
             r    (if rewrite? (rewrite-string orig path) (scan-string orig path))
             changed? (and rewrite? (not= orig (:source r)))]
         (when (and write? changed?) (spit f (:source r)))
-        (assoc r :path path :changed? (boolean changed?)))
+        (assoc r :path path :changed? (boolean changed?)
+               :census (census/scan orig path)))
       (catch Exception e
         {:path path :changed? false :sites 0 :left-alone 0 :suggestions []
+         ;; A file the reader cannot read is one refusal, not two: the
+         ;; census population is empty here for the same reason the
+         ;; fixer's is, and `:parse-error` already says so.
+         :census {:entries [] :reagent? false :unresolved? false}
          :entries [{:file path :line 0 :col 0 :form "" :head nil
                     :class :parse-error :action :refused
                     :detail {:message (.getMessage e)}
@@ -286,6 +292,7 @@
     (report/build
      {:entries          (vec (mapcat :entries results))
       :suggestions      (vec (mapcat :suggestions results))
+      :census           (census/build (mapv :census results))
       :files-scanned    (count files)
       :files-changed    (count (filter :changed? results))
       :dry-run?         (and rewrite? (not write?))
@@ -329,9 +336,11 @@
       (let [rep (run paths {:rewrite? (contains? flags "--rewrite")
                             :write?   (contains? flags "--write")})]
         (report/print-lines (:entries rep))
+        (census/print-lines (:entries (:census rep)))
         (report/write! rep report-p)
         (println)
         (println (pr-str (:summary rep)))
+        (println (census/describe (:census rep)))
         (println (str "report: " report-p))
         ;; Exit 0 for any run that COMPLETED. A migration tool that fails a
         ;; build because a consumer's code needs a human decision is a tool

--- a/migration/reagent-to-hicasso/codemod/src/re_frame/migration/hicasso/report.clj
+++ b/migration/reagent-to-hicasso/codemod/src/re_frame/migration/hicasso/report.clj
@@ -137,8 +137,14 @@
          sketch-indent "}})")))
 
 (defn build
-  "Assemble the report artefact from the per-file results."
-  [{:keys [entries suggestions files-scanned sites-total sites-left-alone
+  "Assemble the report artefact from the per-file results.
+
+  `:census` is a SECOND SECTION, not more `:entries`. The fixer's entries
+  count `[:>]`-family crossing sites; the census counts Reagent API call
+  sites. Merging them would produce one number that answers neither
+  question, and the golden corpus — which asserts `:entries` — would stop
+  being a statement about the fixer."
+  [{:keys [entries suggestions census files-scanned sites-total sites-left-alone
            files-changed dry-run?]}]
   (let [entries (sort-entries entries)
         by-class (->> entries (group-by :class)
@@ -158,6 +164,7 @@
                :entries           (count entries)
                :by-class          by-class}
      :entries entries
+     :census  census
      :suggestions
      (when (seq suggestions)
        {:caution suggestion-caution

--- a/migration/reagent-to-hicasso/codemod/src/re_frame/migration/hicasso/rewrite.clj
+++ b/migration/reagent-to-hicasso/codemod/src/re_frame/migration/hicasso/rewrite.clj
@@ -279,6 +279,55 @@
 (def ^:private reagent-namespaces
   '#{reagent.core reagent.dom reagent.dom.client reagent.ratom})
 
+(defn ns-form?
+  "Is this node the file's `ns` form? Public because the census asks it of
+  a zipper LOCATION (it wants the form's line), and one spelling of \"this
+  is the `ns` form\" is one spelling."
+  [node]
+  (and (list-node? node) (= 'ns (sexpr-safe (element-at node 0)))))
+
+(defn- ns-form-node
+  "This file's `ns` form, as a node, or `nil`."
+  [root-node]
+  (first (filter ns-form? (elements root-node))))
+
+(defn names-reagent?
+  "Does this file's `ns` form NAME a Reagent namespace — whatever the
+  reader was able to make of the form?
+
+  [[ns-context]] answers the stronger question (which local symbols are
+  bound to it) and answers `#{}` for a require the reader cannot resolve:
+  `#?(:cljs [reagent.core :as r])` is the common one, and it is the only
+  legal way to require Reagent from a `.cljc` file. The two answers
+  disagreeing is precisely the state a census must REPORT rather than
+  read as \"no Reagent here\" — see
+  [[re-frame.migration.hicasso.census/scan]].
+
+  Read off the TEXT of the `ns` form's CLAUSES, against the
+  `reagent-namespaces` roster, so it is blind to nothing the reader is
+  blind to.
+
+  **The clauses, and not the whole form.** Reading the form entire found
+  five files in this repository's own example corpus whose `ns`
+  DOCSTRING discusses `reagent.ratom/run!` in prose — a legal, clean
+  population reported as five migration blockers. A census that reports
+  what a sentence says is the same defect as one that reports nothing,
+  arriving from the other side. Token and multi-line nodes (the namespace
+  symbol, the docstring) and the attribute map are dropped; lists and
+  reader-conditional nodes are kept, which is every shape a require can
+  arrive in.
+
+  The one shape this does not see is the deprecated prefix list
+  `[reagent [core :as r]]`, which spells no Reagent namespace in full;
+  [[ns-context]] does not see that either."
+  [root-node]
+  (boolean
+   (when-let [nsf (ns-form-node root-node)]
+     (let [clauses (remove #(contains? #{:token :multi-line :map} (n/tag %))
+                           (elements nsf))
+           s       (apply str (map n/string clauses))]
+       (some #(str/includes? s (str %)) reagent-namespaces)))))
+
 (defn ns-context
   "Read a file's `ns` form and answer which symbols name Reagent's API.
 
@@ -290,10 +339,7 @@
   it — unless the `ns` form referred Reagent's, so the referred set is
   read rather than assumed."
   [root-node]
-  (let [ns-form (->> (elements root-node)
-                     (filter #(and (list-node? %)
-                                   (= 'ns (sexpr-safe (element-at % 0)))))
-                     first)
+  (let [ns-form (ns-form-node root-node)
         form    (some-> ns-form sexpr-safe)
         reqs    (when (seq? form)
                   (->> form

--- a/migration/reagent-to-hicasso/codemod/src/re_frame/migration/hicasso/rewrite.clj
+++ b/migration/reagent-to-hicasso/codemod/src/re_frame/migration/hicasso/rewrite.clj
@@ -282,14 +282,29 @@
 (defn ns-form?
   "Is this node the file's `ns` form? Public because the census asks it of
   a zipper LOCATION (it wants the form's line), and one spelling of \"this
-  is the `ns` form\" is one spelling."
+  is the `ns` form\" is one spelling.
+
+  **Through metadata.** `^:cljstyle/ignore (ns …)` is an ordinary
+  top-level shape, and reading it as \"not the `ns` form\" is not a
+  cosmetic miss: [[ns-context]] then binds NOTHING for the whole file, so
+  W4 and W5 go dead in it, every Reagent API in it goes unnamed, and the
+  report stays non-empty — `:>` needs no alias — so nothing looks wrong.
+  Athens' `views/pages/graph.cljs` is exactly this file: four `(r/atom …)`
+  invisible under a `^:cljstyle/ignore`, in a namespace whose report had
+  eleven other entries in it."
   [node]
-  (and (list-node? node) (= 'ns (sexpr-safe (element-at node 0)))))
+  (let [nd (second (unwrap-metas node))]
+    (and (list-node? nd) (= 'ns (sexpr-safe (element-at nd 0))))))
 
 (defn- ns-form-node
-  "This file's `ns` form, as a node, or `nil`."
+  "This file's `ns` form, as a node, or `nil` — under any metadata chain,
+  so callers get the list whose elements are the clauses."
   [root-node]
-  (first (filter ns-form? (elements root-node))))
+  (some->> (elements root-node)
+           (filter ns-form?)
+           first
+           unwrap-metas
+           second))
 
 (defn names-reagent?
   "Does this file's `ns` form NAME a Reagent namespace — whatever the
@@ -323,7 +338,7 @@
   [root-node]
   (boolean
    (when-let [nsf (ns-form-node root-node)]
-     (let [clauses (remove #(contains? #{:token :multi-line :map} (n/tag %))
+     (let [clauses (remove #(contains? #{:token :multi-line :map :meta} (n/tag %))
                            (elements nsf))
            s       (apply str (map n/string clauses))]
        (some #(str/includes? s (str %)) reagent-namespaces)))))

--- a/migration/reagent-to-hicasso/codemod/test/re_frame/migration/hicasso/census_test.clj
+++ b/migration/reagent-to-hicasso/codemod/test/re_frame/migration/hicasso/census_test.clj
@@ -99,6 +99,35 @@
             be bound, so a call with no alias is not evidence of it."
     (is (not-any? #(= 5 (:line %)) (:entries (census/scan conditional-require "app/ssr.cljc"))))))
 
+(deftest an-ns-form-under-metadata-is-still-the-ns-form
+  (testing "`^:cljstyle/ignore (ns …)` is ordinary. Reading it as `nil` binds
+            NOTHING for the whole file — W4 and W5 dead, every Reagent API
+            unnamed — and nothing looks wrong, because `:>` needs no alias and
+            the fixer's report stays non-empty. Athens'
+            `views/pages/graph.cljs` is that file: four `(r/atom …)` invisible
+            under the ignore, in a namespace already carrying eleven entries.
+            A `r/atom` cross-check against the corpus read 47 where the text
+            said 51, and the four were all in it."
+    (let [src (str "^:cljstyle/ignore\n"
+                   "(ns ^{:doc \"Graph and controls.\"}\n"
+                   " app.graph\n"
+                   "  (:require\n"
+                   "   [re-frame.core :as rf]\n"
+                   "   [reagent.core :as r]))\n"
+                   "\n"
+                   "(def graph-ref-map (r/atom {}))\n")
+          {:keys [entries reagent? unresolved?]} (census/scan src "app/graph.cljs")]
+      (is (true? reagent?))
+      (is (false? unresolved?) "resolved, not merely reported")
+      (is (= [:local-reactive-cell] (mapv :class entries)))
+      (is (= 8 (:line (first entries))))))
+  (testing "and the ns is reported ONCE when it cannot be bound, though
+            `ns-form?` matches at the meta node and at the list inside it"
+    (let [src (str "^:cljstyle/ignore\n"
+                   "(ns app.graph\n"
+                   "  (:require #?(:cljs [reagent.core :as r])))\n")]
+      (is (= [:unresolved-reagent-require] (classes src "app/graph.cljc"))))))
+
 ;; ---------------------------------------------------------------------------
 ;; A legal population comes back CLEAN
 ;; ---------------------------------------------------------------------------

--- a/migration/reagent-to-hicasso/codemod/test/re_frame/migration/hicasso/census_test.clj
+++ b/migration/reagent-to-hicasso/codemod/test/re_frame/migration/hicasso/census_test.clj
@@ -1,0 +1,187 @@
+(ns re-frame.migration.hicasso.census-test
+  "The census, gated on the two ways a census fails.
+
+  A census fails by **answering nothing** — an empty population that
+  cannot redden, so every run is green and no run means anything — and it
+  fails by **answering too much** — a legal codebase reported as a wall of
+  blockers, which trains its reader to stop looking. Both failures are
+  confident and neither announces itself, so both get a control here, and
+  the second one is not decoration: it caught two real over-reports in
+  this repository's own example corpus while this namespace was being
+  written.
+
+  * `ns` DOCSTRING prose mentioning `reagent.ratom/run!` made five clean
+    example files read as five migration blockers. `names-reagent?` now
+    reads the `ns` form's CLAUSES.
+  * `(atom nil)` — `clojure.core`'s — sat one line above the `rdc/render`
+    that is the genuine finding in the SSR examples, and both were
+    reported. `:unresolved-alias` now needs a qualified head, because the
+    thing that could not be bound is an ALIAS."
+  (:require [clojure.string :as str]
+            [clojure.test :refer [deftest is testing]]
+            [re-frame.migration.hicasso.census :as census]
+            [re-frame.migration.hicasso.codemod :as cm]))
+
+(defn- classes [src file] (mapv :class (:entries (census/scan src file))))
+
+;; ---------------------------------------------------------------------------
+;; It can answer NON-EMPTY, on exactly the source the fixer answers empty on
+;; ---------------------------------------------------------------------------
+
+(def ^:private form-2
+  "The most common thing in a Reagent codebase, and the fixer's blind
+  spot: local reactive state, no crossing anywhere."
+  (str "(ns app.counter\n"
+       "  (:require [reagent.core :as r]))\n"
+       "\n"
+       "(defn counter []\n"
+       "  (let [n (r/atom 0)]\n"
+       "    (fn [] [:div {:on-click #(swap! n inc)} @n])))\n"))
+
+(deftest the-fixer-is-silent-here
+  (testing "the crossing population is genuinely empty in this file — the census is
+            not being compared against a fixer that simply failed"
+    (let [r (cm/scan-string form-2 "app/counter.cljs")]
+      (is (= [] (:entries r)))
+      (is (= 0 (:sites r))))))
+
+(deftest the-census-answers-non-empty
+  (let [{:keys [entries reagent? unresolved?]} (census/scan form-2 "app/counter.cljs")]
+    (is (true? reagent?))
+    (is (false? unresolved?))
+    (is (= [:local-reactive-cell] (mapv :class entries)))
+    (is (= [:runtime-blocker] (mapv :verdict entries)))
+    (testing "with the coordinate a person greps for, and the api that named it"
+      (is (= {:line 5 :col 11 :api "atom"}
+             (-> entries first (select-keys [:line :col]) (assoc :api (get-in (first entries) [:detail :api]))))))
+    (testing "and a sentence to act on"
+      (is (str/includes? (:note (first entries)) "NO view-local state tier")))))
+
+(deftest every-roster-class-has-a-recovery-sentence
+  (doseq [[api {:keys [class verdict]}] census/surface]
+    (testing (str api)
+      (is (contains? (set census/verdicts) verdict))
+      (is (string? (:note (first (:entries (census/scan
+                                            (str "(ns a (:require [reagent.core :as r]))\n"
+                                                 "(r/" api " x)\n")
+                                            "a.cljs")))))
+          "a class the roster can produce but the notes cannot describe"))))
+
+;; ---------------------------------------------------------------------------
+;; What it cannot resolve is REPORTED, never skipped
+;; ---------------------------------------------------------------------------
+
+(def ^:private conditional-require
+  "The only legal way to require Reagent from a `.cljc` file — and the
+  shape `ns-context` binds nothing for. `examples/capabilities/ssr/`
+  carries three real ones."
+  (str "(ns app.ssr\n"
+       "  (:require [re-frame.core :as rf]\n"
+       "            #?(:cljs [reagent.dom.client :as rdc])))\n"
+       "\n"
+       "#?(:cljs (defonce react-root (atom nil)))\n"
+       "\n"
+       "#?(:cljs (defn mount! [] (rdc/render @react-root [:div])))\n"))
+
+(deftest an-unbindable-require-is-reported
+  (let [{:keys [entries unresolved?]} (census/scan conditional-require "app/ssr.cljc")]
+    (is (true? unresolved?))
+    (is (= [:unresolved-reagent-require :unresolved-alias] (mapv :class entries)))
+    (testing "the require is reported at the `ns` form, where the fix goes"
+      (is (= 1 (:line (first entries)))))
+    (testing "and the call that could not be bound names the symbol it could not bind"
+      (is (= {:api "render" :symbol "rdc/render"} (:detail (second entries)))))
+    (testing "the note says the whole tool family is blind here, not just the census"
+      (is (str/includes? (:note (first entries)) "PARTIALLY BLIND")))))
+
+(deftest the-unqualified-core-call-beside-it-is-not-reported
+  (testing "`(atom nil)` on line 5 is `clojure.core`'s. An alias is what could not
+            be bound, so a call with no alias is not evidence of it."
+    (is (not-any? #(= 5 (:line %)) (:entries (census/scan conditional-require "app/ssr.cljc"))))))
+
+;; ---------------------------------------------------------------------------
+;; A legal population comes back CLEAN
+;; ---------------------------------------------------------------------------
+
+(deftest a-corpus-without-reagent-is-clean
+  (let [src (str "(ns app.views\n"
+                 "  (:require [re-frame.core :as rf]))\n"
+                 "\n"
+                 "(defn page []\n"
+                 "  [:div (for [x @(rf/subscribe [:xs])] ^{:key x} [:span x])])\n")
+        {:keys [entries reagent? unresolved?]} (census/scan src "app/views.cljs")]
+    (is (= [] entries))
+    (is (false? reagent?))
+    (is (false? unresolved?))))
+
+(deftest prose-about-reagent-is-not-a-finding
+  (testing "the `ns` docstring is not a require. Five files in examples/ discuss
+            `reagent.ratom/run!` in prose and are clean."
+    (let [src (str "(ns app.editor\n"
+                   "  \"Settle is driven by causal events, not Form-3 `reagent.ratom/run!`\n"
+                   "   reactions watching a settle, and there is no `reagent.core/atom` here.\"\n"
+                   "  (:require [clojure.string :as str]))\n"
+                   "\n"
+                   "(defn page [] [:div (str/upper-case \"x\")])\n")
+          {:keys [entries reagent?]} (census/scan src "app/editor.cljs")]
+      (is (= [] entries))
+      (is (false? reagent?)))))
+
+(deftest a-word-in-a-comment-is-not-a-call
+  (testing "`grep -c with-let` over examples/ answers 10; the corpus holds ONE.
+            Nine of the ten are prose."
+    (let [src (str "(ns app.bench\n"
+                   "  \"The wrapper's `r/with-let` cleanup dispatches :cancel on unmount.\"\n"
+                   "  (:require [reagent.core :as r]))\n"
+                   "\n"
+                   ";; riding on Reagent's own `reagent.core/with-let`\n"
+                   "(defn bench []\n"
+                   "  (r/with-let [_ nil]\n"
+                   "    [:div]\n"
+                   "    (finally (dispatch [:cancel]))))\n")]
+      (is (= [:with-let] (classes src "app/bench.cljs")))
+      (is (= 7 (:line (first (:entries (census/scan src "app/bench.cljs")))))))))
+
+(deftest a-core-name-is-not-reagents-without-a-binding
+  (testing "half the roster shares a name with `clojure.core`. Only a bound alias,
+            or a `:refer` the `ns` form actually wrote, makes one Reagent's."
+    (let [src (str "(ns app.util\n"
+                   "  (:require [clojure.string :as str]))\n"
+                   "\n"
+                   "(def cache (atom {}))\n"
+                   "(defn go [f xs] (run! f xs))\n"
+                   "(defn f [g] (partial g 1))\n"
+                   "(defn h [m] (flush))\n")]
+      (is (= [] (classes src "app/util.cljs")))))
+  (testing "but a `:refer` from Reagent does"
+    (let [src (str "(ns app.util\n"
+                   "  (:require [reagent.core :refer [atom]]))\n"
+                   "\n"
+                   "(def cache (atom {}))\n")]
+      (is (= [:local-reactive-cell] (classes src "app/util.cljs"))))))
+
+;; ---------------------------------------------------------------------------
+;; Determinism, and a summary that cannot hide an empty bucket
+;; ---------------------------------------------------------------------------
+
+(deftest a-second-scan-reports-identically
+  (is (= (census/scan form-2 "app/counter.cljs")
+         (census/scan form-2 "app/counter.cljs")))
+  (is (= (census/scan conditional-require "app/ssr.cljc")
+         (census/scan conditional-require "app/ssr.cljc"))))
+
+(deftest the-summary-names-every-bucket-including-the-empty-ones
+  (let [built (census/build [(census/scan form-2 "app/counter.cljs")
+                             (census/scan conditional-require "app/ssr.cljc")
+                             (census/scan "(ns a)\n(defn f [] [:div])\n" "app/plain.cljs")])
+        s     (:summary built)]
+    (is (= (set census/verdicts) (set (keys (:by-verdict s))))
+        "an absent key is a count nobody can tell from a bug")
+    (is (= 0 (get-in s [:by-verdict :mechanical]))
+        "nothing outside a crossing is mechanical, and the census says so with a zero")
+    (is (= 3 (:files-scanned s)))
+    (is (= 2 (:files-with-reagent s)))
+    (is (= 1 (:files-unresolved s)))
+    (is (= 3 (:entries s)))
+    (testing "ordering is file, then line, then column"
+      (is (= (:entries built) (vec (sort-by (juxt :file :line :col) (:entries built))))))))


### PR DESCRIPTION
Bead: **rf2-hic-055** — *Migration: the reporter, then shadow comparison.*

The title names an order, and the order is the design: **shadow comparison is only meaningful against a population you can enumerate.** The reporter turned out to be the whole of one bead, so this PR is the reporter and `rf2-kyum` is the shadow half. Splitting is stated below, in full.

## The premise that did not hold

The bead says *"codemod explicitly not built here — filed as a follow-up bead gated on reviewed reporter samples showing a high safe-applicability rate."* **The codemod was already built** — `rf2-2rtt6.143`, six rewrite families, a golden corpus — and the draft guide teaches its scan mode *as* the reporter. So the ordering the programme wrote down was already inverted in practice.

That is not the interesting part. The interesting part is what the existing reporter's **population** is.

It is the `[:>]`-family crossing. That is not a Reagent codebase. Run over this repository's own 81-file example corpus, the fixer reports **zero entries** — not "clean", not "nothing to do": nothing — and a migrator reading that report sees eighty-one files that are not mentioned. Its `:reagent-api-residue` class exists, but fires only for a Reagent call inside a crossing's props, so the single most common thing a Hicasso migration has to answer for —

```clojure
(defn counter []
  (let [n (r/atom 0)]
    (fn [] [:div {:on-click #(swap! n inc)} @n])))
```

— was invisible.

## What this PR adds

`migration/reagent-to-hicasso/codemod/src/re_frame/migration/hicasso/census.clj` — the census, emitted as a **second section** of the same report, never merged into `:entries`.

| Half | Population | Addressed at | Verdicts |
|---|---|---|---|
| fixer (`:entries`) | `[:>]`-family crossing sites | the site | rewrote / refused |
| census (`:census`) | Reagent API call sites | the call | `:mechanical`, `:human-decision`, `:runtime-blocker` |

*(4 columns; 2 body rows.)*

Two estimands, both named in the report's own `:estimand` field, **neither a denominator for the other**. The roster is Reagent's public API — 34 callables over 13 classes — each with a recovery sentence in the migrator's vocabulary. The three verdict buckets are the ones the migration page already teaches; no new vocabulary was minted.

**`:mechanical` is always emitted, always `0`.** That is a measurement, not an omission: every mechanical rewrite this tool family knows is a W-rule, and every W-rule sits at a crossing. A bucket that can only appear when non-zero is a bucket nobody can tell from a bug.

**No hot-zone file, no new `deps.edn` path, no npm dependency, no new public export of the library.** The census lives inside the artefact that already has rewrite-clj on its classpath, and the whole diff is confined to `migration/reagent-to-hicasso/codemod/**`. Two internal `rewrite.clj` names became public (`ns-form?`, `names-reagent?`) so there is one spelling of each question rather than two.

## What it REPORTS rather than skips

`#?(:cljs [reagent.core :as r])` is the **only legal way** to require Reagent from a `.cljc` file, and `ns-context` binds nothing for it. Verified at source before anything was written:

```
(ns a (:require [reagent.core :as r]))                 => {:aliases #{reagent.core r} :referred #{}}
(ns a (:require #?(:cljs [reagent.core :as r])))       => {:aliases #{}               :referred #{}}
(ns a (:require #?@(:cljs [[reagent.core :as r]])))    => {:aliases #{}               :referred #{}}
```

So such a file was *silently a file with no Reagent in it* — W4 and W5 dead, every API unnamed — and the report stayed **non-empty**, because `:>` head detection needs no alias. Nothing looked wrong. Three real instances live in `examples/capabilities/ssr/`.

It is now `:unresolved-reagent-require` at the `ns` form's own line, with every **qualified** roster-named call in the file reported as `:unresolved-alias` naming the symbol it could not bind. The fixer's blindness is left exactly as it was and filed as **rf2-m4hm** — a fixer that starts rewriting files it previously could not see is a behaviour change, and this is a reporter bead.

The same class covers a vendored Reagent: re-frame-10x ships `day8.re-frame-10x.inlined-deps.reagent.v1v2v0.reagent.core`, which no resolver should guess at and every migrator needs told. Its whole census is 8 unresolved requires and 12 unresolved aliases — an honest, actionable, non-empty *"I am blind in these ten files"*.

**What it cannot name, it does not count.** A Form-2 component is a `defn` returning a `fn` and nothing else marks it; a structural test for that reports every higher-order function in the corpus. The `r/atom` it closes over is on the roster; the shape itself is left uncounted and said so, in the namespace docstring.

## Calibration against known landmarks

`docs/design/freehand/studio/fitness-harness.md` Part 2 is the revision-pinned census of `examples/{core,capabilities,patterns,real-apps}`. Reproduced **before** any new number was believed:

| Landmark | Census pin | Naive `grep` | This reporter | |
|---|---|---|---|---|
| `r/atom` in views (row 5) | **0** | 3 | **0** | ✅ all three greps are prose |
| `with-let` (row 6) | **1**, `long_running_work/views.cljs:143` | 10 | **1**, at `143:3` | ✅ line exact |
| foreign React components (row 10) | **0** | — | **0** crossings | ✅ |
| files in scope | 85 | — | **81** | ⚠️ see below |

The file count is the one that did not reproduce. The scope is unambiguous and today yields 81; `git ls-tree` over the same four directories reads 73 at 2026-07-15 and 81 today, and before that the tree used a substrate-first layout (`examples/reagent`, `examples/uix`, `examples/helix`) in which the four directories do not exist. **The corpus grew into and past the pinned number**; the pin is explicitly revision-pinned, so this is expected drift and not a reader defect. Reported rather than filed.

A second calibration is revision-proof and exact: **the fixer's golden corpus is byte-unchanged.** The census is a separate report section, `corpus_test.clj` compares `:entries`, and 28 tests / 300 assertions passed identically before and after.

**And a cross-check against the text the census is supposed to outperform.** Over athens, `r/atom`: grep read 51 lines, the census read 47. The four were all in one file, and finding out why produced the third defect below. After the fix the two agree **exactly, in both directions, at file-and-line granularity** (`51 = 51`, empty both ways).

## Three defects found, all in the reader, all by a control

1. **Over-report — the `ns` docstring.** `names-reagent?` read the whole `ns` form's text, so five example files whose docstrings discuss `reagent.ratom/run!` in prose reported as five migration blockers. Caught by *a legal population must come back clean*. It now reads the `ns` form's **clauses**, dropping token, multi-line and map nodes.
2. **Over-report — `clojure.core`'s `atom`.** In an unresolved file, `(atom nil)` sat one line above the `rdc/render` that is the genuine finding, and both were reported. `:unresolved-alias` now requires a **qualified** head, because the thing that could not be bound is an *alias*.
3. **Under-report — `^:cljstyle/ignore (ns …)`.** An ordinary top-level shape that `ns-form?` read as "not the `ns` form", so `ns-context` bound **nothing for the whole file**: W4 and W5 dead, every Reagent API unnamed, and nothing looking wrong because `:>` needs no alias. Athens' `views/pages/graph.cljs` is that file — four `(r/atom …)` invisible under the ignore, in a namespace whose report already carried eleven entries. **This one is a fixer fix too**, and the goldens are unchanged, so it is a plain repair rather than a scope expansion.

## The planted-finding proof, both directions

Victim: `examples/core/todomvc/views.cljs`, sha256 `31ed11ab…31e5`, which names Reagent nowhere.

**Planted** a Form-2 closure over `(r/atom "")` inside an `(r/with-let …)` with a `finally` teardown — a shape the fixer is structurally silent on. The reporter named it with file, line **and column**:

```
examples\core\todomvc\views.cljs:187:15  local-reactive-cell  runtime-blocker  atom
examples\core\todomvc\views.cljs:189:7   with-let             human-decision   with-let
```

Both coordinates verified by hand against the planted text. Corpus totals moved `62 → 64` entries, `28 → 29` files, `with-let 1 → 2`, `local-reactive-cell 0 → 1`.

**Removed**, and the restore verified by hashing the bytes:

```
restored sha256 : 31ed11ab1c8856cd1d35e5ceecc5e0d9757020fed4877707450eddc262a631e5
backup   sha256 : 31ed11ab1c8856cd1d35e5ceecc5e0d9757020fed4877707450eddc262a631e5
BYTE-EXACT      : True
```

`git status` clean, and the census returned to exactly **62 / 28 / 1 / 0** with `todomvc/views.cljs` no longer mentioned. The plant script never lived in the repo; it ran from the session scratchpad.

**And it does not over-report.** `implementation/hicasso/src` — 23 files, no Reagent — comes back `0 crossings, 0 census entries, 0 files that name Reagent`. `census_test.clj` carries the same control in five shapes: a Reagent-free view file, prose in a docstring, a word in a comment, and `atom`/`run!`/`partial`/`flush` as `clojure.core`'s.

## The three representative repositories

Cloned read-only into the session scratchpad; nothing entered the repo.

| Corpus | Commit | Files | Fixer entries | Census sites | Files naming Reagent | Unresolved |
|---|---|---|---|---|---|---|
| in-repo — `examples/{core,capabilities,patterns,real-apps}` | this branch | 81 | **0** | 62 | 28 | 3 |
| [athensresearch/athens](https://github.com/athensresearch/athens) | `b463a97a0d28cbc0a29bec55feebcbe54c20de54` | 131 | 271 | **109** | 30 | 0 |
| [district0x/memefactory](https://github.com/district0x/memefactory) | `71bf92b4b4b935bda089783fd6c07041f84d34f8` | 102 | 14 | **85** | 28 | 0 |
| [day8/re-frame-10x](https://github.com/day8/re-frame-10x) — vendored-Reagent control | `a3c309430d9e24456b4760f125133abbffc9bdfa` | 68 | **0** | 20 | 10 | **8** |
| `implementation/hicasso/src` — clean control | this branch | 23 | 0 | **0** | 0 | 0 |

*(7 columns; 5 body rows.)*

athens and memefactory are the bead's two external open-source re-frame v1 **applications**; both clear its `>=30 Reagent views` rule (30 and 28 Reagent-naming files, several views each). re-frame-10x is a fourth run kept because it is the vendored-dependency case and nothing else in the set exercises it.

athens' census by class: `local-reactive-cell 47`, `as-element 45`, `derived-cell 3`, `lifecycle-class 2`, `with-let 2`, `adapt-react-class 1`, `root-mount 1`.

**Determinism** (bead acceptance): two full athens runs produce byte-identical report EDN, sha256 `ce954f01b9f923be9ea0a039cce9f1d201c3effe5de4ee1a4d96a1164066014c` both times, `diff` exit `0`.

## Quality gates

Every gate run alone, foreground, to completion, output redirected, exit code echoed on the same command line. No test-count baseline is quoted from memory — the base was measured on this branch's merge-base before the first edit.

| Command | Exit | Result |
|---|---|---|
| `cd migration/reagent-to-hicasso/codemod && clojure -M:test` *(base, before any edit)* | **0** | 28 tests, 300 assertions, 0 failures |
| `cd migration/reagent-to-hicasso/codemod && clojure -M:test` *(final)* | **0** | **40 tests, 403 assertions, 0 failures** |
| `sh scripts/test-jvm-tools.sh` | **0** | `PASS tools JVM artefacts` (both codemod artefacts; the v1 sibling still 45/158) |
| `python scripts/check_doc_slugs.py` | **0** | clean |
| `python scripts/check_readme_inventories.py` | **0** | clean |
| `python scripts/check_readme_links.py` | **0** | clean |
| `python scripts/check_fast_pr_gap.py --list` | **0** | see below |

**The lane that owns this surface.** `TESTING.md` line 219 and `.github/workflows/test.yml`: the classifier arm `migration_hicasso_codemod` fires on any change under `migration/reagent-to-hicasso/codemod/**` and produces `jvm-migration-hicasso-codemod`, whose only step is `cd migration/reagent-to-hicasso/codemod && clojure -M:test` — the gate above, verbatim. The diff touches nothing else, so no other required job is reached. `clj-kondo` does not lint `migration/` (lint.yml lines 319–333), so `Lint required` decides nothing here; `docs.yml` stages `migration/` into the site and executes none of it.

**What the fast-PR spine does not decide.** `check_fast_pr_gap.py --list` reports 97 required checks the spine does not run, `jvm-migration-hicasso-codemod` among them — the spine decides **nothing** about this diff, which is why the artefact gate was run directly and by its lane script.

## Split, and what remains

Filed, with everything a worker needs:

- **rf2-kyum** — shadow comparison, the dual-render canonical-DOM/intent diff. Note for that worker: `ht/shadow!` is **already documented** in the fenced draft guide §3 with a worked example and a stated return value, and `grep -rn 'shadow!' implementation/` is empty. Build to that shape or change the page — not neither.
- **rf2-m4hm** — the fixer's reader-conditional blindness (this PR reports it; the fixer still cannot act on it).
- **rf2-me76** — the draft guide's §1 reporter table and its `ht/shadow!` recipe. **Filed, not fixed**: three operator worktrees hold that page live.

Not filed, reported only: the fitness-harness census's 85-file pin against today's 81 (revision drift by design, per the doc's own "revision-pinned").

`rf2-hic-055` stays **OPEN** — its shadow-mode deliverable and its acceptance clause about a seeded behavioural difference are rf2-kyum's.
