### PR TITLE
fix(hmr-gate): a one-engine run no longer prints an unqualified PASS (rf2-l92i)

### DIFF
--- a/implementation/scripts/serve-and-run-hicasso-hmr-testbed.cjs
+++ b/implementation/scripts/serve-and-run-hicasso-hmr-testbed.cjs
@@ -100,6 +100,15 @@
  * pins the witnesses by name and `REQUIRED_RECORDS` pins the keys each
  * measured row carries.
  *
+ * A divergence needs two engines to be visible at all, so a run narrowed by
+ * `HICASSO_HMR_ENGINES` has no comparison available to it. That narrowing
+ * stays — it is a real developer convenience and a narrowed run still exits
+ * 0 — but it does NOT get to close with the words a compared run closes
+ * with. The two verdicts are separate strings, `HICASSO HMR PASS` and
+ * `HICASSO HMR PARTIAL PASS`, neither a substring of the other, so no skim
+ * of a log and no grep for the full-matrix verdict can mistake one for the
+ * other (rf2-l92i).
+ *
  * The verdict logic and the hot-line rewriter both carry mutation teeth
  * that run before any browser launches. The rewriter needs them as much as
  * the comparator does: a gate whose "save" silently stopped editing the
@@ -215,6 +224,22 @@ const ONLY = (process.env.HICASSO_HMR_ENGINES || '').trim();
 const ENGINES = ONLY
   ? ALL_ENGINES.filter((e) => ONLY.split(',').map((s) => s.trim()).includes(e))
   : ALL_ENGINES;
+
+// The two closing verdicts, kept as separate strings on purpose.
+//
+// `divergenceReport` needs two engines before there is any disagreement to
+// find, and below that it correctly returns nothing. What would NOT be
+// correct is for the run to then close with the line a compared run prints:
+// a PASS meaning "three engines ran and agreed" and a PASS meaning "one
+// engine ran and the comparator never ran" must not be the same words
+// (rf2-l92i). Neither token is a substring of the other, so a grep for the
+// full-matrix verdict cannot be answered by a narrowed run.
+//
+// The CI job passes no narrowing at all and a classifier regression in
+// `_changed-surfaces.test.cjs` pins that, so this pair is about the LOCAL
+// run and about any future job that might acquire the variable.
+const FULL_VERDICT = 'HICASSO HMR PASS';
+const NARROWED_VERDICT = 'HICASSO HMR PARTIAL PASS';
 
 // ---------------------------------------------------------------------------
 // The coverage floor — names, not a total
@@ -478,6 +503,35 @@ function divergenceReport(perEngine, narrowings = NARROWINGS) {
   return problems;
 }
 
