### PR TITLE
docs(hicasso): register hic-034's deterministic island-band figures (rf2-373v)

### DIFF
--- a/docs/design/hicasso/product/budgets.md
+++ b/docs/design/hicasso/product/budgets.md
@@ -149,6 +149,9 @@ it exists to make assertable.
 | D11 | Prop-pipeline entries a direct return drops (`codec/convert-props`) | **3** | as D10 | as D10 — reads 3 against a floor of 0 |
 | D12 | Event-lowering entries a direct return drops (`intent/lower-prop`) | **2** | as D10 | as D10 — reads 2 against a floor of 0 |
 | D13 | Controlled-repair entries a direct return drops (`controlled/install!`) | **3** | as D10 | as D10 — reads 3 against a floor of 0 |
+| D14 | Wrappers between the element type React reconciles and the author's own function, declared island | **0** | `three_way_parity_cljs_test` | the `:client-only` default answers a gate instead; UIx's route answers a generated component |
+| D15 | Slots on the props object React carries, and they are the author's own | **1** | as D14 | UIx's route also reads 1 — but the slot is `argv`, which the author never wrote |
+| D16 | Unwrapping hops per render, per component, native and handwritten React | **0** | as D14 | the UIx route reads 1 — the `argv` carrier being opened |
 
 **These figures are cited, not re-derived.** D1–D8 were established by the two
 witness apps that landed on `main` ahead of this page; re-deriving them here
@@ -196,6 +199,37 @@ a window a duration can be attributed in. Nothing in D10–D13 licenses a claim
 about how much faster a direct return is, and a reader wanting the remedy's
 price must wait for that row rather than read one off these. It is tracked as
 `rf2-5yn9`.
+
+**On D14–D16 — the island band's structural half (`rf2-hic-034`).** These read the
+construction cost of a native island as a structural fact rather than as a clock,
+over one subject written three times: a cell that paints a label, as a declared
+native island, as a handwritten React component, and as a UIx component. D14 is
+the element type each route hands React — the native tier's is `identical?` to the
+author's own function, and so is the handwritten arm's, so nothing sits between
+React and the body. D15 reads the props object React then carries: one slot on
+every route, and on those two arms it is the author's own `label`. D16 is what the
+first two make of the third. UIx's element type is a generated component and its
+one slot is `argv`, a carrier `uix/$` builds around the map the author wrote, so
+that route pays one unwrapping hop per render per component where the other two
+pay none.
+
+**This is a stronger reading than a timing, not a weaker one.** A declared island
+and a handwritten React component are the same element type carrying the same
+props object, so there is no interposed work for a stopwatch to find — a thing a
+counter can decide and a clock could only fail to detect. It is also why §6
+requires the native tier to be co-instrumented against handwritten React and not
+against UIx alone: a floor set by UIx would have D16's hop inside it.
+
+Three qualifications, in the order a reader meets them. **The band is stated over
+the DECLARED arm** — since `rf2-hic-046` the `:client-only` default answers a gate
+rather than the author's function, costing one fiber and one hook the declared arm
+does not, and that is the ruled price of a conservative default rather than a
+figure about `n/defcomponent`. **They are counts and identities, not clocks**, so
+like D10–D13 they carry no hardware profile, which is what lets them sit in this
+section rather than §4. And **they are the deterministic half of C7 only**: they
+say there is no interposed work, never how long a render takes, so C7 stays
+`UNPINNED` and its clock half remains `rf2-hic-071`'s, along with the ladder re-pin
+and the package-resident clock instrument that half needs.
 
 **On D9.** This is teardown residue in **counters and objects**, which is a
 deterministic reading the package can make. It is *not* S5, the teardown row
@@ -511,7 +545,7 @@ and no figure may be scaled from one onto the other.
 
 | Family | Enforcement home |
 |---|---|
