### PR TITLE
docs(mayor): a hash-verified plant still needs proof the runtime saw it (rf2-hs3i)

### DIFF
--- a/docs/the-mayor-method/dispatch-prompt-template.md
+++ b/docs/the-mayor-method/dispatch-prompt-template.md
@@ -230,7 +230,24 @@ none of them is obvious from the gate command itself.
   which is worse than no proof. Hash the file before the plant and compare after
   the restore. On a checkout whose line endings are translated, **anchor a patch to
   a single line**: one worker's first multi-line anchor matched nothing, with no
-  error and no edit, and only the hash caught it.
+  error and no edit, and only the hash caught it. **A hash proves the SOURCE
+  changed, not that the runtime ever saw it** — and that second half has a false
+  green of its own. On 2026-08-12 a worker planted a one-line egress fault in
+  `implementation/hicasso/src/re_frame/hicasso/tool.cljs` and its live wire witness
+  came back GREEN. The hashes differed (`2c6ecbed…5148` before, `915aaf91…e424`
+  planted), so the plant had genuinely applied and the rule above reported success
+  — but `re-frame.hicasso.tool` is not in the host build's module graph, so
+  `shadow-cljs watch` never noticed the edit and served the pre-plant compile.
+  Restarting the watch produced the red at once, naming the fault exactly. So **a
+  green sabotage run is evidence only once both halves hold**: the hash for the
+  source, and positive evidence the runtime observed the plant — restart the watch,
+  assert the plant's own marker in the served bundle, or confirm the build reported
+  recompiling the file you edited. Read without that second half, the green says
+  *the control is vacuous, my witness proves nothing*, and the worker's next move is
+  to tune the witness until it reds against a fault that was never being compiled —
+  a conclusion about the wrong artefact altogether. The hash deepens this trap
+  rather than closing it, because it is genuine evidence for a narrower claim than
+  the worker needs.
 - **Put *every* gate artefact where git ignores it, and name each one FOR your
   worktree** — the log and the exit-code file both. `*.log`, `*.exit` and
   `*-exit.txt` are all ignored, and the `-<worktree>` suffix is what stops a


### PR DESCRIPTION
Closes `rf2-hs3i`. One paragraph of guidance, no tooling.

## The gap

`docs/the-mayor-method/dispatch-prompt-template.md` tells workers to verify a
sabotage plant and its restore **by hashing the file bytes, never by reading
`git diff`**. That rule closes one hole — *"the patch never applied"*, which
produces a diff identical to an exact restore. It does not close the hole one
step downstream: **the patch applied to the source and the runtime never saw
it.**

