### PR TITLE
fix(hmr-gate): GEN-1 waits for a registration signal, not for the page (rf2-odh3)

### DIFF
--- a/implementation/scripts/serve-and-run-hicasso-hmr-testbed.cjs
+++ b/implementation/scripts/serve-and-run-hicasso-hmr-testbed.cjs
@@ -46,6 +46,50 @@
  * hook fired": a counter alone would be satisfied by an after-load hook
  * running against the module it already had.
  *
+ * ## The first save, and the runtime the watch had not met yet
+ *
+ * A save is only a save if the watch KNOWS about the page it is meant to
+ * reach. shadow's worker pushes `:cljs-build-complete` to the runtimes it
+ * has already met and to no others — `send-to-runtimes` in
+ * `shadow/cljs/devtools/server/worker/impl.clj` is `(when (seq runtimes)
+ * ...)`, so an unknown runtime draws SILENCE rather than an error — and a
+ * runtime is met only when the relay tells the worker about it while
+ * handling that runtime's `:hello`.
+ *
+ * `:hello` goes out after the websocket has opened and the relay's
+ * `:welcome` has come back. The app's mount is on a different clock
+ * entirely: the devtools client only STARTS the connect, and then the
+ * module's `:init-fn` runs and paints in the same task. So gating the
+ * first save on the mount alone left one unprotected moment — GEN-1, on
+ * whichever engine goes first — in which the recompile could land while
+ * the handshake was still in flight, be pushed to nobody, and leave the
+ * wait to run out its ceiling underneath a perfectly healthy watch log
+ * (rf2-odh3; twice in CI, chromium both times, chromium being the engine
+ * that goes first and so pays for every cold path on the relay's accept
+ * side). The harness makes exactly ONE save per generation, so there is
+ * no second compile to rescue a push that went nowhere.
+ *
+ * The answer is a positive signal, not more time. Immediately after
+ * `:hello` the client asks the relay which client is the worker for this
+ * build; the relay handles one client's messages in order, and it
+ * notifies the worker WHILE handling `:hello`. So that query's reply,
+ * arriving back at the page, is proof the worker has already been told.
+ * `driveEngine` waits for it before the first save. The save ceiling is
+ * untouched, and on the failing interleaving the run now gets SHORTER,
+ * because the save lands instead of timing out.
+ *
+ * ## Whose server answered
+ *
+ * `:dev-http` is a fixed port, so a second `shadow-cljs watch` anywhere on
+ * the machine — another checkout, a leftover from a killed run — binds it
+ * first and this one silently does not. The watch log carries the
+ * `BindException`, but the gate's HTTP probe answers 200 either way, and
+ * every witness below would then be measuring somebody else's bundle
+ * against this tree's saves. That produces the IDENTICAL red as the race
+ * above, from an entirely different cause, which is how it was found.
+ * `waitForBuild` therefore checks that the bytes the server hands back
+ * are the bytes this watch just wrote.
+ *
  * ## Two verdicts, kept apart — as in the controlled-input gate
  *
  * REQUIRED rows are the spec's assertions; a throw in any engine fails.
@@ -94,6 +138,7 @@
  *   browser fact. Nothing here duplicates it.
  */
 
+const crypto = require('crypto');
 const fs = require('fs');
 const http = require('http');
 const path = require('path');
@@ -109,6 +154,12 @@ const PORT = Number(process.env.HICASSO_HMR_PORT) || 8061;
 const HOT_FILE = path.join(
   IMPL_ROOT, 'hicasso', 'testbed', 'hicasso_hmr_testbed', 'views.cljs');
 const SPEC = require(path.join(IMPL_ROOT, 'hicasso', 'testbed', 'hmr_spec.cjs'));
+// The module `:dev-http` serves at `/main.js`, named here so this run can
+// prove the server answering on PORT is the one THIS watch is feeding. It
+// restates `:output-dir` from shadow-cljs.edn, exactly as PORT above
+// restates that build's `:dev-http`; the two facts travel together and the
+// check below turns a drift in either into a loud red.
+const BUNDLE_FILE = path.join(IMPL_ROOT, 'out', 'hicasso-hmr-testbed', 'main.js');
 
 // The label the file is committed with and must be restored to.
 const CANONICAL_LABEL = 'GEN-A';
@@ -124,6 +175,17 @@ const NAV_TIMEOUT_MS = 60000;
 // Deliberately NOT the build ceiling: by this point the slow part is done,
 // so a long wait here only delays a red.
 const MOUNT_TIMEOUT_MS = 60000;
