### PR TITLE
test(pair-mcp): a live wire witness for the Hicasso provider (rf2-hic-059)

### DIFF
--- a/tools/re-frame2-pair-mcp/package.json
+++ b/tools/re-frame2-pair-mcp/package.json
@@ -22,7 +22,8 @@
     "test:stdin-eof-shutdown": "node test/stdin-eof-shutdown.cjs",
     "test:post-merge-hook": "node test/post-merge-hook-test.cjs",
     "test:roots-discovery-live": "node test/roots-discovery-live.js",
-    "test:live-e2e-fixture": "node test/live-e2e-fixture.cjs"
+    "test:live-e2e-fixture": "node test/live-e2e-fixture.cjs",
+    "test:live-hicasso-wire": "node test/live-hicasso-wire.cjs"
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.29.0",

--- a/tools/re-frame2-pair-mcp/test/README.md
+++ b/tools/re-frame2-pair-mcp/test/README.md
@@ -14,6 +14,7 @@ integration scripts.
 | Does the compiled `out/server.js` complete an MCP handshake and surface the documented tool descriptors? | **JS** — `stdio-roundtrip.js` |
 | Does the persistent nREPL socket survive multiple ops on one server process without leaking / hanging? | **JS** — `live-nrepl.js` |
 | Do connect / dispatch / trace / hot-reload work end-to-end against a live browser-hosted fixture, through the real MCP boundary? | **JS** — `live-e2e-fixture.cjs` |
+| Do the three Hicasso evidence-door tools return a schema-matched, non-empty, value-free projection when actually run against a live Hicasso application? | **JS** — `live-hicasso-wire.cjs` |
 | Does closing stdin (EOF) retire the session — close the persistent nREPL socket and exit 0 — with no out-of-band kill? | **JS** — `stdin-eof-shutdown.cjs` |
 
 If a regression would only be visible **after** the CLJS compiles to
@@ -144,6 +145,40 @@ Run with: `npm run test:live-e2e-fixture` (after `npm run build` and booting
 the fixture; `RE_FRAME2_PAIR_FIXTURE_URL` / `SHADOW_CLJS_NREPL_PORT`
 override discovery).
 
+#### `live-hicasso-wire.cjs` — the Hicasso evidence door, actually run (rf2-hic-059)
+
+The one witness in this tree that executes a Pair tool against a real
+Hicasso provider. `hicasso_tool_test.cljs` stubs the eval with canned
+envelopes and `hicasso_wire_test.cljs` compares emitted strings with the
+provider's source; both are static seam checks, and neither had ever sent
+the emitted form, compiled it, evaluated it in a runtime, or carried a
+result back through the schema gate.
+
+This one does. It boots the `rf2-hic-025` slice application through its
+own `-main` over `eval-cljs`, then calls `read-mounted-boundaries`,
+`read-read-attribution` and `explain-render` as MCP tools, asserting per
+read that the envelope is `:ok? true` stamped with the schema this build
+consumes, that it names the slice's own frame and its `::subs/draft`
+read, and — the point of the file — that it does **not** carry the
+secret seeded into that draft. Non-vacuity comes first: `read-sub`, the
+same server on the same socket, returns the secret, so the absence rows
+are about the door rather than about an empty runtime.
+
+Requires a browser build carrying the `re-frame2-pair.runtime` preload
+whose classpath can reach `re-frame.hicasso.tool` and the slice — the
+implementation tree is one:
+
+```
+cd implementation
+npx shadow-cljs watch hicasso/hmr-testbed \
+  --config-merge '{:devtools {:preloads [re-frame2-pair.runtime]}}'
+```
+
+SOFT-SKIPS (exit 0, `SKIP` banner) when the server bundle, the page, the
+nREPL port file or Playwright is absent. Run with:
+`npm run test:live-hicasso-wire` (`RF2_HICASSO_WIRE_URL` /
+`SHADOW_CLJS_NREPL_PORT` override discovery).
+
 #### `stdin-eof-shutdown.cjs` — EOF lifecycle contract (rf2-j538f7.32)
 
 The self-contained lifecycle grader. Spawns `out/server.js` and drives it
@@ -209,7 +244,8 @@ Is the regression visible in CLJS source?
             ├── concerns the stdio handshake / tool catalogue?   → stdio-roundtrip.js
             ├── concerns the stdin-EOF shutdown lifecycle?        → stdin-eof-shutdown.cjs
             ├── concerns the live nREPL socket?                   → live-nrepl.js
