### PR TITLE
fix(migration): reader-conditional requires and a stale corpus citation (rf2-m4hm, rf2-cvjp)

### DIFF
--- a/migration/reagent-to-hicasso/codemod/README.md
+++ b/migration/reagent-to-hicasso/codemod/README.md
@@ -58,15 +58,23 @@ buckets — including `:mechanical 0`, which is a measurement rather than an
 omission: every mechanical rewrite this tool family knows is a W-rule, and every
 W-rule sits at a crossing.
 
-**What the census cannot resolve, it reports.** `#?(:cljs [reagent.core :as r])`
-is the only legal way to require Reagent from a `.cljc` file and the reader
-binds nothing for it, so before the census such a file was silently a file with
-no Reagent in it — W4 and W5 dead, every API in it unnamed, and the report
-non-empty enough (`:>` needs no alias) that nothing looked wrong. It is now
+**A reader-conditional require binds.** `#?(:cljs [reagent.core :as r])` is the
+only legal way to require Reagent from a `.cljc` file, and the tool reads it —
+both the plain shape and the splicing `#?@`, and a conditional around the whole
+`(:require …)` clause too. It did not always: `ns-context` used to read the `ns`
+form through one `sexpr`, which throws on a reader-conditional node, so the whole
+form went unreadable and every alias came back empty. Such a file was silently a
+file with no Reagent in it — W4 and W5 dead, every API in it unnamed, and the
+report non-empty enough (`:>` needs no alias) that nothing looked wrong. Three
+files under `examples/capabilities/ssr/` are real instances (rf2-m4hm).
+
+**What the census still cannot resolve, it reports.** A namespace that SPELLS a
+Reagent name without being Reagent's — a project vendoring it under an inlined
+name, such as `day8.re-frame-10x.inlined-deps.reagent.v1v2v0.reagent.core` — is
 `:unresolved-reagent-require` at the `ns` form, with every qualified
-roster-named call in the file reported as `:unresolved-alias`. Three files under
-`examples/capabilities/ssr/` are real instances; so is every namespace of a
-project that vendors Reagent under an inlined name.
+roster-named call in the file reported as `:unresolved-alias`. The tool does not
+guess that such a copy is `reagent.core`: a wrong binding rewrites working code,
+which is worse than naming what it cannot resolve.
 
 **What it cannot name, it does not count.** A Form-2 component is a `defn`
 returning a `fn` and nothing else marks it; a structural test for that would

--- a/migration/reagent-to-hicasso/codemod/src/re_frame/migration/hicasso/census.clj
+++ b/migration/reagent-to-hicasso/codemod/src/re_frame/migration/hicasso/census.clj
@@ -40,21 +40,29 @@
   ## The law this file exists to obey
 
   **What cannot be resolved is REPORTED, never skipped.** [[ns-context]]
-  answers `#{}` for a require the reader cannot read, and the common one
-  is not exotic — `#?(:cljs [reagent.core :as r])` is the ONLY legal way
-  to require Reagent from a `.cljc` file. Before this namespace, such a
-  file was silently a file with no Reagent in it: every `r/atom`,
+  answers `#{}` for a require it cannot resolve. Such a file would
+  otherwise be silently a file with no Reagent in it: every `r/atom`,
   `r/as-element` and `(r/partial …)` in it invisible, W4 and W5 dead, and
   the report non-empty enough (the `:>` head needs no alias) that nobody
   would suspect a hole. That is a census that cannot fail, which is a
   census that cannot be believed.
 
-  It is now `:unresolved-reagent-require`, at the `ns` form's own line, and
+  It is `:unresolved-reagent-require`, at the `ns` form's own line, and
   every roster-named call in such a file is `:unresolved-alias` with the
-  symbol it could not bind. The FIXER's blindness is unchanged and
-  deliberate — a fixer that starts rewriting `.cljc` files it previously
-  could not see is a behaviour change, and this is a reporter — so the
-  census's job is to make the hole loud, not to paper over it.
+  symbol it could not bind.
+
+  **The population that class names has SHRUNK, and deliberately.** The
+  original one was `#?(:cljs [reagent.core :as r])` — the only legal way
+  to require Reagent from a `.cljc` file, and so the commonest unbindable
+  require there was. rf2-m4hm taught [[ns-context]] to read require
+  clauses structurally, through the reader-conditional node, so that shape
+  now BINDS: its call sites get their real classes and the fixer sees the
+  file. What remains is the genuinely undecidable — chiefly a namespace
+  that spells a Reagent name without being Reagent's, such as
+  re-frame-10x's vendored
+  `day8.re-frame-10x.inlined-deps.reagent.v1v2v0.reagent.core`. The tool
+  reports those and does not guess at them; guessing would be a worse
+  tool than the blind one.
 
   ## What it does not guess
 
@@ -194,12 +202,14 @@
 
    :unresolved-reagent-require
    (str "This file's `ns` form NAMES a Reagent namespace, and the reader could not bind a "
-        "single symbol to it — a reader-conditional require (`#?(:cljs [reagent.core :as r])`), "
-        "the only legal way to require Reagent from a `.cljc` file, is the usual cause. EVERY "
-        "TOOL IN THIS FAMILY IS PARTIALLY BLIND IN THIS FILE: `r/partial` is not wrapped (W4), "
-        "`(r/adapt-react-class …)` is not respelled (W5), and Reagent API inside a crossing is "
-        "not named. Read this file by hand, or move the require out of the reader conditional "
-        "and re-run.")
+        "single symbol to it. The usual cause is a namespace that SPELLS a Reagent name "
+        "without being Reagent's — a vendored or inlined copy such as "
+        "`day8.re-frame-10x.inlined-deps.reagent.v1v2v0.reagent.core`, or a submodule outside "
+        "the roster. EVERY TOOL IN THIS FAMILY IS PARTIALLY BLIND IN THIS FILE: `r/partial` is "
+        "not wrapped (W4), `(r/adapt-react-class …)` is not respelled (W5), and Reagent API "
+        "inside a crossing is not named. Read this file by hand. The tool will not guess that "
+        "such a copy is `reagent.core`: a wrong binding rewrites working code, which is worse "
+        "than naming what it cannot resolve.")
 
    :unresolved-alias
    (str "A call whose NAME is on the Reagent roster, in a file whose Reagent require the reader "

--- a/migration/reagent-to-hicasso/codemod/src/re_frame/migration/hicasso/rewrite.clj
+++ b/migration/reagent-to-hicasso/codemod/src/re_frame/migration/hicasso/rewrite.clj
@@ -311,12 +311,15 @@
   reader was able to make of the form?
 
   [[ns-context]] answers the stronger question (which local symbols are
-  bound to it) and answers `#{}` for a require the reader cannot resolve:
-  `#?(:cljs [reagent.core :as r])` is the common one, and it is the only
-  legal way to require Reagent from a `.cljc` file. The two answers
-  disagreeing is precisely the state a census must REPORT rather than
-  read as \"no Reagent here\" — see
-  [[re-frame.migration.hicasso.census/scan]].
+  bound to it) and answers `#{}` for a require it cannot resolve. Since
+  rf2-m4hm that no longer includes the reader-conditional shape
+  `#?(:cljs [reagent.core :as r])`, which is read structurally; what
+  remains is chiefly a namespace that SPELLS a Reagent name without being
+  Reagent's — re-frame-10x's vendored
+  `day8.re-frame-10x.inlined-deps.reagent.v1v2v0.reagent.core` — and the
+  prefix-list shape below. The two answers disagreeing is precisely the
+  state a census must REPORT rather than read as \"no Reagent here\" —
+  see [[re-frame.migration.hicasso.census/scan]].
 
   Read off the TEXT of the `ns` form's CLAUSES, against the
   `reagent-namespaces` roster, so it is blind to nothing the reader is