Measured on this wave, not hypothesised. `worker/mcpwire-hic059` (`rf2-hic-059`,
#7997) planted a one-line egress fault in
`implementation/hicasso/src/re_frame/hicasso/tool.cljs` and its live wire witness
came back **GREEN**. The hashes differed — `2c6ecbed…5148` before,
`915aaf91…e424` planted — so the plant had genuinely applied and the hash rule
reported success. But `re-frame.hicasso.tool` is not in the host build's module
graph (it is REPL-required into the runtime), so `shadow-cljs watch` never
noticed the edit and served the pre-plant compile. Restarting the watch produced
the expected red, naming the fault exactly: `EGRESS: the read-mounted-boundaries
envelope carried the seeded secret at the wire`.

**Why this is worth an amendment rather than a shrug.** The whole purpose of a
plant is to prove an assertion CAN fail. A green sabotage run gets read as *"my
control is vacuous, my witness proves nothing"* — or worse, the worker starts
tuning the witness until the sabotage reds, chasing a fault that was never being
compiled. Either way the conclusion is about the wrong artefact. It is the same
fail-open family this repo has spent the week deleting: a check reporting a
result about a case it never exercised. The hash rule makes it *more* dangerous,
not less, because the hash is genuine evidence — for a narrower claim than the
worker needs.

## The change

18 lines added, 1 changed, one file. The existing bullet — *"Verify a restore by
hashing the bytes, never by reading `git diff`"*, under **How a gate is run, not
just which one** — now carries its downstream twin:

- hashing proves the **source** changed;
- a watch/compile/bundle check proves the **runtime** changed;
- **a green sabotage run is evidence only once both halves hold.**

It names the three discriminators the worker used or could have used: restart the
watch, assert the plant's own marker appears in the served bundle, or confirm the
build reported recompiling the file you edited. The incident is cited with its
evidence, which is the register the rest of the file already uses — that is what
makes these rules stick rather than read as nagging.

**Extended in place rather than added as a sixth bullet.** The section opens
*"Five rules about the mechanics"*, and this is the same rule's second half
against the same symptom (a false-green sabotage run), one cause further down.
Making it a sibling bullet would have meant re-counting the section and splitting
a pair that only makes sense read together. The bead says *"keep it to that
paragraph"*, and it is kept there. The mid-bullet bolded escalation matches the
existing house pattern (cf. *"The number you quote is the one you captured"* in
the pipe bullet).

## Fences honoured

- **No tooling built, deliberately.** No gate, no script, no checker. `rf2-j9tl`
  declined a prose-checking gate and `rf2-maiw` declined remedies (b) and (c) on
  the same reasoning; the bead applies that judgement here explicitly and so do
  I. This is guidance.
- **No restructuring.** One bullet extended; no headings, links or anchors added
  or moved.
- **`.claude/commands/mayor-*.md` untouched** — loop bodies carry dispatch
  mechanics; this is worker-facing gate mechanics.
- **Sits beside `rf2-maiw` rather than duplicating it.** Branched from
  `7413b6c772` (#7996) and rebased onto `5891dad9b4`, so the current state of the
  file is what I amended. `rf2-maiw` hardened the `gate root:` check and
  worktree-suffixed the gate-artefact names, both further down the same section.
  The two are complementary and I have kept them distinct: **`rf2-maiw`'s fix
  stops you reading *someone else's* result; this one stops you reading a *stale*
  result of your own.** Neither paragraph restates the other.
- I checked the hash rule has only one statement in the tree (`git grep` over
  `docs/the-mayor-method/`), so unlike `rf2-maiw`'s suffix rule there is no second
  carrier to keep in step.

## Quality gates

Each run alone, nothing appended, never piped, redirect and exit code captured on
the same command line. Artefacts named for this worktree
(`gate-*-sabotage-hs3i.log` / `.exit`) — the rule this file states, applied to the
PR amending it.

| Gate | Exit | Note |
|---|---|---|
| `python scripts/check_doc_slugs.py` | `0` | silent on pass |
| `python -m mkdocs build --strict` | `0` | built in 50.27s, no warnings |

Both premises the brief asked me to confirm rather than assume were confirmed at
source:

- **mkdocs genuinely covers this surface.** `mkdocs.yml`'s `exclude_docs` lists
  `tools/playground/`, the two codemod trees, `design/freehand/` and
  `design/hicasso/` — `docs/the-mayor-method/` is not among them, and the built
  page exists at `site/the-mayor-method/dispatch-prompt-template/index.html`.
- **Bare `mkdocs` is not on PATH here**; the `python -m mkdocs` form is what runs.

`check_doc_slugs.py` also genuinely covers this tree rather than skipping it:
`FENCED_DOC_LINK_TREES = ("docs/design/hicasso", "docs/the-mayor-method")`, added
by `rf2-qdqf`. My diff adds no link and no heading, so the gate is close to inert
against it — recorded honestly rather than quoted as though it proved more than
it did.

**I applied this PR's own rule to this PR.** Rather than stopping at "the source
changed", I confirmed the *built* artefact saw the edit: `grep -c "915aaf91"` in
`site/the-mayor-method/dispatch-prompt-template/index.html` returns `1`. Source
hash and runtime evidence, both halves.

No `implementation/` or `spec/` change, no hot-zone file, no other worker's
surface. Generated `site/`, `docs/spec/`, `docs/migration/` and `__pycache__`
residue removed; `git status --porcelain --ignored` is empty, so this worktree
will reap cleanly.