-            └── concerns an end-to-end flow against a live app?   → live-e2e-fixture.cjs
+            ├── concerns an end-to-end flow against a live app?   → live-e2e-fixture.cjs
+            └── concerns the Hicasso door against a live app?     → live-hicasso-wire.cjs
 ```
 
 ## Why this layout is unusual

--- a/tools/re-frame2-pair-mcp/test/live-hicasso-wire.cjs
+++ b/tools/re-frame2-pair-mcp/test/live-hicasso-wire.cjs
@@ -1,0 +1,495 @@
+// live-hicasso-wire.cjs — THE LIVE WIRE WITNESS for the three Hicasso
+// evidence-door tools (rf2-hic-059, #7986 merged-PR audit).
+//
+// ## The gap this closes
+//
+// Two suites in this tree already look at these tools and neither one runs
+// them:
+//
+//   - `hicasso_tool_test.cljs` stubs `nrepl/cljs-eval-value` with canned
+//     envelopes, so it checks the emitter and the schema gate against
+//     itself;
+//   - `hicasso_wire_test.cljs` parses the emitted STRING and reads the
+//     provider's own source, so it checks that the two sides agree on
+//     names and on the schema literal.
+//
+// Both are valuable static seam checks and neither executes a Pair tool
+// against a Hicasso provider. The claim that the privacy-projected
+// evidence surface works THROUGH the MCP plumbing was therefore
+// unwitnessed: the emitted form had never been compiled, sent, evaluated
+// in a runtime, or had its result carried back through the gate.
+//
+// ## What one call actually traverses here
+//
+// Every assertion below rides the shipped path, end to end:
+//
+//   MCP `tools/call` frame on stdio
+//     -> `out/server.js` (the SHIPPED bundle, `:simple` optimised)
+//     -> `tools/invoke` (build resolution, precheck, cache, cap)
+//     -> `hicasso-tool/<read>-tool`
+//     -> `probe/eval-after-runtime!` (the `__re_frame2_pair_runtime`
+//        preload probe + the JVM-side liveness re-check)
+//     -> `nrepl/cljs-eval-value` — bencode frames on a REAL socket
+//     -> shadow-cljs COMPILES the `cljs.core/exists?`-guarded form that
+//        `hicasso-tool/projection-form` built, and evaluates it inside the
+//        browser CLJS runtime
+//     -> `re-frame.hicasso.tool/<read>` runs against the live application
+//     -> the projection returns over the same socket
+//     -> `versioned-envelope-result` GATES it against
+//        `consumed-evidence-schema`
+//     -> `probe/map-envelope-result` -> elision -> the token cap
+//     -> the MCP result frame this script reads.
+//
+// Nothing on that list is stubbed, faked or re-implemented here.
+//
+// ## The application is the slice, booted by its own entry point
+//
+// The population is the `rf2-hic-025` slice application, started with its
+// own `-main` — `rf/init!`, `make-frame!`, `h/root!` — over `eval-cljs`.
+// This script registers no subscription, no event and no view, so every
+// id that appears in an answer below was written by another bead for
+// another purpose. The one thing it supplies the host page is a `<div
+// id="app">` for the slice's root to mount into, because the page hosting
+// the runtime is not the slice's own page.
+//
+// ## The negative control, and why it is not vacuous
+//
+// The door promises to carry NO read value at any classification. So the
+// control seeds a value that exists nowhere else in the process into the
+// slice's draft — through the slice's OWN `::events/edit` event — and then
+// proves TWO things at the wire, in this order:
+//
+//   1. NON-VACUITY. `read-sub` (a different shipped Pair tool, same
+//      socket, same server) returns the secret. The runtime really holds
+//      it and the wire really can carry it.
+//   2. ABSENCE. None of the three Hicasso envelopes contains it, while all
+//      three name `::subs/draft` — the very read whose value it is.
+//
+// Without step 1 the absence assertion would pass just as happily against
+// a runtime that never saw the value.
+//
+// ## A finding this witness produced, recorded rather than fixed
+//
+// The tools' documented degradation for an app that has no evidence door
+// (`:reason :evidence-tier-unavailable`) is NOT what a live absent door
+// answers. `cljs.core/exists?` guards a missing VAR; it does not stop
+// shadow's analyzer rejecting a var in a namespace the build has never
+// loaded, so the call comes back
+// `:reason :rf.error/eval-cljs-compile-error` instead. That is exactly the
+// class of divergence a static seam check cannot see. It is recorded on
+// rf2-hic-059 and left alone here: this bead's repair is a witness, not a
+// provider change.
+//
+// ## Running it
+//
+// Opt-in, like its `live-nrepl.js` / `live-e2e-fixture.cjs` siblings, and
+// it SOFT-SKIPS (exit 0 with a `SKIP` banner) when the infrastructure is
+// absent, so it is safe to invoke anywhere.
+//
+//   # 1. a browser build carrying the pair preload, on the implementation
+//   #    classpath (which is where the slice and the door both live):
+//   cd implementation
+//   npx shadow-cljs watch hicasso/hmr-testbed \
+//     --config-merge '{:devtools {:preloads [re-frame2-pair.runtime]}}'
+//
+//   # 2. build the server and run the witness
+//   cd tools/re-frame2-pair-mcp && npm run build
+//   npm run test:live-hicasso-wire
+//
+// `RF2_HICASSO_WIRE_URL` overrides the page (default http://localhost:8061)
+// and `SHADOW_CLJS_NREPL_PORT` the port. Any page will do provided it
+// carries the `re-frame2-pair.runtime` preload and its build can reach
+// `re-frame.hicasso.tool` and the slice on its classpath.
+//
+// Exit code 0 = pass OR soft-skip; non-zero = a live assertion failed.
+
+'use strict';
+
+const fs = require('node:fs');
+const path = require('node:path');
+const http = require('node:http');
+const { spawn } = require('node:child_process');
+
+const HERE = __dirname;
+const PAIR_MCP_DIR = path.resolve(HERE, '..');
+const REPO_ROOT = path.resolve(PAIR_MCP_DIR, '..', '..');
+const IMPL_DIR = path.join(REPO_ROOT, 'implementation');
+const SERVER = path.join(PAIR_MCP_DIR, 'out', 'server.js');
+
+const APP_URL = process.env.RF2_HICASSO_WIRE_URL || 'http://localhost:8061';
+
+// Kept aligned with pair-mcp's own `port-file-candidates` and the two
+// sibling live harnesses. The host build is served out of `implementation`,
+// so that is where shadow writes the port file.
+const NREPL_PORT_FILE_CANDIDATES = [
+  path.join(IMPL_DIR, '.shadow-cljs', 'nrepl.port'),
+  path.join(IMPL_DIR, 'target', 'shadow-cljs', 'nrepl.port'),
+  path.join(IMPL_DIR, '.nrepl-port'),
+];
+
+// Same name and value as the sibling harnesses' preload budget.
+const RUNTIME_PRELOAD_TIMEOUT_MS = 60000;
+
+// The slice's own namespaces. Spelled once, here, because every form below
+// calls them fully qualified — an alias would be this script's vocabulary
+// rather than the application's.
+const SLICE = 're-frame.hicasso.examples.slice';
+const FRAME = `:${SLICE}.app/frame`;
+
+// A value that exists nowhere else in this process, so finding it in a
+// projection is proof of egress rather than a coincidence of spelling.
+const THE_SECRET = 'RF2-HIC-059-WIRE-SECRET-4d2a1f';
+
+// The consumer-owned schema literal `versioned-envelope-result` gates on.
+// Asserted as a STRING because this is the wire, which is where the two
+// sides have to agree.
+const EXPECTED_SCHEMA = ':re-frame.hicasso.evidence/v2';
+
+const DOOR_READS = ['read-mounted-boundaries', 'read-read-attribution', 'explain-render'];
+
+function skip(reason) {
+  // The same leading-line banner the mcp-conformance hermetic orchestrator
+  // greps for, so a soft-skip is never mistaken for a passing run.
+  console.log(`SKIP live-hicasso-wire — ${reason}`);
+  process.exit(0);
+}
+
+function assert(cond, msg) {
+  if (!cond) throw new Error(msg);
+}
+
+function readNreplPort() {
+  if (process.env.SHADOW_CLJS_NREPL_PORT) {
+    const n = parseInt(process.env.SHADOW_CLJS_NREPL_PORT, 10);
+    if (Number.isFinite(n)) return n;
+  }
+  for (const p of NREPL_PORT_FILE_CANDIDATES) {
+    try {
+      const n = parseInt(fs.readFileSync(p, 'utf8').trim(), 10);
+      if (Number.isFinite(n)) return n;
+    } catch {
+      // try the next candidate
+    }
+  }
+  return null;
+}
+
+function pingApp(url, timeoutMs = 1500) {
+  return new Promise((resolve) => {
+    const req = http.get(url, (res) => {
+      res.resume();
+      resolve(res.statusCode >= 200 && res.statusCode < 500);
+    });
+    req.on('error', () => resolve(false));
+    req.setTimeout(timeoutMs, () => {
+      req.destroy();
+      resolve(false);
+    });
+  });
+}
+
+// Playwright is lazy-required and its absence is a soft-skip: the browser
+// is infrastructure that hosts the CLJS runtime, not the unit under test.
+function resolvePlaywright() {
+  for (const root of [PAIR_MCP_DIR, IMPL_DIR]) {
+    try {
+      return require(require.resolve('playwright', { paths: [root] }));
+    } catch {
+      // try the next root
+    }
+  }
+  return null;
+}
+
+// --------------------------------------------------------------------------
+// Stdio MCP client — spawn the SHIPPED server bundle and drive it with
+// line-delimited JSON-RPC frames. Modelled on `live-e2e-fixture.cjs`.
+// --------------------------------------------------------------------------
+function spawnMcpClient(nreplPort) {
+  const env = { ...process.env, SHADOW_CLJS_NREPL_PORT: String(nreplPort) };
+  // cwd = implementation so the server's port-file discovery has a fallback
+  // even if the env var were ever cleared.
+  const child = spawn(process.execPath, [SERVER], {
+    stdio: ['pipe', 'pipe', 'pipe'],
+    cwd: IMPL_DIR,
+    env,
+  });
+
+  let stderrBuf = '';
+  child.stderr.on('data', (d) => {
+    stderrBuf += d.toString();
+  });
+
+  const waitForStderr = (pattern, { timeoutMs = 20000, intervalMs = 25 } = {}) =>
+    new Promise((res, rej) => {
+      const deadline = Date.now() + timeoutMs;
+      const tick = () => {
+        if (pattern.test(stderrBuf)) return res();
+        if (child.exitCode !== null) {
+          return rej(new Error(`server exited (code=${child.exitCode}) before matching ${pattern}`));
+        }
+        if (Date.now() >= deadline) {
+          return rej(new Error(`timed out waiting for ${pattern} on stderr; saw:\n${stderrBuf}`));
+        }
+        setTimeout(tick, intervalMs);
+      };
+      tick();
+    });
+
+  let next = 1;
+  const pending = new Map();
+  let buf = '';
+  child.stdout.on('data', (chunk) => {
+    buf += chunk.toString('utf8');
+    let idx;
+    while ((idx = buf.indexOf('\n')) >= 0) {
+      const line = buf.slice(0, idx).trim();
+      buf = buf.slice(idx + 1);
+      if (!line) continue;
+      try {
+        const frame = JSON.parse(line);
+        if (frame.id && pending.has(frame.id)) {
+          pending.get(frame.id)(frame);
+          pending.delete(frame.id);
+        }
+      } catch {
+        // Non-JSON stdout noise is ignored; a malformed response for a
+        // pending id surfaces as a call timeout instead.
+      }
+    }
+  });
+
+  const rawCall = (method, params) => {
+    const id = next++;
+    return new Promise((resolve, reject) => {
+      const timer = setTimeout(() => {
+        pending.delete(id);
+        reject(new Error(`MCP call ${method} (id ${id}) timed out`));
+      }, 60000);
+      pending.set(id, (frame) => {
+        clearTimeout(timer);
+        resolve(frame);
+      });
+      child.stdin.write(JSON.stringify({ jsonrpc: '2.0', id, method, params }) + '\n');
+    });
+  };
+  const notify = (method, params) =>
+    child.stdin.write(JSON.stringify({ jsonrpc: '2.0', method, params }) + '\n');
+
+  return { child, waitForStderr, rawCall, notify, stderr: () => stderrBuf };
+}
+
+async function callTool(client, name, args) {
+  const resp = await client.rawCall('tools/call', { name, arguments: args });
+  const text = resp.result?.content?.[0]?.text || '';
+  return { isError: !!resp.result?.isError, text };
+}
+
+// `eval-cljs` is how the population is arranged: a shipped Pair tool,
+// evaluating the application's OWN entry point and OWN events in the
+// runtime. Anything it refuses is a setup failure and says so.
+async function evalCljs(client, form, what) {
+  const r = await callTool(client, 'eval-cljs', { form });
+  assert(!r.isError, `${what} — eval-cljs returned isError: ${r.text}`);
+  assert(/^\{:ok\? true\b/.test(r.text.trim()), `${what} — eval-cljs was not :ok? true: ${r.text}`);
+  return r.text;
+}
+
+// The envelope's own header, asserted structurally on the wire text: the
+// `:ok? true` the schema gate forwards, and the schema literal it forwards
+// it AGAINST. A gate that let an unrecognised producer stamp through would
+// fail here rather than downstream.
+const OK_AND_SCHEMA = new RegExp(
+  `^\\{:ok\\? true, :schema ${EXPECTED_SCHEMA.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')},`,
+);
+
+async function main() {
+  // ---- Preconditions / soft-skips --------------------------------------
+  if (!fs.existsSync(SERVER)) {
+    skip(`server bundle missing at ${SERVER} — run \`npm run build\` first`);
+  }
+  const appUp = await pingApp(APP_URL);
+  if (!appUp) {
+    skip(
+      `no runtime host reachable at ${APP_URL} — boot one with ` +
+        "`cd implementation && npx shadow-cljs watch hicasso/hmr-testbed " +
+        "--config-merge '{:devtools {:preloads [re-frame2-pair.runtime]}}'` " +
+        '(set RF2_HICASSO_WIRE_URL to override)',
+    );
+  }
+  const nreplPort = readNreplPort();
+  if (!nreplPort) {
+    skip('nREPL port file not found under implementation/ (set SHADOW_CLJS_NREPL_PORT to override)');
+  }
+  const playwright = resolvePlaywright();
+  if (!playwright) {
+    skip('playwright not resolvable — `npm install` in tools/re-frame2-pair-mcp or implementation/');
+  }
+
+  console.log(`[live-hicasso-wire] host ${APP_URL}, nREPL :${nreplPort}`);
+
+  const browser = await playwright.chromium.launch({ headless: true });
+  let client = null;
+  try {
+    const context = await browser.newContext();
+    const page = await context.newPage();
+    page.on('pageerror', (err) => process.stderr.write(`[browser:pageerror] ${err.message}\n`));
+    await page.goto(APP_URL, { waitUntil: 'commit', timeout: RUNTIME_PRELOAD_TIMEOUT_MS });
+    await page.waitForFunction(
+      () => typeof window.__re_frame2_pair_runtime !== 'undefined',
+      undefined,
+      { timeout: RUNTIME_PRELOAD_TIMEOUT_MS },
+    );
+    console.log('OK   runtime preload present');
+
+    // ---- The MCP server, over real stdio --------------------------------
+    client = spawnMcpClient(nreplPort);
+    await client.waitForStderr(/\bready\b/);
+    const init = await client.rawCall('initialize', {
+      protocolVersion: '2025-06-18',
+      capabilities: {},
+      clientInfo: { name: 'live-hicasso-wire', version: '0' },
+    });
+    assert(init.result?.protocolVersion, 'initialize failed: ' + JSON.stringify(init));
+    client.notify('notifications/initialized', {});
+    console.log('OK   initialize ->', JSON.stringify(init.result.serverInfo));
+
+    // The host build is whatever `shadow-cljs watch` is running, and the
+    // server names it. Read it once and pass it to every call rather than
+    // spelling a build id here: `read-sub` defaults to `:app` and would
+    // otherwise refuse with `:build-not-running` against any other host.
+    const disc = await callTool(client, 'discover-app', {});
+    assert(!disc.isError, 'discover-app returned isError: ' + disc.text);
+    const buildMatch = /:auto-selected-build (:[^\s,}]+)/.exec(disc.text);
+    assert(buildMatch, 'discover-app did not name a build: ' + disc.text.slice(0, 400));
+    const build = buildMatch[1];
+    console.log(`OK   discover-app -> build ${build}`);
+
+    // ---- Boot the slice through its own entry point ----------------------
+    await evalCljs(client, `(require '${SLICE}.app)`, 'require the slice');
+    // The slice mounts into `#app`, and the page hosting the runtime is
+    // somebody else's, so the container is supplied rather than assumed —
+    // the only thing this script contributes to the application. It is
+    // created in the SAME form as the mount: shadow pushes modules to the
+    // page as the requires above are compiled, and a container planted from
+    // the Playwright side minutes earlier is not guaranteed to still be
+    // there when `-main` looks for it.
+    await evalCljs(
+      client,
+      '(do (when-not (js/document.getElementById "app")' +
+        ' (let [d (js/document.createElement "div")]' +
+        ' (set! (.-id d) "app") (.appendChild js/document.body d)))' +
+        ` (${SLICE}.app/-main) :booted)`,
+      'boot the slice',
+    );
+    // Nothing in `re-frame.hicasso` requires the door — that is how a
+    // production build never loads it — so a Hicasso app has it only once
+    // something pulls it in. Xray does; here this line does.
+    await evalCljs(client, "(require 're-frame.hicasso.tool)", 'load the evidence door');
+    console.log('OK   slice booted by its own -main; evidence door loaded');
+
+    // ---- Seed the secret through the slice's OWN events ------------------
+    await evalCljs(
+      client,
+      `(re-frame.core/with-frame ${FRAME}` +
+        ` (re-frame.core/dispatch-sync [:rf.route/navigate {:to :${SLICE}.routes/article :params {:slug "hicasso"}}])` +
+        ` (re-frame.core/dispatch-sync [:${SLICE}.events/edit "hicasso" :title "${THE_SECRET}"])` +
+        ' :seeded)',
+      'seed the secret',
+    );
+    // React commits the article route's boundaries on a later tick, and the
+    // rosters below are about what is MOUNTED. The readiness signal is the
+    // roster itself rather than a DOM selector: this witness is about the
+    // projection, and coupling its setup to the editor's markup would make
+    // an unrelated view change read as an evidence failure.
+    const mountDeadline = Date.now() + 30000;
+    let ready = '';
+    while (Date.now() < mountDeadline) {
+      const r = await callTool(client, 'read-mounted-boundaries', { build, 'max-tokens': 0 });
+      ready = r.text;
+      if (!r.isError && ready.includes(`:${SLICE}.subs/draft`)) break;
+      await new Promise((res) => setTimeout(res, 500));
+    }
+    assert(
+      ready.includes(`:${SLICE}.subs/draft`),
+      'the article route never appeared in the mounted roster, so the secret ' +
+        'is not being read by any boundary: ' + ready.slice(0, 600),
+    );
+    console.log('OK   article route mounted, secret seeded into the draft');
+
+    // ---- NON-VACUITY: the wire really can carry this value ---------------
+    const sub = await callTool(client, 'read-sub', {
+      sub: `[:${SLICE}.subs/draft "hicasso"]`,
+      frame: FRAME,
+      build,
+      'max-tokens': 0,
+    });
+    assert(!sub.isError, 'read-sub returned isError: ' + sub.text);
+    assert(
+      sub.text.includes(THE_SECRET),
+      'NON-VACUITY FAILED: read-sub did not carry the seeded secret, so the ' +
+        'absence assertions below would be passing against a runtime that ' +
+        'never held it: ' + sub.text,
+    );
+    console.log('OK   read-sub carries the secret — the absence rows below are about the DOOR');
+
+    // ---- The three door reads, live -------------------------------------
+    for (const read of DOOR_READS) {
+      // `max-tokens: 0` disables the cap: a capped response is an overflow
+      // marker, not the projection, and there is nothing to assert on one.
+      const r = await callTool(client, read, { build, 'max-tokens': 0 });
+      assert(!r.isError, `${read} returned isError: ${r.text}`);
+      assert(
+        OK_AND_SCHEMA.test(r.text.trim()),
+        `${read} did not answer :ok? true with the schema this build consumes ` +
+          `(${EXPECTED_SCHEMA}) — head was: ${r.text.slice(0, 200)}`,
+      );
+      // Non-empty, and about the SLICE: every id here was registered by
+      // rf2-hic-025 for another purpose.
+      //
+      // The frame id is asserted UNQUALIFIED by its key because the three
+      // reads do not spell it the same way — the two rosters carry
+      // `:frame`, attribution's edges carry `:frame-id`, and a boundary KEY
+      // carries it positionally. That is a wire-shape qualifier a consumer
+      // meets, and it was found by writing the assertion the other way and
+      // watching `read-read-attribution` fail it.
+      assert(
+        r.text.includes(`${SLICE}.app/frame`),
+        `${read} answered without a single ${SLICE} boundary — the projection ` +
+          `is not reading the booted application: ${r.text.slice(0, 400)}`,
+      );
+      assert(
+        r.text.includes(`:${SLICE}.subs/draft`),
+        `${read} did not name ::subs/draft, the read whose value the secret is`,
+      );
+      // THE NEGATIVE CONTROL. The door promises no read value at any
+      // classification; `read-sub` above proved the value is there to leak.
+      assert(
+        !r.text.includes(THE_SECRET),
+        `EGRESS: the ${read} envelope carried the seeded secret at the wire`,
+      );
+      console.log(
+        `OK   ${read} -> :ok? true, ${EXPECTED_SCHEMA}, slice boundaries present, secret absent`,
+      );
+    }
+
+    console.log('\nRE-FRAME2-PAIR-MCP LIVE HICASSO WIRE WITNESS GREEN');
+  } finally {
+    if (client && client.child) {
+      try {
+        client.child.kill();
+      } catch {
+        // best effort
+      }
+    }
+    await browser.close().catch(() => {});
+  }
+}
+
+main()
+  .then(() => process.exit(0))
+  .catch((err) => {
+    console.error('FAIL:', err && err.message ? err.message : err);
+    if (err && err.stack) console.error(err.stack);
+    process.exit(1);
+  });


