### PR TITLE
fix(ci): gates that cannot fire on the edits they police (rf2-x1mz, rf2-uomk)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -929,6 +929,64 @@ jobs:
       - name: Verify the register against the runtime, Spec 009 and the guide
         run: python implementation/hicasso/scripts/check_complaint_catalogue.py
 
+  # THE BUDGET-LEDGER GATE (rf2-hic-089; this routing is rf2-uomk, and it is
+  # the job above's hole in a second place — filed as such by the hic-089
+  # worker, who stopped at the hot zone rather than take the scheduling
+  # decision).
+  #
+  # `implementation/hicasso/scripts/check_budget_ledger.py` reads THREE input
+  # families:
+  #
+  #   docs/design/hicasso/product/budgets.md          the reconciliation ledger
+  #   docs/design/hicasso/product/substrate-decision.md   the disposition
+  #                                                   records L3 resolves
+  #   implementation/hicasso/**                       the witness files
+  #
+  # It shipped chained into `npm run test:hicasso-invariants`, whose only hosted
+  # invocation is a step of the `cljs` job under
+  # `needs.detect_changed_surfaces.outputs.cljs_node_test == 'true'`. ONLY THE
+  # LAST FAMILY ARMS THAT OUTPUT. Direct classifier probes measure the ledger
+  # page and the disposition page at every output `false`, so a LEDGER-ONLY
+  # edit — precisely the edit this gate exists to police, and the one a
+  # ledger-keeping habit produces most often — skips every check on the pull
+  # request. The gate would then next run on somebody else's source PR, red,
+  # over a row they did not write.
+  #
+  # UNCONDITIONAL, rather than a new classifier output, for the reason the job
+  # above gives at length and this one will not restate: the defect being
+  # repaired IS a surface gate that did not cover a checker's inputs, so a new
+  # arm is a fresh chance to make the same mistake and needs re-widening every
+  # time the checker learns to read another file. It is a sub-second pure-Python
+  # static read — no node, no JVM — so there is nothing to gate for.
+  #
+  # IT STAYS CHAINED INTO `test:hicasso-invariants` TOO. That chain is the local
+  # spine lane and the artefact's one-command run; this job is the CI
+  # reachability the chain cannot give it.
+  hicasso-budget-ledger:
+    name: Hicasso budget-ledger contract (rf2-hic-089)
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+
+      - name: Set up Python
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
+        with:
+          python-version: '3.12'
+
+      # Self-test first, then the live read — the order every other pure-Python
+      # contract in this workflow uses. It drives every rule the checker
+      # publishes red in turn, so a green live run below is a verdict rather
+      # than a checker that has quietly stopped firing. HOW MANY rules is not
+      # written here on purpose (rf2-93u6): nothing links a count in this file
+      # to the case list in that one, so the correction is already scheduled.
+      # The self-test names its own cases as it runs.
+      - name: Self-test the budget-ledger rules
+        run: python implementation/hicasso/scripts/check_budget_ledger.py --self-test
+
+      - name: Verify the ledger against its registrations and dispositions
+        run: python implementation/hicasso/scripts/check_budget_ledger.py
+
   # rf2-3mh2f — CI arm of the STALE WORKER-SNAPSHOT guard (rf2-ia8o7).
   #
   # `bd` auto-stages the full-database JSONL export in EVERY checkout, so a
@@ -5909,6 +5967,13 @@ jobs:
       # its own gate says, which would put the contract back one `if:` from the
       # nowhere it just came from.
       - hicasso-complaint-catalogue
+      # rf2-uomk — required for the same reason, one gate over. Two of the
+      # three file families the budget-ledger gate reads arm no classifier
+      # output, so before this job a ledger-only or disposition-only PR ran the
+      # check nowhere. A job absent from this list is advisory whatever its own
+      # gate says, which would put the contract back one `if:` from the nowhere
+      # it just came from.
+      - hicasso-budget-ledger
       # rf2-3mh2f — the .beads guard's CI arm. Required, so the tracker
       # database cannot ride a PR past a `--no-verify` or an uninstalled hook.
       - beads-pr-boundary

--- a/implementation/hicasso/scripts/check_lint_export.py
+++ b/implementation/hicasso/scripts/check_lint_export.py
@@ -28,10 +28,23 @@ take, and the two rules are circular for anything shaped like a deftest.
 A checker is not a workaround for that -- it is this artefact's OWN idiom.
 `check_freeze.py` sits beside this file and is the same shape: a gate over the
 package, with a `--self-test` that proves its own red.  This one runs the real
-clj-kondo, at the version CI pins, with the SHIPPED export directory as its
-`--config-dir`, which is exactly how a consumer's copied config is loaded.
-There is no second description of the rules here and no mock: a rule that
-passes this gate is the rule the artefact publishes.
+clj-kondo, with the SHIPPED export directory as its `--config-dir`, which is
+exactly how a consumer's copied config is loaded.  There is no second
+description of the rules here and no mock: a rule that passes this gate is the
+rule the artefact publishes.
+
+AT THE VERSION CI PINS -- WHEN IT CAN GET IT (rf2-x1mz).  This paragraph used
+to say so flatly, and it was TRUE ONLY IN CI, where the job installs the pin
+before running.  Locally the resolver took whatever was on PATH, and the two
+versions do not agree: measured on one line of `overlay.cljs`, 2025.10.23
+reports `errors: 0, exit 0` where 2026.04.15 reports `Expected: array,
+received: function` and exits 3.  The binary is now resolved through
+`scripts/lint_kondo.py`, which reads the pin off `lint.yml` and provisions it
+-- the npm distribution stops at 2025.10.23, so there is no other way to get
+it.  Where that fails (no network, an unpublished platform) the gate still runs
+on whatever is available, because a fixture witness at the wrong version is
+weaker evidence rather than none -- but it SAYS SO, loudly, naming both
+versions.  A quiet fallback is what made the old sentence a lie.
 
     python scripts/check_lint_export.py             run the gate
     python scripts/check_lint_export.py --self-test prove the gate fires
@@ -71,15 +84,56 @@ EXPECTED = {
 }
 
 
+REPO_ROOT = os.path.dirname(os.path.dirname(ARTEFACT_ROOT))
+PINNED_RESOLVER = os.path.join(REPO_ROOT, "scripts", "lint_kondo.py")
+_KONDO_COMMAND = []  # one-slot memo; see `_kondo_command`
+
+
+def _pinned_kondo():
+    """The binary at lint.yml's pin, or `None` with the reason printed.
+
+    Delegated rather than re-derived: `scripts/lint_kondo.py` already reads the
+    pin off the workflow, knows the per-platform release archives and caches
+    the download outside the repository. A second copy of that knowledge here
+    is a second thing to keep in step with a pin bump.
+    """
+    if not os.path.isfile(PINNED_RESOLVER):
+        return None
+    try:
+        proc = subprocess.run([sys.executable, PINNED_RESOLVER, "--print-binary"],
+                              capture_output=True, text=True, timeout=300)
+    except (OSError, subprocess.SubprocessError) as exc:
+        print("NOTE: could not run the pinned clj-kondo resolver (%s)" % exc)
+        return None
+    if proc.returncode != 0:
+        print("NOTE: clj-kondo at lint.yml's pin is unavailable here, so this "
+              "witness runs at whatever version is on PATH. Versions disagree "
+              "about which findings are errors (rf2-x1mz), so a green below is "
+              "weaker than CI's.")
+        for line in (proc.stderr or "").splitlines():
+            print("      " + line)
+        return None
+    return proc.stdout.strip() or None
+
+
 def _kondo_command():
