### PR TITLE
docs(freehand): bench docstrings name h/error-boundary (rf2-4uhh)

### DIFF
--- a/implementation/freehand/test/re_frame/bench/hicasso/arm1/boundary.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/arm1/boundary.cljs
@@ -1,5 +1,5 @@
 (ns re-frame.bench.hicasso.arm1.boundary
-  "`h/boundary` — THE RUNTIME'S OWN ERROR BOUNDARY (HD-020(c),
+  "`h/error-boundary` — THE RUNTIME'S OWN ERROR BOUNDARY (HD-020(c),
   rf2-2rtt6.41).
 
   HD-020(c) rules that \"the runtime ships one internal class-based
@@ -7,7 +7,11 @@
   it is the P1 witness's *real error boundary*\". validation.md's
   `:foreign/host-and-error-boundary` row names it by that description.
   This is it, and it is deliberately the smallest thing that satisfies
-  the three keys.
+  the three keys. The decision's words are quoted as it wrote them; the
+  export it names has since been spelled `h/error-boundary`, which is
+  what the naming ledger ruled (row 12, rf2-g8rb). The var HERE keeps the
+  short name — it is this arm's own, mirroring `impl.boundary`, and it is
+  what the `:rf.error/hicasso-boundary-*` ids are named after.
 
       [boundary {:fallback  [:p.oops \"that did not work\"]
                  :reset-key attempt
@@ -149,7 +153,7 @@
   nil)
 
 (def boundary
-  "`h/boundary` — a legal hiccup head, marked the way a `defview` product
+  "`h/error-boundary` — a legal hiccup head, marked the way a `defview` product
   is, and a React **class** so React will hand it a render-phase throw
   from anything below.
 

--- a/implementation/freehand/test/re_frame/bench/hicasso/arm1/host_hatch_dom_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/arm1/host_hatch_dom_cljs_test.cljs
@@ -53,7 +53,7 @@
   dispatch. Filed as rf2-2rtt6.66 rather than smoothed here, because it
   was presence's frame plumbing and not the door's; repaired on main
   (presence resolves the frame through the substrate's context and binds
-  it around its one `as-element` call), and `h/boundary` since took the
+  it around its one `as-element` call), and `h/error-boundary` since took the
   identical repair for its fallback and children (rf2-uo9di).
 
   That repair could not witness its own host half — the door was still

--- a/implementation/freehand/test/re_frame/bench/hicasso/arm1/lifecycle_dom_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/arm1/lifecycle_dom_cljs_test.cljs
@@ -375,7 +375,7 @@
 
 (deftest the-boundary-spends-no-shell-hook
   (testing "HD-020(b)'s ≤2 is the boundary SHELL's budget, and
-           `h/boundary` is a class — it calls no hooks at all. Counted at
+           `h/error-boundary` is a class — it calls no hooks at all. Counted at
            React's own dispatcher, on a page that wraps one Hicasso
            boundary in another"
     (if-not (mount/browser?)

--- a/implementation/freehand/test/re_frame/bench/hicasso/front/codec.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/front/codec.cljs
@@ -1071,8 +1071,8 @@
   entire subtree rather than bail out of it.
 
   Opt-in at the mint site rather than applied to every marked head, so
-  heads that are not reactive boundaries — `h/boundary`'s error-boundary
-  class, presence — keep the semantics they were written with."
+  heads that are not reactive boundaries — `h/error-boundary`'s class,
+  presence — keep the semantics they were written with."
   [f]
   (let [memo (react/memo f boundary-props=)]
     (unchecked-set memo "displayName" (unchecked-get f "displayName"))


### PR DESCRIPTION
rf2-g8rb renamed the Hicasso error-region export to `h/error-boundary` (PR #7973,
operator ruling 2026-08-12 17:18 AUSEST). The rf2-j9tl carrier sweep (PR #7991) found
six stale `h/boundary` prose carriers under `implementation/freehand/test/re_frame/bench/hicasso/`
and correctly declined to touch them, because rf2-o0n1 held that tree. rf2-o0n1 has since
merged (`f46af808ff`), so the tree is free and this PR finishes the sweep.

**Prose spelling only.** No code, no ids, no module names.

## What changed: five of six

| site | verdict |
|---|---|
| `arm1/boundary.cljs:2` | changed — ns docstring headline naming the export |
| `arm1/boundary.cljs:6` | **left standing** — verbatim HD-020(c) quotation (see below) |
| `arm1/boundary.cljs:152` | changed — `def boundary` docstring headline |
| `arm1/host_hatch_dom_cljs_test.cljs:56` | changed — live prose |
| `arm1/lifecycle_dom_cljs_test.cljs:378` | changed — live `testing` string |
| `front/codec.cljs:1074` | changed — live prose |

### The one left standing, and why

`arm1/boundary.cljs:6` sits inside an attributed, escaped-quote quotation:

> HD-020(c) rules that `\"the runtime ships one internal class-based boundary exposed as
> `h/boundary` (`:fallback`/`:reset-key`/`:on-error`); it is the P1 witness's *real error
> boundary*\"`.

Editing that would falsify the record of what HD-020(c) actually wrote — the decision text
still reads `h/boundary` at `docs/design/hicasso/decisions.md:1347-1348`, which is the source
this sentence quotes. This is the identical call rf2-j9tl already made at
`implementation/hicasso/src/re_frame/hicasso/impl/boundary.cljs:6`, where the same sentence
was left alone and the correction written beside it. I followed that precedent exactly,
including adding the matching note — without it, the reader sees the updated headline at
line 2 disagree with the quotation at line 6 and has no way to tell which is right.

### Untouched, deliberately

The stable `:rf.error/hicasso-boundary-*` ids, the `:where` symbols, and the
`re-frame.hicasso.impl.boundary` emitter module names are all unchanged. They are named after
the implementation module `impl.boundary/boundary`, which the rename deliberately left alone;
renaming it would move a diagnostic id for the sake of a spelling and drag `spec/**` in. The
diff confirms this — the only lines matching those patterns are additions in the new
explanatory note, never a modification.

One incidental wording fix: `front/codec.cljs` read ``h/boundary`'s error-boundary class``,
which becomes redundant under the new spelling, so it is now ``h/error-boundary`'s class``.

## No gate can red on this, by construction

The catalogue checks bind the register to Spec 009 **by id**, never by prose, and the ids are
unchanged. So this drift is invisible to CI by construction — a green build is not evidence
the spelling is right, and never was. **I verified it by reading all six sites**, not by
running anything. Per rf2-j9tl, no prose-checking gate is added; that was considered and
rejected as over-engineering for this defect class.

The gates below prove only that the tree still compiles and runs — which is a real risk, since
these are compiled CLJS and a malformed docstring can break a build even though a spelling
cannot.

## Quality gates

| gate | exit | result |
|---|---|---|
| `npm run test:cljs` (from `implementation/`) | **0** | Ran 13638 tests / 69041 assertions — 0 failures, 0 errors |
| `scripts/test-fast-pr.sh` | **0** | fast-PR spine, no `FAIL in`/`ERROR in` anywhere in the log |
| `python scripts/check_fast_pr_gap.py --list` | **0** | re-captured on this base, not trusted from an older capture |

Exit codes are the ones I captured with `echo "$?" > …` on the same command line as the gate,
not values reported by the harness. Each gate's log begins with a `gate root:` line reading
`C:/Users/miket/code/re-frame2-worktrees/benchdoc-4uhh`, verified before the colour was believed.

**One note on how that green was obtained, because it nearly went the other way.** My first
`test:cljs` attempt hit a 10-minute foreground cap and was SIGTERM'd. Its orphaned child kept
the log file descriptor open and went on writing into the same path after the next run had
truncated it, so the log briefly showed 15 `FAIL in` blocks against a `0 failures, 0 errors`
tally — the failures were all `spawn-runner` children exiting `3221225794` (`0xC0000142`,
STATUS_DLL_INIT_FAILED) with empty stdout, i.e. processes that never launched because the
harness had killed their process group. They sat in `implementation/test-quiet/`, a different
artefact with no dependency on `bench/hicasso`, so no docstring edit could reach them. I
re-ran into a fresh log filename (immune, since the zombie holds a descriptor to the old path)
and that clean run is the exit 0 quoted above: zero `FAIL in`, zero `ERROR in`.

Base is `f46af808ff`, which already contains PR #7994's clj-kondo pin and widened lint paths
(`e7b9924f4b` verified as an ancestor), so the spine run above is the current one.

Skipped: every browser/bundle/release gate. This diff reaches no runtime behaviour, no bundle
and no rendered doc — it changes docstring and comment text inside the bench test tree.

## Carrier sweep beyond my surface

`git grep -n "h/boundary"` across tracked files finds carriers outside my write surface. Per
the dispatch fence I changed **none** of them. rf2-j9tl deliberately left the
`docs/design/hicasso/` historical records standing and I have kept that. Judgement per site:

**Clearly historical — leave (editing these would falsify a dated record):**

- `decisions.md:1290` — inside the `>` blockquote of a dated reopen clause.
- `decisions.md:1348` — **the HD-020(c) decision text itself**, i.e. the origin of the
  verbatim quotation the two `boundary.cljs` files carry. Changing this would break both
  quotations and rewrite the decision.
- `decisions.md:1359` — the HD-020 Rationale prose, same dated entry.
- `studio/raw-escape-spec.md:559` — a blockquote that explicitly recites a roster it has
  already declared unverified and superseded. Editing it would falsify the correction.
- `studio/108-the-theming-taught-default-priced.md:223` — dated record of two 2026-08-05 rulings.
- `studio/arm1-lean-react-dogfood-judgement.md:640` — dated judgement of what is not witnessed.
- `product/authoring-report-slice.md:149`, `product/authoring-report-todo.md:94` — dated
  authoring-session reports.
- `product/correction-ledger.md:60` — a ledger row, and that file's own rule (`:56`) is that
  corrective PRs never edit it; transitions are the ledger keeper's.

**Reads more like a live instruction — worth a bead (mayor's call, not actioned here):**

- `validation.md:589` — the validation grid names the surface a validation row must exercise,
  and `impl/boundary.cljs` actively cites this file's `:foreign/host-and-error-boundary` row.
- `product/prototype-suite-triage.md:232` and `:249` — a triage naming public door surfaces and
  suites still to port; a future porter reads these as current-surface instruction.
- `studio/revision-prop-spec.md:106` — names the live export inside an open API-freeze flag
  about the reset-name trio.

`tools/xray/test/day8/re_frame2_xray/panels/hicasso_helpers_cljs_test.cljc` hits are **false
positives** — `hh/boundary-slug`, a different alias and a different var. Confirmed, not counted.

Closes rf2-4uhh.
