### PR TITLE
test(ui): real-DOM prefetch arms for :on-focus and :on-touch-start (rf2-2n3p)

### DIFF
--- a/implementation/ui/test/re_frame/ui/route_link_dom_cljs_test.cljs
+++ b/implementation/ui/test/re_frame/ui/route_link_dom_cljs_test.cljs
@@ -16,11 +16,17 @@
   routing cascade and navigate the Playwright page (destroying the execution
   context), so the DOM fixture deliberately stops at the render contract.
 
-  The `:prefetch :intent` arm IS driven with real DOM events, and belongs here
-  rather than beside the click: a prefetch does not navigate, so hovering the
-  mounted anchor is safe in this page, and hover-to-dispatch is exactly the
-  behaviour a synthetic-event test cannot vouch for — whether the handler
-  reached the real element at all.
+  The `:prefetch :intent` arms ARE driven with real DOM events, and belong here
+  rather than beside the click: a prefetch does not navigate, so hovering,
+  focusing and touching the mounted anchor are all safe in this page, and
+  intent-to-dispatch is exactly the behaviour a synthetic-event test cannot
+  vouch for — whether the handler reached the real element at all, under the
+  real event name. EVERY position of the closed intent class
+  (`re-frame.routing.link/prefetch-intent-keys`) gets a real-DOM arm here, not
+  just the pointer one: `ui/route-link` is the one link surface still writing
+  the three positions out LITERALLY instead of mapping over that class
+  (rf2-drpa3.57), so a per-position gesture is what would catch the copy
+  drifting from the law.
 
   routing rides the TEST classpath (deps.edn :test alias) so its late-bind hooks
   publish; production `re-frame.ui` never requires it."
@@ -33,7 +39,10 @@
             [re-frame.ui.test :as uit]
             ;; publishes :routing/link-model + :routing/activate-link!
             ;; + :routing/prefetch-payload + :routing/prefetch-on-intent!
-            [re-frame.routing]))
+            [re-frame.routing]
+            ;; the closed intent class itself — read so the roster of arms below
+            ;; can be checked against the law rather than restated from memory
+            [re-frame.routing.link :as routing-link]))
 
 (defn- browser? []
   (and (exists? js/document) (some? (.-createElement js/document))))
