### PR TITLE
test(hicasso): the rejection arm's standing root, torn down on the tail (rf2-fqof)

### DIFF
--- a/implementation/hicasso/test/re_frame/hicasso/native_abi_dom_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/native_abi_dom_cljs_test.cljs
@@ -176,14 +176,45 @@
 (defn- label-key [frame-kw] [frame-kw [::label]])
 (defn- readers-of [sub-key] (inventory/cell-readers sub-key))
 
+(defonce ^:private !minted
+  ;; Every root a row has minted through `mount-live!`, oldest first.
+  ;; Emptied by `release-minted!` on the row's single trailing step.
+  ;; `defonce` takes no docstring, hence the comment.
+  (atom []))
+
+(defn- release-minted!
+  "Release every root this row minted, and forget them. Rides the single
+  trailing step, which BOTH arms reach, so the teardown is written once
+  and runs once per path; `mount/release!` is idempotent, so a row whose
+  success path already tore its root down pays nothing here.
+
+  **Why the rejection arm cannot do this itself (rf2-fqof).**
+  [[mount-live!]] mints its root SYNCHRONOUSLY and hands it over only
+  once the wait succeeds, so a rejection reaches the arm with a live root
+  the arm has no name for — the wait's own deadline is one such path, and
+  a throw anywhere in the row body above is another. Reporting and
+  finishing there leaves a mounted React root and its container standing
+  in the document for the NEXT namespace to inherit, which is the very
+  contamination the rf2-fyba campaign is about, arriving by a second
+  door (rf2-o0n1)."
+  []
+  (run! mount/release! @!minted)
+  (reset! !minted [])
+  nil)
+
 (defn- mount-live!
   "Mount `hiccup` under `frame-kw` and return only once `sub-key` has
   exactly `readers` subscribed readers — a commit-owned fact, so a row
   that started before it would be measuring a tree that had not yet
-  joined the runtime."
+  joined the runtime.
+
+  Enrols the root in [[!minted]] the instant it exists, because from that
+  instant until [[release-minted!]] runs there is a live root on the page
+  and this promise is the only thing that could ever name it."
   [frame-kw hiccup sub-key readers]
   (let [container (mount/fresh-container!)
         handle    (mount/root! container frame-kw hiccup)]
+    (swap! !minted conj handle)
     (-> (support/wait-until! #(= readers (count (readers-of sub-key))))
         (.then (fn [subscribed?]
                  (when-not subscribed?
@@ -209,11 +240,13 @@
                    " | residue " (pr-str (inventory/residue))))
     nil))
 
-;; Teardown is NOT hoisted onto those trailing steps in the `mount-live!`
-;; rows: the rejection arm never had the handle at all, because `mount-live!`
-;; resolves WITH it, so the two arms were never writing the same release.
-;; `a-lazy-head-suspends-and-then-names-its-own-component` is the one row
-;; that holds its handle before the wait, and it hoists — it says so there.
+;; Teardown IS hoisted onto those trailing steps, through [[release-minted!]].
+;; That the rejection arm never had the handle — `mount-live!` resolves WITH
+;; it — is not a reason to leave the teardown on the success path; it is the
+;; defect (rf2-fqof). The root is already on the page when the promise is
+;; created, so the arm that cannot name it is the arm that strands it.
+;; `a-lazy-head-suspends-and-then-names-its-own-component` holds its handle in
+;; an enclosing `let` and hoists that one directly — it says so there.
 
 ;; ---------------------------------------------------------------------------
 ;; 1. The outward bridge
@@ -255,8 +288,10 @@
                 (support/teardown-census! handle)
                 nil))
             (.catch (report-failure! "outward bridge"))
-            ;; The single `done`, with nothing after it.
-            (.then (fn [_] (done))))))))
+            ;; The single trailing step, which BOTH arms reach: this row's
+            ;; roots go down first, and the single `done` is the last act,
+            ;; with nothing after it.
+            (.then (fn [_] (release-minted!) (done))))))))
 
 (deftest two-frames-are-two-cells-across-the-bridge
   (async done
@@ -297,8 +332,10 @@
                 (support/teardown-census! b)
                 nil))
             (.catch (report-failure! "two frames across the bridge"))