### PR DESCRIPTION
Closes the ONE gap the merged-PR audit of #7986 reopened `rf2-hic-059` for. The spike's direct-door suite, its verdict, and its criteria are untouched: **Q1 and Q2 were not revisited, and no verdict criterion was read as anything other than settled.** This PR adds a witness and nothing else.

## The gap, restated from the audit

The suite that landed in #7986 imports `re-frame.hicasso.tool` and calls the three reads **directly**. The two Pair suites that look at these tools do not close that: `hicasso_tool_test.cljs` stubs `nrepl/cljs-eval-value` with canned envelopes, and `hicasso_wire_test.cljs` parses the emitted string and reads the provider's source. Both are valuable **static seam checks** and neither had ever run a Pair tool against a Hicasso provider. So the claim that the privacy-projected surface works *through the MCP plumbing* was unproved — nothing had compiled the emitted form, sent it, evaluated it in a runtime, or carried a result back through the schema gate.

## What the witness actually traverses

`tools/re-frame2-pair-mcp/test/live-hicasso-wire.cjs`, one call:

```
MCP tools/call frame on stdio
  -> out/server.js                      the SHIPPED bundle (:simple optimised)
  -> tools/invoke                       build resolution, precheck, cache, cap
  -> hicasso-tool/<read>-tool
  -> probe/eval-after-runtime!          __re_frame2_pair_runtime preload probe
                                        + the JVM-side liveness re-check
  -> nrepl/cljs-eval-value              bencode frames on a REAL socket
  -> shadow-cljs COMPILES the exists?-guarded form projection-form built
     and evaluates it inside the browser CLJS runtime
  -> re-frame.hicasso.tool/<read>       against the live application
  -> the projection returns over the same socket
  -> versioned-envelope-result          the consumer-owned SCHEMA GATE
  -> probe/map-envelope-result -> elision -> the token cap
  -> the MCP result frame the script reads
```

