### PR TITLE
docs(hicasso): refresh two stale HD- index ranges, and keep HD-029's provenance straight (rf2-nxtt)

### DIFF
--- a/docs/EP/EP-0038-the-hicasso-view-layer-programme.md
+++ b/docs/EP/EP-0038-the-hicasso-view-layer-programme.md
@@ -3,7 +3,7 @@
 Status: accepted
 Type: standards-track
 Created: 2026-07-30
-Resolution: accepted 2026-07-30 (HD-001–HD-021 resolved under delegated authority; operator-overturnable)
+Resolution: accepted 2026-07-30 (HD-001–HD-021 resolved under delegated authority; operator-overturnable); HD-022–HD-028 resolved under that same authority; P2 fork ruled by the operator directly 2026-08-13 (HD-029 — Hicasso graduates, as a success)
 
 ## Abstract
 
@@ -19,7 +19,7 @@ graduates exactly one arm — or stops, with "adapters + sugar" recorded as a
 deleted (no absorption programme); on a loss, the adapters stand. The durable
 design record is `docs/design/hicasso/` (excluded from the published site, read
 in the source tree — the EP-0036 precedent); every design decision is resolved
-in `docs/design/hicasso/decisions.md` (HD-001–HD-021).
+in `docs/design/hicasso/decisions.md` (HD-001–HD-029).
 
 ## Motivation
 
@@ -148,7 +148,7 @@ below). On a stop, the repo's shipped surface is exactly what it was.
 
 ## Resolved Decisions
 
-All twenty-one design decisions are resolved in
+The twenty-one design decisions resolved at acceptance are in
 `docs/design/hicasso/decisions.md`; dispositions in brief: HD-001 name/alias ·
 HD-002 sub-read tiers (grouped default / collector challenger / scalar
 comparator; both-fail→null) · HD-003 hooks placement rule (taught, not policed)
@@ -160,6 +160,17 @@ HD-013 deciders (operator at P2; delegated advisory at the donor gate) · HD-014
 the clock · HD-015 start now · HD-016 invocation + component ABI · HD-017 code
 residence + bench-lane carve-out · HD-018 delete-on-win · HD-019 the
 synchronous door · HD-020 v0 host mechanics · HD-021 root/HMR/headless.
+
+**The series has since grown to HD-029, and the last entry does not share the
+others' provenance.** HD-022–HD-028 were resolved under the same delegated
+authority as the twenty-one above — HD-022 `:ref`'s reserved vector value-space ·
+HD-023 the `:&` attribute merge · HD-024 one callback form · HD-025
+presence-as-data · HD-026 the `::h/prevent` head · HD-027 `route-link`'s
+`::h/navigate` head · HD-028 value equality as the boundary default. **HD-029,
+the P2 fork, was given by the operator directly on 2026-08-13** — the decider
+HD-013 reserves that ruling to — and is therefore not a delegated resolution.
+Each entry carries its own rationale and reopen condition in `decisions.md`.
+
 **Future operator rulings made under this EP — the donor-gate ruling and the P2
 fork ruling — are recorded here when made** (per EP-0009 rule 2), with their
 evidence on the standard bead.

--- a/docs/design/hicasso/hd-002-adjudication.md
+++ b/docs/design/hicasso/hd-002-adjudication.md
@@ -9,7 +9,7 @@
 > rather than an operator gate, on the pattern HD-013 already uses for the donor
 > gate: produced by a worker, adversarially reviewed, recorded on the standard
 > bead. **The operator may overturn any part of it.** Normative source:
-> [decisions.md](decisions.md) (HD-001…HD-025).
+> [decisions.md](decisions.md) (HD-001…HD-029).
 
 HD-002 is a measurement and the measurement has not run. This page does not argue
 about whether the ambient collector should be the product mechanism. It makes the


### PR DESCRIPTION
Closes `rf2-nxtt`.

`docs/design/hicasso/decisions.md` is titled *"Hicasso — decisions (HD-001 … HD-029)"*. Two index pages still cited older ranges. One of those citations is a **provenance claim**, not a number, and bumping it blind would have misattributed eight entries.

## What the provenance check established

Read every entry from HD-022 to HD-029 in `decisions.md` and looked for a decider marker (operator ruling, "Mike", "in chat", "verbatim", a standard-bead delegation):

| Entry | Subject | Provenance |
|---|---|---|
| HD-022 | `:ref`'s vector value-space reserved, refused in v0 | delegated — no operator marker |
| HD-023 | the `:&` attribute merge, owned-literal law | delegated — no operator marker |
| HD-024 | one callback form; the position selects the contract | delegated (`rf2-2rtt6.74`, `.115`, `.116`, `.120`, `rf2-hic-035`) |
| HD-025 | presence: phase as a prop, `::h/mounting`/`::h/unmounting` as data | delegated (`rf2-2rtt6.66`) |
| HD-026 | `::h/prevent` as a reserved head, metadata retired | delegated — no operator marker |
| HD-027 | `route-link` and the `::h/navigate` head | delegated (`rf2-6c237`, `rf2-cno31`) |
| HD-028 | value equality is the boundary default | delegated (`rf2-2rtt6.58`/`.61`/`.79`). Its *open disposition* is called the operator's, but the ruling itself is not an operator ruling |
| HD-029 | the P2 fork: Hicasso graduates, as a success | **operator, directly** — "Given by the operator directly in chat on 2026-08-13 at 04:57 AUSEST, which is the decider HD-013 reserves this ruling to; the advisory passes advised it and did not make it" |