-| Deterministic rows D1–D13 | ordinary blocking PR gates; framework in `rf2-hic-089`, full gates in `rf2-hic-071` |
+| Deterministic rows D1–D16 | ordinary blocking PR gates; framework in `rf2-hic-089`, full gates in `rf2-hic-071` |
 | Distributional rows S1–S7, U1–U4 | pinned interleaved evidence runs on P-DEV-1; never converted into flaky PR thresholds |
 | Shell breach disposition | `rf2-hic-018` |
 | K3 per-read record | `rf2-hic-070` — [`k3-disposition.md`](k3-disposition.md), whose §8 makes the 10% same-witness per-read rule executable for `rf2-hic-071` |
@@ -564,7 +598,14 @@ user-visible budgets behave differently in tier (§1's accepted limitation is
 the standing invitation); a package-resident heap instrument producing shell or
 per-read figures materially apart from S1–S4 (§6 says how to build it); the
 operator freezing the byte line somewhere other than the §5 recommendation; or
-any deterministic row D1–D13 moving without a topology change to explain it.
+any deterministic row D1–D16 moving without a topology change to explain it.
+
+**On the scope of the run above.** The table records the confirmation this page
+took at `0c0aa22898`, which is the browser lane and therefore D1–D9. D10–D13 and
+D14–D16 landed later and run in the node lane, each with its own witness named in
+§9's ledger and run by every pull request; the falsification clause is stated over
+all sixteen because the claim it makes — a deterministic row does not move without
+a topology change — is the same claim whichever lane decides it.
 
 ---
 
@@ -648,6 +689,9 @@ today. *Disposition* is a link that must resolve to a section naming the row.
 | D11 | 3 prop-pipeline entries dropped by a direct return (`codec/convert-props`) | 3 — the hiccup arm reads 3 against a floor of 0 | package | `MET` | `implementation/hicasso/test/re_frame/hicasso/direct_return_cljs_test.cljs` (PR gate) | `rf2-hic-033` | — |
 | D12 | 2 event-lowering entries dropped by a direct return (`intent/lower-prop`) | 2 — the hiccup arm reads 2 against a floor of 0 | package | `MET` | `implementation/hicasso/test/re_frame/hicasso/direct_return_cljs_test.cljs` (PR gate) | `rf2-hic-033` | — |
 | D13 | 3 controlled-repair entries dropped by a direct return (`controlled/install!`) | 3 — the hiccup arm reads 3 against a floor of 0 | package | `MET` | `implementation/hicasso/test/re_frame/hicasso/direct_return_cljs_test.cljs` (PR gate) | `rf2-hic-033` | — |