+// The devtools handshake, waited out BEFORE the first save rather than
+// after it (rf2-odh3). Not a save budget and deliberately not spelled as
+// one: a slow handshake now SHORTENS the failing path, because the save
+// that follows lands instead of being pushed to nobody. Same reasoning as
+// the mount ceiling — the compile is already done, so a generous ceiling
+// here only delays a red that is certain either way. Not env-tunable,
+// because there is no run in which more of it buys a pass.
+const REGISTER_TIMEOUT_MS = 60000;
+// PROOF INSTRUMENT, default 0 = off. See `delayRelaySocket`.
+const REGISTER_DELAY_MS = parseInt(
+  process.env.HICASSO_HMR_REGISTER_DELAY_MS || '0', 10);
 
 // ONE console error that is not a fault, matched as narrowly as it can be.
 //
@@ -214,6 +276,162 @@ function restoreHotFile() {
   const source = readHotFile();
   if (readHotLabel(source) !== CANONICAL_LABEL) {
     writeHotFile(rewriteHotLabel(source, CANONICAL_LABEL));
+  }
+}
+
+// ---------------------------------------------------------------------------
+// The devtools relay socket — the watch's proof that it has met this page
+// ---------------------------------------------------------------------------
+//
+// Watched from OUTSIDE the page, through Playwright's own websocket events,
+// so nothing has to be injected into the runtime to read it and the census
+// survives a reload that would wipe anything installed in the page.
+
+const RELAY_URL_RE = /\/api\/remote-relay/;
+// OUTBOUND frames are transit-json written with a FRESH writer per message
+// (`transit-str`, shadow/cljs/devtools/client/shared.cljs), so the op is
+// always spelled out and never a back-reference into transit's write cache.
+// This match is therefore exact, and it is the one the verdict rests on.
+const WORKER_QUERY_RE = /request-clients/;
+// INBOUND frames are the relay's, whose writer this gate does not own, so a
+// repeated op may come back as a cache reference. This is a FLOOR on the
+// pushes delivered — printed as evidence, never asserted on.
+const BUILD_PUSH_RE = /cljs-build-(?:start|complete)/;
+
+function makeRelayCensus() {
+  return {
+    socket: false,
+    closed: false,
+    sent: 0,
+    received: 0,
+    askedForWorker: false,
+    registered: false,
+    registeredAt: 0,
+    buildPushes: 0,
+  };
+}
+
+/** Note a frame the PAGE sent to the relay. */
+function noteRelayFrameSent(census, payload) {
+  census.sent += 1;
+  if (WORKER_QUERY_RE.test(String(payload))) census.askedForWorker = true;
+  return census;
+}
+
+/**
+ * Note a frame the page RECEIVED from the relay.
+ *
+ * Registration is banked on the first frame that arrives AFTER the worker
+ * query went out, and never on an earlier one. That ordering is the whole
+ * point rather than an implementation detail: `:welcome` arrives BEFORE the
+ * page has said `:hello`, so a census that banked the first inbound frame
+ * would declare this runtime registered at precisely the moment it
+ * provably is not, and the wait below would wave through the interleaving
+ * it exists to exclude.
+ */
+function noteRelayFrameReceived(census, payload, now) {
+  census.received += 1;
+  if (BUILD_PUSH_RE.test(String(payload))) census.buildPushes += 1;
+  if (census.askedForWorker && !census.registered) {
+    census.registered = true;
+    census.registeredAt = now;
+  }
+  return census;
+}
+
+function describeRelayCensus(census) {
+  if (!census.socket) return 'no devtools relay socket was ever opened';
+  return `${census.sent} frame(s) sent, ${census.received} received, `
+    + `${census.buildPushes}+ build push(es) delivered, `
+    + `${census.registered ? 'registered with the watch' : 'NEVER registered with the watch'}`
+    + `${census.closed ? ', socket since closed' : ''}`;
+}
+
+/** Attach the census to a page. Must run before the page navigates. */
+function watchRelaySocket(page) {
+  const census = makeRelayCensus();
+  page.on('websocket', (ws) => {
+    if (!RELAY_URL_RE.test(ws.url())) return;
+    census.socket = true;
+    ws.on('framesent', ({ payload }) => noteRelayFrameSent(census, payload));
+    ws.on('framereceived', ({ payload }) =>
+      noteRelayFrameReceived(census, payload, Date.now()));
+    ws.on('close', () => { census.closed = true; });
+  });
+  return census;
+}
+
+async function waitForRegistration(census, engine, deadline) {
+  while (Date.now() < deadline) {
+    if (census.registered) return census;
+    await sleep(50);
+  }
+  throw new Error(
+    `[${engine}] shadow's devtools handshake did not complete within `
+    + `${REGISTER_TIMEOUT_MS}ms, so the watch has never met this page and `
+    + `would push the first save to nobody — ${describeRelayCensus(census)}.`);
+}
+
+/**
+ * PROOF INSTRUMENT (`HICASSO_HMR_REGISTER_DELAY_MS`, default 0 = off).
+ *
+ * Forces the interleaving rf2-odh3 is about, by letting the app mount on
+ * time while shadow's devtools socket connects `delayMs` late. Against the
+ * wait above the save simply happens later and lands; take the wait away
+ * and the same run reds at GEN-1 with the CI signature — which is how the
+ * fix is shown to bite rather than merely to have passed once.
+ *
+ * Safe to ship because it can only ever make this gate HARDER: it delays a
+ * connection, and every verdict below still has to be earned afterwards.
+ *
+ * Runs in the page via `addInitScript`, and in the mutation teeth in Node
+ * against a stub `WebSocket` — the same function either way, which is what
+ * keeps the tested thing and the shipped thing one thing.
+ */
+function delayRelaySocket(options) {
+  const delayMs = Number(options.delayMs) || 0;
+  const g = globalThis;
+  const Real = g.WebSocket;
+  if (typeof Real !== 'function' || delayMs <= 0) return;
+  const match = new RegExp(options.pattern);
+
+  function Delayed(url, protocols) {
+    const self = this;
+    let real = null;
+    let closed = false;
+    const queued = [];
+    self.url = String(url);
+    self.readyState = 0;
+    self.onopen = null;
+    self.onmessage = null;
+    self.onclose = null;
+    self.onerror = null;
+    self.send = (data) => { if (real) real.send(data); else queued.push(data); };
+    self.close = () => { closed = true; if (real) real.close(); };
+    g.setTimeout(() => {
+      if (closed) return;
+      real = new Real(url, protocols);
+      real.onopen = (e) => {
+        self.readyState = real.readyState;
+        while (queued.length > 0) real.send(queued.shift());
+        if (self.onopen) self.onopen(e);
+      };
+      real.onmessage = (e) => { if (self.onmessage) self.onmessage(e); };
+      real.onclose = (e) => {
+        self.readyState = real.readyState;
+        if (self.onclose) self.onclose(e);
+      };
+      real.onerror = (e) => { if (self.onerror) self.onerror(e); };
+    }, delayMs);
+  }
+
+  g.WebSocket = function (url, protocols) {
+    return match.test(String(url))
+      ? new Delayed(url, protocols)
+      : new Real(url, protocols);
+  };
+  for (const k of ['CONNECTING', 'OPEN', 'CLOSING', 'CLOSED']) {
+    g.WebSocket[k] = Real[k];
   }
 }
 
