### PR TITLE
fix(freehand): promise chains no longer catch downstream of their own done (rf2-o0n1)

### DIFF
--- a/implementation/freehand/test/re_frame/bench/hicasso/ssr/spike_dom_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/ssr/spike_dom_cljs_test.cljs
@@ -676,13 +676,24 @@
         (do (skip! ":node-test has no DOM") (done))
         (do
           (same-snapshot!)
-          (let [{:keys [html]} (server!)]
+          (let [{:keys [html]} (server!)
+                survivor*      (atom nil)]
             (-> (hydrate-and-adopt! html)
+                ;; RETAINED, not carried forward as a pair. The awaited timer
+                ;; below settles long after this root exists, so a throw in
+                ;; those assertions takes the rejection arm — which cannot see
+                ;; any fulfilment value. Holding the survivor here is what lets
+                ;; its release run on both paths (audit of #7942/#7968), and it
+                ;; is why the second adoption no longer needs a nested chain to
+                ;; thread the first one through.
                 (.then (fn [survivor]
-                         (-> (hydrate-and-adopt! html)
-                             (.then (fn [doomed] [survivor doomed])))))
+                         (reset! survivor* survivor)
+                         (hydrate-and-adopt! html)))
                 (.then
-                  (fn [[survivor doomed]]
+                  (fn [doomed]
+                    ;; The doomed root's teardown is the ACT UNDER TEST, not
+                    ;; cleanup: what follows reads what it left behind. It stays
+                    ;; exactly here.
                     (mount/unmount! (:handle doomed))
                     ;; The reaper's horizon is a MACROTASK, and the row has to
                     ;; AWAIT it rather than let a bare timer carry the
@@ -702,7 +713,6 @@
                               (is (pos? (:cell-refs (rt/residue)))
                                   "and it is visible as held references, which is
                                    the quantity X5 asserts to be zero")
-                              (mount/release! (:handle survivor))
                               (resolve nil)
                               (catch :default e (reject e))))
                           reaper-horizon-ms)))))
@@ -711,4 +721,12 @@
                 ;; `.catch` downstream of it would claim a later namespace's
                 ;; throw as this row's and fire `done` a second time.
                 (.catch (fn [e] (is false (str "the X5 mutation proof threw: " e)) nil))
-                (.then (fn [_] (done))))))))))
+                ;; The survivor's release is hoisted onto the single trailing
+                ;; step: written once, run exactly once per path, and AFTER the
+                ;; residue reading it would otherwise erase. `release!` is
+                ;; idempotent and `some->` no-ops when the first adoption is the
+                ;; thing that rejected — so the row cannot hand a live adopted
+                ;; screen to the namespace after it.
+                (.then (fn [_]
+                         (some-> @survivor* :handle mount/release!)
+                         (done))))))))))

--- a/implementation/freehand/test/re_frame/freehand/client_only_dom_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/freehand/client_only_dom_cljs_test.cljs
@@ -124,11 +124,19 @@
         (let [{:keys [props] expected :text flips :flips} (:mount root-008)
               container (js/document.createElement "div")
               flip-evs  (atom [])
+              root*     (atom nil)
               k         (listen! (:flip-operation (:hydrate root-008)) flip-evs)]
           (.appendChild js/document.body container)
           (-> (act #(v/mount [views/two-sites props] container))
               (.then
                 (fn [mounted]
+                  ;; RETAINED, not merely destructured. The timer below settles
+                  ;; AFTER the mount resolved, so from here on there IS a live
+                  ;; root — and the rejection handler, which is the arm a throw
+                  ;; in those assertions now takes, cannot see this fulfilment
+                  ;; value. Holding it here is what lets the teardown run on
+                  ;; both paths (audit of #7942/#7968).
+                  (reset! root* mounted)
                   ;; `settle` is a bare timer, so what it carries has to be
                   ;; AWAITED or it runs off the end of the chain. Returned as a
                   ;; promise these assertions stay UPSTREAM of the rejection
@@ -148,10 +156,6 @@
                                 (str "a non-hydrating mount never flips. Saw: " (pr-str @flip-evs)))
                             (is (false? (root/hydrated? mounted))
                                 "and it is not a hydration")
-                            ;; Success-only: `mounted` is what the mount
-                            ;; resolved with, and the rejection arm never had a
-                            ;; root to unmount.
-                            (v/unmount! mounted)
                             (resolve nil)
                             (catch :default e (reject e)))))))))
               ;; Reports and RELEASES; it never finishes (rf2-o0n1). `done` runs