-            ;; The single `done`, with nothing after it.
-            (.then (fn [_] (done))))))))
+            ;; The single trailing step, which BOTH arms reach: this row's
+            ;; roots go down first, and the single `done` is the last act,
+            ;; with nothing after it.
+            (.then (fn [_] (release-minted!) (done))))))))
 
 (deftest the-views-memo-wrapper-survives-the-bridge
   (async done
@@ -341,8 +378,10 @@
                 (support/teardown-census! handle)
                 nil))
             (.catch (report-failure! "memo across the bridge"))
-            ;; The single `done`, with nothing after it.
-            (.then (fn [_] (done))))))))
+            ;; The single trailing step, which BOTH arms reach: this row's
+            ;; roots go down first, and the single `done` is the last act,
+            ;; with nothing after it.
+            (.then (fn [_] (release-minted!) (done))))))))
 
 ;; ---------------------------------------------------------------------------
 ;; 2. The inward door
@@ -390,8 +429,10 @@
                 (support/teardown-census! handle)
                 nil))
             (.catch (report-failure! "inward door"))
-            ;; The single `done`, with nothing after it.
-            (.then (fn [_] (done))))))))
+            ;; The single trailing step, which BOTH arms reach: this row's
+            ;; roots go down first, and the single `done` is the last act,
+            ;; with nothing after it.
+            (.then (fn [_] (release-minted!) (done))))))))
 
 ;; ---------------------------------------------------------------------------
 ;; 3. The helpers, across a second render and a remount
@@ -434,8 +475,10 @@
                 (support/teardown-census! handle)
                 nil))
             (.catch (report-failure! "memo across a re-render"))
-            ;; The single `done`, with nothing after it.
-            (.then (fn [_] (done))))))))
+            ;; The single trailing step, which BOTH arms reach: this row's
+            ;; roots go down first, and the single `done` is the last act,
+            ;; with nothing after it.
+            (.then (fn [_] (release-minted!) (done))))))))
 
 (deftest a-fresh-mint-replaces-the-subtree-and-that-is-the-hmr-contract
   (async done
@@ -477,8 +520,10 @@
                 (support/teardown-census! handle)
                 nil))
             (.catch (report-failure! "fresh mint"))
-            ;; The single `done`, with nothing after it.
-            (.then (fn [_] (done))))))))
+            ;; The single trailing step, which BOTH arms reach: this row's
+            ;; roots go down first, and the single `done` is the last act,
+            ;; with nothing after it.
+            (.then (fn [_] (release-minted!) (done))))))))
 
 (deftest strict-modes-double-mount-crosses-the-bridge-exactly-once
   (async done
@@ -503,8 +548,10 @@
                 (support/teardown-census! handle)
                 nil))
             (.catch (report-failure! "strict mode"))
-            ;; The single `done`, with nothing after it.
-            (.then (fn [_] (done))))))))
+            ;; The single trailing step, which BOTH arms reach: this row's
+            ;; roots go down first, and the single `done` is the last act,
+            ;; with nothing after it.
+            (.then (fn [_] (release-minted!) (done))))))))
 
 (deftest a-ref-reaches-a-real-dom-node-through-the-memo-helper
   (async done
@@ -613,8 +660,10 @@
                 (exercised! :bridge/teardown)
                 nil))
             (.catch (report-failure! "teardown"))