Nothing on that list is stubbed, faked or re-implemented. The emitted-eval leg is `probe/eval-after-runtime!` → `nrepl/cljs-eval-value`; the result leg is `versioned-envelope-result` → `probe/map-envelope-result`.

**The application is the `rf2-hic-025` slice, booted by its own `-main`** (`rf/init!`, `make-frame!`, `h/root!`) over `eval-cljs`. The witness registers no subscription, no event and no view: every id in an answer below was written by another bead for another purpose.

## (a) A schema-matched, non-empty projected envelope

Per read, asserted on the wire text:

| Read | `:ok? true` + `:schema` | Non-empty and about the SLICE | Live result |
|---|---|---|---|
| `read-mounted-boundaries` | `:re-frame.hicasso.evidence/v2` | slice frame + `::subs/draft` present | PASS |
| `read-read-attribution` | `:re-frame.hicasso.evidence/v2` | slice frame + `::subs/draft` present | PASS |
| `explain-render` | `:re-frame.hicasso.evidence/v2` | slice frame + `::subs/draft` present | PASS |

The schema assertion is the gate doing its job at the wire: `versioned-envelope-result` converts any envelope stamped a schema this build was not written against into a typed `isError` mismatch, so a `:ok? true` **carrying that literal** is the only shape that reaches the caller.

