### PR TITLE
fix(pair-mcp): an absent evidence door reaches its degradation rung (rf2-t2ec)

### DIFF
--- a/tools/re-frame2-pair-mcp/spec/003-Tool-Catalogue.md
+++ b/tools/re-frame2-pair-mcp/spec/003-Tool-Catalogue.md
@@ -2610,10 +2610,22 @@ production build entirely. An app on the Reagent or UIx adapter never has
 it at all. Requiring it in the generic preload would make the preload
 uncompilable in those apps.
 
-So each tool evals a self-contained form guarded by
-`cljs.core/exists?`: the door is called only when present, and its
-absence is surfaced honestly as `:reason :evidence-tier-unavailable` —
-*tolerate absent evidence explicitly*, not a fabricated emptiness.
+So each tool evals a self-contained form that **resolves** the door at
+runtime — `cljs.core/find-ns-obj` on the namespace, `unchecked-get` on
+the munged read — and calls it only when present. Its absence is
+surfaced honestly as `:reason :evidence-tier-unavailable` — *tolerate
+absent evidence explicitly*, not a fabricated emptiness.
+
+**The form must never reference a door var as a symbol** (rf2-t2ec).
+It once did, behind a `cljs.core/exists?` guard, and the guard was fine
+while the branch it guarded was not: shadow's analyzer resolves every
+form it compiles before any of it runs, so against an app that has never
+loaded `re-frame.hicasso.tool` the whole eval came back
+`:rf.error/eval-cljs-compile-error` with a raw `:undeclared-var`
+warning. The one population `:evidence-tier-unavailable` is written for
+was the one population that could not reach it. A runtime lookup asks the
+question the rung is actually about — *is this namespace loaded* — and
+the analyzer has nothing to reject.
 
 ### The coupling is a wire STRING, and it has a witness
 

--- a/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/descriptors_data.cljs
+++ b/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/descriptors_data.cljs
@@ -1262,8 +1262,11 @@
 
 ;; ---------------------------------------------------------------------------
 ;; The three re-frame.hicasso.tool reads — the adapter-neutral evidence a