-            ;; The single `done`, with nothing after it.
-            (.then (fn [_] (done))))))))
+            ;; The single trailing step, which BOTH arms reach: this row's
+            ;; roots go down first, and the single `done` is the last act,
+            ;; with nothing after it.
+            (.then (fn [_] (release-minted!) (done))))))))
 
 (deftest the-declared-population-was-actually-exercised
   (if-not (mount/browser?)

--- a/implementation/hicasso/test/re_frame/hicasso/native_hooks_dom_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/native_hooks_dom_cljs_test.cljs
@@ -192,6 +192,34 @@
 
 (defn- readers-of [sub-key] (inventory/cell-readers sub-key))
 
+(defonce ^:private !minted
+  ;; Every root a row has minted through `mount-live!`, oldest first.
+  ;; Emptied by `release-minted!` on the row's single trailing step.
+  ;; `defonce` takes no docstring, hence the comment.
+  (atom []))
+
+(defn- release-minted!
+  "Release every root this row minted, and forget them. Rides the single
+  trailing step, which BOTH arms reach, so the teardown is written once
+  and runs once per path; `mount/release!` is idempotent, so a row whose
+  success path already tore its root down pays nothing here — and the
+  `teardown!` assertions below stay exactly where they are, because they
+  are the act under test rather than a cleanup.
+
+  **Why the rejection arm cannot do this itself (rf2-fqof).**
+  [[mount-live!]] mints its root SYNCHRONOUSLY and hands it over only
+  once the wait succeeds, so a rejection reaches the arm with a live root
+  the arm has no name for — the wait's own deadline is one such path, and
+  a throw anywhere in the row body above is another. Reporting and
+  finishing there leaves a mounted React root and its container standing
+  in the document for the NEXT namespace to inherit, which is the very
+  contamination the rf2-fyba campaign is about, arriving by a second
+  door (rf2-o0n1)."
+  []
+  (run! mount/release! @!minted)
+  (reset! !minted [])
+  nil)
+
 (defn- mount-live!
   "Mount `hiccup` under `frame-kw` and return only once `sub-key` has
   exactly `readers` readers — which is to say, once every holder in the
@@ -208,10 +236,15 @@
   because a tree may hold the key more than once — the shared-entry row
   mounts a boundary and an island on one key deliberately — and a wait
   that stopped at the first arrival would let the second commit land
-  underneath the assertions."
+  underneath the assertions.
+
+  Enrols the root in [[!minted]] the instant it exists, because from that
+  instant until [[release-minted!]] runs there is a live root on the page
+  and this promise is the only thing that could ever name it."
   [frame-kw hiccup sub-key readers]
   (let [container (mount/fresh-container!)
         handle    (mount/root! container frame-kw hiccup)]
+    (swap! !minted conj handle)
     (-> (support/wait-until! #(= readers (count (readers-of sub-key))))
         (.then (fn [subscribed?]
                  (when-not subscribed?
@@ -223,8 +256,9 @@
 (defn- skip! [why] (is true (str "a native-hook claim needs a real React DOM — " why)))
 
 (defn- report-failure!
-  "Reports a rejection against `label`, releasing `handle` when this row's
-  rejection arm has one; it does NOT finish the row.
+  "Reports a rejection against `label`; it does NOT finish the row, and it
+  does not tear anything down — [[release-minted!]] on the trailing step
+  owns that, for both arms and for roots this one could never name.
 
   `done` hands `cljs.test/run-block` a continuation that runs the WHOLE
   remainder of the run synchronously, so a `.catch` sitting downstream of the
@@ -234,18 +268,18 @@
   `run-browser-tests.cjs` promotes to a fatal console match (rf2-e8kc). Every
   chain below therefore reports here and finishes on a single trailing step,
   with nothing after it."
-  [label handle]
+  [label]
   (fn [e]
     (is false (str label " — " (.-message e)
                    " | residue " (pr-str (inventory/residue))))
-    (when handle (mount/release! handle))
     nil))
 
-;; Teardown is NOT hoisted onto those trailing steps anywhere in this file,
-;; and the reason is one reason: in the success arm it IS the assertion —
-;; `(is (= support/released (teardown! handle)))` — while the rejection arm
-;; never had the handle at all, because `mount-live!` resolves WITH it. The
-;; two arms were never writing the same release, so there is nothing to hoist.
+;; The success arm's `(is (= support/released (teardown! handle)))` is an
+;; ASSERTION under test and stays where it is — what rides the trailing step
+;; is [[release-minted!]], which is idempotent and therefore costs that
+;; assertion nothing. What it buys is the arm that has no handle at all: a
+;; rejection arriving before the row ever received one used to report and
+;; finish with a live React root standing in the document (rf2-fqof).
 
 (defn- teardown!
   "Unmount, read the census while it is still exact, then finish the
@@ -322,9 +356,11 @@
                 (testing "teardown releases every membership the mount took"
                   (is (= support/released (teardown! handle))))
                 nil))
-            (.catch (report-failure! "W1 mounted read" nil))
-            ;; The single `done`, with nothing after it.
-            (.then (fn [_] (done))))))))
+            (.catch (report-failure! "W1 mounted read"))
+            ;; The single trailing step, which BOTH arms reach: this row's
+            ;; roots go down first, and the single `done` is the last act,
+            ;; with nothing after it.
+            (.then (fn [_] (release-minted!) (done))))))))
 
 ;; ---------------------------------------------------------------------------
 ;; W2. A write wakes its readers and nobody else
