### PR TITLE
fix(gates): a softened gate says so in its own output (rf2-qzm8, rf2-maiw)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -69,11 +69,22 @@ Never pipe a gate through `tail`, `head` or `grep` — a pipeline's exit status 
 its *last* command's, so a red runner reads green. Redirect to a file, capture
 the runner's own exit code, and quote that number in the PR body. **Every**
 artefact that produces — the log *and* the exit-code file — must land on an
-ignored path; `*.log`, `*.exit` and `*-exit.txt` all are:
+ignored path (`*.log`, `*.exit` and `*-exit.txt` all are) **and carry your
+worktree's name**:
 
 ```bash
-sh <WORKTREE_ROOT>/scripts/test-fast-pr.sh > gate-fastpr.log 2>&1; echo "$?" > gate-fastpr.exit
+sh <WORKTREE_ROOT>/scripts/test-fast-pr.sh > gate-fastpr-<worktree>.log 2>&1; echo "$?" > gate-fastpr-<worktree>.exit
 ```
+
+The suffix is not tidiness — a bare name fails the gate open. Concurrent
+workers share one scratchpad directory (its path carries the session id, not
+the worktree), so a peer silently overwrites a bare `gate-fastpr.exit`, and the
+loser then reads an exit code belonging to another worker's run: a `0` somebody
+else earned, quoted as its own green. Two of six workers in a single wave
+collided exactly that way. Confirm a scratch file is your own before believing
+it, and check the gate's printed `gate root:` line against your worktree (the
+section above) — that check, not this naming rule, is what caught both
+observed collisions.
 
 A single untracked leftover makes `git worktree remove` refuse the tree from
 then on, and nine worktrees accumulated exactly that way before anyone worked

--- a/implementation/scripts/serve-and-run-hicasso-hmr-testbed.cjs
+++ b/implementation/scripts/serve-and-run-hicasso-hmr-testbed.cjs
@@ -109,6 +109,16 @@
  * of a log and no grep for the full-matrix verdict can mistake one for the
  * other (rf2-l92i).
  *
+ * The three timeout ceilings are knobs of the same kind (rf2-qzm8).
+ * `HICASSO_HMR_BUILD_TIMEOUT_MS`, `HICASSO_HMR_SAVE_TIMEOUT_MS` and
+ * `HICASSO_HMR_SPEC_TIMEOUT_MS` stay tunable — a slow box is real — but no
+ * override passes in silence: every non-default value is announced up
+ * front, and a RAISED ceiling closes with the partial token too, because a
+ * pass that may have needed a wider window than the contract's did not
+ * demonstrably pass the contract. A lowered ceiling is stricter than the
+ * contract, so it only announces itself. See `TIMEOUT_DEFAULTS` and
+ * `verdictLine`.
+ *
  * The verdict logic and the hot-line rewriter both carry mutation teeth
  * that run before any browser launches. The rewriter needs them as much as
  * the comparator does: a gate whose "save" silently stopped editing the
@@ -176,9 +186,48 @@ const CANONICAL_LABEL = 'GEN-A';
 // future re-indentation of the form survive the rewrite untouched.
 const HOT_LINE_RE = /"([A-Za-z0-9-]+)"\)(\s*);; rf2-vsgq:HOT-LINE/;
 