-;; pairing agent reads from a running app. Each ships one exists?-guarded
-;; self-describing form; every read answers inside the four-axis evidence
+;; pairing agent reads from a running app. Each ships one self-describing form
+;; that RESOLVES the door at runtime rather than referencing its vars — a
+;; namespace the build never loaded is rejected by shadow's analyzer before the
+;; form runs, which is what used to hide :evidence-tier-unavailable (rf2-t2ec);
+;; every read answers inside the four-axis evidence
 ;; projection (:scope / :basis / :complete? / :loss) stamped with :schema and
 ;; :read, and egresses only bounded serializable data (no cell / React handle,
 ;; and no read VALUE at all). Absence is honest: :evidence-tier-unavailable (the

--- a/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/hicasso_tool.cljs
+++ b/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/hicasso_tool.cljs
@@ -63,10 +63,11 @@
   that is how the substrate keeps the door out of a production build entirely.
   An app on the Reagent or UIx adapter never has it at all. Requiring it in the
   generic preload would make the preload uncompilable in those apps. So each
-  tool evals a self-contained form guarded by `cljs.core/exists?`: the door is
-  called only when present, and its absence is surfaced HONESTLY as
+  tool evals a self-contained form that RESOLVES the door at runtime and calls
+  it only when present, surfacing its absence HONESTLY as
   `:reason :evidence-tier-unavailable` — 'tolerate absent evidence explicitly',
-  not a fabricated emptiness.
+  not a fabricated emptiness. [[projection-form]] carries why that resolution
+  cannot be a fully-qualified var reference.
 
   ## Absent / older evidence + schema gate
 
@@ -194,9 +195,8 @@
     (probe/map-envelope-result v)))
 
 (defn projection-form
-  "Build the `cljs.core/exists?`-guarded, self-describing eval form for a
-  `re-frame.hicasso.tool` read. Pure string → string, so the form composition
-  is unit-checkable off the wire.
+  "Build the self-describing eval form for a `re-frame.hicasso.tool` read. Pure
+  string → string, so the form composition is unit-checkable off the wire.
 
     `read-fn`  the reader fn name (e.g. \"read-mounted-boundaries\").
 
@@ -208,17 +208,60 @@
   such argument.)
 
   The whole form is one `try` so a throwing read degrades to
-  `:evidence-tier-error` rather than rejecting the eval."
+  `:evidence-tier-error` rather than rejecting the eval.
+
+  ## The door is resolved, never REFERENCED (rf2-t2ec)
+
+  This form names `re-frame.hicasso.tool` in two STRINGS and nowhere as a
+  symbol, and that is the whole point rather than a stylistic preference.
+  The guard here used to be `(cljs.core/exists? re-frame.hicasso.tool/<read>)`
+  around a direct call to the same fully-qualified var. `exists?` is a fair
+  test — it resolves under `no-warn` and answers `false` for an absent door —
+  but the CALL it guarded is a var reference like any other, and shadow's
+  analyzer resolves every form it compiles before any of it runs. Against
+  `:hicasso/hmr-testbed` with the door not required, the emitted form came back:
+
+      {:ok? false, :reason :rf.error/eval-cljs-compile-error,
+       :err \"WARNING - :undeclared-var … Use of undeclared Var
+             re-frame.hicasso.tool/read-mounted-boundaries\"}
+
+  So the one case `:evidence-tier-unavailable` names — a Reagent/UIx app, or a
+  Hicasso app nothing pulled the door into — was the one case that branch could
+  not reach, and the operator got an analyzer warning where the load-the-door
+  hint belonged.
+
+  `cljs.core/find-ns-obj` is the fix because it asks the question the rung is
+  actually about — *is this NAMESPACE loaded* — as a runtime lookup on
+  `goog/global`, which the analyzer has nothing to reject. It takes the door's
+  name in the provider's own spelling and munges it with the runtime's own
+  `munge`, so [[tier-ns]] stays on the wire verbatim and Pair never has to
+  carry a second munging implementation that could disagree with the compiler's
+  (`goog.getObjectByName`, the other candidate, works but wants a pre-munged
+  `re_frame.hicasso.tool.read_mounted_boundaries` built here). It is marked
+  *bootstrap only* in `cljs.core`, meaning it is not the everyday API; it is
+  nonetheless public, present in every dev build, and the only supported way to
+  reach a namespace object by name. This eval path is dev-only in both
+  directions — the tools require the `re-frame2-pair.runtime` preload, which a
+  `:release` build does not run — so the `:advanced` renaming that would defeat
+  it cannot arise here.
+
+  A door that is loaded but INACTIVE is untouched by all of this: its namespace
+  object is present, the read resolves, and it answers `nil` — the
+  `:evidence-tier-inactive` rung, exactly as before. A door that is loaded but
+  whose read has been RENAMED resolves to `undefined`, and calling it throws
+  into the `catch` as `:evidence-tier-error` rather than claiming the door is
+  absent; [[re-frame2-pair-mcp.hicasso-wire-test]] is what stops that reaching
+  a user."
   [read-fn]
-  (let [fq (str tier-ns "/" read-fn)]
-    (str "(try"
-         " (if (cljs.core/exists? " fq ")"
-         " (let [p (" fq ")]"
-         " (if (cljs.core/nil? p)"
-         " {:ok? false, :reason :evidence-tier-inactive, :hint " (pr-str inactive-hint) "}"
-         " (cljs.core/assoc p :ok? true)))"
-         " {:ok? false, :reason :evidence-tier-unavailable, :hint " (pr-str unavailable-hint) "})"
-         " (catch :default e {:ok? false, :reason :evidence-tier-error, :message (cljs.core/str e)}))")))
+  (str "(try"
+       " (let [d (cljs.core/find-ns-obj " (pr-str tier-ns) ")]"
+       " (if (cljs.core/nil? d)"
+       " {:ok? false, :reason :evidence-tier-unavailable, :hint " (pr-str unavailable-hint) "}"
+       " (let [p ((cljs.core/unchecked-get d (cljs.core/munge " (pr-str read-fn) ")))]"
+       " (if (cljs.core/nil? p)"
+       " {:ok? false, :reason :evidence-tier-inactive, :hint " (pr-str inactive-hint) "}"
+       " (cljs.core/assoc p :ok? true)))))"
+       " (catch :default e {:ok? false, :reason :evidence-tier-error, :message (cljs.core/str e)}))"))
 
 (defn- door-read-tool
   "The shared handler for the three nullary door reads."

--- a/tools/re-frame2-pair-mcp/test/README.md
+++ b/tools/re-frame2-pair-mcp/test/README.md
@@ -175,12 +175,15 @@ var in an unloaded namespace is rejected by shadow's analyzer before any
 branch of it runs. No stubbed suite can see that, because no stub
 compiles anything.
 
-Consequently **the witness wants a FRESH watch**. Its own
-`(require 're-frame.hicasso.tool)` loads the door for the life of the
-`shadow-cljs watch`, so a second run finds it already there; rather than
-skip the row — a skip and a pass being indistinguishable, which is the
-very failure shape the row exists to catch — the script fails and names
-the remedy.
+The row's population is self-restoring: the script's own
+`(require 're-frame.hicasso.tool)` reaches the RUNTIME rather than the
+build's module graph, and each run opens a fresh page, so consecutive
+runs against one long-lived watch all see the door absent again. What
+the row cannot survive is a host page that already carries the door —
+one hosting Xray, say — and `RF2_HICASSO_WIRE_URL` accepts any host, so
+the script probes first and fails rather than skipping: a skip and a
+pass are indistinguishable, which is the very failure shape the row
+exists to catch.
 
 Requires a browser build carrying the `re-frame2-pair.runtime` preload
 whose classpath can reach `re-frame.hicasso.tool` and the slice — the

--- a/tools/re-frame2-pair-mcp/test/README.md
+++ b/tools/re-frame2-pair-mcp/test/README.md
@@ -14,7 +14,7 @@ integration scripts.
 | Does the compiled `out/server.js` complete an MCP handshake and surface the documented tool descriptors? | **JS** — `stdio-roundtrip.js` |
 | Does the persistent nREPL socket survive multiple ops on one server process without leaking / hanging? | **JS** — `live-nrepl.js` |
 | Do connect / dispatch / trace / hot-reload work end-to-end against a live browser-hosted fixture, through the real MCP boundary? | **JS** — `live-e2e-fixture.cjs` |
-| Do the three Hicasso evidence-door tools return a schema-matched, non-empty, value-free projection when actually run against a live Hicasso application? | **JS** — `live-hicasso-wire.cjs` |
+| Do the three Hicasso evidence-door tools return a schema-matched, non-empty, value-free projection when actually run against a live Hicasso application — and, against a build that has never loaded the door, reach `:evidence-tier-unavailable` rather than an analyzer compile error? | **JS** — `live-hicasso-wire.cjs` |
 | Does closing stdin (EOF) retire the session — close the persistent nREPL socket and exit 0 — with no out-of-band kill? | **JS** — `stdin-eof-shutdown.cjs` |
 
 If a regression would only be visible **after** the CLJS compiles to
@@ -163,6 +163,24 @@ read, and — the point of the file — that it does **not** carry the
 secret seeded into that draft. Non-vacuity comes first: `read-sub`, the
 same server on the same socket, returns the secret, so the absence rows
 are about the door rather than about an empty runtime.
+
+**It also witnesses the door-ABSENT rung, and that row runs first**
+(rf2-t2ec). Before anything pulls `re-frame.hicasso.tool` in, the same
+three tools must answer `:reason :evidence-tier-unavailable` with the
+load-the-door hint — the population being a Hicasso build that has never
+compiled the door, which is what a Reagent or UIx app is permanently.
+This is the row that found the original defect: the tools answered a raw
+`:rf.error/eval-cljs-compile-error` instead, because a form referencing a
+var in an unloaded namespace is rejected by shadow's analyzer before any
+branch of it runs. No stubbed suite can see that, because no stub
+compiles anything.
+
+Consequently **the witness wants a FRESH watch**. Its own
+`(require 're-frame.hicasso.tool)` loads the door for the life of the
+`shadow-cljs watch`, so a second run finds it already there; rather than
+skip the row — a skip and a pass being indistinguishable, which is the
+very failure shape the row exists to catch — the script fails and names
+the remedy.
 
 Requires a browser build carrying the `re-frame2-pair.runtime` preload
 whose classpath can reach `re-frame.hicasso.tool` and the slice — the

--- a/tools/re-frame2-pair-mcp/test/live-hicasso-wire.cjs
+++ b/tools/re-frame2-pair-mcp/test/live-hicasso-wire.cjs
@@ -88,15 +88,19 @@
 // called against the plain host build and must answer
 // `:evidence-tier-unavailable` with its hint. The row runs FIRST, because
 // it is the only assertion here whose population is destroyed by the rest
-// of the script.
+// of the script — `(require 're-frame.hicasso.tool)` below pushes the door
+// into the runtime this script is about to interrogate.
 //
-// **That makes the run order load-bearing, and it makes the witness a
-// once-per-watch instrument.** `(require 're-frame.hicasso.tool)` below
-// compiles the door into this build for the life of the `shadow-cljs
-// watch` — a second run against the same watch finds the door already
-// there. Rather than skip the row (a skip here is indistinguishable from
-// a pass, which is the failure shape this bead is about), the script
-// checks the precondition and FAILS with the remedy: restart the watch.
+// The population comes back on its own. A REPL `require` reaches the
+// RUNTIME, not the build's module graph, and every run of this script
+// opens a fresh Playwright page — so the next run's page starts without
+// the door again and the script is re-runnable against one long-lived
+// `shadow-cljs watch`. What is NOT safe is a page that already carries
+// the door: `RF2_HICASSO_WIRE_URL` accepts any host, and a page hosting
+// Xray has pulled the door in. Rather than skip the row on such a host —
+// a skip and a pass being indistinguishable, which is precisely the
+// failure shape this bead is about — the script probes for the door and
+// FAILS, naming the host as the reason.
 //
 // ## Running it
 //
@@ -104,9 +108,8 @@
 // it SOFT-SKIPS (exit 0 with a `SKIP` banner) when the infrastructure is
 // absent, so it is safe to invoke anywhere.
 //
-//   # 1. a FRESH browser build carrying the pair preload, on the
-//   #    implementation classpath (which is where the slice and the door
-//   #    both live). Fresh matters: see the door-absent section above.
+//   # 1. a browser build carrying the pair preload, on the implementation
+//   #    classpath (which is where the slice and the door both live):
 //   cd implementation
 //   npx shadow-cljs watch hicasso/hmr-testbed \
 //     --config-merge '{:devtools {:preloads [re-frame2-pair.runtime]}}'
@@ -401,10 +404,10 @@ async function main() {
     assert(!doorLoaded.isError, 'the door-presence probe returned isError: ' + doorLoaded.text);
     assert(
       /:value false\b/.test(doorLoaded.text),
-      `${DOOR_NS} is ALREADY loaded in this build, so the door-absent rung cannot ` +
-        'be witnessed. This script loads the door itself further down, for the ' +
-        'life of the watch — restart `shadow-cljs watch hicasso/hmr-testbed` and ' +
-        're-run. Probe answered: ' + doorLoaded.text,
+      `${DOOR_NS} is ALREADY loaded in this runtime, so the door-absent rung ` +
+        `cannot be witnessed here. Point RF2_HICASSO_WIRE_URL at a page that ` +
+        'has not pulled the door in — a page hosting Xray has — or reload the ' +
+        'one you have. Probe answered: ' + doorLoaded.text,
     );
     for (const read of DOOR_READS) {
       const r = await callTool(client, read, { build, 'max-tokens': 0 });
@@ -451,8 +454,9 @@ async function main() {
     // Nothing in `re-frame.hicasso` requires the door — that is how a
     // production build never loads it — so a Hicasso app has it only once
     // something pulls it in. Xray does; here this line does. It is also the
-    // line that ends the door-absent population above, for the life of the
-    // watch rather than of this process.
+    // line that ends the door-absent population above — for the life of this
+    // PAGE, which is why the row runs first and why the next run's fresh page
+    // gets its population back.
     await evalCljs(client, `(require '${DOOR_NS})`, 'load the evidence door');
     console.log('OK   slice booted by its own -main; evidence door loaded');
 

--- a/tools/re-frame2-pair-mcp/test/live-hicasso-wire.cjs
+++ b/tools/re-frame2-pair-mcp/test/live-hicasso-wire.cjs
@@ -30,7 +30,7 @@
 //     -> `probe/eval-after-runtime!` (the `__re_frame2_pair_runtime`
 //        preload probe + the JVM-side liveness re-check)
 //     -> `nrepl/cljs-eval-value` — bencode frames on a REAL socket
-//     -> shadow-cljs COMPILES the `cljs.core/exists?`-guarded form that
+//     -> shadow-cljs COMPILES the door-resolving form that
 //        `hicasso-tool/projection-form` built, and evaluates it inside the
 //        browser CLJS runtime
 //     -> `re-frame.hicasso.tool/<read>` runs against the live application
@@ -68,17 +68,35 @@
 // Without step 1 the absence assertion would pass just as happily against
 // a runtime that never saw the value.
 //
-// ## A finding this witness produced, recorded rather than fixed
+// ## The DOOR-ABSENT rung, witnessed first (rf2-t2ec)
 //
-// The tools' documented degradation for an app that has no evidence door
-// (`:reason :evidence-tier-unavailable`) is NOT what a live absent door
-// answers. `cljs.core/exists?` guards a missing VAR; it does not stop
-// shadow's analyzer rejecting a var in a namespace the build has never
-// loaded, so the call comes back
-// `:reason :rf.error/eval-cljs-compile-error` instead. That is exactly the
-// class of divergence a static seam check cannot see. It is recorded on
-// rf2-hic-059 and left alone here: this bead's repair is a witness, not a
-// provider change.
+// The tools document a degradation ladder whose first rung is an app that
+// has no evidence door — a Reagent/UIx app, or a Hicasso app nothing
+// pulled the door into. This witness in its first form (rf2-hic-059)
+// found that the rung was unreachable: `cljs.core/exists?` guards a
+// missing VAR, but the call it guarded was a var reference like any
+// other, and shadow's analyzer rejects a var in a namespace the build
+// has never loaded before any of the form runs. The rung answered
+// `:reason :rf.error/eval-cljs-compile-error` and an analyzer warning
+// where the load-the-door hint belonged. That is exactly the class of
+// divergence a static seam check cannot see — the emitted string
+// contained the branch, and the branch could not run.
+//
+// rf2-t2ec resolves the door at runtime instead (`find-ns-obj` on the
+// namespace, `unchecked-get` on the munged read), and THIS is where the
+// repair is proved: before anything loads the door, the three tools are
+// called against the plain host build and must answer
+// `:evidence-tier-unavailable` with its hint. The row runs FIRST, because
+// it is the only assertion here whose population is destroyed by the rest
+// of the script.
+//
+// **That makes the run order load-bearing, and it makes the witness a
+// once-per-watch instrument.** `(require 're-frame.hicasso.tool)` below
+// compiles the door into this build for the life of the `shadow-cljs
+// watch` — a second run against the same watch finds the door already
+// there. Rather than skip the row (a skip here is indistinguishable from
+// a pass, which is the failure shape this bead is about), the script
+// checks the precondition and FAILS with the remedy: restart the watch.
 //
 // ## Running it
 //
@@ -86,8 +104,9 @@
 // it SOFT-SKIPS (exit 0 with a `SKIP` banner) when the infrastructure is
 // absent, so it is safe to invoke anywhere.
 //
-//   # 1. a browser build carrying the pair preload, on the implementation
-//   #    classpath (which is where the slice and the door both live):
+//   # 1. a FRESH browser build carrying the pair preload, on the
+//   #    implementation classpath (which is where the slice and the door
+//   #    both live). Fresh matters: see the door-absent section above.
 //   cd implementation
 //   npx shadow-cljs watch hicasso/hmr-testbed \
 //     --config-merge '{:devtools {:preloads [re-frame2-pair.runtime]}}'
@@ -146,6 +165,11 @@ const THE_SECRET = 'RF2-HIC-059-WIRE-SECRET-4d2a1f';
 const EXPECTED_SCHEMA = ':re-frame.hicasso.evidence/v2';
 
 const DOOR_READS = ['read-mounted-boundaries', 'read-read-attribution', 'explain-render'];
+
+// The evidence door itself. Spelled once because the door-absent row below
+// asserts on it three ways — the presence probe, the hint text, and the
+// require that ends the absent population.
+const DOOR_NS = 're-frame.hicasso.tool';
 
 function skip(reason) {
   // The same leading-line banner the mcp-conformance hermetic orchestrator
@@ -365,6 +389,48 @@ async function main() {
     const build = buildMatch[1];
     console.log(`OK   discover-app -> build ${build}`);
 
+    // ---- THE DOOR-ABSENT RUNG, before anything loads the door -----------
+    // Nothing in `re-frame.hicasso` requires `re-frame.hicasso.tool`, so a
+    // freshly-watched build has not compiled it and this host is, for the
+    // moment, indistinguishable from a Reagent/UIx app: the population the
+    // `:evidence-tier-unavailable` rung is written for.
+    const doorLoaded = await callTool(client, 'eval-cljs', {
+      form: `(cljs.core/some? (cljs.core/find-ns-obj "${DOOR_NS}"))`,
+      build,
+    });
+    assert(!doorLoaded.isError, 'the door-presence probe returned isError: ' + doorLoaded.text);
+    assert(
+      /:value false\b/.test(doorLoaded.text),
+      `${DOOR_NS} is ALREADY loaded in this build, so the door-absent rung cannot ` +
+        'be witnessed. This script loads the door itself further down, for the ' +
+        'life of the watch — restart `shadow-cljs watch hicasso/hmr-testbed` and ' +
+        're-run. Probe answered: ' + doorLoaded.text,
+    );
+    for (const read of DOOR_READS) {
+      const r = await callTool(client, read, { build, 'max-tokens': 0 });
+      // Every `:ok? false` rides isError:true, so a degraded read is never
+      // cached and never reads as a successful answer.
+      assert(r.isError, `${read} answered a door-less app without isError: ${r.text}`);
+      assert(
+        r.text.includes(':reason :evidence-tier-unavailable'),
+        `${read} did not reach the documented absent-door rung against a build ` +
+          `that has never loaded ${DOOR_NS}. rf2-t2ec: a form that REFERENCES a ` +
+          'var in an unloaded namespace is rejected by shadow\'s analyzer before ' +
+          'any branch of it runs, and the answer is a raw compile warning ' +
+          `instead. Got: ${r.text.slice(0, 500)}`,
+      );
+      assert(
+        !r.text.includes(':rf.error/eval-cljs-compile-error'),
+        `${read} answered the absent door with an analyzer compile error — the ` +
+          `exact rf2-t2ec regression: ${r.text.slice(0, 500)}`,
+      );
+      assert(
+        r.text.includes(`Load ${DOOR_NS} into the running build and retry`),
+        `${read} reached the rung without the hint an operator acts on: ${r.text.slice(0, 500)}`,
+      );
+      console.log(`OK   ${read} (door absent) -> :evidence-tier-unavailable + load-the-door hint`);
+    }
+
     // ---- Boot the slice through its own entry point ----------------------
     await evalCljs(client, `(require '${SLICE}.app)`, 'require the slice');
     // The slice mounts into `#app`, and the page hosting the runtime is
@@ -384,8 +450,10 @@ async function main() {
     );
     // Nothing in `re-frame.hicasso` requires the door — that is how a
     // production build never loads it — so a Hicasso app has it only once
-    // something pulls it in. Xray does; here this line does.
-    await evalCljs(client, "(require 're-frame.hicasso.tool)", 'load the evidence door');
+    // something pulls it in. Xray does; here this line does. It is also the
+    // line that ends the door-absent population above, for the life of the
+    // watch rather than of this process.
+    await evalCljs(client, `(require '${DOOR_NS})`, 'load the evidence door');
     console.log('OK   slice booted by its own -main; evidence door loaded');
 
     // ---- Seed the secret through the slice's OWN events ------------------

--- a/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/conformance_test.cljs
+++ b/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/conformance_test.cljs
@@ -1776,24 +1776,28 @@
      :reason :no-target-arg}}
 
    ;; ---------- the three re-frame.hicasso.tool reads ---------------------
-   ;; Each ships an exists?-guarded self-describing form calling
-   ;; re-frame.hicasso.tool/<read>; the form resolves to an {:ok? ...} envelope
-   ;; projected via map-envelope-result (every :ok? false is isError). The stub
-   ;; returns the envelope the guarded form would produce, so the corpus pins the
-   ;; happy passthrough (with :schema + the four projection axes) AND the honest
-   ;; absent/inactive envelopes.
+   ;; Each ships one self-describing form that RESOLVES re-frame.hicasso.tool at
+   ;; runtime — `find-ns-obj` on the door, `unchecked-get` on the munged read —
+   ;; and resolves to an {:ok? ...} envelope projected via map-envelope-result
+   ;; (every :ok? false is isError). The stub returns the envelope that form
+   ;; would produce, so the corpus pins the happy passthrough (with :schema + the
+   ;; four projection axes) AND the honest absent/inactive envelopes.
    ;;
-   ;; THE STUB KEY IS THE WIRE STRING, so these fixtures pin the emitter and
-   ;; nothing else — a form naming a read the provider does not publish matches a
+   ;; THE STUB KEY IS THE WIRE STRING — `(cljs.core/munge "<read>")`, the one
+   ;; place each read is named in the emitted form since rf2-t2ec replaced the
+   ;; fully-qualified var reference. These fixtures therefore pin the emitter and
+   ;; nothing else: a form naming a read the provider does not publish matches a
    ;; stub here just as happily as a real one. `hicasso-wire-test` is what reads
-   ;; the provider's own source and holds the other side of that.
+   ;; the provider's own source and holds the other side of that, and the
+   ;; door-absent rung is only witnessed live (test/live-hicasso-wire.cjs) —
+   ;; a stub cannot reject a form the way shadow's analyzer can.
    {:fixture/id    :read-mounted-boundaries/happy
-    :fixture/doc   "read-mounted-boundaries forwards the versioned roster; the form calls re-frame.hicasso.tool/read-mounted-boundaries under an exists? guard. A boundary is keyed by its READ SET — the runtime mints no boundary identity — so :view and :source ride as :unknown under the :naming projection rather than being omitted."
+    :fixture/doc   "read-mounted-boundaries forwards the versioned roster; the form resolves re-frame.hicasso.tool at runtime and calls read-mounted-boundaries off it. A boundary is keyed by its READ SET — the runtime mints no boundary identity — so :view and :source ride as :unknown under the :naming projection rather than being omitted."
     :fixture/tool  "read-mounted-boundaries"
     :fixture/args  {}
     :fixture/eval-script
     [["__re_frame2_pair_runtime"                         true]
-     ["re-frame.hicasso.tool/read-mounted-boundaries"    {:ok? true :schema :re-frame.hicasso.evidence/v2
+     ["(cljs.core/munge \"read-mounted-boundaries\")"    {:ok? true :schema :re-frame.hicasso.evidence/v2
                                                           :producer :re-frame/hicasso
                                                           :read :mounted-boundaries
                                                           :scope :mounted-boundaries
@@ -1813,7 +1817,8 @@
                                                                  :commit :unknown :paint :unknown}}]
      [:default                                           nil]]
     :fixture/eval-form-must-contain
-    ["re-frame.hicasso.tool/read-mounted-boundaries" "cljs.core/exists?"]
+    ["(cljs.core/munge \"read-mounted-boundaries\")"
+     "(cljs.core/find-ns-obj \"re-frame.hicasso.tool\")"]
     :fixture/expect
     {:isError? false
      :edn-submap {:ok? true :schema :re-frame.hicasso.evidence/v2
@@ -1826,7 +1831,7 @@
     :fixture/args  {}
     :fixture/eval-script
     [["__re_frame2_pair_runtime"                         true]
-     ["re-frame.hicasso.tool/read-mounted-boundaries"    {:ok? true :schema :re-frame.hicasso.evidence/v2
+     ["(cljs.core/munge \"read-mounted-boundaries\")"    {:ok? true :schema :re-frame.hicasso.evidence/v2
                                                           :read :mounted-boundaries
                                                           :complete? true :loss nil
                                                           :boundaries []}]
@@ -1836,12 +1841,12 @@
      :edn-submap {:ok? true :boundaries []}}}
 
    {:fixture/id    :read-mounted-boundaries/tier-unavailable-iserror
-    :fixture/doc   "when re-frame.hicasso.tool is not loaded - a Reagent/UIx app, or a Hicasso app nothing pulled the door into (nothing in re-frame.hicasso requires it, which is how a production build never loads it) - the guarded form resolves to {:ok? false :reason :evidence-tier-unavailable}, surfaced as an isError envelope. Absent evidence tolerated explicitly, never a fabricated empty roster."
+    :fixture/doc   "when re-frame.hicasso.tool is not loaded - a Reagent/UIx app, or a Hicasso app nothing pulled the door into (nothing in re-frame.hicasso requires it, which is how a production build never loads it) - find-ns-obj answers nil and the form resolves to {:ok? false :reason :evidence-tier-unavailable}, surfaced as an isError envelope. Absent evidence tolerated explicitly, never a fabricated empty roster."
     :fixture/tool  "read-mounted-boundaries"
     :fixture/args  {}
     :fixture/eval-script
     [["__re_frame2_pair_runtime"                         true]
-     ["re-frame.hicasso.tool/read-mounted-boundaries"    {:ok? false :reason :evidence-tier-unavailable
+     ["(cljs.core/munge \"read-mounted-boundaries\")"    {:ok? false :reason :evidence-tier-unavailable
                                                           :hint "the re-frame.hicasso.tool evidence door is not loaded..."}]
      [:default                                           nil]]
     :fixture/expect
@@ -1854,7 +1859,7 @@
     :fixture/args  {}
     :fixture/eval-script
     [["__re_frame2_pair_runtime"                         true]
-     ["re-frame.hicasso.tool/read-mounted-boundaries"    {:ok? true :schema :re-frame.hicasso.evidence/v1
+     ["(cljs.core/munge \"read-mounted-boundaries\")"    {:ok? true :schema :re-frame.hicasso.evidence/v1
                                                           :boundaries []}]
      [:default                                           nil]]
     :fixture/expect
@@ -1869,7 +1874,7 @@
     :fixture/args  {}
     :fixture/eval-script
     [["__re_frame2_pair_runtime"                         true]
-     ["re-frame.hicasso.tool/read-read-attribution"      {:ok? true :schema :re-frame.hicasso.evidence/v2
+     ["(cljs.core/munge \"read-read-attribution\")"      {:ok? true :schema :re-frame.hicasso.evidence/v2
                                                           :read :read-attribution
                                                           :scope :read-edges :basis :observation
                                                           :complete? true :loss nil
@@ -1880,19 +1885,19 @@
                                                           :host {:basis :host-opaque :complete? false}}]
      [:default                                           nil]]
     :fixture/eval-form-must-contain
-    ["re-frame.hicasso.tool/read-read-attribution"]
+    ["(cljs.core/munge \"read-read-attribution\")"]
     :fixture/expect
     {:isError? false
      :edn-submap {:ok? true :complete? true :basis :observation}
      :edn-contains-keys #{:edges}}}
 
    {:fixture/id    :read-read-attribution/tier-inactive-iserror
-    :fixture/doc   "a production build nil-gates the whole door - every read answers nil under :advanced with goog.DEBUG false - so the guarded form resolves to {:ok? false :reason :evidence-tier-inactive}, surfaced as isError. Distinguishable from :evidence-tier-unavailable, which is the door being absent rather than dev-gated."
+    :fixture/doc   "a production build nil-gates the whole door - every read answers nil under :advanced with goog.DEBUG false - so the door RESOLVES and the form resolves to {:ok? false :reason :evidence-tier-inactive}, surfaced as isError. Distinguishable from :evidence-tier-unavailable, which is the door being absent rather than dev-gated."
     :fixture/tool  "read-read-attribution"
     :fixture/args  {}
     :fixture/eval-script
     [["__re_frame2_pair_runtime"                         true]
-     ["re-frame.hicasso.tool/read-read-attribution"      {:ok? false :reason :evidence-tier-inactive
+     ["(cljs.core/munge \"read-read-attribution\")"      {:ok? false :reason :evidence-tier-inactive
                                                           :hint "the evidence door is DEV-ONLY..."}]
      [:default                                           nil]]
     :fixture/expect
@@ -1905,7 +1910,7 @@
     :fixture/args  {}
     :fixture/eval-script
     [["__re_frame2_pair_runtime"                         true]
-     ["re-frame.hicasso.tool/explain-render"             {:ok? true :schema :re-frame.hicasso.evidence/v2
+     ["(cljs.core/munge \"explain-render\")"             {:ok? true :schema :re-frame.hicasso.evidence/v2
                                                           :read :explain-render
                                                           :scope :mounted-boundaries
                                                           :basis :observation
@@ -1930,7 +1935,7 @@
                                                           :host {:basis :host-opaque :complete? false}}]
      [:default                                           nil]]
     :fixture/eval-form-must-contain
-    ["re-frame.hicasso.tool/explain-render"]
+    ["(cljs.core/munge \"explain-render\")"]
     :fixture/expect
     {:isError? false
      :edn-submap {:ok? true :complete? false
@@ -1943,7 +1948,7 @@
     :fixture/args  {}
     :fixture/eval-script
     [["__re_frame2_pair_runtime"                         true]
-     ["re-frame.hicasso.tool/explain-render"             {:ok? true :schema :re-frame.hicasso.evidence/v2
+     ["(cljs.core/munge \"explain-render\")"             {:ok? true :schema :re-frame.hicasso.evidence/v2
                                                           :read :explain-render
                                                           :scope :mounted-boundaries
                                                           :basis :observation
@@ -1972,7 +1977,7 @@
     :fixture/args  {}
     :fixture/eval-script
     [["__re_frame2_pair_runtime"                         true]
-     ["re-frame.hicasso.tool/explain-render"             {:ok? false :reason :evidence-tier-error
+     ["(cljs.core/munge \"explain-render\")"             {:ok? false :reason :evidence-tier-error
                                                           :message "TypeError: cannot read .-epoch of null"}]
      [:default                                           nil]]
     :fixture/expect

--- a/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/hicasso_tool_test.cljs
+++ b/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/hicasso_tool_test.cljs
@@ -4,19 +4,42 @@
 
   Two layers (mirroring read-ui-test):
 
-    1. Form composition — each tool ships ONE exists?-guarded self-describing
-       form calling `re-frame.hicasso.tool/<read>`. We check the pure
-       `projection-form` builder and, via a capturing eval stub, that the tool
-       emits an exists? guard, is READ-ONLY, and does NOT route through a
-       `re-frame2-pair.runtime` wrapper (the deliberate divergence — the door
-       is optional and absent in a Reagent/UIx app, so it must not be
-       hard-required in the preload).
+    1. Form composition — each tool ships ONE self-describing form that
+       RESOLVES `re-frame.hicasso.tool` at runtime and calls the read off it.
+       We check the pure `projection-form` builder and, via a capturing eval
+       stub, that the tool resolves rather than references the door, is
+       READ-ONLY, and does NOT route through a `re-frame2-pair.runtime`
+       wrapper (the deliberate divergence — the door is optional and absent in
+       a Reagent/UIx app, so it must not be hard-required in the preload).
 
     2. Tool wiring — the schema gate, and the map-envelope-result passthrough
-       of the guarded form's envelope.
+       of the form's envelope.
 
-  What this suite deliberately does NOT prove is that the provider actually
-  publishes the reads these forms name — that is
+  ## The absent-door rung is EXERCISED here, not asserted (rf2-t2ec)
+
+  This suite used to satisfy itself that the emitted form CONTAINED the
+  `:evidence-tier-unavailable` branch. It did, always — and the branch was
+  unreachable in every real app, because the form referenced
+  `re-frame.hicasso.tool/<read>` as a var and shadow's analyzer rejects a var
+  in a namespace the build has never loaded, before any of the form runs. A
+  string assertion about an emitted branch is the same fail-open shape as a
+  census that cannot fail: it passes whether or not the branch can be reached.
+
+  So the absent path is now RUN. `re-frame.hicasso.tool` is genuinely absent
+  from this Node test process — Pair must never require it, and the
+  bundle-isolation fence means it never will — which makes this process a
+  faithful stand-in for a Reagent/UIx app. The test lifts the door name and the
+  read name out of the ACTUAL emitted form and drives the SAME `cljs.core`
+  lookup the form performs, with a loaded namespace as the positive control so
+  a nil answer is proof of absence rather than of a broken probe.
+
+  What no in-process test can see is the analyzer half — the emitted form is
+  compiled by shadow in somebody else's JVM. That is
+  `test/live-hicasso-wire.cjs`, which drives the three tools against a build
+  with the door NOT loaded and asserts the rung is reached with its hint.
+
+  What this suite also deliberately does NOT prove is that the provider
+  actually publishes the reads these forms name — that is
   [[re-frame2-pair-mcp.hicasso-wire-test]], and it is a separate file because
   it asserts against a DIFFERENT artefact's source. A suite that only exercised
   the emitter cannot see the failure this coupling is prone to."
@@ -46,12 +69,13 @@
 ;; projection-form — the pure guarded-form builder
 ;; ---------------------------------------------------------------------------
 
-(deftest projection-form-guards-the-door-and-calls-it-nullary
+(deftest projection-form-resolves-the-door-and-calls-it-nullary
   (let [form (hicasso-tool/projection-form "read-mounted-boundaries")]
-    (is (str/includes? form "cljs.core/exists? re-frame.hicasso.tool/read-mounted-boundaries")
-        "the read is called only when the door is present")
-    (is (str/includes? form "(re-frame.hicasso.tool/read-mounted-boundaries)")
-        "the read is nullary — this door has no id to narrow by")
+    (is (str/includes? form "(cljs.core/find-ns-obj \"re-frame.hicasso.tool\")")
+        "the door is looked up by NAME — the question the unavailable rung asks")
+    (is (str/includes? form
+                       "((cljs.core/unchecked-get d (cljs.core/munge \"read-mounted-boundaries\")))")
+        "the read is resolved off the namespace object and called NULLARY — this door has no id to narrow by")
     (is (str/includes? form ":evidence-tier-unavailable")
         "an absent door degrades honestly, not a fabricated emptiness")
     (is (str/includes? form ":reason :evidence-tier-inactive")
@@ -60,6 +84,90 @@
         "a present projection is forwarded verbatim, stamped :ok? true")
     (is (str/includes? form "catch :default e")
         "a throwing read degrades to :evidence-tier-error")))
+
+(deftest no-form-references-a-door-var-as-a-symbol
+  ;; rf2-t2ec, the regression fence. A fully-qualified `re-frame.hicasso.tool/…`
+  ;; symbol ANYWHERE in the emitted form is resolved by shadow's analyzer before
+  ;; the form runs, so against an app without the door the whole eval comes back
+  ;; :rf.error/eval-cljs-compile-error and every branch below it — including the
+  ;; unavailable rung this door's honesty rests on — is dead. The door's name may
+  ;; ride as a STRING (that is how it is resolved, and how the hint spells it);
+  ;; what may never ride is `<tier-ns>/<anything>`.
+  (doseq [read-fn hicasso-tool/tier-reads]
+    (let [form (hicasso-tool/projection-form read-fn)]
+      (is (nil? (re-find (re-pattern (str (str/replace hicasso-tool/tier-ns "." "\\.")
+                                          "/[a-zA-Z0-9?!*<>=+_-]"))
+                         form))
+          (str read-fn ": the form must not reference a var in the door namespace — "
+               "the analyzer rejects it in an app that has not loaded the door, and "
+               "the :evidence-tier-unavailable branch never runs")))))
+
+;; ---------------------------------------------------------------------------
+;; The absent-door rung, EXERCISED (rf2-t2ec)
+;;
+;; `re-frame.hicasso.tool` is genuinely absent from this process — Pair does not
+;; and must not require it — so the same lookup the emitted form performs can be
+;; run here against a real absence. See the ns docstring for why a
+;; `str/includes?` on the emitted branch was not a test of this at all.
+;; ---------------------------------------------------------------------------
+
+(defn- emitted-door-ns
+  "The namespace name the ACTUAL emitted form hands to `find-ns-obj`."
+  [form]
+  (second (re-find #"\(cljs\.core/find-ns-obj \"([^\"]+)\"\)" form)))
+
+(defn- emitted-read-name
+  "The read name the ACTUAL emitted form hands to `munge`."
+  [form]
+  (second (re-find #"\(cljs\.core/munge \"([^\"]+)\"\)" form)))
+
+(defn- resolve-door-read
+  "The emitted form's own resolution step, run in THIS process: the namespace
+  object by name, then the read off it by munged name. `nil` on either leg is
+  exactly what drives the form to `:evidence-tier-unavailable`."
+  [door-ns read-fn]
+  (some-> (cljs.core/find-ns-obj door-ns)
+          (cljs.core/unchecked-get (cljs.core/munge read-fn))))
+
+(deftest the-lookup-the-form-performs-resolves-a-namespace-that-IS-loaded
+  ;; The positive control, and it is what makes the absence test below mean
+  ;; something: `this` suite's own namespace is loaded here, so the same two
+  ;; steps must hand back a callable. Without it a broken probe would report
+  ;; every door in the world as absent and the suite would still be green.
+  (let [f (resolve-door-read "re-frame2-pair-mcp.tools.hicasso-tool" "projection-form")]
+    (is (fn? f)
+        "find-ns-obj + unchecked-get + munge resolves a read off a LOADED namespace")
+    (is (string? (f "read-mounted-boundaries"))
+        "…and what it resolves is the real fn, callable")))
+
+(deftest an-absent-door-drives-the-form-to-the-unavailable-rung
+  (doseq [read-fn hicasso-tool/tier-reads]
+    (let [form     (hicasso-tool/projection-form read-fn)
+          door-ns  (emitted-door-ns form)
+          read-nm  (emitted-read-name form)]
+      (is (= hicasso-tool/tier-ns door-ns)
+          (str read-fn ": the form resolves the door this build targets"))
+      (is (= read-fn read-nm)
+          (str read-fn ": …and names this read at the resolution site"))
+      ;; The rung's own condition, evaluated: this process has no
+      ;; re-frame.hicasso.tool, exactly like a Reagent or UIx app.
+      (is (nil? (cljs.core/find-ns-obj door-ns))
+          (str read-fn ": re-frame.hicasso.tool is absent here — if this ever "
+               "resolves, Pair has acquired a dependency on the provider and the "
+               "bundle-isolation fence is broken"))
+      (is (nil? (resolve-door-read door-ns read-nm))
+          (str read-fn ": the resolution the form performs yields nil, so the form "
+               "takes the :evidence-tier-unavailable branch")))))
+
+(deftest the-unavailable-rung-carries-the-load-the-door-hint
+  ;; The rung is only useful if it tells the operator what to do; the live
+  ;; witness asserts the same hint arrives at the wire.
+  (let [form (hicasso-tool/projection-form "read-mounted-boundaries")
+        i    (str/index-of form ":evidence-tier-unavailable")]
+    (is (some? i))
+    (is (str/includes? (subs form i (min (count form) (+ i 600)))
+                       "Load re-frame.hicasso.tool into the running build and retry")
+        "the unavailable branch carries the load-the-door instruction, not just a reason")))
 
 (deftest projection-form-carries-no-view-shaped-vocabulary
   ;; The donor family this replaced took a `:view-id` and could answer
@@ -85,7 +193,7 @@
 ;; Tool wiring — form composition through the real tool fns
 ;; ---------------------------------------------------------------------------
 
-(deftest each-tool-emits-a-guarded-door-call
+(deftest each-tool-emits-a-runtime-resolved-door-call
   (async done
     (let [seen (atom nil)
           canned {:ok? true :schema hicasso-tool/consumed-evidence-schema}
@@ -99,14 +207,18 @@
                                (fn [] (tool-fn (fresh-conn) #js {})))
                              (.then (fn [_]
                                       (let [form @seen]
-                                        (is (str/includes? form (str "re-frame.hicasso.tool/" read-fn))
+                                        (is (= read-fn (emitted-read-name form))
                                             (str read-fn " calls the framework read directly"))
+                                        (is (= hicasso-tool/tier-ns (emitted-door-ns form))
+                                            "…off the adapter-neutral door, resolved by name")
                                         (is (not (str/includes? form "re-frame2-pair.runtime/"))
                                             "does NOT route through the preload runtime — the door is optional")
                                         (is (not (str/includes? form "freehand"))
                                             "no donor name survives on the wire")
-                                        (is (str/includes? form "cljs.core/exists?")
-                                            "guards the door's presence"))))))))
+                                        (is (nil? (resolve-door-read (emitted-door-ns form)
+                                                                     (emitted-read-name form)))
+                                            (str "the door is absent in this process, so the form this tool "
+                                                 "sent would take the :evidence-tier-unavailable branch")))))))))
             (js/Promise.resolve nil)
             cases)
           (.then (fn [_] (done)))))))

--- a/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/hicasso_wire_test.cljs
+++ b/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/hicasso_wire_test.cljs
@@ -84,15 +84,30 @@
 (def ^:private provider-evidence-src
   (delay (slurp-repo "implementation/hicasso/src/re_frame/hicasso/evidence.cljs")))
 
-(defn- emitted-fq-symbols
-  "Every `re-frame.hicasso.tool/<read>` occurrence in a form Pair will actually
-  send, as a set of bare read names."
+(defn- emitted-read-names
+  "Every read name a form Pair will actually send resolves off the door, as a
+  set.
+
+  Since rf2-t2ec the emitted form carries no `re-frame.hicasso.tool/<read>`
+  SYMBOL — a var reference into a namespace the running build has not loaded is
+  rejected by shadow's analyzer before the form can run, which is what made the
+  `:evidence-tier-unavailable` rung unreachable. The door is now resolved at
+  runtime, so the read name rides as the string handed to `cljs.core/munge`,
+  and that is the occurrence this parses. Still the EMITTED form rather than a
+  list: what is asserted against the provider is what Pair will send."
   [form]
   (into #{}
         (map second)
-        (re-seq (re-pattern (str (str/replace hicasso-tool/tier-ns "." "\\.")
-                                 "/([a-z0-9?!*<>=+-]+)"))
-                form)))
+        (re-seq #"\(cljs\.core/munge \"([^\"]+)\"\)" form)))
+
+(defn- emitted-door-namespaces
+  "Every namespace name the form asks `cljs.core/find-ns-obj` to resolve. The
+  other half of the wire coupling, and the half that decides whether the
+  absent-door rung is reached at all."
+  [form]
+  (into #{}
+        (map second)
+        (re-seq #"\(cljs\.core/find-ns-obj \"([^\"]+)\"\)" form)))
 
 ;; ---------------------------------------------------------------------------
 ;; 1. Every read the emitter names is published by the provider
@@ -103,9 +118,11 @@
     (doseq [read-fn hicasso-tool/tier-reads]
       (testing read-fn
         (let [form  (hicasso-tool/projection-form read-fn)
-              named (emitted-fq-symbols form)]
+              named (emitted-read-names form)]
           (is (= #{read-fn} named)
               "the emitted form names this read and no other")
+          (is (= #{hicasso-tool/tier-ns} (emitted-door-namespaces form))
+              "…resolved off the door namespace and no other")
           ;; A public `defn` at column 0. `defn-` would not match, and must
           ;; not: a private read is unreachable from an eval form even though
           ;; the name is spelled identically.
@@ -121,7 +138,7 @@
   ;; provider answers.
   (let [src   @provider-tool-src
         named (into #{}
-                    (mapcat #(emitted-fq-symbols (hicasso-tool/projection-form %)))
+                    (mapcat #(emitted-read-names (hicasso-tool/projection-form %)))
                     hicasso-tool/tier-reads)]
     (is (= (set hicasso-tool/tier-reads) named)
         "the emitted forms name exactly the declared reads")


### PR DESCRIPTION
Closes rf2-t2ec.

The three Hicasso evidence-door tools documented a degradation ladder whose first rung is an app without `re-frame.hicasso.tool` loaded — a Reagent/UIx app, or a Hicasso app nothing pulled the door into — answering `{:ok? false :reason :evidence-tier-unavailable}` with a load-the-door hint. Live, that rung never ran. `cljs.core/exists?` was a fair guard, but the **call** it guarded was a fully-qualified var reference, and shadow's analyzer resolves every form it compiles before any of it runs. Against `:hicasso/hmr-testbed` with the door not required, the whole eval came back:

```
{:ok? false, :reason :rf.error/eval-cljs-compile-error,
 :err "------ WARNING - :undeclared-var ---
       Resource: <eval>:1:85
       Use of undeclared Var re-frame.hicasso.tool/read-mounted-boundaries"}
```

Column 85 is the call site. `exists?` sits at column 29 and is *not* what warned — measured directly: `(cljs.core/exists? re-frame.hicasso.tool/read-mounted-boundaries)` evaluated alone against that same door-less build returns `{:ok? true, :value false}`. The guard was never the problem; the thing it guarded was.

## The guard approach, and why

`projection-form` now **resolves** the door instead of referencing it:

```clojure
(try
 (let [d (cljs.core/find-ns-obj "re-frame.hicasso.tool")]
 (if (cljs.core/nil? d)
 {:ok? false, :reason :evidence-tier-unavailable, :hint "…"}
 (let [p ((cljs.core/unchecked-get d (cljs.core/munge "read-mounted-boundaries")))]
 (if (cljs.core/nil? p)
 {:ok? false, :reason :evidence-tier-inactive, :hint "…"}
 (cljs.core/assoc p :ok? true)))))
 (catch :default e {:ok? false, :reason :evidence-tier-error, :message (cljs.core/str e)}))
```

Three candidates were measured against the live door-less build before choosing (`eval-cljs` through the shipped server, transcript in the gate log):

| candidate | door absent | door loaded | verdict |
|---|---|---|---|
| `cljs.core/find-ns-obj` + `unchecked-get` + `munge` | `nil` → the rung | resolves all three reads, projection forwarded | **chosen** |
| `js/goog.getObjectByName` | `nil` → the rung | works | rejected, see below |
| `cljs.core/exists?` on the FQ var, then call it | guard says `false`, call is rejected by the analyzer | works | the defect |

`find-ns-obj` asks the question the rung is *actually* about — is this NAMESPACE loaded — as a runtime lookup on `goog/global`, which the analyzer has nothing to reject. It takes the door's name in the provider's own spelling and munges it with the runtime's own `munge`, so `tier-ns` stays on the wire verbatim and Pair carries no second munging implementation that could disagree with the compiler's. `goog.getObjectByName` works equally well but wants a pre-munged `re_frame.hicasso.tool.read_mounted_boundaries`, i.e. exactly that second implementation, built on the Pair side. `find-ns-obj` is marked *bootstrap only* in `cljs.core`; it is nonetheless public, present in every dev build, and the only supported way to reach a namespace object by name. The `:advanced` renaming that would defeat it cannot arise on this path — the tools require the `re-frame2-pair.runtime` preload, which a `:release` build does not run.

**The loaded-but-inactive rung is untouched.** Its namespace object is present, the read resolves, and it answers `nil` — the `:evidence-tier-inactive` branch, byte-for-byte the same envelope as before. Measured: the pre-fix and post-fix forms return identical projections against a build with the door loaded. A door that is loaded but whose read has been *renamed* now resolves to `undefined` and throws into the existing `catch` as `:evidence-tier-error` rather than claiming the door is absent; no new rung was added.

## The live-witness transcript, door absent

Verbatim envelope from `read-mounted-boundaries` against `:hicasso/hmr-testbed` before anything loaded the door (`isError: true`, all three reads identical):

```
{:ok? false, :reason :evidence-tier-unavailable,
 :hint "the re-frame.hicasso.tool evidence door is not loaded in this app. It lives in
        day8/re-frame2-hicasso and NOTHING in re-frame.hicasso requires it — that is how a
        production build never loads it — so a Hicasso app has it only once something pulls
        it in (Xray does), and an app on the Reagent or UIx adapter does not have it at all.
        Load re-frame.hicasso.tool into the running build and retry."}
```

And the witness run that carries it:

```
[live-hicasso-wire] host http://localhost:8061, nREPL :60794
OK   runtime preload present
OK   discover-app -> build :hicasso/hmr-testbed
OK   read-mounted-boundaries (door absent) -> :evidence-tier-unavailable + load-the-door hint
OK   read-read-attribution   (door absent) -> :evidence-tier-unavailable + load-the-door hint
OK   explain-render          (door absent) -> :evidence-tier-unavailable + load-the-door hint
OK   slice booted by its own -main; evidence door loaded
OK   article route mounted, secret seeded into the draft
OK   read-sub carries the secret — the absence rows below are about the DOOR
OK   read-mounted-boundaries -> :ok? true, :re-frame.hicasso.evidence/v2, slice boundaries present, secret absent
OK   read-read-attribution   -> :ok? true, :re-frame.hicasso.evidence/v2, slice boundaries present, secret absent
OK   explain-render          -> :ok? true, :re-frame.hicasso.evidence/v2, slice boundaries present, secret absent

RE-FRAME2-PAIR-MCP LIVE HICASSO WIRE WITNESS GREEN
```

**Proved able to fail, three legs, hash-verified — and against a restarted watch each time, per the #7997 caution about `re-frame.hicasso.tool` being out of the host build's module graph.** The plant is the pre-fix `projection-form` body, nothing else:

```
fixed     sha256 03935180fd54f83fec3b4834394d0c14f20ebf5ca534b9d9cab0aceb14eeae8a -> witness EXIT 0
pre-fix   sha256 ee478f2e13d9615a53481563c91f7b643e5939e75beb1f5db11dddf0dd162324 -> witness EXIT 1
restored  sha256 03935180fd54f83fec3b4834394d0c14f20ebf5ca534b9d9cab0aceb14eeae8a -> witness EXIT 0
```

The red leg reproduces the bead's symptom exactly:

```
FAIL: read-mounted-boundaries did not reach the documented absent-door rung against a build
that has never loaded re-frame.hicasso.tool. … Got: {:ok? false, :message "cljs eval compile
error/warning: WARNING - :undeclared-var … Resource: <eval>:1:85 … Use of undeclared Var
re-frame.hicasso.tool/read-mounted-boundaries", :reason :rf.error/eval-cljs-compile-error, …}
```

## How the test changed

`hicasso_tool_test` used to assert `(str/includes? form ":evidence-tier-unavailable")` — a string check on an emitted branch, which passed happily for the whole life of the defect because it says nothing about whether the branch can run. That is the fail-open shape of a census that cannot fail. It is gone. In its place:

- **`an-absent-door-drives-the-form-to-the-unavailable-rung`** — lifts the door name and the read name out of the *actually emitted* form and runs the same `cljs.core` lookup the form performs. `re-frame.hicasso.tool` is genuinely absent from this Node test process (Pair must never require it, and the bundle-isolation fence means it never will), so the process is a faithful stand-in for a Reagent/UIx app and the rung's own condition is evaluated against a real absence.
- **`the-lookup-the-form-performs-resolves-a-namespace-that-IS-loaded`** — the positive control, without which a broken probe would report every door in the world as absent and the suite would still be green. It resolves `projection-form` off this suite's own namespace object and calls it.
- **`no-form-references-a-door-var-as-a-symbol`** — the regression fence: no `<tier-ns>/<var>` symbol may appear anywhere in any emitted form, in any position, because that is the single construct the analyzer rejects. The door's name may ride as a string.
- **`the-unavailable-rung-carries-the-load-the-door-hint`** — the rung is only useful if it tells the operator what to do.
- **`each-tool-emits-a-runtime-resolved-door-call`** now runs the resolution against each tool's captured form rather than grepping it for a symbol.

What no in-process test can see is the analyzer half — the emitted form is compiled in somebody else's JVM. That is the live witness above, and the ns docstring says so rather than implying the unit suite covers it.

`hicasso_wire_test` (the both-sides witness) still extracts read names from the emitted form rather than a list, now from the `(cljs.core/munge "<read>")` site, and additionally asserts the form resolves `tier-ns` and no other namespace. The conformance corpus's stub keys move to the same site; the door-family fixture docs were corrected where they said "exists? guard".

**A doc correction inside this PR, recorded rather than quietly amended.** The first draft claimed the witness was a once-per-watch instrument because its own `(require 're-frame.hicasso.tool)` compiles the door into the build. Measured: two consecutive runs against one long-lived watch both reach the rung. A REPL require reaches the *runtime*, not the module graph, and each run opens a fresh Playwright page. The precondition probe stays, because the case it actually guards is a *host page* that already carries the door — `RF2_HICASSO_WIRE_URL` accepts any page, and one hosting Xray has pulled it in. Its positive direction (probe answers true → hard fail) is not exercised by any run here; the same probe form was measured returning `true` once the door is loaded.

## Quality gates

Every gate run alone, nothing appended, never piped; exit code captured on the same command line.

| gate | exit | note |
|---|---|---|
| `tools/re-frame2-pair-mcp` `npm test` | **0** | 1228 tests / 4465 assertions, 0 failures |
| `tools/re-frame2-pair-mcp` `npm run build` | **0** | shipped bundle, 0 warnings |
| `npm run test:live-hicasso-wire` (door-absent + door-present) | **0** | transcript above; run twice, both green |
| live witness against the planted pre-fix emitter | **1** | falsifiability leg, hash-verified |
| `tools/mcp-conformance` `npm test` | **0** | ALL GREEN, 6 `[SKIP]` live rows (need `$SHADOW_CLJS_NREPL_PORT`) |
| `scripts/test-jvm-tools.sh` | **0** | PASS tools JVM artefacts |
| `scripts/test-fast-pr.sh` | **0** | `gate root: /c/Users/miket/code/re-frame2-worktrees/doorguard-t2ec` |

clj-kondo runs inside the fast-PR spine at `errors: 0`; per repo convention a local pass does not decide CI's pinned 2026.04.15 run, and the only finding on a file this PR touches (`conformance_test.cljs:99` unused private var `error?`) is pre-existing and untouched.

**One environmental note worth recording**, because it will bite the next person who runs the pair-mcp suite beside a shadow watch: the first `npm test` run reported 2 failures in `writes_test/discovery-error-structured-content-preserves-reason-namespace`. That test needs a "pristine, no-port harness" so `ensure-connection!` rejects; a `shadow-cljs watch` running in the same tree publishes `implementation/.shadow-cljs/nrepl.port` and the harness discovers it. With the watch stopped the same suite is 0 failures. Nothing in this diff touches that path.

## Refused / out of scope

- **`docs/design/hicasso/product/mcp-runtime-query-spike.md:103`** still says the three tools are "each an `exists?`-guarded eval of `re-frame.hicasso.tool`". That is now stale by one phrase, and it is outside this bead's write surface (`tools/re-frame2-pair-mcp/**`); `docs/design/hicasso/` also carries its own provenance-pin gate. Left for a follow-on rather than rippled into here.
- **`skills/re-frame2-pair/references/ops.md`** needs no change: it already documents `:evidence-tier-unavailable` as what a Reagent/UIx app answers. That claim was false before this PR and is true after it.
- No new rung, no audit of the rest of the ladder, no general "is this namespace loaded" facility — a local guard sufficed.
- No provider change; `implementation/hicasso/src/**` is untouched.