@@ -366,9 +402,11 @@
                 (exercised! :hooks/selective-wake)
                 (is (= support/released (teardown! handle)))
                 nil))
-            (.catch (report-failure! "W2 selective wake" nil))
-            ;; The single `done`, with nothing after it.
-            (.then (fn [_] (done))))))))
+            (.catch (report-failure! "W2 selective wake"))
+            ;; The single trailing step, which BOTH arms reach: this row's
+            ;; roots go down first, and the single `done` is the last act,
+            ;; with nothing after it.
+            (.then (fn [_] (release-minted!) (done))))))))
 
 ;; ---------------------------------------------------------------------------
 ;; W3. THE characteristic failure: a re-render that changed no read
@@ -435,9 +473,11 @@
                   (exercised! :hooks/no-resubscribe)
                   (is (= support/released (teardown! handle)))
                   nil)))
-            (.catch (report-failure! "W3 no re-subscribe" nil))
-            ;; The single `done`, with nothing after it.
-            (.then (fn [_] (done))))))))
+            (.catch (report-failure! "W3 no re-subscribe"))
+            ;; The single trailing step, which BOTH arms reach: this row's
+            ;; roots go down first, and the single `done` is the last act,
+            ;; with nothing after it.
+            (.then (fn [_] (release-minted!) (done))))))))
 
 ;; ---------------------------------------------------------------------------
 ;; W4. StrictMode's double mount, and exact teardown
@@ -493,9 +533,11 @@
                                        :edges 0 :entries 0}
                                       (inventory/residue))))
                              nil)))))
-            (.catch (report-failure! "W4 StrictMode" nil))
-            ;; The single `done`, with nothing after it.
-            (.then (fn [_] (done))))))))
+            (.catch (report-failure! "W4 StrictMode"))
+            ;; The single trailing step, which BOTH arms reach: this row's
+            ;; roots go down first, and the single `done` is the last act,
+            ;; with nothing after it.
+            (.then (fn [_] (release-minted!) (done))))))))
 
 ;; ---------------------------------------------------------------------------
 ;; W5. Frames are isolated contexts — on this side of the fence too
@@ -543,9 +585,11 @@
                   (is (= support/released (teardown! b)))
                   (mount/release! (assoc a :root nil))
                   nil)))
-            (.catch (report-failure! "W5 frame isolation" nil))
-            ;; The single `done`, with nothing after it.
-            (.then (fn [_] (done))))))))
+            (.catch (report-failure! "W5 frame isolation"))
+            ;; The single trailing step, which BOTH arms reach: this row's
+            ;; roots go down first, and the single `done` is the last act,
+            ;; with nothing after it.
+            (.then (fn [_] (release-minted!) (done))))))))
 
 ;; ---------------------------------------------------------------------------
 ;; W6. `use-frame`, both halves of the incarnation rule
@@ -638,24 +682,18 @@
                             (exercised! :hooks/incarnation)
                             (is (= support/released (teardown! handle)))
                             nil))