-const BUILD_TIMEOUT_MS = parseInt(process.env.HICASSO_HMR_BUILD_TIMEOUT_MS || '300000', 10);
-const SAVE_TIMEOUT_MS = parseInt(process.env.HICASSO_HMR_SAVE_TIMEOUT_MS || '90000', 10);
-const SPEC_TIMEOUT_MS = parseInt(process.env.HICASSO_HMR_SPEC_TIMEOUT_MS || '600000', 10);
+// The three ceilings a run may override from the environment, held in ONE
+// table so the values the run enforces and the disclosure it prints cannot
+// drift apart (rf2-qzm8). Raising one SOFTENS the gate — a wider window can
+// admit a pass the contract's window would have refused, which is the
+// flake-hiding move rf2-odh3's bead forbids in prose — and before this
+// table a raised ceiling left no trace in the log at all, so a run that
+// passed only because someone widened a threshold read identically to one
+// that passed on merit. Now every non-default value is announced up front
+// in `main`, in the same register as the HICASSO_HMR_ENGINES narrowing
+// banner, and a raised one costs the run its full verdict in `verdictLine`.
+const TIMEOUT_DEFAULTS = {
+  HICASSO_HMR_BUILD_TIMEOUT_MS: 300000,
+  HICASSO_HMR_SAVE_TIMEOUT_MS: 90000,
+  HICASSO_HMR_SPEC_TIMEOUT_MS: 600000,
+};
+
+/** The ceilings this run uses: the environment's word, else the default. */
+function resolveTimeouts(env = process.env, defaults = TIMEOUT_DEFAULTS) {
+  return Object.fromEntries(Object.entries(defaults).map(
+    ([name, dflt]) => [name, parseInt(env[name] || String(dflt), 10)]));
+}
+
+/**
+ * Every ceiling whose resolved value differs from its default, with the
+ * direction it moved. `raised` is the fail-open direction and the only one
+ * that costs the run its full verdict; a lowered ceiling is stricter than
+ * the contract, so it is disclosed and nothing more.
+ */
+function timeoutOverrides(timeouts, defaults = TIMEOUT_DEFAULTS) {
+  return Object.entries(defaults)
+    .filter(([name, dflt]) => timeouts[name] !== dflt)
+    .map(([name, dflt]) => ({
+      name, value: timeouts[name], dflt, raised: timeouts[name] > dflt,
+    }));
+}
+
+const TIMEOUTS = resolveTimeouts();
+const TIMEOUT_OVERRIDES = timeoutOverrides(TIMEOUTS);
+
+const BUILD_TIMEOUT_MS = TIMEOUTS.HICASSO_HMR_BUILD_TIMEOUT_MS;
+const SAVE_TIMEOUT_MS = TIMEOUTS.HICASSO_HMR_SAVE_TIMEOUT_MS;
+const SPEC_TIMEOUT_MS = TIMEOUTS.HICASSO_HMR_SPEC_TIMEOUT_MS;
 const NAV_TIMEOUT_MS = 60000;
 // The app's own mount, once shadow is already serving a compiled bundle.
 // Deliberately NOT the build ceiling: by this point the slow part is done,
@@ -234,6 +283,10 @@ const ENGINES = ONLY
 // engine ran and the comparator never ran" must not be the same words
 // (rf2-l92i). Neither token is a substring of the other, so a grep for the
 // full-matrix verdict cannot be answered by a narrowed run.
+//
+// A raised timeout ceiling (rf2-qzm8) closes with the same narrowed token:
+// both are runs that proved less than the contract, and the sentence after
+// the token names the knob either way, so the reader knows which to unset.
 //
 // The CI job passes no narrowing at all and a classifier regression in
 // `_changed-surfaces.test.cjs` pins that, so this pair is about the LOCAL
