### PR TITLE
test(core): the resource read-path guard, and the spine's ambient hook under SSR (rf2-w67y, rf2-5rqn)

### DIFF
--- a/implementation/adapters/uix/test/re_frame/adapter/uix_use_subscribe_dom_cljs_test.cljs
+++ b/implementation/adapters/uix/test/re_frame/adapter/uix_use_subscribe_dom_cljs_test.cljs
@@ -32,6 +32,7 @@
             [re-frame.core :as rf]
             [re-frame.frame :as frame]
             [re-frame.adapter.uix :as uix-adapter]
+            [re-frame.adapter.context :as adapter-context]
             [re-frame.adapter.react-shared-suite :as suite]
             [re-frame.test-support :as test-support]))
 
@@ -75,6 +76,25 @@
   (let [v (uix-adapter/use-subscribe [:rf.uix-use-subscribe-test/k])]
     (swap! probe-frame-provider-observed conj v)
     ($ :div (str "k=" v))))
+
+;; ---- rf2-5rqn: which context slot does the SERVER renderer populate? -------
+;; Reads all three observation points off the SHARED frame-context during a
+;; render, so the suite can pin the MECHANISM of the SSR refusal rather than
+;; only its symptom: the private `_currentValue` slot (what the
+;; `:adapter/current-frame` reader consults), the private `_currentValue2`
+;; slot (React's secondary-renderer slot), and the PUBLIC `useContext` return
+;; (renderer-agnostic). Deliberately calls no re-frame hook — it must render
+;; under `react-dom/server` without tripping the very refusal being measured.
+
+(def ^:private ssr-slot-observed (atom nil))
+
+(defui ProbeSsrSlots []
+  (let [ctx adapter-context/frame-context]
+    (reset! ssr-slot-observed
+            {:current-value  (.-_currentValue ^js ctx)
+             :current-value2 (.-_currentValue2 ^js ctx)
+             :use-context    (React/useContext ctx)})
+    ($ :div "slots")))
 
 ;; ---- use-frame probe (rf2-y6dz8t) ------------------------------------------
 ;; Pushes each render's `use-frame` ops map into a side-channel atom; the
@@ -318,6 +338,12 @@
    :probe-frame-provider-observed probe-frame-provider-observed
    :frame-provider-frame          :rf.uix-use-subscribe-test/frame-provider-frame
    :frame-provider-query          :rf.uix-use-subscribe-test/k
+   ;; rf2-5rqn — the ambient (1-arg) form under `react-dom/server`. Its own
+   ;; frame: the row is a COLD server render and must not read a sub-cache
+   ;; some earlier browser-lane row warmed.
+   :ssr-ambient-frame             :rf.uix-5rqn/ssr-ambient-frame
+   :probe-ssr-slots-element       (fn [] (uix/$ ProbeSsrSlots))
+   :ssr-slot-observed             ssr-slot-observed
    ;; rf2-y6dz8t — use-frame (capture-frame in hook position)
    :probe-use-frame-element (fn [] (uix/$ ProbeUseFrame))
    :use-frame-observed      use-frame-observed
@@ -417,6 +443,9 @@
 
 (deftest use-subscribe-frame-provider-resolution
   (suite/assert-use-subscribe-frame-provider-resolution cfg))
+
+(deftest use-subscribe-ambient-under-ssr
+  (suite/assert-use-subscribe-ambient-under-ssr cfg))
 
 (deftest use-subscribe-2-arg-pins-explicit-frame
   (suite/assert-use-subscribe-2-arg-pins-explicit-frame cfg))

--- a/implementation/core/test/re_frame/adapter/react_shared_suite.cljs
+++ b/implementation/core/test/re_frame/adapter/react_shared_suite.cljs
@@ -3600,6 +3600,113 @@
             (finally
               (try (.unmount root) (catch :default _ nil))))))))))
 
