### PR TITLE
docs(ci): correct the HMR job's engine-narrowing rationale (rf2-agps)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1522,9 +1522,15 @@ jobs:
     # waits for the NEW LITERAL to appear on screen before asserting — which is
     # what separates "shadow delivered code" from "an after-load hook fired".
     # 36 real reloads per run, 105 checks per engine. Narrowing the engine set
-    # would be the quiet way to keep the name and drop the claim: the runner's
-    # cross-engine comparator is inert below two engines, so this job passes NO
-    # `HICASSO_HMR_ENGINES`, and a classifier regression pins that.
+    # would be the quiet way to keep the name and drop the claim, and there are
+    # TWO distinct losses in it — so "the comparator would be inert" is not the
+    # whole reason. The comparator's floor is two engines
+    # (`if (engines.length < 2) return problems`), and only a ONE-engine run is
+    # below it. A TWO-engine narrowing IS still compared; what it drops is one
+    # of the three pinned engines — `HICASSO_HMR_ENGINES=chromium,firefox`
+    # never starts WebKit, while this job's name goes on promising it. So this
+    # job passes NO `HICASSO_HMR_ENGINES` at all, and a classifier regression
+    # pins that.
     #
     # PER-PR on its own changed surface rather than nightly, for the reason
     # TESTING.md's placement table gives for slow essential coverage: this is


### PR DESCRIPTION
Closes rf2-agps.

## What was wrong

`.github/workflows/test.yml`, in the `cljs-hicasso-hmr` job's header comment, gave one reason for the job passing no `HICASSO_HMR_ENGINES`:

> the runner's cross-engine comparator is inert below two engines, so this job passes NO `HICASSO_HMR_ENGINES`

That is literally true of a one-engine run and understated as a rationale. `divergenceReport` in `implementation/scripts/serve-and-run-hicasso-hmr-testbed.cjs` returns early on `engines.length < 2`, and `comparedAcrossEngines` is `engines.length >= 2` — so `HICASSO_HMR_ENGINES=chromium,firefox` **is** compared across engines. What that narrowing loses is the third pinned engine, not the comparison. Reading the sentence as written, a reader concludes a two-engine tier would be safe; it would not be, because the job's name promises Chromium + Firefox + WebKit.

The actual line was **1526** — the bead's approximate `~L1526` was exact.

## The change

Comment/prose only, in one block.

```diff
     # 36 real reloads per run, 105 checks per engine. Narrowing the engine set
-    # would be the quiet way to keep the name and drop the claim: the runner's
-    # cross-engine comparator is inert below two engines, so this job passes NO
-    # `HICASSO_HMR_ENGINES`, and a classifier regression pins that.
+    # would be the quiet way to keep the name and drop the claim, and there are
+    # TWO distinct losses in it — so "the comparator would be inert" is not the
+    # whole reason. The comparator's floor is two engines
+    # (`if (engines.length < 2) return problems`), and only a ONE-engine run is
+    # below it. A TWO-engine narrowing IS still compared; what it drops is one
+    # of the three pinned engines — `HICASSO_HMR_ENGINES=chromium,firefox`
+    # never starts WebKit, while this job's name goes on promising it. So this
+    # job passes NO `HICASSO_HMR_ENGINES` at all, and a classifier regression
+    # pins that.
     #
     # PER-PR on its own changed surface rather than nightly, for the reason
```

That is the whole diff: `git diff` reports 9 insertions, 3 deletions, all of them comment lines.

## Proof the change is behaviour-free

Two independent checks, both scripted rather than eyeballed:

1. **Every changed line is a comment.** Each `+`/`-` line in `git diff -U0` matches `^[+-]\s*#` — 12 changed lines, 0 non-comment. No `run:`, `if:`, `env:`, `needs:`, `name:` or any other key was added, removed or moved.
2. **The parsed workflow is identical.** `yaml.safe_load` of `origin/main:.github/workflows/test.yml` and of this branch's copy compare **equal** as Python objects. Comments are discarded by the parser, so structural equality is a complete proof that GitHub Actions sees exactly the same workflow.

CRLF was preserved: the file's CRLF count went 6163 → 6169, matching +6 net lines, with no LF-only line introduced.

## The sweep

`git grep` across tracked files (excluding `.beads/`) for `inert`, `below two engines`, `fewer than two`, `comparator`, `cross-engine`, `comparedAcrossEngines`, `ranFullMatrix`, `HICASSO_HMR_ENGINES`. Four carriers of the claim exist; each is disposed of:

| carrier | disposition |
|---|---|
| `.github/workflows/test.yml:1526` (`cljs-hicasso-hmr`) | **Fixed here.** This is the bead's target. |
| `.github/workflows/test.yml:1425` (`cljs-hicasso-controlled`) | **Right as it stands — not edited.** It reads "that comparator is inert below two engines (`if (engines.length < 2) return problems`)", which quotes `serve-and-run-hicasso-controlled-testbed.cjs:416` exactly, and its hypothetical is named in the preceding sentence as *"a one-engine smoke with the rest nightly"* — the one case where the comparator genuinely is inert. Nothing in #8015 touched the controlled runner. Editing it would be churn in a hot-zone file. |
| `implementation/scripts/serve-and-run-hicasso-hmr-testbed.cjs:104` (header) | **Already fixed in the still-open PR #8015**, which rewrites the sentence to "narrowed by `HICASSO_HMR_ENGINES` **to one engine**". Not touched here: that file is the in-flight PR's, and an edit would conflict. |
| `implementation/scripts/_changed-surfaces.test.cjs:3391` | **Already fixed in the still-open PR #8015**, which appends the correcting paragraph ("a TWO-engine narrowing does get compared…"). Not touched here. |

Two near-misses checked and left alone: `.github/scripts/report-changed-surfaces.sh:1562` and `:1582` mention "the cross-engine comparator" only to say the launcher owns it — neither makes the two-engine claim. `TESTING.md:25` says recorded rows "are compared across engines and red an unnamed divergence", which is correct.

## A brief premise that did not hold

The dispatch brief said PR #8015 (`rf2-l92i`) had **landed** and that `ranFullMatrix` was on `main`. It has not: **#8015 is still OPEN** on `worker/hmrverdict-l92i`, and `git grep ranFullMatrix` at `origin/main` is empty. The sister-site fix the bead cites is therefore inside that open PR, not on `main`.

Consequence for the wording: this comment is written so that it is **true both before and after #8015 merges**, and it deliberately does **not** name `ranFullMatrix` or the `HICASSO HMR PARTIAL PASS` verdict, which would be a forward reference to code that does not exist on `main`. The correction it does make — the comparator's floor is two, so only a one-engine run silences it — is a fact about `divergenceReport` / `comparedAcrossEngines`, both of which are unchanged by #8015 and already on `main`. Merge order between the two PRs is therefore free.

One claim from #8015's own `ranFullMatrix` docstring was checked and deliberately **not** repeated here: that WebKit is "the one every `NARROWINGS` entry is about". The HMR runner's `NARROWINGS` array is empty (`// Populated only by a divergence this gate actually measured.`), so the statement is vacuous; this comment says only that a two-engine narrowing leaves WebKit unrun.

## Quality gates

Run from `C:/Users/miket/code/re-frame2-worktrees/wfcomment-agps` (and `…/implementation` for the node rows). Exit codes captured with `; echo "$?" > …`, never through a pipe.

| gate | exit |
|---|---|
| `python -c "import yaml; yaml.safe_load(open('.github/workflows/test.yml'))"` | **0** (`YAML OK`) |
| `node scripts/_changed-surfaces.test.cjs` | **0** — `changed-surfaces tests: 325 passed.` |
| `node scripts/_lint-workflow-policy.test.cjs` | **0** — `lint-workflow-policy tests: 4 passed.` |
| `node scripts/_docs-workflow-policy.test.cjs` | **0** — `docs-workflow-policy tests: 5 passed.` |
| `python scripts/check_gate_scheduling.py` | **0** — `50 gate commands, 42 scheduled, 8 declared (0 of them known holes with beads)` |
| comment-only diff check (script above) | **0** — 12 changed lines, 0 non-comment |
| parsed-YAML equality vs `origin/main` | **0** — `parsed trees identical: True` |

`_changed-surfaces.test.cjs` is the gate that matters most here: it carries the row asserting this very job narrows no engine set, and it reads the job's **executable** text with comment lines filtered out (`.filter((line) => !/^\s*#/.test(line))`) — which is why the new comment may name `HICASSO_HMR_ENGINES=chromium,firefox` in prose without reddening it. Verified green with the new comment in place.

`npm run test:hicasso-hmr` was **not** run, deliberately: it binds `:dev-http` 8061 and `assertOwnBundle` refuses a second run while other workers are live on this machine. The change is comment-only and provably cannot alter that gate's result (see the parsed-YAML equality above), so it is left to CI.

No markdown was touched, so `scripts/check_readme_links.py` is not implicated.