@@ -102,6 +111,26 @@
                            :source     (:source ev)}))))
     [log #(trace-tooling/unregister-listener! k)]))
 
+(def ^:private arms-driven
+  "The intent positions THIS fixture drives with real DOM events: pointer in
+  `…-warms-on-real-dom-intent`, keyboard-focus and touch in
+  `…-warms-on-real-focus-and-touch`. Checked against the published class
+  below — a position added to the law with no gesture here would otherwise
+  arrive unwitnessed on this surface, which is the exact failure the literal
+  copy in `ui/route-link` invites."
+  #{:on-mouse-enter :on-focus :on-touch-start})
+
+(defn- touch-start-event
+  "A real `touchstart` DOM event to dispatch at the anchor. Chromium exposes
+  the `TouchEvent` constructor only on touch-capable builds, so fall back to
+  the base `Event` under the SAME name: what is under test is React's
+  delegated `touchstart` listener finding the compiled view's handler, and
+  that listener keys off the event name, not the interface."
+  []
+  (if (exists? js/TouchEvent)
+    (js/TouchEvent. "touchstart" #js {:bubbles true})
+    (js/Event. "touchstart" #js {:bubbles true})))
+
 (deftest ui-route-link-prefetch-intent-warms-on-real-dom-intent
   (when (browser?)
     (rf/reg-route :route/article {} "/articles/:slug")
@@ -151,6 +180,87 @@
                      (rf/destroy-frame! f)
                      (is false (str "prefetch DOM fixture rejected: " e))
                      (done))))))))
+
+(deftest ui-route-link-prefetch-intent-warms-on-real-focus-and-touch
+  ;; The hover arm above proves the pointer position. These are the other two
+  ;; members of the closed class — the keyboard user who Tabs onto the link and
+  ;; the touch user whose finger lands on it — driven the same way: a REAL
+  ;; gesture at the REAL element, not a call through the attrs map. `ui.cljc`
+  ;; writes all three positions out literally, so each needs its own witness;
+  ;; a copy that dropped one would sail through a fixture that only hovers.
+  (when (browser?)
+    (rf/reg-route :route/article {} "/articles/:slug")
+    (let [f              (rf/make-frame {:id :route-link/host4 :initial-events [[:rf/set-db {}]]})
+          [log unregister!] (prefetch-log)
+          callers        (atom {})
+          caller         (fn [position]
+                           (fn [_]
+                             (swap! callers update position (fnil inc 0))
+                             (swap! log conj [:caller position])))
+          gestures       [{:position :on-focus
+                           :gesture  "a real .focus() — the Tab-to-a-link gesture"
+                           :fire!    (fn [a]
+                                       (.focus a)
+                                       (is (identical? a (.-activeElement js/document))
+                                           (str ":on-focus — .focus() moved the document's active "
+                                                "element, so the gesture itself landed (without "
+                                                "this, a silent no-op would read as a clean pass "
+                                                "on the cold-link control)")))}
+                          {:position :on-touch-start
+                           :gesture  "a real touchstart at the anchor"
+                           :fire!    (fn [a] (.dispatchEvent a (touch-start-event)))}]
+          warmed         {:dispatched [:rf.route/prefetch
+                                       {:to :route/article :params {:slug "the-intro"}}]
+                          :frame      :route-link/host4
+                          :source     :router}]
+      (async done
+        (-> (uit/with-root
+              [root [ui/frame-provider {:frame f}
+                     [:nav
+                      [ui/route-link {:to :route/article
+                                      :params {:slug "the-intro"}
+                                      :prefetch :intent
+                                      :on-focus (caller :on-focus)
+                                      :on-touch-start (caller :on-touch-start)
+                                      :data-testid "warm"} "Read"]
+                      [ui/route-link {:to :route/article
+                                      :params {:slug "cold"}
+                                      :data-testid "cold"} "Cold"]]]]
+              (let [warm (.querySelector root "a[data-testid='warm']")
+                    cold (.querySelector root "a[data-testid='cold']")]
+                (testing "a passive render warms nothing — intent is a user act"
+                  (is (= [] @log)))
+                (doseq [{:keys [position gesture fire!]} gestures]
+                  (testing (str position " — " gesture
+                                " dispatches ONE prefetch for the link's own address, after the caller")
+                    (reset! log [])
+                    (fire! warm)
+                    (is (= 1 (get @callers position))
+                        (str position " — the caller's own handler at this position still runs"))
+                    (is (= [[:caller position] warmed] @log)
+                        (str position " — composed, not replaced: caller first, then ONE warm-up "
+                             "for this link's own address on the rendering frame, stamped "
+                             ":source :router. A literal position missing from ui/route-link "
+                             "shows up here as an empty log")))
+                  (testing (str position " — a link that did not opt in warms nothing on the same gesture")
+                    (reset! log [])
+                    (fire! cold)
+                    (is (= [] @log))))))
+            (.then (fn [] (unregister!) (rf/destroy-frame! f) (done))
+                   (fn [e]
+                     (unregister!)
+                     (rf/destroy-frame! f)
+                     (is false (str "focus/touch prefetch DOM fixture rejected: " e))
+                     (done))))))))
+
+(deftest ui-route-link-prefetch-real-dom-arms-cover-the-whole-intent-class
+  (testing "the three arms above are the WHOLE published class, not a sample of
+            it — `re-frame.routing.link/prefetch-intent-keys` is routing's law
+            and `ui/route-link` still copies it out literally, so a position
+            added to the law lands on this surface only if someone edits the
+            view. This assertion is the alarm: it reds the moment the class
+            grows, naming the gesture this fixture owes it."
+    (is (= arms-driven (set routing-link/prefetch-intent-keys)))))
 
 (deftest ui-route-link-native-anchor-renders-its-native-attribute
   (when (browser?)


### PR DESCRIPTION
Closes rf2-2n3p.

`re-frame.routing.link/prefetch-intent-keys` is a closed class of three —
`[:on-mouse-enter :on-focus :on-touch-start]` — and Spec 012 sells all three as
credible-intent triggers. Only one of them had a real-browser witness. The
direct-handler test in `implementation/routing/test/re_frame/route_link_cljs_test.cljs`
covers all three, but by calling the handler off the attrs map: that proves the
handler is installed under the key, not that React attaches it to the real
element under the real event name.

This adds the two missing arms beside the existing hover deftest in
`implementation/ui/test/re_frame/ui/route_link_dom_cljs_test.cljs`, reusing that
file's `prefetch-log` helper:

- **`:on-focus`** — driven by a real `.focus()` on the mounted anchor (the
  Tab-to-a-link gesture), with `document.activeElement` asserted to have moved,
  so a silent focus no-op cannot make the negative control pass vacuously.
- **`:on-touch-start`** — driven by a real `touchstart` dispatched at the anchor.
- **the cold-link control on each gesture** — a second link that did not opt in
  warms nothing under the same gesture.

Both arms share one mount, so the two handlers are also shown coexisting on the
same element, and a `testing` block before the loop keeps the passive-render
control (a render warms nothing) ahead of the log resets.

One extra assertion, four lines: `ui-route-link-prefetch-real-dom-arms-cover-the-whole-intent-class`
pins the roster of gestures this fixture drives against
`re-frame.routing.link/prefetch-intent-keys` itself. `ui/route-link` is the one
link surface still writing the three positions out LITERALLY instead of mapping
over the published class (recorded in `link.cljc`'s own docstring as an
explicitly temporary exception, rf2-drpa3.57), so a position added to the law
reaches `rf/route-link` and `v/route-link` and misses `ui/route-link`. The
per-position arms catch a literal that drops a position; this assertion catches
a class that grows one.

Test-only change. `implementation/ui/src/re_frame/ui.cljc` is NOT touched by
this PR — it was modified only transiently for the sabotage control below, and
restored byte-identically (sha256 verified).

## Quality gates

| gate | exit code |
| --- | --- |
| `npm run test:browser` (pristine tree) | **0** — 1425 tests, 8777 assertions, 0 failures, 0 errors |
| `npm run test:browser` (with the planted fault, see below) | **1** — 2 failures, both in the new deftest |

Both runs printed `gate root: /c/Users/miket/code/re-frame2-worktrees/prefetch-2n3p/implementation`,
checked against this worker's own worktree before the colours were believed.
The quoted numbers are the ones captured by `echo "$?"` on the same command
line as the runner (the harness reported the second, red, run as "exit code 0" —
the captured status is 1).

### Control evidence — the arms are not decorative

**Positive control (the gesture warms).** On the pristine tree each arm asserts
the whole ordered log, not mere occurrence: `[[:caller <position>] {:dispatched
[:rf.route/prefetch {:to :route/article :params {:slug "the-intro"}}] :frame
:route-link/host4 :source :router}]` — the caller's own handler at that position
ran FIRST, then exactly ONE warm-up for the link's own address reached the
rendering frame, stamped `:source :router`. The focus arm additionally asserts
`document.activeElement` is the anchor, so the gesture is proven to have landed.

**Negative control (cold link).** A sibling link with no `:prefetch` opt-in gets
the same gesture; the log stays empty on both positions.

**Sabotage control (does the arm bite?).** The two positions were deleted from
`ui.cljc`'s literal `assoc` — exactly the drift `link.cljc` warns about — the
gate re-run, and the file restored.

- ui.cljc sha256 before plant: `26d47b169d28a19cbc21e84198302b1c3014ce6425b53e3fcc5d1549dfe8f113`
- ui.cljc sha256 planted: `93a3198bd31992c8632b2d8c02f1a668828843f2e60080ea81abd719090383e6`
- ui.cljc sha256 after restore: `26d47b169d28a19cbc21e84198302b1c3014ce6425b53e3fcc5d1549dfe8f113` (identical to before)

The runtime demonstrably observed the plant — `npm run test:browser` recompiles
from source on every invocation (no watch), and the failure named the exact
missing behaviour on each position:

```
FAIL in (ui-route-link-prefetch-intent-warms-on-real-focus-and-touch)
:on-focus — a real .focus() — the Tab-to-a-link gesture dispatches ONE prefetch …
  actual: (not (= [[:caller :on-focus] {:dispatched [:rf.route/prefetch …]}]
                  [[:caller :on-focus]]))

FAIL in (ui-route-link-prefetch-intent-warms-on-real-focus-and-touch)
:on-touch-start — a real touchstart at the anchor dispatches ONE prefetch …
  actual: (not (= [[:caller :on-touch-start] {:dispatched [:rf.route/prefetch …]}]
                  [[:caller :on-touch-start]]))
```

Note what survived the plant in that output: `[:caller :on-focus]` and
`[:caller :on-touch-start]` are still in the log. The caller's handler was
reached through the passthrough, so the gesture unquestionably fired at the real
element — only the framework's own warm-up went missing. That is the failure
shape a dropped literal position would actually produce, and the cold-link
controls stayed green throughout (as they must — they never opted in).

### Finding: the literal copy is still there, and it is still correct

The bead asked for a precise report if the arms found the literal enumeration.
They did not find it broken — `implementation/ui/src/re_frame/ui.cljc` (in the
`overrides` `cond->`) still writes `:on-mouse-enter` / `:on-focus` /
`:on-touch-start` out one at a time rather than mapping over
`prefetch-intent-keys` the way routing's own `prefetch-intent-attrs` does, but
today all three members of the class are present and behave identically. So this
PR is a witness, not a repair: the arms now make the copy's correctness a
measured fact per position rather than an assumption, and the roster assertion
makes the class growing a red rather than a silence.