All three reads are called with `max-tokens: 0`. Uncapped they are 11 KB / 32 KB / 16 KB of text; at the default 5000-token cap all three come back as an overflow marker rather than a projection — recorded because it is the first thing a consumer of these tools meets.

## (b) The seeded sensitive-value negative control, at the wire

The door promises to carry **no read value at any classification**. So the control seeds `RF2-HIC-059-WIRE-SECRET-4d2a1f` into the slice's draft **through the slice's own `::events/edit` event**, and proves two things in order:

1. **NON-VACUITY.** `read-sub` — a different shipped Pair tool, same server, same socket — returns it:
   `{:ok? true, :query-v [::subs/draft "hicasso"], :value {:title "RF2-HIC-059-WIRE-SECRET-4d2a1f", …}, :elision true}`. The runtime holds it and the wire can carry it.
2. **ABSENCE.** None of the three envelopes contains it, while all three name `::subs/draft` — the very read whose value it is.

Without step 1 the absence rows would pass just as happily against a runtime that never saw the value.

### Sabotage — the control was shown able to go red, and the first attempt was a FALSE GREEN

Single-line plant in `implementation/hicasso/src/re_frame/hicasso/tool.cljs`, in `read-row` (the `:reads` builder on the `read-mounted-boundaries` path):