@@ -343,6 +346,57 @@
            s       (apply str (map n/string clauses))]
        (some #(str/includes? s (str %)) reagent-namespaces)))))
 
+(defn- reader-conditional-node?
+  "Is this node a reader conditional — `#?(…)` or `#?@(…)`?
+
+  A `:reader-macro` node whose first element is the `?` or `?@` token. Any
+  OTHER reader macro (a tagged literal, `#'var`) is not one, and is left
+  alone."
+  [node]
+  (and (= :reader-macro (n/tag node))
+       (contains? #{"?" "?@"} (some-> (element-at node 0) n/string))))
+
+(defn- conditional-values
+  "Every BRANCH VALUE of a reader conditional, from every feature.
+
+  The body is a list of alternating feature keyword and value, so the
+  values are the odd positions. A splicing `#?@` branch holds a COLLECTION
+  of values where a plain `#?` branch holds one, so its elements are
+  lifted a level — that is the whole difference between the two shapes.
+
+  **Every feature, not the `:cljs` one.** The tool reads source text; it
+  does not resolve a platform, and it has no business deciding which
+  branch a consumer's build will take. Reading all of them is also the
+  conservative direction for this tool specifically: the answer feeds
+  [[reagent-call?]], and a symbol bound to Reagent under ANY feature is a
+  symbol whose call sites a migrator must see."
+  [node]
+  (let [values (->> (element-at node 1) elements (drop 1) (take-nth 2))]
+    (if (= "?@" (n/string (element-at node 0)))
+      (mapcat elements values)
+      values)))
+
+(defn- through-conditionals
+  "`nodes`, with every reader conditional replaced by its branch values.
+  Everything else passes through untouched."
+  [nodes]
+  (mapcat #(if (reader-conditional-node? %) (conditional-values %) [%]) nodes))
+
+(defn- require-specs
+  "Every require SPEC node in this `ns` form, as nodes.
+
+  Reader conditionals are seen through at BOTH levels — a conditional
+  wrapping the whole `(:require …)` clause, and the far commoner one
+  wrapping a single spec inside it."
+  [ns-form]
+  (->> (elements ns-form)
+       through-conditionals
+       (filter #(and (list-node? %)
+                     (contains? #{:require :require-macros}
+                                (sexpr-safe (element-at % 0)))))
+       (mapcat #(rest (elements %)))
+       through-conditionals))
+
 (defn ns-context
   "Read a file's `ns` form and answer which symbols name Reagent's API.
 
@@ -352,25 +406,49 @@
   literal call through a symbol this map resolves. A bare `partial` is
   `clojure.core/partial` — which IS a function, so the donor never wrapped
   it — unless the `ns` form referred Reagent's, so the referred set is
-  read rather than assumed."
+  read rather than assumed.
+
+  **Read SPEC BY SPEC, never as one `sexpr` of the whole form**, and that
+  is the entire reason [[require-specs]] exists. `sexpr` throws on a
+  reader-conditional node, so reading the form entire answered
+  `::unreadable` for the WHOLE `ns` — hence `#{}` for every alias — the
+  moment any one require sat behind a `#?`. And
+
+      (ns app.ssr (:require #?(:cljs [reagent.dom.client :as rdc])))
+
+  is the ONLY legal way to require Reagent from a `.cljc` file. So W4 and
+  W5 were dead in every such file, every Reagent API in them went unnamed,
+  and nothing looked wrong because a `:>` head needs no alias and kept the
+  report non-empty. A spec node on its own is ordinary data and reads
+  fine; only the conditional WRAPPER was ever unreadable (rf2-m4hm).
+
+  The mixed file is why this is read per spec rather than fixed with a
+  fallback: one ordinary require beside one conditional require left the
+  alias set non-empty, so a whole-form retry would have found nothing to
+  retry while the conditional half stayed invisible.
+
+  **A namespace that merely SPELLS `reagent.core` is not Reagent's.** Only
+  the exact roster in `reagent-namespaces` binds, so re-frame-10x's
+  vendored `day8.re-frame-10x.inlined-deps.reagent.v1v2v0.reagent.core`
+  still binds NOTHING and is still reported unresolved by the census. That
+  is a different case and the tool must not guess at it."
   [root-node]
-  (let [ns-form (ns-form-node root-node)
-        form    (some-> ns-form sexpr-safe)
-        reqs    (when (seq? form)
-                  (->> form
-                       (filter #(and (seq? %) (contains? #{:require :require-macros} (first %))))
-                       (mapcat rest)))]
-    (reduce
-     (fn [acc spec]
-       (let [spec (if (symbol? spec) [spec] spec)]
-         (if (and (sequential? spec) (contains? reagent-namespaces (first spec)))
-           (let [opts (apply hash-map (rest spec))]
-             (cond-> (update acc :aliases conj (first spec))
-               (:as opts)    (update :aliases conj (:as opts))
-               (:refer opts) (update :referred into (:refer opts))))
-           acc)))
-     {:aliases #{} :referred #{}}
-     reqs)))
+  (reduce
+   (fn [acc spec]
+     (let [spec (if (symbol? spec) [spec] spec)]
+       (if (and (sequential? spec) (contains? reagent-namespaces (first spec)))
+         ;; Pairwise rather than `(apply hash-map …)`, and `:refer` taken
+         ;; only when it is a collection: this reads source nobody in this
+         ;; repository wrote, and a lone trailing option or `:refer :all`
+         ;; must leave the tool answering less, never throwing.
+         (let [opts (into {} (comp (partition-all 2) (filter #(= 2 (count %))) (map vec))
+                          (rest spec))]
+           (cond-> (update acc :aliases conj (first spec))
+             (symbol? (:as opts))          (update :aliases conj (:as opts))
+             (sequential? (:refer opts))   (update :referred into (:refer opts))))
+         acc)))
+   {:aliases #{} :referred #{}}
+   (map sexpr-safe (some-> (ns-form-node root-node) require-specs))))
 
 (defn reagent-call?
   "Is `node` a literal call to Reagent's `sym`, through an alias this

--- a/migration/reagent-to-hicasso/codemod/test/corpus/reader-conditional-not-reagent/expected-report.edn
+++ b/migration/reagent-to-hicasso/codemod/test/corpus/reader-conditional-not-reagent/expected-report.edn
@@ -1,0 +1,32 @@
+[{:line 23,
+  :col 3,
+  :class :cljc-site,
+  :action :refused,
+  :head "Btn",
+  :detail {},
+  :note
+  "This crossing is in a `.cljc` file. `[:>]` is a ClojureScript-only node — the JVM side of this file has no React to cross into — so check that this branch is reader-conditioned to `:cljs`."}
+ {:line 23,
+  :col 3,
+  :class :computed-value,
+  :action :refused,
+  :head "Btn",
+  :detail {:props [":on-pick"]},
+  :note
+  "These prop values are computed, so the tool cannot see what crosses. Three things a computed value may silently be, each of which diverges: a KEYWORD or symbol (Reagent named it, Hicasso keeps it whole), a NESTED MAP (Reagent camelCased its keys, Hicasso does not), or a non-fn `IFn` such as an `r/partial` reached through a symbol (Reagent wrapped it, Hicasso passes it opaque and the handler stops firing). Check each by hand."}
+ {:line 29,
+  :col 3,
+  :class :cljc-site,
+  :action :refused,
+  :head "Btn",
+  :detail {},
+  :note
+  "This crossing is in a `.cljc` file. `[:>]` is a ClojureScript-only node — the JVM side of this file has no React to cross into — so check that this branch is reader-conditioned to `:cljs`."}
+ {:line 29,
+  :col 3,
+  :class :computed-value,
+  :action :refused,
+  :head "Btn",
+  :detail {:props [":label"]},
+  :note
+  "These prop values are computed, so the tool cannot see what crosses. Three things a computed value may silently be, each of which diverges: a KEYWORD or symbol (Reagent named it, Hicasso keeps it whole), a NESTED MAP (Reagent camelCased its keys, Hicasso does not), or a non-fn `IFn` such as an `r/partial` reached through a symbol (Reagent wrapped it, Hicasso passes it opaque and the handler stops firing). Check each by hand."}]

--- a/migration/reagent-to-hicasso/codemod/test/corpus/reader-conditional-not-reagent/expected.cljc
+++ b/migration/reagent-to-hicasso/codemod/test/corpus/reader-conditional-not-reagent/expected.cljc
@@ -1,0 +1,29 @@
+(ns app.reader-conditional-not-reagent
+  "THE ADVERSARIAL CASE for rf2-m4hm: a `.cljc` whose reader conditionals
+  require things that are NOT Reagent.
+
+  Seeing through a reader conditional is only correct if it also declines
+  to bind. The failure mode this pins is a fix that reads every branch as
+  Reagent's because a branch is where Reagent usually lives — which would
+  wrap a `clojure.core/partial`, respell a head that is not
+  `adapt-react-class`, and rewrite a file with no Reagent in it at all.
+
+  A namespace that merely SPELLS a Reagent name is the same class and is
+  here too: re-frame-10x's vendored copy is not `reagent.core`, and
+  guessing that it is would be worse than not seeing it. Only the exact
+  roster binds, so this file's `r` is `10x`'s and must stay unbound.
+
+  Nothing below may be rewritten."
+  (:require [clojure.string :as str]
+            #?(:cljs [goog.dom :as gdom])
+            #?@(:cljs [[day8.re-frame-10x.inlined-deps.reagent.v1v2v0.reagent.core :as r]])))
+
+(defn a-partial-that-is-not-reagents []
+  ;; `r` here is the VENDORED reagent, not `reagent.core`. W4 must not fire.
+  [:> Btn {:on-pick (r/partial handler @cart)}])
+
+(defn a-head-that-is-not-adapt-react-class []
+  [(gdom/adapt-react-class Foo) {:variant :big}])
+
+(defn no-reagent-anywhere []
+  [:> Btn {:label (str/upper-case "go")}])

--- a/migration/reagent-to-hicasso/codemod/test/corpus/reader-conditional-not-reagent/input.cljc
+++ b/migration/reagent-to-hicasso/codemod/test/corpus/reader-conditional-not-reagent/input.cljc
@@ -1,0 +1,29 @@
+(ns app.reader-conditional-not-reagent
+  "THE ADVERSARIAL CASE for rf2-m4hm: a `.cljc` whose reader conditionals
+  require things that are NOT Reagent.
+
+  Seeing through a reader conditional is only correct if it also declines
+  to bind. The failure mode this pins is a fix that reads every branch as
+  Reagent's because a branch is where Reagent usually lives — which would
+  wrap a `clojure.core/partial`, respell a head that is not
+  `adapt-react-class`, and rewrite a file with no Reagent in it at all.
+
+  A namespace that merely SPELLS a Reagent name is the same class and is
+  here too: re-frame-10x's vendored copy is not `reagent.core`, and
+  guessing that it is would be worse than not seeing it. Only the exact
+  roster binds, so this file's `r` is `10x`'s and must stay unbound.
+
+  Nothing below may be rewritten."
+  (:require [clojure.string :as str]
+            #?(:cljs [goog.dom :as gdom])
+            #?@(:cljs [[day8.re-frame-10x.inlined-deps.reagent.v1v2v0.reagent.core :as r]])))
+
+(defn a-partial-that-is-not-reagents []
+  ;; `r` here is the VENDORED reagent, not `reagent.core`. W4 must not fire.
+  [:> Btn {:on-pick (r/partial handler @cart)}])
+
+(defn a-head-that-is-not-adapt-react-class []
+  [(gdom/adapt-react-class Foo) {:variant :big}])
+
+(defn no-reagent-anywhere []
+  [:> Btn {:label (str/upper-case "go")}])

--- a/migration/reagent-to-hicasso/codemod/test/corpus/reader-conditional-require/expected-report.edn
+++ b/migration/reagent-to-hicasso/codemod/test/corpus/reader-conditional-require/expected-report.edn
@@ -1,0 +1,101 @@
+[{:line 18,
+  :col 3,
+  :class :cljc-site,
+  :action :refused,
+  :head "Btn",
+  :detail {},
+  :note
+  "This crossing is in a `.cljc` file. `[:>]` is a ClojureScript-only node — the JVM side of this file has no React to cross into — so check that this branch is reader-conditioned to `:cljs`."}
+ {:line 18,
+  :col 3,
+  :class :partial-wrapper,
+  :action :rewrote,
+  :head "Btn",
+  :detail
+  {:prop ":on-pick",
+   :was "(r/partial handler @cart)",
+   :now
+   "(let [f__rf2 handler a0__rf2 @cart] (fn [& args__rf2] (apply f__rf2 a0__rf2 args__rf2)))",
+   :captured ["@cart"]},
+  :note
+  "Reagent's `convert-prop-value` ends with an `ifn?` arm that wrapped a `PartialFn` in `(fn [& args] (apply x args))`. Hicasso has no such arm, so the object would have crossed opaque and this handler would have stopped firing with nothing thrown. The wrapper is Reagent's own, transcribed — return-transparent, so whatever it returned before it returns now. The `let` is not decoration: `r/partial` evaluated the callee and every argument ONCE when the prop was built, and the `let` is what keeps that true instead of re-evaluating them on every invocation."}
+ {:line 22,
+  :col 3,
+  :class :cljc-site,
+  :action :refused,
+  :head "Foo",
+  :detail {},
+  :note
+  "This crossing is in a `.cljc` file. `[:>]` is a ClojureScript-only node — the JVM side of this file has no React to cross into — so check that this branch is reader-conditioned to `:cljs`."}
+ {:line 22,
+  :col 3,
+  :class :adapt-react-class-head,
+  :action :rewrote,
+  :head "Foo",
+  :detail {:head "Foo"},
+  :note
+  "`vec-to-elem` sent a `NativeWrapper` head and a `[:> C …]` head to the SAME `native-element`, with the props slot at a different index — two spellings of one path. Respelled as `[:> …]`, which is the form Hicasso accepts; left alone it is a head Hicasso answers with `:rf.error/hicasso-bad-head`."}
+ {:line 22,
+  :col 3,
+  :class :named-value,
+  :action :rewrote,
+  :head "Foo",
+  :detail {:prop ":variant", :was ":big", :now "big"},
+  :note
+  "Reagent named every keyword and symbol prop value; Hicasso keeps them whole except at HTML-attribute slots. The string is a fixpoint on both walks."}
+ {:line 25,
+  :col 3,
+  :class :cljc-site,
+  :action :refused,
+  :head "Grid",
+  :detail {},
+  :note
+  "This crossing is in a `.cljc` file. `[:>]` is a ClojureScript-only node — the JVM side of this file has no React to cross into — so check that this branch is reader-conditioned to `:cljs`."}
+ {:line 25,
+  :col 3,
+  :class :as-element-island,
+  :action :refused,
+  :head "Grid",
+  :detail {},
+  :note
+  "An `r/as-element` inside a callback body at this site. Port it by hand: the closure runs when the library calls it, OUTSIDE the owner's render window, so swapping Reagent's lowering for Hicasso's is not a text substitution."}
+ {:line 28,
+  :col 3,
+  :class :cljc-site,
+  :action :refused,
+  :head "C",
+  :detail {},
+  :note
+  "This crossing is in a `.cljc` file. `[:>]` is a ClojureScript-only node — the JVM side of this file has no React to cross into — so check that this branch is reader-conditioned to `:cljs`."}
+ {:line 28,
+  :col 3,
+  :class :reagent-api-residue,
+  :action :refused,
+  :head "C",
+  :detail {},
+  :note
+  "Reagent API — `r/atom`, `r/cursor`, `r/track`, a form-2 or form-3 shape — inside this site. That is outside this tool's fence entirely; it is named here so you are not surprised by it later."}
+ {:line 28,
+  :col 3,
+  :class :computed-value,
+  :action :refused,
+  :head "C",
+  :detail {:props [":value"]},
+  :note
+  "These prop values are computed, so the tool cannot see what crosses. Three things a computed value may silently be, each of which diverges: a KEYWORD or symbol (Reagent named it, Hicasso keeps it whole), a NESTED MAP (Reagent camelCased its keys, Hicasso does not), or a non-fn `IFn` such as an `r/partial` reached through a symbol (Reagent wrapped it, Hicasso passes it opaque and the handler stops firing). Check each by hand."}
+ {:line 32,
+  :col 3,
+  :class :cljc-site,
+  :action :refused,
+  :head "Btn",
+  :detail {},
+  :note
+  "This crossing is in a `.cljc` file. `[:>]` is a ClojureScript-only node — the JVM side of this file has no React to cross into — so check that this branch is reader-conditioned to `:cljs`."}
+ {:line 32,
+  :col 3,
+  :class :computed-value,
+  :action :refused,
+  :head "Btn",
+  :detail {:props [":on-pick"]},
+  :note
+  "These prop values are computed, so the tool cannot see what crosses. Three things a computed value may silently be, each of which diverges: a KEYWORD or symbol (Reagent named it, Hicasso keeps it whole), a NESTED MAP (Reagent camelCased its keys, Hicasso does not), or a non-fn `IFn` such as an `r/partial` reached through a symbol (Reagent wrapped it, Hicasso passes it opaque and the handler stops firing). Check each by hand."}]

--- a/migration/reagent-to-hicasso/codemod/test/corpus/reader-conditional-require/expected.cljc
+++ b/migration/reagent-to-hicasso/codemod/test/corpus/reader-conditional-require/expected.cljc
@@ -1,0 +1,32 @@
+(ns app.reader-conditional
+  "A Reagent require behind a NON-SPLICING reader conditional (rf2-m4hm).
+
+  `#?(:cljs [reagent.core :as r])` is the ONLY legal way to require
+  Reagent from a `.cljc` file, and `ns-context` used to read the `ns` form
+  through one `sexpr` — which throws on a reader-conditional node. So the
+  whole form answered `::unreadable`, every alias set came back `#{}`, and
+  W4, W5, `:as-element-island` and `:reagent-api-residue` were all dead
+  here. Nothing looked wrong: a `:>` head needs no alias, so the report
+  stayed non-empty.
+
+  Every site below is a site this file could not see before."
+  (:require [re-frame.core :as rf]
+            #?(:cljs [reagent.core :as r])))
+
+(defn w4-partial-capture []
+  ;; W4 — the non-fn `IFn` literal. Dead in this file before rf2-m4hm.
+  [:> Btn {:on-pick (let [f__rf2 handler a0__rf2 @cart] (fn [& args__rf2] (apply f__rf2 a0__rf2 args__rf2)))}])
+
+(defn w5-adapt-react-class-head []
+  ;; W5 — the inline `adapt-react-class` head. Also dead before rf2-m4hm.
+  [:> Foo {:variant "big"} "kid"])
+
+(defn as-element-island []
+  [:> Grid {:on-render-cell (fn [row] (r/as-element [:span (:name row)]))}])
+
+(defn reagent-api-residue []
+  [:> C {:value @(r/atom 1)}])
+
+(defn clojure-cores-partial-is-still-not-reagents []
+  ;; The alias resolving must not make `clojure.core/partial` Reagent's.
+  [:> Btn {:on-pick (partial handler 1)}])

--- a/migration/reagent-to-hicasso/codemod/test/corpus/reader-conditional-require/input.cljc
+++ b/migration/reagent-to-hicasso/codemod/test/corpus/reader-conditional-require/input.cljc
@@ -1,0 +1,32 @@
+(ns app.reader-conditional
+  "A Reagent require behind a NON-SPLICING reader conditional (rf2-m4hm).
+
+  `#?(:cljs [reagent.core :as r])` is the ONLY legal way to require
+  Reagent from a `.cljc` file, and `ns-context` used to read the `ns` form
+  through one `sexpr` — which throws on a reader-conditional node. So the
+  whole form answered `::unreadable`, every alias set came back `#{}`, and
+  W4, W5, `:as-element-island` and `:reagent-api-residue` were all dead
+  here. Nothing looked wrong: a `:>` head needs no alias, so the report
+  stayed non-empty.
+
+  Every site below is a site this file could not see before."
+  (:require [re-frame.core :as rf]
+            #?(:cljs [reagent.core :as r])))
+
+(defn w4-partial-capture []
+  ;; W4 — the non-fn `IFn` literal. Dead in this file before rf2-m4hm.
+  [:> Btn {:on-pick (r/partial handler @cart)}])
+
+(defn w5-adapt-react-class-head []
+  ;; W5 — the inline `adapt-react-class` head. Also dead before rf2-m4hm.
+  [(r/adapt-react-class Foo) {:variant :big} "kid"])
+
+(defn as-element-island []
+  [:> Grid {:on-render-cell (fn [row] (r/as-element [:span (:name row)]))}])
+
+(defn reagent-api-residue []
+  [:> C {:value @(r/atom 1)}])
+
+(defn clojure-cores-partial-is-still-not-reagents []
+  ;; The alias resolving must not make `clojure.core/partial` Reagent's.
+  [:> Btn {:on-pick (partial handler 1)}])

--- a/migration/reagent-to-hicasso/codemod/test/corpus/reader-conditional-splicing/expected-report.edn
+++ b/migration/reagent-to-hicasso/codemod/test/corpus/reader-conditional-splicing/expected-report.edn
@@ -1,0 +1,45 @@
+[{:line 20,
+  :col 3,
+  :class :cljc-site,
+  :action :refused,
+  :head "Btn",
+  :detail {},
+  :note
+  "This crossing is in a `.cljc` file. `[:>]` is a ClojureScript-only node — the JVM side of this file has no React to cross into — so check that this branch is reader-conditioned to `:cljs`."}
+ {:line 20,
+  :col 3,
+  :class :partial-wrapper,
+  :action :rewrote,
+  :head "Btn",
+  :detail
+  {:prop ":on-pick",
+   :was "(r/partial handler @cart)",
+   :now
+   "(let [f__rf2 handler a0__rf2 @cart] (fn [& args__rf2] (apply f__rf2 a0__rf2 args__rf2)))",
+   :captured ["@cart"]},
+  :note
+  "Reagent's `convert-prop-value` ends with an `ifn?` arm that wrapped a `PartialFn` in `(fn [& args] (apply x args))`. Hicasso has no such arm, so the object would have crossed opaque and this handler would have stopped firing with nothing thrown. The wrapper is Reagent's own, transcribed — return-transparent, so whatever it returned before it returns now. The `let` is not decoration: `r/partial` evaluated the callee and every argument ONCE when the prop was built, and the `let` is what keeps that true instead of re-evaluating them on every invocation."}
+ {:line 23,
+  :col 3,
+  :class :cljc-site,
+  :action :refused,
+  :head "Foo",
+  :detail {},
+  :note
+  "This crossing is in a `.cljc` file. `[:>]` is a ClojureScript-only node — the JVM side of this file has no React to cross into — so check that this branch is reader-conditioned to `:cljs`."}
+ {:line 23,
+  :col 3,
+  :class :adapt-react-class-head,
+  :action :rewrote,
+  :head "Foo",
+  :detail {:head "Foo"},
+  :note
+  "`vec-to-elem` sent a `NativeWrapper` head and a `[:> C …]` head to the SAME `native-element`, with the props slot at a different index — two spellings of one path. Respelled as `[:> …]`, which is the form Hicasso accepts; left alone it is a head Hicasso answers with `:rf.error/hicasso-bad-head`."}
+ {:line 23,
+  :col 3,
+  :class :named-value,
+  :action :rewrote,
+  :head "Foo",
+  :detail {:prop ":variant", :was ":big", :now "big"},
+  :note
+  "Reagent named every keyword and symbol prop value; Hicasso keeps them whole except at HTML-attribute slots. The string is a fixpoint on both walks."}]

--- a/migration/reagent-to-hicasso/codemod/test/corpus/reader-conditional-splicing/expected.cljc
+++ b/migration/reagent-to-hicasso/codemod/test/corpus/reader-conditional-splicing/expected.cljc
@@ -1,0 +1,27 @@
+(ns app.reader-conditional-splicing
+  "A Reagent require behind a SPLICING reader conditional, beside an
+  ordinary one (rf2-m4hm, and the merged-PR-audit #7979 edge on it).
+
+  `#?@(:cljs [[reagent.core :as r]])` splices a COLLECTION of specs where
+  `#?(…)` carries one, so the branch value has to be lifted a level. Both
+  shapes are legal and both were invisible.
+
+  This file is also the MIXED case, which is the edge that made a
+  whole-form fallback the wrong repair: `reagent.dom.client` arrives
+  ordinarily and binds, so the alias set was never empty and the census
+  read the file as fully resolved — while the spliced `r` stayed unbound
+  and every `r/…` site in it vanished with NO diagnostic at all, neither
+  `:unresolved-reagent-require` nor `:unresolved-alias`. One require
+  resolving must not vouch for another."
+  (:require [reagent.dom.client :as rdc]
+            #?@(:cljs [[reagent.core :as r]])))
+
+(defn w4-behind-the-splice []
+  [:> Btn {:on-pick (let [f__rf2 handler a0__rf2 @cart] (fn [& args__rf2] (apply f__rf2 a0__rf2 args__rf2)))}])
+
+(defn w5-behind-the-splice []
+  [:> Foo {:variant "big"}])
+
+(defn the-ordinary-require-still-binds []
+  ;; `rdc` bound before this fix and must still bind after it.
+  (rdc/render root [:div]))

--- a/migration/reagent-to-hicasso/codemod/test/corpus/reader-conditional-splicing/input.cljc
+++ b/migration/reagent-to-hicasso/codemod/test/corpus/reader-conditional-splicing/input.cljc
@@ -1,0 +1,27 @@
+(ns app.reader-conditional-splicing
+  "A Reagent require behind a SPLICING reader conditional, beside an
+  ordinary one (rf2-m4hm, and the merged-PR-audit #7979 edge on it).
+
+  `#?@(:cljs [[reagent.core :as r]])` splices a COLLECTION of specs where
+  `#?(…)` carries one, so the branch value has to be lifted a level. Both
+  shapes are legal and both were invisible.
+
+  This file is also the MIXED case, which is the edge that made a
+  whole-form fallback the wrong repair: `reagent.dom.client` arrives
+  ordinarily and binds, so the alias set was never empty and the census
+  read the file as fully resolved — while the spliced `r` stayed unbound
+  and every `r/…` site in it vanished with NO diagnostic at all, neither
+  `:unresolved-reagent-require` nor `:unresolved-alias`. One require
+  resolving must not vouch for another."
+  (:require [reagent.dom.client :as rdc]
+            #?@(:cljs [[reagent.core :as r]])))
+
+(defn w4-behind-the-splice []
+  [:> Btn {:on-pick (r/partial handler @cart)}])
+
+(defn w5-behind-the-splice []
+  [(r/adapt-react-class Foo) {:variant :big}])
+
+(defn the-ordinary-require-still-binds []
+  ;; `rdc` bound before this fix and must still bind after it.
+  (rdc/render root [:div]))

--- a/migration/reagent-to-hicasso/codemod/test/re_frame/migration/hicasso/census_test.clj
+++ b/migration/reagent-to-hicasso/codemod/test/re_frame/migration/hicasso/census_test.clj
@@ -16,7 +16,17 @@
   * `(atom nil)` — `clojure.core`'s — sat one line above the `rdc/render`
     that is the genuine finding in the SSR examples, and both were
     reported. `:unresolved-alias` now needs a qualified head, because the
-    thing that could not be bound is an ALIAS."
+    thing that could not be bound is an ALIAS.
+
+  **What `unresolved` MEANS here changed with rf2-m4hm**, and these tests
+  are where that is pinned. `#?(:cljs [reagent.core :as r])` used to be
+  the archetypal unbindable require; `ns-context` now reads it
+  structurally, so it RESOLVES and its call sites get their real classes.
+  The class did not become decorative — it moved to the population that is
+  genuinely unbindable, of which the vendored copy below is the honest
+  example. A tool that started GUESSING that copy was `reagent.core`
+  would be a worse tool than the blind one, so both directions are
+  asserted."
   (:require [clojure.string :as str]
             [clojure.test :refer [deftest is testing]]
             [re-frame.migration.hicasso.census :as census]
@@ -72,9 +82,12 @@
 ;; ---------------------------------------------------------------------------
 
 (def ^:private conditional-require
-  "The only legal way to require Reagent from a `.cljc` file — and the
-  shape `ns-context` binds nothing for. `examples/capabilities/ssr/`
-  carries three real ones."
+  "The only legal way to require Reagent from a `.cljc` file.
+  `examples/capabilities/ssr/` carries three real ones.
+
+  This was the archetypal UNBINDABLE require until rf2-m4hm taught
+  `ns-context` to read require clauses through reader-conditional nodes.
+  It now resolves, and the assertions below say so."
   (str "(ns app.ssr\n"
        "  (:require [re-frame.core :as rf]\n"
        "            #?(:cljs [reagent.dom.client :as rdc])))\n"
@@ -83,21 +96,108 @@
        "\n"
        "#?(:cljs (defn mount! [] (rdc/render @react-root [:div])))\n"))
 
+(def ^:private vendored-require
+  "A namespace that SPELLS a Reagent name without being Reagent's.
+
+  re-frame-10x ships its dependencies inlined under a private prefix, so
+  `names-reagent?` — which reads the `ns` form's text — says yes while
+  `ns-context` correctly binds nothing, because only the exact roster
+  binds. This is the population `:unresolved-reagent-require` exists for
+  now that the reader-conditional shape resolves, and the tool must keep
+  REPORTING it rather than guessing that `r` is `reagent.core`."
+  (str "(ns app.panel\n"
+       "  (:require [day8.re-frame-10x.inlined-deps.reagent.v1v2v0.reagent.core :as r]))\n"
+       "\n"
+       "(defonce state (atom nil))\n"
+       "\n"
+       "(defn panel [] (r/atom {}))\n"))
+
 (deftest an-unbindable-require-is-reported
-  (let [{:keys [entries unresolved?]} (census/scan conditional-require "app/ssr.cljc")]
+  (let [{:keys [entries unresolved?]} (census/scan vendored-require "app/panel.cljs")]
     (is (true? unresolved?))
     (is (= [:unresolved-reagent-require :unresolved-alias] (mapv :class entries)))
     (testing "the require is reported at the `ns` form, where the fix goes"
       (is (= 1 (:line (first entries)))))
     (testing "and the call that could not be bound names the symbol it could not bind"
-      (is (= {:api "render" :symbol "rdc/render"} (:detail (second entries)))))
+      (is (= {:api "atom" :symbol "r/atom"} (:detail (second entries)))))
     (testing "the note says the whole tool family is blind here, not just the census"
       (is (str/includes? (:note (first entries)) "PARTIALLY BLIND")))))
 
 (deftest the-unqualified-core-call-beside-it-is-not-reported
-  (testing "`(atom nil)` on line 5 is `clojure.core`'s. An alias is what could not
+  (testing "`(atom nil)` on line 4 is `clojure.core`'s. An alias is what could not
             be bound, so a call with no alias is not evidence of it."
-    (is (not-any? #(= 5 (:line %)) (:entries (census/scan conditional-require "app/ssr.cljc"))))))
+    (is (not-any? #(= 4 (:line %)) (:entries (census/scan vendored-require "app/panel.cljs"))))))
+
+;; ---------------------------------------------------------------------------
+;; A require behind a reader conditional RESOLVES (rf2-m4hm)
+;; ---------------------------------------------------------------------------
+
+(deftest a-reader-conditional-require-binds
+  (testing "the non-splicing shape — `ns-context` used to sexpr the whole `ns`
+            form, which throws on a reader-conditional node, so EVERY alias
+            came back empty and the file's real findings were reported only as
+            `:unresolved-alias`"
+    (let [{:keys [entries reagent? unresolved?]} (census/scan conditional-require "app/ssr.cljc")]
+      (is (true? reagent?))
+      (is (false? unresolved?) "resolved, not merely reported")
+      (is (= [:root-mount] (mapv :class entries))
+          "the class the call actually has, not the fallback")
+      (is (= {:api "render"} (:detail (first entries))))))
+
+  (testing "the splicing shape — `#?@` carries a COLLECTION of specs where `#?`
+            carries one, so its branch value is lifted a level"
+    (let [src (str "(ns app.ssr\n"
+                   "  (:require #?@(:cljs [[reagent.core :as r]])))\n"
+                   "\n"
+                   "(defn v [] (r/atom 1))\n")]
+      (is (= [:local-reactive-cell] (classes src "app/ssr.cljc")))))
+
+  (testing "a conditional wrapping the whole `(:require …)` clause, not one spec"
+    (let [src (str "(ns app.ssr\n"
+                   "  #?(:cljs (:require [reagent.core :as r])))\n"
+                   "\n"
+                   "(defn v [] (r/atom 1))\n")]
+      (is (= [:local-reactive-cell] (classes src "app/ssr.cljc")))))
+
+  (testing "`:refer` through a conditional binds the referred names too"
+    (let [src (str "(ns app.ssr\n"
+                   "  (:require #?(:cljs [reagent.core :refer [partial]])))\n"
+                   "\n"
+                   "(defn v [] (partial f 1))\n")]
+      (is (= [:reagent-partial] (classes src "app/ssr.cljc"))))))
+
+(deftest one-resolving-require-does-not-vouch-for-another
+  (testing "MERGED-PR AUDIT #7979's edge. An ordinary Reagent require beside a
+            conditional one left the alias UNION non-empty, so `unresolved?` was
+            false and the conditional half's call sites vanished with NO
+            diagnostic — neither `:unresolved-reagent-require` nor
+            `:unresolved-alias`. That is why the repair reads spec by spec
+            rather than retrying the whole form when the alias set comes back
+            empty: here it never was empty."
+    (let [src (str "(ns app.mixed\n"
+                   "  (:require [reagent.core :as r]\n"
+                   "            #?(:cljs [reagent.dom.client :as rdc])))\n"
+                   "\n"
+                   "(defn v [] (r/atom 1))\n"
+                   "(defn m [] (rdc/render nil nil))\n")
+          {:keys [entries unresolved?]} (census/scan src "app/mixed.cljc")]
+      (is (false? unresolved?))
+      (is (= [:local-reactive-cell :root-mount] (mapv :class entries))
+          "BOTH requires' call sites are named, not just the ordinary one")
+      (is (= [5 6] (mapv :line entries))))))
+
+(deftest a-conditional-that-is-not-reagents-binds-nothing
+  (testing "seeing THROUGH a reader conditional is only correct if it also
+            declines to bind — a fix that read every branch as Reagent's would
+            report a file with no Reagent in it"
+    (let [src (str "(ns app.util\n"
+                   "  (:require #?(:cljs [clojure.string :as str])))\n"
+                   "\n"
+                   "(defn v [] (str/atom 1))\n")
+          {:keys [entries reagent? unresolved?]} (census/scan src "app/util.cljc")]
+      (is (false? reagent?))
+      (is (false? unresolved?))
+      (is (= [] entries)))))
 
 (deftest an-ns-form-under-metadata-is-still-the-ns-form
   (testing "`^:cljstyle/ignore (ns …)` is ordinary. Reading it as `nil` binds
@@ -125,8 +225,17 @@
             `ns-form?` matches at the meta node and at the list inside it"
     (let [src (str "^:cljstyle/ignore\n"
                    "(ns app.graph\n"
-                   "  (:require #?(:cljs [reagent.core :as r])))\n")]
-      (is (= [:unresolved-reagent-require] (classes src "app/graph.cljc"))))))
+                   "  (:require [day8.re-frame-10x.inlined-deps.reagent.v1v2v0.reagent.core\n"
+                   "             :as r]))\n")]
+      (is (= [:unresolved-reagent-require] (classes src "app/graph.cljc")))))
+  (testing "a conditional require under that same metadata resolves — the
+            metadata path and the conditional path compose"
+    (let [src (str "^:cljstyle/ignore\n"
+                   "(ns app.graph\n"
+                   "  (:require #?(:cljs [reagent.core :as r])))\n"
+                   "\n"
+                   "(def graph-ref-map (r/atom {}))\n")]
+      (is (= [:local-reactive-cell] (classes src "app/graph.cljc"))))))
 
 ;; ---------------------------------------------------------------------------
 ;; A legal population comes back CLEAN
@@ -197,11 +306,13 @@
   (is (= (census/scan form-2 "app/counter.cljs")
          (census/scan form-2 "app/counter.cljs")))
   (is (= (census/scan conditional-require "app/ssr.cljc")
-         (census/scan conditional-require "app/ssr.cljc"))))
+         (census/scan conditional-require "app/ssr.cljc")))
+  (is (= (census/scan vendored-require "app/panel.cljs")
+         (census/scan vendored-require "app/panel.cljs"))))
 
 (deftest the-summary-names-every-bucket-including-the-empty-ones
   (let [built (census/build [(census/scan form-2 "app/counter.cljs")
-                             (census/scan conditional-require "app/ssr.cljc")
+                             (census/scan vendored-require "app/panel.cljs")
                              (census/scan "(ns a)\n(defn f [] [:div])\n" "app/plain.cljs")])
         s     (:summary built)]
     (is (= (set census/verdicts) (set (keys (:by-verdict s))))

--- a/skills/reagent-migration/spec/inputs.md
+++ b/skills/reagent-migration/spec/inputs.md
@@ -47,14 +47,24 @@ rather than trusting this list**; it grows a row at a time.
 
 ## 3. Where the design corpus is a HAZARD, not an input
 
-`docs/EP/EP-0036-*`, `docs/design/freehand/decisions/` and
-`docs/design/freehand/draft-guide/` describe the design, including forms that
-are **declared and not exported** — `local`, `effect`, `ref`,
+`docs/EP/EP-0036-*` and `docs/design/freehand/` describe the design, including
+forms that are **declared and not exported** — `local`, `effect`, `ref`,
 `v/check`, a React interop hook tier. They are useful for understanding *why* a
 shape is the way it is, and dangerous as a source of call shapes: some names once
 on this list (`v/->react`, `v/client-only`, `v/html`) have since shipped, which is exactly
 why **every verb goes through §1 before it is written** (design L9) rather than a
 remembered "not yet" list.
+
+The hazard is the whole `docs/design/**` tree, not a subdirectory of it. That
+tree is the working design RECORD — `mkdocs.yml` excludes it from the published
+site for exactly that reason — so design prose carrying unexported call shapes is
+as likely in `codex-design.md` or `studio/` as in `decisions/`, and naming
+subdirectories only invites the list to go stale as they are added and removed.
+
+**`docs/core/freehand/` is NOT on this list.** It is the promoted, digest-pinned
+guide — published documentation whose fenced blocks are hashed against the
+shipped surface — so it is a valid input, second only to §1's roster. Do not
+re-add it here as a hazard.
 
 ## 4. Tertiary inputs (shape the discipline, not quoted)
 


### PR DESCRIPTION
Closes rf2-m4hm. Closes rf2-cvjp.

Two defects on the reagent→hicasso migration-tooling surface. Both were
re-derived at `origin/main` HEAD before any edit, rather than taken from the
bead text — see below.

## rf2-m4hm — a Reagent require behind a reader conditional bound nothing

### Re-derived at `origin/main` (c6694fa80b), not assumed

Probed `rw/ns-context` directly at HEAD. The bead's cases B and C reproduce
exactly, and the probe also reproduces the merged-PR-audit #7979 edge (case D):

| case | `ns` form | `ns-context` at `origin/main` |
|---|---|---|
| A | `(:require [reagent.core :as r])` | `{:aliases #{reagent.core r}}` |
| B | `(:require #?(:cljs [reagent.core :as r]))` | `{:aliases #{}}` — **blind** |
| C | `(:require #?@(:cljs [[reagent.core :as r]]))` | `{:aliases #{}}` — **blind** |
| D | `[reagent.core :as r]` **+** `#?(:cljs [reagent.dom.client :as rdc])` | `{:aliases #{reagent.core r}}` — `rdc` **missing** |
| E | `(:require #?(:cljs [clojure.string :as str]))` | `{:aliases #{}}` — correct |

*(3 columns; 5 body rows.)*

Case D is the worse one and it is the reason the repair is shaped the way it
is. `census/scan` on a mixed file at `origin/main` returned `:unresolved? false`
— because the alias UNION was non-empty — and the `(rdc/render …)` call
produced **no entry at all**: not `:root-mount`, not `:unresolved-alias`, not
`:unresolved-reagent-require`. One require resolving vouched for another. A
fallback keyed on "alias set came back empty" would never have fired here.

### The fix

`ns-context` read the whole `ns` form through one `sexpr`. `sexpr` throws on a
reader-conditional node, so `sexpr-safe` answered `::unreadable` for the ENTIRE
form the moment any one require sat behind a `#?`.

It now reads **spec by spec**. `require-specs` walks the `ns` form's clause
NODES and expands reader conditionals at both the clause and the spec level;
each spec is `sexpr`'d on its own. A spec node is ordinary data and reads fine —
only the conditional WRAPPER was ever unreadable. Both shapes are handled (`#?`
carries one branch value, `#?@` carries a collection, so the splicing branch is
lifted a level), and every feature is read rather than just `:cljs`: the tool
reads source text, it does not resolve a platform.

Two small robustness guards came with it, because this reads source nobody in
this repository wrote: options are paired off rather than `(apply hash-map …)`,
and `:refer` is taken only when it is a collection. A lone trailing option or
`:refer :all` now makes the tool answer *less* instead of throwing. Probed
eight malformed/edge `ns` shapes (empty conditional body, odd option tail,
`:refer :all`, prefix list, tagged literal, no `ns` form at all) — none throws,
none misfires.

### The fixer-behaviour question, MEASURED rather than argued

This is the part rf2-hic-055 declined to do, on the grounds that it is a fixer
behaviour change: files the tool could not see would start being rewritten. The
bead rules that closing the hole properly is this bead's job, so the question
was not whether to proceed but **how wide the blast radius actually is**.

Ran the fixer and the census over **all 2661 `.cljs`/`.cljc` files in the repo**,
before and after the change, and diffed.

- **The FIXER's output is BYTE-IDENTICAL.** 16 files changed before, the same
  16 after, the same bytes. Not one file is newly rewritten.
- **Every single difference is the census naming what it could previously only
  point at** — `:unresolved-reagent-require` + `:unresolved-alias` collapsing
  into the real class: `:root-mount`, `:local-reactive-cell`, `:with-let`,
  `:lifecycle-class`. Affected: the three `examples/capabilities/ssr/` files,
  14 `tools/story/**` `.cljc` files, and the three reagent templates under
  `tools/template/`.

So the capability is restored — W4/W5 *can* now fire in a `.cljc` file — without
rewriting one byte anybody had not already agreed to. **No refusal was needed
and none is made.** Had the fixer diff been non-empty I would have stopped and
reported it; it was empty, so the separable "parser fix vs fixer behaviour"
split the brief offered did not need to be taken.

`examples/` was not touched, per the test-free lock (rf2-8cevm). The regression
lives entirely in the codemod's own test tree.

### What deliberately did NOT change

A namespace that merely SPELLS a Reagent name still binds nothing. re-frame-10x's
vendored `day8.re-frame-10x.inlined-deps.reagent.v1v2v0.reagent.core` stays
unresolved and reported, per the bead's CAUTION. Guessing it is `reagent.core`
would rewrite working code — worse than the blindness this fixes. That is now
the population `:unresolved-reagent-require` names, and it is asserted.

### Tests — a real regression, and an adversarial case per surface

Golden corpus **11 → 14** cases (the corpus IS the spec, design §5):

- `reader-conditional-require` — the non-splicing shape. **W4
  (`:partial-wrapper`), W5 (`:adapt-react-class-head`), `:as-element-island`
  and `:reagent-api-residue` all fire** where they previously could not.
- `reader-conditional-splicing` — the `#?@` shape, plus the mixed
  resolved+conditional file from the audit note.
- `reader-conditional-not-reagent` — **the adversarial/negative case.** A
  `.cljc` whose conditionals require `goog.dom` and a *vendored* Reagent.
  Asserts zero misfire: the vendored `r/partial` is left alone, the
  `gdom/adapt-react-class` head is left alone, nothing is rewritten. Only
  `:cljc-site` and `:computed-value` fire — the two that need no alias.

Census `+3` deftests covering both shapes, a conditional around the whole
`(:require …)` clause, `:refer` through a conditional, the mixed edge, and a
non-Reagent conditional. The existing census tests that encoded the old
blindness as *expected behaviour* are re-pointed at a vendored fixture.

Suite: **40 → 43 tests, 436 assertions, 0 failures.**

### Stale prose corrected in the same PR

The `:unresolved-reagent-require` recovery note told the reader to *"move the
require out of the reader conditional and re-run"*. That advice is now wrong, so
it names the vendored-copy cause and its real recovery instead. The same
now-false claim was asserted in `census.clj`'s namespace docstring, in
`rewrite.clj`'s `names-reagent?` docstring, and in the artefact README's front
door; all four are corrected.

## rf2-cvjp — a stale corpus citation in skills/reagent-migration

### Re-derived at `origin/main`

Both halves confirmed: `skills/reagent-migration/spec/inputs.md:51` does carry
`docs/design/freehand/draft-guide/`, and `ls docs/design/freehand/` returns
`README.md`, `codex-design.md`, `decisions/`, `fable-design.md`,
`product-completion-setpoint.md`, `studio/` — no `draft-guide/`.

### Applied the operator ruling on the bead

The bead carries an **operator ruling (Mike, 2026-08-12) — OPTION 3,
GENERALIZE**, which post-dates the brief's framing of this as an open judgement.
Followed the bead: replace the two `docs/design/freehand/` **subdirectory** names
with the tree itself, and add one clarifying clause that `docs/core/freehand/`
is the promoted, digest-pinned guide and IS a valid input. The
`docs/EP/EP-0036-*` clause stands.

Verified the ruling's own justification at source rather than taking it: `mkdocs.yml`
`exclude_docs` does list `design/freehand/` and `design/hicasso/`, so that tree
is working design record and not published documentation — which is exactly why
the hazard is the tree and not a subdirectory of it.

The edit is generic to any consumer re-frame2 app: it names doc trees and their
status, not this repo's testbeds or build paths.

### Grep sweep — every carrier settled

`git grep 'docs/design/freehand/draft-guide'` over tracked files: **one carrier**,
the one fixed here. It now returns nothing outside `.beads/`.

Swept the broader `draft-guide` term too, to be sure the bounded repair bounded
the CHANGE and not the SEARCH. **30 tracked files still mention `draft-guide`,
and every one of them is the hicasso tree — left standing, all correctly:**

- **12 cite `docs/design/hicasso/draft-guide/` in full.** A DIFFERENT tree,
  which exists. Also **fenced** — three operator worktrees hold it live — so
  reported and not touched, per the brief.
- **15 more live inside `docs/design/hicasso/` and cite it relatively**
  (`product/**`, `studio/**`, `authoring.md`, `decisions.md`,
  `production-server-arm.md`, `draft-guide/REWRITE-NOTES.md`). Same fenced
  tree.
- **3 are hicasso implementation files** pointing at that same guide:
  `implementation/hicasso/scripts/check_complaint_catalogue.py`,
  `check_optional_module_reachability.py`, and
  `implementation/hicasso/test/re_frame/hicasso/codec_cljs_test.cljs`.

`.github/workflows/test.yml` (commented glob),
`implementation/scripts/_changed-surfaces.test.cjs` (fixture path) and
`scripts/check_doc_slugs.py` are among the above and are path-shaped
fixtures/globs, not stale citations.

Also left, and flagged here so it is not re-discovered as new: the bead itself
records 13 references to `draft-guide/05-interop.md` in the hicasso design
record (renumbered to `09-interop.md` by `93ad830cc6`) as **correctly
historical**, with `defhost-ssr-provider-costing.md` §3 already ruling them "not
worth a PR of its own".

## Quality gates

Every gate run ALONE, output redirected and exit code captured on the same
command line, in the same shell. Exit codes quoted are the ones I captured.

| gate | captured exit | notes |
|---|---|---|
| `migration/reagent-to-hicasso/codemod` `clojure -M:test` | **0** | 43 tests, 436 assertions, 0 failures. The deciding gate for rf2-m4hm — and a required CI job (`jvm-migration-hicasso-codemod`) the fast-PR spine does not run. |
| `scripts/test-fast-pr.sh` | **0** | `gate root:` verified as `/c/Users/miket/code/re-frame2-worktrees/codemod-m4hm`. **Read this green narrowly** — see the skip note below. |
| `scripts/test-jvm-tools.sh` | **0** | tool JVM artefacts. |
| `python scripts/check_doc_slugs.py` | **0** | `skills/` is in its `DEFAULT_ROOTS`, so the rf2-cvjp edit is in scope. |
| `clojure -M -m re-frame.api-manifest.skills-check` | **0** | 561 public-var references in sync. `skills/reagent-migration/` is NOT exempt from this gate (only `skills/re-frame-migration/` is), so it was run deliberately. |
| `python scripts/check_fast_pr_gap.py --list` | **0** | see below. |

**What the spine's green does and does not cover here.** The spine is
surface-gated, and it said so: `implementation_jvm surface unchanged → skipping
JVM artefact suites` and `cljs_node_test surface unchanged → skipping
npm/CLJS/isolation`. That is correct for a diff confined to `migration/` and
`skills/` — and it is exactly why the codemod's own suite was run directly
rather than leaned on the spine for. What the spine DID decide here is the docs
and invariant tier: `mkdocs build --strict`, the docs corpus anchor validator,
provenance pins on changed pages, the README link/anchor validators, the
gate-scheduling audit and the retired-vocabulary residue sweeps.

**A gate-log collision, and how it was caught.** The first spine run was
launched to a generically-named log (`gate-fastpr.log`) in a shared scratchpad
and was **clobbered by a sibling worker's run** — its `gate root:` line read
`/c/.../gatereach-x1mz`, another worker's worktree, and the line count went
backwards. That log and its exit code were discarded, and the spine re-run to a
worktree-unique name. This is precisely why the `gate root:` line is worth
checking before believing any colour; the exit code in the table is from the
verified re-run.

### Required checks this local spine does NOT run

`python scripts/check_fast_pr_gap.py --list` reports **97**. Green here is not
green in CI. The ones that actually reach this diff:

- **`jvm-migration-hicasso-codemod`** — the codemod artefact's own suite. No
  lane in the spine, so it was **run directly** (exit 0, top row).
- **`api-manifest`** (`Lint required`) — its `skills-check` step covers
  `skills/**/*.md`. **Run directly** (exit 0).
- **`clj-kondo`** / **`splint`** — CI pins clj-kondo 2026.04.15; a differently
  versioned local binary proves nothing, so not claimed here. The Clojure change
  is confined to `migration/`, which is outside clj-kondo's `--lint` roots.
- **`skills-structural`** — runs structural tests for `re-frame2-pair`,
  `shared` and `re-frame2-setup` only. `skills/reagent-migration/` has no
  `tests/` directory, so it has no lane there.
- The remaining ~93 are browser, bundle-isolation, MCP-conformance and
  production-elision lanes on `implementation/` and `tools/` surfaces this diff
  does not touch.

## Changed files

- `migration/reagent-to-hicasso/codemod/src/re_frame/migration/hicasso/rewrite.clj`
  — the fix, plus corrected `names-reagent?` prose
- `migration/reagent-to-hicasso/codemod/src/re_frame/migration/hicasso/census.clj`
  — namespace docstring and the `:unresolved-reagent-require` recovery note
- `migration/reagent-to-hicasso/codemod/README.md` — the front-door claim
- `migration/reagent-to-hicasso/codemod/test/re_frame/migration/hicasso/census_test.clj`
- `migration/reagent-to-hicasso/codemod/test/corpus/reader-conditional-require/**` (new)
- `migration/reagent-to-hicasso/codemod/test/corpus/reader-conditional-splicing/**` (new)
- `migration/reagent-to-hicasso/codemod/test/corpus/reader-conditional-not-reagent/**` (new)
- `skills/reagent-migration/spec/inputs.md` — rf2-cvjp

Nothing outside the declared write surface (`migration/reagent-to-hicasso/**`,
`skills/reagent-migration/**`). `docs/design/hicasso/draft-guide/**` not touched.
