### PR TITLE
docs(hicasso): attribute the +139 B/read to one ratom-only line (rf2-l50z)

### DIFF
--- a/docs/design/hicasso/product/budgets.md
+++ b/docs/design/hicasso/product/budgets.md
@@ -273,9 +273,15 @@ published anchors. S3's candidate slope did not: `1,278 → 1,417 B/read`,
 `+139 B` and `+10.9%`, with the two bands disjoint. The governed contrast
 against Reagent therefore deepens from `1.3492×` to `1.4953×`, while S4's win
 against UIx is unchanged to the fourth decimal (`0.7099× → 0.7098×`).
-**Attribution is `rf2-hic-018`'s**, and it is deliberately not attempted here:
-the window's terms are a single invocation, and the ablations that would name a
-cause are exactly what a measurement window may not run.
+**Attribution was deliberately not attempted in that window** — its terms are a
+single invocation, and the ablations that would name a cause are exactly what a
+measurement window may not run. It was taken afterwards, by `rf2-l50z`, and the
+answer is **one line**: `interop/activate-derived-value!` in the collector's
+`wire-cell!`, a ratom-only correctness repair that landed between the two
+sessions. **The figure does not move** — S3 stays `1,417 B/read` — because the
+attribution names the cost rather than removing it. The bisection is
+[on the ladder](../studio/reads-per-boundary-heap-ladder.md#the-139-bread-attributed-to-one-line-and-the-premise-it-had-to-correct-first-rf2-l50z);
+the disposition is [substrate-decision §6](substrate-decision.md#6-what-this-page-does-not-decide).
 
 **S1 and S2 carry the substantive news for the shell.** The breach is not an
 artefact of the prototype — it survives the move to the package essentially
@@ -737,7 +743,9 @@ Three rows have a disposition record of their own and point at it: `S1` and
 `S2` at [the substrate decision's §5.2](substrate-decision.md#52-the-read-free-boundary-shell--the-disposition),
 where the shell breach was carried red on the evidence, and `S3` at
 [its §6](substrate-decision.md#6-what-this-page-does-not-decide), where the
-`+139 B/read` package move is left open. Every other row that is not `MET`
+`+139 B/read` package move is now attributed to one ratom-only correctness line
+(`rf2-l50z`) — an attribution, not a change to the figure, so `S3` is still
+`UNRESOLVED` against its own rule. Every other row that is not `MET`
 points here, and here is what each is waiting on.
 
 - **No package-resident clock instrument exists.** `U1`, `U2`, `U3` and `U4`

--- a/docs/design/hicasso/product/k3-disposition.md
+++ b/docs/design/hicasso/product/k3-disposition.md
@@ -399,16 +399,16 @@ worse than none. Re-issuing it requires the same decider.
 
 ## 11. What this record does not decide
 
-- **[OPEN] The mechanism of the `+139 B/read` package move on the ratom
-  segment.** `rf2-hic-018` left it open and said it is owed an attribution to
-  this bead or to one of its own; **this record takes the second route and files
-  it as `rf2-l50z`.** No verdict above needs it: the move sits entirely inside
-  the arm that does not ship, and the shipped column reproduced to the byte. The
-  ablation that would settle it is **named on `rf2-hic-018`, not guessed at
-  here** — the A–B–A bisection on the ratom segment only, riding the spine
-  segment as a negative control, with one suspect carrying a precedent *as a
-  suspect and not as an answer*. This page repeats neither the suspect nor a
-  cause; it cites [where both are written down](substrate-decision.md#6-what-this-page-does-not-decide).
+- **[SETTLED elsewhere] The mechanism of the `+139 B/read` package move on the
+  ratom segment.** `rf2-hic-018` left it open and said it is owed an attribution
+  to this bead or to one of its own; **this record took the second route and
+  filed it as `rf2-l50z`**, which ran the named A–B–A bisection and attributed
+  the whole move to one ratom-only correctness line. **No verdict above changes,
+  and none ever needed it**: the move sits entirely inside the arm that does not
+  ship, the shipped column reproduced to the byte, and the attribution names the
+  cost rather than moving the figure — S3 is still `1,417 B/read`. This page
+  repeats neither the mechanism nor its evidence; it cites
+  [where both are written down](substrate-decision.md#6-what-this-page-does-not-decide).
 - **The R=0 shell breach.** `rf2-hic-018`'s, carried red against the frozen
   `1,024 B` line, with the substrate arm refused on the evidence because the two
   shells are five bytes apart.
@@ -428,8 +428,8 @@ worse than none. Re-issuing it requires the same decider.
   comparative and regression rules, the reference profiles, and §7's enforcement
   homes.
 - [`substrate-decision.md`](substrate-decision.md) — `rf2-hic-018`: which
-  substrate ships, the `+698 B/read` premium, the shell disposition, and the open
-  `+139 B/read` attribution with its named ablation.
+  substrate ships, the `+698 B/read` premium, the shell disposition, and the
+  `+139 B/read` attribution its named ablation settled (`rf2-l50z`).
 - [`../studio/reads-per-boundary-heap-ladder.md`](../studio/reads-per-boundary-heap-ladder.md#the-package-itself-priced-on-this-rung-at-last-rf2-fe0l)
   — the package run: rows, fitted lines, the ten-quantity reproduction table, and
   the gate reproduction that anchors the donors.

--- a/docs/design/hicasso/product/substrate-decision.md
+++ b/docs/design/hicasso/product/substrate-decision.md
@@ -423,30 +423,42 @@ verdict beside it.
 
 ## 6. What this page does not decide
 
-**[OPEN] The mechanism of the `+139 B/read` package move.** Nine of the ten
-quantities the package re-pin took reproduce the prototype; exactly one moved —
-the candidate's ratom-segment slope, `1,278 → 1,417 B/read`, bands disjoint by
-136 B — so the move is the candidate's and not the instrument's. **This
-adjudication does not need it**, because the move sits entirely inside the arm
-that is not selected: the spine segment reproduced to the byte (`2,115 →
-2,115`). It is left open rather than guessed at, and it is not nothing — S3 is a
-K3 scoreboard input and the figure the programme quotes as the design's bill
-against Reagent, so a 10.9% move in it is owed an attribution to `rf2-hic-070` or
-to a bead of its own.
+**[SETTLED 2026-08-13, `rf2-l50z`] The mechanism of the `+139 B/read` package
+move.** It is **one line**, and it is a correctness repair rather than a package
+regression: `interop/activate-derived-value!` in `wire-cell!`, landed by
+`9d01cd171e` (`rf2-2kshh`) on 2026-08-07. The A–B–A bisection this section
+called for was run on the ratom segment with the spine segment as the negative
+control, and the whole of the move came back on that line — `1,417 → 1,278 →
+1,417 B/read`, the two hook-armed readings agreeing to the byte around the
+hook-less one, while the spine read `2,115` in all three arms.
+[The bisection, its controls and its provenance](../studio/reads-per-boundary-heap-ladder.md#the-139-bread-attributed-to-one-line-and-the-premise-it-had-to-correct-first-rf2-l50z)
+are on the ladder. **No figure on this page changes** — S3 is still
+`1,417 B/read` and the premium is still `+698` — because the attribution names a
+cost rather than moving one.
 
-**The ablation that would settle it** is the one this corpus has already run once
-on this exact axis: the A–B–A bisection that attributed the disposal hook
-(`rf2-2rtt6.60`). Take the package tree and the prototype tree the 1,278 was
-measured on, bisect the per-cell path between them on the **ratom segment only**,
-and ride the spine segment as the negative control — it is a control by
-measurement here, having reproduced exactly. One suspect has a precedent worth
-naming *as a suspect and not as an answer*: that earlier bisection found a single
-added per-cell callback costing **+104 B on the ratom segment and +36 B on the
-spine**, because Reagent's `Reaction` keeps on-dispose callbacks on a JS array
-under V8's growth policy while the spine's container pre-allocates a vector. A
-package landing that adds or moves one per-cell retained item would produce
-exactly this shape. That is a hypothesis with a precedent; it is not an
-attribution, and the bisection is what would make it one.
+The mechanism is the ratom-only line [§2 above](#the-correctness-axis-which-is-one-sided-and-total)
+already identifies. Activation is `deref-capture`, so the `Reaction` afterwards
+holds a populated `watching` array and is enrolled in each captured source's
+watcher map; both are retained per cell, cells are B·R on this rung, and the
+whole price therefore lands in the marginal slope. On the React-hook spine the
+hook is published by nobody and the call allocates nothing, which is why the
+spine reproduced exactly.
+
+**The suspect this section named was not the answer, and the premise had to be
+corrected before the ablation could be aimed.** The two columns of the package
+run's comparison table are two runs eight days apart rather than two source
+trees, and the `wire-cell!` bodies of the package and the prototype are
+identical today — so what the table prices is the whole interval between the
+sessions, not the package/prototype difference its columns are named after. That
+is why the move showed in one segment and not both: nothing in the window added
+per-cell state to the spine.
+
+**What that costs the collector's own bill, stated rather than glossed.** The
+`139 B/read` is what a Reagent-hosted Hicasso boundary pays to answer writes at
+all; without it the arm paints once at mount and goes deaf. It is a real cost on
+a real axis and it is carried, not normalised — the same posture
+[the disposal hook](../studio/reads-per-boundary-heap-ladder.md#the-slope-went-stale-before-this-section-merged-and-the-landing-that-moved-it-rf2-2rtt660)
+was recorded under.
 
 **[OPEN] The clock and migration contrasts for the ratom family.** Neither
 exists, on any tree. Settling them needs a candidate-on-ratom segment added to

--- a/docs/design/hicasso/studio/reads-per-boundary-heap-ladder.md
+++ b/docs/design/hicasso/studio/reads-per-boundary-heap-ladder.md
@@ -2893,13 +2893,28 @@ contention does to it — a deliberately contended trial landed within about
 
 ---
 
-### The `+139 B/read` attributed, and the premise it had to correct first (rf2-l50z)
+### The `+139 B/read` attributed to one line, and the premise it had to correct first (rf2-l50z)
 
-**Pre-registered 2026-08-13 06:13 +1000, before any arm of this bisection ran.**
-The section above left the mechanism of its one moved quantity `[OPEN]` and said
-so plainly; [`substrate-decision.md` §6](../product/substrate-decision.md#6-what-this-page-does-not-decide)
+**Measured 2026-08-13 for `rf2-l50z`.** The section above left the mechanism of
+its one moved quantity `[OPEN]` and said so plainly;
+[`substrate-decision.md` §6](../product/substrate-decision.md#6-what-this-page-does-not-decide)
 named the ablation that would settle it and declined to guess. This subsection
-runs that ablation.
+runs that ablation, and the answer is one line:
+
+```
+per read at Q = E                     ratom seg.   spine seg.
+  A   main as it stands                    1,417        2,115
+  B   minus interop/activate-derived-value! 1,278        2,115
+  A2  restored                             1,417        2,115
+
+      the activation                        +139           +0
+```
+
+**The whole of the moved quantity, priced to a single line, with the negative
+control flat to the byte.** The prediction below was registered before arm B was
+built; `1,278` is what it named, and `1,278` [1,276–1,280] is what arm B
+returned — the published prototype figure, `1,278` [1,275–1,280], recovered
+exactly.
 
 #### The premise did not survive being checked, and the asymmetry is why
 
@@ -2954,21 +2969,191 @@ nothing.
 **This is a hypothesis with a mechanism, and it is not yet an attribution.** The
 ablation below is what makes it one.
 
-#### The registered prediction
+#### The registered prediction, and what it got
 
-Written before the first arm was measured, in the terms the A–B–A bisection
-above established:
+Written before any arm was measured and **committed before arm B — the arm that
+decides — was built** (authored at `f36bf0df1f` on this branch, off `origin/main`
+`c6b7da3cd8`, 06:13 +1000; arm B's bundle compiled at 06:15), so the
+pre-registration is mechanical here rather than
+disciplinary, in the same shape the two-dispatch package re-pin above used at a
+larger scale. The A arm was already running when the prediction was written and
+had returned when it was committed, which cannot inform a prediction *about B*
+and is stated so a reader does not have to reconstruct the order:
 
-| quantity | A (main as it stands) | B (main minus the one line) | A2 (restored) |
-|---|---:|---:|---:|
-| slope, Reagent segment | 1,417 B/read | **≈ 1,278 B/read** | 1,417 B/read |
-| slope, UIx segment | 2,115 B/read | **2,115 B/read — unchanged** | 2,115 B/read |
-| both donors, both floors, both shells | published | **unchanged** | published |
+| quantity | A (main as it stands) | B (main minus the one line) | A2 (restored) | outcome |
+|---|---:|---:|---:|---|
+| slope, Reagent segment | 1,417 | **predicted ≈ 1,278** → **measured 1,278** | 1,417 | **hit** |
+| slope, UIx segment | 2,115 | **predicted 2,115 unchanged** → **measured 2,115** | 2,115 | **hit** |
+| both donors, both floors, both shells | published | **predicted unchanged** → unchanged | published | **hit** |
 
 The **UIx segment is the negative control and it is a control by measurement**,
-having reproduced `2,115` to the byte across the tree move the whole delta is
-supposed to live in. If the ablation moves it, activation is not the mechanism
-and the reading is refused rather than published.
+having reproduced `2,115` to the byte across the tree move the whole delta lives
+in. Had the ablation moved it, activation would not have been the mechanism and
+the reading would have been refused rather than published.
+
+#### The three runs
+
+All three on this instrument — `p0_run.cjs --only ladder`, six rounds, default
+rungs, same collector, same guard — on 2026-08-13, **strictly one at a time**,
+with the rig untouched throughout: all nine instrument blobs are byte-identical
+to the package run above, and the only file that differs between arms is the one
+line in `impl/collector.cljs`.
+
+| run | tree | Hicasso, Reagent seg. | Hicasso, UIx seg. | donors (Rg / UIx) | `main.js` |
+|---|---|---:|---:|---:|---|
+| *§6's package run (2026-08-12, above)* | *`ce31a30b77`* | *1,417 [1,416–1,417]* | *2,115 [2,109–2,118]* | *948 / 2,980* | *—* |
+| **A1** | `c6b7da3cd8`, which is `origin/main` | **1,417** [1,416–1,418] | **2,115** [2,110–2,118] | 947 / 2,978 | sha256 `2c794d01…` |
+| **B** | the same, minus the one activation line | **1,278** [1,276–1,280] | **2,115** [2,110–2,117] | 947 / 2,979 | sha256 `0bbdce6f…` |
+| **A2** | restored, byte-identical to A1 | **1,417** [1,415–1,418] | **2,115** [2,110–2,118] | 948 / 2,979 | sha256 `2c794d01…` |
+
+**A1 is the box control and it is the strongest one available**, because the
+instrument and the measured collector are literally the same objects the package
+run used: `impl/collector.cljs` hashes `3876ae02…` in both, and A1 returns the
+package run's `1,417` and `2,115` inside their published bands, its positive
+control landing on the identical `4,700,284 B`.
+
+**A1 and A2 are an A–B–A bracket in time**, and they agree **to the byte** —
+`1,417` / `2,115` both times — around the hook-less reading between them. So the
+139 B is the line and not the box, which is the same test the disposal-hook
+bisection above had to pass.
+
+**The bands are disjoint** — `[1,276–1,280]` against `[1,416–1,418]` and
+`[1,415–1,418]`, a gap of **136 B** at A1 and **135 B** at A2, which is the same
+gap the package run measured between the prototype's published slope and its
+own.
+
+#### What the ablation prices, and what it deliberately does not
+
+The removed line is a **correctness repair**, and this is its price on this axis,
+not an argument for reverting it. Without it the arm is the deaf arm `rf2-2kshh`
+found: it paints once at mount and no later write becomes re-render work. What
+`139 B/read` buys is that a Reagent-hosted Hicasso boundary answers writes at
+all.
+
+Two figures the ablation moves that are **not** claims:
+
+- The fitted **intercept** on the Reagent segment reads `1,096 B` at both A arms
+  and `1,301 B` at B. The directly measured R=0 **shell** does not move at all
+  (`1,099` / `1,101` / `1,100` across the three runs), which is the reading that
+  matters and the one this page publishes — activation costs nothing at R=0
+  because a boundary with no reads has no cells to activate. The intercept is
+  fit geometry over a moved slope, and this page has never quoted it as the
+  shell.
+- The **first read** reads `1,848` and `1,850 B` at the A arms and `1,727 B` at
+  B. It is a separate quantity from the slope, reported by the driver and not
+  restated here.
+
+**No published figure changes.** S3 stays `1,417 B/read`, the bracket a shipped
+Hicasso sits in stays `1,417 – 2,115 B/read`, and the governed contrast against
+Reagent stays `1.4953×`. This subsection attributes a figure; it does not move
+one.
+
+#### What this correction is worth beyond this one number
+
+The section above reads its result as a *package versus prototype* contrast and
+concludes "the move is the candidate's and not the instrument's". Both halves
+survive — it is the candidate's, and it is not the instrument's — but the
+sentence sits on a premise that does not hold, and the premise is the reusable
+part. **A ten-quantity reproduction table across two sessions prices the whole
+interval between them, not the one difference the columns are named after.**
+Nine quantities reproduced not because nothing else changed but because nothing
+else in that window touched them; the tenth moved because one landing did. A
+table like that is a strong instrument for *localising* a move and a weak one
+for *naming* it, and the fe0l window was right to refuse the naming.
+
+#### The controls
+
+Every control below is **from these three runs**. Nothing is scaled in.
+
+**The positive control** — the same dense array of 587,500 unboxed doubles,
+`4,700,000 B` fixed before every run: measured **4,700,284 / 4,700,230 /
+4,700,230 B**, ratios 1.0001 / 1.0000 / 1.0000, `ok` under
+`lane/control-verdict` on all three.
+
+**The donors, the floors and both shells ride every run as negative controls**,
+and none of them moves: Reagent 947 / 947 / 948 B/read, UIx 2,978 / 2,979 /
+2,979, floors 258 / 256 / 258 and 256 / 256 / 257 B, candidate shells 1,099 /
+1,101 / 1,100 and 1,096 / 1,096 / 1,094 B. **The ablation reaches the one
+quantity it was aimed at and nothing else on the page.**
+
+**The runtime demonstrably saw the plant, which a source hash alone cannot
+show.** The `:advanced` bundle the driver built and served is `2c794d01…`
+(836,168 B) for A1, `0bbdce6f…` (836,100 B) for B, and `2c794d01…` (836,168 B)
+again for A2 — **byte-identical across the bracket and different in the middle**.
+The restore is verified the same way at the source: `impl/collector.cljs` hashes
+`3876ae02…` before the plant and `3876ae02…` after it, `6468c2aa…` in between,
+with `git status --porcelain` empty at the end.
+
+**The ladder is its own control for the slope**: reads walk 0 → 20 and every arm
+of every run answers with a line — r² 0.99833 to 0.99996, **6 of 6 rounds linear
+on all four arms of all three runs**, including arm B, whose r² on the ablated
+Reagent segment is 0.99932.
+
+**The fit's own self-test** ran in the page before anything was measured in each
+run: an exact line recovered to the byte with R=0 excluded, a quadratic refused
+by the r² floor at 0.96464, and an absurd 99,999 B R=0 rung moving the fit by not
+one bit.
+
+**The arm-order guard** returned `reportable` on all three, the structural
+witness answered every expected count on every arm of every round and read zero
+after teardown, and **0 unverified of 154 mounts** each time. Captured exit **0**
+on all three.
+
+#### Provenance
+
+Whole-tree anchor **`c6b7da3cd8`**, which is `origin/main` — the measured tree
+and the published tree are the same tree, and `git status --porcelain` was empty
+before arm A1 and again after arm A2. The one line under test, in
+`implementation/hicasso/src/re_frame/hicasso/impl/collector.cljs`:
+
+| arm | line 675 | `impl/collector.cljs` blob |
+|---|---|---|
+| **A1, A2** | `(interop/activate-derived-value! reaction)` | `3876ae023224f670e2cdaa086cf364f5fdbf4844` |
+| **B** | the same, commented out | `6468c2aaf15ae9d69996f5736f09753146bff0b3` |
+
+The instrument, all under `implementation/core/test/re_frame/bench/`, **all nine
+byte-identical to the package run above** — `p0_run.cjs` `ce4f01a9e5`,
+`p0_heap.cljs` `ef9b5adcf0`, `p0_hicasso.cljs` `7a91564f59`, `p0_reagent.cljs`
+`419e166a93`, `p0_uix.cljs` `f1aaf9cb1e`, `p0_fixture.cljc` `de27135ce8`,
+`p0_arms.cljs` `beced24315`, `p0_harness.cljs` `e18c2f50d4`, `p0_floor.cljs`
+`6b61e125f4`. `impl/collector.cljs` and `impl/inventory.cljs` are likewise
+byte-identical to it; `impl/mount.cljs` and the facade moved after it, and
+neither is on the per-cell path this bisection cuts.
+
+**The convicting landing is `9d01cd171e`** (`rf2-2kshh`, merged 2026-08-07 09:32
++1000), whose whole code change is the line in the table above.
+
+Reproduce — arm A as the tree stands, arm B by commenting out that one line:
+
+```
+node implementation/core/test/re_frame/bench/p0_run.cjs --only ladder
+```
+
+**Conditions.** 2026-08-13 06:07–06:22 +1000, three runs of ~4 minutes each
+(build ~24 s, six rounds), run strictly one at a time. React 19.2.0, Reagent
+2.0.1, UIx 1.4.4, `:advanced` with `goog.DEBUG false`, headless Chromium via
+Playwright, Windows 11, 24 logical cores, 63 GB.
+
+**The box was NOT quiet, and that is stated rather than corrected for.** Real
+CPU occupancy — summed per-process CPU-time deltas over a 5-second window
+divided by the core count, never `LoadPercentage` — read **4.90%** at open,
+**10.61%** and **6.13%** during arms B and A2 (both including this run's own
+Chromium), and **0.82%** at close; `\System\Processor Queue Length` was **0 on
+every sample**, so nothing was ever waiting for a core. Around a dozen sibling
+worker agents were running browser and JVM gates in other worktrees throughout.
+Zero java in this checkout, ~33 GB free.
+
+Two things carry that, and neither is an argument that load does not matter:
+this is a **retained-heap** row rather than a clock row, and this page has
+already priced contention on it — a deliberately contended trial landed within
+about 0.07% of a quiet six-round range. More decisively, **A1 reproduced the
+package run's `1,417` and `2,115` inside their published bands, and its positive
+control landed on the identical `4,700,284 B`, on an instrument and a collector
+that are byte-for-byte the same objects.** That is the box saying, by
+measurement rather than by probe, that it had not moved. Had A1 missed, the
+right answer would have been to refuse the window rather than to publish a
+number taken under load — and the bracket A1 = A2 to the byte is what would have
+caught it if the box had drifted mid-window instead.
 
 ---
 

--- a/docs/design/hicasso/studio/reads-per-boundary-heap-ladder.md
+++ b/docs/design/hicasso/studio/reads-per-boundary-heap-ladder.md
@@ -2893,6 +2893,85 @@ contention does to it — a deliberately contended trial landed within about
 
 ---
 
+### The `+139 B/read` attributed, and the premise it had to correct first (rf2-l50z)
+
+**Pre-registered 2026-08-13 06:13 +1000, before any arm of this bisection ran.**
+The section above left the mechanism of its one moved quantity `[OPEN]` and said
+so plainly; [`substrate-decision.md` §6](../product/substrate-decision.md#6-what-this-page-does-not-decide)
+named the ablation that would settle it and declined to guess. This subsection
+runs that ablation.
+
+#### The premise did not survive being checked, and the asymmetry is why
+
+The section above reads its own result as a *package versus prototype* contrast,
+and records the thing that does not fit: "a package carrying more per-read state
+than the frozen prototype would be expected to show it in **both** segments; it
+shows in one, to the byte."
+
+It shows in one because the contrast is not the one the table's columns imply.
+Those two columns are **two runs separated in time**, not two source trees
+measured together — the prototype's last published slope was taken
+**2026-08-04** (the frame-prop section above, whole-tree anchor `2303ef6781` off
+`origin/main` `1ce64c06a2`, which landed 2026-08-04 03:03 +1000), and the
+package run was taken **2026-08-12**. Everything that landed in that window is
+inside the delta, and the `wire-cell!` bodies of the two trees are *identical
+today* — the package's `impl/collector.cljs` and the prototype's
+`arm1/runtime.cljs` carry the same subscribe / activate / baseline / watch /
+on-dispose sequence, line for line.
+
+One landing in that window adds exactly one per-cell retained item and adds it
+**to the ratom family alone**: `9d01cd171e`, `fix(hicasso): arm1 must activate
+its Reaction before watching it` (`rf2-2kshh`), merged **2026-08-07 09:32
++1000** — three days after the 1,278 reading and five before the package run.
+Its whole code change is one line inside `wire-cell!`:
+
+```clojure
+(interop/activate-derived-value! reaction)
+```
+
+and its own commit message states the property that makes the observed shape
+predictable rather than puzzling: *"The op is a routed no-op on the React-hook
+spine, so UIx is untouched."*
+
+**The mechanism, in objects.** A `re-frame.subs` subscription under the ratom
+family IS a bare `reagent.ratom/Reaction` built without `:auto-run`, and a
+Reaction learns its sources only through `deref-capture`. The baseline deref
+`wire-cell!` takes is outside `*ratom-context*`, so before this landing the
+reaction ran its body raw and left `watching` **nil** — watchable, watched, and
+notifying nobody (the deafness `rf2-2kshh` repaired). Activation is
+`ratom/run`, a real capture: afterwards the reaction holds a populated
+`watching` array **and** is enrolled in each captured source's watcher map. Both
+are retained for the life of the cell, and cells are B·R on this rung's
+mandatory distinct-query witness — so the whole price lands in the marginal
+slope and none of it in the shell, which is the same reason
+[the disposal hook](#the-slope-went-stale-before-this-section-merged-and-the-landing-that-moved-it-rf2-2rtt660)
+was invisible to work pointed at the shell. On the React-hook spine
+`:adapter/activate-derived-value!` is published by nobody
+(`make-derived-value-fn` wires one watch per source at construction), the
+late-bound lookup finds no hook, and the call returns `nil` having allocated
+nothing.
+
+**This is a hypothesis with a mechanism, and it is not yet an attribution.** The
+ablation below is what makes it one.
+
+#### The registered prediction
+
+Written before the first arm was measured, in the terms the A–B–A bisection
+above established:
+
+| quantity | A (main as it stands) | B (main minus the one line) | A2 (restored) |
+|---|---:|---:|---:|
+| slope, Reagent segment | 1,417 B/read | **≈ 1,278 B/read** | 1,417 B/read |
+| slope, UIx segment | 2,115 B/read | **2,115 B/read — unchanged** | 2,115 B/read |
+| both donors, both floors, both shells | published | **unchanged** | published |
+
+The **UIx segment is the negative control and it is a control by measurement**,
+having reproduced `2,115` to the byte across the tree move the whole delta is
+supposed to live in. If the ablation moves it, activation is not the mechanism
+and the reading is refused rather than published.
+
+---
+
 ## 7. Anchors, and one that does not fully reproduce
 
 The R=0 rung is here to tie this instrument to the published sub-free rows


### PR DESCRIPTION
Closes `rf2-l50z`.

## The verdict

**Attributed, to one line.** The `+139 B/read` the `rf2-fe0l` package re-pin
found on the Hicasso candidate's ratom segment is
`interop/activate-derived-value!` in the collector's `wire-cell!` — a ratom-only
correctness repair that landed as `9d01cd171e` (`rf2-2kshh`) on 2026-08-07,
between the two sessions the re-pin's table compares.

```
per read at Q = E                     ratom seg.   spine seg.
  A1  main as it stands                    1,417        2,115
  B   minus interop/activate-derived-value! 1,278       2,115
  A2  restored                             1,417        2,115

      the activation                        +139           +0
```

The whole of the moved quantity, priced to a single line, with the negative
control flat to the byte. Arm B recovered the published prototype figure
`1,278` [1,275–1,280] **exactly**, and the prediction that it would was
committed before arm B was built (`f36bf0df1f`).

**No published figure changes.** S3 stays `1,417 B/read`, the bracket stays
`1,417 – 2,115`, the premium stays `+698`. This names a cost; it does not move
one — and the cost is what a Reagent-hosted Hicasso boundary pays to answer
writes at all. Without the line the arm paints once at mount and goes deaf.

## The premise the bead's framing rested on did not hold

The bead, `rf2-hic-018` and the ladder all read the move as a *package versus
prototype* contrast, and all three record the thing that does not fit: a package
carrying more per-read state than the frozen prototype should show it in **both**
segments, and it shows in one.

It shows in one because the contrast is not the one the columns imply. Those two
columns are **two runs eight days apart**, not two source trees measured
together — the prototype's last published slope is 2026-08-04, the package run
is 2026-08-12 — and the `wire-cell!` bodies of the two trees are **byte-identical
today** (verified: the fourteen lines from `[^js cell]` to `cell))` diff clean
between `impl/collector.cljs` and `arm1/runtime.cljs`). So the table prices the
whole interval, not the package/prototype difference. One landing in that
interval adds one per-cell retained item and adds it to the ratom family alone,
and its own commit message states the property that makes the asymmetry
predictable: *"The op is a routed no-op on the React-hook spine, so UIx is
untouched."*

The general lesson is recorded on the ladder: **a multi-quantity reproduction
table across two sessions is a strong instrument for localising a move and a
weak one for naming it.** The `rf2-fe0l` window was right to refuse the naming.

The bead's named suspect — a second on-dispose callback, the `rf2-2rtt6.60`
precedent — is **not** the answer, and could not have been: that shape costs
`+36 B` on the spine, and this move costs zero there.

## The mechanism, in objects

A `re-frame.subs` subscription under the ratom family is a bare
`reagent.ratom/Reaction` built without `:auto-run`, and a Reaction learns its
sources only through `deref-capture`. `wire-cell!`'s baseline deref is taken
outside `*ratom-context*`, so before the landing the reaction ran its body raw
and left `watching` nil. Activation is `ratom/run` — a real capture — so the
reaction afterwards holds a populated `watching` array **and** is enrolled in
each captured source's watcher map. Both are retained per cell; cells are B·R on
this rung's distinct-query witness, so the whole price lands in the marginal
slope and none of it in the shell (the measured R=0 shell reads 1,099 / 1,101 /
1,100 across the three arms — flat). On the React-hook spine
`:adapter/activate-derived-value!` is published by nobody, the late-bound lookup
finds no hook, and the call allocates nothing.

## Discipline

- **The rig was not touched.** All nine instrument blobs are byte-identical to
  the `rf2-fe0l` run, as are `impl/collector.cljs` and `impl/inventory.cljs`. The
  only difference between arms is the one line. No build id was added; the driver
  rides `:hicasso-bench` as documented.
- **Three arms, strictly one at a time**, no iteration, no mid-window tuning.
- **A1 is the box control, and it is the strongest one available**: it returns
  the package run's `1,417` and `2,115` inside their published bands, on the same
  instrument and the same collector object, with its positive control landing on
  the identical `4,700,284 B`.
- **A1 = A2 to the byte** brackets B in time, so the 139 B is the line and not
  the box.

## Conditions, stated rather than corrected for

The box was **not quiet**: around a dozen sibling worker agents were running
browser and JVM gates in other worktrees throughout. Real CPU occupancy (summed
per-process CPU-time deltas over 5 s / core count, never `LoadPercentage`) read
**4.90%** at open, **10.61%** and **6.13%** during arms B and A2 — both including
this run's own Chromium — and **0.82%** at close. `\System\Processor Queue
Length` was **0 on every sample**: nothing was ever waiting for a core.

This is a retained-heap row, not a clock row, and the page already prices
contention on it (a deliberately contended trial landed within ~0.07% of a quiet
six-round range). More decisively, A1's reproduction of the anchor **is** the box
control by measurement. Had A1 missed, the correct deliverable would have been a
refusal, not a number.

## Quality gates

Ran from `C:/Users/miket/code/re-frame2-worktrees/ratom-l50z`. Every run's
`shadow-cljs - config:` line names this worktree; exit codes captured with
`; echo "$?" > …` on one command line, never through a pipe.

| gate | exit |
|---|---:|
| `python scripts/check_doc_slugs.py` | **0** |
| `python scripts/check_provenance_pins.py --changed-since origin/main --verbose` | **0** |
| measurement arm A1 — `p0_run.cjs --only ladder` | **0** |
| measurement arm B — `p0_run.cjs --only ladder` | **0** |
| measurement arm A2 — `p0_run.cjs --only ladder` | **0** |

`mkdocs build --strict` is **deliberately not nominated**: `exclude_docs` keeps
`docs/design/**` out of the site, so it covers none of this change.
**Anchors and table column counts were verified by hand**, in addition to
`check_doc_slugs.py`: the three tables added to the ladder are 5×5, 6×6 and 3×3
(header, separator and every row agreeing), and the new cross-links —
`substrate-decision.md#6-what-this-page-does-not-decide`,
`…#the-139-bread-attributed-to-one-line-and-the-premise-it-had-to-correct-first-rf2-l50z`
and `…#the-slope-went-stale-…-rf2-2rtt660` — resolve to real headings on the
pages named.

### Gate selection proved by negative control

Both doc gates were shown to be **exact**, not merely present. Restores verified
by hashing the bytes, never by reading `git diff`.

| plant | gate | exit | finding |
|---|---|---:|---|
| broken anchor `substrate-decision.md#no-such-anchor-negctl-l50z` | `check_doc_slugs.py` | **1** | `BROKEN ANCHOR … :2901` |
| restored | `check_doc_slugs.py` | **0** | `sha256sum -c` OK against the pre-plant digest |
| stranded pin `0123…4567` alone in its block | `check_provenance_pins.py` | **1** | `:2957 … [UNRESOLVABLE]` |
| restored | `check_provenance_pins.py` | **0** | `sha256sum -c` OK against the pre-plant digest |

### The measurement's own plant, and its runtime witness

The ablation is itself a plant, and a source hash alone would not prove the
runtime saw it. Three independent witnesses say it did:

| arm | `impl/collector.cljs` blob | served `main.js` sha256 | size |
|---|---|---|---:|
| A1 | `3876ae02…` | `2c794d01…` | 836,168 |
| B | `6468c2aa…` | `0bbdce6f…` | 836,100 |
| A2 | `3876ae02…` (restored, hash-verified) | `2c794d01…` | 836,168 |

The bundle the driver built and served is **byte-identical across the bracket
and different in the middle**, so the compile consumed the edit. `git status
--porcelain` is empty of source changes; the only files this PR touches are
markdown.

## Scope

Four pages, no code:

- `docs/design/hicasso/studio/reads-per-boundary-heap-ladder.md` — the new
  section: the premise correction, the mechanism, the registered prediction, the
  three runs, the controls, the provenance.
- `docs/design/hicasso/product/substrate-decision.md` — §6's `[OPEN]` bullet
  becomes `[SETTLED]`.
- `docs/design/hicasso/product/budgets.md` — two sentences that asserted the
  attribution was open.
- `docs/design/hicasso/product/k3-disposition.md` — two sentences, same reason.

The last two are outside the dispatch's named surface and were touched because
they each asserted, in one sentence, that a now-settled thing is open. No open PR
touches `docs/design/hicasso/**`.

Two commits, and the order is load-bearing: `f36bf0df1f` registers the
prediction, `58deb7f143` reports what it got.