```clojure
:frame-id frame-id :value (some-> ^js (get @collector/!cells sub-key) (.-reaction) deref)
```

| Step | sha256 of `tool.cljs` | Witness |
|---|---|---|
| before the plant | `2c6ecbed81cbf7025557188915e68c726eed7f85a8247884673cf82ba8da5148` | EXIT 0, GREEN |
| planted | `915aaf917eb072565bc64002ddcdf0e9e2ce81e862400d319835ead53f8ee424` | **EXIT 1** — `FAIL: EGRESS: the read-mounted-boundaries envelope carried the seeded secret at the wire` |
| restored | `2c6ecbed81cbf7025557188915e68c726eed7f85a8247884673cf82ba8da5148` (equal to before) | EXIT 0, GREEN |

**The first sabotage run came back GREEN and it was not a proof of anything.** `re-frame.hicasso.tool` is not in the host build's module graph — it is REPL-required into the runtime — so `shadow-cljs watch` never noticed the edited file and served the pre-plant compile. The plant had applied (the hashes differ) and the diff would have looked identical either way. Restarting the watch made the red appear. This is exactly the failure mode the byte-hash discipline exists to catch, and it is recorded rather than quietly re-run: anyone re-doing this sabotage against an out-of-graph namespace must restart the watch, not trust the watcher.

