### PR TITLE
fix(hicasso): the lazy head's Client-only policy is behaviour, not metadata (rf2-hic-041)

### DIFF
--- a/implementation/hicasso/src/re_frame/hicasso/native.cljc
+++ b/implementation/hicasso/src/re_frame/hicasso/native.cljc
@@ -116,7 +116,9 @@
   ## The ABI helpers, and the two directions across the boundary
 
   [[memo]] and [[lazy]] are `react/memo` and `react/lazy` with the tier
-  [[marker]] carried across, and they are the whole helper surface: React
+  [[marker]] carried across — and [[lazy]] additionally behind the
+  Client-only gate its `:server` names, so the server does not fetch a
+  chunk it can do nothing with. They are the whole helper surface: React
   19 hands a function component its `ref` as an ordinary prop, so refs
   need no helper and get none. Neither helper touches props or children —
   the ABI is one raw JavaScript props object at every rung, and a second
@@ -447,12 +449,22 @@
 
   The gate hands its own props straight through, `ref` included, so the
   ABI a `:client-only` island sees is the one a `:render` island sees:
-  one raw JavaScript props object, children at `.-children`."
+  one raw JavaScript props object, children at `.-children`.
+
+  **`f` is an element TYPE and not necessarily a function**, which is
+  what makes [[lazy]] the second caller: a `react/lazy` record is an
+  element type too, so the same gate withholds a chunk from the server
+  exactly as it withholds an island. That caller passes `nil` for the
+  name — a head declared before its component exists has none to give,
+  and its marker is where the name appears on arrival — so the display
+  name is set only when there is one to set. `undefined` there is what
+  React already reads for any anonymous type."
        [component-name f]
        (let [gate (fn [props]
                     (when (codec/adopted?)
                       (react/createElement f props)))]
-         (set! (.-displayName gate) component-name)
+         (when component-name
+           (set! (.-displayName gate) component-name))
          gate))
 
      (defn component
@@ -520,8 +532,16 @@
      ;; wrapper and Xray names an anonymous boundary where an island
      ;; should be. Neither changes the props or children ABI at all: a
      ;; memo passes props through untouched and a lazy resolves TO the
-     ;; component. So the whole of the repair is carrying the two stamps
-     ;; across, and these helpers are deliberately nothing else.
+     ;; component. So carrying the two stamps across is the whole of
+     ;; [[memo]], and it is deliberately nothing else.
+     ;;
+     ;; [[lazy]] carries one thing more, because a lazy head's `:server`
+     ;; is a POLICY and a policy that only the marker knows about is a
+     ;; comment. React calls a pending loader while it is producing
+     ;; server bytes — measured, not assumed (merged-PR audit #7969) —
+     ;; so the head goes behind [[mint-server-gate]], the same gate a
+     ;; Client-only `defcomponent` wears. No second mechanism, and the
+     ;; marker then DESCRIBES the gate instead of standing in for one.
 
      (defn- carry!
        "Copy `f`'s display name and tier marker onto `wrapper`, and answer
@@ -564,7 +584,8 @@
        ([f props=] (carry! (react/memo f props=) f)))
 
      (defn lazy
-       "**`React.lazy`, with the marker intact and the loader unwrapped.**
+       "**`React.lazy`, with the marker intact, the loader unwrapped, and
+  the chunk behind the Client-only gate.**
 
       (def chart-loadable (lazy/loadable app.charts.island/heavy-chart))
       (def heavy-chart (n/lazy #(lazy/load chart-loadable)))
@@ -616,17 +637,44 @@
   arrival the honest answer is that the head has no name, and that is
   what it says.
 
-  **`:server` is `client-only` and is not the inner component's to
-  override.** The server never sent the chunk, so no policy the component
-  declares can make bytes exist: the region is Client-only whatever
-  `n/defcomponent` said.
+  The marker is stamped on the GATE, because the gate is the element
+  type a parent writes and therefore the object every seam is handed.
+  The `react/lazy` record is an implementation detail one fiber below
+  it, exactly as a Client-only island's own function is.
 
-  **Nothing stands in for it on the server unless a DECLARATION says so.**
-  The `defhost` that crosses to this head emits server bytes only where
-  it was given a `:fallback`, and React's own Suspense fallback is not
-  that fallback — it is a prop at a ReactNode slot, and a Client-only
-  region renders nothing at all, slot included. A page that wants a
-  skeleton in its server response declares one.
+  ## The head IS the Client-only gate, and that is the whole of `:server`
+
+  **`:server` is `client-only`, it is not the inner component's to
+  override, and it is BEHAVIOUR rather than a note on the marker.** What
+  this answers is [[mint-server-gate]] — the identical gate a
+  `:client-only` `n/defcomponent` wears, reading the identical
+  [[re-frame.hicasso.impl.codec/adopted?]] — with the `react/lazy` record
+  behind it. So the loader is not called while React is producing server
+  bytes, is not called on hydration's first client pass, and IS called on
+  the first pass of a fresh mount. The chunk is a client artefact and the
+  server never reaches for one.
+
+  **That gate is the mechanism and the marker merely describes it.** The
+  marker alone was the defect: React's `lazyInitializer` runs during
+  `renderToString` like any other render, so an ungated head reached from
+  a native parent — `(n/$ heavy-chart …)` under a `:render` island —
+  fetched the chunk on the server and wrote React's switched-to-client
+  template into the response. Measured in
+  [[re-frame.hicasso.lazy-boundary-dom-cljs-test]], whose control renders
+  a raw `react/lazy` in the same shape and counts the call this one does
+  not make.
+
+  The price is a Client-only island's exactly: one fiber, one hook, no
+  server bytes. Hydration needs no separate argument for the same reason
+  — one gate, already witnessed
+  ([[re-frame.hicasso.native-ssr-dom-cljs-test]]).
+
+  **Nothing stands in for the region on the server unless a DECLARATION
+  says so.** The gate renders `nil`, so the region is absent — React's
+  own Suspense fallback is a prop at a ReactNode slot inside it and is
+  never reached. A page that wants a skeleton in its server response
+  declares one: `defhost`'s `:fallback`, inert markup on the declaration
+  that the crossing renders on the server and on hydration's first pass.
 
   Declared at top level, never in a render — `React.lazy`'s own law.
   Minting inside a body allocates a fresh identity per pass, so the
@@ -640,9 +688,10 @@
                               (fn [component]
                                 (when-some [inner (marker component)]
                                   (unchecked-set m "name" (unchecked-get inner "name")))
-                                #js {:default component}))))]
-         (unchecked-set lazy* tier-sentinel m)
-         lazy*))
+                                #js {:default component}))))
+             head  (mint-server-gate nil lazy*)]
+         (unchecked-set head tier-sentinel m)
+         head))
 
      ;; ----------------------------------------------------------------
      ;; The two hooks (rf2-hic-031)

--- a/implementation/hicasso/test/re_frame/hicasso/lazy_boundary_dom_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/lazy_boundary_dom_cljs_test.cljs
@@ -19,7 +19,8 @@
   | [[a-lazy-boundary-paints-the-fallback-then-the-component-with-the-props-it-was-written-with]] | load, fallback and arrival, with the props and the one child intact across a crossing that was deferred | a bridge that re-ran the loader on arrival; a `:children` slot that lost the single child |
   | [[a-lazy-suspension-retains-the-committed-subscription-and-the-arrival-leaves-exact-ownership]] | the post-commit suspension result, re-measured across a LAZY boundary specifically | a lazy retry that quietly re-subscribed — the screen is right under it |
   | [[a-rejected-lazy-head-re-throws-its-cached-error-and-only-a-fresh-head-reloads]] | rejection is TERMINAL at the payload; `:reset-key` clears the boundary and reloads nothing | the claim, made in this repo until this bead, that changing `:reset-key` retries the chunk |
-  | [[a-client-only-lazy-region-writes-nothing-and-a-declared-fallback-writes-the-skeleton]] | which declaration actually emits server bytes | a region documented as sending a skeleton whose declaration sends nothing |
+  | [[a-client-only-lazy-region-writes-nothing-and-a-declared-fallback-writes-the-skeleton]] | which DECLARATION actually emits server bytes, at the `defhost` crossing | a region documented as sending a skeleton whose declaration sends nothing |
+  | [[a-bare-lazy-head-under-native-suspense-writes-nothing-and-never-calls-its-loader]] | `n/lazy`'s OWN Client-only policy, with nothing in front of it and a raw `react/lazy` control beside it | a policy that lives on the marker while the head stays an ungated lazy record — and a witness whose zero is really two `defhost` gates |
   | [[the-declared-population-was-actually-exercised]] | the roster, asserted rather than described | a row that started returning early |
 
   ## The instrument is the LOADER CALL COUNT, not the paint
@@ -50,10 +51,22 @@
   ## Lanes
 
   `-dom-cljs-test`, so `:browser-test` runs the whole file against a real
-  React DOM. Two rows need no DOM and run under `:node-test` as well: the
-  module gate is pure re-frame, and the server render is
+  React DOM. THREE rows need no DOM and run under `:node-test` as well:
+  the module gate is pure re-frame, and both server rows are
   `renderToString`. Every other row degrades on the node lane to a STATED
-  skip rather than to a green for a render that never happened."
+  skip rather than to a green for a render that never happened.
+
+  ## Two server rows, and why one could not have been both
+
+  They ask different questions and the second is not a widening of the
+  first. Row 5 is about a DECLARATION — which `defhost` key puts bytes in
+  a server response — and it renders through two Client-only hosts
+  because that is the shape it is describing. Row 7 is about `n/lazy`
+  ITSELF, so it must have nothing in front of it: under row 5's shape the
+  loader would stay uncalled even if the lazy head were server-active,
+  which is exactly what merged-PR audit #7969 found when row 5 was the
+  only server row here. A witness dominated by unrelated gates measures
+  the gates."
   (:require [clojure.set :as set]
             [cljs.test :refer-macros [async deftest is testing use-fixtures]]
             [re-frame.adapter.uix :as uix-adapter]
@@ -125,7 +138,8 @@
     :lazy/post-commit-suspension
     :lazy/rejection-is-terminal
     :lazy/fresh-head-reloads
-    :lazy/server-render})
+    :lazy/server-render
+    :lazy/unshadowed-server-gate})
 
 (defonce ^:private !exercised (atom #{}))
 
@@ -229,6 +243,38 @@
 (def ^:private ssr-loader (deferred-loader))
 (def ^:private ssr-head (n/lazy (:load ssr-loader)))
 (h/defhost ssr-host ssr-head)
+
+;; --- scenario 7: the UNSHADOWED server render ------------------------------
+;;
+;; Scenario 6's row is dominated by two `defhost` declarations, each of
+;; them independently Client-only, so it cannot distinguish `n/lazy`'s own
+;; policy from two unrelated gates in front of it (audit #7969). These two
+;; heads sit under NOTHING but React's own Suspense.
+
+(def ^:private bare-loader (deferred-loader))
+(def ^:private bare-head (n/lazy (:load bare-loader)))
+
+;; THE CONTROL, and the row is worthless without it. `renderToString` is
+;; allowed to be inert — a renderer that never reached the region would
+;; leave the count at zero for a reason that has nothing to do with the
+;; gate. This head is `react/lazy` with no gate at all, in the same shape
+;; and through the same `n/$`, and its count says what an ungated head
+;; does here.
+(def ^:private raw-loader (deferred-loader))
+(def ^:private raw-head (react/lazy (fn [] (.then ((:load raw-loader))
+                                                  (fn [c] #js {:default c})))))
+
+(defn- suspense-tree
+  "The shipped shape from the audit's control, written in `n/$`: a
+  Suspense host with a fallback SLOT and one lazy head under it. No
+  `defhost`, no provider, no root element — nothing between
+  `renderToString` and the head but React."
+  [head]
+  (n/$ :div
+       (n/$ :h1 {:id "title"} "metrics")
+       (n/$ (.-Suspense react)
+            {:fallback (n/$ :div {:id "react-fallback"} "loading")}
+            (n/$ head {:points #js [1 2 3]}))))
 
 ;; ---------------------------------------------------------------------------
 ;; Views
@@ -704,14 +750,60 @@
   (exercised! :lazy/server-render))
 
 ;; ---------------------------------------------------------------------------
+;; 7. The UNSHADOWED server render — `n/lazy`'s own policy, alone
+;; ---------------------------------------------------------------------------
+
+(deftest a-bare-lazy-head-under-native-suspense-writes-nothing-and-never-calls-its-loader
+  (testing "THE CONTROL, first, because the row above it is a zero and a
+            zero is what an inert renderer also produces. A raw
+            `react/lazy` head — no gate, no `defhost`, the identical
+            shape — has its loader called ONCE while `renderToString`
+            runs, and React abandons the boundary to the client. That is
+            what `n/lazy` looked like before this bead: React 19's
+            `lazyInitializer` runs during a server render like any other
+            render, so a chunk the server can do nothing with is fetched
+            anyway and the response carries a switched-to-client template
+            instead of the region"
+    (let [html (react-dom-server/renderToString (suspense-tree raw-head))]
+      (is (= 1 @(:calls raw-loader))
+          (str "an ungated lazy head IS reached by the server renderer: " html))
+      (is (re-find #"react-fallback" html)
+          (str "and React wrote the Suspense fallback into the response: " html))
+      (is (re-find #"Switched to client rendering" html)
+          (str "having abandoned the boundary: " html))))
+
+  (testing "and `n/lazy`'s head, in that same shape, with NOTHING in front
+            of it — no `defhost`, no provider, no root element, one
+            Suspense host and the head. The loader is never called: the
+            server does not reach for a chunk it cannot use, and that is
+            the whole of the `:server client-only` the marker advertises.
+            Narrowing caught: the policy living on the marker while the
+            head stayed an ungated `react/lazy` record (audit #7969) —
+            metadata that no renderer reads"
+    (let [html (react-dom-server/renderToString (suspense-tree bare-head))]
+      (is (re-find #"metrics" html)
+          (str "the premise: the render happened and reached the region's
+                sibling, so a zero below is a gate and not an inert
+                renderer — " html))
+      (is (zero? @(:calls bare-loader))
+          (str "THE ROW: the loader was not called — " html))
+      (is (not (re-find #"react-fallback" html))
+          (str "the region is absent entirely, React's fallback slot with
+                it: a gate that renders nil never reaches the prop — " html))
+      (is (not (re-find #"Switched to client rendering" html))
+          (str "and nothing was abandoned to the client, because nothing
+                suspended — " html))))
+  (exercised! :lazy/unshadowed-server-gate))
+
+;; ---------------------------------------------------------------------------
 ;; The roster, asserted rather than described
 ;; ---------------------------------------------------------------------------
 
 (deftest the-declared-population-was-actually-exercised
   (if-not (mount/browser?)
-    (is (set/subset? #{:gate/dedupe-and-retry :lazy/server-render} @!exercised)
+    (is (set/subset? #{:gate/dedupe-and-retry :lazy/server-render :lazy/unshadowed-server-gate} @!exercised)
         (str "the two lane-independent rows must run everywhere; missing "
-             (pr-str (set/difference #{:gate/dedupe-and-retry :lazy/server-render} @!exercised))))
+             (pr-str (set/difference #{:gate/dedupe-and-retry :lazy/server-render :lazy/unshadowed-server-gate} @!exercised))))
     (is (= declared-population @!exercised)
         (str "every declared mechanism must actually have been reached; missing "
              (pr-str (set/difference declared-population @!exercised))))))

--- a/implementation/hicasso/test/re_frame/hicasso/native_abi_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/native_abi_cljs_test.cljs
@@ -21,7 +21,7 @@
   | [[the-children-a-body-reads-are-the-same-through-either-crossing]] | ONE body, rendered from a hiccup parent and from a React parent at 0, 1 and N children, reads the same `:children` — the falsifiable form of the ABI-preserving claim | copying React's `props.children` through unchanged, which is a vector at two children and the element itself at one (audit #7874) |
   | [[n-memo-keeps-the-marker-where-a-raw-react-memo-loses-it]] | the helper's entire reason to exist, with its own control beside it | a `memo` that forwarded the call and stamped nothing |
   | [[n-lazy-is-a-native-head-from-the-moment-it-is-declared]] | a code-split head is recognisable during the whole window it is waiting | a marker minted inside the loader — nil until the chunk lands |
-  | [[a-lazy-region-is-client-only-whatever-its-component-declared]] | the server never sent the chunk, so no declaration can make bytes exist | copying `:server` off the loaded component |
+  | [[a-lazy-region-is-client-only-whatever-its-component-declared]] | the declared policy, and that it is the GATE's and not the loaded component's | copying `:server` off the loaded component; a marker that describes a gate the head does not wear |
   | [[refs-need-no-helper-because-ref-is-an-ordinary-slot]] | why the helper surface is two and not three | a `forward-ref` helper preserving what nothing took away |
 
   ## The DOM half
@@ -405,10 +405,19 @@
 
 (deftest n-lazy-is-a-native-head-from-the-moment-it-is-declared
   (let [head (n/lazy (fn [] (js/Promise.resolve quote-cell*)))]
-    (testing "React's own lazy record, so Suspense and the error boundary
-              treat it exactly as they treat any other"
-      (is (= (unchecked-get (react/lazy (fn [] (js/Promise.resolve #js {}))) "$$typeof")
-             (unchecked-get head "$$typeof"))))
+    (testing "the head is the Client-only GATE — an ordinary element type,
+              with React's lazy record one fiber below it. It is not the
+              raw `react/lazy` record and must not be: React calls a
+              pending loader during `renderToString`, so a head that WAS
+              that record fetched the chunk on the server while its
+              marker said Client-only (audit #7969). Suspense and the
+              error boundary see the suspension from the record below and
+              treat the region exactly as they treat any other, which is
+              a claim about a render and is measured in
+              `re-frame.hicasso.lazy-boundary-dom-cljs-test`"
+      (is (fn? head))
+      (is (not= (unchecked-get (react/lazy (fn [] (js/Promise.resolve #js {}))) "$$typeof")
+                (unchecked-get head "$$typeof"))))
 
     (testing "declared, and already a native head. Narrowing caught:
               stamping the marker on resolve — every seam reading the
@@ -427,10 +436,17 @@
             from one that was never asked for"
     (is (= "render" (unchecked-get (n/marker server-cell*) "server"))))
 
-  (testing "and the lazy head around it is Client-only. The server never
-            sent the chunk, so no declaration inside it can make bytes
-            exist; copying the component's policy up would have the
-            runtime claiming hydration for markup it never emitted"
+  (testing "and the lazy head around it is Client-only. Copying the
+            component's policy up would have the runtime claiming
+            hydration for markup it never emitted.
+
+            This is the DECLARATION and not the mechanism: the marker
+            describes the gate the head wears, and a marker on an ungated
+            head is the exact defect audit #7969 found. What the server
+            actually does — the loader call that does not happen, with a
+            raw `react/lazy` control beside it that does — is
+            `a-bare-lazy-head-under-native-suspense-writes-nothing-and-never-calls-its-loader`
+            in `re-frame.hicasso.lazy-boundary-dom-cljs-test`"
     (let [head (n/lazy (fn [] (js/Promise.resolve server-cell*)))]
       (is (= "client-only" (unchecked-get (n/marker head) "server"))))))
 


### PR DESCRIPTION
Merged-PR audit #7969 found that `n/lazy`'s advertised Client-only policy was a
string on its marker and nothing else: `n/lazy` answered a raw `react/lazy`
record, and neither `n/$` nor the head itself read `{:server "client-only"}` or
installed a gate. The SSR row that appeared to prove otherwise
(`a-client-only-lazy-region-…`) renders through two independently Client-only
`defhost` declarations, so its `(zero? calls)` would have held even if the lazy
head were fully server-active. The witness measured the hosts, not the bridge.

## The defect, re-derived at `origin/main` HEAD

Before writing anything I ran the audit's control against this repo's React
(19.2.0), with no Hicasso in the picture at all — `React.Suspense` over a pending
`React.lazy`, rendered with `renderToString`:

```
loader calls = 1
html = <div><h1 id="title">metrics</h1><!--$!--><template data-msg="Switched to
client rendering because the server rendering aborted due to: The server used
&quot;renderToString&quot; …"></template><div id="react-fallback">loading</div><!--/$--></div>
```

So React calls a pending loader while it is producing server bytes, and writes a
switched-to-client template into the response. A native parent doing
`(n/$ heavy-chart …)` under a `:render` island therefore fetched the chunk on the
server. The claim was false and the defect was live at HEAD.

## Fork taken: **(1) make the claim true**

The audit permits making the claim true or narrowing it to the `defhost`
crossing, and says option 1 must not invent a new gating mechanism — *the same*
gate Client-only native components already use. That gate exists and is already
private to this namespace: `mint-server-gate`, which reads
`re-frame.hicasso.impl.codec/adopted?` and is the whole of the `:client-only`
mechanism for `n/defcomponent`. So option 1 costs one call, not a mechanism, and
the audit's own tie-breaker ("if no such reusable gate exists, that is evidence
for option 2") points the other way.

Against the stance: a lazy head that fetches a client chunk under
`react-dom/server` is a live correctness defect — the server does work it can do
nothing with and abandons the boundary — and the price of the repair is exactly
a Client-only island's, one fiber and one hook. Narrowing the claim instead
would have left a footgun that the tier's own default gates everywhere else.

The change in `n/lazy` is one binding:

```clojure
head (mint-server-gate nil lazy*)
```

The marker moves onto the gate, which is now the element type a parent writes and
therefore the object every seam is handed; the `react/lazy` record sits one fiber
below it, exactly as a Client-only island's own function does. `mint-server-gate`
gained one clause — it sets `displayName` only when given one, because a head
declared before its component exists has no name to give (the marker's `:name`
is still filled on arrival, in the same object, unchanged).

**Hydration needs no new argument, which is the point of reusing the gate.**
`adopted?` is `false` on the server and on hydration's first client pass and
`true` on a fresh mount's first pass, and that conduct is already witnessed by
`a-client-only-island-hydrates-with-nothing-there-and-mounts-after-adoption` in
`native_ssr_dom_cljs_test`. Fresh-mount conduct for the lazy head specifically is
witnessed unchanged by this file's existing `createRoot` rows (fallback→arrival,
post-commit suspension, rejection/retry), which all still pass.

## The new unshadowed server witness

`a-bare-lazy-head-under-native-suspense-writes-nothing-and-never-calls-its-loader`
renders, through `n/$`, the audit's exact shape:

```clojure
(n/$ :div
     (n/$ :h1 {:id "title"} "metrics")
     (n/$ (.-Suspense react)
          {:fallback (n/$ :div {:id "react-fallback"} "loading")}
          (n/$ head {:points #js [1 2 3]})))
```

No `defhost`, no `mount/provider`, no `codec/root-element` — nothing between
`renderToString` and the head but React's own Suspense. It asserts the loader was
never called, that the region is absent *including* React's fallback slot (a gate
that renders `nil` never reaches a prop inside it), and that nothing was
abandoned to the client.

**The loader-call control is in the same deftest and runs first.** `raw-head` is
a bare `react/lazy` in the identical shape through the identical `n/$`, and the
control asserts its loader IS called once and that React DOES write the fallback
and the switched-to-client template. Without it, `(zero? calls)` is also what an
inert renderer produces. With it, the zero is a measurement of the gate.

`a-client-only-lazy-region-…` is retained unchanged: it tests which `defhost`
*declaration* emits server bytes, which is a real and different question. The
file's docstring now says why one row could not have been both.

## Sabotage proof — the witness bites, and the restore is hash-verified

One line, anchored to a single binding in `n/lazy`: `head (mint-server-gate nil lazy*)`
→ `head lazy*`. That is exactly the pre-repair shape.

| step | sha256 of `implementation/hicasso/src/re_frame/hicasso/native.cljc` |
|---|---|
| before plant | `0b2b0c69c6251fce8139086f4eac62c7c4d424b95e6ab6fb2af189159e12f5e2` |
| after plant | `1fdb1937828d2c4c7c601ce62f1f3bf2f5d0f1398a6e28f6ebd201d6b275b36a` |
| after restore | `0b2b0c69c6251fce8139086f4eac62c7c4d424b95e6ab6fb2af189159e12f5e2` |

The hashes differ across the plant, so the patch really applied — a clean `git diff`
alone cannot tell an exact restore from a plant that never landed. `npm run test:cljs`
under the plant: **exit 1**, 5 failures, and the new row named the loader call:

```
FAIL in (a-bare-lazy-head-under-native-suspense-writes-nothing-and-never-calls-its-loader)
  (lazy_boundary_dom_cljs_test.cljs:788:11)
THE ROW: the loader was not called — <div><h1 id="title">metrics</h1><!--$!--><template
  data-msg="Switched to client rendering because the server rendering aborted…"
expected: (zero? (clojure.core/deref (:calls bare-loader)))
  actual: (not (zero? 1))
```

The other four are the same defect at its other assertions (the fallback and the
switched-to-client template reappear; `n-lazy-is-a-native-head-…` sees the raw lazy
record again). **The control row stayed GREEN under the plant** — it is measuring
React, not the gate, which is what makes it a control.

## Quality gates

Every gate run alone, redirected with its exit code captured on the same command
line, logs named for this worktree. `gate root:` in the spine log reads
`/c/Users/miket/code/re-frame2-worktrees/lazybridge-hic041` — checked, it is mine.
All figures below are from runs on the **rebased** base (`e7b9924f4b`, PR #7994's
new gate matrix).

| gate | exit | notes |
|---|---|---|
| `npm run test:cljs` (node lane — **deciding; the SSR behaviour lives here**) | **0** | 13639 tests / 69049 assertions, 0 failures, 0 errors |
| `sh scripts/test-fast-pr.sh` | **0** | see the "what it actually ran" note below |
| `npm run test:browser` | **0** | 1393 tests / 8642 assertions, 0 failures, 0 errors — this is where the lazy head's FRESH-MOUNT rows live (fallback→arrival, post-commit suspension, rejection/retry), all unchanged and all still green behind the new gate |
| `python scripts/check_fast_pr_gap.py --list` | **0** | 95 required checks the spine does not run |
| `npm run test:cljs` **under sabotage** | **1** | intended red — the proof above |

**What the spine actually ran, since a green can be narrow.** It classified
`docs=false jvm=false node=true`, so the JVM and docs lanes were surface-gated away
— correct, this diff touches no JVM artefact and no docs page. It did run, in full:
the CLJS `:node-test` lane (the 13639-test figure above is from inside the spine, on
the rebased base), the **pinned clj-kondo lane at 2026.04.15** — the one PR #7994
added, and the one whose `--lint` roots now finally cover
`implementation/hicasso/src/` — reporting **errors: 0** (4549 warnings, all
pre-existing, none in either file I touched), plus the hicasso invariants gate and
the hicasso compile gate.

**Required checks this spine does not decide** (`check_fast_pr_gap.py --list`, 95
of them; the ones plausibly reachable by this diff):

- `test.yml` / `All required checks passed`: `cljs-browser` — run locally, see the
  table; `cljs-hicasso-controlled`, `cljs-hicasso-hmr`, `cljs-bundle-isolation`,
  `cljs-elision`, `cljs-perf-bundle`, `cljs-examples-compile`, `ui-smoke`,
  `adapter-testbed-smokes`, and the step *"Hicasso release build (:advanced,
  goog.DEBUG false)"* which lives inside the `CLJS (shadow-cljs :node-test)` job.
- `lint.yml` / `Lint required`: `splint`, `eslint`, `api-manifest`, `detect`. The
  clj-kondo half IS decided locally now, at CI's pin.
- `docs.yml` / `Docs required`: `detect` only — no docs page changed.

## Audit #7914's earlier repairs: intact and untouched

Verified present on `origin/main` before I started and unchanged by this branch:

- **Both `:loading` and `:loaded` gate the module event** —
  `lazy_boundary_dom_cljs_test.cljs:120`,
  `(when-not (contains? #{:loading :loaded} …))`, with the comment above it
  explaining the hover-then-click race. Untouched.
- **The identity-replacing rejection retry** —
  `a-rejected-lazy-head-re-throws-its-cached-error-and-only-a-fresh-head-reloads`
  (line 619) with its two heads over one loader and the `(= 1 …)` / `(= 2 …)`
  loader counts. Untouched.
- **The declared server/fallback path** — `suspense-skeleton-host` with
  `:fallback [:div {:id "server-skeleton" :aria-busy true} …]` and the row that
  measures it. Untouched.

`git diff origin/main` on the witness file is **99 insertions / 7 deletions**, and
all seven deletions are in the namespace docstring's row table, the lanes
paragraph, and the `declared-population` roster. No existing assertion changed.

## What I did NOT touch

- `implementation/shadow-cljs.edn` — **not touched.** The new rows are
  `renderToString` in the existing `lazy_boundary_dom_cljs_test` namespace, so no
  new build id was needed. The bead's hot-zone flag stays unspent.
- `spec/**`, `.github/workflows/**`, root `scripts/**` — not touched.
- `implementation/core/**`, `implementation/adapters/**` — not touched.
- `rf2-hic-046` — not widened into, and no duplicate filed against it.
