### PR TITLE
docs(method): name detaching a long gate correct, and poll the .exit file too (rf2-n3qt)

### DIFF
--- a/docs/the-mayor-method/dispatch-prompt-template.md
+++ b/docs/the-mayor-method/dispatch-prompt-template.md
@@ -176,19 +176,25 @@ relying on CI"). A silent skip fails review.
 Five rules about the mechanics. Each is here because it cost real hours, and
 none of them is obvious from the gate command itself.
 
-- **Foreground, to completion — within the harness's ten-minute ceiling.** A
-  worker that backgrounds a long gate and ends its turn waiting for the
-  completion notification can wait forever: the
-  notification does not always arrive, and a turn that has ended has nothing
-  left to wake. The worker then reports "standing by" through idle tick after
-  idle tick while its branch sits unmoved — four such incidents in a single day,
-  every one recovered intact the moment somebody asked it for a status. If you
-  background a gate anyway, **poll its log on a timer**; never end a turn
-  waiting to be woken. For the full spine that polling is the normal path and
-  not the exception: the harness hard-kills a foreground command at ten minutes
-  (exit 143) and `scripts/test-fast-pr.sh` needs roughly twenty-five, so "to
-  completion" is not on offer for it however the brief is worded. That ceiling
-  killed four spine runs in one night before it was written down here.
+- **Detaching a long gate is CORRECT; ending the turn afterwards is the defect.**
+  The harness hard-kills a foreground command at ten minutes (exit 143) and
+  `scripts/test-fast-pr.sh` needs roughly twenty-five, so for the full spine
+  "foreground, to completion" is not on offer however the brief is worded — that
+  ceiling killed four spine runs in one night before it was written down here.
+  Foreground a gate that fits inside the ten minutes; **detach one that does not,
+  then poll both its log and its `.exit` file in a bounded loop, within the same
+  turn.** Poll both, because they answer different questions: the log shows
+  progress, while the `.exit` file is what carries the verdict and appears only
+  once the run is actually over. What strands a worker is ending the turn
+  instead, waiting for a completion notification — it does not always arrive, and
+  a turn that has ended has nothing left to wake. The worker then reports
+  "standing by" through idle tick after idle tick while its branch sits unmoved:
+  four such incidents in a single day, then three more inside one hour on
+  2026-08-13, every one recovered intact the moment somebody asked it for a
+  status. Two of that last three apologised for *detaching*, which is why this
+  bullet no longer grudges it — a worker who believes it has already erred reads
+  for how to atone rather than for what to do next, and reads straight past the
+  instruction that would have saved it.
 - **Invoke a backgrounded gate by its ABSOLUTE path.** The gate scripts derive
   their repo root from `${BASH_SOURCE[0]}`, which is relative when the
   invocation is — and a `cd <worktree> && sh scripts/…` does not reliably keep


### PR DESCRIPTION
Closes rf2-n3qt.

`docs/the-mayor-method/dispatch-prompt-template.md` owns the gate-mechanics text
that every worker dispatch pastes — `.claude/commands/mayor-dispatch.md` cites it
as a must-paste rather than restating it (rf2-oieu, PR #8010) — so the words in
that bullet are the words that reach every worker. Two corrections, both confined
to the FIRST bullet of "How a gate is run, not just which one". Nothing else in
the file, and nothing under `.claude/commands/**`, is touched.

## The two corrections

**1. Incomplete: "poll its log on a timer".** The log is not the artefact that
carries the verdict — the `.exit` file is, and the same section already says so
("the number you quote is the one you captured"). A worker polling only the log
has to infer completion from output rather than read it. It now reads: **poll
both its log and its `.exit` file in a bounded loop, within the same turn**, with
one clause on why both (the log shows progress; the `.exit` file appears only
once the run is actually over).

**2. Grudging register: "If you background a gate anyway".** That phrasing
tolerates a deviation the same bullet elsewhere establishes is forced — the
harness hard-kills a foreground command at ten minutes and the spine needs about
twenty-five. Two of the three workers stranded on 2026-08-13 *apologised for
detaching*, which is the finding: a worker who believes it has already erred
reads for how to atone rather than for what to do next, and reads straight past
the instruction that would have saved it. The bullet now opens **"Detaching a
long gate is CORRECT; ending the turn afterwards is the defect"**, states the
ceiling arithmetic as the reason, gives the poll as the ordinary path, and names
the actual failure (ending the turn) rather than the thing that was never wrong.

The four other things the bullet must convey — absolute-path invocation, the
`gate root:` check, `$?` captured on one command line into a worktree-suffixed
file, and quoting the number from that file rather than the harness's — were
already conveyed squarely and are unchanged.

Section structure is intact: still five bullets under a heading whose text is
untouched, so no anchor moved.

## Quality gates

| Gate | Exit | Notes |
| --- | --- | --- |
| `python scripts/check_doc_slugs.py` | **0** | read from `gate-slugs-final-pollword-n3qt.exit` |
| `mkdocs build --strict` | skipped locally | `mkdocs` is not installed in this checkout (`mkdocs: command not found`); CI's **MkDocs build** job ran on this PR and passed. Coverage established at source rather than assumed: `mkdocs.yml`'s `exclude_docs` block lists only `tools/playground/`, the two codemod trees, `design/freehand/` and `design/hicasso/` — `the-mayor-method/` is not excluded, so the site build does read this file. |

**Proof the slug gate reached the edited file** (it is silent on success, so exit
0 alone proves nothing). Hash of the file after the edit, before the plant:

```
7228e03cf624bbe497a00da890777f6bebaf44d56f03fb690497617d9ff90011
```

A bogus anchor was planted on the exact edited line (single-line anchor, since
this checkout translates line endings) and the gate re-run — exit **1**:

```
BROKEN ANCHOR: docs\the-mayor-method\dispatch-prompt-template.md:186 -> dispatch-prompt-template.md#rf2-n3qt-bogus-anchor
```

Line 186 is inside the rewritten bullet. Restored, and the restore verified by
hashing the bytes rather than by reading `git diff`:

```
7228e03cf624bbe497a00da890777f6bebaf44d56f03fb690497617d9ff90011
```

Identical to the pre-plant hash. Gate re-run after the restore: exit **0**.

**Verified by hand** (nothing else validates structure in this tree): no heading
was added, removed or reworded, so every anchor into this file is unchanged; the
section still has exactly five bullets under its "Five rules" preamble; the new
bullet's bold spans, italics and backticks are balanced; and the file contains no
second statement of the same rule that could now contradict it (grep for
foreground/background/detach across the file returns only the title line and the
absolute-path bullet).