+;; ---- the ambient hook under react-dom/server (rf2-5rqn) --------------------
+;;
+;; THE COVERAGE GAP THIS CLOSES. Every `use-subscribe` witness that exercises
+;; the AMBIENT (1-arg) form ran on the BROWSER lane — `assert-use-subscribe-
+;; frame-provider-resolution` above is wrapped in `with-browser-act`, and the
+;; only node-lane SSR row (`assert-use-subscribe-ssr-render-without-commit-
+;; nets-zero-at-the-horizon`) drives the EXPLICIT 2-arg probe. So the ambient
+;; form's server behaviour had never been executed anywhere, and an
+;; application server-rendering a UIx tree meets it on its first page.
+;;
+;; THIS ROW PINS A KNOWN DEFECT, NOT A DESIRED BEHAVIOUR. rf2-5rqn is open and
+;; names three candidate dispositions (repair / document / refuse) without
+;; picking one; picking one changes the SSR contract and is an operator
+;; ruling, so this row records what the runtime DOES today and the mechanism
+;; behind it. Whoever lands the repair should expect part 1 to go red BY
+;; DESIGN and should rewrite it to assert resolution — part 2 is the evidence
+;; that the repair is available and cheap.
+
+(defn assert-use-subscribe-ambient-under-ssr
+  "rf2-5rqn: the AMBIENT (1-arg) `use-subscribe` cannot resolve a frame under
+  `react-dom/server`, even beneath the adapter's own `frame-provider`.
+
+  Three parts, measured on the node lane under React 19.2:
+
+    1. THE SYMPTOM — an ambient `use-subscribe` inside a `frame-provider`
+       REFUSES a server render with `:rf.error/no-frame-context`, an error
+       whose own recovery ladder tells the author to establish a scope with a
+       `frame-provider` they have already established.
+
+    2. THE MECHANISM — during that same server render the shared
+       frame-context's PRIVATE `_currentValue` slot holds the no-provider
+       SENTINEL while the SECONDARY `_currentValue2` slot holds the real
+       frame, and the PUBLIC `useContext` return answers with the real frame.
+       `function-component-current-frame` (the `:adapter/current-frame`
+       reader the whole ambient chain funnels through) reads `_currentValue`,
+       classifies the sentinel as 'no scope', and the refusal follows. This is
+       the same renderer split rf2-2rzx0 already repaired for the compiled
+       ViewCell by sourcing the frame from the `useContext` RETURN — and the
+       spine's 1-arg arm ALREADY calls that hook (for the repaint
+       subscription) and discards its value.
+
+    3. THE SUPPORTED ROUTE — the EXPLICIT 2-arg form renders the subscribed
+       value under the same server renderer, so the refusal is specific to the
+       ambient tier rather than to SSR, and Spec 002's ladder item (3) 'pass
+       an explicit {:frame <id>}' is a real way out.
+
+  Node-safe: no DOM, no `act()`, no root — `renderToString` only.
+
+  cfg keys: `:frame-provider-mount-element`, `:probe-frame-provider-element`,
+  `:probe-frame-provider-observed`, `:frame-provider-query`,
+  `:probe-ssr-slots-element`, `:ssr-slot-observed`, `:probe-element`,
+  `:refcount-target`, `:us-query`, and `:ssr-ambient-frame` (its own frame)."
+  [{:keys [name frame-provider-mount-element probe-frame-provider-element
+           probe-frame-provider-observed ssr-ambient-frame frame-provider-query
+           probe-element refcount-target us-query
+           probe-ssr-slots-element ssr-slot-observed]}]
+  (testing (str name " — ambient use-subscribe under react-dom/server (rf2-5rqn)")
+    ;; Clear the fixture's ambient `:rf/default` dynamic scope: the 1-arg form
+    ;; resolves tier 1 (dynamic var) FIRST, so a bound `*current-frame*` would
+    ;; answer before the React-context tier and mask the very resolution this
+    ;; row measures — the same masking note `assert-use-subscribe-frame-
+    ;; provider-resolution` carries.
+    (binding [frame/*current-frame* nil]
+      (reset! probe-frame-provider-observed [])
+      (reset! ssr-slot-observed nil)
+      (rf/make-frame {:id ssr-ambient-frame :doc "rf2-5rqn SSR ambient probe frame"})
+      (rf/reg-event ::ssr-ambient-seed (fn [_ _] {:db {:k :wrapped :n 7}}))
+      (rf/dispatch-sync [::ssr-ambient-seed] {:frame ssr-ambient-frame})
+      (rf/reg-sub frame-provider-query (fn [db _] (:k db)))
+      (rf/reg-sub us-query (fn [db _] (:n db)))
+      (testing "1. the ambient form REFUSES a server render (the defect)"
+        (let [thrown (try (.renderToString react-dom-server
+                            (frame-provider-mount-element
+                              ssr-ambient-frame (probe-frame-provider-element)))
+                          nil
+                          (catch :default e e))]
+          (is (some? thrown)
+              "the server render of an ambient use-subscribe threw")
+          (is (= :rf.error/no-frame-context (:rf.error/id (ex-data thrown)))
+              "and threw the ABSENCE category — under a frame-provider that
+               did establish a scope (rf2-5rqn)")
+          (is (empty? @probe-frame-provider-observed)
+              "the hook never returned a value, so no markup could be produced")))
+      (testing "2. the MECHANISM — the server renderer populates the SECONDARY slot"
+        (.renderToString react-dom-server
+          (frame-provider-mount-element
+            ssr-ambient-frame (probe-ssr-slots-element)))
+        (let [{:keys [current-value current-value2 use-context]} @ssr-slot-observed]
+          (is (= adapter-context/no-provider-sentinel current-value)
+              "`_currentValue` — the slot the :adapter/current-frame reader
+               consults — holds the NO-PROVIDER SENTINEL on the server, which
+               classifies to nil ('no scope') and produces the refusal above")
+          (is (= ssr-ambient-frame current-value2)
+              "while React's SECONDARY slot `_currentValue2` holds the frame
+               the provider established — the value was never absent, only
+               unreachable from the slot the reader reads")
+          (is (= ssr-ambient-frame use-context)
+              "and the PUBLIC useContext return — renderer-agnostic, and the
+               hook the spine's 1-arg arm ALREADY calls and discards —
+               resolves the frame correctly under react-dom/server")))
+      (testing "3. the EXPLICIT 2-arg form is the supported route under SSR"
+        (reset! refcount-target ssr-ambient-frame)
+        (let [html (.renderToString react-dom-server (probe-element))]
+          (is (re-find #"n=7" html)
+              "an explicitly-framed use-subscribe server-renders its value —
+               the refusal is specific to the AMBIENT tier, not to SSR"))))))
+
 ;; ---- use-frame — capture-frame in hook position (rf2-y6dz8t) ---------------
 
 (defn assert-use-frame-capture-frame-in-hook-position

--- a/implementation/resources/test/re_frame/resources_runtime_cljs_test.cljc
+++ b/implementation/resources/test/re_frame/resources_runtime_cljs_test.cljc
@@ -31,6 +31,7 @@
   (:require
    #?(:clj  [clojure.test :refer [deftest is testing use-fixtures]]
       :cljs [cljs.test :refer-macros [deftest is testing use-fixtures]])
+   [clojure.string :as str]
    [re-frame.core :as rf]
    [re-frame.fx :as fx]
    [re-frame.frame :as frame]
@@ -109,6 +110,27 @@
 (def ^:private article-spec-request
   (fn [{:keys [slug]} _ctx]
     {:request {:method :get :url (str "/api/articles/" slug)}}))
+
+(defn- record-error-records!
+  "Run `body-fn` with an `:errors` listener installed; return the vector of
+  every always-on error record fanned during it (capture order).
+
+  The `:errors` stream — not stdout, not the dev trace — is where a framework
+  REFUSAL is legible: per Spec 009 §Observability channels the runtime ships no
+  default console sink, so a category that fans a record here is loud in dev
+  AND in a production build, while a category that fans nothing is invisible
+  everywhere. A refusal that reaches NO channel is indistinguishable from a
+  silent no-op at the call site, which is exactly the gap rf2-06lp closed on
+  the mutation path; this is the copy that lets the read path assert the same
+  way (rf2-w67y, sibling of `record-error-records!` in
+  `resources_mutation_cljs_test.cljc`)."
+  [body-fn]
+  (let [seen (atom [])
+        k    ::error-record-recorder]
+    (rf/register-listener! :errors k (fn [rec] (swap! seen conj rec)))
+    (try (body-fn)
+         (finally (rf/unregister-listener! :errors k)))
+    @seen))
 
 ;; ===========================================================================
 ;; 1. Canonical params + scope identity
@@ -477,6 +499,109 @@
     (is (thrown-with-msg?
           #?(:clj Throwable :cljs js/Error) #"resource-sub-unresolved-scope"
           (subs/resolve-scoped-key {:resource :ss/from-caller :params {:slug "x"}} {})))))
+
+;; ===========================================================================
+;; 2b. The registration guard on the READ path (rf2-w67y)
+;; ===========================================================================
+;;
+;; `registry/require-resource-spec!` is the read-path twin of the mutation
+;; registrar's `require-mutation-spec!`. It is the loud, fail-closed boundary
+;; behind SIX public surfaces — the four `:rf.resource/*` event handlers
+;; (`ensure` / `refetch` / `remove`, plus the `:rf.resource/*` internal
+;; arm in `events.cljc`), the route integration (`route.cljc`), and the
+;; subscription (`subs.cljc`).
+;;
+;; The guard was real and NOTHING in the corpus asserted it: `git grep
+;; resource-not-registered` over `implementation/` returned the throw site,
+;; the docs page and the Spec 009 catalogue row — no test. That is the same
+;; shape rf2-06lp repaired one registrar over, where the mutation path's
+;; `execute-unregistered-is-loud` asserted only `(nil? @last-managed-args)` —
+;; a claim a SILENT NO-OP satisfies exactly as well as a refusal does, so it
+;; could not fail. These three rows are written so a no-op FAILS them: each
+;; asserts the POSITIVE PRESENCE of the error record, not merely the absence
+;; of an effect.
+
+(deftest ensure-unregistered-refuses-and-names-the-id
+  ;; rf2-w67y. `require-resource-spec!` runs as the FIRST statement of the
+  ;; ensure handler's `let` — before scope resolution, before params
+  ;; canonicalization, before any entry write, work-ledger row or transport
+  ;; lowering. So "nothing was written" is a truthful reading of the abort
+  ;; rather than a half-built one, exactly as the mutation twin refuses
+  ;; before minting its instance.
+  (testing "Spec 016 §Public API — an unregistered resource id REFUSES"
+    (let [scoped-key (state/scoped-resource-key :rf.scope/global :r/nope {:slug "w"})
+          recs (record-error-records!
+                 #(rf/dispatch-sync [:rf.resource/ensure
+                                     {:resource :r/nope :scope :rf.scope/global
+                                      :params {:slug "w"} :owner [:app :test 1]}]))
+          rec  (first (filterv #(= :rf.error/handler-exception (:error %)) recs))]
+      (testing "the event ABORTED — no entry written, no request lowered"
+        (is (nil? (entry scoped-key)) "no cache entry was written")
+        (is (nil? @last-managed-args) "no request reached the transport"))
+      (testing "and the refusal is READABLE — the runtime did not stay silent"
+        ;; Read off the always-on `:errors` axis, not stderr: per Spec 009
+        ;; §Observability channels the framework ships NO default console sink,
+        ;; so this listener is where a refusal is legible in dev AND in prod.
+        ;; Without this half the two rows above are satisfied by a silent
+        ;; no-op and the test cannot fail.
+        (is (some? rec)
+            ":rf.resource/ensure fanned an always-on error record")
+        (is (= :rf.resource/ensure (:event-id rec)))
+        (let [data (ex-data (:exception rec))]
+          (is (= :rf.error/resource-not-registered (:rf.error/id data))
+              "the canonical catalogued category, not a bare host throw")
+          (is (= :r/nope (:resource-id data))
+              "the refusal NAMES the resource id the caller typed")
+          (is (= :fix-registration (:recovery data))
+              "and carries the catalogued recovery disposition"))
+        (is (str/includes? (str (some-> (:exception rec) ex-message)) ":r/nope")
+            "the human message names the id too")))))
+
+(deftest ensure-registered-under-another-kind-still-refuses
+  ;; rf2-w67y, the identity half. `require-resource-spec!` keys on the
+  ;; `:resource` REGISTRAR KIND, not on "is this keyword registered
+  ;; somewhere" — a mutation id reads as a perfectly well-formed keyword and
+  ;; resolves in a sibling registrar, so a guard widened to any known id
+  ;; would sail past here. rf2-06lp's sabotage proved this is the direction
+  ;; that silently lowers the WRONG THING: widening the mutation guard to
+  ;; the resource registrar made the runtime lower a resource's GET as a
+  ;; mutation write. The mirror hazard here is a mutation's POST lowered as
+  ;; a cache read.
+  (rf/reg-mutation :m/save
+                   {:params-schema [:map [:slug :string]]}
+                   (fn [{:keys [slug]} _ctx]
+                     {:request {:method :post :url (str "/api/articles/" slug)}}))
+  (testing "a MUTATION id passed as :resource refuses like any unknown id"
+    (let [scoped-key (state/scoped-resource-key :rf.scope/global :m/save {:slug "w"})
+          recs (record-error-records!
+                 #(rf/dispatch-sync [:rf.resource/ensure
+                                     {:resource :m/save :scope :rf.scope/global
+                                      :params {:slug "w"} :owner [:app :test 1]}]))
+          rec  (first (filterv #(= :rf.error/handler-exception (:error %)) recs))]
+      (is (nil? (entry scoped-key)) "no cache entry was written")
+      (is (nil? @last-managed-args) "no request reached the transport")
+      (is (some? rec) "the refusal fanned an always-on error record")
+      (is (= :rf.error/resource-not-registered
+             (:rf.error/id (ex-data (:exception rec))))
+          "the resource registrar, not the mutation one, decides")
+      (is (= :m/save (:resource-id (ex-data (:exception rec))))
+          "and the refusal names the id the caller typed"))))
+
+(deftest ensure-registered-resource-is-not-refused
+  ;; rf2-w67y, the restraint half — the direction a guard is almost never
+  ;; tested for. A REGISTERED resource must run exactly as before: entry
+  ;; written, request lowered, and the always-on `:errors` axis SILENT. An
+  ;; over-eager guard shows up here as a spurious record on an otherwise
+  ;; working read, which no other assertion in this suite would notice.
+  (rf/reg-resource :r/ok (article-spec) article-spec-request)
+  (let [scoped-key (state/scoped-resource-key :rf.scope/global :r/ok {:slug "w"})
+        recs (record-error-records!
+               #(rf/dispatch-sync [:rf.resource/ensure
+                                   {:resource :r/ok :scope :rf.scope/global
+                                    :params {:slug "w"} :owner [:app :test 1]}]))]
+    (is (= [] recs) "a registered resource raises NO error record")
+    (is (= :loading (:status (entry scoped-key))) "the cache entry was written")
+    (is (some? @last-managed-args) "and the request reached the transport")))
 
 ;; ===========================================================================
 ;; 3. Pure lifecycle status transition fn (NOT a spawned machine)


### PR DESCRIPTION
Two beads on the test surface. One closes a real assertion gap; the other closes a coverage gap and **stops short of a behaviour change that needs an operator ruling**.

## rf2-w67y — the resource read-path guard now has a test that can fail

`registry/require-resource-spec!` throws `:rf.error/resource-not-registered` behind six public surfaces (four `:rf.resource/*` event handlers, the route integration, the subscription).

**Re-derived at `origin/main`:** the premise holds. `git grep resource-not-registered` over `implementation/` returns the throw site (`registry.cljc:663`), `docs/api/re-frame.resources.md`, the Spec 009 catalogue row, and one *prose* mention in an `epoch` test docstring — no assertion anywhere.

Three rows land in `resources_runtime_cljs_test.cljc` (the read-path twin of `resources_mutation_cljs_test.cljc`, whose `record-error-records!` is copied per the bead):

- an unregistered id on `:rf.resource/ensure` refuses — no entry, no request, and the always-on `:errors` axis carries the category, the id, and `:recovery :fix-registration`;
- the **identity half** — a MUTATION id passed as `:resource` still refuses, because the guard keys on the `:resource` registrar KIND rather than on "known keyword";
- the **restraint half** — a REGISTERED resource raises no error record.

Each asserts the **positive presence of the error record**, not merely the absence of an effect. That is the whole lesson of rf2-06lp, whose predecessor asserted only `(nil? @last-managed-args)` — a claim a silent no-op satisfies as well as a refusal does. The `:errors` listener is required because a framework refusal reaches no other channel: per Spec 009 the runtime ships no default console sink, so stdout and stderr are both empty.

### Sabotage proof (hash-verified, not diff-verified)

A single-line `#_` plant eliding the `throw` in `require-resource-spec!`:

| stage | sha256 of `registry.cljc` |
|---|---|
| before plant | `84ce8184c0b084f267c2f6aa71ef17c9fe698d041b6c73413295a0efa5773634` |
| planted | `86203658e07b77decf83ef4b5a47ba5c83e38a27af73ebd457b0d9dd807d586e` |
| after restore | `84ce8184c0b084f267c2f6aa71ef17c9fe698d041b6c73413295a0efa5773634` |

The middle hash proves the patch actually applied; the third proves the restore is byte-exact. Under the plant: **exit 1, 6 failures** across both refusal rows, the runtime instead dying on a bare `Cannot invoke "clojure.lang.IFn.invoke(Object, Object)" because "req_fn" is null` that names no resource. The restraint row correctly stayed green.

## rf2-5rqn — the ambient hook under SSR: witness landed, **behaviour change withheld**

**Re-derived at `origin/main`:** the premise holds, and the mechanism is now *measured* rather than inferred. Node lane, React 19.2, ambient probe wrapped in the UIx adapter's own `frame-provider`, rendered with `react-dom/server`:

```
{:ambient-html  nil
 :observed      []
 :ambient-error :rf.error/no-frame-context
 :slots {:current-value  :rf.frame/no-provider           ; <- the reader reads THIS
         :current-value2 :rf.uix-5rqn/ssr-ambient-frame  ; <- the frame is HERE
         :use-context    :rf.uix-5rqn/ssr-ambient-frame} ; <- and useContext ANSWERS
 :explicit-html "<div>n=7</div>"}
```

During a server render the shared frame-context's `_currentValue` holds the **no-provider sentinel** while `_currentValue2` holds the real frame, and the public `useContext` return resolves it. The frame was never absent — only unreachable from the slot `function-component-current-frame` reads. The explicit 2-arg form server-renders fine, so the refusal is specific to the **ambient tier**, not to SSR.

**The coverage gap was real.** Both UIx `use-subscribe` behavioural witnesses are `*_dom_cljs_test`; the ambient-form row (`assert-use-subscribe-frame-provider-resolution`) is wrapped in `with-browser-act`, and the only node-lane SSR row drives the *explicit* probe. The ambient form's server behaviour had never executed anywhere. The new row runs on the node lane, where the behaviour lives.

### Which reading I took, and why I did not ship the repair

The bead names three dispositions (repair / document / refuse) and **explicitly picks none**. Every one of them changes the SSR contract, so per the dispatch brief I shipped the witness — in scope under all three readings — and left the ruling to the operator. Costed options are recorded on the bead; the short version:

- **Repair is far cheaper than the bead assumed**, because it is a pattern *already merged here*: rf2-2rzx0 hit this exact renderer split and fixed it for the sibling caller (`re-frame.ui.viewcell/use-frame-context!`) by sourcing the frame from the `useContext` RETURN; `adapter-context/context-value->current-frame` is already documented as serving **two** callers; and the spine's 1-arg arm **already calls that hook** for its repaint subscription and discards the value.
- **But it is not free.** Copying the ViewCell's `(or frame/*current-frame* (context-value->current-frame ctx))` verbatim into the spine would **bypass the ambient-refusal tier** (`resolve-current-frame` withdraws tier 2 while `*ambient-frame-refusal*` is set — rf2-2rtt6.122 / rf2-nqj22). A correct repair keeps `require-current-frame!` primary and consults the hook value only when the reader returned nil *and* no extent has refused. An arguably better site is the reader itself (`_currentValue2` fallback), which preserves precedence and the refusal tier for free because the hook is never called while a refusal is in effect.

**This row therefore pins a known defect, not a desired behaviour.** Part 1 is expected to go red when the repair lands and should then be rewritten to assert resolution; part 2 (the slot measurement) is the evidence and should survive.

## Deviations from the dispatch brief

- The brief's write surface named `implementation/core/**`; **the bead governs** and rf2-w67y states `implementation/resources/test/` — that is where its three rows landed. `implementation/resources/**` is held by no other worker this wave.
- rf2-5rqn also touched `implementation/adapters/uix/test/**` (probe components + cfg), which the brief allowed.
- No `spec/**` edit; none was needed. No runtime change in either bead.

## Quality gates

Rebased onto `origin/main` **after** PR #7994 (`e7b9924f4b`) changed the gate spine; every exit code below is from a post-rebase run, and each gate ran alone, unpiped, with its exit code captured on the same command line. Each log's `gate root:` line was checked to be `/c/Users/miket/code/re-frame2-worktrees/resources-w67y`.

| gate | exit | result |
|---|---|---|
| `clojure -M:test` (`implementation/resources`) | **0** | 817 tests / 7268 assertions, 0 failures — decides rf2-w67y |
| `npm run test:cljs` (`implementation`) | **0** | 13642 tests / 69064 assertions, 0 failures — decides rf2-5rqn (node lane) |
| `sh scripts/test-jvm-implementation.sh` | **0** | `PASS implementation JVM artefacts` |
| `python scripts/lint_kondo.py` | **0** | clj-kondo **2026.04.15** (CI's pin), `errors: 0`; my files carry only pre-existing info/warnings |
| `sh scripts/test-fast-pr.sh` | **0** | `PASS fast PR spine` (every `FAIL` string in the log is a `PASS … FAILS` self-test line) |
| `python scripts/check_fast_pr_gap.py --list` | n/a | informational — see below |

Sabotage run (deliberate, on the planted tree): `clojure -M:test` → **exit 1**, 6 failures. Restored and re-run green.

No gate was skipped.

**Not decided locally.** `check_fast_pr_gap.py --list` reports **95 required checks this spine does not run**. The ones most relevant to this diff:

- `cljs-browser` — `shadow-cljs :browser-test`. The new SSR row is node-lane by design, but `uix_use_subscribe_dom_cljs_test.cljs` also runs in the browser lane, where my new `deftest` executes too. Its `renderToString` path is DOM-independent, so it should behave identically; CI's browser job is the arbiter.
- `jvm-*-prod-gate` lanes (`-Dre-frame.debug=false`) — the `:errors` axis is always-on per Spec 009, so the rf2-w67y rows should hold under the production gate, but that is CI's to confirm.
- `adapter-testbed-smokes`, `ui-smoke`, `story-xray-browser` and the bundle-isolation lanes — untouched by a test-only diff.

Local clj-kondo now matches CI's pin, so the version-skew hazard that motivated #7994 does not apply to this PR.
