### PR TITLE
test(hicasso): the controlled-input law on three engines — already green; repair the two audit fail-opens (rf2-hic-016)

### DIFF
--- a/docs/design/hicasso/native-ime-scripted-witness.md
+++ b/docs/design/hicasso/native-ime-scripted-witness.md
@@ -8,7 +8,7 @@
 > over-engineering, and no further rig work or IME-automation attempt is sanctioned. **Read [§11](#11-the-outcome-and-the-three-walls) first**: it
 > carries the three walls, their run evidence, and the amended close rule.
 >
-> **The rig is not deprecated and this document is not history.** It stays in the tree with its 39 teeth, because it is
+> **The rig is not deprecated and this document is not history.** It stays in the tree with its 43 teeth, because it is
 > what found all three walls — each of them honestly, and none of them guessed at. Sections 1–10 describe it as built,
 > in the present tense of its own design; read them as the record of a sanctioned attempt rather than as instructions
 > to run one.
@@ -117,6 +117,16 @@ blur, the reloads, every selector and every read. Because the driver is unarmed,
 `INCONCLUSIVE` against the named premise *"no composition ever started"*, which is the truth about a rehearsal. It
 reports itself as a rehearsal and its verdicts say nothing about any engine.
 
+That paragraph describes what a rehearsal does when it works, and for a while nothing checked that it had. Merged-PR
+audit **#7956** found the rehearsal able to **exit 0 having driven no check at all**: `driveEngine` catches a prepare
+failure into `results: []` — right conduct, so one engine's refusal cannot discard the other two — and `main` then
+returned 0 for every non-inject mode regardless, printing *"every page-side step of every check ran"* over a run in
+which none had. The same fail-open shape as [wall 2](#112-wall-2--the-open-status-gate-read-back-its-own-write), one
+layer out. It is now measured rather than asserted: every requested engine must have produced a run, none may have
+been refused in prepare, each must have driven the full roster, and **every check must carry its `READBACK`** — the
+clause that separates a rehearsal whose selectors all resolved from one whose selectors silently returned `null`.
+A rehearsal that fails any of those prints what is missing and **exits 1**.
+
 Useful flags: `--engines=firefox,webkit`, `--key-delay=<ms>` (default 80), `--port=<n>` (default 8066),
 `--keep-open`.
 
@@ -162,8 +172,8 @@ Three verdicts, and the third is the point:
 - **INCONCLUSIVE** — the check could not be decided because its **premise** was not met, most often that no composition
   ever started. An inconclusive check leaves the disposition cell unfillable; the run says so and exits non-zero.
 
-The verdict functions are pure and carry **39 mutation teeth** (`--self-test`, which prints
-`verdict logic teeth bit: 39`), because a witness whose verdict logic cannot be shown to fail is decoration. The teeth
+The verdict functions are pure and carry **43 mutation teeth** (`--self-test`, which prints
+`verdict logic teeth bit: 43`), because a witness whose verdict logic cannot be shown to fail is decoration. The teeth
 cover each check's tick shape, its defect shape and its premise-not-met shape, plus the recording rule that a crossed
 or incomplete run can never be written into `dispositions.md` as verified.
 
@@ -311,9 +321,18 @@ evidence to report one engine's failure. #7956 caught engagement failure at the 
 With conduct as the gate, the third run answered the only question left, and answered it against the avenue.
 
 **The modern Microsoft IME never composed for the Playwright browser windows.** Not from `IMEON`. Not from an injected
-半角/全角 carrying a correct scan code. And **not from the operator's physical toggle at the keyboard**: the IME badge
-stayed **"A"** — alphanumeric — for the focused browser window. The "previous version" compatibility engine, tried
-next, reported **"Japanese IME not ready"** pending a session restart.
+半角/全角. And **not from the operator's physical toggle at the keyboard**: the IME badge stayed **"A"** —
+alphanumeric — for the focused browser window. The "previous version" compatibility engine, tried next, reported
+**"Japanese IME not ready"** pending a session restart.
+
+> **One claim here was narrowed after the fact, and it costs this wall nothing.** This section used to say the
+> injected toggle *carried a correct scan code*. Merged-PR audit **#7956** established that it did not: `SendKey`
+> populates `wScan` but never sets `KEYEVENTF_SCANCODE`, and Microsoft's
+> [`KEYBDINPUT`](https://learn.microsoft.com/en-us/windows/win32/api/winuser/ns-winuser-keybdinput) contract is that
+> the flag is what makes `wScan` identify the key and `wVk` ignored. So the literal `0x29` was **calculated and
+> reported, never delivered as the key's identity**, and the injected toggle is evidence of nothing. The wall stands
+> on the clause after it — **the operator's physical toggle**, a real keystroke from real hardware with no rig
+> between it and the text service, which left the badge on "A" anyway.
 
 That last clause is what makes this wall decisive. It is not the rig failing to drive the IME. It is **the IME
 declining to engage for those windows at all, including under a human hand on the physical key.** There is no
@@ -331,9 +350,17 @@ work or IME-automation attempt is sanctioned.
 ### 11.5 Where acceptance goes
 
 **Back to the bounded manual session.** [`native-ime-manual-witness.md`](native-ime-manual-witness.md) — with its trace
-table, its armed buttons and its discriminating check 7 — **is** the witness. Manual hardware typing is not speculative
-here: the operator's partial session of 2026-08-11 composed real drafts in these same Playwright shells. Eight checks
-per engine, Firefox and WebKit, once.
+table, its armed buttons and its discriminating check 7 — **is** the witness. Eight checks per engine, Firefox and
+WebKit, once.
+
+What the 2026-08-11 partial session establishes about that path is narrower than this section once claimed, and the
+narrower reading is [§8](#8-check-5-and-the-observation-it-exists-to-resolve)'s own: typed **drafts reached the field**
+in these Playwright shells. Whether any of it was a **real composition** was never discriminated — the engine went
+unrecorded and the underline / candidate-window question unanswered — and §8 lists "the IME never engaged, so the
+romaji went in as ASCII" as one of the two readings that still fit. So the session is not yet proof that manual
+hardware typing composes in these shells, and given wall 3 the honest expectation is that **the first thing the manual
+session must record is whether the IME engages at all.** That is the finding either way: an engine in which the
+Playwright shell will not accept Windows IME input is a recorded cross and a bead, not a reason to re-run.
 
 The amended, final close rule:
 
@@ -347,7 +374,7 @@ resolved by the manual session's **check 5**, per that document.
 
 ### 11.6 What becomes of this rig
 
-**It stays in the tree, with its 39 teeth and its findings.** Nothing here is deprecated, withdrawn or apologised for.
+**It stays in the tree, with its 43 teeth and its findings.** Nothing here is deprecated, withdrawn or apologised for.
 It is **documentation of a refused avenue** — and the avenue is refused *on evidence* precisely because this rig
 produced the evidence. Read back through the three walls and the pattern is the same each time: the foreground
 interlock refused rather than sprayed; the readback fail-open was caught because the rig reported `compositionstart: 0`

--- a/implementation/scripts/lib/windows-ime-driver.ps1
+++ b/implementation/scripts/lib/windows-ime-driver.ps1
@@ -114,8 +114,26 @@
   behind it in any layout table. `ScanFor` therefore asks the target
   window's own layout first, falls back to this thread's, and puts a LITERAL
   `0x29` under the IME toggle beneath both, which is the only one of the
-  three that can answer for it. `KEYS` reports the scans it sent, so a zero
-  can never again be invisible.
+  three that can answer for it.
+
+  BUT THE LITERAL WAS NEVER DELIVERED AS THE KEY'S IDENTITY, and merged-PR
+  audit #7956 is right about it. `SendKey` writes `wScan` but sets neither
+  `KEYEVENTF_SCANCODE` (0x0008) nor anything else in `dwFlags` on the
+  key-down. Microsoft's `KEYBDINPUT` contract is explicit — "If specified,
+  wScan identifies the key and wVk is ignored" — so WITHOUT that flag the
+  input is defined in terms of `wVk`, and the calculated `0x29` is carried
+  rather than used to name the key.
+  <https://learn.microsoft.com/en-us/windows/win32/api/winuser/ns-winuser-keybdinput>
+
+  So `KEYS` and `RESOLVE` report the scan this driver CALCULATED, not one it
+  can prove `SendInput` delivered. A zero is still never invisible, which is
+  what those lines were added for. The flag is deliberately NOT set now: no
+  armed run is sanctioned (see the scripted-witness doc §11), so selecting
+  scan-code mode would change the identity of EVERY key this driver sends —
+  romaji included — with no run permitted that could witness the change. An
+  unwitnessable behaviour change to an artefact retained as a record is worse
+  than an accurate account of what it does, so the account is corrected here
+  instead.
 #>
 
 [CmdletBinding()]
@@ -332,6 +350,11 @@ public static class Rf2Ime
   /// question for the ordinary keys, whose scan codes DO differ between
   /// layouts, and a zero surviving all three is a real answer that `KEYS`
   /// reports rather than hides.
+  ///
+  /// WHAT THIS DOES NOT ESTABLISH: that the answer reached the target as the
+  /// key's identity. `SendKey` does not set `KEYEVENTF_SCANCODE`, so the
+  /// keystroke is defined by `wVk` and this scan rides along beside it. The
+  /// number below is the one CALCULATED; see the header.
   public static ushort ScanFor(ushort vk, IntPtr hwnd)
   {
     long hkl = LayoutOf(hwnd);
@@ -348,6 +371,13 @@ public static class Rf2Ime
   /// PARAMETER rather than something computed here: the only correct answer
   /// depends on the window being typed into, which this function is not
   /// told, and a witness has to be able to print what it actually sent.
+  ///
+  /// `dwFlags` deliberately does NOT carry `KEYEVENTF_SCANCODE` (0x0008).
+  /// Under that flag `wScan` would identify the key and `wVk` would be
+  /// IGNORED — for every key here, not just the toggle — and no armed run is
+  /// sanctioned that could witness the difference. So the input is defined by
+  /// `wVk`, `wScan` rides beside it, and nothing in this file may be read as
+  /// proof that a literal physical scan was delivered. See the header.
   public static uint SendKey(ushort vk, ushort scan)
   {
     INPUT[] two = new INPUT[2];
@@ -473,9 +503,11 @@ while ($null -ne ($line = [Console]::In.ReadLine())) {
         # The window handle is OPTIONAL, because which scan code a key carries
         # is a question about the layout of the thread that owns the window
         # and the preflight asks this before any window is found. Given one,
-        # the answer is what `KEYS` would actually send — which is how the
-        # REHEARSAL can show the 半角/全角 toggle carrying a non-zero scan
-        # without sending a single keystroke.
+        # the answer is the scan `KEYS` would CALCULATE and pass to `SendKey`
+        # — which is how the REHEARSAL can show the 半角/全角 toggle resolving
+        # to a non-zero scan without sending a single keystroke. It is not a
+        # claim that the scan identifies the key on the wire: `SendKey` sets
+        # no `KEYEVENTF_SCANCODE`, so `wVk` does that. See `ScanFor`.
         $h = if ($parts.Length -gt 3) { [IntPtr][int64]$parts[3] } else { [IntPtr]::Zero }
         Reply $id 'OK' ([ordered]@{
           tokens = ($tokens -join ',')
@@ -523,7 +555,9 @@ while ($null -ne ($line = [Console]::In.ReadLine())) {
           $vks = @($tokens | ForEach-Object { Resolve-Vk $_ })
           # Resolved against the TARGET window's layout, once, before the
           # first key goes out — see `ScanFor`. Reported below, because the
-          # zero that stopped the IME toggle working was invisible.
+          # zero that stopped the IME toggle working was invisible. The
+          # report says what was CALCULATED and handed to `SendKey`, not what
+          # arrived: absent `KEYEVENTF_SCANCODE` the key is named by `wVk`.
           $scans = @($vks | ForEach-Object { [Rf2Ime]::ScanFor($_, $h) })
           $sent = 0
           for ($i = 0; $i -lt $vks.Count; $i++) {

--- a/implementation/scripts/run-hicasso-native-ime-witness.cjs
+++ b/implementation/scripts/run-hicasso-native-ime-witness.cjs
@@ -289,6 +289,59 @@ const NOT_REAL = {
 const OPEN = { ...REAL, compositionend: 0, compositionendData: null };
 const CLOSED = { ...REAL, compositionend: 1 };
 
+/**
+ * Did the REHEARSAL actually rehearse? Pure, so the teeth below can drive it.
+ *
+ * The rehearsal's whole claim is procedural — "every page-side step of every
+ * check ran and every read came back" — and until now nothing checked it.
+ * `driveEngine` catches a prepare failure and returns `results: []` so that one
+ * engine's refusal cannot take the other two down with it (the right conduct,
+ * added after Firefox's honest abort discarded WebKit on 2026-08-12), and it
+ * catches a per-check throw into an INCONCLUSIVE. Both are correct locally and
+ * both were invisible to the caller: `main` returned 0 for every non-inject
+ * mode regardless, so a run that found no window, mounted nothing and drove
+ * ZERO checks printed REHEARSAL COMPLETE and exited 0.
+ *
+ * That is the same fail-open shape as wall 2 one layer out — a claim that
+ * satisfied itself instead of being measured — so it is measured here.
+ *
+ * READBACK is the load-bearing clause. Every one of the eight runners emits
+ * one, and a check that threw mid-drive is caught into a verdict that has
+ * none. A rehearsal in which every selector silently resolved to `null` would
+ * otherwise print the same eight INCONCLUSIVEs as one in which they all
+ * worked; requiring the readback is what separates them, which is precisely
+ * the discriminator §5 of the scripted-witness doc already names for a human
+ * reading the log.
+ *
+ * This says nothing about any ENGINE — a rehearsal never can. It says only
+ * whether the rig ran, which is the only thing a rehearsal is entitled to
+ * assert.
+ */
+function rehearsalOutcome(runs, engines, checkCount) {
+  const problems = [];
+  const seen = new Set(runs.map((r) => r.engine));
+  for (const engine of engines) {
+    if (!seen.has(engine)) problems.push(`${engine} produced no run at all`);
+  }
+  for (const run of runs) {
+    if (run.refusal) {
+      problems.push(`${run.engine} was refused before any check was driven, so ` +
+        `none of its page-side steps ran: ${run.refusal}`);
+      continue;
+    }
+    if (run.results.length !== checkCount) {
+      problems.push(`${run.engine} drove ${run.results.length} of ${checkCount} checks`);
+    }
+    const mute = run.results.filter((r) => !r.readback).map((r) => r.id);
+    if (mute.length > 0) {
+      problems.push(`${run.engine} produced no READBACK for ${mute.length} ` +
+        `check(s) — ${mute.join(', ')} — so its reads cannot be said to have ` +
+        'come back');
+    }
+  }
+  return { ok: problems.length === 0, problems };
+}
+
 function runMutationTeeth() {
   const teeth = [];
   const bite = (name, fn) => {
@@ -579,6 +632,39 @@ function runMutationTeeth() {
     const cell = W.dispositionCell(W.summarise(full),
       { engine: 'firefox', build: 'firefox-1511', date: '2026-08-11' });
     return cell.includes('Witness-verified') && cell.includes('firefox-1511');
+  });
+
+  // --- the REHEARSAL's own claim, fail-closed in every direction ---
+  // Merged-PR audit #7956 found `--dry-run` able to exit 0 having executed no
+  // check at all. These four are the alternatives that used to pass.
+  const drove = (engine) => ({
+    engine,
+    refusal: null,
+    results: W.CHECKS.map((c) => ({ id: c.id, verdict: W.INCONCLUSIVE, readback: 'read' })),
+  });
+  const ENG = ['chromium', 'firefox', 'webkit'];
+  const rehearsed = ENG.map(drove);
+
+  bite('a rehearsal that drove every check on every engine is complete', () =>
+    rehearsalOutcome(rehearsed, ENG, W.CHECKS.length).ok === true);
+
+  bite('an engine REFUSED in prepare cannot pass the rehearsal', () => {
+    const r = rehearsalOutcome(
+      [drove('chromium'), { engine: 'firefox', refusal: 'no window', results: [] }, drove('webkit')],
+      ENG, W.CHECKS.length);
+    return r.ok === false && r.problems.some((p) => p.includes('firefox') && p.includes('refused'));
+  });
+
+  bite('an engine that never ran at all cannot pass the rehearsal', () => {
+    const r = rehearsalOutcome([drove('chromium'), drove('firefox')], ENG, W.CHECKS.length);
+    return r.ok === false && r.problems.some((p) => p.includes('webkit') && p.includes('no run'));
+  });
+
+  bite('a check with no READBACK cannot pass the rehearsal', () => {
+    const quiet = drove('webkit');
+    quiet.results[3] = { ...quiet.results[3], readback: undefined };
+    const r = rehearsalOutcome([drove('chromium'), drove('firefox'), quiet], ENG, W.CHECKS.length);
+    return r.ok === false && r.problems.some((p) => p.includes('READBACK'));
   });
 
   return teeth;
@@ -1402,6 +1488,15 @@ async function main() {
     }
 
     if (args.mode !== 'inject') {
+      const rehearsal = rehearsalOutcome(runs, args.engines, W.CHECKS.length);
+      if (!rehearsal.ok) {
+        console.error(
+          '\nREHEARSAL INCOMPLETE — it did NOT run every page-side step of every\n' +
+          'check, so it says nothing about the rig either, and nothing above may\n' +
+          'be cited as proof that the pipeline works:');
+        for (const p of rehearsal.problems) console.error(`  - ${p}`);
+        return 1;
+      }
       console.log(
         '\nREHEARSAL COMPLETE. Every page-side step of every check ran and every\n' +
         'read came back; no keystroke was sent, so no verdict above says\n' +


### PR DESCRIPTION
## What this is, and what it is not

**It is not the three-engine matrix.** That was asked for again in the dispatch brief, and it is already on `main` —
built and repaired across PRs #7745, #7757, #7760, #7815, #7846 and #7908. I verified it rather than taking the
brief's word for it, and the verification is the first finding here:

```
PASS  chromium — 97 checks across 13 sections
PASS  firefox  — 97 checks across 13 sections
PASS  webkit   — 97 checks across 13 sections
HICASSO CONTROLLED-INPUT PASS (chromium + firefox + webkit)
```

Every behaviour the bead enumerates has a pinned section in `REQUIRED_SECTIONS`: echo
(`same-turn-convergence`), rejection and normalisation, caret (`caret-across-the-echo`,
`caret-under-real-typing`), composition (`composition-safety`, `composition-release-edges`,
`an-accepting-model-during-a-composition`, `beforeinput-does-not-drive-the-converge`), selection range and
direction (`selection-across-an-out-of-band-write`), revision reset (`revision-reset-preserves-identity`,
`a-revision-arriving-mid-composition`), blur/unmount (`armed-edges-are-wired`), and autofill + form reset
(`form-reset-and-fill-proxy`, recorded and named as a proxy — the full matrix stays `rf2-hic-040`'s).

**No browser divergence exists to fix or to narrow.** All four RECORDED rows came back byte-identical on the three
engines, `NARROWINGS` is empty, and — the direct evidence — `controlled.cljs` contains no engine branch at all:

```
$ grep -niE "firefox|webkit|chrom|safari|userAgent|navigator|gecko|blink" \
    implementation/hicasso/src/re_frame/hicasso/impl/controlled.cljs
(no matches)
```

So nothing is owed to the `hic-005` support table from this bead, and `controlled.cljs` is unchanged in this PR.

**What this PR actually does** is the work the bead's two newest notes ask for — merged-PR audits **#7956** and
**#7960** — both verified at source before being acted on.

## The three repairs

**1. The rehearsal could exit 0 having driven no check at all** (`run-hicasso-native-ime-witness.cjs`).
`driveEngine` catches a prepare failure into `results: []`, which is right conduct — it stops one engine's refusal
discarding the other two, the defect that cost WebKit its run on 2026-08-12. But `main` then returned 0 for every
non-inject mode regardless, printing *"every page-side step of every check ran and every read came back"* over a run
in which none had. That is wall 2's own shape — a claim that satisfied itself instead of being measured — one layer
out, inside the rig built to catch it.

Replaced by a pure `rehearsalOutcome`: every requested engine produced a run, none was refused in prepare, each drove
the full roster, and **every check carries its `READBACK`**. The readback clause is the load-bearing one — all eight
runners emit one and a check caught mid-drive has none, so it separates a rehearsal whose selectors resolved from one
whose selectors silently returned `null`, which is exactly the discriminator §5 of the doc already named for a human
reading the log. Four teeth, **39 → 43**.

**2. The driver never delivered the literal scan it calculated** (`windows-ime-driver.ps1`). `SendKey` writes `wScan`
but sets `dwFlags = 0` on the key-down; `KEYEVENTF_SCANCODE` (0x0008) is defined nowhere in the file. Microsoft's
[`KEYBDINPUT`](https://learn.microsoft.com/en-us/windows/win32/api/winuser/ns-winuser-keybdinput) contract — read at
source, not from memory — is that the flag is what makes `wScan` identify the key and `wVk` ignored. So the
calculated `0x29` rode along beside a keystroke named by `wVk`. Four sites claimed otherwise; each now says
CALCULATED.

**The flag is deliberately not set**, and that is a judgment worth stating rather than burying. Audit #7956 offers
the fork: repair the code *if the rig is kept as a supported diagnostic*, otherwise narrow the record. §11.6 keeps it
as **documentation of a refused avenue**, and selecting scan-code mode would change the identity of every key the
driver sends — romaji included — with no armed run sanctioned that could witness the change. An unwitnessable
behaviour change to an artefact retained as a record is worse than an accurate account of what it does.

**Wall 3 survives this untouched**, which matters: its decisive clause is the operator's *physical* toggle leaving the
IME badge on "A", a real keystroke with no rig between it and the text service.

**3. Three overstated claims in the record** (`native-ime-scripted-witness.md`). §5's "remain honest about what they
prove" now records the fail-open above and the four clauses that replaced it. §11.3 drops "carrying a correct scan
code" and records why, noting the wall stands regardless. §11.5 said the 2026-08-11 partial session "composed real
drafts" — the reading §8 explicitly lists as *unestablished*, with no engine recorded and the underline/candidate
discriminator unanswered. Narrowed to what §8 supports (drafts reached the field), with the consequence stated: the
first thing the manual session must record is whether the IME engages at all. Teeth count 39 → 43 at all four sites.

## Sabotage

Both new mechanisms were sabotaged rather than reasoned about, and both reds are verbatim:

```
$ # rehearsalOutcome forced to { ok: true }
Error: MUTATION TOOTH DID NOT BITE: an engine REFUSED in prepare cannot pass the rehearsal   (exit 1)

$ # the readback clause alone neutered
Error: MUTATION TOOTH DID NOT BITE: a check with no READBACK cannot pass the rehearsal       (exit 1)
```

Both reverted; the tree is byte-identical to the committed state and `--self-test` returns to `teeth bit: 43`.

The **other** direction was measured too, which is the half a fail-closed change usually skips: the full unarmed
rehearsal was run end-to-end and still exits **0**. All three engines launched, all 8 × 3 = 24 checks were driven,
every one printed its `READBACK`, and every one returned `INCONCLUSIVE` against the named premise *"no composition
ever started"* — with the report ending, correctly, on `REHEARSAL COMPLETE`. So the new floor does not red a
rehearsal that genuinely rehearsed; it reds only one that did not.

## Quality gates

Each run alone, redirected to its own log, exit code captured on the same command line. Every code below is one I
captured, not one the harness reported.

| Gate | Command | Exit |
|---|---|---|
| Three-engine controlled-input (the deciding gate) | `npm run test:hicasso-controlled` | **0** |
| Fast-PR spine | `sh scripts/test-fast-pr.sh` | **0** |
| IME witness self-test (43 teeth) | `node scripts/run-hicasso-native-ime-witness.cjs --self-test` | **0** |
| IME witness rehearsal, unarmed, three engines | `node scripts/run-hicasso-native-ime-witness.cjs --dry-run` | **0** |
| ESLint on the changed `.cjs` | `npx eslint implementation/scripts/run-hicasso-native-ime-witness.cjs` | **0** |
| Doc slugs / anchors | `python scripts/check_doc_slugs.py` | **0** |
| Provenance pins, self-test | `python scripts/check_provenance_pins.py --self-test` | **0** |
| Provenance pins, changed pages (the CI form) | `python scripts/check_provenance_pins.py --changed-since origin/main --verbose` | **0** |
| PowerShell parse of the driver | `[Parser]::ParseFile(...)` | **0 findings** |
| Whitespace | `git diff --check origin/main...HEAD` | **0** |

The `gate root:` line printed by the fast-PR spine reads
`/c/Users/miket/code/re-frame2-worktrees/controlled-hic016` — my worktree, not the mayor checkout.

**Skips, with reasons.** `npm run test:browser` was not run: it is the Chromium `:browser-test` lane over
`implementation/**` CLJS, and this diff contains **no CLJS at all** (one `.cjs`, one `.ps1`, one `.md`). The lane that
does cover this bead's surface is `test:hicasso-controlled`, which I ran and which is green. The corpus-wide
`check_provenance_pins.py` (no flag) reports 7 findings — **all of them pre-existing on `main`**, all under
`docs/design/hicasso/studio/**`, none in a file this PR touches; I confirmed them identical from a pristine mayor
checkout, and the CI job is the `--changed-since` form above, which is clean.

`python scripts/check_fast_pr_gap.py --list` reports **97** required checks the local spine does not decide. The ones
this diff could plausibly reach are `cljs-hicasso-controlled` (run locally, exit 0), `eslint` under `Lint required`
(run locally, exit 0), and `provenance-pins` under `Docs required` (run locally in its CI form, exit 0). The
remainder are surface-gated in CI and this diff does not reach them. Per that tool's own note, clj-kondo and Splint
are **not** claimed here — CI pins clj-kondo 2026.04.15 and a differently-versioned local binary proves nothing; this
diff touches no Clojure source in any case.

## Fences

No `.github/workflows/**` edit, and none was needed — the retained rig has no CI lane by design and the
`cljs-hicasso-controlled` job already arms on `implementation/hicasso/**` and on its launcher. No
`implementation/shadow-cljs.edn` edit; no build id or `:dev-http` port was required. No root `scripts/**` edit
(rf2-x1mz/rf2-uomk's surface this wave) — the rig lives under `implementation/scripts/`, which is a different tree.
Nothing under `implementation/hicasso/test/` (rf2-5zt9's). No `.beads/*` database file.

Out-of-fence files, named rather than assumed: `implementation/scripts/run-hicasso-native-ime-witness.cjs`,
`implementation/scripts/lib/windows-ime-driver.ps1` and `docs/design/hicasso/native-ime-scripted-witness.md`. All
three are this bead's own scripted-witness surface, they are the exact files audits #7956/#7960 name, and this bead's
earlier PRs set the precedent of naming such files in the body.

Per the `docs/design/**` rule: `mkdocs build --strict` does not cover this tree, so the anchors were checked by
`check_doc_slugs.py` (exit 0) and **no table row was added, removed or reflowed** — verified with
`git diff -U0 … | grep '|'`, which returns nothing.

## The bead stays open

`rf2-hic-016`'s close rule is the operator's, ruled 2026-08-12 13:11 AUSEST and reaffirmed as final: it closes when
the **manual session** results for Firefox and WebKit are recorded in `dispositions.md` §2.3 with date and engine
builds. Those two cells still read *Pending the manual session*, and filling them needs a human at a physical
keyboard on the live desktop — three armed runs established the OS will not let an automated session take it. This PR
does not close the bead and must not be read as doing so.
