### PR TITLE
test(hicasso): tear the mount down on the rejected arm too (rf2-hic-051)

### DIFF
--- a/implementation/hicasso/test/re_frame/hicasso/examples/forms/flow_dom_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/examples/forms/flow_dom_cljs_test.cljs
@@ -29,6 +29,19 @@
   end would re-render the field, re-commit the element and re-assert the
   model — and the revision would test green while doing nothing.
 
+  ## The two rows that WAIT, and what waiting costs if it fails
+
+  The last two rows wait on a bounded `poll-until`, because a submission
+  leaves on the async dispatch queue and no React flush can help. A
+  bounded poll can REJECT, and a chain carrying only a fulfillment
+  handler loses two things when it does: `done` is never called, so the
+  row hangs rather than fails, and the mount is never taken down, so it
+  is still standing when the next row reads the page. Both go through
+  [[finish-after]], which reports the rejection and tears down on either
+  arm — and
+  [[a-poll-that-never-settles-still-takes-its-mount-down]] arranges a
+  rejection on purpose to prove it.
+
   ## Browser lane
 
   Every row needs a real document and a real React DOM. `:node-test`
@@ -135,6 +148,35 @@
   "Tear down, assert this mount left nothing behind, and end the row."
   [m done]
   (-> (hm/unmount! m) (hm/assert-clean!) (.then done)))
+
+(defn- report-rejection!
+  "The default reporter: a rejected wait is this row's failure, said in
+  `cljs.test`'s own voice and carrying the label the poll was given."
+  [e]
+  (is false (str "the flow never settled: " (or (ex-message e) (str e)) " "
+                 (pr-str (ex-data e))))
+  nil)
+
+(defn- finish-after
+  "End the row when `p` settles — reporting a rejected `p` rather than
+  letting it hang the run, and tearing the mount down on BOTH arms.
+
+  `poll-until`'s own docstring names this shape: the rejection handler
+  sits UPSTREAM of the single trailing step that calls `done`, and the
+  teardown both paths share lives in that step, where it is written once
+  and still runs once per path. A chain with only a fulfillment handler
+  loses both halves at once — `done` is never called, so the row hangs,
+  and the live mount is never unmounted, so it is still standing when the
+  next row takes its readings.
+
+  `report!` is the seam
+  [[a-poll-that-never-settles-still-takes-its-mount-down]] uses to watch
+  a rejection go past without the control itself going red."
+  ([p m done] (finish-after p m done report-rejection!))
+  ([p m done report!]
+   (-> p
+       (.catch report!)
+       (.then (fn [_] (finish m done))))))
 
 ;; ---------------------------------------------------------------------------
 ;; Recipe 1 — the buffered field, driven
