### PR TITLE
fix(hicasso/test-kit): shadow! compares live control state, not markup alone (rf2-kyum)

### DIFF
--- a/implementation/hicasso/test_kit/src/re_frame/hicasso/test.cljs
+++ b/implementation/hicasso/test_kit/src/re_frame/hicasso/test.cljs
@@ -504,7 +504,15 @@
   It answers the DOM's shape and nothing about React: two canonically
   equal pages may still differ in lifecycle, identity and hydration —
   distinct claims, each owed its own witness (004B, and the specification
-  §9 on naming the equality a witness proves)."
+  §9 on naming the equality a witness proves).
+
+  **Nor in a form control's live state**, and that is a fact about markup
+  rather than a gap here. A control's attributes carry its DEFAULTS —
+  `value` is `defaultValue`, `checked` is `defaultChecked`, an option's
+  `selected` is `defaultSelected` — while the live values are properties
+  no serialiser can reach, so two byte-identical pages can be showing
+  different selections to a user. `re-frame.hicasso.test.mounted/shadow!`
+  compares those slots beside this equality for exactly that reason."
   [node]
   (when-not (and (some? node) (number? (.-nodeType node)))
     (refuse! :rf.error/hicasso-test-not-a-dom-node

--- a/implementation/hicasso/test_kit/src/re_frame/hicasso/test/mounted.cljs
+++ b/implementation/hicasso/test_kit/src/re_frame/hicasso/test/mounted.cljs
@@ -1381,10 +1381,17 @@
 ;; ---------------------------------------------------------------------------
 ;;
 ;; `re-frame.hicasso.test/canonical-dom` answers WHETHER two pages differ; a
-;; red owes the programmer WHERE. This walk is that second question, and it is
-;; deliberately the same equality: comments are dropped and adjacent text runs
-;; join, exactly as they do when `canonical-dom` flattens a subtree to one
-;; string, so the two instruments cannot disagree about a page.
+;; red owes the programmer WHERE. This walk is that second question, and over
+;; MARKUP it is deliberately the same equality: comments are dropped and
+;; adjacent text runs join, exactly as they do when `canonical-dom` flattens a
+;; subtree to one string, so the two instruments cannot disagree about the
+;; bytes of a page.
+;;
+;; It then compares one thing more, which a serialiser structurally cannot:
+;; the LIVE CONTROL STATE below. So the two instruments can disagree after
+;; all, in exactly one direction — this walk reddens pairs `canonical-dom`
+;; calls equal, never the reverse — and that direction is the repair rather
+;; than a drift.
 
 (def ^:private absent
   "What a difference reports where one side has no value at all — a
@@ -1399,6 +1406,70 @@
     (reduce (fn [m a] (assoc! m (.-name a) (de-address-text frame-kw (.-value a))))
             (transient {})
             (array-seq (.-attributes el)))))
+
+;; ---------------------------------------------------------------------------
+;; The live control state — the half of a form control that is not in the page
+;; ---------------------------------------------------------------------------
+;;
+;; A form control has TWO values and only one of them is in the page's bytes.
+;; The content attribute is the DEFAULT — `value` is `defaultValue`, `checked`
+;; is `defaultChecked`, an option's `selected` is `defaultSelected` — and the
+;; live one is a property no serialiser can reach. React writes the live one
+;; directly, so `HTMLSelectElement.value` moves `option.selected` while
+;; `outerHTML` stays byte-identical.
+;;
+;; Which made this door green for a pair a user could tell apart at a glance:
+;; a reference `<select>` showing "Two" beside a candidate showing "One", the
+;; same three `<option>`s under each, `{:status :green :checkpoints 1}`. PR
+;; #8007's merged-PR audit found it and it is the reason this walk reads
+;; properties as well as attributes — a port can select the wrong option with
+;; every byte of markup and every intent agreeing.
+
+(def ^:private live-properties
+  "The live control state each element kind carries in a PROPERTY, by tag.
+
+  One entry per slot the content attribute does not track:
+
+  - `input` — `value` and `checked` go DIRTY the moment a user touches
+    the field, and the attribute stays at whatever the element mounted
+    with; `indeterminate` is never an attribute at all, and it is the
+    third thing a checkbox can look like on screen.
+  - `textarea` — `value`; the markup carries only the text child it was
+    born with.
+  - `select` — `value`, which is the selected option's, and which is
+    written by moving `option.selected` rather than any attribute.
+  - `option` — `selected`, because a MULTIPLE select's `value` is only
+    its FIRST selected option, and two different selections can share
+    one.
+
+  Nothing else is here, and the two exclusions are settled rather than
+  pending. A property the content attribute REFLECTS — `<progress value>`,
+  `<details open>` — is already compared as an attribute, and reading it
+  again would only report it twice. And media playback state
+  (`currentTime`, `paused`) moves on the wall clock, so comparing it would
+  make a verdict depend on when it was taken.
+
+  Everything the door already declined stays declined: focus, caret, IME,
+  layout and paint are not here and are not properties of this kind — see
+  [[shadow!]] §What it does not claim."
+  {"input"    ["value" "checked" "indeterminate"]
+   "textarea" ["value"]
+   "select"   ["value"]
+   "option"   ["selected"]})
+
+(defn- props-of
+  "One element's live control state as `{property value}` — empty for
+  everything that is not a control.
+
+  A string value is de-addressed exactly as an attribute's is: a field
+  holds whatever the application put in it, a frame keyword included."
+  [el frame-kw]
+  (persistent!
+    (reduce (fn [m p]
+              (let [v (unchecked-get el p)]
+                (assoc! m p (if (string? v) (de-address-text frame-kw v) v))))
+            (transient {})
+            (get live-properties (node-tag el)))))
 
 (defn- element-outline
   "How a red NAMES an element: its opening tag with attribute names
@@ -1465,6 +1536,31 @@
                :candidate (get b k absent)}))
           (sort (distinct (concat (keys a) (keys b)))))))
 