The committed diff touches nothing under `implementation/`.

## What this witness does NOT prove

- Nothing about `:advanced` / production erasure. It is a development-build read by construction (the door is dev-only) and the erasure proof stays where it is, in `build:hicasso-release`.
- Nothing about a schema MISMATCH on the wire. The gate's negative arm still has only its stubbed unit row (`hicasso_tool_test`) — falsifying it live needs a provider stamped a different schema, which means changing the provider.
- Nothing about capped responses. It disables the cap deliberately.
- It is **opt-in and soft-skipping**, like `live-nrepl.js` and `live-e2e-fixture.cjs` — infrastructure absent is a `SKIP` banner, never a false red, and CI therefore does not run it. That is the sibling precedent for this artefact's live layer, not a weakening of it.

## A finding, recorded and NOT fixed: `rf2-t2ec`

Running the tools against an app that has **not** loaded the door produced the divergence a static seam check cannot see. The documented first rung of the degradation ladder is `{:ok? false :reason :evidence-tier-unavailable}` with a load-the-door hint. Live, it never runs:

```
{:ok? false,
 :message "cljs eval compile error/warning: … Use of undeclared Var
           re-frame.hicasso.tool/read-mounted-boundaries",
 :reason :rf.error/eval-cljs-compile-error, …}
```