@@ -516,20 +569,33 @@ function comparedAcrossEngines(engines) {
 /**
  * The line the run closes with.
  *
- * A narrowed run passed everything it ran, so it still exits 0 and still
- * says PASS — what it must not do is say it the same way. Below two engines
- * the verdict token changes, the sentence states that the cross-engine
- * comparison was NOT performed, and it names the variable that caused it so
- * the reader knows which knob to unset.
+ * A weakened run passed everything it ran, so it still exits 0 and still
+ * says PASS — what it must not do is say it the same way. Two weakenings
+ * cost the full token: an engine set below two, whose sentence states that
+ * the cross-engine comparison was NOT performed, and a RAISED timeout
+ * ceiling (rf2-qzm8), whose sentence states that the pass may have needed
+ * a wider window than the contract allows. Either way the sentence names
+ * the variable that caused it, so the reader knows which knob to unset. A
+ * LOWERED ceiling is stricter than the contract and costs nothing here —
+ * the up-front banner in `main` is its only trace.
  */
-function verdictLine(engines, reloads) {
+function verdictLine(engines, reloads, overrides = TIMEOUT_OVERRIDES) {
   const tail = `${reloads} real shadow reloads`;
-  if (comparedAcrossEngines(engines)) {
+  const causes = [];
+  if (!comparedAcrossEngines(engines)) {
+    causes.push('HICASSO_HMR_ENGINES narrowed this run, so the cross-engine '
+      + 'comparison was NOT performed');
+  }
+  for (const o of overrides.filter((x) => x.raised)) {
+    causes.push(`${o.name}=${o.value} raised the ${o.dflt}ms ceiling, so `
+      + 'this pass may have needed a wider window than the contract allows');
+  }
+  if (causes.length === 0) {
     return `${FULL_VERDICT} (${engines.join(' + ')}) — ${tail}`;
   }
-  return `${NARROWED_VERDICT} (${engines.join(' + ') || 'no engine'} only; `
-    + `HICASSO_HMR_ENGINES narrowed this run, so the cross-engine comparison `
-    + `was NOT performed) — ${tail}`;
+  return `${NARROWED_VERDICT} (${engines.join(' + ') || 'no engine'}`
+    + `${comparedAcrossEngines(engines) ? '' : ' only'}; `
+    + `${causes.join('; ')}) — ${tail}`;
 }
 
 function coverageReport(result, required = REQUIRED_SECTIONS) {
@@ -755,7 +821,7 @@ function runMutationTeeth() {
   // alone.
 
   bite('a compared run prints the full verdict and names its engines', () => {
-    const line = verdictLine(ALL_ENGINES, 36);
+    const line = verdictLine(ALL_ENGINES, 36, []);
     return line.startsWith(FULL_VERDICT)
       && line.includes('chromium + firefox + webkit')
       && line.includes('36 real shadow reloads')
@@ -763,10 +829,10 @@ function runMutationTeeth() {
   });
 
   bite('a one-engine run does NOT print the full verdict', () =>
-    !verdictLine(['chromium'], 36).includes(FULL_VERDICT));
+    !verdictLine(['chromium'], 36, []).includes(FULL_VERDICT));
 
   bite('a one-engine run says the comparison was skipped and names the knob', () => {
-    const line = verdictLine(['webkit'], 12);
+    const line = verdictLine(['webkit'], 12, []);
     return line.startsWith(NARROWED_VERDICT)
       && /cross-engine comparison was NOT performed/.test(line)
       && /HICASSO_HMR_ENGINES/.test(line)
@@ -791,11 +857,64 @@ function runMutationTeeth() {
     // disagree with — but the run that got that silence must not close as
     // though it had been compared.
     return divergenceReport(one, []).length === 0
-      && verdictLine(Object.keys(one), 1).startsWith(NARROWED_VERDICT)
+      && verdictLine(Object.keys(one), 1, []).startsWith(NARROWED_VERDICT)
       // ...and two engines ARE compared, which is what makes the silence
       // above a fact about the engine count and nothing else.
       && divergenceReport(two, []).length === 1
-      && verdictLine(Object.keys(two), 1).startsWith(FULL_VERDICT);
+      && verdictLine(Object.keys(two), 1, []).startsWith(FULL_VERDICT);
+  });
+
+  // --- the ceilings, which may move but not in silence (rf2-qzm8) --------
+  //
+  // Same defect class as the narrowed engine set: a knob that softens the
+  // gate must leave a trace, or a pass bought with a wider window reads
+  // identically to one earned inside the contract's. The overrides list is
+  // derived from the same resolution the run enforces, so the disclosure
+  // cannot describe different values than the ceilings used.
+
+  bite('a default environment overrides no ceiling', () =>
+    timeoutOverrides(resolveTimeouts({})).length === 0);
+
+  bite('setting a knob TO its default is not an override', () =>
+    timeoutOverrides(resolveTimeouts(
+      { HICASSO_HMR_SAVE_TIMEOUT_MS: '90000' })).length === 0);
+
+  bite('a raised ceiling is an override in the fail-open direction', () => {
+    const o = timeoutOverrides(resolveTimeouts(
+      { HICASSO_HMR_SAVE_TIMEOUT_MS: '180000' }));
+    return o.length === 1
+      && o[0].name === 'HICASSO_HMR_SAVE_TIMEOUT_MS'
+      && o[0].value === 180000 && o[0].dflt === 90000 && o[0].raised === true;
+  });
+
+  bite('a lowered ceiling is an override but not a raised one', () => {
+    const o = timeoutOverrides(resolveTimeouts(
+      { HICASSO_HMR_BUILD_TIMEOUT_MS: '60000' }));
+    return o.length === 1 && o[0].raised === false;
+  });
+
+  bite('a raised ceiling costs the full verdict, and the line names the knob', () => {
+    const line = verdictLine(ALL_ENGINES, 36, timeoutOverrides(resolveTimeouts(
+      { HICASSO_HMR_SAVE_TIMEOUT_MS: '180000' })));
+    return line.startsWith(NARROWED_VERDICT)
+      && !line.includes(FULL_VERDICT)
+      && line.includes('HICASSO_HMR_SAVE_TIMEOUT_MS=180000')
+      && line.includes('90000ms ceiling')
+      && line.includes('chromium + firefox + webkit')
+      && line.includes('36 real shadow reloads');
+  });
+
+  bite('a lowered ceiling alone leaves the full verdict intact', () =>
+    verdictLine(ALL_ENGINES, 36, timeoutOverrides(resolveTimeouts(
+      { HICASSO_HMR_SPEC_TIMEOUT_MS: '60000' }))).startsWith(FULL_VERDICT));
+
+  bite('a narrowed run under a raised ceiling names both causes', () => {
+    const line = verdictLine(['chromium'], 12, timeoutOverrides(resolveTimeouts(
+      { HICASSO_HMR_BUILD_TIMEOUT_MS: '600000' })));
+    return line.startsWith(NARROWED_VERDICT)
+      && /cross-engine comparison was NOT performed/.test(line)
+      && line.includes('HICASSO_HMR_BUILD_TIMEOUT_MS=600000')
+      && line.includes('12 real shadow reloads');
   });
 
   // --- the floors -------------------------------------------------------
@@ -1271,6 +1390,21 @@ async function main() {
     }
   }
 
+  // The ceilings get the same up-front honesty (rf2-qzm8): a run about to
+  // spend half an hour says NOW that it is not running under the contract's
+  // windows, rather than leaving the reader to discover it — or worse, not
+  // — in the closing line. A raised ceiling also costs the full verdict;
+  // see `verdictLine`.
+  for (const o of TIMEOUT_OVERRIDES) {
+    console.log(`> ${o.name}=${o.value} — ${o.raised ? 'RAISED' : 'lowered'} `
+      + `from its default ${o.dflt}ms. `
+      + (o.raised
+        ? 'A wider ceiling can admit a pass the contract\'s window would '
+          + `have refused, so this run closes with at most "${NARROWED_VERDICT}".`
+        : 'A lower ceiling only makes this run stricter; the verdict is '
+          + 'unaffected.'));
+  }
+
   // FAIL CLOSED on a dirty tree. The gate edits a tracked file, so a
   // previous run killed between its edit and its restore would otherwise
   // hand this run a source whose "canonical" state is already a fixture —
@@ -1356,6 +1490,9 @@ module.exports = {
   NARROWINGS,
   REQUIRED_SECTIONS,
   REQUIRED_RECORDS,
+  TIMEOUT_DEFAULTS,
+  resolveTimeouts,
+  timeoutOverrides,
 };
 
 if (require.main === module) {


### PR DESCRIPTION
Two gate-integrity beads, one defect class: a knob or a naming slip that lets a gate report a colour it did not earn. The remedy in both is that a weakened run says so in its own output — no knob is removed, no operator control lost.

## rf2-maiw — un-suffixed gate artefacts read a sibling's exit code

**What landed:** `AGENTS.md`'s "Gate Artefacts Go Where Git Ignores Them" section carried its own copy of the worked example with the bare names (`gate-fastpr.log` / `gate-fastpr.exit`) — the exact carrier PR #7996 fixed in `docs/the-mayor-method/dispatch-prompt-template.md` but did not sweep. A worker copying AGENTS.md literally writes into the shared session scratchpad under a name a peer also writes, and can read a sibling's `0` as its own green. The example now carries the `-<worktree>` suffix, plus the one-paragraph why (the exit code a PR body quotes is the artefact the collision corrupts) and the `gate root:` check that actually caught both observed collisions.

**Verified already in step at HEAD (no edit needed):** `docs/the-mayor-method/dispatch-prompt-template.md` carries the rule consistently in the boundary block (lines 60–70), the gate-artefact bullet with the suffixed worked example (line 257), and the failure-modes index — remedy (a) from PR #7996 is intact. `.claude/commands/mayor-dispatch.md` carries no gate-artefact example of its own; it delegates to the template and mandates pasting the boundary block verbatim, so it is consistent by construction. Sweep: `git grep gate-fastpr -- '*.md'` over tracked files finds no remaining bare-name carrier after this change.

**Not actioned, per the bead's own record:** remedy (b) (worktree-keyed scratchpad) is a harness change outside this repo; remedy (c) (spine-side refuse-to-overwrite guard) changes `scripts/test-fast-pr.sh` behaviour and remains the operator's call as the bead notes state.

## rf2-qzm8 — timeout knobs softened the HMR gate in silence

`HICASSO_HMR_BUILD_TIMEOUT_MS`, `HICASSO_HMR_SAVE_TIMEOUT_MS` and `HICASSO_HMR_SPEC_TIMEOUT_MS` in `implementation/scripts/serve-and-run-hicasso-hmr-testbed.cjs` printed nothing when raised, so a pass bought with a widened window read identically to one earned inside the contract's window.

**Pattern matched: rf2-l92i's (PR #8004), not a new one.** Same three moves that PR made for `HICASSO_HMR_ENGINES`: (1) one table (`TIMEOUT_DEFAULTS`) owns defaults, parse and disclosure so they cannot drift; (2) every non-default value is announced up front in the same register as the narrowing banner; (3) a weakened run closes with the existing `HICASSO HMR PARTIAL PASS` token — no third verdict string — with the sentence naming the knob and its default so the reader knows which to unset.

**The judgement call the bead left open — whether a raised ceiling degrades the verdict — decided YES, on this reasoning:** the up-front banner alone leaves the closing line (the line PR bodies quote and greps find) still reading `HICASSO HMR PASS`, which is the fail-open surviving at exactly the point of quotation; and without measuring every wait, a run under a wider window cannot demonstrate it would have passed under the contract's, so the full token is unearned. A LOWERED ceiling is stricter than the contract: it is disclosed up front and costs nothing. A raised-ceiling run still exits 0 — the degradation is in the words, exactly as for a narrowed engine set.

Mutation teeth go 34 → 41: override classification (default env / set-to-default / raised / lowered), raised-costs-the-verdict naming the knob, lowered-keeps-the-full-verdict, and both-causes-named for a narrowed run under a raised ceiling. Existing verdict teeth now pass an explicit overrides list so they stay hermetic when the gate itself runs under a raised environment (verified: 41/41 bite with `HICASSO_HMR_SAVE_TIMEOUT_MS=180000` set, while the default-argument call site `main` uses degrades correctly).

## Quality gates

Exit codes below are the ones this worker captured on its own single-command-line redirect (`…; echo "$?" > gate-*.exit`), never the harness's report; every gate's `gate root:` line was checked to name this worktree.

| Gate | Captured exit | Result |
|---|---|---|
| `sh scripts/test-fast-pr.sh` (tiers: docs=true, node=true, jvm=false) | **0** | `PASS fast PR spine` — 13643 tests / 69072 assertions, **0 failures, 0 errors** |
| `npm run test:hicasso-hmr` — full run, default env (deciding gate) | **0** | `HICASSO HMR PASS (chromium + firefox + webkit) — 36 real shadow reloads`; 105 checks × 8 sections per engine (315 total), 41 teeth bit |
| `npm run test:hicasso-hmr` — proof run, `HICASSO_HMR_ENGINES=chromium` + `HICASSO_HMR_SAVE_TIMEOUT_MS=120000` | **0** | degraded exactly as designed — see transcript below |
| `npm run test:script-policy` | **0** | all suites green, 0 failures — changed-surfaces 325, script-spawn-policy 168, orchestrator-teardown 34, impl-browser-runners-verdict 17, navigation-ceiling 4 |
| rig mutation teeth (direct `require` + `runMutationTeeth()`) | **0** | **41 teeth bit** (34 before this PR); still 41/41 under a raised env, proving the teeth are hermetic |

Each gate ran alone, in its own shell, redirected on one command line with `echo "$?" > gate-*.exit`; the numbers above were read back **from those files**, not from the harness. Every log's `gate root:` line reads `/c/Users/miket/code/re-frame2-worktrees/gatehyg-qzm8`.

### The rf2-qzm8 proof — the trace a raised ceiling now leaves

Head of the proof run (the up-front banner, in the same register as the narrowing banner):

```
> HICASSO_HMR_ENGINES=chromium — narrowed to chromium of chromium + firefox + webkit.
> a divergence needs two engines to be visible, so the cross-engine comparison will NOT be performed on this run.
> HICASSO_HMR_SAVE_TIMEOUT_MS=120000 — RAISED from its default 90000ms. A wider ceiling can admit a pass the contract's window would have refused, so this run closes with at most "HICASSO HMR PARTIAL PASS".
> verdict logic teeth bit: 41
```

and its closing line, naming both causes:

```
HICASSO HMR PARTIAL PASS (chromium only; HICASSO_HMR_ENGINES narrowed this run, so the cross-engine comparison was NOT performed; HICASSO_HMR_SAVE_TIMEOUT_MS=120000 raised the 90000ms ceiling, so this pass may have needed a wider window than the contract allows) — 12 real shadow reloads
```

The run still exited **0** — operator control is intact; only the silence is gone. And the disclosure is inert at the default: `grep -c "RAISED from its default\|lowered from its default"` over the full default-env log returns **0**, so an unweakened run prints no banner and closes with the full verdict. Before this PR the same raised ceiling produced no output whatever and closed with `HICASSO HMR PASS`.

**Hash transcript (the restore is proved by bytes, not by `git diff`).** `implementation/hicasso/testbed/hicasso_hmr_testbed/views.cljs` — the file the gate rewrites once per save, 12 times in the proof run and 36 in the full run:

| point | sha256 |
|---|---|
| before any HMR run | `9b2f7c82e967d9ba21b4befe53852d835b7642002147f9584d38b66c5b9f704a` |
| after the proof run | `9b2f7c82e967d9ba21b4befe53852d835b7642002147f9584d38b66c5b9f704a` |
| after the full run | `9b2f7c82e967d9ba21b4befe53852d835b7642002147f9584d38b66c5b9f704a` |

Identical at all three points, `git status` clean after each. The rig itself (`serve-and-run-hicasso-hmr-testbed.cjs`, `31ded8fb148f1ded852261362323c175ec62803e5b0f109e8f2eecea84f5d6ee`) is unchanged across both runs. No source plant was needed for this proof: the knob under test is an environment variable, so the weakening was applied without touching the tree at all — which is itself why the defect was invisible.

**What the local spine does not decide:** `python scripts/check_fast_pr_gap.py --list` reports **95** required checks not decided locally (browser lanes, prod-elision/bundle-isolation, adapter smokes, Xray matrix, mcp-conformance, tool JVM suites, the `Lint required` and `Docs required` contexts, and steps inside jobs the spine does run). Note its clj-kondo caveat: CI pins 2026.04.15 and a differently-versioned local pass proves nothing. This diff arms `hicasso_hmr`, `cljs_node_test`, `cljs_browser`, `cljs_prod`, `bundle_isolation` and `reagent_slim_bundle`; the deciding `hicasso_hmr` lane was run locally in full (above) because it is this PR's own surface.

**Hand-verified (no automated gate covers it):** the AGENTS.md prose edit. `check_doc_slugs.py` covers its link targets and heading anchors — the section heading is unchanged so no anchor moved, and the edit introduces no links — but nothing checks semantics, so the new paragraph was read against the template's corrected bullet to confirm the two carry the same rule, the same example shape and the same gate-root backstop. `mkdocs build --strict` ran inside the spine (docs tier armed, `Documentation built in 34.77 seconds`).