+(defn- property-difference
+  "The first live-control property at which two elements of the same tag
+  disagree, as data — or nil.
+
+  Taken AFTER the attributes and BEFORE the children, and both halves of
+  that placement earn their keep. A difference visible in the markup is
+  the one a reader can go and look at, so where an element differs both
+  ways the attribute is what the red names. And a `<select>` whose value
+  moved is named at the SELECT rather than at whichever `<option>`
+  changed selectedness underneath it, which is the sentence a programmer
+  can act on."
+  [ref-el can-el ref-frame can-frame path]
+  (let [a (props-of ref-el ref-frame)
+        b (props-of can-el can-frame)]
+    (some (fn [k]
+            (when (not= (get a k absent) (get b k absent))
+              {:kind      :dom
+               :reason    :property
+               :property  k
+               :at        (at path)
+               :path      path
+               :reference (get a k absent)
+               :candidate (get b k absent)}))
+          (sort (distinct (concat (keys a) (keys b)))))))
+
 (defn- children-difference
   [ref-n can-n ref-frame can-frame path]
   (let [a (comparable-children ref-n)
@@ -1514,6 +1610,7 @@
       {:kind :dom :reason :tag :at (at path) :path path
        :reference rt :candidate ct}
       (or (attribute-difference ref-el can-el ref-frame can-frame path)
+          (property-difference ref-el can-el ref-frame can-frame path)
           (children-difference ref-el can-el ref-frame can-frame path)))))
 
 (defn- dom-difference
@@ -1769,8 +1866,15 @@
     `:reference` and `:candidate` vectors. Reported BEFORE any DOM
     difference at the same checkpoint, because it is the cause.
   - `:kind :dom` — `:at`, a readable path from the mounted root, plus
-    `:reason` (`:tag`, `:attribute`, `:text`, `:node-kind`,
+    `:reason` (`:tag`, `:attribute`, `:property`, `:text`, `:node-kind`,
     `:only-in-reference`, `:only-in-candidate`) and both sides' values.
+    `:property` names a **live control** slot and carries `:property`
+    beside the values — a `<select>` at a different option, a dirty
+    `value` or `checked`, an `indeterminate` checkbox. Those are the
+    user-visible state a form control keeps OUT of its markup, so this
+    is the one `:reason` a serialiser could never have reached; see
+    [[live-properties]] for the closed roster and for what is
+    deliberately not in it.
   - `:kind :script` — the step could not run as written. A selector that
     matched one side only IS a difference; one that matched neither is a
     broken script, and it is still red, because a checkpoint reached by a
@@ -1797,10 +1901,18 @@
 
   ## What it does not claim
 
-  Canonical DOM and intents. Not focus, caret, IME, layout or paint —
-  those are L4 and the browser levels own them. Not residue either: no
-  reading is taken, so no reset is performed, and `assert-clean!` remains
-  the door for that claim.
+  Canonical DOM, the live control state named in [[live-properties]],
+  and intents. Not focus, caret, IME, layout or paint — those are L4 and
+  the browser levels own them. Not residue either: no reading is taken,
+  so no reset is performed, and `assert-clean!` remains the door for that
+  claim.
+
+  The control state is inside the claim rather than beside it because
+  markup cannot carry it and a user can see it: an `<option>`'s
+  selectedness, a dirty `value` or `checked`, an `indeterminate`
+  checkbox. Comparing attributes alone made this door green for a
+  candidate visibly showing the wrong option (PR #8007's merged-PR
+  audit), which is the one thing it exists not to do.
 
   Synchronous. A step's effects are settled through `flushSync` before
   the checkpoint after it, so anything landing in a later turn — a

--- a/implementation/hicasso/test_kit/test/re_frame/hicasso/shadow_dom_cljs_test.cljs
+++ b/implementation/hicasso/test_kit/test/re_frame/hicasso/shadow_dom_cljs_test.cljs
@@ -24,10 +24,26 @@
   | — | one attribute that drifted | the checkpoint and the exact node |
   | — | a step that matched nothing | the selector, and RED rather than green |
   | one mount driven, the other not | — | `:only-in-reference` |
+  | two selects on the same option | a select showing another option | `:property \"value\"`, at the select |
+  | — | a dirty `checked`, `value`, `indeterminate` | `:property`, at the exact input |
+  | — | a multiple select's other selection | `:property \"selected\"`, at the option |
 
   The three drifted views differ from [[candidate-row]] by **one form
   each**, so a red proves the comparator saw that form and not the shape
   of the view around it.
+
+  ## The last three rows are a REGRESSION, and they were once green
+
+  PR #8007's merged-PR audit reproduced this exactly: a reference select
+  at `\"two\"` beside a candidate at `\"one\"`, identical option markup,
+  `{:status :green :checkpoints 1}`. A form control keeps two values and
+  only the DEFAULT is in the bytes — `value` is `defaultValue`, `checked`
+  is `defaultChecked`, an option's `selected` is `defaultSelected` —
+  while the live one is a property no serialiser can reach. So each of
+  those rows proves the SAME two things before it reads a verdict: that
+  the two live pages genuinely differ, and that `ht/canonical-dom` still
+  calls them byte-identical. Without the second half the row would not
+  be about the defect at all.
 
   ## Two frames, and the one slot the comparison is blind at
 
@@ -52,6 +68,7 @@
             [re-frame.core :as rf]
             [re-frame.hicasso :as h]
             [re-frame.hicasso.impl.collector :as collector]
+            [re-frame.hicasso.test :as ht]
             [re-frame.hicasso.test.mounted :as hm]
             [re-frame.test-support :as test-support]))
 