+/**
+ * Whether this engine set can be compared at all.
+ *
+ * The same two-engine floor `divergenceReport` applies, named once so the
+ * comparator's silence and the verdict's admission cannot drift apart.
+ */
+function comparedAcrossEngines(engines) {
+  return engines.length >= 2;
+}
+
+/**
+ * The line the run closes with.
+ *
+ * A narrowed run passed everything it ran, so it still exits 0 and still
+ * says PASS — what it must not do is say it the same way. Below two engines
+ * the verdict token changes, the sentence states that the cross-engine
+ * comparison was NOT performed, and it names the variable that caused it so
+ * the reader knows which knob to unset.
+ */
+function verdictLine(engines, reloads) {
+  const tail = `${reloads} real shadow reloads`;
+  if (comparedAcrossEngines(engines)) {
+    return `${FULL_VERDICT} (${engines.join(' + ')}) — ${tail}`;
+  }
+  return `${NARROWED_VERDICT} (${engines.join(' + ') || 'no engine'} only; `
+    + `HICASSO_HMR_ENGINES narrowed this run, so the cross-engine comparison `
+    + `was NOT performed) — ${tail}`;
+}
+
 function coverageReport(result, required = REQUIRED_SECTIONS) {
   const problems = [];
   const sections = (result && result.sections) || {};
@@ -690,6 +744,59 @@ function runMutationTeeth() {
     divergenceReport({
       chromium: { row: { a: 1 } }, firefox: { row: { a: 2 } },
     }, [{ row: 'row', engines: ['webkit'], why: 'tooth' }]).length === 1);
+
+  // --- the verdict a narrowed run is allowed to print -------------------
+  //
+  // The comparator going quiet below two engines is correct. A closing line
+  // that does not say so is not, and these teeth are what stop the two
+  // verdicts collapsing back into one string (rf2-l92i). The last of them
+  // is the load-bearing one: it holds the comparator's silence and the
+  // verdict's admission against each other, so neither can be changed
+  // alone.
+
+  bite('a compared run prints the full verdict and names its engines', () => {
+    const line = verdictLine(ALL_ENGINES, 36);
+    return line.startsWith(FULL_VERDICT)
+      && line.includes('chromium + firefox + webkit')
+      && line.includes('36 real shadow reloads')
+      && !/NOT performed/.test(line);
+  });
+
+  bite('a one-engine run does NOT print the full verdict', () =>
+    !verdictLine(['chromium'], 36).includes(FULL_VERDICT));
+
+  bite('a one-engine run says the comparison was skipped and names the knob', () => {
+    const line = verdictLine(['webkit'], 12);
+    return line.startsWith(NARROWED_VERDICT)
+      && /cross-engine comparison was NOT performed/.test(line)
+      && /HICASSO_HMR_ENGINES/.test(line)
+      && line.includes('webkit')
+      && line.includes('12 real shadow reloads');
+  });
+
+  bite('neither verdict token can be grepped for the other', () =>
+    !NARROWED_VERDICT.includes(FULL_VERDICT)
+    && !FULL_VERDICT.includes(NARROWED_VERDICT));
+
+  bite('two engines are enough, so the floor is the comparator\'s and not a guess', () =>
+    comparedAcrossEngines(ALL_ENGINES)
+    && comparedAcrossEngines(['chromium', 'firefox'])
+    && !comparedAcrossEngines(['chromium'])
+    && !comparedAcrossEngines([]));
+
+  bite('the comparator\'s silence and the verdict\'s admission move together', () => {
+    const one = { chromium: { row: { a: 1 } } };
+    const two = { chromium: { row: { a: 1 } }, firefox: { row: { a: 2 } } };
+    // Silent below two engines — not a defect, there is nothing to
+    // disagree with — but the run that got that silence must not close as
+    // though it had been compared.
+    return divergenceReport(one, []).length === 0
+      && verdictLine(Object.keys(one), 1).startsWith(NARROWED_VERDICT)
+      // ...and two engines ARE compared, which is what makes the silence
+      // above a fact about the engine count and nothing else.
+      && divergenceReport(two, []).length === 1
+      && verdictLine(Object.keys(two), 1).startsWith(FULL_VERDICT);
+  });
 
   // --- the floors -------------------------------------------------------
   const fullSections = () => ({ ...REQUIRED_SECTIONS });
@@ -1151,6 +1258,19 @@ async function main() {
     return 1;
   }
 
+  // Said UP FRONT as well as at the end, for the same reason the delay
+  // instrument announces itself: this run is about to spend half an hour,
+  // and the reader should not discover only in the last line that it was
+  // never going to compare anything.
+  if (ONLY) {
+    console.log(`> HICASSO_HMR_ENGINES=${ONLY} — narrowed to `
+      + `${ENGINES.join(' + ')} of ${ALL_ENGINES.join(' + ')}.`);
+    if (!comparedAcrossEngines(ENGINES)) {
+      console.log('> a divergence needs two engines to be visible, so the '
+        + 'cross-engine comparison will NOT be performed on this run.');
+    }
+  }
+
   // FAIL CLOSED on a dirty tree. The gate edits a tracked file, so a
   // previous run killed between its edit and its restore would otherwise
   // hand this run a source whose "canonical" state is already a fixture —
@@ -1190,6 +1310,15 @@ async function main() {
     for (const engine of ENGINES) {
       console.log(`  [${engine}] ${JSON.stringify(recorded[engine])}`);
     }
+    if (!comparedAcrossEngines(ENGINES)) {
+      // The rows above were measured and not compared. Saying so HERE, next
+      // to them, is the half the closing line cannot do: this is the point
+      // at which a reader is looking at the numbers and would otherwise
+      // assume something had checked them.
+      console.log(`  cross-engine comparison NOT PERFORMED — ${ENGINES.length} `
+        + `engine ran, and a divergence needs two to be visible. Unset `
+        + `HICASSO_HMR_ENGINES for the full ${ALL_ENGINES.join(' + ')} matrix.`);
+    }
     const problems = divergenceReport(recorded);
     if (problems.length > 0) {
       console.error('\nCROSS-ENGINE DIVERGENCE:');
@@ -1199,8 +1328,7 @@ async function main() {
     for (const n of NARROWINGS) {
       console.log(`  narrowing: ${n.row} on ${n.engines.join('+')} — ${n.why}`);
     }
-    console.log(`\nHICASSO HMR PASS (${ENGINES.join(' + ')}) — ` +
-      `${labelCounter} real shadow reloads`);
+    console.log(`\n${verdictLine(ENGINES, labelCounter)}`);
     return 0;
   } finally {
     restoreHotFile();
@@ -1210,6 +1338,10 @@ async function main() {
 
 module.exports = {
   divergenceReport,
+  comparedAcrossEngines,
+  verdictLine,
+  FULL_VERDICT,
+  NARROWED_VERDICT,
   runMutationTeeth,
   coverageReport,
   recordSchemaReport,


### PR DESCRIPTION
`HICASSO_HMR_ENGINES` can narrow this gate to a single engine. `divergenceReport`
needs two engines before there is any disagreement to find, so below that it
returns nothing — correctly. What was not correct is that the run then closed
with `HICASSO HMR PASS (chromium)`, which is the verdict a three-engine run that
actually compared prints. A PASS meaning *"three engines ran and agreed"* and a
PASS meaning *"one engine ran and the comparator never ran"* were the same words.

The narrowing stays. It is a real developer convenience and a narrowed run still
exits 0. What changes is that it says what it did.

## What landed — remedy (a) only

- `comparedAcrossEngines(engines)` names the two-engine floor **once**, so the
  comparator's silence and the verdict's admission cannot drift apart.
- `verdictLine(engines, reloads)` closes a narrowed run with a **different
  token**: `HICASSO HMR PARTIAL PASS`. Neither token is a substring of the other,
  so a grep for the full-matrix verdict cannot be answered by a narrowed run —
  and nothing in the repo greps for the old string, so the rename costs nothing
  (`HICASSO HMR PASS` appeared only in this file).
- The RECORDED block says it too, next to the numbers a reader would otherwise
  assume something had checked.
- A narrowed run **announces itself up front** as well, exactly as the
  register-delay instrument already does. Half an hour is too long to discover in
  the last line that nothing was ever going to be compared.
- Mutation teeth **28 → 34**. The last of the six is the load-bearing one: it
  holds `divergenceReport`'s silence at one engine and `verdictLine`'s admission
  against each other in a single assertion, so neither can be changed alone.

### Where the new coverage lives, and why not in the cheap lane

In `runMutationTeeth`, with the comparator teeth it is paired to. It does **not**
go in a `scripts/*.test.cjs` file, because the `JS harness self-tests` job runs
`test:script-policy && test:script-helpers` with **no `npm ci`** — those suites
are Node-builtins-only by construction, and this module `require`s `playwright`
at load. The teeth run at the head of `cljs-hicasso-hmr`, before any browser
launches, and that job arms on any diff to this launcher (already pinned by
`_changed-surfaces.test.cjs`'s arming row), so a softening of the new logic reds
on the same PR that introduces it.

## Remedy (b) was NOT added, because it already exists

The bead's second shape — "assert in CI that `HICASSO_HMR_ENGINES` is unset" —
is already on main and has been since rf2-hic-015. `_changed-surfaces.test.cjs`,
in `the hicasso HMR job installs the PINNED three engines and narrows none`,
strips comment lines out of the `cljs-hicasso-hmr` job block and asserts
`!/HICASSO_HMR_ENGINES/` over what remains, with the reason spelled out in the
same words the bead uses. `test.yml` also carries no workflow-level `env:` block,
so there is no ambient path into that job either. Adding a second assertion of
the same fact would be duplication, not defence in depth — **no workflow change
in this PR**.

That leaves the runtime half, which is what this PR is: the classifier pins what
CI *passes*; `verdictLine` makes the run honest whatever it is handed, including
a local run and any future job that acquires the variable.

## Proof — both legs, on the real rig

Run against a live `shadow-cljs watch :hicasso/hmr-testbed`, three real engines,
real saves. `HICASSO_HMR_PORT=8961` on both legs (a peer worktree's watch held
the default `:dev-http` 8061 — see the note at the end); the port is the runner's
probe target and nothing else, and the bundle-identity digest from #7998 still
attributed the served bytes to this run's own watch.

**Leg 1 — narrowed, `HICASSO_HMR_ENGINES=chromium`. Exit 0.**

```
> HICASSO_HMR_ENGINES=chromium — narrowed to chromium of chromium + firefox + webkit.
> a divergence needs two engines to be visible, so the cross-engine comparison will NOT be performed on this run.
> verdict logic teeth bit: 34
...
PASS  chromium — 105 checks across 8 sections (the watch met this page 668ms after launch)

--- RECORDED conduct (measured, not required) ---
  [chromium] {"caret-after-a-save":{"start":7,"end":7},"ref-traffic-across-a-save":{"attachments":6,"detachments":5},"retained-census":{"cells":6,"cell-refs":6,"boundaries":6,"edges":6,"entries":6}}
  cross-engine comparison NOT PERFORMED — 1 engine ran, and a divergence needs two to be visible. Unset HICASSO_HMR_ENGINES for the full chromium + firefox + webkit matrix.

HICASSO HMR PARTIAL PASS (chromium only; HICASSO_HMR_ENGINES narrowed this run, so the cross-engine comparison was NOT performed) — 12 real shadow reloads
```

**Leg 2 — unset, full matrix. Exit 0.**

```
> verdict logic teeth bit: 34
> :hicasso/hmr-testbed is live on http://127.0.0.1:8961
PASS  chromium — 105 checks across 8 sections (the watch met this page 643ms after launch)
PASS  firefox — 105 checks across 8 sections (the watch met this page 1751ms after launch)
PASS  webkit — 105 checks across 8 sections (the watch met this page 782ms after launch)

--- RECORDED conduct (measured, not required) ---
  [chromium] {"caret-after-a-save":{"start":7,"end":7},"ref-traffic-across-a-save":{"attachments":6,"detachments":5},"retained-census":{"cells":6,"cell-refs":6,"boundaries":6,"edges":6,"entries":6}}
  [firefox] {...identical...}
  [webkit] {...identical...}

HICASSO HMR PASS (chromium + firefox + webkit) — 36 real shadow reloads
```

Note the absences on this leg, which are the half that would show a degraded
three-engine message: no `HICASSO_HMR_ENGINES` banner at the top, no
`cross-engine comparison NOT PERFORMED` line in the RECORDED block, and a
closing line byte-identical to main's apart from being produced by
`verdictLine` — same token, same engine list, same reload count, nothing
appended.

## Quality gates

Every gate run alone, output redirected and `$?` captured on the same command
line, nothing piped. Exit codes are the ones captured that way, and each log
carries a `gate root:` line naming this worktree.

| gate | exit | note |
|---|---|---|
| `npm run test:hicasso-hmr` — leg 1, `HICASSO_HMR_ENGINES=chromium` | **0** | proof leg 1; 105 checks, 12 reloads, 34 teeth |
| `npm run test:hicasso-hmr` — leg 2, engines unset | **0** | proof leg 2; 3 × 105 checks, 36 reloads, 34 teeth |
| `npm run test:script-policy` (from `implementation/`) | **0** | the `JS harness self-tests` job's first half — includes `_changed-surfaces.test.cjs`, which owns remedy (b) |
| `npm run test:script-helpers` (from `implementation/`) | **0** | that job's second half |
| `sh scripts/test-fast-pr.sh` | **0** | `PASS fast PR spine` — tiers below |

Which spine tiers actually ran, since a bare green would overstate it: the
**always-on** static/drift checks and **clj-kondo**, plus the **node tier** —
the `:node-test` shadow build (2353 files), the JS harness self-tests and the
per-namespace isolation gate. The spine's own PASS line names what it did **not**
run: the documentation gates (surface unchanged), **all** JVM artefact suites
(`implementation_jvm` surface unchanged — this diff is one `.cjs` script), and
the CI-only lanes. The one CI job this diff genuinely arms, `cljs-hicasso-hmr`,
is in no tier of the spine and is exactly what the two proof legs above ran by
hand.

One earlier run is worth recording rather than hiding: leg 1's **first** attempt
exited **1** on the default port, refused by `assertOwnBundle`. That is the
#7998 guard, not a failure of this change — see the port note below.

## Other env knobs of this shape — listed, not filed

Per the bead, this was **not** widened into a general audit of the rig's knobs
(rf2-6ng7's class question, awaiting a ruling). Noticed while working, for the
mayor to route:

- `HICASSO_HMR_SAVE_TIMEOUT_MS`, `HICASSO_HMR_BUILD_TIMEOUT_MS`,
  `HICASSO_HMR_SPEC_TIMEOUT_MS` — all three soften the gate when raised, which is
  the exact move rf2-odh3's bead forbade in prose ("DO NOT EXTEND THE 90s
  TIMEOUT"). Nothing asserts they are unset in CI and, unlike the engine
  narrowing, nothing prints the value the run actually used, so a raised ceiling
  leaves no trace in the log at all.
- `HICASSO_HMR_PORT` — cannot fail open since #7998: a probe pointed at somebody
  else's server is now caught by the bundle digest.
- `HICASSO_HMR_REGISTER_DELAY_MS` — correctly handled already, and the model for
  the others: it can only make the gate harder, and it announces itself in the
  log when non-zero.

## A note on the port

The first attempt at leg 1 failed exit 1 with `assertOwnBundle`'s refusal — a
peer worktree (`doorguard-t2ec`) was running its own
`shadow-cljs watch hicasso/hmr-testbed` and held `:dev-http` 8061. That is
PR #7998's guard doing precisely its job: without it this run would have driven
somebody else's bundle. Both proof legs were then run on 8961 via the existing
`HICASSO_HMR_PORT` knob, with `shadow-cljs.edn`'s `:dev-http` key shifted to
match **locally and uncommitted**; it is reverted and this PR does not touch
`shadow-cljs.edn`.