@@ -164,8 +168,17 @@
                         (trace-tooling/unregister-listener! k)
                         (is false (str "mount rejected: " e))
                         nil))
-              ;; Shared teardown, hoisted onto the single trailing step.
-              (.then (fn [_] (.remove container) (reset-all!) (done)))))))))
+              ;; Shared teardown, hoisted onto the single trailing step: written
+              ;; once, run exactly once per path. The unmount reads the RETAINED
+              ;; root rather than a fulfilment value, so the row cannot leave a
+              ;; live root standing into the next namespace when its own
+              ;; assertions throw; `some->` no-ops on the one path that never
+              ;; had a root, which is the mount rejecting.
+              (.then (fn [_]
+                       (some-> @root* v/unmount!)
+                       (.remove container)
+                       (reset-all!)
+                       (done)))))))))
 
 ;; ===========================================================================
 ;; A hydrating root adopts the fallbacks, then flips ONCE


### PR DESCRIPTION
Closes rf2-o0n1 — the correction its merged-PR audit of #7968 asked for, and only that.

## What this bead still had open, and what it did not

**Read bottom-up, rf2-o0n1's scope is no longer 54 chains.** The brief that
dispatched me described part 4 of the freehand split — "54 chains across the 24
files carrying 3 or fewer" — and the bead's own DESCRIPTION says the same. Both
are the oldest text on the bead. The two notes underneath them are newer and
they govern:

1. the mayor's **SCOPE RESTATED** note (100 chains / 38 files, after #7964), and
2. the **MERGED-PR AUDIT of #7968**, which is the last word on the bead.

**PR #7968 landed the whole positional repair on 2026-08-12** — 60 chains in 31
files, `worker/fh4-o0n1`, merged. What the audit left open is two sites, named
exactly, and this PR is those two.

## The census, re-derived rather than inherited