@@ -88,6 +105,12 @@
 ;; stream moves and the page does not.
 (rf/reg-event :hicasso.shadow/noted
               (fn [{:keys [db]} [_ x]] {:db (update db :notes (fnil conj []) x)}))
+
+;; [[select-row]]'s handler. Nothing in this namespace fires it — the live
+;; rows below move a control's state directly, precisely so that the intent
+;; streams stay equal and a red can only be the DOM comparison's.
+(rf/reg-event :hicasso.shadow/pick
+              (fn [{:keys [db]} [_ v]] {:db (assoc db :picked v)}))
 
 (use-fixtures :each
   (test-support/make-reset-runtime-fixture
@@ -176,6 +199,37 @@
       [:button.save {:on-click [:hicasso.shadow/save]} "Save"]]
      [:button.edit {:on-click [:hicasso.shadow/edit]} "Edit"])
    [:p.saved (str "saved: " (or (h/sub [:hicasso.shadow/saved]) "—"))]])
+
+;; ---------------------------------------------------------------------------
+;; The live-control pair — one prop apart, and not one byte apart
+;; ---------------------------------------------------------------------------
+
+(h/defview select-row
+  "A native `<select>` bound to a value. Two mounts of it differ by that
+  ONE prop and by nothing in the markup: React writes a selection by
+  moving `option.selected`, and no content attribute tracks it."
+  [{:keys [value]}]
+  [:div.pick
+   [:select.pick {:value     value
+                  :on-change [:hicasso.shadow/pick ::h/value]}
+    [:option {:value "one"} "One"]
+    [:option {:value "two"} "Two"]
+    [:option {:value "three"} "Three"]]])
+
+(h/defview uncontrolled-fields
+  "Three UNCONTROLLED controls — no bound value, no handler, nothing
+  read. Each can be made dirty by hand without dispatching an intent,
+  which is what makes a red here unambiguously the DOM comparison's:
+  bind them and the intent stream would redden first and prove nothing
+  about the page."
+  [_]
+  [:div.fields
+   [:input.flag {:type "checkbox"}]
+   [:input.text {:type "text"}]
+   [:select.multi {:multiple true}
+    [:option {:value "a"} "A"]
+    [:option {:value "b"} "B"]
+    [:option {:value "c"} "C"]]])
 
 ;; ---------------------------------------------------------------------------
 ;; The lane