So the range splits, and the split is recorded rather than averaged.

## The three edits

**1. `EP-0038` line 6 — the `Resolution:` header.** The parenthetical is attached to a *dated event* (`accepted 2026-07-30`), and on that date HD-001–HD-021 were exactly the resolved series — so bumping `HD-021` to `HD-029` in place would have rewritten an accurate historical record *and* swept HD-029 into a delegated-authority claim it does not belong to. Instead the line follows the append-a-later-event precedent already in the tree (`EP-0030`: *"accepted 2026-07-11 (program ratification); adapter disposition reframed 2026-07-17"*; `EP-0034`; `EP-0036`):

```
Resolution: accepted 2026-07-30 (HD-001–HD-021 resolved under delegated authority; operator-overturnable); HD-022–HD-028 resolved under that same authority; P2 fork ruled by the operator directly 2026-08-13 (HD-029 — Hicasso graduates, as a success)
```

**2. `EP-0038` line 22 — the Abstract's pointer.** Present-tense pointer at the file's current contents, no provenance attached: `(HD-001–HD-021)` → `(HD-001–HD-029)`.

**3. `hd-002-adjudication.md` line 12 — the normative-source pointer.** `(HD-001…HD-025)` → `(HD-001…HD-029)`. The blockquote's *"Delegated advisory, operator-overturnable"* label describes **that page**, not the range it points at, so nothing about the label moves.

**Also, and in the same defect class:** `EP-0038`'s *Resolved Decisions* section opened *"All twenty-one design decisions are resolved in …"* — a completeness claim that covered 21 of 29 and would have contradicted edit 2 on the same page. The acceptance-time roster is left intact as the record of what acceptance resolved (its tense is corrected to *"The twenty-one design decisions resolved at acceptance"*), and one short paragraph extends the series in the section's own idiom, naming HD-022–HD-028's dispositions and stating plainly that HD-029 was the operator's own ruling. Per EP-0009 rule 3 this is a mechanical correction — a reader's understanding of the proposal, alternatives, rationale, ruling and scope is unchanged; the original roster text is preserved, not replaced.

## Sweep

`git grep` for `HD-001`, `HD-021`, `HD-025`, `HD-028` across tracked files (excluding `.beads/`). Every hit outside `decisions.md` is either a reference to a *specific* entry — which is correct as it stands and must not be bumped — or one of the range citations above. Two carriers found outside this PR's fence, reported and **not** edited:

- `docs/design/hicasso/README.md:11` — `HD-001…HD-028`, held by PR #8021 (`worker/ceiling-2rtt6-145`), which already carries the `…HD-029` fix.
- `docs/design/hicasso/decisions.md:5` — the file's own preamble, *"These were resolved under delegated authority"*, now over-claims for HD-029 by exactly the mechanism this PR fixed elsewhere. Read-only for this bead; filed as `rf2-k6bv` alongside the missing EP addendum.

## Quality gates

`gate root: C:/Users/miket/code/re-frame2-worktrees/hdrange-nxtt` on every run.

| Gate | Exit | Note |
|---|---|---|
| `python scripts/check_doc_slugs.py` | **0** | covers both `docs/**` trees |
| `python -m mkdocs build --strict` | **0** | `docs/EP/` is in the site corpus; `docs/design/**` is not (`exclude_docs`) |
| `python scripts/check_ep_status_sync.py` | **0** | run because this PR touches an EP header line |
| `check_doc_slugs.py` — negative control | **1** | as designed |
| `mkdocs build --strict` — negative control | **1** | as designed |

**Negative controls, planted at sites this PR actually edits.**

- `hd-002-adjudication.md:12` — the link target this PR's edit sits on, repointed to `decisions-planted-negative-control.md`. `check_doc_slugs.py` exit **1**, naming `hd-002-adjudication.md:12 -> decisions-planted-negative-control.md`.
- `EP-0038:22` — the Abstract line this PR edits, turned into a link to `planted-negative-control.md`. `mkdocs build --strict` exit **1**: *"contains a link 'planted-negative-control.md', but the target 'EP/planted-negative-control.md' is not found … Aborted with 1 warnings in strict mode!"*

**Restores verified by hashing the bytes**, not by reading `git diff`:

| File | Before | Planted | After restore |
|---|---|---|---|
| `hd-002-adjudication.md` | `0f131b42…e4cd` | `17f4976b…2ffd` | `0f131b42…e4cd` ✓ |
| `EP-0038…md` | `63ae0881…7ac5` | `1b87e038…2f54` | `63ae0881…7ac5` ✓ |

Both gates re-run on the restored tree: exit **0** and **0**.

**Verified by hand, because no gate covers that tree's rendering** (`mkdocs` says nothing about `docs/design/**`): `hd-002-adjudication.md` has **five tables**, at lines 31, 209, 219, 260 and 267, and every row of each has a column count matching its header (2, 2, 2, 2 and 3 columns respectively) — no mismatches. Neither edited file contains any internal `](#…)` anchor link, so there are no anchors to re-target; the one link this PR touches (`[decisions.md](decisions.md)`) keeps its target unchanged and is covered by `check_doc_slugs.py` regardless.