-                        ;; The inner chain now finishes NOTHING — it is
-                        ;; returned into the outer one below, whose single
-                        ;; trailing step is this row's only exit. Its own
-                        ;; diagnostic is kept rather than folded into the
-                        ;; outer one, because only this arm can say the
-                        ;; reincarnation never landed.
-                        ;;
-                        ;; Its `handle` release stays here rather than riding
-                        ;; the tail: the success arm's `teardown!` is an
-                        ;; ASSERTION under test — the census must read
-                        ;; `support/released` — so the failure arm does
-                        ;; strictly less, not the same thing.
-                        (.catch (report-failure! "W6 incarnation" handle)))))))
-            (.catch (report-failure! "W6 incarnation" nil))
-            ;; The single `done`, on the single trailing step, with nothing
-            ;; after it. Both of the inner chain's arms reach it, because the
-            ;; inner chain is returned into this one.
-            (.then (fn [_] (done))))))))
+                        ;; The inner chain finishes NOTHING and tears nothing
+                        ;; down — it is returned into the outer one below,
+                        ;; whose single trailing step is this row's only exit
+                        ;; and the only teardown. Its own diagnostic is kept
+                        ;; rather than folded into the outer one, because only
+                        ;; this arm can say the reincarnation never landed.
+                        (.catch (report-failure! "W6 incarnation")))))))
+            (.catch (report-failure! "W6 incarnation"))
+            ;; The single trailing step, which BOTH arms reach — including
+            ;; both of the inner chain's, because the inner chain is returned
+            ;; into this one. Roots down first, `done` last, nothing after it.
+            (.then (fn [_] (release-minted!) (done))))))))
 
 ;; ---------------------------------------------------------------------------
 ;; W7. The external-store ceiling, measured
@@ -696,9 +734,11 @@
                 (exercised! :hooks/transition)
                 (is (= support/released (teardown! handle)))
                 nil))
-            (.catch (report-failure! "W7 transition" nil))
-            ;; The single `done`, with nothing after it.
-            (.then (fn [_] (done))))))))
+            (.catch (report-failure! "W7 transition"))
+            ;; The single trailing step, which BOTH arms reach: this row's
+            ;; roots go down first, and the single `done` is the last act,
+            ;; with nothing after it.
+            (.then (fn [_] (release-minted!) (done))))))))
 
 ;; ---------------------------------------------------------------------------
 ;; The roster

--- a/implementation/hicasso/test/re_frame/hicasso/reincarnation_paint_dom_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/reincarnation_paint_dom_cljs_test.cljs
@@ -143,6 +143,32 @@
   [pred label]
   (test-support/poll-until pred {:label label :timeout-ms 4000}))
 