-    """How to invoke clj-kondo here, preferring the NATIVE BINARY.
+    """How to invoke clj-kondo here, preferring the PINNED NATIVE BINARY.
 
     The binary is what `.github/workflows/lint.yml` installs, at the pin this
     gate asserts against, and it needs no JDK — which is what lets the fixture
     witness run as a step of the existing `clj-kondo` job rather than waiting
     for a JVM lane that does not exist. The artefact's `:clj-kondo` alias is
-    the local fallback, so a developer with no binary still gets the gate.
+    the last fallback, so a developer with neither still gets the gate.
     """
+    # Memoised: `check()` lints three times and the self-test calls `check()`
+    # once per mutation, so resolving afresh each time would spawn a process
+    # per lint AND repeat the notice above dozens of times.
+    if _KONDO_COMMAND:
+        return list(_KONDO_COMMAND[0])
+    pinned = _pinned_kondo()
+    if pinned:
+        _KONDO_COMMAND.append([pinned])
+        return [pinned]
     for name in ("clj-kondo", "clojure"):
         # The RESOLVED path, not the bare name. On Windows an npm-installed
         # tool leaves both an extensionless shell shim and a `.cmd`; only the
@@ -88,7 +142,9 @@ def _kondo_command():
         found = (shutil.which(name + ".cmd") or shutil.which(name + ".bat")
                  or shutil.which(name))
         if found:
-            return [found] if name == "clj-kondo" else [found, "-M:clj-kondo"]
+            cmd = [found] if name == "clj-kondo" else [found, "-M:clj-kondo"]
+            _KONDO_COMMAND.append(cmd)
+            return list(cmd)
     raise SystemExit(
         "FAIL: neither `clj-kondo` nor `clojure` is on PATH, so the Hicasso "
         "lint export gate cannot run. This is a HARD failure on purpose: it "

--- a/scripts/_test_fixtures/test_fast_pr_docs_gate/run-self-test.sh
+++ b/scripts/_test_fixtures/test_fast_pr_docs_gate/run-self-test.sh
@@ -582,6 +582,73 @@ else
   fail_count=$((fail_count + 5))
 fi
 
+# ---------------------------------------------------------------------------
+# THE PINNED clj-kondo LANE (rf2-x1mz).  `PLAN-KONDO` is its machine-readable
+# arming, and it is a FOURTH surface rather than a view of the three above: the
+# lane's roots come from lint.yml's own `--lint` list, which reaches trees no
+# runtime tier owns (`examples/`, `testbeds/`, `tools/*`) and misses trees the
+# runtime tiers do own.  Both directions are pinned, because the bead is a gate
+# that could not fire on the edit it policed — and a lane armed by everything
+# would be the same defect wearing the opposite coat.
+#
+# `PLAN` deliberately keeps three fields; a fourth would rewrite fourteen
+# assertions above to say nothing they do not already say.
+# ---------------------------------------------------------------------------
+plan_kondo() {
+  bash "$spine" --plan --repo-root "$1" 2>/dev/null | grep '^PLAN-KONDO' \
+    || printf 'PLAN-KONDO <none>\n'
+}
+
+# AF — the exact file the bead was found on: source under a `--lint` root that
+# no local lane read before this one existed.
+r="$tmp_root/kondo-src"; mkrepo "$r"
+mkdir -p "$r/implementation/hicasso/src/re_frame/hicasso/impl"
+printf 'x\n' > "$r/implementation/hicasso/src/re_frame/hicasso/impl/overlay.cljs"
+git -C "$r" add -A; git -C "$r" commit -q -m src
+assert "AF hicasso source → the pinned kondo lane is armed" \
+  "PLAN-KONDO run" "$(plan_kondo "$r")"
+
+# AF1 — a root NO runtime tier owns.  `examples/` arms neither implementation_jvm
+# nor cljs_node_test, so before this lane a broken example reached CI unlinted.
+r="$tmp_root/kondo-examples"; mkrepo "$r"
+mkdir -p "$r/examples/capabilities/resources/linearlite"
+printf 'x\n' > "$r/examples/capabilities/resources/linearlite/core.cljs"
+git -C "$r" add -A; git -C "$r" commit -q -m example
+assert "AF1 examples/ → armed, though no runtime tier owns it" \
+  "PLAN-KONDO run" "$(plan_kondo "$r")"
+
+# AF2 — the shared config decides every finding's level without being linted.
+r="$tmp_root/kondo-config"; mkrepo "$r"
+mkdir -p "$r/.clj-kondo"; printf '{}\n' > "$r/.clj-kondo/config.edn"
+git -C "$r" add -A; git -C "$r" commit -q -m kondocfg
+assert "AF2 .clj-kondo/ config → armed" \
+  "PLAN-KONDO run" "$(plan_kondo "$r")"
+
+# AF3 — the workflow carries the pin AND the target list, so editing it changes
+# the verdict without touching one line of Clojure.
+r="$tmp_root/kondo-workflow"; mkrepo "$r"
+mkdir -p "$r/.github/workflows"; printf 'name: lint\n' > "$r/.github/workflows/lint.yml"
+git -C "$r" add -A; git -C "$r" commit -q -m workflow
+assert "AF3 lint.yml itself → armed" \
+  "PLAN-KONDO run" "$(plan_kondo "$r")"
+
+# AF4 — the counterweight.  A docs-only diff must not pay ~70s of linting; a
+# lane that runs on everything is as useless as one that runs on nothing.
+r="$tmp_root/kondo-docs"; mkrepo "$r"
+mkdir -p "$r/docs/design/hicasso/product"
+printf '# b\n' > "$r/docs/design/hicasso/product/budgets.md"
+git -C "$r" add -A; git -C "$r" commit -q -m docs
+assert "AF4 a docs-only diff does NOT arm the kondo lane" \
+  "PLAN-KONDO skip" "$(plan_kondo "$r")"
+
+# AF5 — an unresolvable base is an indeterminate change set, not an empty one.
+r="$tmp_root/kondo-nobase"; mkdir -p "$r"
+git -C "$r" init -q -b main 2>/dev/null
+git -C "$r" config user.email "self-test@local"; git -C "$r" config user.name "self-test"
+printf 'x\n' > "$r/thing.cljs"
+assert "AF5 no origin/main base → armed conservatively" \
+  "PLAN-KONDO run" "$(plan_kondo "$r")"
+
 # ---- Summary ----
 total=$((pass_count + fail_count))
 printf '\n%s/%s self-test cases passed.\n' "$pass_count" "$total"

--- a/scripts/check_fast_pr_gap.py
+++ b/scripts/check_fast_pr_gap.py
@@ -243,6 +243,45 @@ SPINE_LANES = (
         "spine node tier: 'hicasso invariants gate' chains this checker "
         "(`npm run test:hicasso-invariants`), both modes",
     ),
+    # rf2-x1mz — the lint gate itself, which had NO local lane at all until
+    # `scripts/lint_kondo.py` landed.  The signature is deliberately anchored
+    # on the flags rather than the `--lint` roots: the roots are read out of
+    # this very step at run time, so pinning them here would put a second copy
+    # of the target list in the file whose whole job is to notice second copies
+    # going stale.
+    Lane(
+        "clj-kondo",
+        r"^clj-kondo --parallel --fail-level error --lint ",
+        "spine lint tier: 'clj-kondo (pinned, CI's own command)' -- "
+        "`python scripts/lint_kondo.py` provisions the pinned binary and runs "
+        "THIS step's command, read from this file",
+    ),
+    # The fixture witness runs as a step of the same job.  It has had a spine
+    # lane in fact since rf2-hic-022 but not in this map, and the omission was
+    # accidentally telling the truth: the gate resolved clj-kondo off PATH, so
+    # the local run proved nothing CI's did (rf2-x1mz measured 2025.10.23 at
+    # `errors: 0` where the pin exits 3).  It now resolves through
+    # `lint_kondo.py` too, which is what makes this lane an honest claim rather
+    # than the over-report it would have been a commit earlier.
+    Lane(
+        "hicasso-lint-export",
+        r"^npm run test:hicasso-lint$",
+        "spine node tier: 'hicasso lint export gate', at lint.yml's pin",
+        working_dir="implementation",
+    ),
+    # rf2-uomk — the budget ledger's own unconditional job, the same shape and
+    # for the same reason as `hicasso-complaint-catalogue` above: the checker's
+    # other input families (the ledger page, the disposition records) arm no
+    # classifier output, so the npm chain alone left a ledger-only PR running
+    # it nowhere.  The spine covers both homes through the chain, so the job's
+    # two steps are not a local gap.
+    Lane(
+        "hicasso-budget-ledger",
+        r"^python implementation/hicasso/scripts/check_budget_ledger\.py"
+        r"(?: --self-test)?$",
+        "spine node tier: 'hicasso invariants gate' chains this checker "
+        "(`npm run test:hicasso-invariants`), both modes",
+    ),
     Lane(
         "mkdocs-strict",
         r"^mkdocs build --strict$",

--- a/scripts/lint_kondo.py
+++ b/scripts/lint_kondo.py
@@ -1,0 +1,489 @@
+#!/usr/bin/env python3
+"""Run CI's clj-kondo gate LOCALLY — same version, same paths, same flags.
+
+WHY THIS EXISTS (rf2-x1mz).  A worker edited
+`implementation/hicasso/src/re_frame/hicasso/impl/overlay.cljs`, ran the local
+spine, got green, pushed, and CI's `clj-kondo` job went red.  No local gate in
+this repo could have caught it, for TWO INDEPENDENT REASONS — either one
+sufficient on its own:
+
+  1. VERSION SKEW.  The only local lane that ran clj-kondo at all
+     (`implementation/hicasso/scripts/check_lint_export.py`) resolved the
+     binary off `PATH`, whatever version that happened to be.  Measured on the
+     exact defect: clj-kondo 2025.10.23 reports `errors: 0, exit 0`; the pinned
+     2026.04.15 reports `Expected: array, received: function` and exits 3.  And
+     the pin is not merely absent from that machine — it is UNOBTAINABLE the
+     usual way: the npm distribution of clj-kondo stops at 2025.10.23, so
+     "install the pin" is not advice a developer can follow.  Hence the
+     provisioning half below.
+
+  2. PATH COVERAGE.  That lane's `--lint` targets are two fixture files and
+     `hicasso/testbed`.  It never linted `hicasso/src/`, so the file was
+     outside every local lane REGARDLESS of version — and even had it been
+     inside, that gate reads only findings in the `re-frame.hicasso/*`
+     namespace, so a built-in kondo ERROR like this one is invisible to it.
+
+WHAT THE DEFECT COST, so the stakes are concrete rather than stylistic: two
+`(aset f "displayName" "...")` calls stamping a React displayName onto a
+FUNCTION with the ARRAY accessor.  With `:checked-arrays` off (the repo
+default) `aset`'s 3-arity emits character-identical output to `unchecked-set`,
+so the shipped consequence was none; with `:checked-arrays :error` it THROWS,
+and because these are top-level `def` forms the throw lands at NAMESPACE
+INITIALIZATION — turning on a standard hardening flag would take the whole
+overlay module out at load time.
+
+NOTHING ABOUT THE GATE IS RESTATED HERE.  The version pin, the flags and the
+`--lint` target list are all READ from the `Run clj-kondo` step of
+`.github/workflows/lint.yml`, through the same workflow parser
+`check_fast_pr_gap.py` uses to audit that file.  A copy of the command in this
+file would be a second description of the gate, and a second description drifts
+— which is the shape of defect this script exists to close, not to repeat.  Add
+a `--lint` root in the workflow and this runner lints it on the next run,
+including in its decision about whether the lane is armed at all.
+
+A SKEWED BINARY IS NOT A FALLBACK.  If the pin cannot be provisioned this
+script exits 2 and says what went unchecked; it never runs a different version
+and reports a verdict.  A green from the wrong version is precisely the false
+assurance that produced rf2-x1mz, and the spine's caller turns exit 2 into a
+LOUD SKIP rather than a pass.
+
+    python scripts/lint_kondo.py                  provision + run the gate
+    python scripts/lint_kondo.py --classify F...  is the lane armed by F...?
+    python scripts/lint_kondo.py --print-binary   path to the pinned binary
+    python scripts/lint_kondo.py --self-test      prove the gate's red
+
+Stdlib only, like every other checker in this directory: CI jobs that run these
+install no pip packages.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import os
+import platform
+import shutil
+import subprocess
+import sys
+import tempfile
+import urllib.error
+import urllib.request
+import zipfile
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from check_fast_pr_gap import (  # noqa: E402  (path shim must precede)
+    _KONDO_PIN_RE,
+    parse_workflow,
+)
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+LINT_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "lint.yml"
+KONDO_JOB = "clj-kondo"
+KONDO_STEP = "Run clj-kondo"
+
+# Exit codes with meanings the caller acts on.  The gate's own verdict passes
+# through untouched (clj-kondo exits 3 on an ERROR-level finding), so 2 is
+# reserved for "the gate did not run" and can never collide with it.
+EXIT_UNPROVISIONED = 2
+
+RELEASES = "https://github.com/clj-kondo/clj-kondo/releases/download"
+
+# The release archive for this host.  clj-kondo publishes one per platform and
+# the names are not derivable from `sys.platform` alone, so the table is
+# explicit — but it is a table of PLATFORMS, not of versions: a pin bump needs
+# no edit here.  Linux takes the `-static-` build, which is what lint.yml
+# installs and what needs no glibc of a particular vintage.
+ARCHIVES = {
+    ("Linux", "x86_64"):   "clj-kondo-{v}-linux-static-amd64.zip",
+    ("Linux", "amd64"):    "clj-kondo-{v}-linux-static-amd64.zip",
+    ("Linux", "aarch64"):  "clj-kondo-{v}-linux-aarch64.zip",
+    ("Linux", "arm64"):    "clj-kondo-{v}-linux-aarch64.zip",
+    ("Darwin", "x86_64"):  "clj-kondo-{v}-macos-amd64.zip",
+    ("Darwin", "arm64"):   "clj-kondo-{v}-macos-aarch64.zip",
+    ("Windows", "AMD64"):  "clj-kondo-{v}-windows-amd64.zip",
+    ("Windows", "x86_64"): "clj-kondo-{v}-windows-amd64.zip",
+}
+
+
+# ---------------------------------------------------------------------------
+# What CI runs, read from CI
+# ---------------------------------------------------------------------------
+
+class GateUnreadable(Exception):
+    """lint.yml no longer describes the gate this runner reproduces."""
+
+
+def gate(workflow: Path = LINT_WORKFLOW):
+    """`(pin, argv)` for CI's clj-kondo gate, read from the workflow.
+
+    `argv` is the step's own command with the leading `clj-kondo` word left in
+    place for the caller to swap for a resolved binary — so the flags, their
+    order and the `--lint` roots are CI's, not this file's.
+    """
+    jobs = parse_workflow(workflow.read_text(encoding="utf-8"), workflow.name)
+    job = jobs.get(KONDO_JOB)
+    if job is None:
+        raise GateUnreadable(
+            "%s has no `%s` job; this runner reproduces that job's gate and "
+            "can no longer find it" % (workflow.name, KONDO_JOB))
+
+    pin = None
+    argv = None
+    for step in job.steps:
+        if step.run:
+            m = _KONDO_PIN_RE.search(step.run)
+            if m and pin is None:
+                pin = m.group(1)
+        if step.name == KONDO_STEP:
+            argv = step.command.split()
+
+    if pin is None:
+        raise GateUnreadable(
+            "no clj-kondo version pin in the `%s` job (looked for a release "
+            "URL of the form `.../clj-kondo/releases/download/v<pin>/...`); "
+            "running an unpinned binary proves nothing, which is rf2-x1mz"
+            % KONDO_JOB)
+    if not argv or argv[0] != "clj-kondo":
+        raise GateUnreadable(
+            "the `%s` step of the `%s` job is missing, or no longer begins "
+            "with a bare `clj-kondo` invocation, so its command cannot be "
+            "reproduced locally" % (KONDO_STEP, KONDO_JOB))
+    return pin, argv
+
+
+def lint_roots(argv) -> list[str]:
+    """The `--lint` targets in a parsed gate command, in order."""
+    return [argv[i + 1] for i, tok in enumerate(argv)
+            if tok == "--lint" and i + 1 < len(argv)]
+
+
+# ---------------------------------------------------------------------------
+# Provisioning the pinned binary
+# ---------------------------------------------------------------------------
+
+def cache_dir(pin: str) -> Path:
+    """Where the pinned binary is kept.
+
+    OUTSIDE the repository, deliberately.  This project runs many linked
+    worktrees at once; an in-tree cache would download 18 MB per worktree and
+    would need a `.gitignore` entry to stay out of everyone's `git status`.
+    One shared user-level cache, keyed by pin, costs one download per machine
+    per bump and is invisible to git by construction.
+    """
+    override = os.environ.get("RF2_KONDO_CACHE")
+    root = Path(override) if override else Path(
+        os.environ.get("XDG_CACHE_HOME") or (Path.home() / ".cache"))
+    return root / "re-frame2" / "clj-kondo" / pin
+
+
+def binary_path(pin: str) -> Path:
+    name = "clj-kondo.exe" if platform.system() == "Windows" else "clj-kondo"
+    return cache_dir(pin) / name
+
+
+def _fetch(url: str, dest: Path) -> None:
+    with urllib.request.urlopen(url, timeout=120) as resp:  # noqa: S310
+        dest.write_bytes(resp.read())
+
+
+def provision(pin: str, quiet: bool = False) -> Path:
+    """The pinned binary, downloading it once if this machine lacks it.
+
+    The archive's `.sha256` sidecar is verified before anything is unpacked:
+    the whole value of a pin is that the bytes are known, and an unverified
+    download is a pin in name only.
+    """
+    exe = binary_path(pin)
+    if exe.is_file():
+        return exe
+
+    key = (platform.system(), platform.machine())
+    template = ARCHIVES.get(key)
+    if template is None:
+        raise RuntimeError(
+            "no clj-kondo release archive is published for this platform "
+            "(%s/%s); upstream builds %s"
+            % (key[0], key[1], ", ".join(sorted({v.split("-", 2)[2]
+                                                 for v in ARCHIVES.values()}))))
+    archive = template.format(v=pin)
+    url = "%s/v%s/%s" % (RELEASES, pin, archive)
+
+    if not quiet:
+        # ASCII only in anything PRINTED: Windows consoles default to cp1252
+        # and a stray em-dash comes out as a replacement character, or raises.
+        print("  fetching clj-kondo %s (%s) - once per machine per pin"
+              % (pin, archive))
+    with tempfile.TemporaryDirectory() as tmp:
+        tmpd = Path(tmp)
+        zip_path = tmpd / archive
+        try:
+            _fetch(url, zip_path)
+            expected = urllib.request.urlopen(  # noqa: S310
+                url + ".sha256", timeout=60).read().decode().split()[0].strip()
+        except (urllib.error.URLError, OSError) as exc:
+            raise RuntimeError("could not download %s: %s" % (url, exc))
+
+        actual = hashlib.sha256(zip_path.read_bytes()).hexdigest()
+        if actual != expected:
+            raise RuntimeError(
+                "%s failed its published sha256 (expected %s, got %s)"
+                % (archive, expected, actual))
+
+        with zipfile.ZipFile(zip_path) as zf:
+            members = [n for n in zf.namelist()
+                       if Path(n).name in ("clj-kondo", "clj-kondo.exe")]
+            if len(members) != 1:
+                raise RuntimeError(
+                    "%s does not contain exactly one clj-kondo binary (found "
+                    "%s)" % (archive, members or "none"))
+            extracted = Path(zf.extract(members[0], tmpd))
+
+        cache_dir(pin).mkdir(parents=True, exist_ok=True)
+        # Move into place through a temp name in the SAME directory, so two
+        # spines racing on one machine cannot observe a half-written binary.
+        staged = exe.with_suffix(exe.suffix + ".%d.part" % os.getpid())
+        shutil.move(str(extracted), str(staged))
+        staged.chmod(0o755)
+        os.replace(staged, exe)
+
+    return exe
+
+
+def resolved(pin: str, quiet: bool = False) -> Path:
+    """The pinned binary, preferring one already on PATH at the right version.
+
+    A CI runner has installed the pin to `/usr/local/bin` before this script
+    runs, and a developer may have it too; downloading a second copy of a
+    binary already present would be waste with no gain.  The version is
+    CHECKED rather than assumed — that check is the whole bead.
+    """
+    found = (shutil.which("clj-kondo.cmd") or shutil.which("clj-kondo.bat")
+             or shutil.which("clj-kondo"))
+    if found:
+        try:
+            out = subprocess.run([found, "--version"], capture_output=True,
+                                 text=True, timeout=60).stdout
+        except (OSError, subprocess.SubprocessError):
+            out = ""
+        if pin in out:
+            return Path(found)
+    return provision(pin, quiet=quiet)
+
+
+# ---------------------------------------------------------------------------
+# Is the lane armed?
+# ---------------------------------------------------------------------------
+
+def arms(paths, roots) -> bool:
+    """True when any of `paths` is inside something the gate reads.
+
+    The `--lint` roots come from the workflow, so a new root arms the lane the
+    moment it is added there.  Two roots are added on top, and both are read
+    rather than linted: `.clj-kondo/` is the shared config the run loads, and
+    the workflow itself carries the pin and the target list — an edit to either
+    changes the verdict without touching a single `.cljs` file.
+    """
+    prefixes = [r.replace("\\", "/").rstrip("/") for r in roots]
+    prefixes += [".clj-kondo", ".github/workflows/lint.yml"]
+    for raw in paths:
+        p = str(raw).replace("\\", "/")
+        # `./x` and `x` are the same path; `lstrip` is the wrong tool for that
+        # trim — it eats every leading `.` and `/`, which silently turned
+        # `.clj-kondo/config.edn` into `clj-kondo/config.edn` and stopped the
+        # shared config arming anything.
+        while p.startswith("./"):
+            p = p[2:]
+        if any(p == pre or p.startswith(pre + "/") for pre in prefixes):
+            return True
+    return False
+
+
+# ---------------------------------------------------------------------------
+# The self-test — proving the red, not merely the green
+# ---------------------------------------------------------------------------
+
+_FIXTURE_JOB = """\
+jobs:
+  clj-kondo:
+    name: clj-kondo (fail on errors, warnings informational)
+    steps:
+      - name: Install clj-kondo
+        run: |
+          curl -fsSL -o /tmp/clj-kondo.zip \\
+            https://github.com/clj-kondo/clj-kondo/releases/download/v9999.01.02/clj-kondo-9999.01.02-linux-static-amd64.zip
+      - name: Run clj-kondo
+        run: |
+          clj-kondo \\
+            --parallel \\
+            --fail-level error \\
+            --lint implementation \\
+            --lint tools/story
+"""
+
+
+def self_test() -> int:
+    ok = True
+
+    def check(label, cond, detail=""):
+        nonlocal ok
+        print("  %s %s%s" % ("ok  " if cond else "FAIL", label,
+                             "" if cond else "  <- " + str(detail)))
+        if not cond:
+            ok = False
+
+    # --- the reader, against a fixture whose answers are known --------------
+    with tempfile.TemporaryDirectory() as tmp:
+        fixture = Path(tmp) / "lint.yml"
+        fixture.write_text(_FIXTURE_JOB, encoding="utf-8")
+        pin, argv = gate(fixture)
+        check("the pin is read off the installer step's release URL",
+              pin == "9999.01.02", pin)
+        check("the gate command is read from the step, flags and all",
+              argv == ["clj-kondo", "--parallel", "--fail-level", "error",
+                       "--lint", "implementation", "--lint", "tools/story"],
+              argv)
+        check("the --lint roots are derived from that command",
+              lint_roots(argv) == ["implementation", "tools/story"],
+              lint_roots(argv))
+
+        # A workflow that stopped describing the gate must RAISE, not shrug: a
+        # runner that silently lints nothing is the fail-open shape this whole
+        # file exists to close.
+        for label, text in (
+            ("a workflow with no clj-kondo job", "jobs:\n  other:\n    steps:\n      - run: echo\n"),
+            ("a job with no version pin",
+             "jobs:\n  clj-kondo:\n    steps:\n      - name: Run clj-kondo\n        run: clj-kondo --lint implementation\n"),
+            ("a job whose gate step is gone",
+             _FIXTURE_JOB.replace("- name: Run clj-kondo", "- name: Run something else")),
+        ):
+            fixture.write_text(text, encoding="utf-8")
+            try:
+                gate(fixture)
+                check(label + " raises", False, "it returned instead")
+            except GateUnreadable:
+                check(label + " raises", True)
+
+    # --- the arming predicate ----------------------------------------------
+    roots = ["implementation", "tools/story"]
+    check("a source file under a --lint root arms the lane",
+          arms(["implementation/hicasso/src/re_frame/hicasso/impl/overlay.cljs"], roots))
+    check("the shared kondo config arms the lane",
+          arms([".clj-kondo/config.edn"], roots))
+    check("the workflow carrying the pin arms the lane",
+          arms([".github/workflows/lint.yml"], roots))
+    check("a doc-only change does not",
+          not arms(["docs/design/hicasso/product/budgets.md", "README.md"], roots))
+    check("a near-miss prefix does not arm the lane",
+          not arms(["implementation-notes/x.cljs"], roots))
+
+    # --- the real workflow still parses ------------------------------------
+    try:
+        pin, argv = gate()
+        real_roots = lint_roots(argv)
+        check("the repo's own lint.yml yields a pin", bool(pin), pin)
+        check("...and at least three --lint roots",
+              len(real_roots) >= 3, real_roots)
+        check("...every one of which exists on disk",
+              all((REPO_ROOT / r).exists() for r in real_roots),
+              [r for r in real_roots if not (REPO_ROOT / r).exists()])
+    except GateUnreadable as exc:
+        check("the repo's own lint.yml describes the gate", False, exc)
+
+    # --- the gate's RED, on a planted defect -------------------------------
+    #
+    # The claim under test is not "clj-kondo works" but "THIS runner, at THIS
+    # pin, over the roots THIS workflow names, reports a defect in a file that
+    # was outside every local lane before it existed". So the plant goes into
+    # a real source tree under a real `--lint` root, and is restored from the
+    # bytes read before it — never from a diff, which cannot tell an exact
+    # restore from a patch that never applied.
+    try:
+        exe = resolved(pin)
+    except RuntimeError as exc:
+        print("  SKIP the planted-defect control - %s" % exc)
+        print("       (the pin could not be provisioned; the RED half of this "
+              "gate is therefore unproven on this host)")
+        ok = False
+        exe = None
+
+    if exe is not None:
+        victim = (REPO_ROOT / "implementation" / "hicasso" / "src" / "re_frame"
+                  / "hicasso" / "impl" / "overlay.cljs")
+        original = victim.read_bytes()
+        before = hashlib.sha256(original).hexdigest()
+        anchor = b'(unchecked-set "displayName" "hicasso/modal")'
+        if original.count(anchor) != 1:
+            check("the planted-defect control has its anchor", False,
+                  "%d occurrences of %r in %s"
+                  % (original.count(anchor), anchor.decode(), victim.name))
+        else:
+            planted = original.replace(
+                anchor, b'(aset "displayName" "hicasso/modal")', 1)
+            try:
+                victim.write_bytes(planted)
+                proc = subprocess.run(
+                    [str(exe), "--fail-level", "error", "--lint", str(victim)],
+                    cwd=REPO_ROOT, capture_output=True, text=True)
+            finally:
+                victim.write_bytes(original)
+            after = hashlib.sha256(victim.read_bytes()).hexdigest()
+            check("an aset-on-a-function is reported as an ERROR",
+                  proc.returncode != 0 and "error" in proc.stdout,
+                  "exit %d: %s" % (proc.returncode, proc.stdout.strip()))
+            check("...naming the file it is in",
+                  victim.name in proc.stdout, proc.stdout.strip())
+            check("the plant was restored byte-for-byte",
+                  after == before, "%s != %s" % (after, before))
+
+    print("lint_kondo self-test: %s" % ("PASS" if ok else "FAIL"))
+    return 0 if ok else 1
+
+
+# ---------------------------------------------------------------------------
+
+def main(argv=None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("--print-binary", action="store_true",
+                        help="provision if needed, print the binary's path")
+    parser.add_argument("--classify", nargs="*", metavar="FILE",
+                        help="print kondo_surface=true|false for these paths")
+    parser.add_argument("--self-test", action="store_true",
+                        help="prove the gate's red/green classification")
+    args = parser.parse_args(argv)
+
+    if args.self_test:
+        return self_test()
+
+    try:
+        pin, command = gate()
+    except GateUnreadable as exc:
+        print("FAIL: %s" % exc, file=sys.stderr)
+        return 1
+
+    if args.classify is not None:
+        print("kondo_surface=%s"
+              % ("true" if arms(args.classify, lint_roots(command)) else "false"))
+        return 0
+
+    try:
+        exe = resolved(pin, quiet=args.print_binary)
+    except RuntimeError as exc:
+        print("clj-kondo %s is NOT AVAILABLE: %s" % (pin, exc), file=sys.stderr)
+        print("A DIFFERENT VERSION IS NOT A FALLBACK (rf2-x1mz): 2025.10.23 "
+              "reports 0 errors on a line 2026.04.15 fails, so a pass from one "
+              "is not a pass from the other. Nothing was linted.",
+              file=sys.stderr)
+        return EXIT_UNPROVISIONED
+
+    if args.print_binary:
+        print(exe)
+        return 0
+
+    print("clj-kondo %s (%s)" % (pin, exe))
+    print("  $ %s" % " ".join(command))
+    return subprocess.run([str(exe)] + command[1:], cwd=REPO_ROOT).returncode
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/test-fast-pr.sh
+++ b/scripts/test-fast-pr.sh
@@ -406,7 +406,32 @@ if [ -n "$changed_files" ]; then
   fi
 fi
 
-# ---- resolve the three tiers, honouring overrides + conservative fallback ----
+# ---- lint surface, delegated to the runner that owns the lint gate ----
+# A SEPARATE classifier because lint.yml has a separate one: the clj-kondo job
+# is armed by its own `detect` job, not by report-changed-surfaces.sh, and the
+# two populations genuinely differ (`examples/`, `testbeds/`, `tools/*` and
+# `.clj-kondo/` arm the linter and no runtime tier).  `lint_kondo.py --classify`
+# answers from the `--lint` roots it reads out of lint.yml, so a root added
+# there arms this lane with no edit here — the same "read the roster, never
+# restate it" discipline the JVM artefact selection below uses.
+kondo_surface=false
+kondo_classify_failed=false
+if [ -n "$changed_files" ]; then
+  _kondo_arr=()
+  while IFS= read -r _f; do
+    [ -n "$_f" ] && _kondo_arr+=("$_f")
+  done <<< "$changed_files"
+  if kondo_out="$(python "$spine_root/scripts/lint_kondo.py" --classify \
+                    "${_kondo_arr[@]}" 2>/dev/null)"; then
+    case "$kondo_out" in
+      *kondo_surface=true*) kondo_surface=true ;;
+    esac
+  else
+    kondo_classify_failed=true
+  fi
+fi
+
+# ---- resolve the tiers, honouring overrides + conservative fallback ----
 run_jvm=false
 run_node=false
 run_docs=false