An independently rebuilt scanner: a small Clojure reader (strings, character
literals, regex literals, `;` comments, reader macros — not a line matcher),
chains recovered structurally from `->` / `some->` threading forms **and** from
nested `(.catch (.then p f) g)` shapes, with three selectable signatures —
literal `(done)`, helper-taking-`done` (rf2-29ua's class), and closure-over-`done`
(rf2-e8kc's class).

It reproduces **all four published campaign landmarks exactly**, which is what
says a disagreement would be about *when* a count was taken and not about *how*:

| commit | literal chains / files | landmark |
|---|---|---|
| `1662f3cc8e` (rf2-qpns) | **184 / 46** | the mayor note's "pre-repair 184 / 46" |
| `2f33b56649` (rf2-d2xz, #7955) | **100 / 38** | the mayor note's "100 on main / 38" |
| `e9aef48d19` (rf2-29ua, #7964) | **55 / 29** | #7964 left the blind census untouched |
| `195a7cb1d0` (#7968's base) | **55 / 29** | #7968's own re-derivation |
| `804adcd59a` (#7968's last commit) | **0 / 0** | **the commit that discharged this bead** |
| `origin/main` = `613dbc781c` | **0 / 0** | this PR's base |

**It was #7968 that discharged rf2-o0n1, not #7974.** The tree at `804adcd59a`
already scans to zero under all three signatures, and none of rf2-e8kc /
#7974's four commits (`e6601b21e1`, `d844756426`, `ae230c8cc0`, `4de7cf5c3c`)
touches `implementation/freehand` at all. The sibling finding that #7974
discharged rf2-sx7g and rf2-5zt9 stands; it simply does not reach freehand.

**RECONCILIATION with the brief's 54 and the note's 100.** Neither number is
wrong; both predate a landing. The bead description's 54 was part 4's share of
the split; #7968 measured 55 at its base and repaired all of them plus 5 of the
closure class — its `host-mounted` reads 4 rather than the census's 3 and
`buffered-controller` 5 rather than 3, against two fewer singles. The mayor
note's 100 was measured four commits early, before #7958 / #7959 / #7961 landed.

**All three signatures now read ZERO over `implementation/freehand`, and zero
repo-wide over `implementation/` and `tools/`.** There is no chain left in this
campaign's census to repair, before this PR or after it. What follows is not a
census item.

## The defect the audit found, which is not a census item

#7968 awaited two bare timers, so their assertions could no longer run off the
end of their chain. That was right, and it changed **which arm a throw in those
assertions takes**: it now reaches the row's outer rejection handler instead of
escaping as an unhandled page error. In both rows the mount had ALREADY resolved
by then, so there is a **live React root** when that handler runs — and neither
handler could see it.

- `freehand/client_only_dom_cljs_test.cljs`, `fh-root-008-a-plain-mount-…`: the
  `.catch` cannot see `mounted` (the mount's fulfilment value). It reported,
  the trailing step removed the container and reset the registries, and `done`
  fired with the root still mounted. The comment #7968 left — "the rejection arm
  never had a root to unmount" — was true of the *mount* rejecting and false of
  the *timer* rejecting that same PR introduced.
- `bench/hicasso/ssr/spike_dom_cljs_test.cljs`,
  `x5-the-residue-reading-can-answer-false`: same shape one level up. The
  `.catch` cannot see `survivor`, so `mount/release!` on it never ran.

A root left standing outlives the row and reaches the next namespace — which is
precisely the contamination this whole campaign exists to prevent, arriving by a
second door.

**This class is exactly two rows wide.** The two-arg-executor shape
`(js/Promise. (fn [resolve reject] …))` wrapping a timer inside a `.then`
handler occurs **twice in the entire `implementation/freehand/test` tree**, and
both occurrences are the audit's two sites.

## The repair

The handle is **RETAINED** where the row can reach it from either arm, and its
teardown is **hoisted onto the single trailing step** — written once, run
exactly once per path, `some->` no-op on the one path that never had a root at
all (the mount itself rejecting). The report-only handler and the single
trailing `done` keep the ordering #7968 landed; nothing about the positional
repair is reopened.

`x5-the-residue-reading-can-answer-false`'s nested chain went with it: it existed
only to thread `survivor` past the second adoption, which the atom now does.
**`doomed`'s `unmount!` stays exactly where it was** — that one is the *act under
test*, not cleanup, and the residue reading after it is a reading of what it left
behind. Hoisting it would have deleted the row.

## No assertion was added, removed, weakened or moved

`(is ` reads **14** in `client_only_dom_cljs_test.cljs` and **45** in
`spike_dom_cljs_test.cljs`, on `origin/main` and on this branch. Zero `deftest`
added or removed. That is the arithmetic behind the unmoved test counts below.

## Prove it — the audit's own proof, run both directions

The audit asked for exactly this: *"Add a deliberate throw inside each awaited
timer and prove the following row sees no standing root/residue."*

A plant script inserts, into **both** rows at once: a `(throw (js/Error. …))` as
the last statement of the awaited timer's `try`, and a **probe row immediately
after** the row under test, which reads whether a root was left standing.

- `client-only`'s probe reads the retained container's `childElementCount` —
  React empties a container when its root unmounts, so a non-zero reading is a
  live tree that outlived the row.
- `spike`'s probe counts `ul.list` under `document.body` — an adopted dogfood
  screen whose `release!` never ran leaves its container attached.

Every patch is anchored to a **single line**, every anchor is asserted to occur
**exactly once**, and the script **hashes the file before and after** and exits
non-zero if the bytes did not change — so a plant that silently no-ops cannot be
mistaken for a green proof.

The same plant, applied to the two trees, run through `npm run test:browser`:

| run | the two files' bytes | captured exit | tests / assertions | failures | probe verdict |
|---|---|---|---|---|---|
| **BEFORE** | `origin/main` (#7968's landed shape) | **1** | 1394 / 8640 | **4** | `AUDIT-PROBE standing-screen ul.list=1`<br>`AUDIT-PROBE standing-root childElementCount=1` |
| **AFTER** | this branch | **1** | 1394 / 8640 | **2** | **silent — both probes passed** |

Both runs printed the row's own diagnostic, which is what says the plant fired
in both and that the report-only handler still owns the message:

```
[browser:log] the X5 mutation proof threw: Error: rf2-o0n1 audit plant
[browser:log] mount rejected: Error: rf2-o0n1 audit plant
```

The BEFORE run then printed **the next row's reading of what was left behind** —
one adopted screen still attached to `document.body`, one React tree still live
in the retained container. On the AFTER run those two lines are **absent**: a
passing `is` prints nothing, and the failure count falls from 4 to 2 — exactly
the two planted throws, with neither probe among them.

**The counts are identical across the two runs, which is the `origin/main`
baseline comparison this diff needs**: same plant, same 1394 / 8640 on both
trees, so nothing about the repair moved a test or an assertion. The shipped
tree reads **1392 / 8635**, and 1394 − 1392 = the 2 probe rows while
8640 − 8635 = their 3 assertions plus the 2 `(is false …)` reports that only
execute when a rejection handler runs. Every number reconciles.

**Restore verified by hashing the bytes, not by reading `git diff`** — both
files return to the exact sha256 they carried before the first plant, and the
plant script would have exited non-zero had a patch failed to change them:

| file | this branch (shipped) | `origin/main` | BEFORE-plant | AFTER-plant | restored, twice |
|---|---|---|---|---|---|
| `client_only_dom_cljs_test.cljs` | `1ddac9144fe3bf2f` | `e9e479d72d6aa57b` | `61c1beac18c2f71b` | `6c867a58ea5875b3` | **`1ddac9144fe3bf2f`** |
| `spike_dom_cljs_test.cljs` | `8b70ecea7df6fdfd` | `8c59b54bae236655` | `d1d0435ac44e61fb` | `b7da4d5b582fa841` | **`8b70ecea7df6fdfd`** |

(The BEFORE tree was obtained with `git checkout origin/main -- …`, so its two
plant hashes derive from `origin/main`'s bytes rather than the branch's. The
restore was hashed twice — once between the two plant runs and once at the end —
and matched the shipped hash both times.)

`git status --untracked-files=all` is empty and `git grep` finds no plant text
anywhere in tracked source.

## Quality gates

Each run **alone**, nothing appended and nothing piped — output redirected and
the exit code captured on the same command line into its own `.exit` file, with
a filename unique to this worktree so no sibling's run can be misread as mine.
Every gate's `gate root:` line reads
`/c/Users/miket/code/re-frame2-worktrees/tail4-o0n1`. **Every number below is
the captured one.**

**The spine changed under this branch and the gates were re-run on the new one.**
PR #7994 (`e7b9924f4b`) rewired `scripts/test-fast-pr.sh` to a *pinned*
clj-kondo and widened its lint roots, so a spine run taken before that merge is
weaker than the one CI runs. This branch is rebased onto `e7b9924f4b`, and every
exit code below is from **after** the rebase.

| gate | captured exit | result |
|---|---|---|
| `npm run test:browser` — **shipped tree, post-rebase** | **0** | `Ran 1392 tests containing 8635 assertions. 0 failures, 0 errors.` |
| `sh scripts/test-fast-pr.sh` — **post-rebase, new spine** | **0** | includes `clj-kondo 2026.04.15` (the CI pin, resolved from the cache rather than `PATH`): **`errors: 0`**, warnings 4549 |
| `npm run test:cljs` — inside that spine | **0** | `Ran 13638 tests containing 69041 assertions. 0 failures, 0 errors.` |
| `python scripts/check_fast_pr_gap.py --list` — post-rebase | **0** | **95** required checks this spine does not decide (the pre-#7994 list said 97 — re-derived, not inherited) |
| `npm run test:freehand` — shipped tree | **0** | `Ran 1406 tests containing 7786 assertions. 0 failures, 0 errors.` |
| `npm run test:browser` — proof run **BEFORE** (`origin/main` bytes + plant) | **1** | 4 failures: 2 planted throws **+ both probes red** |
| `npm run test:browser` — proof run **AFTER** (this branch + same plant) | **1** | 2 failures: the 2 planted throws only — **both probes green** |

The browser gate read **1392 / 8635, exit 0** both before and after the rebase —
the same numbers, from two independent runs.

Exit **1** is the *expected* value for the two proof runs: the plant is a
deliberate throw, so a green there would have proved nothing.

**Lane coverage, checked rather than assumed.**

- `re-frame.freehand.client-only-dom-cljs-test` — decided by `:browser-test`
  (`^(?!re-frame\.freehand\.bench\.).*-dom-cljs-test$`); also compiled and run
  by `:node-test` (`test:cljs`) and `:node-test-freehand` (`test:freehand`),
  where every DOM claim degrades to a stated skip.
- `re-frame.bench.hicasso.ssr.spike-dom-cljs-test` — also decided by
  `:browser-test`: that negative lookahead excludes only
  `re-frame.freehand.bench.`, and this namespace is `re-frame.bench.hicasso.`.
  It is **not** in `:node-test-freehand` (whose regexp is
  `^re-frame\.freehand\.`), so `test:freehand` does not reach it and
  `test:cljs` is the node lane that does. Both were run.

`clj-kondo` and `splint` reach `implementation/`, but CI pins clj-kondo
2026.04.15 and a differently-versioned local binary proves nothing, so those are
left to CI. Every other required job is surface-gated off a diff that changes
**two CLJS test files and nothing else**.