`cljs.core/exists?` guards a missing **var**; it does not stop shadow's analyzer rejecting a var in a namespace the build has never loaded. So the one case the honest-degradation branch names is the one case it cannot reach. Filed as **rf2-t2ec** and deliberately left alone: this bead's bounded repair is a witness, and editing the emitter to make the witness's story tidier is the shape the #7986 audit forbade.

A second, smaller qualifier is recorded in the file: the three reads do not spell the frame the same way — the rosters carry `:frame`, attribution's edges carry `:frame-id`, and a boundary KEY carries it positionally. Found by writing the assertion the other way and watching `read-read-attribution` fail it.

## The pairing session, honestly

The original acceptance's session evidence was superseded by the operator ruling of 2026-08-12 (`rf2-xpq9`) that a decision-shaped item completes when the spike runs and its verdict is made, and #7986 recorded the verdict under that ruling. What can be recorded here is smaller and true: an agent used the three tools **through MCP** against this application, and they answered — one useful finding came out of it (`rf2-t2ec`, above) that reading the source had not produced. No controlled comparison against log-reading was run, so no claim is made that the surface is faster than reading logs.

## Fences

No new public export. No `implementation/` → `tools/` require edge (the witness runs from the tools side and reaches the provider over the wire). No npm dependency — Playwright is resolved from the existing trees and its absence is a soft-skip. No new retention, no parallel history, no hot-zone file, no change under `implementation/` or `spec/`. Q1/Q2 and the verdict criteria untouched.

## Quality gates

Each run alone, redirected with its exit code captured on the same command line.

| Gate | Exit | Note |
|---|---|---|
| `npm run test:live-hicasso-wire` (the new witness, live) | `0` | `RE-FRAME2-PAIR-MCP LIVE HICASSO WIRE WITNESS GREEN` |
| `npm run test:live-hicasso-wire` (sabotaged provider) | `1` | the negative control fires — see above |
| `npm test` (pair-mcp CLJS suite) | `0` | |
| `tools/mcp-conformance` `npm test` | `0` | |
| `sh scripts/test-jvm-tools.sh` | `0` | |
| `sh scripts/test-fast-pr.sh` | `0` | |
| `python scripts/check_fast_pr_gap.py --list` | `0` | **95** required checks the local spine does not decide |

Rebased onto `e7b9924f4b` (#7994, the pinned-clj-kondo lane) and every gate above re-run on that base; the exit codes quoted are the post-rebase runs. The spine printed `gate root: /c/Users/miket/code/re-frame2-worktrees/mcpwire-hic059` — this worktree.

`test-fast-pr.sh` explicitly does not decide mcp-conformance or the tool JVM suites, which is why both are run separately above. Of the 95 required checks it does not decide, the ones this diff could plausibly arm are `node-test-tools-re-frame2-pair-mcp` and `mcp-conformance-re-frame2-pair` — both run locally here, green. **clj-kondo is NOT decided locally**: CI pins 2026.04.15 and this box has a different build, so per the spine's own note a local pass would prove nothing; the diff adds no Clojure source, so the exposure is a `.cjs`, a `package.json` line and Markdown.

One environment note, not a code finding: `tools/mcp-conformance` first failed with `Cannot find module 'cross-spawn'` because a fresh worktree has no `node_modules` there. Junctioned to the primary checkout's and re-run; the `0` above is that run.

## Files

- `tools/re-frame2-pair-mcp/test/live-hicasso-wire.cjs` — the witness
- `tools/re-frame2-pair-mcp/package.json` — one script, `test:live-hicasso-wire`
- `tools/re-frame2-pair-mcp/test/README.md` — the routing table row, the decision tree leaf, and the section describing it