@@ -323,8 +365,8 @@
               {:label "the dispatch queue to reach a marker enqueued after the submit"})
             (.then (fn [_]
                      (is (= [] @!requests)
-                         "and nothing was asked of the server")
-                     (finish m done))))))))
+                         "and nothing was asked of the server")))
+            (finish-after m done))))))
 
 (deftest a-valid-submission-goes-busy-from-the-writes-own-status
   (async done
@@ -359,5 +401,57 @@
                 (is (= "" (.-value (node m "#ticket-assignee")))
                     "the reply landed at the named event and blanked the form —
                      there is no completion callback anywhere in this
-                     application")
-                (finish m done))))))))
+                     application")))
+            (finish-after m done))))))
+
+;; ---------------------------------------------------------------------------
+;; The control — what the two rows above are protected FROM
+;; ---------------------------------------------------------------------------
+
+(deftest a-poll-that-never-settles-still-takes-its-mount-down
+  ;; The sabotage control for [[finish-after]]. Both rows above wait on a
+  ;; bounded poll, and a poll can reject; this row arranges the rejection
+  ;; deliberately and reads what the page is left holding.
+  ;;
+  ;; The reading is `hm/census` — the page-wide one — and not a successor
+  ;; mount's own `assert-clean!`, which would be the WRONG instrument and
+  ;; quietly so. A successor takes its baseline after the stranded mount
+  ;; exists, so the strand sits in its baseline and in its final reading
+  ;; alike and subtracts to nothing; `leaked` also removes every facade
+  ;; frame as a peer. A stranded mount is therefore invisible to the very
+  ;; assertion a reader would expect to catch it, and visible here.
+  (async done
+    (if-not (browser?)
+      (do (skip! "a real mount to strand") (done))
+      (let [before    (hm/census)
+            m         (mount-screen!)
+            !reported (atom nil)]
+        (is (not= before (hm/census)) "the mount is up and the page shows it")
+        (-> (test-support/poll-until
+              (constantly false)
+              {:label "a condition arranged never to hold" :timeout-ms 50 :interval-ms 5})
+            (finish-after
+              m
+              ;; `finish` ends at `(.then done)` on `assert-clean!`, so the
+              ;; row's last step is handed the residue REPORT — the three
+              ;; facts below are read from the instrument rather than
+              ;; inferred from the row having got this far.
+              (fn [report]
+                (is (= :rf.error/poll-until-timeout
+                       (:rf.error/id (ex-data @!reported)))
+                    "the rejection was reported UPSTREAM of the trailing step
+                     — with only a fulfillment handler it would have gone
+                     nowhere, and this row would have timed out instead of
+                     failing")
+                (is (false? (:still-mounted? report))
+                    "the teardown ran on the REJECTED arm: that is the half a
+                     `.then`-only chain drops")
+                (is (true? (:clean? report)))
+                (is (zero? (:standing report))
+                    "and no facade mount is left standing")
+                (is (= before (hm/census))
+                    "so the page a following row opens on is the page this
+                     row found — nothing retained, no residue to be charged
+                     to whoever runs next")
+                (done))
+              (fn [e] (reset! !reported e))))))))


### PR DESCRIPTION
Closes the merged-PR audit reopen on rf2-hic-051 (audit of PR #7971).

## What the audit found, confirmed at source

The two rows in `implementation/hicasso/test/re_frame/hicasso/examples/forms/flow_dom_cljs_test.cljs` that wait on a bounded `test-support/poll-until` — the refused-submit marker wait and the valid-submit transport wait — each carried a `.then` and nothing else.

A rejected poll lost both halves at once:

- `done` was never called, so the row **hung** rather than failing;
- `(finish m done)` lived *inside* the fulfillment handler, so `hm/unmount!` never ran and the live mount was **still standing** when the next row took its readings.

`poll-until`'s own docstring already prescribes the fix: the rejection handler sits **upstream** of the single trailing step that calls `done`, and the teardown both paths share lives in that step, "where it is written once and still runs once per path". The sibling slice suite (`examples/slice/flow_dom_cljs_test.cljs`) already carries it as `finish-after`.

## What changed

- **`finish-after` added** to the forms suite and applied to both rows. Assertions move into a `.then` upstream of it, so a rejected poll — or a throw inside the assertion block — is reported as this row's failure and the mount comes down on either arm. Exactly one trailing `done`.
- **A deliberate rejected-poll control**, `a-poll-that-never-settles-still-takes-its-mount-down`. It arranges a rejection on purpose (a `(constantly false)` predicate on a 50 ms deadline), routes it through the *same* `finish-after` via a reporter seam, and asserts the rejection reached the reporter as `:rf.error/poll-until-timeout`, that the teardown ran on the rejected arm, and that nothing is retained.

### One judgement worth flagging for review

The control proves "the following row sees no retained mount" with **`hm/census`**, the page-wide reader — deliberately *not* with a successor mount's own `assert-clean!`, which would be the wrong instrument and quietly so. A successor takes its baseline *after* the stranded mount exists, so the strand sits in its baseline and in its final reading alike and subtracts to nothing; `leaked` additionally removes every facade frame as a peer. A stranded mount is invisible to the very assertion a reader would expect to catch it. The reasoning is recorded in the control's own comment.

The control also reads three facts out of the residue **report** rather than inferring them from having got that far — `finish` ends at `(.then done)` on `assert-clean!`, so the trailing step is handed the report.

No runtime change and no forms API change. Test-only, and confined to one file.

## Second-consumer condition (for the record)

The bead's original deliverables shipped in PR #7971 and are on `main`: the recipes, their structural tests, and the extracted helper at `implementation/hicasso/src/re_frame/hicasso/forms.cljs`. This PR is scoped to the audit reopen only.

## Quality gates

| Gate | Covers | Exit code | Notes |
|---|---|---|---|
| `npm run test:cljs` | Compiles + runs the `:node-test` build, which includes this namespace (`cljs-test$` matches `-dom-cljs-test`); the rows degrade to stated skips there, so this gate is the **compile** proof. | **0** | `Ran 13644 tests containing 69073 assertions. 0 failures, 0 errors.` |
| `npm run test:browser` | The `:browser-test` build (`ns-regexp` `-dom-cljs-test$`) — the lane that **actually runs** these rows, including the new control, on a real React DOM. | **0** | `Browser tests: Ran 1395 tests containing 8656 assertions. 0 failures, 0 errors.` |
| `python scripts/lint_kondo.py` | CI's clj-kondo gate at its **pinned version** — `--classify` confirms this file is `kondo_surface=true`, so the lane is genuinely armed. | **0** | `linting took 103841ms, errors: 0, warnings: 4549` on `clj-kondo 2026.04.15`, the version CI pins. |
| `npm run test:hicasso-hmr` | HMR testbed | **not run — deferred to CI** | Machine-exclusive: it binds `:dev-http` 8061 and a second run is refused by `assertOwnBundle`. Another worker holds that window locally. It does not cover this file (test-only change under `examples/forms/`), and CI runs it uncontended. |

### The first clj-kondo run was an install flake, not a finding

CI's `clj-kondo (fail on errors, warnings informational)` went red on the first attempt. The failing **step** was `Install clj-kondo`, not `Run clj-kondo` — the log is five consecutive `curl: (22) The requested URL returned error: 503` plus a `curl: (56) Connection died, tried 5 times before giving up`, and `Run clj-kondo` never executed (it shows as skipped). GitHub's release CDN 503'd; nothing was linted.

That is confirmed rather than assumed: the gate has since been run locally at CI's pinned version via `scripts/lint_kondo.py`, with the same `--lint` roots and the same `--fail-level error`, and it reports **0 errors** (exit 0). The job has been re-run.

No suppression was added, and none is warranted.

**One pre-existing warning is left in place, deliberately.** `flow_dom_cljs_test.cljs:51:50: warning: #'cljs.test/testing is referred but never used` predates this PR (it sits at `38:50` on `main`; my docstring addition only shifted the line). It is a warning under a `--fail-level error` gate, it is one of 4549 repo-wide, and removing it here would be unrelated churn in an audit-correction PR. Flagged rather than silently swept.

Exit codes were captured on the same command line into `.exit` files and read back from them; both runs' logs name this worktree as their root (`shadow-cljs - config: …\re-frame2-worktrees\forms-hic051\implementation\shadow-cljs.edn`).

**The control is not vacuous, and its green is the proof.** It is registered in the browser build's test registry (`out/browser-test/js/cljs-runtime/shadow.test.browser.js`), so it ran rather than being compiled away. Both of its load-bearing assertions fail closed:

- had the rejection not been routed through `finish-after`'s `.catch`, `@!reported` would still be `nil` and the `:rf.error/id` comparison would red;
- had the teardown not run on the rejected arm, the trailing step would never have been reached and `done` never called — the row would have **timed out**, which is precisely the failure mode being fixed.

`spec/**`, `.github/workflows/**`, `implementation/deps.edn` and `implementation/shadow-cljs.edn` are untouched. No new `:rf.error/*` id is minted, so no Spec 009 catalogue row is owed.