@@ -362,6 +580,96 @@ function runMutationTeeth() {
   bite('the real source file is in its canonical state and carries the marker', () =>
     readHotLabel(readHotFile()) !== null);
 
+  // --- the relay census, which is what makes GEN-1 a save at all --------
+  //
+  // The failure this guards against is not a wrong answer but a premature
+  // one: a census that banks registration too early restores the race in
+  // silence, because every later verdict still passes on a healthy run.
+
+  bite('the welcome frame alone is NOT registration', () => {
+    const c = makeRelayCensus();
+    noteRelayFrameReceived(c, '["^ ","~:op","~:welcome","~:client-id",7]', 100);
+    return c.received === 1 && c.registered === false && c.registeredAt === 0;
+  });
+
+  bite('registration is banked only once the worker query has gone out', () => {
+    const c = makeRelayCensus();
+    noteRelayFrameReceived(c, '["^ ","~:op","~:welcome"]', 100);
+    noteRelayFrameSent(c, '["^ ","~:op","~:hello","~:client-info",["^ "]]');
+    noteRelayFrameReceived(c, '["^ ","~:op","~:ping"]', 200);
+    if (c.registered) return false;
+    noteRelayFrameSent(c, '["^ ","~:op","~:request-clients","~:notify",true]');
+    noteRelayFrameReceived(c, '["^ ","~:op","~:clients","~:clients",[]]', 300);
+    return c.registered === true && c.registeredAt === 300 && c.sent === 2;
+  });
+
+  bite('registration is banked once and later traffic does not move it', () => {
+    const c = makeRelayCensus();
+    noteRelayFrameSent(c, '["^ ","~:op","~:request-clients"]');
+    noteRelayFrameReceived(c, '["^ ","~:op","~:clients"]', 300);
+    noteRelayFrameReceived(c, '["^ ","~:op","~:cljs-build-complete"]', 900);
+    return c.registeredAt === 300 && c.buildPushes === 1 && c.received === 2;
+  });
+
+  bite('the census tells a silent socket from a delivering one', () => {
+    const silent = makeRelayCensus();
+    silent.socket = true;
+    const delivering = makeRelayCensus();
+    delivering.socket = true;
+    noteRelayFrameSent(delivering, '~:request-clients');
+    noteRelayFrameReceived(delivering, '~:cljs-build-complete', 1);
+    return /NEVER registered/.test(describeRelayCensus(silent))
+      && /1\+ build push/.test(describeRelayCensus(delivering))
+      && /no devtools relay socket/.test(describeRelayCensus(makeRelayCensus()));
+  });
+
+  // --- the delay instrument, which is how the fix is shown to bite ------
+  bite('the register-delay instrument is inert at its default', () => {
+    const g = globalThis;
+    const saved = g.WebSocket;
+    try {
+      const Stub = function () {};
+      g.WebSocket = Stub;
+      delayRelaySocket({ delayMs: 0, pattern: RELAY_URL_RE.source });
+      return g.WebSocket === Stub;
+    } finally { g.WebSocket = saved; }
+  });
+
+  bite('the register-delay instrument defers the relay socket and nothing else', () => {
+    const g = globalThis;
+    const saved = g.WebSocket;
+    const opened = [];
+    try {
+      const Stub = function (url) { opened.push(String(url)); this.url = url; };
+      g.WebSocket = Stub;
+      delayRelaySocket({ delayMs: 50, pattern: RELAY_URL_RE.source });
+      const other = new g.WebSocket('ws://127.0.0.1:1/echo');
+      const relay = new g.WebSocket(
+        'ws://127.0.0.1:9630/api/remote-relay?server-token=x');
+      relay.send('queued, because nothing is connected yet');
+      relay.close();
+      return opened.length === 1
+        && opened[0] === 'ws://127.0.0.1:1/echo'
+        && other instanceof Stub
+        && !(relay instanceof Stub);
+    } finally { g.WebSocket = saved; }
+  });
+
+  // --- whose server answered --------------------------------------------
+  bite('a bundle that matches this watch\'s raises nothing', () =>
+    bundleIdentityProblem('abcd1234', 'abcd1234') === null);
+
+  bite('a bundle from another watch is refused, and the message names both', () => {
+    const problem = bundleIdentityProblem('aaaaaaaaaaaaaa', 'bbbbbbbbbbbbbb');
+    return problem !== null
+      && problem.includes('aaaaaaaaaaaa') && problem.includes('bbbbbbbbbbbb');
+  });
+
+  bite('two unreadable bundles are refused rather than counted as equal', () =>
+    bundleIdentityProblem(null, null) !== null
+    && bundleIdentityProblem(null, 'abcd') !== null
+    && bundleIdentityProblem('abcd', null) !== null);
+
   // --- the comparator ---------------------------------------------------
   bite('agreement across engines raises nothing', () =>
     divergenceReport({
@@ -456,6 +764,87 @@ function get(url) {
 
 const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
 
+/** sha256 of a URL's body, or null when it cannot be read. */
+function hashUrl(url) {
+  return new Promise((resolve) => {
+    const req = http.get(url, (res) => {
+      if (res.statusCode !== 200) { res.resume(); resolve(null); return; }
+      const h = crypto.createHash('sha256');
+      res.on('data', (d) => h.update(d));
+      res.on('end', () => resolve(h.digest('hex')));
+      res.on('error', () => resolve(null));
+    });
+    req.on('error', () => resolve(null));
+    req.setTimeout(30000, () => { req.destroy(); resolve(null); });
+  });
+}
+
+/** sha256 of a file, or null when it cannot be read. */
+function hashFile(file) {
+  try {
+    return crypto.createHash('sha256').update(fs.readFileSync(file)).digest('hex');
+  } catch (err) {
+    return null;
+  }
+}
+
+/**
+ * Why the served bundle is not this watch's, or null when it is.
+ *
+ * Separated from the I/O so it can be bitten: a comparison that silently
+ * degrades to "both unreadable, therefore equal" is the shape that would
+ * hand this whole check back to the collision it exists to catch.
+ */
+function bundleIdentityProblem(served, own) {
+  if (!own) {
+    return 'this watch has written no bundle to compare against, so the '
+      + 'server\'s answer cannot be attributed to it at all';
+  }
+  if (!served) return 'the server did not hand back a readable bundle';
+  if (served !== own) {
+    return `the served bundle (sha256 ${served.slice(0, 12)}) is not the one `
+      + `this watch wrote (sha256 ${own.slice(0, 12)})`;
+  }
+  return null;
+}
+
+/**
+ * Refuse to run against a bundle this watch did not write.
+ *
+ * `:dev-http` is a fixed port. A second `shadow-cljs watch` anywhere on the
+ * machine binds it first, this one's bind quietly fails, and the probe in
+ * `waitForBuild` gets its 200 from the other process — after which the page
+ * runs somebody else's app, that app's runtime registers with somebody
+ * else's worker, and the saves made here reach nothing. The red is
+ * indistinguishable from a lost build push: same GEN-1, same ninety
+ * seconds, same healthy `Build completed` above it.
+ *
+ * shadow bakes a per-process `proc_id` and `server_token` into every dev
+ * bundle, so two watches can never write the same bytes and a whole-file
+ * digest settles the question outright. One retry absorbs a compile landing
+ * between the two reads.
+ */
+async function assertOwnBundle(baseUrl, watchLog) {
+  let problem = null;
+  for (let attempt = 0; attempt < 2; attempt += 1) {
+    if (attempt > 0) await sleep(500);
+    // Served first: a recompile between the reads then shows as a stale
+    // FILE rather than a stale response, and the retry clears it.
+    const served = await hashUrl(`${baseUrl}/main.js`);
+    problem = bundleIdentityProblem(served, hashFile(BUNDLE_FILE));
+    if (problem === null) return;
+  }
+  throw new Error(
+    `${baseUrl}/main.js is not the bundle this watch just wrote — ${problem}.\n`
+    + `Port ${PORT} is shadow's :dev-http for ${BUILD_ID}, so a second `
+    + `shadow-cljs watch anywhere on this machine (another checkout, a `
+    + `leftover from a killed run) binds it first and this one does not. The `
+    + `page would load that other tree's app, whose worker never hears the `
+    + `saves made here, and every witness below would be measuring somebody `
+    + `else's bundle. The watch says so itself — look for `
+    + `::dev-http/http-start-ex on port ${PORT} in its output.\n${watchLog.tail()}`);
+}
+
 /**
  * Wait until THIS watch has completed a compile and shadow is serving it.
  *
@@ -485,7 +874,10 @@ async function waitForBuild(baseUrl, watchLog, deadline) {
       const [page, bundle] = await Promise.all([
         get(`${baseUrl}/`), get(`${baseUrl}/main.js`),
       ]);
-      if (page === 200 && bundle === 200) return true;
+      if (page === 200 && bundle === 200) {
+        await assertOwnBundle(baseUrl, watchLog);
+        return true;
+      }
     }
     await sleep(500);
   }
@@ -552,12 +944,13 @@ let labelCounter = 0;
  * re-rendering. Requiring both is what makes every `ctx.save()` in the
  * spec a proof that shadow carried code into this page.
  */
-function makeSave(page, watchLog) {
+function makeSave(page, watchLog, relay) {
   return async () => {
     labelCounter += 1;
     const label = `GEN-${labelCounter}`;
     const before = await page.evaluate(() => window.__RF2_HMR__.reloads());
     const from = watchLog.mark();
+    const relayBefore = describeRelayCensus(relay);
     writeHotFile(rewriteHotLabel(readHotFile(), label));
     try {
       await Promise.race([
@@ -579,7 +972,15 @@ function makeSave(page, watchLog) {
     } catch (err) {
       throw new Error(
         `the save to ${label} never reached the page. A compile error in the ` +
-        `watch is the usual cause — its last output follows.\n` +
+        `watch is the usual cause — its last output follows. If the watch ` +
+        `instead reports a clean "Build completed" for this save, the code ` +
+        `was compiled and NOT DELIVERED, and the relay census below says ` +
+        `which half failed: a runtime that never registered was pushed to ` +
+        `nobody (rf2-odh3), while a registered runtime that took no build ` +
+        `push has a delivery fault, and one that took the push but did not ` +
+        `re-render has a reload fault in the app.\n` +
+        `  relay before this save: ${relayBefore}\n` +
+        `  relay now:              ${describeRelayCensus(relay)}\n` +
         `${watchLog.tail()}\nUnderlying: ${err.message}`);
     }
     return label;
@@ -596,9 +997,21 @@ async function driveEngine(engine, baseUrl, watchLog) {
   const log = (s) => lines.push(s);
   let passed = false;
   let result = null;
+  let registerMs = null;
+  const launchedAt = Date.now();
   try {
     const context = await browser.newContext();
     const page = await context.newPage();
+    // Before anything navigates: the census reads shadow's devtools socket
+    // from outside the page, and the delay instrument (default off) is the
+    // only thing that may sit in front of it.
+    const relay = watchRelaySocket(page);
+    if (REGISTER_DELAY_MS > 0) {
+      await page.addInitScript(delayRelaySocket,
+        { delayMs: REGISTER_DELAY_MS, pattern: RELAY_URL_RE.source });
+      log(`[${engine}] HICASSO_HMR_REGISTER_DELAY_MS=${REGISTER_DELAY_MS} — `
+        + `the devtools socket is being held back on purpose.`);
+    }
     page.on('console', (msg) => {
       if (msg.type() === 'error' && !BENIGN_CONSOLE_ERROR.test(msg.text())) {
         consoleErrors.push(msg.text());
@@ -646,8 +1059,23 @@ async function driveEngine(engine, baseUrl, watchLog) {
           (pageErrors[0] ? pageErrors[0].message : consoleErrors[0]))),
     ]);
 
+    // The mount proves the APP is up; it says nothing about whether the
+    // watch has met this page, and the very next thing this gate does is
+    // save. rf2-odh3 — see the relay-socket section above.
+    await Promise.race([
+      waitForRegistration(relay, engine, Date.now() + REGISTER_TIMEOUT_MS),
+      pollUntil(
+        () => pageErrors.length > 0,
+        REGISTER_TIMEOUT_MS,
+        () => new Error(
+          'the page reported an error while shadow\'s devtools handshake was '
+          + `still in flight: ${pageErrors[0] && pageErrors[0].message}`)),
+    ]);
+    registerMs = relay.registeredAt - launchedAt;
+    log(`[${engine}] the watch has met this page (${describeRelayCensus(relay)})`);
+
     result = await withTimeout(
-      SPEC.run(page, { engine, save: makeSave(page, watchLog) }),
+      SPEC.run(page, { engine, save: makeSave(page, watchLog, relay) }),
       SPEC_TIMEOUT_MS, `${SPEC.name} (${engine})`);
 
     if (pageErrors.length > 0) {
@@ -674,7 +1102,8 @@ async function driveEngine(engine, baseUrl, watchLog) {
   if (!passed) for (const ln of lines) console.log(ln);
   console.log(passed
     ? `PASS  ${engine} — ${result.checks} checks across ` +
-      `${Object.keys(result.sections).length} sections`
+      `${Object.keys(result.sections).length} sections ` +
+      `(the watch met this page ${registerMs}ms after launch)`
     : `FAIL  ${engine}`);
   return { passed, result };
 }
@@ -786,6 +1215,12 @@ module.exports = {
   recordSchemaReport,
   readHotLabel,
   rewriteHotLabel,
+  bundleIdentityProblem,
+  makeRelayCensus,
+  noteRelayFrameSent,
+  noteRelayFrameReceived,
+  describeRelayCensus,
+  delayRelaySocket,
   NARROWINGS,
   REQUIRED_SECTIONS,
   REQUIRED_RECORDS,


### PR DESCRIPTION
Closes rf2-odh3.

The bead filed a HYPOTHESIS and said so. It is now **CONFIRMED**, at the source and by a forced reproduction, and the remedy is in the gate's own harness. **The 90s save ceiling is untouched** — nothing in this diff lengthens a timeout, and on the failing interleaving the run now gets *shorter*, because the save lands instead of timing out.

## The mechanism, read at source

shadow's worker pushes a completed build only to runtimes it has already met:

```clojure
;; shadow/cljs/devtools/server/worker/impl.clj:55
(defn send-to-runtimes [{:keys [runtimes] :as worker-state} msg]
  (when (seq runtimes)
    (relay-msg worker-state (assoc msg :to (-> runtimes keys set)))))
```

An unknown runtime therefore draws **silence**, not an error. A runtime enters `:runtimes` only via `add-runtime` (`impl.clj:771`), reached only from the relay's `:client-connect` notification (`worker.clj:195`), which the relay emits while handling that runtime's `:hello` (`shadow/remote/relay/local.clj:252`). And `:hello` is sent only after the websocket has opened and the relay's `:welcome` has come back (`shadow/remote/runtime/shared.cljc:78`).

The harness gated its first save on the app's **mount** — `window.__RF2_HMR__` plus both roots. That is a different clock entirely: shadow's devtools client only *starts* the connect, then the module's `:init-fn` runs and paints in the same task. So GEN-1 could be written while the handshake was still in flight, compiled into a worker that had never heard of the page, and pushed to nobody. The harness makes exactly one save per generation, so **there is no second compile to rescue it** — which is why the failure is always the same save, always the first engine, and why a re-run clears it.

## The remedy: a positive signal, not more time

Immediately after `:hello` the client asks the relay who the worker for this build is. The relay handles one client's messages in order and notifies the worker *while* handling `:hello`, so **the reply to that query, arriving back at the page, is proof the worker has already been told**. `driveEngine` now waits for that reply before the first save, watching shadow's socket through Playwright's own websocket events — nothing is injected into the runtime, and the census survives a reload.

The same census is carried into every save's failure message, so the next occurrence of this red names itself instead of costing a day:

```
  relay before this save: no devtools relay socket was ever opened
  relay now:              18 frame(s) sent, 18 received, 0+ build push(es) delivered, registered with the watch
```

## Proving it bites — the losing interleaving, forced

A green run is not proof for a race, so the harness ships `HICASSO_HMR_REGISTER_DELAY_MS` (default `0` = off): it holds the devtools socket back while letting the app mount on time. It is safe to ship because it can only ever make this gate *harder* — it delays a connection, and every verdict still has to be earned afterwards.

| leg | command | result |
|---|---|---|
| **A — the race** | delay 8000ms, registration wait bypassed by a temporary local edit | **exit 1**, `chromium`, GEN-1, `page.waitForFunction: Timeout 90000ms exceeded`, under a healthy `Build completed. (225 files, 2 compiled, 0 warnings, 0.98s)` |
| **B — the fix** | delay 8000ms, registration wait in place | **exit 0**, `PASS chromium — 105 checks across 8 sections (the watch met this page 8646ms after launch)`, 12 real shadow reloads |

Leg A reproduces the CI signature byte for byte, and its census settles the mechanism outright: *at the moment of the save the socket was not even open*, and ninety seconds later the runtime had registered having taken **zero build pushes**. Compiled, and not delivered.

The leg-A edit was a two-line env guard, reverted with `git checkout` and verified **by hashing the file bytes**, not by reading a diff: sha256 `aa55be5c976ea38f39199f19d3937217a444fef2b38805c441d88766813d1ae8` before the experiment and after the restore, with `git status` clean and no residue of the guard's name anywhere in the tree.

Attribution of the two historical CI reds stays inferential — nothing recorded the socket at the time. The shipped census makes the next one decisive either way.

### The margin, now that the PASS line reports it

The window the old code raced against is one filesystem-watch tick plus a 0.25s recompile — call it a second and a half. Across three healthy three-engine runs on this machine the watch met the page in **645–2172 ms** (chromium 645–752, webkit 782–909, firefox 1609–2172).

**This PR's own CI run is the sharper number.** On `cljs-hicasso-hmr`, green, three engines, 36 real reloads:

```
PASS  chromium — 105 checks across 8 sections (the watch met this page 726ms after launch)
PASS  firefox  — 105 checks across 8 sections (the watch met this page 1517ms after launch)
PASS  webkit   — 105 checks across 8 sections (the watch met this page 5027ms after launch)
```

Five seconds for webkit. Under the old harness that page would have been written to at roughly half a second and the recompile pushed at about one and a half — **three and a half seconds before the worker had any idea the page existed.** The race was not a rare alignment; it was open on a routine green run, on the engine that happened not to go first. That the reds landed on chromium is an artefact of chromium being the engine that pays for the cold JVM path, not of chromium being special.

## A second cause, found by reproducing the first — and it is a fail-open

The very first local run reproduced the CI signature exactly, from an entirely different cause: `BindException Address already in use` on `:dev-http` 8061. A sibling worktree was running `shadow-cljs watch hicasso/hmr-testbed`; it had the port, this run's bind quietly failed, and `waitForBuild`'s HTTP probe got its 200 **from the other process**. The page then ran another tree's app, that app registered with another tree's worker, and the saves made here reached nothing.

That is worse than a confusing red. The two watches here held *different* source trees, so it failed — but a leftover watch from a **killed earlier run of this same gate** compiles the same sources, so the saves would land, the page would reload, and this gate would report a confident green witnessed entirely by a process this run did not start. The file's own header already records learning that "a gate that can serve stale code is a gate that can report a green on code nobody compiled"; the fix then pinned on the watch's own completion line, which is this run's — but the *bytes* still were not.

`waitForBuild` now checks that the bundle the server hands back is the one this watch just wrote. shadow bakes a per-process `proc_id` and `server_token` into every dev bundle, so two watches can never write the same bytes and a whole-file digest settles it outright.

## Teeth

`runMutationTeeth` goes 19 → 28, all of them biting logic a plausible refactor could soften rather than break:

- **the census** (4) — the sharpest is *"the welcome frame alone is NOT registration"*: `:welcome` arrives **before** the page has said `:hello`, so a census that banked the first inbound frame would declare the runtime registered at exactly the moment it provably is not, and wave through the interleaving the wait exists to exclude. Every other verdict in the gate still passes on a healthy run, so nothing else would notice.
- **the delay instrument** (2) — that it is inert at its default, and that it defers the relay socket and nothing else. It runs in the page via `addInitScript` and in the teeth against a stub `WebSocket`: the same function either way, so the tested thing and the shipped thing stay one thing.
- **bundle identity** (3) — including that two *unreadable* bundles are refused rather than compared equal, which is the shape that would hand the whole check back to the collision it exists to catch.

One tooth caught a wrong assertion of mine while I was writing them.

## Not done, deliberately

- **The 90s ceiling is untouched.** The new wait is a separate, pre-save wait for a positive fact, and it is not env-tunable, because there is no run in which more of it buys a pass.
- **The `:hmr-testbed` / `:hicasso/hmr-testbed` console error is left alone** — confirmed cosmetic and printed on green runs too, exactly as the bead records.
- **The gate's path-filter arming is left broad.**

## Quality gates

| gate | command | exit | notes |
|---|---|---|---|
| HMR gate, 3 engines, run 1 | `node scripts/serve-and-run-hicasso-hmr-testbed.cjs` | 0 | the deciding gate |
| HMR gate, 3 engines, run 2 | same | 0 | repeated — one green run is not evidence a race is gone |
| HMR gate, 3 engines, run 3 | same | 0 | |
| HMR race, leg A (proof) | `HICASSO_HMR_ENGINES=chromium HICASSO_HMR_REGISTER_DELAY_MS=8000`, wait bypassed | 1 | RED **as intended** — the race, forced |
| HMR race, leg B (proof) | `HICASSO_HMR_ENGINES=chromium HICASSO_HMR_REGISTER_DELAY_MS=8000` | 0 | GREEN — the fix, under the same fault |
| JS harness self-tests (policy) | `npm run test:script-policy` | 0 | |
| JS harness self-tests (helpers) | `npm run test:script-helpers` | 0 | the `js-harness-self-tests` CI job is these two |
| fast-PR spine | `scripts/test-fast-pr.sh` | 0 | |

Each gate was run alone, nothing appended, with the exit code captured on the same command line; no gate was piped through `tail`/`head`/`grep`. Logs are worktree-scoped (`odh3-*`) and each carries its own `gate root: .../re-frame2-worktrees/hmrrace-odh3/implementation` header, checked against this worktree.

Rebased onto `origin/main` after #7994 and #7992 landed; the only thing main had gained since the local runs' base was a `.beads` checkpoint, and **the deciding gate has been re-run on the rebased commit by CI itself** — `cljs-hicasso-hmr`, green in 1m56s, three engines, 36 real reloads (the numbers above). `ESLint` is also green, which is the lint job this JS-only diff can reach.

`python scripts/check_fast_pr_gap.py --list` reports **95** required checks the local spine does not decide. The ones that matter for this diff, none of which run locally:

- **`CLJS hicasso HMR contract through a real shadow reload (Chromium + Firefox + WebKit)`** — the job this diff exists for. It arms on this launcher's own path (`report-changed-surfaces.sh`, the self-protection case for this file), so it runs on this PR.
- `JS harness self-tests (quiet reporters + path policy)` — run locally as its two npm scripts, but the job itself is CI's.
- The `cljs_node_test` / `cljs_browser` / `cljs_prod` / `bundle_isolation` / `reagent_slim_bundle` surfaces this launcher's path also arms, none of which this diff can reach.

## For the mayor — one more fail-open in this rig, not fixed here

`HICASSO_HMR_ENGINES` can narrow the run to one engine, and the cross-engine comparator then disables itself silently (`divergenceReport` returns no problems below two engines) while the run still prints `HICASSO HMR PASS`. CI does not set the variable today, and nothing asserts that it did not. Worth a bead; deliberately out of this diff's fence.