+| D14 | 0 wrappers between the element type React reconciles and the author's own function, declared island | 0 — the type is `identical?` to the function, on the native and handwritten-React routes alike; UIx's is a generated component | package | `MET` | `implementation/hicasso/test/re_frame/hicasso/three_way_parity_cljs_test.cljs` (PR gate) | `rf2-hic-034` | — |
+| D15 | 1 slot on the props object React carries, and it is the author's own | 1 — `label`, the name the call site wrote; UIx also reads 1, and it is the `argv` carrier | package | `MET` | `implementation/hicasso/test/re_frame/hicasso/three_way_parity_cljs_test.cljs` (PR gate) | `rf2-hic-034` | — |
+| D16 | 0 unwrapping hops per render, per component, native and handwritten React | 0 — the UIx route reads 1, opening `argv` | package | `MET` | `implementation/hicasso/test/re_frame/hicasso/three_way_parity_cljs_test.cljs` (PR gate) | `rf2-hic-034` | — |
 | S1 | 1,024 B, R=0 shell, Reagent segment | 1,100 B [1,091–1,107] | package | `BREACH` | P0 heap ladder, package candidate arm (P-DEV-1 evidence run) | `rf2-hic-018` | [substrate-decision §5.2](substrate-decision.md#52-the-read-free-boundary-shell--the-disposition) |
 | S2 | 1,024 B, R=0 shell, UIx segment | 1,095 B [1,087–1,101] | package | `BREACH` | P0 heap ladder, package candidate arm (P-DEV-1 evidence run) | `rf2-hic-018` | [substrate-decision §5.2](substrate-decision.md#52-the-read-free-boundary-shell--the-disposition) |
 | S3 | ≤ 10% regression on the same pinned witness | 1,417 vs Reagent 948 per read | package | `UNRESOLVED` | P0 heap ladder, package candidate arm (P-DEV-1 evidence run) | `rf2-hic-070` | [substrate-decision §6](substrate-decision.md#6-what-this-page-does-not-decide) |
@@ -673,7 +717,7 @@ today. *Disposition* is a link that must resolve to a section naming the row.
 
 <!-- rf2-hic-089: end-ledger -->
 
-Thirty-five rows: the thirteen deterministic figures of §3, the seven distributional
+Thirty-eight rows: the sixteen deterministic figures of §3, the seven distributional
 rows and six user-visible budgets of §4, the eight comparative rules §4 now
 gives ids to, and one row registered off this page — **I9**, the two-hook
 ceiling frozen by
@@ -719,11 +763,17 @@ points here, and here is what each is waiting on.
   the quality floor. This is a property of the readings rather than of the
   rig, so it is `UNPINNED` rather than `UNRESOLVED`: nothing crossed a line,
   because nothing reached one.
-- **`C7` and `C8` have no population yet.** The native-island rule and the
-  escape-benefit rule are both stated over landed escapes and islands, and the
-  apps that would carry them are `rf2-hic-034`, `rf2-hic-047` and `rf2-hic-045`.
-  `rf2-hic-071` names them as the beads it extends over, which is the same
-  statement from the other side.
+- **`C8` has no population yet, and `C7` no longer does.** The native-island rule
+  and the escape-benefit rule are both stated over landed escapes and islands,
+  and the apps that would carry them are `rf2-hic-034`, `rf2-hic-047` and
+  `rf2-hic-045`. `rf2-hic-034` has landed, bringing `C7` its population and the
+  deterministic half of its band — D14–D16 above, the structural question a
+  hosted runner is allowed to decide. `C7` stays `UNPINNED` for the other half
+  only: no package-resident clock instrument exists to take the reading, the 5%
+  rule has no same-instrument anchor until the ladder is re-pinned, and §7
+  forbids converting a distributional row into a pull-request threshold in any
+  case. All three are `rf2-hic-071`'s, which names these beads as the ones it
+  extends over — the same statement from the other side.
 - **`C5` and `C6` are rules whose readings have been dispositioned, and the
   rules have not.** `C5` is the shell rule; its evidence is `S1` and `S2`,
   carried red by the substrate decision's §5.2. `C6` is the per-read rule; its

--- a/docs/design/hicasso/product/budgets.md
+++ b/docs/design/hicasso/product/budgets.md
@@ -763,7 +763,7 @@ points here, and here is what each is waiting on.
   the quality floor. This is a property of the readings rather than of the
   rig, so it is `UNPINNED` rather than `UNRESOLVED`: nothing crossed a line,
   because nothing reached one.
-- **`C8` has no population yet, and `C7` no longer does.** The native-island rule
+- **`C8` has no population yet; `C7` now has one.** The native-island rule
   and the escape-benefit rule are both stated over landed escapes and islands,
   and the apps that would carry them are `rf2-hic-034`, `rf2-hic-047` and
   `rf2-hic-045`. `rf2-hic-034` has landed, bringing `C7` its population and the

--- a/implementation/hicasso/scripts/check_budget_ledger.py
+++ b/implementation/hicasso/scripts/check_budget_ledger.py
@@ -156,7 +156,9 @@ LANES = ("PR gate", "P-DEV-1 evidence run", "none")
 #
 # This is a REGISTRY, not a rule: it transcribes which ids §3 registers, so it
 # grows when §3 does.  `rf2-hic-033` added D10–D13, the direct-return delta,
-# and §3 states the test this list applies in terms — *they are counts, not
+# and `rf2-hic-034` added D14–D16, the island band's structural half — element
+# type identity, props-object slots and the unwrapping hop those two price.
+# §3 states the test this list applies in terms — *they are counts, not
 # clocks, so they are deterministic and carry no hardware profile; that is
 # what lets them sit in this section rather than §4*.  Note which way the
 # entry cuts: a row NAMED here must run in the `PR gate` lane and must name a
@@ -164,7 +166,7 @@ LANES = ("PR gate", "P-DEV-1 evidence run", "none")
 # that lane and has its witness checked not at all.  Adding an id tightens
 # this gate; leaving a deterministic id out is the loophole.
 DETERMINISTIC_IDS = frozenset(
-    ["D%d" % n for n in range(1, 14)] + ["U5", "U6", "I9"])
+    ["D%d" % n for n in range(1, 17)] + ["U5", "U6", "I9"])
 
 # L4.  Rows registered somewhere other than budgets.md, with the anchor that
 # registers them.  Held here rather than in a ledger column because it is a
@@ -177,12 +179,13 @@ EXTRA_ROWS = {
 # `rf2-fe0l` (PRs #7939, #7941) re-pinned S1–S5 on `implementation/hicasso`
 # and left S6, S7 and U1–U4 exactly where they were.  Changing one of these
 # is a deliberate act — a new measurement window and an edit here — which is
-# the whole point.  D10–D13 join the D rows' `package` pin on the same terms:
-# `rf2-hic-033` took them on `implementation/hicasso` and §3's heading is what
-# they landed under.  An unpinned row is the hole this constant exists to
-# close, so a new row is pinned as it lands rather than later.
+# the whole point.  D10–D13 and D14–D16 join the D rows' `package` pin on the
+# same terms: `rf2-hic-033` and `rf2-hic-034` took them on
+# `implementation/hicasso` and §3's heading is what they landed under.  An
+# unpinned row is the hole this constant exists to close, so a new row is
+# pinned as it lands rather than later.
 POPULATION_PIN = dict(
-    [("D%d" % n, "package") for n in range(1, 14)]
+    [("D%d" % n, "package") for n in range(1, 17)]
     + [("S%d" % n, "package") for n in range(1, 6)]
     + [("S6", "bench-tree"), ("S7", "bench-tree")]
     + [("U%d" % n, "—") for n in range(1, 5)]


### PR DESCRIPTION
Registers `rf2-hic-034`'s three deterministic island-band figures as ledger rows
D14–D16, following `f1185fabc6`'s precedent for D10–D13 exactly: the rows are
added to budgets.md §3 and §9, and the gate's two id registries are widened to
match.

## The three figures, as the witness gives them

Read off `implementation/hicasso/test/re_frame/hicasso/three_way_parity_cljs_test.cljs`'s
own rows, not transcribed from the dispatch brief. **They agree with the brief
in substance and I found no discrepancy**; what follows is the file's own
wording and assertions.

| | The figure | The witness's assertion |
|---|---|---|
| **D14** | A declared native island's element type **is** the author's own function — 0 wrappers. So is the handwritten-React arm's. UIx's is a generated component. | `(is (identical? native-cell (.-type (n/$ native-cell #js {:label "42"}))))`, and the same sentence for `react-cell`; UIx is stamped `(is (true? (.-uix-component? uix-cell)))` |
| **D15** | The props object React carries has **one** slot on every route. On the native and handwritten arms it is the author's own `label`; on UIx it is `argv`, which the author never wrote. | `(is (= ["label"] (slots (n/$ native-cell …))))`, `(is (= ["label"] (slots (react/createElement react-cell …))))`, `(is (= ["argv"] (slots (uix/$ uix-cell …))))` — plus `(is (nil? (.-label (.-props uix-el))))` |
| **D16** | Therefore **0** unwrapping hops per render per component on the native and handwritten-React routes, and **1** on UIx. | the consequence the two deftests state in terms: *"one unwrapping hop per render, per component, on the UIx route and ZERO on the other two"* |

The witness names the reason this matters beyond bookkeeping, and §3's new
paragraph carries it: a floor set by UIx would have D16's hop inside it, which
is why §6 requires the native tier to be co-instrumented against handwritten
React and not against UIx alone.

Nothing was re-measured and no measurement window was opened. These are
deterministic structural facts that were already established when
`rf2-hic-034` landed; this PR registers them.

## Yes, this edits the gate as well as the page — and why

Stating it plainly, as `f1185fabc6` did for the same reason. **L6 classifies a
row by id, and both of its id registries stopped at D13.** An honest D14 — a
package figure whose witness a pull request runs — reds as *"a distributional
row wired to the PR-gate lane"*.

That is not hypothesis. It is the state of the tree at the intermediate commit,
observed before the gate was touched:

```
$ python implementation/hicasso/scripts/check_budget_ledger.py     # page edited, gate not
FAIL: Hicasso budget-line reconciliation ledger

  L6 D14 is a distributional row wired to the PR-gate lane. …
  L6 D15 is a distributional row wired to the PR-gate lane. …
  L6 D16 is a distributional row wired to the PR-gate lane. …
exit 1
```

The two ways to green that without touching the gate are to write a false lane
or to drop the rows, and the gate's own message names the second as the thing
it exists to stop. Both registries therefore widen from `range(1, 14)` to
`range(1, 17)`. **No rule is changed, no threshold moved, no id removed.**

## Negative control — the gate demonstrably sees these rows

Four plants against the real page, each run through the real gate, each restored
from a pristine copy. **Restores verified by hashing the bytes**, not by reading
a diff: a patch that never applied and an exact restore give the identical clean
diff. Hashes below are of the **shipped** file: pristine `budgets.md` =
`9a1ab9c8c12c8efadecd8f5d06781023465ace62752197b094874e9e7fa5c7b1`, unchanged
gate = `25a45de3930f346a845f714dede98899309f0994920928b95a7fa770db85067b`.

| Plant | Planted sha256 (moved) | Exit | The gate's own words | Restored sha256 |
|---|---|---:|---|---|
| **A** L4 — D16's ledger row deleted, its §3 registration left standing | `cef6162d…3e36a` ✔ | `1` | `L4 D16 is registered in budgets.md and has no ledger row. Dropping a row is the cheapest way to make a ledger green` | `9a1ab9c8…5c7b1` ✔ identical |
| **B** L6 — D14 moved out of the blocking lane | `b23b082f…332a7` ✔ | `1` | `L6 D14 is a deterministic row in the 'P-DEV-1 evidence run' lane. A counter reads the same on a loaded box…` | `9a1ab9c8…5c7b1` ✔ identical |
| **C** L5 — D15 demoted to `bench-tree` | `2c2355b4…bde73` ✔ | `1` | `L5 D15 is pinned to the package population and reads 'bench-tree'. rf2-fe0l settled which rows are package figures; promoting one is a measurement window, not a cell edit` | `9a1ab9c8…5c7b1` ✔ identical |
| **D** L6 — D16 pointed at a witness that does not exist | `1d34017c…12b212` ✔ | `1` | `L6 D16 names the witness implementation/hicasso/test/re_frame/hicasso/no_such_witness_cljs_test.cljs, which does not exist` | `9a1ab9c8…5c7b1` ✔ identical |

The plant harness fails loudly if a doctored text does not apply, so none of
these controls is vacuous. B and D are the same pair `f1185fabc6` proved for
D10–D13, and they show which way the registry entry cuts: **outside**
`DETERMINISTIC_IDS`, L6 only forbids the `PR gate` lane and never checks the
witness; **inside** it, that lane is required and the named file must exist.
C is the `POPULATION_PIN` half — before this PR these rows had no entry, so any
population passed. All three plants were silent before the widening.

## Does rf2-uomk's reachability change affect how these rows are exercised?

**Yes, and decisively in this PR's favour.** `e7b9924f4b` / `ec07186dbf`
(PR #7994) made the budget-ledger gate an **unconditional** `hicasso-budget-ledger`
job in `test.yml`, running `--self-test` and then the live read, rather than
leaving it reachable only through the `cljs` job's `npm run test:hicasso-invariants`
chain under `cljs_node_test`.

Probing this branch's own classifier settles what that buys:

```
$ .github/scripts/report-changed-surfaces.sh docs/design/hicasso/product/budgets.md
cljs_node_test=false          ← a LEDGER-ONLY edit skips the npm-chain home entirely

$ .github/scripts/report-changed-surfaces.sh implementation/hicasso/scripts/check_budget_ledger.py
cljs_node_test=true

$ .github/scripts/report-changed-surfaces.sh <both, i.e. this PR's diff>
cljs_node_test=true
```

So this PR arms the chain home too — but only *incidentally*, because L6 forced
me to edit the gate. Had the registries already reached D16, this would have
been a page-only diff and the chain would have skipped it, which is exactly the
hole rf2-uomk names. After rf2-uomk, D14–D16 are exercised on every pull
request through the unconditional job regardless, and any future ledger-only
edit to these rows is too. The job's `--self-test` step also exercises the
widened registries through its own L5/L6 cases.

## What else moved on the page, and what deliberately did not

Three counting sentences follow the rows, per §7/§8/§9's own conventions:

- **§7's routing table** now reads `Deterministic rows D1–D16`.
- **§8's falsification clause** is stated over `D1–D16`, with a new paragraph
  noting the scope of the run table above it: that table records the browser
  lane's confirmation at `0c0aa22898`, which is D1–D9, while D10–D13 and
  D14–D16 run in the **node lane** (verified in both witnesses' docstrings:
  `three_way_parity_cljs_test` says *"runs under `:node-test`"*,
  `direct_return_cljs_test` says *"reachable in the node lane"*). No row was
  added to §8's run table, because these figures were not part of that run.
- **§9's roster sentence** reads *thirty-eight rows … the sixteen deterministic
  figures of §3* (16 + 7 + 6 + 8 + 1 = 38).

**C7's row is untouched.** It stays `UNPINNED`, population `—`, authority
`rf2-hic-071`, disposition §9.2 — the gate's UNPINNED count is 10 before and
after. This PR pins the deterministic half only; the clock half needs the
ladder re-pin and the package-resident clock instrument `rf2-hic-071` owns, and
§3's new paragraph says so in terms.

**One judgement call worth flagging for review.** §9.2's bullet opened
*"`C7` and `C8` have no population yet … the apps that would carry them are
`rf2-hic-034`, `rf2-hic-047` and `rf2-hic-045`"*, which `rf2-hic-034`'s landing
made false for C7 — the witness's own docstring says it *"lands the population
and the DETERMINISTIC half of the band"*. Leaving it would have had §3 cite
rf2-hic-034 as landed while §9.2 spoke of it as a future app. The bullet is
corrected to say C7 now has its population and stays `UNPINNED` for the clock
half alone. **This changes no cell of C7's row** — status, population,
authority and disposition are all as they were. Revert this hunk if the
mayor would rather it wait for `rf2-hic-071`.

**`rf2-l50z`'s S3 ratom-segment row was not touched.** No collision: this diff
does not reach the S-rows.

## Quality gates

Each run alone, nothing appended, exit code captured on the same command line
and quoted from my own capture.

| Gate | Exit | Note |
|---|---:|---|
| `python implementation/hicasso/scripts/check_budget_ledger.py` — **the deciding gate** | **0** | `OK: 38 ledger rows -- 21 MET, 5 BREACH, 2 UNRESOLVED, 10 UNPINNED.` MET rises 18 → 21; UNPINNED unchanged at 10, which is C7 staying put. |
| `python implementation/hicasso/scripts/check_budget_ledger.py --self-test` | **0** | `OK: check_budget_ledger self-test passed (38 rows: …)` — drives every published rule red in turn, so the green above is a verdict rather than a checker that stopped firing. |
| `npm run test:hicasso-invariants` | **0** | the full chain the bead names — freeze, optional-module reachability, complaint catalogue, then the ledger gate's self-test and live read. |
| `python scripts/check_doc_slugs.py` | **0** | budgets.md is a docs page; this is what validates `docs/design/**` link targets and heading anchors. |
| `python scripts/check_provenance_pins.py --changed-since origin/main` | **0** | the mode `docs.yml` runs. The unscoped full-corpus audit exits 1 on a **pre-existing** backlog of stranded pins in `docs/design/hicasso/studio/**`; `budgets.md` appears nowhere in that report, and this diff adds no SHA pin. |
| `sh scripts/test-fast-pr.sh` | **1** | classified `docs=true jvm=false node=true`; `gate root:` confirmed as this worktree. **Environmental, and provably upstream of this diff — see below.** Every docs-tier and lint-tier stage passed, including the spine's own provenance check on changed pages (`1 files, 4 cited pins (4 landed, 0 stranded, 0 unresolvable, 0 foreign)`), `mkdocs --strict`, clj-kondo, and the whole JS harness self-test tier. |

### The one red, and why it is not this diff's

The spine's last stage, `CLJS node integration`, failed:

```
> node scripts/compile-node-test.cjs node-test out/node-test.js && node out/node-test.js
compile-node-test: could not resolve shadow-cljs: Cannot find module 'shadow-cljs/cli/runner.js'
FAIL CLJS node integration
```

That is **module resolution failing before a single source file is read**: this
is a fresh worker worktree and I deliberately did not create the
`implementation/node_modules` junction, so shadow-cljs is not installed in it.
`ls implementation/node_modules` → absent here; the mayor checkout's real one is
intact at 101 top-level entries, untouched, because no junction was ever made
and so none had to be removed.

It cannot be caused by this diff in any case — the diff is one markdown page and
one Python script, and neither is on any CLJS classpath.

**CI answers the question properly, on a machine that has the dependencies.**
Because the gate file lives under `implementation/hicasso/**`, this PR arms
`cljs_node_test=true`, so `CLJS (shadow-cljs :node-test)` runs here rather than
skipping — which also means `three_way_parity_cljs_test`, the witness D14–D16
name, is executed by this very pull request. **That job's result is the one to
read for this stage, not my local capture.**

**CI has now settled, fully green: 27 pass, 0 fail, 0 pending** (65 skipping).
The checks that matter for this change:

| CI check | Result |
|---|---|
| **`CLJS (shadow-cljs :node-test)`** — the stage my worktree could not run, carrying `three_way_parity_cljs_test` itself | **pass** |
| **Hicasso budget-ledger contract (rf2-hic-089)** — the deciding gate, and rf2-uomk's unconditional job | **pass** (11s) |
| MkDocs build · Provenance pins · Detect docs surface | pass |
| `CLJS (shadow-cljs :browser-test)` · hicasso controlled-input · hicasso HMR contract | pass |
| Hicasso complaint-catalogue contract (rf2-hic-021) · Repo invariant checks · Beads PR boundary | pass |
| clj-kondo · Splint · Lint required · Public-API manifest drift-check | pass |

So the local red is fully accounted for and nothing about it is outstanding.

`mkdocs build --strict` is **not** the gate for this edit and was not run:
`mkdocs.yml`'s `exclude_docs` keeps `design/hicasso/` out of the site.
Per CLAUDE.md, since nothing validates this tree's tables or rendering, I
verified them by hand: a mechanical pass over all 14 markdown tables on the
page reports every one rectangular, with §3 now 16 rows × 5 columns and §9's
ledger 38 rows × 8 columns (the gate independently enforces the 8-cell shape
and parsed all 38 rows without raising). No headings and no links were added,
and `check_doc_slugs.py` covers the anchors that already existed.

Closes rf2-373v.