+(defonce ^:private !minted
+  ;; Every root a row has minted through `mount-live!`, oldest first.
+  ;; Emptied by `release-minted!` on the row's single trailing step.
+  ;; `defonce` takes no docstring, hence the comment.
+  (atom []))
+
+(defn- release-minted!
+  "Release every root this row minted, and forget them. Rides the single
+  trailing step, which BOTH arms reach, so the teardown is written once
+  and runs once per path; `mount/release!` is idempotent, so a row whose
+  success path already tore its root down pays nothing here.
+
+  **Why the rejection arms cannot do this themselves (rf2-fqof).**
+  [[mount-live!]] mints its root SYNCHRONOUSLY and hands it over only
+  once the polls succeed, so the OUTER arm below — the one that reports
+  with no handle at all — is reachable with a live root on the page: its
+  own poll can time out, and a throw anywhere in the body above the inner
+  chain unwinds straight past it. Reporting and finishing there leaves a
+  mounted React root and its container standing in the document for the
+  NEXT namespace to inherit, which is the very contamination rf2-d3tc's
+  repair is about, arriving by a second door (rf2-o0n1)."
+  []
+  (run! mount/release! @!minted)
+  (reset! !minted [])
+  nil)
+
 (defn- mount-live!
   "Mount, and return only once the boundary is provably SUBSCRIBED.
 
@@ -153,10 +179,15 @@
   runtime that never corrected anything. The wait is therefore a write
   round-trip, exactly as `kernel_commit_owns_dom_cljs_test`'s
   `prove-live!` is: dispatch, and poll until the boundary repaints. Only
-  a live subscription can produce that repaint."
+  a live subscription can produce that repaint.
+
+  Enrols the root in [[!minted]] the instant it exists, because from that
+  instant until [[release-minted!]] runs there is a live root on the page
+  and this promise is the only thing that could ever name it."
   []
   (let [container (mount/fresh-container!)
         handle    (mount/root! container frame-id [who-line {}])]
+    (swap! !minted conj handle)
     (-> (poll #(= "A" (text handle)) "the predecessor's value is committed")
         (.then (fn [_]
                  (mount/dispatch! handle [:reinc-paint/seed "A-live"])
@@ -178,8 +209,12 @@
   (js/Promise. (fn [resolve] (js/setTimeout (fn [] (resolve (f))) 30))))
 
 (defn- report-failure!
-  "Record `label` against THIS row, release its root, and DELIBERATELY
-  DO NOT finish the row — the chain's single trailing `done` does that.
+  "Record `label` against THIS row and DELIBERATELY DO NOT finish it —
+  the chain's single trailing step does that, and owns the teardown too
+  ([[release-minted!]]), so this handler reads the DOM for its diagnostic
+  and releases nothing. `handle` is therefore a witness here rather than
+  a possession: an arm that has one can say what was on screen, and an
+  arm that has none is no longer an arm that strands a root.
 
   **A rejection handler may not sit downstream of the `.then` that calls
   `done` (rf2-d3tc).** `cljs.test/run-block` hands `done` a continuation
@@ -205,7 +240,6 @@
     (is false (str label " — " (.-message e)
                    " | DOM was " (pr-str (when handle (text handle)))
                    " | residue " (pr-str (dissoc (inventory/residue) :entries))))
-    (when handle (mount/release! handle))
     nil))
 
 ;; ---------------------------------------------------------------------------
@@ -282,7 +316,9 @@
                                  (fn [_] (mount/release! handle) nil))))
                       (.catch (report-failure! "W1 paint-order witness" handle))))))
             (.catch (report-failure! "W1 paint-order witness" nil))
-            (.then (fn [_] (done))))))))
+            ;; The single trailing step, which BOTH arms reach: this row's
+            ;; roots go down first, and the single `done` is the last act.
+            (.then (fn [_] (release-minted!) (done))))))))
 
 ;; ---------------------------------------------------------------------------
 ;; W1's sabotage — Evidence law 3
@@ -342,7 +378,9 @@
                                (fn [_] (mount/release! handle) nil))))
                     (.catch (report-failure! "W1 sabotage control" handle)))))
             (.catch (report-failure! "W1 sabotage control" nil))
-            (.then (fn [_] (done))))))))
+            ;; The single trailing step, which BOTH arms reach: this row's
+            ;; roots go down first, and the single `done` is the last act.
+            (.then (fn [_] (release-minted!) (done))))))))
 
 ;; ---------------------------------------------------------------------------
 ;; W2. The staged render→commit gap — the bead's point 4
@@ -424,7 +462,9 @@
                   (.then (inventory/quiesced!)
                          (fn [_] (mount/release! handle) nil))))
               (.catch (report-failure! "W2 staged-gap witness" handle))
-              (.then (fn [_] (done)))))))))
+              ;; The single trailing step, which BOTH arms reach: this row's
+              ;; roots go down first, and the single `done` is the last act.
+              (.then (fn [_] (release-minted!) (done)))))))))
 
 ;; ---------------------------------------------------------------------------
 ;; The population, asserted rather than described


### PR DESCRIPTION
rf2-fqof asked two questions of `implementation/hicasso/test`, the one tree rf2-104z could not sweep. The first is answered EMPTY at source. The second is not, and this is the repair.

## PRIMARY — the timer conversion never happened here either (verified empty)

The census re-run at `origin/main` `4b8ca72467`, not at the bead's text:

- **The campaign's footprint on this tree is six files across three PRs**, and I read all three diffs in full: #7937 (`reincarnation_paint_dom`), #7942 (`activity_suspense_dom`, `kernel_commit_owns_dom`, `read_extent_dom`), #7974 (`native_abi_dom`, `native_hooks_dom`). Every hunk without exception is the same pure chain-reorder — `done` pulled out of the `.then`/`.catch`, the rejection arm reports and returns `nil`, one trailing `.then` calls `done`. **Not one hunk wraps a `js/setTimeout` in a `(js/Promise. …)`.**
- **`(js/Promise. (fn [resolve reject] …))` occurs exactly ONCE in the whole tree** — `lazy_boundary_dom_cljs_test.cljs:167` — and it wraps `(reset! !settle {:resolve resolve :reject reject})` for a hand-settled lazy loader, not a timer. `git log -S` puts it in `c409905263` (the lazy-boundary suite), which is not a campaign PR.
- **The two genuine timer-in-promise sites both predate the campaign and cannot reject.** `reincarnation_paint_dom_cljs_test.cljs:178`'s `next-task` (`0f58d4d347`, rf2-2l17) and `roots_frames_support.cljs:331`'s `wait-until!` (`604dffb2b1`, rf2-hic-012) are single-arm `(fn [resolve] …)`; the poll resolves `false` on deadline rather than rejecting.

So the bead's antecedent never happened here either, exactly as rf2-104z found for its four trees. No scanner was built, per the bead and per rf2-j9tl / rf2-maiw.

## SECONDARY — and here the class is NOT empty

Only 13 files in the tree carry a `.catch` at all; 8 of those mount a real React root. Five are already correct: `activity_suspense_dom`, `kernel_commit_owns_dom`, `read_extent_dom`, `imperative_sdk_dom` and `lazy_boundary_dom` all bind `handle` in an enclosing synchronous `let`, so `report-failure!` can see the root and does release it.

The other three share one shape. Their `mount-live!` mints the root **synchronously** — `mount/root!` runs before the promise is even created — and hands it over only once a poll succeeds, so **two paths reach the rejection arm with a live root the arm has no name for**: the poll's own deadline, which `mount-live!` converts into a throw, and any throw in the row body above. The arm reports, returns, and the trailing step calls `done` — with a mounted React root and its attached container standing in the document for the next namespace to inherit. That is rf2-o0n1's finding, in the tree the original contamination was captured on.

Both #7974 files say so themselves, and read it as an exemption:

> Teardown is NOT hoisted onto those trailing steps in the `mount-live!` rows: the rejection arm never had the handle at all, because `mount-live!` resolves WITH it, so the two arms were never writing the same release.

"The rejection arm never had the handle" is not a reason not to hoist. It is the defect.

## What lands

Each of the three files keeps a private `!minted` roster that `mount-live!` enrols into at mint time, and releases from `release-minted!` on the single trailing step **both arms reach**, with `done` as the last act. One mechanism covers both leak paths, and it generalises to the two rows that mount two roots.

- **`native_abi_dom_cljs_test.cljs`** — 8 `mount-live!` rows. `a-lazy-head-suspends-and-then-names-its-own-component` was already correct (lexical handle, released on the trailing step) and is untouched; the corrected comment now points at it as the exemplar rather than as the exception.
- **`native_hooks_dom_cljs_test.cljs`** — 7 rows. `report-failure!` loses its `handle` parameter, which every outer call site passed `nil` for. The `(is (= support/released (teardown! handle)))` assertions stay exactly where they are: they are the act under test, and `mount/release!` is idempotent — React's `root.unmount()` is a silent no-op once `_internalRoot` is null (read at `react-dom/cjs/react-dom-client.development.js:27895`) — so the trailing release costs them nothing.
- **`reincarnation_paint_dom_cljs_test.cljs`** — 3 rows. `report-failure!` keeps `handle` for its `DOM was …` diagnostic but releases nothing, so the teardown has one owner instead of two.

## Proof that it bites

The rejection arm is only reachable when a row is already failing, so the repair was measured rather than asserted. `native_abi_dom`'s first row was perturbed to throw after its mount and before its success-path teardown, and its own trailing step made to assert that `document.body` is back to the child count it held before the row mounted anything.