@@ -271,6 +325,146 @@
               :selector "button.no-such-control"
               :matched  :neither}
              difference)))))
+
+;; ---------------------------------------------------------------------------
+;; The live control state — the false green PR #8007's audit found
+;; ---------------------------------------------------------------------------
+
+(defn- markup-of [handle] (ht/canonical-dom (:container handle)))
+
+(deftest a-select-showing-a-different-option-is-not-a-green
+  (if-not (browser?)
+    (skip! "a selection lives in a real element's properties")
+    (let [s (hm/shadow! {:reference [select-row {:value "two"}]
+                         :candidate [select-row {:value "one"}]})]
+      (try
+        (testing "the two pages genuinely show a user different options"
+          (is (= ["two" "one"]
+                 [(.-value (.querySelector (:container (:reference s)) "select.pick"))
+                  (.-value (.querySelector (:container (:candidate s)) "select.pick"))])))
+        (testing "and their markup is byte-identical, which is why this was green"
+          (is (= (markup-of (:reference s)) (markup-of (:candidate s)))
+              (str "a selection is written by moving option.selected and no "
+                   "attribute tracks it, so the serialiser sees one page twice")))
+        (testing "the comparator now names the select, the slot and both values"
+          (let [{:keys [status checkpoints difference]} ((:checkpoint! s))]
+            (is (= :red status)
+                (str "this answered {:status :green :checkpoints 1} before "
+                     "rf2-kyum's reopening: a port could select the wrong "
+                     "option with every byte of markup and every intent agreeing"))
+            (is (= 1 checkpoints))
+            (is (= :dom (:kind difference)))
+            (is (= :property (:reason difference)))
+            (is (= "value" (:property difference)))
+            (is (= "two" (:reference difference)))
+            (is (= "one" (:candidate difference)))
+            (is (re-find #"select" (:at difference))
+                (str "named at the select rather than at whichever option "
+                     "changed underneath it: " (:at difference)))))
+        (finally ((:stop! s)))))))
+
+(deftest two-selects-showing-the-same-option-stay-green
+  (if-not (browser?)
+    (skip! "a selection lives in a real element's properties")
+    (let [s (hm/shadow! {:reference [select-row {:value "two"}]
+                         :candidate [select-row {:value "two"}]})]
+      (try
+        (is (= {:status :green :checkpoints 1} ((:checkpoint! s)))
+            (str "the live-control comparison reports a difference the two "
+                 "pages have; an instrument that reddened a matched pair "
+                 "would be the opposite defect and just as useless"))
+        (finally ((:stop! s)))))))
+
+;; ---------------------------------------------------------------------------
+;; The adjacent slots — so the repair is not a `select` special case
+;; ---------------------------------------------------------------------------
+;;
+;; `value` and `checked` go DIRTY under a real user and the attribute stays at
+;; the default the element mounted with; `indeterminate` is never an attribute
+;; at all. Each of these drives the pair apart at exactly one such slot,
+;; touching no attribute and dispatching no intent, and each checks that the
+;; markup is STILL identical afterwards — without which the row would be
+;; asserting something the old comparator already caught.
+
+(defn- live-difference
+  "Mount an identical pair, prove the comparator starts green, move one
+  or both sides' live control state with `mutate!`, and answer the next
+  verdict — with `::started-green?` and `::same-markup?` beside it."
+  [form mutate!]
+  (let [s (hm/shadow! {:reference form :candidate form})]
+    (try
+      (let [green? (= :green (:status ((:checkpoint! s))))]
+        (mutate! (:container (:reference s)) (:container (:candidate s)))
+        (assoc ((:checkpoint! s))
+               ::started-green? green?
+               ::same-markup?   (= (markup-of (:reference s))
+                                   (markup-of (:candidate s)))))
+      (finally ((:stop! s))))))
+
+(defn- is-live-only
+  "Every live-slot row's shared preamble: the pair began indistinguishable
+  and its markup never moved, so the verdict below is about the property
+  and about nothing else."
+  [v]
+  (is (true? (::started-green? v)) "the pair began indistinguishable")
+  (is (true? (::same-markup? v))
+      "and no byte of markup moved — the attributes cannot see this")
+  (is (= :red (:status v)))
+  (is (= :dom (:kind (:difference v))))
+  (is (= :property (:reason (:difference v))))
+  (:difference v))
+
+(defn- pick-options!
+  [container indexes]
+  (let [opts (.-options (.querySelector container "select.multi"))]
+    (doseq [i indexes] (set! (.-selected (.item opts i)) true))))
+
+(deftest the-adjacent-live-slots-redden-too
+  (if-not (browser?)
+    (skip! "a dirty control is one a real browser has been driven through")
+    (do
+      (testing "a checkbox one side ticked"
+        (let [d (is-live-only
+                  (live-difference [uncontrolled-fields {}]
+                                   (fn [r _] (.click (.querySelector r "input.flag")))))]
+          (is (= "checked" (:property d)))
+          (is (= [true false] [(:reference d) (:candidate d)]))
+          (is (re-find #"input\[0\]" (:at d)) (:at d))))
+
+      (testing "a text field one side typed into"
+        (let [d (is-live-only
+                  (live-difference [uncontrolled-fields {}]
+                                   (fn [r _]
+                                     (set! (.-value (.querySelector r "input.text"))
+                                           "typed"))))]
+          (is (= "value" (:property d)))
+          (is (= ["typed" ""] [(:reference d) (:candidate d)]))
+          (is (re-find #"input\[1\]" (:at d)) (:at d))))
+
+      (testing "a checkbox one side left in the third state"
+        (let [d (is-live-only
+                  (live-difference [uncontrolled-fields {}]
+                                   (fn [r _]
+                                     (set! (.-indeterminate
+                                             (.querySelector r "input.flag"))
+                                           true))))]
+          (is (= "indeterminate" (:property d))
+              (str "never an attribute in any markup, and the third thing a "
+                   "checkbox can look like on screen"))
+          (is (= [true false] [(:reference d) (:candidate d)]))))
+
+      (testing "a MULTIPLE select whose value alone cannot tell the two apart"
+        (let [d (is-live-only
+                  (live-difference [uncontrolled-fields {}]
+                                   (fn [r c]
+                                     (pick-options! r [0 2])
+                                     (pick-options! c [0 1]))))]
+          (is (= "selected" (:property d))
+              (str "a multiple select's `value` is only its FIRST selected "
+                   "option, so {a c} and {a b} share one — the option's own "
+                   "selectedness is what separates them"))
+          (is (= [false true] [(:reference d) (:candidate d)]))
+          (is (re-find #"option\[1\]" (:at d)) (:at d)))))))
 
 ;; ---------------------------------------------------------------------------
 ;; Isolation, and the one slot the comparison is blind at


### PR DESCRIPTION
rf2-kyum, reopened by PR #8007's merged-PR audit for a confirmed false green.

A reference `<select>` at value `"two"` and a candidate at value `"one"`, with
identical option markup, compared as `{:status :green :checkpoints 1}`. The
live nodes genuinely differed — a user could see the wrong option selected —
and every byte of markup and every intent agreed.

## The mechanism

A form control keeps **two** values and only one of them is in the page's
bytes. The content attribute is the DEFAULT — `value` is `defaultValue`,
`checked` is `defaultChecked`, an option's `selected` is `defaultSelected` —
and the live one is a property no serialiser can reach. React writes the live
one directly, so `HTMLSelectElement.value` moves `option.selected` while
`outerHTML` stays byte-identical.

`attrs-of` read the `NamedNodeMap` and `element-difference` had no live-control
property comparison, so the whole of that state was outside the claim.

## The repair

`shadow!`'s DOM walk now reads a closed roster of live control properties
**between** the attributes and the children, reporting `:reason :property`
beside `:property`, `:at` and both values.

| Tag | Slots | Why it is not an attribute |
|---|---|---|
| `input` | `value`, `checked`, `indeterminate` | the first two go dirty under a real user; the third is never an attribute at all |
| `textarea` | `value` | markup carries only the text child it was born with |
| `select` | `value` | written by moving `option.selected` |
| `option` | `selected` | a MULTIPLE select's `value` is only its FIRST selected option, so two different selections can share one |

Placement earns both halves of its keep. **After** the attributes, because a
difference visible in the markup is the one a reader can go and look at, so
where an element differs both ways the attribute is what the red names — which
is also why the existing `placeholder` twin still reports `:reason :attribute`
unchanged. **Before** the children, so a `<select>` whose value moved is named
at the select rather than at whichever option changed underneath it.

Two exclusions are settled rather than pending, and the roster's docstring says
so: a property the content attribute REFLECTS (`<progress value>`,
`<details open>`) is already compared as an attribute, and media playback state
(`currentTime`, `paused`) moves on the wall clock, so comparing it would make a
verdict depend on when it was taken.

**The bead's non-claims are untouched.** Focus, caret, IME, layout and paint
are not in the roster and are not properties of this kind; `shadow!`'s
*What it does not claim* section still declines them by name.

## The stated invariant this changes, deliberately

The walk's own comment claimed it and `canonical-dom` were "the same equality,
so the two instruments cannot disagree about a page". That is now amended
rather than quietly broken: over MARKUP the equality is still exactly
`canonical-dom`'s, and the walk compares one thing more that a serialiser
structurally cannot. So the two CAN disagree, **in exactly one direction** —
this walk reddens pairs `canonical-dom` calls equal, never the reverse — and
that direction is the repair.

`canonical-dom` itself is unchanged. It is a markup serialiser and the live
state is not markup; its docstring now names the gap and points at `shadow!`,
so a consumer comparing two pages through it is not left to find this the way
the audit did.

## Witnesses

Added to `shadow_dom_cljs_test.cljs`, all browser-lane:

- **`a-select-showing-a-different-option-is-not-a-green`** — the audit's exact
  twin. It proves the two pages show a user different options (`["two" "one"]`)
  **and** that `ht/canonical-dom` still calls them byte-identical, before
  reading the verdict. Without that second half the row would not be about this
  defect at all.
- **`two-selects-showing-the-same-option-stay-green`** — the control in the
  other direction. An instrument that reddened a matched pair is the opposite
  defect and just as useless.
- **`the-adjacent-live-slots-redden-too`** — four sub-rows over the adjacent
  slots: a ticked checkbox (`checked`), a typed field (`value`), an
  `indeterminate` checkbox, and a MULTIPLE select where `value` is `"a"` on
  both sides and only `option.selected` separates `{a c}` from `{a b}`. Each
  drives an **uncontrolled** control so no intent is dispatched — a red is then
  unambiguously the DOM comparison's — and each asserts the pair started green
  and the markup never moved.

## Quality gates

| Gate | Exit |
|---|---|
| `npm run test:browser` | **0** — 1426 tests / 8809 assertions, 0 failures, 0 errors |
| `npm run test:hicasso-invariants` | **0** |
| `npm run test:browser` with the repair sabotaged | **1** — 26 failures, 4 errors |

Both gates printed `gate root: /c/Users/miket/code/re-frame2-worktrees/select-kyum/implementation`,
and both exit codes are the ones captured beside the run's own log.

### Sabotage control — both halves

**The source changed.** `element-difference`'s call to `property-difference`
was replaced by `(do ::SABOTAGE-rf2-kyum nil)` — a single-line anchor, so the
patch cannot silently no-op on a checkout with translated line endings.

| | sha256 of `mounted.cljs` |
|---|---|
| before the plant | `fe837aa848df41ff17b6ddbfbb207886d760e03b17625e0ae4da9f7a410be5c2` |
| planted | `ab7bce322589ae36b74c07f9f46c1da9cbb124e3787e306cb6275df20e6a9c52` |
| after restore | `fe837aa848df41ff17b6ddbfbb207886d760e03b17625e0ae4da9f7a410be5c2` (equal to the baseline) |

**The runtime observed it**, confirmed positively rather than assumed.
`test:browser` is a fresh `shadow-cljs compile` rather than a watch, so there
is no stale-bundle path in principle — but that is an argument, and the
evidence is the served bundle itself. In
`out/browser-test/js/cljs-runtime/re_frame.hicasso.test.mounted.js`,
`property_difference` appears at its **definition only, with no call site**,
and the compiled `element_difference` reads:

```js
var or__5162__auto__ = re_frame.hicasso.test.mounted.attribute_difference(ref_el,can_el,ref_frame,can_frame,path);
…
var or__5162__auto____$1 = (function (){ return null; })();
```

— the plant, compiled and served. (Its `::SABOTAGE-rf2-kyum` keyword is *not*
in the bundle: a constant in statement position is elided, so the missing call
site is the marker that survives. Worth stating, because a worker who greps
only for the keyword would read a genuine plant as a no-op.)

The run's failures are then exactly the new rows, each `expected :red /
actual :green` — the audit's sentence, reproduced on demand.

```
FAIL in (a-select-showing-a-different-option-is-not-a-green)  ×6
  expected: (= :red status)
    actual: (not (= :red :green))
FAIL in (the-adjacent-live-slots-redden-too)                  ×20
Ran 1426 tests containing 8809 assertions
26 failures, 4 errors
```

The two preamble assertions in each row **passed** under the sabotage — the
live pages really did differ and `canonical-dom` really did call them
byte-identical — so what the plant removed is exactly the verdict and nothing
about the fixture. `two-selects-showing-the-same-option-stay-green` stayed
green throughout, as it must: the plant cannot make a matched pair red.

No other row moved, which is the second thing the control has to show: the
repair is not reddening the suite at large.

## Notes

- `implementation/shadow-cljs.edn` is untouched; the witness lives in the
  existing `hicasso/test_kit/test` source path and the existing namespace.
- The draft guide still spells the door `ht/shadow!` where it is `hm/shadow!`.
  That page is `docs/design/hicasso/**` (another worker's surface) and the
  discrepancy is already tracked by **rf2-me76**, so it is left alone here.