@@ -472,6 +497,19 @@ case "$with_docs" in
   force) run_docs=true ;;
   skip)  run_docs=false ;;
 esac
+
+# The clj-kondo lane decides on its OWN surface, not on the tiers above — it
+# reads trees no runtime tier owns.  `--all` runs it; an unresolvable base or a
+# classifier that itself failed runs it, because an indeterminate change set is
+# not evidence of absence.
+run_kondo=false
+if [ "$run_all" = true ]; then
+  run_kondo=true
+elif [ "$base_resolved" != true ] || [ "$kondo_classify_failed" = true ]; then
+  run_kondo=true
+else
+  run_kondo="$kondo_surface"
+fi
 
 # ---------------------------------------------------------------------------
 # WHICH JVM ARTEFACT SUITES — the roster is READ, never listed here (rf2-uwszd).
@@ -546,6 +584,7 @@ if [ "$plan_only" = true ]; then
   printf '  mkdocs --strict:     %s\n' "$mkdocs_plan"
   printf '  JVM tier:            %s\n' "$([ "$run_jvm" = true ] && echo run || echo skip)"
   printf '  node/CLJS suite:     %s\n' "$([ "$run_node" = true ] && echo run || echo skip)"
+  printf '  clj-kondo (pinned):  %s\n' "$([ "$run_kondo" = true ] && echo run || echo skip)"
   printf '  reason:              %s\n' "$plan_reason"
   printf '  JVM artefact suites: %s\n' \
     "$([ "$run_jvm" = true ] && echo "${jvm_run_list# }" || echo '(tier skipped)')"
@@ -557,7 +596,12 @@ if [ "$plan_only" = true ]; then
   printf ' here (scripts/test-jvm-implementation.sh).\n'
   printf '                       No browser, bundle, adapter, Xray, MCP or'
   printf ' tool-JVM gate is in any tier.\n'
+  # `PLAN` keeps its three fields (rf2-x1mz): the self-test asserts that line
+  # verbatim in fourteen cases, and a fourth field would rewrite every one of
+  # them to say nothing new.  The kondo lane gets its own machine-readable
+  # line, as `PLAN-JVM` / `PLAN-MKDOCS` / `PLAN-SELFTEST` already do.
   printf 'PLAN docs=%s jvm=%s node=%s\n' "$run_docs" "$run_jvm" "$run_node"
+  printf 'PLAN-KONDO %s\n' "$([ "$run_kondo" = true ] && echo run || echo skip)"
   printf 'PLAN-JVM%s\n' "$([ "$run_jvm" = true ] && printf '%s' "$jvm_run_list")"
   printf 'PLAN-MKDOCS %s\n' "$mkdocs_plan"
   printf 'PLAN-SELFTEST %s\n' "$([ "$spine_self_surface" = true ] && echo run || echo skip)"
@@ -1320,6 +1364,49 @@ if [ "$run_docs" = true ]; then
 else
   printf '\n--- documentation surface unchanged → skipping doc gates (override with --with-docs) ---\n'
   note_skipped "documentation gates (surface unchanged; --with-docs forces)"
+fi
+
+# ---------------------------------------------------------------------------
+# clj-kondo, AT THE VERSION CI PINS, OVER THE PATHS CI LINTS (rf2-x1mz).
+#
+# Before this lane the repo had no local gate that could catch a source error
+# lint.yml fails on, for two independent reasons.  The only local lane that ran
+# clj-kondo at all was the Hicasso fixture witness below, and it (a) took
+# whatever binary was on PATH — 2025.10.23 here, which reports `errors: 0` on
+# the exact line CI fails at 2026.04.15 — and (b) lints two fixture files and
+# `hicasso/testbed`, never `hicasso/src/`.  An `(aset f "displayName" …)` pair
+# went out green locally and red in CI, and no amount of care locally could
+# have found it.
+#
+# It runs BEFORE the JVM and node tiers because it is the cheapest of the three
+# and the one whose red is most often a one-line fix: ~70s warm over the whole
+# corpus, against minutes for either tier below.
+#
+# `lint_kondo.py` provisions the pinned binary once per machine and runs the
+# workflow's OWN command; nothing about the gate is restated in this file.  If
+# the pin cannot be provisioned it exits 2 WITHOUT LINTING, and that becomes a
+# loud skip rather than a pass — a green from another version is the false
+# assurance this lane exists to remove, not a fallback.
+# ---------------------------------------------------------------------------
+if [ "$run_kondo" = true ]; then
+  kondo_status=0
+  python "$spine_root/scripts/lint_kondo.py" --print-binary >/dev/null 2>&1 \
+    || kondo_status=$?
+  if [ "$kondo_status" -eq 2 ]; then
+    printf '\n    NOT CHECKED: clj-kondo — the version lint.yml pins could not be\n'
+    printf '      provisioned on this host (no network, or no published build for\n'
+    printf '      this platform).  This is NOT a pass: a differently-versioned\n'
+    printf '      binary disagrees about which findings are errors, so running one\n'
+    printf '      would report a verdict it has not earned.  Left with NO local\n'
+    printf '      gate: every .clj/.cljs/.cljc file under the roots lint.yml lists.\n'
+    note_skipped "clj-kondo (pinned) — the pinned binary could not be provisioned, so no local lane linted implementation/, examples/, testbeds/ or tools/ this run"
+  else
+    run "clj-kondo (pinned, CI's own command)" "python scripts/lint_kondo.py" \
+      bash -lc "cd '$spine_root' && python scripts/lint_kondo.py"
+  fi
+else
+  printf '\n--- no clj-kondo lint surface in the diff → skipping the lint lane ---\n'
+  note_skipped "clj-kondo (pinned) — no file under a --lint root, .clj-kondo/ or lint.yml changed"
 fi
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Two gates that could not fire on the edits they exist to police. Clustered
because both repairs land in `scripts/` and `.github/workflows/`, which two
workers must never share.

## rf2-x1mz — clj-kondo: no local gate could catch a source error CI fails on

Both of the bead's reasons were verified at source, and both hold.

**Version skew — measured, not inferred.** `implementation/hicasso/scripts/check_lint_export.py`
(the bead calls it `scripts/check_lint_export.py`; that is its only inaccuracy)
resolved clj-kondo through `shutil.which`. The pin is read off `.github/workflows/lint.yml:285`
and is **2026.04.15**, as the brief claimed. The same one-line defect, the same
file, the two binaries:

```
$ clj-kondo --version                       # npm, on PATH
clj-kondo v2025.10.23
$ clj-kondo --fail-level error --lint implementation/hicasso/src/re_frame/hicasso/impl/overlay.cljs
linting took 194ms, errors: 0, warnings: 0
EXIT 0

$ ./clj-kondo.exe --version                 # CI's pin
clj-kondo v2026.04.15
$ ./clj-kondo.exe --fail-level error --lint implementation/hicasso/src/re_frame/hicasso/impl/overlay.cljs
implementation/hicasso/src/re_frame/hicasso/impl/overlay.cljs:359:11: error: Expected: array, received: function.
linting took 26ms, errors: 1, warnings: 0
EXIT 3
```

**One premise the brief did not carry: the pin is unobtainable the usual way.**
`npm view clj-kondo versions` tops out at **2025.10.23** — 2026.04.15 is not
published to npm at all. "Install the pin" was therefore not advice a developer
on this machine could follow, which is why the repair provisions the binary
rather than asking for it.

**Path coverage.** That lane's `--lint` targets are `lint-fixtures/positive.cljs`,
`lint-fixtures/negative.cljs` and `hicasso/testbed`. It never lints `hicasso/src/`.
And a second reason the brief did not name: the corpus arm filters findings
through `_ours()`, which keeps only types under `re-frame.hicasso/`. So even had
`src/` been in that list, a built-in kondo ERROR like this one would have been
invisible to it. Widening the target list alone would not have closed the hole.

**The source defect is already fixed on main.** `10ee362e77` ("the displayName
stamp is an object write, not an array one", rf2-hic-052) replaced both `aset`
calls with `unchecked-set` before this bead was dispatched. Nothing in
`overlay.cljs` is changed by this PR; the file is used only as the plant target
for the negative control below, and restored byte-for-byte. **The finder's
`Cannot infer target type` observation was left alone as instructed.**

### The repair

`scripts/lint_kondo.py` — a local runner that provisions clj-kondo at lint.yml's
pin and runs lint.yml's own command. **Nothing about the gate is restated in it.**
The pin, the flags and the `--lint` roots are all read out of the `Run clj-kondo`
step through the workflow parser `check_fast_pr_gap.py` already uses on that
file, so a root added in the workflow is linted on the next local run and arms
the lane too. The download verifies the release's published `.sha256` before
unpacking and caches outside the repository, keyed by pin — one download per
machine per bump, shared by every worktree, invisible to git without a
`.gitignore` entry.

**A skewed binary is not a fallback.** If the pin cannot be provisioned the
runner exits 2 *without linting*, and the spine turns that into a loud skip that
names what went unchecked. A green from the wrong version is the false assurance
this bead is about.

`scripts/test-fast-pr.sh` gains a fourth surface, decided by
`lint_kondo.py --classify` rather than by `report-changed-surfaces.sh` — the two
populations genuinely differ, since `examples/`, `testbeds/` and `tools/*` arm
the linter and no runtime tier. It runs before the JVM and node tiers: ~70s warm
against minutes for either, and its red is usually a one-line fix.

`PLAN` keeps its three fields and the lane gets its own `PLAN-KONDO` line, as
`PLAN-JVM` / `PLAN-MKDOCS` / `PLAN-SELFTEST` already do — a fourth field would
have rewritten fourteen self-test assertions to say nothing new.

`check_lint_export.py` now resolves through the same provisioner, so its
docstring's "at the version CI pins" is true locally as well as in CI; where the
pin is unreachable it still runs, but says so rather than claiming CI's verdict.

## rf2-uomk — CI reachability for the budget-ledger gate

The bead's premise holds exactly as stated. Probed at this branch's head:

```
$ bash .github/scripts/report-changed-surfaces.sh docs/design/hicasso/product/budgets.md
implementation_jvm=false
cljs_node_test=false
... every one of the 31 outputs false
```

Same for `substrate-decision.md`. `check_budget_ledger.py`'s only hosted
invocation was a step of test.yml's `cljs` job under `cljs_node_test == 'true'`,
so a ledger-only edit — the edit the gate exists to police — skipped every PR
check, and the gate would next run red on somebody else's source PR over a row
they did not write.

Adds `hicasso-budget-ledger`: unconditional, pure Python, a near-copy of
`hicasso-complaint-catalogue` and unconditional for the reason that job's own
comment gives — the defect being repaired *is* a surface gate that did not cover
a checker's inputs, so a new classifier arm is a fresh chance to make the same
mistake. It stays chained into `test:hicasso-invariants`.

## Do the two share a common cause worth ruling as a class?

**Yes, and a third instance is likely.** The shared cause is not "somebody
forgot"; it is that **a gate's inputs and a gate's arming are described in two
different files, and nothing holds them in step.** `check_gate_scheduling.py`
answers "does this gate run *anywhere*?" and `check_fast_pr_gap.py` answers "does
the spine run what CI runs?" — but neither asks **"is the gate armed by every
file it reads?"**, which is the question both beads answer NO to.

Three instances are now on record, all in the same shape:

| gate | reads | armed by | found as |
|---|---|---|---|
| `check_complaint_catalogue.py` | 4 families | 1 | rf2-hic-021 (fixed) |
| `check_budget_ledger.py` | 3 families | 1 | rf2-uomk (this PR) |
| lint.yml `clj-kondo` | 12 `--lint` roots | n/a locally | rf2-x1mz (this PR) |

Each was found by a human noticing, and each was repaired one at a time. The
class-level remedy would be a checker that reads each gate script's input paths
and asserts the arming covers them — but that is a real piece of work, it needs a
way for a script to declare its inputs, and it is **not** something this PR
should smuggle in. Filing it is the operator's call. **Recorded here as a
recommendation, not actioned.**

## Required job-name delta

Read this before re-checking the five sibling PRs in flight this wave.

- **Added, one job:** `hicasso-budget-ledger`, display name
  `Hicasso budget-ledger contract (rf2-hic-089)`, in `test.yml`. Added to
  `all-required-passed`'s `needs:`, so it is required rather than advisory.
- **Renamed:** none.
- **Re-scoped:** none. No existing job's `if:`, `needs:` or step list changed.
- **Required status contexts:** unchanged — still `All required checks passed`,
  `Lint required`, `Docs required`.

Sibling PRs run *their own branch's* `test.yml`, so their check sets are
unaffected until they rebase onto main after this merges. A verdict computed
against the old matrix is still valid for them today.

`scripts/test-fast-pr.sh` and `scripts/lint_kondo.py` are local-only and change
no CI job.

## Negative controls

Both restores were verified by **hashing the file bytes**, never by reading a
diff — a patch that never applied and an exact restore produce the same clean
diff, so the hash is the only thing that distinguishes a real plant from a
silent no-op. Each plant is anchored to a single line and aborts unless the
anchor occurs exactly once.

### rf2-x1mz — the lane must fire on the defect that got through

Plant: `(unchecked-set "displayName" "hicasso/modal")` → `(aset ...)`, one line,
in `implementation/hicasso/src/re_frame/hicasso/impl/overlay.cljs` — a path that
was outside every local lane before this PR.

```
sha256 before plant  7cbd21fda52ab2c5989ced3ea6dfb47e75a00ddd2d1dff12ff952795f76cd1f7
sha256 planted       0a43bf69d6cfb67e9c3e7d6c03108f2b041be184cffbaaa3cd1fcd50223889bc

$ python scripts/lint_kondo.py                  # PLANTED
implementation\hicasso\src\re_frame\hicasso\impl\overlay.cljs:359:11: error: Expected: array, received: function.
linting took 119735ms, errors: 1, warnings: 4549
EXIT 3          <- names the file AND the line

sha256 after restore 7cbd21fda52ab2c5989ced3ea6dfb47e75a00ddd2d1dff12ff952795f76cd1f7   (== before)

$ python scripts/lint_kondo.py                  # RESTORED
linting took 87554ms, errors: 0, warnings: 4549
EXIT 0
```

The same control runs inside `lint_kondo.py --self-test`, so it is permanent
rather than a one-off transcript.

### rf2-uomk — the checker must fire on a ledger defect, and the job must be reachable

Plant: `D3`'s status `MET` → `FINE`, one line, in
`docs/design/hicasso/product/budgets.md`.

```
sha256 before plant  ad6e0a370ead5e210a51dd5135008f5ebe7340b8831daccb65dbb87e03b9ec1c
sha256 planted       d1da92db11413a32f49e27e6e941927d2d6e9fade1a7abed361baa3a1e6ab224

$ python implementation/hicasso/scripts/check_budget_ledger.py    # PLANTED
FAIL: Hicasso budget-line reconciliation ledger
  L1 D3 has status 'FINE', which is not one of MET, BREACH, UNRESOLVED, UNPINNED
EXIT 1

sha256 after restore ad6e0a370ead5e210a51dd5135008f5ebe7340b8831daccb65dbb87e03b9ec1c   (== before)
EXIT 0
```

Reachability itself cannot be planted locally — it is a property of the workflow
graph — so it is asserted structurally, from a real YAML parse of the file in
this branch:

```
needs of hicasso-budget-ledger:            NONE
job keys:                                  ['name', 'runs-on', 'steps', 'timeout-minutes']   <- no `if:`
listed in all-required-passed needs:       True
classifier outputs armed by a ledger-only edit:  0 of 31   <- unchanged, and why the job is unconditional
```

### The fail-closed path — a skip that cannot report a pass

The whole repair rests on "a skewed binary is not a fallback", so that branch
needs a control of its own: a claim about what happens when provisioning fails
is worth nothing until provisioning has actually failed.

Plant: the release host in `scripts/lint_kondo.py` → an unresolvable domain, one
line.

```
sha256 before plant  399e4407aa3536c21c2895cfdbf66756396d3381144dea05c7bc41f043fd08a2

$ RF2_KONDO_CACHE=<empty dir> python scripts/lint_kondo.py
clj-kondo 2026.04.15 is NOT AVAILABLE: could not download
  https://invalid.example.invalid/.../clj-kondo-2026.04.15-windows-amd64.zip:
  <urlopen error [Errno 11001] getaddrinfo failed>
A DIFFERENT VERSION IS NOT A FALLBACK (rf2-x1mz): ... Nothing was linted.
EXIT 2          <- not 0, and it did not fall back to the 2025.10.23 on PATH

sha256 after restore 399e4407aa3536c21c2895cfdbf66756396d3381144dea05c7bc41f043fd08a2   (== before)
```

`git status --porcelain` was empty after the restore, and the spine run below had
not yet reached the kondo lane while the plant was in place — checked, not
assumed.

## The fast-PR gap map

`python scripts/check_fast_pr_gap.py --list`, before and after:

```
BEFORE  REQUIRED CHECKS THIS SPINE DOES NOT RUN (97)   51 required jobs with no lane at all
AFTER   REQUIRED CHECKS THIS SPINE DOES NOT RUN (95)   50 required jobs with no lane at all
```

**The list moves, and it moves the right way while the required matrix grows.**
The one job that left the no-lane list is
`clj-kondo (fail on errors, warnings informational)` — both its steps now have
local lanes (the pinned run, and the Hicasso fixture witness, whose lane was
missing from the map and whose absence was *accidentally honest* until the commit
that gave it the pin). No job joined the list. The two steps rf2-uomk adds to the
required matrix arrive already covered, through the npm chain the spine runs, so
they do not enter it.

The 95 that remain are the same population as before: browser, bundle, adapter,
Xray, MCP, tool-JVM and per-artefact JVM jobs, none of which this change touches.

## Quality gates

Every gate run alone, output redirected and the exit code captured on the same
command line. Exit codes below are the ones **I** captured, not the harness's.
`gate root:` on every spine run was
`/c/Users/miket/code/re-frame2-worktrees/gatereach-x1mz`.

| gate | exit | notes |
|---|---|---|
| `bash scripts/_test_fixtures/test_fast_pr_docs_gate/run-self-test.sh` | 0 | 43/43 cases, including 6 new `PLAN-KONDO` rows |
| `python scripts/lint_kondo.py --self-test` | 0 | 17 rows: reader, arming both ways, planted-defect RED, hash-verified restore |
| `python scripts/lint_kondo.py` (clean tree) | 0 | CI's exact command, pinned binary, `errors: 0` |
| `python scripts/check_fast_pr_gap.py --self-test` | 0 | |
| `python scripts/check_fast_pr_gap.py --verbose` | 0 | the drift ratchet; all three new lanes match a real step |
| `python implementation/hicasso/scripts/check_lint_export.py --self-test` | 0 | 11 mutations, all still RED **at the pin** (they had only ever been proven at 2025.10.23) |
| `python implementation/hicasso/scripts/check_lint_export.py` | 0 | |
| `python implementation/hicasso/scripts/check_budget_ledger.py --self-test` | 0 | |
| `python implementation/hicasso/scripts/check_budget_ledger.py` | 0 | |
| `yaml.safe_load` on `test.yml` + `lint.yml` | 0 | real YAML parse, not the repo's line parser |
| `python scripts/lint_kondo.py` with the release host sabotaged | **2** | the fail-closed control: exits 2 rather than falling back, restore hash-verified |
| `sh scripts/test-fast-pr.sh` | **0** | `PASS fast PR spine` — 82 lanes, 0 `FAIL`, every tier armed (`spine self-change`) |

`gate root: /c/Users/miket/code/re-frame2-worktrees/gatereach-x1mz` on every spine
run — checked, not assumed.

The spine's own `NOT RUN` list is the only set of skips, and it is the standard
one: the JVM artefact suites the diff did not touch, and the browser / bundle /
adapter / Xray / mcp-conformance / tool-JVM lanes that are CI-only. Nothing was
skipped on account of this change.

**The first attempt at this run failed, and the reason is worth recording.** The
worktree had no `implementation/node_modules`, so `CLJS node integration` died on
`Cannot find module 'shadow-cljs/cli/runner.js'` — an environment gap, not a
defect in the diff. I junctioned `node_modules` at the mayor checkout's real one,
re-ran the whole spine, and got the exit 0 above; the junction (never its target)
was removed afterwards, with the mayor's `node_modules` entry count checked at
103 before and after. The clj-kondo lane, the spine self-test and the gap map are
all pure Python plus a native binary, so they were green in both runs.

**One process note, because it nearly produced a false green.** Sibling workers
in this wave share one scratchpad directory, and my first spine run wrote its
log and exit code to the un-suffixed `gate-fastpr.log` / `gate-fastpr.exit` — the
names the dispatch brief uses as its example. Another worker's run had already
created `gate-fastpr.exit`, so reading it returned **somebody else's `0`** while
my spine was still in its JVM tier. I caught it because the lane list did not
match the run I was watching, discarded that run entirely and re-ran under
`gate-fastpr-gatereach-x1mz.*`. The exit code quoted above is from the
namespaced re-run. Worth knowing when reading any worker's gate evidence this
wave: an un-suffixed gate log in a shared scratchpad is not evidence of
anything.

## What I did NOT conclude

- **I did not fix the 8 `Cannot infer target type` notes** at `overlay.cljs:160/161/179/180`.
  The bead files them for triage and records the `:advanced` build at 0 warnings;
  the brief says leave them. Untouched.
- **I did not add a class-level checker** for "is every gate armed by every file
  it reads". The evidence for one is in this PR; the decision is the operator's.
- **I did not measure whether the ~70s lint is acceptable to Mike** on every
  armed diff. It is surface-gated so a docs-only or spec-only change pays
  nothing, and `RF2_FAST_PR_ALL=1` / `--all` still force it — but if it proves
  irritating in practice, moving it behind a flag is a one-line change and I have
  no data either way.
- **I did not verify the download path on macOS or Linux.** The platform table
  and the archive names were checked against the release's real asset list (all
  five platform zips plus `.sha256` sidecars are published for 2026.04.15), but
  only the Windows arm was executed here.
- **I did not touch `implementation/shadow-cljs.edn`, `spec/009-Instrumentation.md`,
  `hicasso/testbed/**`, `controlled.cljs`, or any other worker's surface.** The
  one file I edited outside `scripts/` and `.github/workflows/` is
  `implementation/hicasso/scripts/check_lint_export.py`, which the bead names as
  the defective resolver and which no other worker owns this wave.