| variant | exit | result |
|---|---|---|
| `release-minted!` NEUTERED (the pre-repair behaviour), perturbation applied | 1 | Ran 1403 tests / 8697 assertions, **2 failures**: the perturbation's own report, and `rf2-fqof CONTROL: the rejection arm left 1 container(s) standing in the document` at `native_abi_dom_cljs_test.cljs:300:26` |
| `release-minted!` intact, same perturbation | 1 | Ran 1403 tests / 8697 assertions, **1 failure**: the perturbation's own report alone. The control is green |

Identical totals in both runs, so the delta is that one assertion and nothing else.

The perturbation and the control were then removed, and the restore verified by hashing the bytes rather than by reading a diff — all three files hash identical to their pre-experiment state, and `git status --short` is empty:

```
1537a6e61f839a85e6626e335341325f5f11c9339de0611d73bb437c115eb0ee  native_abi_dom_cljs_test.cljs
12616c6ebd53cd4609ddaf4436b9e126211b690568f19454839e755da6d84aa7  native_hooks_dom_cljs_test.cljs
4561d68237929bf5c49c4fcb971fa937340a9b7e2ac9b47ac984ca9c1231e165  reincarnation_paint_dom_cljs_test.cljs
```

## The neighbouring late-`finally` class (the ssrwitness lead), measured and NOT widened into

`worker/ssrwitness-hic046` (#8011) found a row whose `after` called `done` from inside a `try`, so the `finally` that restored the console and unmounted the root ran only once `run-block`'s synchronous continuation returned. I measured that shape across this tree: every `try`/`finally` whose `finally` does teardown puts `done` INSIDE the `finally`, after the teardown — the correct order — with exactly two exceptions, `host_ssr_dom_cljs_test.cljs:673` and `native_ssr_dom_cljs_test.cljs:440`, both `(try (after container @seen html) (finally (restore) (.unmount root) …))`. **Both are held by #8011 and repaired there.** Nothing outside that PR's fence carries the shape, so nothing was widened into.

## Quality gates

Run from this worktree (`re-frame2-worktrees/teardown-fqof`), foreground to completion, never piped. Each exit code is the captured `$?` read back from its own worktree-suffixed file; the spine's `gate root:` line names this worktree.

| Gate | Exit | Result |
|---|---|---|
| `npm run test:browser` (clean, before the experiment) | 0 | Ran 1403 tests / 8695 assertions, **0 failures, 0 errors** |
| `npm run test:browser` (perturbed, fix neutered) | 1 | 2 failures — see the proof table above |
| `npm run test:browser` (perturbed, fix intact) | 1 | 1 failure — see the proof table above |
| `sh scripts/test-fast-pr.sh` | 0 | `PASS fast PR spine`. Node tier: 13652 tests / 69105 assertions, **0 failures, 0 errors**. clj-kondo (CI's pinned 2026.04.15 command), the hicasso invariants gate, the hicasso lint-export gate, the hicasso bench-lane compile (124 namespaces, 0 warnings) and the per-ns isolation gate all ran inside it. Docs and JVM tiers are not armed by this diff |
| `npm run test:hicasso-hmr` | *not run* | **Deferred to CI, deliberately.** The gate binds `:dev-http` 8061 and `assertOwnBundle` refuses a second run, and other workers hold that rig this wave. My surface arms `cljs-hicasso-hmr` even though this diff touches only `-dom-cljs-test` files, which the HMR testbed build does not compile. No port shift was attempted |
| `npm run test:hicasso-controlled` | *not run* | Deferred to CI — three-engine gate, armed by surface; this diff touches no `hicasso/testbed/` or `src/` file it exercises |
| `npm run build:hicasso-release` | *not run* | Deferred to CI. The release build does not compile `test/`, so this diff cannot reach it, and a gate over an unchanged surface attests nothing |

**What the local spine does not decide**: the spine's own tail names 95 required CI checks in no tier of it, including the browser lanes beyond the three runs above, `cljs-hicasso-controlled` and `cljs-hicasso-hmr`, production-elision / bundle-isolation / perf-bundle, adapter smokes, the Xray feature matrix, mcp-conformance, the tool JVM suites and docs.yml's full build. Green here is not green in CI.
