### PR TITLE
feat(xray): the cause-aware hot-view advisor and one mutation-proved causal slice

### DIFF
--- a/tools/xray/spec/028-Hicasso-Advisor.md
+++ b/tools/xray/spec/028-Hicasso-Advisor.md
@@ -1,0 +1,314 @@
+# 028 — The hot-view advisor and the causal slice
+
+**Status**: shipped (rf2-hic-037) · **Tab**: `:hicasso`, sub-views `Advisor` and `Causal`
+**Producers**: `re-frame.hicasso.tool` (the four evidence reads) + Spec 009's retained ring
+**Consumer**: `day8.re-frame2-xray.panels.hicasso-advisor` + `…panels.hicasso-causal`
+**Normative upstream**: `docs/design/hicasso/product/specification.md` §10 ·
+`docs/design/hicasso/product/lanes/hot-path-architecture.md` ·
+`docs/design/hicasso/product/lanes/left-field-ideas.md` §Capability receipts
+
+---
+
+## What these two views are for
+
+Spec SN §10 calls the advisor *the differentiating feature*: it *ranks
+time/frequency/read churn/fan-out, then classifies computation, topology,
+lowering, React, or layout pressure. It recommends native extraction only when
+it addresses the measured owner.* The causal slice is the other half of the same
+section — §10's chain, `event → subscriptions recomputed → values changed →
+boundaries notified → bodies run → React commit → paint`, with the rule that
+*each link needs an explicit evidence seam*.
+
+They are **sub-views of the Hicasso tab**, not a tab of their own, and that is a
+correctness choice rather than a layout one. Both are derivations of the same
+one-turn read (`:rf.xray.hicasso/data`). A second tab would take a second turn,
+and a mount landing between them would give a ranking about a census the slice no
+longer agrees with — the same reason the four evidence envelopes are taken
+together in the first place.
+
+Adding them moved **no governance pin**. The tab, its L4 registration, the focus
+mirror, the registry schema version, the palette counts and the feature-matrix
+handoff are all unchanged; `hicasso-helpers/sub-modes` grew from four entries to
+six, and `empty-copy` grew two matching entries. The `:rf.xray.hicasso/*` sub and
+event ids are the same three.
+
+---
+
+## The instrument table, and the refusal that follows from it
+
+| Pressure class | Instrument | Available here? |
+|---|---|---|
+| application computation | Spec 009 `:rf.sub/elapsed-ms` on the retained ring | **yes** |
+| read topology | the cell table's fan-out, the entry cache's read orders, the ring's recompute counts | **yes** |
+| Hiccup lowering | — | no |
+| React reconciliation / commit | — | no |
+| DOM layout / paint | — | no |
+
+The three unavailable rows are not an oversight awaiting a later bead.
+
+- **Boundary self time was KILLED as a decision** (`lanes/left-field-ideas.md`
+  §Capability receipts, from the `rf2-hic-081` spike). Chrome clamps its timer to
+  a 0.1 ms grain while the quantity is single-digit microseconds, so a
+  per-attempt interval reads either zero or one whole tick and *a ranking built
+  on it orders noise*; independently, two clock reads per attempt inflate a
+  boundary in proportion to its attempt COUNT rather than its true cost, so two
+  boundaries close in true self time and far apart in attempt count invert.
+- **Commit, paint and attempt outcome are React's.** `re-frame.hicasso.tool`'s
+  `host-projection` states all three `:host-opaque` on every envelope it emits.
+- Hicasso emits no `:rf.view/render` trace, and its User-Timing `:render`
+  measures ride `re-frame.performance/enabled?` — an independently gated,
+  observer-first channel that is off by default.
+
+Rungs 3, 4 and 5 of the performance ladder
+(`lanes/hot-path-architecture.md` §The performance ladder) — a direct `n/$`
+element, a named native island, a native screen — **all address a class in the
+unavailable half**. So the honest consequence of §10's sentence is that
+
+> **from this evidence the advisor never recommends a native route.**
+
+Not once, not for the hottest boundary on the page. A tool that ranked
+boundaries by the one clock it has and then pointed at the native ladder would be
+recommending an expensive, semantics-changing, diagnostics-losing change on
+evidence that cannot speak to whether it helps — which is exactly what a *sorted
+list of render durations* invites, and the single most expensive mistake this
+surface could make a developer make. **The refusal is the product.**
+
+### The refusal is about the evidence, not about a missing arm
+
+`hicasso-advisor/ladder` is a real table keyed on the measured OWNER, carrying
+all five rungs with their working-loop steps. Hand it `:lowering` and it answers
+rung 3; `:react-work`, rung 4; `:react-shaped`, rung 5. Those three owner keys are
+**unreachable from `classify`** on this door, and that is the whole claim.
+
+The suite asserts the pair, because either half alone is worthless:
+
+| Row | Asserts |
+|---|---|
+| `the-advisor-never-recommends-a-native-route-from-this-evidence` | over every classification `classify` emits, driven from real windows rather than hand-built maps, `(:native? (recommend c))` is false — and the emitted owner set is exactly `#{:computation :read-topology :unattributed}` |
+| `the-native-ladder-is-real-and-the-refusal-is-about-the-EVIDENCE` | the same table returns rungs 3, 4 and 5 with their steps for the three owners the door cannot measure |
+
+The first row would be equally true of a `recommend` that answered
+`:measure-first` unconditionally — which is a stub, not a finding. The second is
+its non-vacuity control.
+
+---
+
+## The advisor
+
+### Four axes, in four units, never a score
+
+| Axis | Unit | Source |
+|---|---|---|
+| **time** | ms | `:rf.sub/elapsed-ms` summed over the boundary's read edges in the retained window |
+| **frequency** | recomputes / dispatches / memo hits | the ring's `:rf.sub/run` and `:rf.sub/skip` events |
+| **read-churn** | reads, read ORDERS | the census's `:reads` and `:read-orders` |
+| **fan-out** | reader slots | the cell table's `:fan-out`, summed over the boundary's edges |
+
+There is deliberately **no composite score**. Weighting milliseconds against
+dispatch counts against read orders against reader slots would make the weights
+the ranking — invented here, and unfalsifiable. Each axis is reported in its own
+unit with its own loss, and `order-axis` states which one the roster was sorted
+on: `:time` when any row has a timed recompute, `:frequency` otherwise, **and
+the summary line says `NOT by time` in that case**. A list ordered by a fallback
+axis while implying it was ordered by time is the quiet version of the mistake
+this whole namespace is arranged against.
+
+The `time` axis measures **subscription** time, not body time, and the tab never
+lets that slide: an untimed read edge answers `:unknown` and never `0.0`. Spec
+009 puts `:rf.sub/elapsed-ms` on the reactive recompute path and not on the pure
+`compute-sub` form, so a fold that read a missing tag as zero would report a
+subscription it never timed as instantaneous — and the reader would then rank it
+LAST. Its loss is `:uncorrelated` rather than `:cap`, because the recomputes were
+observed and it is the DURATION that joins to nothing; reporting a cap there
+would send the reader to the retention knob, which is not the remedy.
+
+The window is scoped **per frame**. Two frames are two applications, and summing
+frame B's clock into frame A's ranking would make an idle boundary look hot
+because something unrelated was busy next door — the defect `explain-render`
+already scopes its leads against (audit #7789).
+
+### Four classifications, and the pair that must not collapse
+
+| `:owner` | `:basis` | Means |
+|---|---|---|
+| `:computation` | `:observation` | one read holds ≥ `dominance` of a total ≥ `computation-floor-ms` |
+| `:read-topology` | `:derivation` | the read set oscillates (`:read-orders` > 1), or it re-runs ≥ `repeat-floor` times for measured work below the floor |
+| `:unattributed` | `:host-opaque` | the window WAS searched and the measured half does not explain it |
+| `:unattributed` | `:cap` | nothing was retained, so no search happened |
+
+The last two are the pair a naive advisor collapses. `:cap` says *raise
+`:rf.trace/events-retained` and reproduce* — free. `:host-opaque` says *the
+answer is real and lives in another tool* — a change of instrument. One sentence
+covering both would send half its readers to the wrong place, so they are two
+sentences under two loss chips.
+
+Three thresholds, each with its reason attached rather than a taste:
+
+| Constant | Value | Why |
+|---|---|---|
+| `computation-floor-ms` | 1.0 | the 0.1 ms timer grain means a smaller sum is fewer than ten ticks, and its ordering against another such sum is noise |
+| `dominance` | 0.6 | below a comfortable majority the time is spread across the read SET, which is a topology finding; a two-read boundary at 55/45 must not be reported as having a hot subscription |
+| `repeat-floor` | 2 | the smallest count that makes a re-run a pattern rather than an occurrence — demanding more would silently require a bigger ring to see a real repeat |
+
+### The route is looked up on the OWNER, never on the rank
+
+| Owner | Route | Rung |
+|---|---|---|
+| `:computation` | narrow or memoize the subscription | — (below the substrate) |
+| `:read-topology` | tune topology without changing language | 2 |
+| `:lowering` | return a direct React element (`n/$`) | 3 |
+| `:react-work` | named native React island | 4 |
+| `:react-shaped` | implement the screen natively | 5 |
+| `:unattributed` | **measure first** — the refusal | — |
+
+This is the mechanism behind *only when it addresses the measured owner*: the
+hottest boundary on the page and the coldest one with the same owner get the same
+rung. A `:computation` owner is routed BELOW the view substrate and told so in
+those words — the subscription body runs beneath the boundary, so every native
+route would move the markup and keep the cost.
+
+Each recommendation carries the working-loop steps that apply to it, taken from
+`lanes/hot-path-architecture.md` §Xray-guided workflow and numbered as they are
+there. The refusal carries the three unmeasured classes with the instrument that
+settles each — never Xray, which is asserted.
+
+---
+
+## The causal slice
+
+Drawn for the boundary the advisor ranked **first** and the newest dispatch the
+ring still holds, so the two views are one workflow rather than two lookups.
+
+| # | Link | Seam | Basis |
+|---|---|---|---|
+| 1 | event | Spec 009's retained ring, the bundle for this dispatch | `:observation` |
+| 2 | subscriptions recomputed | that bundle's `:subs` events, keyed `:rf.sub/id` | `:observation` |
+| 3 | values changed | the cell table's epoch stamps, at the boundary's peak | `:observation` |
+| 4 | boundaries notified | the cells' reader arrays — the reverse edge `notify!` walks | `:derivation` |
+| 5 | bodies run | — | `:host-opaque` |
+| 6 | React commit | — | `:host-opaque` |
+| 7 | paint | — | `:host-opaque` |
+
+### A link's basis and its JOIN are different questions
+
+Collapsing them is how a causal display starts lying, so each link renders both,
+on separate rows, under separate testids.
+
+Links 2 and 3 are both `:observation` — the sub really recomputed, the cell's
+epoch really moved — and **the join between them is `:uncorrelated`**, because an
+epoch stamp carries no dispatch id and Hicasso's commit seam records no cascade
+id. Two solid facts, printed adjacent, joined by nothing: exactly the adjacency
+`re-frame.hicasso.tool` refuses to call causality, surfaced as its own row rather
+than implied away by the arrow between two green links. The 1→2 join, by
+contrast, IS evidenced — the ring GROUPS by dispatch-id, so that join is the
+storage rather than an inference.
+
+Link 4 is derived even when green. The reader array is what `collector/notify!`
+walks, so the notified set follows from it — but the notify CALL is not recorded,
+and the array is read at ASK time rather than at commit time, so a boundary that
+unmounted in between is absent from a set it was in. The link says so on the page.
+
+Links 5, 6 and 7 are three different absences with three different authorities,
+not three phrasings of one. React DevTools answers the first two; the browser's
+own performance tools answer the third. A reader deciding what to open next needs
+to know which one they are missing.
+
+The slice's own envelope is `:complete? false` with `:loss {:reason
+:uncorrelated}` **unconditionally**. A slice that reported itself complete
+because its first four links came back green would be claiming the chain, having
+evidenced its prefix.
+
+### Every evidenced link is mutation-tested
+
+A display that renders `evidenced` from a seam it is not actually reading is
+worse than one that renders `unknown`, and on a healthy application the two are
+indistinguishable from outside. Each row below breaks one seam and asserts the
+link stops being evidenced — degrading to a stated loss, never to a confident
+wrong answer, and never borrowing a neighbouring seam to keep its colour. **Each
+sabotage asserts the link is green FIRST, on the same runtime**, because a
+sabotage that reds a link which was never green proves the fixture was broken and
+nothing else.
+
+| Link | Sabotage | Must degrade to |
+|---|---|---|
+| 1 event | `clear-trace-buffer!` on the frame — the dispatch happened, the seam no longer holds it | `:cap`, `:holds :unknown`, "capped window" — never *a dispatch that did not happen*; link 2 follows it down |
+| 2 subs recomputed | the runtime's own events with `:rf.sub/id` stripped | `:holds :unknown` with `{:reason :uncorrelated :dropped n}` — **never `[]`**, which would say this dispatch recomputed nothing |
+| 3 values changed | a real read-free boundary (`:latest-reads :unknown`) | not evidenced, and says *not a gap in the instrument* — a boundary holding no read is a fact about the boundary |
+| 4 boundaries notified | the attribution envelope suppressed | `:holds :unknown`, and the row asserts the mounted census was **available and not substituted** — it holds the forward edge, and answering a reverse-edge question from it would be a different fact under this one's name |
+
+Two of the four act on the SEAM'S OWN DATA rather than on the runtime — the trace
+tag and the attribution envelope — because those are the seams; the events they
+carry are otherwise the runtime's own.
+
+---
+
+## Rendering contract
+
+Every absence renders through the existing `hicasso-helpers/loss-chip`, so the
+five states stay pairwise distinct in words and testid suffix on these two views
+exactly as on the other four.
+
+| Surface | testid |
+|---|---|
+| advisor root | `rf-xray-hicasso-advisor` |
+| one advice row | `rf-xray-hicasso-advice-<slug>` |
+| its classification + loss chip | `…-class`, `…-class-loss-<kind>` |
+| its route or refusal | `…-route`, `…-refusal`, `…-refusal-<class>` |
+| the three unmeasured classes | `rf-xray-hicasso-advisor-unmeasured[-<class>]` |
+| causal root | `rf-xray-hicasso-causal` |
+| one link | `rf-xray-hicasso-causal-link-<id>` |
+| its basis, loss chip and JOIN | `…-basis`, `…-loss-<kind>`, `…-join` |
+| the two new empties | `rf-xray-hicasso-empty-advisor`, `rf-xray-hicasso-empty-causal` |
+
+Row slugs are the existing `boundary-slug`, so the advisor's rows share the
+injective encoding `027-Hicasso-Evidence.md` §The key is INJECTIVE established,
+and two frames' boundaries over one query cannot collide here either.
+
+The three unmeasured classes render on **every** advisor render, rows or none —
+they are the reason the top row is not a verdict, and a reader who saw them only
+when the roster was empty would read a populated one as complete. The 200-row
+panel budget applies through `common-helpers/cap-rows` as elsewhere.
+
+---
+
+## Read-only, dev-only, bundle-isolated
+
+`hicasso-reads/trace-windows` is the only new live read. It calls
+`re-frame.trace.tooling/trace-buffer` for the frames `explain-render`'s `:window
+:frames` already names — the union of the frames the runtime dispatches through
+and any frame a boundary reads from, computed by the producer for exactly the
+reason a per-boundary window is scoped that way. Reading every frame in the
+process instead would let an unrelated application's activity inflate this one's
+ranking.
+
+It is a **second producer**, not a fifth Hicasso read, and it is stamped as one:
+`hicasso-advisor/sub-timing` carries `:day8.re-frame2-xray.hicasso-advisor.timing/v1`
+and `:producer :re-frame/trace`, so a reader can see which producer vouched for
+which number. The advice and slice envelopes likewise stamp Xray's own schemas —
+stamping the producer's would tell a reader that Hicasso vouched for a ranking it
+has never seen.
+
+Nothing is pinned, dispatched or acquired; the read is `try`-guarded and degrades
+to `{}`, which the advisor renders as a capped window rather than as a quiet
+application. Every underlying read is `nil` or `[]` in a production build (the
+Hicasso door and the trace ring both nil-gate on
+`re-frame.interop/debug-enabled?`), and Xray never reaches a production bundle.
+The dependency points one way only: `tools/xray` → `implementation/`.
+
+Production erasure is rf2-hic-024's sentinel proof and is unchanged by this
+bead: no new sentinel, no new evidence machinery, and no code under
+`implementation/` was touched.
+
+---
+
+## Test coverage
+
+| Suite | Tier | Proves |
+|---|---|---|
+| `…panels.hicasso-advisor-cljs-test` | node + JVM | the timing fold (untimed ≠ zero; a memo hit is not work; an unnamed run is `:uncorrelated`, never dropped; the per-frame scope); the top-3 against a HAND profile whose frequency order deliberately inverts its time order; the fallback axis says `NOT by time`; the four classifications, each driven from a real window; `:cap` and `:host-opaque` are two remedies in two sentences; **the native refusal as a property over the classifier's whole output**, with the ladder's non-vacuity control beside it; the refusal names a non-Xray authority per candidate |
+| `…panels.hicasso-causal-cljs-test` | node (reactive substrate) | the seven links on a REAL interaction through the real commit seam and the real router; links 1–4 evidenced and 5–7 host-opaque with three distinct authorities; the 2→3 join `:uncorrelated` while the 1→2 join is `:evidenced`; **four mutation rows, each with its positive control**; the loss chips reach the page under distinct testids and change between two genuinely different window states; the advisor answers on the running app and still refuses the ladder; advice and slice come from ONE turn |
+
+Both suites run in the existing `:node-test` build (`tools/xray/test` is already
+on its source paths) and the `.cljc` one additionally under
+`tools/xray`'s `clojure -M:test`. No new build id, no new `:dev-http` port, no
+`implementation/shadow-cljs.edn` change.

--- a/tools/xray/spec/README.md
+++ b/tools/xray/spec/README.md
@@ -156,6 +156,22 @@ main read**.
   through unchanged, which is what makes byte-for-byte structural rather
   than separately asserted. An L4-only Dynamic tab (not in `panel-enum`).
   Read-only, dev-only.
+- **[028-Hicasso-Advisor.md](028-Hicasso-Advisor.md)** — The Hicasso tab's
+  two derived sub-views (rf2-hic-037). The **hot-view advisor** ranks the
+  mounted census on four axes in four units — never a composite score —
+  classifies what owns the pressure, and looks the route up on the OWNER
+  rather than on the rank. Two of Spec SN §10's five pressure classes have
+  an instrument here and three do not, every native ladder rung addresses
+  one of the three, and so the advisor **refuses the native ladder from
+  this evidence** and names the tool that settles each candidate instead;
+  the refusal is asserted as a property, with a non-vacuity control
+  proving the ladder is real. The **causal slice** walks §10's seven-link
+  chain for one dispatch, carrying each link's own basis AND its join to
+  the previous link as separate facts — links 2 and 3 are both
+  observations and the join between them is `:uncorrelated` — with every
+  evidenced link mutation-tested against its own positive control. No
+  governance pin moves: sub-views of an existing tab, no new build id and
+  no new port.
 
 ### Reference
 

--- a/tools/xray/src/day8/re_frame2_xray/panels/hicasso.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/hicasso.cljs
@@ -398,7 +398,11 @@
       [:span {:style {:color (:text-secondary tokens)}}
        (str "owner: " (hh/format-id (:owner class))
             " (" (hh/format-id (:basis class)) ")  ")]
-      (loss-chip (str stem "-class") (hh/loss-chip (:loss class) hh/unknown))
+      ;; One-arity on purpose. Passing `hh/unknown` as the value would mint
+      ;; an `unknown` chip for a classification that IS known — a measured
+      ;; `:computation` owner carries no loss, and a chip beside it saying
+      ;; the field is not held would contradict the sentence next to it.
+      (loss-chip (str stem "-class") (hh/loss-chip (:loss class)))
       [:div {:style {:margin-top "3px"}} (:says class)]]
      ;; THE ROUTE — or the refusal, which is the same field and never a
      ;; blank. A boundary the advisor will not route is the case a reader

--- a/tools/xray/src/day8/re_frame2_xray/panels/hicasso.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/hicasso.cljs
@@ -1,8 +1,8 @@
 (ns day8.re-frame2-xray.panels.hicasso
-  "Hicasso tab — the glass on the live tier (rf2-hic-023).
+  "Hicasso tab — the glass on the live tier (rf2-hic-023, rf2-hic-037).
 
-  Four views over one evidence surface, answering the four questions Spec
-  SN §10 says a developer actually asks of a view substrate:
+  Six views over ONE evidence surface. The first four answer the questions
+  Spec SN §10 says a developer actually asks of a view substrate:
 
     - **Mounted** — which boundaries are mounted, over which frames?
     - **Reads** — which boundaries read each subscription, and at what
@@ -10,6 +10,18 @@
     - **Intents** — what was dispatched, in order, inside the retained
       window?
     - **Why** — which reads changed, and what does that prove?
+
+  The last two are derivations over the same one-turn read (rf2-hic-037):
+
+    - **Advisor** — ranks the census by time, frequency, read churn and
+      fan-out; classifies what owns the pressure; and recommends the
+      smallest route that addresses THAT owner — which, from this
+      evidence, is never a native one. See
+      `hicasso_advisor.cljc` for why the refusal is the product.
+    - **Causal** — §10's chain, `event → subscriptions recomputed →
+      values changed → boundaries notified → bodies run → React commit →
+      paint`, walked link by link for one real dispatch, with each link's
+      basis AND its join to the previous link printed separately.
 
   ## The tab's job is to make the LOSS legible, not to hide it
 
@@ -46,6 +58,8 @@
   Normative owner: `tools/xray/spec/027-Hicasso-Evidence.md`."
   (:require [clojure.string :as string]
             [day8.re-frame2-xray.panel-registry :as panel-registry]
+            [day8.re-frame2-xray.panels.hicasso-advisor :as advisor]
+            [day8.re-frame2-xray.panels.hicasso-causal :as causal]
             [day8.re-frame2-xray.panels.hicasso-helpers :as hh]
             [day8.re-frame2-xray.panels.hicasso-reads :as reads]
             [day8.re-frame2-xray.panels.overflow-indicator :as overflow]
@@ -337,6 +351,139 @@
                        "  leads not searched — the window holds nothing")]])
                  [(overflow/overflow-row {:panel-id (str panel-id "-explain") :over-cap? over? :hidden-count hidden})])))]))
 
+;; ---- view 5 — the advisor -------------------------------------------------
+
+(def ^:private route-style
+  {:margin-top "6px" :padding "6px 8px" :border-radius "4px"
+   :background (:bg-1 tokens)
+   :border (str "1px solid " (:border-subtle tokens))
+   :font-family sans-stack :font-size "12px" :line-height "1.45"
+   :color (:text-secondary tokens)})
+
+(def ^:private refusal-style
+  (assoc route-style
+         :background (with-alpha :warning 10)
+         :border (str "1px solid " (with-alpha :warning 35))))
+
+(defn- axis-line
+  "The four axes on one line, each in its own unit.
+
+  Never a composite score: the units are milliseconds, dispatch counts,
+  read orders and reader slots, and any single number over them would be
+  the weights talking rather than the evidence."
+  [{:keys [time frequency read-churn fan-out]}]
+  (string/join " · "
+               [(str "time " (advisor/format-ms (:ms time)))
+                (str "freq " (:runs frequency) " recompute"
+                     (when (not= 1 (:runs frequency)) "s")
+                     " / " (:memo-hits frequency) " memo hit"
+                     (when (not= 1 (:memo-hits frequency)) "s"))
+                (str "churn " (:reads read-churn) " read"
+                     (when (not= 1 (:reads read-churn)) "s")
+                     ", " (:read-orders read-churn) " order"
+                     (when (not= 1 (:read-orders read-churn)) "s"))
+                (str "fan-out " (:total fan-out))]))
+
+(defn- advice-row
+  [row]
+  (let [{:keys [class advice]} row
+        stem (str "rf-xray-" panel-id "-advice-" (:slug row))]
+    [:li {:data-testid stem :style row-style}
+     [:div
+      [:span {:style {:font-family mono-stack}} (str "#" (:rank row) "  " (:label row))]
+      (loss-chip (str stem "-frame") (hh/loss-chip nil (:frame row)))]
+     [:div {:style detail-style} (axis-line (:axes row))]
+     ;; WHAT OWNS IT — with the loss for the half that was not measured.
+     [:div {:data-testid (str stem "-class") :style detail-style}
+      [:span {:style {:color (:text-secondary tokens)}}
+       (str "owner: " (hh/format-id (:owner class))
+            " (" (hh/format-id (:basis class)) ")  ")]
+      (loss-chip (str stem "-class") (hh/loss-chip (:loss class) hh/unknown))
+      [:div {:style {:margin-top "3px"}} (:says class)]]
+     ;; THE ROUTE — or the refusal, which is the same field and never a
+     ;; blank. A boundary the advisor will not route is the case a reader
+     ;; most needs a sentence for.
+     [:div {:data-testid (str stem "-route")
+            :style       (if (:refusal advice) refusal-style route-style)}
+      [:div [:strong (:label advice)]
+       (when (:rung advice) (str "  · ladder rung " (:rung advice)))]
+      [:div {:style {:margin-top "3px"}} (:says advice)]
+      (when-some [r (:refusal advice)]
+        [:div {:data-testid (str stem "-refusal") :style {:margin-top "5px"}}
+         [:div (:says r)]
+         (into [:ul {:style {:margin "4px 0 0 16px" :padding 0}}]
+               (for [n (:next r)]
+                 ^{:key (str (:class n))}
+                 [:li {:data-testid (str stem "-refusal-" (name (:class n)))}
+                  (str (:label n) " — " (:authority n))]))])
+      (into [:ol {:data-testid (str stem "-loop")
+                  :style {:margin "6px 0 0 16px" :padding 0
+                          :color (:text-tertiary tokens)}}]
+            (for [[i s] (map-indexed vector (:working-loop advice))]
+              ^{:key i} [:li s]))]]))
+
+(defn- advisor-view
+  [{:keys [advice envelope]}]
+  (let [rows (:rows advice)
+        [shown over? hidden] (ch/cap-rows rows)]
+    [:div {:data-testid (str "rf-xray-" panel-id "-advisor")}
+     (or (presence-note (hh/presence envelope (empty? rows)) :advisor)
+         (into [:ol {:style {:list-style "none" :margin 0 :padding 0}}]
+               (concat (for [row shown] ^{:key (:slug row)} [advice-row row])
+                       [(overflow/overflow-row {:panel-id     (str panel-id "-advisor")
+                                                :over-cap?    over?
+                                                :hidden-count hidden})])))
+     ;; Stated on EVERY render, rows or none. The three classes this tab
+     ;; does not measure are the reason its top row is not a verdict, and a
+     ;; reader who saw that only when the roster was empty would read a
+     ;; populated roster as complete.
+     [:div {:data-testid (str "rf-xray-" panel-id "-advisor-unmeasured")
+            :style       (assoc state-style :margin-top "10px")}
+      [:div "Three of the five pressure classes are not measured here:"]
+      (into [:ul {:style {:margin "4px 0 0 16px" :padding 0}}]
+            (for [c (:unmeasured advice)]
+              ^{:key (str (:class c))}
+              [:li {:data-testid (str "rf-xray-" panel-id "-advisor-unmeasured-"
+                                      (name (:class c)))}
+               [:strong (:label c)] " — " (:authority c) ". " (:why c)]))]]))
+
+;; ---- view 6 — the causal slice --------------------------------------------
+
+(defn- causal-link
+  [link]
+  (let [stem (str "rf-xray-" panel-id "-causal-link-" (name (:id link)))]
+    [:li {:data-testid stem :style row-style}
+     [:div
+      [:span {:style {:font-family mono-stack}}
+       (str (:ordinal link) ". " (:label link))]
+      (loss-chip stem (hh/loss-chip (:loss link)
+                                    (if (:evidenced? link) ::present hh/unknown)))
+      [:span {:data-testid (str stem "-basis")
+              :style (assoc detail-style :display "inline" :margin-left "8px")}
+       (str (if (:evidenced? link) "evidenced" "not evidenced")
+            " · basis " (hh/format-id (:basis link)))]]
+     (when (:seam link)
+       [:div {:style detail-style} (str "seam: " (:seam link))])
+     [:div {:style detail-style} (:says link)]
+     ;; THE JOIN, on its own row. A link's own basis and its join to the
+     ;; previous link are different questions, and printing only the first
+     ;; is how four solid facts in a row come to read as a proven cause.
+     (when-some [j (:joins link)]
+       [:div {:data-testid (str stem "-join")
+              :style       (assoc detail-style :margin-top "4px")}
+        [:span (str "join to the link above: " (hh/format-id (:status j))
+                    (when (:on j) (str " on " (hh/format-id (:on j)))) " — ")]
+        (:says j)])]))
+
+(defn- causal-view
+  [{:keys [slice]}]
+  [:div {:data-testid (str "rf-xray-" panel-id "-causal")}
+   (if (nil? slice)
+     (presence-note :idle :causal)
+     (into [:ol {:style {:list-style "none" :margin 0 :padding 0}}]
+           (for [link (:links slice)]
+             ^{:key (name (:id link))} [causal-link link])))])
+
 ;; ---- the sub-strip and the panel -----------------------------------------
 
 ;; `dispatch` (rf2-1w07r) is the reg-view-injected frame-bound dispatcher
@@ -374,11 +521,27 @@
                                   :mounted     :mounted-boundaries
                                   :attribution :read-attribution
                                   :intents     :intents
-                                  :explain     :explain-render))]
+                                  :explain     :explain-render
+                                  ;; The advisor ranks the mounted census and
+                                  ;; the slice starts from the boundary it
+                                  ;; named, so both inherit that envelope's
+                                  ;; presence — absent, mismatched or idle
+                                  ;; means the same three things here.
+                                  :advisor     :mounted-boundaries
+                                  :causal      :mounted-boundaries))]
     [:section {:data-testid (str "rf-xray-" panel-id) :style panel-root-style}
      (sub-strip dispatch selected)
      [:div {:data-testid (str "rf-xray-" panel-id "-summary") :style summary-style}
-      (or (hh/read-summary envelope) "no envelope")]
+      ;; The derived views state their OWN claim, not the census's. An
+      ;; advice envelope and a slice envelope have their own scope, basis
+      ;; and loss, and printing the producer's summary over them would
+      ;; credit Hicasso with a completeness claim about a derivation Xray
+      ;; made.
+      (or (case selected
+            :advisor (advisor/advice-summary (:advice data))
+            :causal  (causal/slice-summary (:slice data))
+            (hh/read-summary envelope))
+          "no envelope")]
      [:div {:style scroll-style}
       (section/section-row
         {:label  (string/upper-case (:label (first (filter #(= selected (:id %))
@@ -388,7 +551,9 @@
           :mounted     [mounted-view     {:envelope envelope :rows (:mounted data)}]
           :attribution [attribution-view {:envelope envelope :rows (:attribution data)}]
           :intents     [intents-view     {:envelope envelope :rows (:intents data)}]
-          :explain     [explain-view     {:envelope envelope :rows (:explain data)}]))]]))
+          :explain     [explain-view     {:envelope envelope :rows (:explain data)}]
+          :advisor     [advisor-view     {:envelope envelope :advice (:advice data)}]
+          :causal      [causal-view      {:slice (:slice data)}]))]]))
 
 ;; ---- installation --------------------------------------------------------
 
@@ -418,12 +583,28 @@
   (rf/reg-sub :rf.xray.hicasso/data
     :<- [:rf.xray/trace-buffer]
     (fn [_tick _query]
-      (let [envelopes (reads/evidence)]
+      (let [envelopes (reads/evidence)
+            ;; The window is taken in the SAME turn as the four envelopes,
+            ;; for the reason the four are taken together: the advisor
+            ;; joins the ring's recompute counts to the census's read
+            ;; edges, and a mount landing between the two reads would
+            ;; price a boundary against a window that never described it.
+            windows   (or (reads/trace-windows envelopes) {})
+            advice    (advisor/advise envelopes (advisor/sub-timing windows))]
         {:envelopes   envelopes
          :mounted     (hh/mounted-rows     (:mounted-boundaries envelopes))
          :attribution (hh/attribution-rows (:read-attribution envelopes))
          :intents     (hh/intent-rows      (:intents envelopes))
-         :explain     (hh/explain-rows     (:explain-render envelopes))})))
+         :explain     (hh/explain-rows     (:explain-render envelopes))
+         :advice      advice
+         ;; The slice is drawn for the boundary the advisor ranked FIRST
+         ;; and the newest dispatch the ring still holds — so the two views
+         ;; are one workflow rather than two lookups, and the causal chain
+         ;; is about the boundary the roster just pointed at.
+         :slice       (when-some [top (first (:rows advice))]
+                        (causal/slice {:envelopes    envelopes
+                                       :windows      windows
+                                       :boundary-key (:key (:boundary top))}))})))
 
   (panel-registry/reg-l4-tab!
     {:id    :hicasso

--- a/tools/xray/src/day8/re_frame2_xray/panels/hicasso_advisor.cljc
+++ b/tools/xray/src/day8/re_frame2_xray/panels/hicasso_advisor.cljc
@@ -1,0 +1,753 @@
+(ns day8.re-frame2-xray.panels.hicasso-advisor
+  "The cause-aware hot-view advisor (rf2-hic-037) — rank, classify,
+  recommend, and REFUSE.
+
+  Spec SN §10 names this the differentiating feature: *ranks
+  time/frequency/read churn/fan-out, then classifies computation,
+  topology, lowering, React, or layout pressure. It recommends native
+  extraction only when it addresses the measured owner.*
+
+  The last clause is the whole design, and taking it seriously produces a
+  surprising deliverable: **from this evidence the advisor never
+  recommends a native route.** Not once, not for the hottest boundary on
+  the page. That is not a stub and it is not timidity — it is what the
+  sentence means when the instruments are enumerated honestly.
+
+  ## What can be measured here, and what cannot
+
+  | Pressure class | Instrument | Available? |
+  |---|---|---|
+  | application computation | Spec 009 `:rf.sub/elapsed-ms` on the retained ring | **yes** |
+  | read topology | the cell table's fan-out + the entry cache's read orders + the ring's recompute counts | **yes** |
+  | Hiccup lowering | — | no |
+  | React reconciliation / commit | — | no |
+  | DOM layout / paint | — | no |
+
+  The three unavailable rows are not an oversight to be closed later.
+  Boundary self time was **killed as a decision**
+  (`lanes/left-field-ideas.md` §Capability receipts): Chrome clamps its
+  timer to a 0.1 ms grain while the quantity is single-digit microseconds,
+  so a per-attempt interval reads either zero or one whole tick and *a
+  ranking built on it orders noise* — and two clock reads per attempt
+  inflate a boundary in proportion to its attempt COUNT rather than its
+  true cost, so two boundaries close in true self time and far apart in
+  attempt count invert. Commit, paint and attempt outcome are React's
+  (`re-frame.hicasso.tool`'s `:host` projection, `:host-opaque` every
+  time). Hicasso emits no `:rf.view/render` trace, and its User-Timing
+  `:render` measures ride an independently-gated channel that is off by
+  default and observer-first.
+
+  So the advisor measures ONE of the five classes and derives a second.
+  The other three it names, with the authority for each, and stops.
+
+  ## Why that makes the refusal the product
+
+  Rungs 3, 4 and 5 of the performance ladder
+  (`lanes/hot-path-architecture.md`) — a direct `n/$` element, a named
+  native island, a native screen — all address lowering, hooks, vendor
+  behaviour or reconciliation. Every one of those is in the unmeasurable
+  half of the table above. A tool that ranked boundaries by the one clock
+  it has and then pointed at the native ladder would be recommending an
+  expensive, semantics-changing, diagnostics-losing change on evidence
+  that cannot speak to whether it helps — which is the single most
+  expensive mistake this surface could make a developer make, and the one
+  a *sorted list of durations* invites. [[recommend]] therefore treats the
+  ladder as a table keyed on the measured OWNER, and no owner this door
+  can produce selects a native rung.
+
+  The table is real, not a stub: hand it `:lowering` and it answers rung 3
+  with its steps. That arm is unreachable from [[classify]] today and its
+  test says so out loud, because a refusal that came from an empty table
+  would be indistinguishable from one that came from the evidence — and
+  only the second is a finding.
+
+  ## Pure, and CLJC on purpose
+
+  Every function here is data → data, so the algebra runs under the JVM
+  unit-test target beside the CLJS one. The live reads are
+  `hicasso_reads.cljs`; the rendering is `hicasso.cljs`.
+
+  Normative owner: `tools/xray/spec/028-Hicasso-Advisor.md`."
+  (:require [clojure.string :as string]
+            [day8.re-frame2-xray.panels.hicasso-helpers :as hh]))
+
+;; ---------------------------------------------------------------------------
+;; The advisor's own version pin
+;; ---------------------------------------------------------------------------
+
+(def advice-schema
+  "The schema this namespace STAMPS on its own output.
+
+  Deliberately not `re-frame.hicasso.evidence`'s: the advice is a
+  derivation Xray performs over three producers' envelopes, and stamping
+  the producer's schema on it would tell a reader that Hicasso vouched
+  for a ranking Hicasso has never seen. Xray owns this shape and says so."
+  :day8.re-frame2-xray.hicasso-advisor/v1)
+
+(def advice-producer
+  "Xray, because Xray is what produced it. See [[advice-schema]]."
+  :re-frame2/xray)
+
+(def timing-schema
+  "The schema the [[sub-timing]] digest stamps.
+
+  A second schema rather than a field on the advice, because the digest
+  has a different PRODUCER (Spec 009's retained ring, not the Hicasso
+  door) and therefore a different loss story: the ring is always a cap,
+  and its `:rf.sub/elapsed-ms` tag is present on the reactive recompute
+  path and absent on the pure `compute-sub` form. A reader who cannot
+  see those two facts separately cannot tell a fast subscription from an
+  untimed one."
+  :day8.re-frame2-xray.hicasso-advisor.timing/v1)
+
+(def timing-producer
+  "Spec 009's per-frame retained ring, read through
+  `re-frame.trace.tooling/trace-buffer`."
+  :re-frame/trace)
+
+;; ---------------------------------------------------------------------------
+;; Thresholds — three numbers, each with its reason attached
+;; ---------------------------------------------------------------------------
+
+(def computation-floor-ms
+  "Below this many milliseconds of attributable subscription time across
+  the WHOLE retained window, computation is not the owner of anything a
+  developer noticed.
+
+  1.0 ms rather than a smaller number because of the clock, not because
+  of a taste about what is slow: Chrome clamps `performance.now` to a
+  0.1 ms grain, so a sum under 1.0 ms is fewer than ten ticks and its
+  ordering against another such sum is noise. Naming an owner from
+  a quantity that cannot be ordered is the failure this floor exists to
+  prevent."
+  1.0)
+
+(def dominance
+  "The share of a boundary's attributable time ONE read must hold before
+  that read is named the owner.
+
+  Below it the time is spread across the read set, and the remedy is the
+  set rather than any member of it — which is a topology finding, not a
+  computation one. 0.6 is a majority with room, chosen so a two-read
+  boundary at 55/45 is not reported as having a hot subscription."
+  0.6)
+
+(def repeat-floor
+  "The recompute count at which a boundary's re-run is a PATTERN rather
+  than an occurrence.
+
+  Two, deliberately the smallest such number: the advisor is ranking
+  within a bounded window, so demanding a larger count would silently
+  require a bigger ring to see a real repeat. One run in the window is a
+  thing that happened; two is a thing that happens."
+  2)
+
+;; ---------------------------------------------------------------------------
+;; The timing digest — Spec 009's ring, folded per read edge
+;; ---------------------------------------------------------------------------
+
+(defn- sub-run?
+  "A trace event that is a subscription RECOMPUTE.
+
+  `:rf.sub/skip` is a memo hit — the cell answered without running, so it
+  is not work and must not be summed into a duration. It is counted
+  separately because it is the single most informative topology signal
+  there is: a read whose runs are mostly skips is well-placed, and one
+  that runs every time is not."
+  [ev]
+  (contains? #{:rf.sub/run :rf.sub/create} (:operation ev)))
+
+(defn- fold-bundle
+  "Fold ONE event bundle's sub events into `acc`, keyed `[frame-id sub-id]`.
+
+  `:elapsed-ms` accumulates only over runs that CARRIED a duration, and
+  `:untimed-runs` counts the rest. Spec 009 puts `:rf.sub/elapsed-ms` on
+  the reactive recompute path and not on the pure `compute-sub` form, so
+  a fold that treated a missing tag as zero would report a subscription
+  it never timed as instantaneous — the loudest possible version of the
+  `unknown is never zero` mistake, because the reader would then rank
+  it last."
+  [acc frame-id bundle]
+  (let [did (:dispatch-id bundle)]
+    (reduce
+      (fn [m ev]
+        (let [sid (get-in ev [:tags :rf.sub/id])
+              k   [frame-id sid]]
+          (cond
+            ;; A sub event with no registration id is a real run that
+            ;; joins to no subscription. It is counted at the window level
+            ;; (below) rather than dropped, because dropping it would let
+            ;; an untagged stream read as an idle one.
+            (nil? sid)      (update m ::unnamed-runs (fnil inc 0))
+
+            (sub-run? ev)
+            (let [ms (get-in ev [:tags :rf.sub/elapsed-ms])]
+              (-> m
+                  (update-in [k :runs] (fnil inc 0))
+                  (update-in [k :dispatch-ids] (fnil conj #{}) did)
+                  (cond->
+                    (number? ms) (-> (update-in [k :elapsed-ms] (fnil + 0.0) ms)
+                                     (update-in [k :timed-runs] (fnil inc 0))
+                                     (update-in [k :max-ms] (fnil max 0.0) ms))
+                    (not (number? ms)) (update-in [k :untimed-runs] (fnil inc 0)))))
+
+            (= :rf.sub/skip (:operation ev))
+            (update-in m [k :memo-hits] (fnil inc 0))
+
+            :else m)))
+      acc
+      (:subs bundle))))
+
+(defn sub-timing
+  "Spec 009's retained window, folded into per-read-edge work.
+
+      (sub-timing {:app/main [bundle bundle …]})
+      ;; => {:schema … :producer :re-frame/trace :read :sub-timing
+      ;;     :scope {:frames [:app/main] :retained-runs 12}
+      ;;     :basis :observation :complete? false
+      ;;     :loss {:reason :cap :dropped :unknown}
+      ;;     :by-read {[:app/main :todo] {:runs 4 :timed-runs 4 :untimed-runs 0
+      ;;                                  :elapsed-ms 6.4 :max-ms 2.1
+      ;;                                  :memo-hits 9 :dispatch-ids #{41 42 43 44}}}}
+
+  `windows` is `{frame-id [event-bundle …]}` exactly as
+  `re-frame.trace.tooling/trace-buffer` answers it, one entry per frame.
+
+  **The key is `[frame-id sub-id]` and not the sub-id**, for the same
+  reason `explain-render` scopes its leads that way: two frames are two
+  applications, and summing frame B's clock into frame A's ranking would
+  make an idle boundary look hot because something unrelated was busy
+  next door.
+
+  **This read is NEVER complete.** A ring of size N cannot say what fell
+  off it, so every number here is a floor and the loss says `:cap`
+  unconditionally — including when the digest is full, because a full
+  window is the case where the most has been dropped."
+  [windows]
+  (let [frames    (vec (sort-by pr-str (keys windows)))
+        folded    (reduce (fn [acc fid]
+                            (reduce (fn [a b] (fold-bundle a fid b)) acc (get windows fid)))
+                          {}
+                          frames)
+        unnamed   (get folded ::unnamed-runs 0)
+        by-read   (dissoc folded ::unnamed-runs)
+        retained  (reduce + 0 (map (comp count val) windows))]
+    {:schema        timing-schema
+     :producer      timing-producer
+     :read          :sub-timing
+     :scope         {:frames frames :retained-runs retained}
+     :basis         :observation
+     :complete?     false
+     :loss          {:reason :cap :dropped hh/unknown}
+     :by-read       by-read
+     ;; A run whose `:rf.sub/id` tag is absent happened and joins to no
+     ;; subscription — the textbook `:uncorrelated` state, surfaced rather
+     ;; than folded away so an untagged stream cannot read as an idle one.
+     :unnamed-runs  unnamed
+     :unnamed-loss  (when (pos? unnamed)
+                      {:reason :uncorrelated :dropped unnamed})}))
+
+;; ---------------------------------------------------------------------------
+;; The join — a boundary's read edges, priced
+;; ---------------------------------------------------------------------------
+
+(defn- read-edges
+  "The `[frame-id sub-id]` pairs a producer boundary row reads.
+
+  Taken from `:reads` (which carries `:frame-id` and `:sub-id` per edge)
+  rather than from the projected `:boundary :key`, because the key's third
+  element is a PROJECTED query and the timing digest is keyed on the
+  registration id — the one spelling redaction cannot take."
+  [row]
+  (into [] (map (juxt :frame-id :sub-id)) (:reads row)))
+
+(defn- fan-out-index
+  "`{[frame-id sub-id] fan-out}` from the attribution envelope.
+
+  Summed rather than maxed across cells sharing a registration id,
+  because two parameterizations of one sub are two cells and a boundary
+  reading both is exposed to both reader populations."
+  [attribution]
+  (if-not (hh/supported? attribution)
+    {}
+    (reduce (fn [m edge]
+              (update m [(:frame-id edge) (:sub-id edge)] (fnil + 0) (or (:fan-out edge) 0)))
+            {}
+            (:edges attribution))))
+
+(defn- attributable
+  "This boundary's read edges with their measured work attached, plus the
+  totals the axes are read off.
+
+  `:ms` is `hh/unknown` — never 0 — when no edge carried a timed run. A
+  boundary whose subscriptions were never timed and a boundary whose
+  subscriptions cost nothing are different facts with different remedies,
+  and zero is the spelling that hides the difference."
+  [timing edges]
+  (let [priced (mapv (fn [[fid sid :as k]]
+                       (let [t (get (:by-read timing) k)]
+                         {:frame-id     fid
+                          :sub-id       sid
+                          :runs         (get t :runs 0)
+                          :timed-runs   (get t :timed-runs 0)
+                          :untimed-runs (get t :untimed-runs 0)
+                          :memo-hits    (get t :memo-hits 0)
+                          :elapsed-ms   (get t :elapsed-ms)
+                          :max-ms       (get t :max-ms)
+                          :dispatch-ids (get t :dispatch-ids #{})}))
+                     edges)
+        timed  (filterv #(pos? (:timed-runs %)) priced)
+        total  (reduce + 0.0 (map #(or (:elapsed-ms %) 0.0) timed))]
+    {:edges       priced
+     :ms          (if (seq timed) total hh/unknown)
+     :timed?      (boolean (seq timed))
+     :untimed-runs-total (reduce + 0 (map :untimed-runs priced))
+     :runs        (reduce + 0 (map :runs priced))
+     :memo-hits   (reduce + 0 (map :memo-hits priced))
+     :dispatches  (reduce into #{} (map :dispatch-ids priced))
+     :hottest     (when (seq timed)
+                    (apply max-key #(or (:elapsed-ms %) 0.0) timed))}))
+
+;; ---------------------------------------------------------------------------
+;; The four axes
+;; ---------------------------------------------------------------------------
+
+(defn- axes
+  "The four ranking axes for one boundary, each carrying its own basis.
+
+  They are four axes and not one score. A composite would need weights
+  between milliseconds, dispatch counts, read orders and reader slots —
+  four incommensurable units — and the weights would be the ranking,
+  invented here and unfalsifiable. Each axis is reported in its own unit
+  with its own loss, and [[order-axis]] picks which one the roster is
+  sorted on, out loud."
+  [row att fan-out]
+  {:time       {:ms    (:ms att)
+                :basis :observation
+                ;; The window is always a cap, so a timed row's total is a
+                ;; FLOOR. An untimed row's loss is `:uncorrelated` instead:
+                ;; the recomputes are real and observed, and it is the
+                ;; duration that joins to nothing — Spec 009 puts
+                ;; `:rf.sub/elapsed-ms` on the reactive recompute path and
+                ;; not on the pure `compute-sub` form. Reporting that as a
+                ;; cap would send the reader to the retention knob, which
+                ;; is not the remedy.
+                :loss  (if (:timed? att)
+                         {:reason :cap :dropped hh/unknown}
+                         {:reason :uncorrelated :dropped (:untimed-runs-total att)})
+                :says  "subscription recompute time attributable to this boundary's reads, inside the retained window"}
+   :frequency  {:runs        (:runs att)
+                :dispatches  (count (:dispatches att))
+                :memo-hits   (:memo-hits att)
+                :basis       :observation
+                :loss        {:reason :cap :dropped hh/unknown}
+                :says        "recomputes of this boundary's reads in the retained window, and the memo hits beside them"}
+   :read-churn {:reads       (count (:reads row))
+                :read-orders (:read-orders row)
+                ;; `:read-orders` > 1 means the entry cache holds more than
+                ;; one ORDER for this edge set — an oscillating read set,
+                ;; which `lanes/hot-path-architecture.md` §Read-topology
+                ;; names as suspect because whole-set reconciliation can
+                ;; become proportional to the current read count.
+                :oscillating? (and (number? (:read-orders row))
+                                   (> (:read-orders row) 1))
+                :basis        :observation
+                :says         "how many reads this boundary holds, and how many distinct read ORDERS folded into it"}
+   :fan-out    {:total     fan-out
+                :instances (:instances row)
+                :basis     :observation
+                :says      "reader slots on the cells this boundary reads — how many boundaries move with it"}})
+
+;; ---------------------------------------------------------------------------
+;; Formatting
+;; ---------------------------------------------------------------------------
+
+(defn format-ms
+  "A duration a reader can compare, at the resolution the clock actually
+  has.
+
+  Two decimals, because the timer grain is 0.1 ms and a third would print
+  precision that is not there. Rounded with arithmetic rather than
+  `Math/round` so the one expression is the same on both platforms —
+  durations are non-negative, so truncation after the half-add is exact."
+  [ms]
+  (if (number? ms)
+    (str (/ (int (+ 0.5 (* 100.0 (double ms)))) 100.0) " ms")
+    "unknown"))
+
+;; ---------------------------------------------------------------------------
+;; Classification — one measured class, one derived, three named and refused
+;; ---------------------------------------------------------------------------
+
+(def unmeasured-classes
+  "The three pressure classes this door cannot weigh, and who can.
+
+  Named as data so the panel can print them and a test can assert the
+  advisor never claims one. Each `:authority` is the instrument Spec SN
+  §10 and `lanes/testing-xray.md` already point at; none of them is Xray."
+  [{:class     :lowering
+    :label     "Hiccup lowering"
+    :authority "the User-Timing `:render` measures Hicasso emits under `re-frame.performance/enabled?` — an independently gated, observer-first channel that is off by default"
+    :why       "Hicasso publishes no per-boundary lowering clock. Boundary self time was killed as a decision, not deferred: the 0.1 ms timer grain is coarser than the quantity, so a ranking built on it orders noise."}
+   {:class     :react
+    :label     "React reconciliation and commit"
+    :authority "the React DevTools Profiler"
+    :why       "Whether a notified boundary re-ran, retried, was abandoned, was bailed out by its memo comparator, or committed is decided above this runtime. The Hicasso door states it `:host-opaque` on every envelope."}
+   {:class     :layout
+    :label     "DOM layout and paint"
+    :authority "the browser's own performance tools"
+    :why       "Nothing in a subscription table or a trace ring observes layout. A timing coincidence here would be a guess wearing a number."}])
+
+(defn classify
+  "What owns this boundary's pressure — as far as the instruments reach.
+
+  Four outcomes, and the difference between the last two is the point:
+
+  | `:owner` | `:basis` | Means |
+  |---|---|---|
+  | `:computation` | `:observation` | one read's measured recompute time dominates, above the clock's floor |
+  | `:read-topology` | `:derivation` | the read set is the problem: it oscillates, or it re-runs repeatedly for little measured work |
+  | `:unattributed` + `:host-opaque` | `:host-opaque` | the window WAS searched and the measured half does not explain it, so the owner is one of the three classes above — and this door cannot say which |
+  | `:unattributed` + `:cap` | `:cap` | nothing was retained, so no search happened; this is an absence of evidence, not evidence of absence |
+
+  The last two rows are the pair a naive advisor collapses. `:cap` says
+  *raise the retention knob and look again*; `:host-opaque` says *the
+  answer is real and lives in another tool*. One remedy is free and the
+  other is a change of instrument."
+  [{:keys [time frequency read-churn]} att]
+  (let [ms       (:ms time)
+        timed?   (:timed? att)
+        hottest  (:hottest att)
+        hot-ms   (or (:elapsed-ms hottest) 0.0)
+        searched? (pos? (:runs frequency))]
+    (cond
+      ;; MEASURED. One read holds the majority of a total the clock can
+      ;; actually order.
+      (and timed?
+           (number? ms)
+           (>= ms computation-floor-ms)
+           (>= (/ hot-ms ms) dominance))
+      {:owner :computation
+       :basis :observation
+       :loss  nil
+       :read  (select-keys hottest [:frame-id :sub-id :elapsed-ms :max-ms :runs])
+       :says  (str "measured: " (hh/format-id (:sub-id hottest))
+                   " accounts for " (int (* 100 (/ hot-ms ms))) "% of "
+                   (format-ms ms) " of attributable subscription time across "
+                   (:runs frequency) " recompute"
+                   (when (not= 1 (:runs frequency)) "s") ".")}
+
+      ;; DERIVED. An oscillating read set is a topology fact on its own,
+      ;; independent of any clock — the entry cache holds more than one
+      ;; read ORDER for this boundary.
+      (:oscillating? read-churn)
+      {:owner :read-topology
+       :basis :derivation
+       :loss  nil
+       :says  (str "the entry cache holds " (:read-orders read-churn)
+                   " distinct read orders for this boundary — an oscillating "
+                   "read set, whose whole-set reconciliation can become "
+                   "proportional to the current read count.")}
+
+      ;; DERIVED. It re-runs repeatedly and the measured work does not
+      ;; account for it, so the read set is bringing it back, not the
+      ;; arithmetic inside it.
+      (and searched?
+           (>= (:runs frequency) repeat-floor)
+           timed?
+           (number? ms)
+           (< ms computation-floor-ms))
+      {:owner :read-topology
+       :basis :derivation
+       :loss  nil
+       :says  (str "recomputed " (:runs frequency) " times for "
+                   (format-ms ms) " of measured work — under the "
+                   (format-ms computation-floor-ms) " floor the clock can "
+                   "order, so the reads are bringing it back rather than the "
+                   "computation inside them.")}
+
+      ;; The window was searched and the measured half does not explain it.
+      searched?
+      {:owner      :unattributed
+       :basis      :host-opaque
+       :loss       {:reason :host-opaque :dropped hh/unknown}
+       :candidates (mapv :class unmeasured-classes)
+       :says       (str "the window was searched and the measured half does not "
+                        "account for this boundary: "
+                        (if (number? ms) (format-ms ms) "no timed recompute")
+                        " across " (:runs frequency) " recompute"
+                        (when (not= 1 (:runs frequency)) "s")
+                        ". The owner is lowering, React or layout — and this "
+                        "door observes none of the three.")}
+
+      ;; Nothing was retained, so nothing was searched.
+      :else
+      {:owner      :unattributed
+       :basis      :cap
+       :loss       {:reason :cap :dropped hh/unknown}
+       :candidates (mapv :class unmeasured-classes)
+       :says       (str "nothing in the retained window recomputed this "
+                        "boundary's reads, so no search happened. This is an "
+                        "absence of evidence — raise `:rf.trace/events-retained` "
+                        "and reproduce the interaction.")})))
+
+;; ---------------------------------------------------------------------------
+;; The route ladder — a table keyed on the OWNER, and the refusal it produces
+;; ---------------------------------------------------------------------------
+
+(def working-loop
+  "`lanes/hot-path-architecture.md` §Xray-guided workflow, verbatim in
+  substance and numbered as it is there.
+
+  Kept as data so a route can attach the steps that actually apply to it
+  rather than printing the whole loop at a reader who needs three of it."
+  {1 "Name a slow interaction and reproduce it with a stable script."
+   2 "Correlate event, changed reads, invalidated boundaries, body work, commit, and paint."
+   3 "Tune read and boundary topology first."
+   4 "If codec work dominates, compare direct React output in the same boundary."
+   5 "If hooks, reconciliation, vendor behavior, or high-rate local work dominate, isolate a named native component and choose Hicasso-native, UIx, or raw React according to its needs."
+   6 "Run behavioral parity, focus/selection, frame routing, SSR/hydration, cleanup, and performance scripts."
+   7 "Keep the escape only if it clears a declared budget."})
+
+(def ladder
+  "The performance ladder, keyed on the OWNER each rung addresses.
+
+  This is the whole mechanism behind *native extraction only when it
+  addresses the measured owner*: a route is selected by looking up the
+  owner, never by how hot the boundary is. A boundary can be the hottest
+  on the page and select rung 2, because rung 2 is what its owner
+  answers to.
+
+  `:owner` keys `:lowering`, `:react-work` and `:react-shaped` are
+  **unreachable from [[classify]]** — this door measures none of them.
+  They are here because the refusal below has to be a statement about the
+  EVIDENCE, and a refusal emitted by a table with no native arm would be
+  a statement about the table. `hicasso-advisor-cljs-test`'s non-vacuity
+  row drives them directly."
+  {:computation
+   {:route    :narrow-the-subscription
+    :rung     nil
+    :native?  false
+    :label    "Narrow or memoize the subscription"
+    :says     (str "The measured owner is the subscription body, which runs "
+                   "BELOW the view substrate. Every native route leaves it "
+                   "exactly where it is — extracting the view would move the "
+                   "markup and keep the cost.")
+    :steps    [1 3 6 7]}
+
+   :read-topology
+   {:route    :tune-topology
+    :rung     2
+    :native?  false
+    :label    "Tune topology without changing language"
+    :says     (str "Place boundaries around independently changing or expensive "
+                   "regions; stabilize keys and props; choose fine, coarse, "
+                   "chunked or visible-window subscriptions to match the "
+                   "workload; virtualize genuinely large collections. Do not "
+                   "split per element mechanically — each boundary retains a "
+                   "React fiber, a memo wrapper and a Hicasso shell.")
+    :steps    [1 3 6 7]}
+
+   :lowering
+   {:route    :direct-element
+    :rung     3
+    :native?  true
+    :label    "Return a direct React element (`n/$`)"
+    :says     (str "The narrowest useful escape for a measured codec/markup "
+                   "hotspot: the same frame, subscription shell, props ABI and "
+                   "component identity, skipping Hiccup lowering for that "
+                   "boundary. Intent lowering, controlled-field normalization "
+                   "and key diagnostics do not apply inside the returned "
+                   "subtree.")
+    :steps    [1 4 6 7]}
+
+   :react-work
+   {:route    :native-island
+    :rung     4
+    :native?  true
+    :label    "Isolate a named native React island"
+    :says     (str "For a virtualizer, editor, animation surface, canvas/WebGL "
+                   "coordinator, retained vendor widget or hook-intensive hot "
+                   "collection. `n/defcomponent` with `n/use-frame` and "
+                   "`n/use-sub` is the default self-contained route; UIx is an "
+                   "optional mature one; JavaScript enters through the host "
+                   "bridge. Same React root, same frame contract.")
+    :steps    [1 5 6 7]}
+
+   :react-shaped
+   {:route    :native-screen
+    :rung     5
+    :native?  true
+    :label    "Implement the screen natively"
+    :says     (str "Only for an intrinsically React-first surface. A local "
+                   "view-implementation choice under the single installed "
+                   "adapter, root and frame contract — not another adapter or "
+                   "Hicasso mode.")
+    :steps    [1 5 6 7]}})
+
+(defn- measure-first
+  "The advice for an owner nothing here measured: what to reach for, in
+  which order, and why this tool is not it.
+
+  This is the shape a *sorted list of durations* cannot produce, and the
+  reason the advisor exists. It is a REFUSAL with a next step, not a
+  shrug: the three candidates are named, each with the instrument that
+  settles it, and the ladder stays shut until one of them comes back
+  with an answer."
+  [classification]
+  {:route    :measure-first
+   :rung     nil
+   :native?  false
+   :label    (if (= :cap (:basis classification))
+               "Widen the window and reproduce"
+               "Measure the unattributed half elsewhere")
+   :says     (if (= :cap (:basis classification))
+               (str "Nothing was retained for this boundary, so no ranking here "
+                    "is about it yet. Raise `:rf.trace/events-retained`, "
+                    "reproduce the interaction, and read this tab again.")
+               (str "The measured half does not own this boundary, and the "
+                    "three classes that might are not observable from a "
+                    "subscription table or a trace ring. Recommending a native "
+                    "route from this evidence would be guessing with a number "
+                    "attached."))
+   :refusal  {:reason      (:basis classification)
+              :refused     [:direct-element :native-island :native-screen]
+              :says        (str "The native ladder addresses lowering, hooks, "
+                                "vendor behaviour and reconciliation. This door "
+                                "observes none of them, so it cannot know "
+                                "whether the change it would be recommending "
+                                "helps — and a native extraction that does not "
+                                "help still costs intent lowering, "
+                                "controlled-field normalization, key "
+                                "diagnostics and structural inspection inside "
+                                "the extracted subtree.")
+              :next        (mapv #(select-keys % [:class :label :authority :why])
+                                 unmeasured-classes)}
+   :steps    (if (= :cap (:basis classification)) [1] [1 2])})
+
+(defn recommend
+  "The smallest credible route for a classified boundary — or the refusal.
+
+  Looks the OWNER up in [[ladder]] and returns nothing else. There is no
+  path from a ranking position to a route, which is the property that
+  makes *native extraction only when it addresses the measured owner*
+  mechanical rather than aspirational: the hottest boundary on the page
+  and the coldest one with the same owner get the same rung."
+  [classification]
+  (let [entry (get ladder (:owner classification))]
+    (if (and entry (not= :unattributed (:owner classification)))
+      (assoc entry
+             :addresses (:owner classification)
+             :because   (:says classification)
+             :working-loop (mapv working-loop (:steps entry)))
+      (let [m (measure-first classification)]
+        (assoc m
+               :addresses (:owner classification)
+               :because   (:says classification)
+               :working-loop (mapv working-loop (:steps m)))))))
+
+;; ---------------------------------------------------------------------------
+;; The roster
+;; ---------------------------------------------------------------------------
+
+(defn- row-for
+  [timing fan-idx row]
+  (let [edges   (read-edges row)
+        att     (attributable timing edges)
+        fan     (reduce + 0 (map #(get fan-idx % 0) edges))
+        ax      (axes row att fan)
+        cls     (classify ax att)]
+    {:boundary   (:boundary row)
+     :label      (hh/boundary-label (:boundary row))
+     :slug       (hh/boundary-slug (:boundary row))
+     :key-str    (pr-str (:key (:boundary row)))
+     :frame      (:frame row)
+     :instances  (:instances row)
+     :axes       ax
+     :attributable att
+     :class      cls
+     :advice     (recommend cls)}))
+
+(defn order-axis
+  "Which axis the roster is sorted on, and why THAT one.
+
+  `:time` when any row has a timed recompute, because a measured
+  millisecond is the only axis that is about cost rather than about
+  shape. Otherwise `:frequency`, and the roster SAYS so — a list ordered
+  by a fallback axis while implying it was ordered by time is the quiet
+  version of the mistake this whole namespace is arranged against."
+  [rows]
+  (if (some #(get-in % [:attributable :timed?]) rows)
+    {:axis :time
+     :says "ordered by attributable subscription time"}
+    {:axis :frequency
+     :says (str "ordered by recompute count — NOT by time. No read edge in the "
+                "retained window carried a `:rf.sub/elapsed-ms` tag, so there "
+                "is no measured duration to order on.")}))
+
+(defn- sort-key
+  [axis row]
+  (case axis
+    :time      (- (if (number? (get-in row [:axes :time :ms]))
+                    (get-in row [:axes :time :ms])
+                    -1.0))
+    :frequency (- (get-in row [:axes :frequency :runs] 0))
+    0))
+
+(defn advise
+  "Rank, classify and recommend over one turn's evidence.
+
+      (advise {:mounted-boundaries E1 :read-attribution E2 :explain-render E4}
+              (sub-timing windows))
+
+  Returns the advisor's own envelope, carrying the same seven axes the
+  Hicasso door's do — under [[advice-schema]], because Xray derived it and
+  Hicasso did not.
+
+  `:complete?` is false unconditionally and the loss is `:host-opaque`: the
+  roster covers every mounted boundary, but the QUESTION is *where is the
+  pressure*, and three of its five answers are outside this door. A
+  `:complete? true` here would be the schema's own fail-open shape,
+  written by the one function best placed to know better."
+  [envelopes timing]
+  (let [mounted (:mounted-boundaries envelopes)]
+    (if-not (hh/supported? mounted)
+      {:schema advice-schema :producer advice-producer :read :hot-view-advice
+       :scope :mounted-boundaries :basis :observation :complete? false
+       :loss {:reason :host-opaque :dropped hh/unknown}
+       :rows [] :ordered-by nil :timing timing :unmeasured unmeasured-classes}
+      (let [fan-idx (fan-out-index (:read-attribution envelopes))
+            rows    (mapv #(row-for timing fan-idx %) (:boundaries mounted))
+            {:keys [axis] :as ordering} (order-axis rows)
+            ordered (vec (sort-by (juxt #(sort-key axis %) :key-str) rows))]
+        {:schema     advice-schema
+         :producer   advice-producer
+         :read       :hot-view-advice
+         :scope      :mounted-boundaries
+         :basis      :derivation
+         :complete?  false
+         :loss       {:reason :host-opaque :dropped hh/unknown}
+         :rows       (into [] (map-indexed (fn [i r] (assoc r :rank (inc i)))) ordered)
+         :ordered-by ordering
+         :timing     timing
+         :unmeasured unmeasured-classes}))))
+
+(defn advice-summary
+  "One muted line stating what the roster is and is not.
+
+  Rendered on every advice, including the ones with a confident top row,
+  for the reason `hicasso-helpers/read-summary` states: a reader who only
+  sees a qualification when it is bad learns to read its absence as good
+  news."
+  [advice]
+  (when advice
+    (string/join " · "
+                 (remove nil?
+                         [(str (count (:rows advice)) " boundar"
+                               (if (= 1 (count (:rows advice))) "y" "ies"))
+                          (:says (:ordered-by advice))
+                          (str "window "
+                               (get-in advice [:timing :scope :retained-runs] 0)
+                               " retained run"
+                               (when (not= 1 (get-in advice [:timing :scope :retained-runs] 0)) "s"))
+                          "lowering, React and layout are not measured here"]))))

--- a/tools/xray/src/day8/re_frame2_xray/panels/hicasso_causal.cljc
+++ b/tools/xray/src/day8/re_frame2_xray/panels/hicasso_causal.cljc
@@ -1,0 +1,383 @@
+(ns day8.re-frame2-xray.panels.hicasso-causal
+  "ONE complete causal slice, link by link (rf2-hic-037).
+
+  Spec SN §10 states the causal lens as a chain:
+
+      event -> subscriptions recomputed -> values changed
+            -> boundaries notified -> bodies run -> React commit -> paint
+
+  and then states the rule that makes it hard: *each link needs an
+  explicit evidence seam. Timing proximity never proves commit, paint,
+  hidden, or suspended state.* This namespace renders the WHOLE chain for
+  one real dispatch against one real boundary, and every link is either
+  read off a named seam or labelled with what it is missing.
+
+  ## The chain is not evenly evidenced, and that is the finding
+
+  | # | Link | Seam | Basis |
+  |---|---|---|---|
+  | 1 | event | Spec 009's retained ring, the bundle for this dispatch | `:observation` |
+  | 2 | subscriptions recomputed | that bundle's `:subs` events, keyed `:rf.sub/id` | `:observation` |
+  | 3 | values changed | the cell table's epoch stamps, at the boundary's peak | `:observation` |
+  | 4 | boundaries notified | the cells' reader arrays — the reverse edge `notify!` walks | `:derivation` |
+  | 5 | bodies run | — | `:host-opaque` |
+  | 6 | React commit | — | `:host-opaque` |
+  | 7 | paint | — | `:host-opaque` |
+
+  **A link's own basis is not the same question as whether it joins to
+  the one before it**, and collapsing the two is how a causal display
+  starts lying. Links 2 and 3 are both `:observation` — the sub really
+  recomputed, the cell's epoch really moved — and the join between them
+  is `:uncorrelated`, because Hicasso's commit seam records no cascade id
+  and an epoch stamp carries no dispatch. Two solid facts, printed
+  adjacent, joined by nothing: exactly the adjacency `re-frame.hicasso.tool`
+  refuses to call causality, surfaced here as its own row rather than
+  implied away by the arrow between two green links.
+
+  Link 4 is the other one worth reading twice. The reverse edge IS what
+  `collector/notify!` walks, so the notified set is derivable — but the
+  notify CALL is not recorded, and the reader arrays are read at ASK time
+  rather than at commit time. A boundary that unmounted between the
+  commit and this read is absent from a set it was in. The link says so.
+
+  ## Every link is mutation-tested
+
+  A display that renders `evidenced` from a seam it is not actually
+  reading is worse than one that renders `unknown`, and the two are
+  indistinguishable from the outside on a healthy application. So each
+  evidenced link has a sabotage row in `hicasso_causal_cljs_test`: break
+  that link's seam, and the link must stop being evidenced — degrading to
+  a stated loss, never to a confident wrong answer, and never borrowing a
+  neighbouring seam to keep its colour. Each sabotage carries the
+  positive control that proves the link was green before it.
+
+  Pure data → data, CLJC, so the algebra runs under the JVM target too.
+
+  Normative owner: `tools/xray/spec/028-Hicasso-Advisor.md`."
+  (:require [clojure.string :as string]
+            [day8.re-frame2-xray.panels.hicasso-helpers :as hh]))
+
+(def causal-schema
+  "Xray's own stamp. See `hicasso-advisor/advice-schema` for why the
+  producer's is not borrowed for a derivation the producer never made."
+  :day8.re-frame2-xray.hicasso-causal/v1)
+
+(def causal-producer :re-frame2/xray)
+
+;; ---------------------------------------------------------------------------
+;; Picking the slice
+;; ---------------------------------------------------------------------------
+
+(defn newest-dispatch
+  "The highest numeric `:dispatch-id` in the retained windows, or nil.
+
+  The id is allocated process-monotonically at queue time, so the highest
+  retained one is the most recent dispatch the ring still holds — the
+  interaction a developer just performed. Non-numeric ids (the producer's
+  unjoinable sentinel) are skipped rather than sorted after: an id that
+  cannot be joined cannot anchor a slice."
+  [windows]
+  (let [ids (for [[_ bundles] windows
+                  b           bundles
+                  :let        [d (:dispatch-id b)]
+                  :when       (number? d)]
+              d)]
+    (when (seq ids) (reduce max ids))))
+
+(defn- bundle-for
+  "The `[frame-id bundle]` for `dispatch-id`, or nil.
+
+  A dispatch that touched two frames is captured in both rings; the first
+  in frame order is taken and the OTHER frames are reported beside it, so
+  the slice never silently describes half of what a dispatch did."
+  [windows dispatch-id]
+  (first (for [fid (sort-by pr-str (keys windows))
+               b   (get windows fid)
+               :when (= dispatch-id (:dispatch-id b))]
+           [fid b])))
+
+(defn- frames-touched
+  [windows dispatch-id]
+  (vec (sort-by pr-str
+                (for [[fid bundles] windows
+                      :when (some #(= dispatch-id (:dispatch-id %)) bundles)]
+                  fid))))
+
+(defn- explanation-for
+  "The `explain-render` row for `boundary-key`, or nil."
+  [explain boundary-key]
+  (when (hh/supported? explain)
+    (first (filter #(= boundary-key (:key (:boundary %))) (:explanations explain)))))
+
+;; ---------------------------------------------------------------------------
+;; The seven links
+;; ---------------------------------------------------------------------------
+
+(def host-opaque-links
+  "Links 5, 6 and 7 — stated once, as data.
+
+  They are not three phrasings of one absence. A body that ran and a
+  commit that landed are different events with different authorities, and
+  a paint is a third; a reader deciding what to open next needs to know
+  which one they are missing. React DevTools answers the first two, the
+  browser's performance tools the third."
+  [{:id    :bodies-run
+    :label "bodies run"
+    :says  (str "Whether a notified boundary re-ran, retried, was abandoned or "
+                "was bailed out by its memo comparator is React's to know. The "
+                "comparator sits ABOVE the boundary's own function, so a "
+                "bail-out never enters it. Hicasso emits no `:rf.view/render` "
+                "trace, and per-boundary self time was killed as a decision: "
+                "the 0.1 ms timer grain is coarser than the quantity, so a "
+                "ranking built on it would order noise.")
+    :authority "React DevTools Profiler"}
+   {:id    :react-commit
+    :label "React commit"
+    :says  (str "A render measure is not a commit. React consults its own "
+                "scheduled work above this runtime, and a notification "
+                "delivered is not a render performed, let alone one committed.")
+    :authority "React DevTools Profiler"}
+   {:id    :paint
+    :label "paint"
+    :says  (str "Nothing in a subscription table or a trace ring observes the "
+                "compositor. Timing proximity to a commit never proves a "
+                "paint.")
+    :authority "the browser's own performance tools"}])
+
+(defn- link-event
+  [frame-id bundle dispatch-id frames]
+  (if (nil? bundle)
+    {:id :event :ordinal 1 :label "event"
+     :seam "Spec 009's per-frame retained ring"
+     :basis :cap :evidenced? false
+     :holds hh/unknown
+     :loss  {:reason :cap :dropped hh/unknown}
+     :says  (str "No bundle for dispatch " (hh/format-id dispatch-id)
+                 " is retained. The ring holds `:rf.trace/events-retained` "
+                 "runs and cannot say what fell off it — so this is a capped "
+                 "window, not a dispatch that never happened.")}
+    {:id :event :ordinal 1 :label "event"
+     :seam "Spec 009's per-frame retained ring"
+     :basis :observation :evidenced? true
+     :holds {:dispatch-id dispatch-id
+             :event-id    (if (vector? (:event bundle)) (nth (:event bundle) 0) hh/unknown)
+             ;; The ARITY, never the arguments. The classification model is
+             ;; fail-open, so an event that declared nothing would ship its
+             ;; arguments raw through the egress chokepoint — and a slice
+             ;; that promised no application data while routing an
+             ;; undeclared payload through would be making the promise
+             ;; falsely. The Trace surface is where Spec 015 governs that.
+             :arg-count   (if (vector? (:event bundle)) (dec (count (:event bundle))) hh/unknown)
+             :frame       frame-id
+             :frames      frames}
+     :loss  {:reason :cap :dropped hh/unknown}
+     :says  "read off the retained bundle for this dispatch."}))
+
+(defn- link-subs
+  [bundle]
+  (if (nil? bundle)
+    {:id :subs-recomputed :ordinal 2 :label "subscriptions recomputed"
+     :seam "the bundle's `:subs` trace events"
+     :basis :cap :evidenced? false
+     :holds hh/unknown
+     :loss  {:reason :cap :dropped hh/unknown}
+     :joins {:on :rf.trace/dispatch-id :status :cap
+             :says "no bundle to join to."}
+     :says  "the window holds no bundle for this dispatch."}
+    (let [subs    (:subs bundle)
+          named   (into [] (distinct) (keep #(get-in % [:tags :rf.sub/id]) subs))
+          unnamed (count (remove #(get-in % [:tags :rf.sub/id]) subs))]
+      {:id :subs-recomputed :ordinal 2 :label "subscriptions recomputed"
+       :seam "the bundle's `:subs` trace events, keyed `:rf.sub/id`"
+       :basis :observation
+       :evidenced? (or (seq named) (zero? unnamed))
+       ;; An empty roster with no unnamed runs is a genuine survey result:
+       ;; this dispatch recomputed nothing. An empty roster WITH unnamed
+       ;; runs is not — work happened and joins to no subscription — so the
+       ;; field states `:unknown` rather than `[]`, which is the one
+       ;; substitution the evidence schema exists to refuse.
+       :holds (if (and (empty? named) (pos? unnamed)) hh/unknown named)
+       :loss  (if (pos? unnamed)
+                {:reason :uncorrelated :dropped unnamed}
+                {:reason :cap :dropped hh/unknown})
+       :joins {:on :rf.trace/dispatch-id :status :evidenced
+               :says (str "every event in the bundle carries this dispatch's "
+                          "own `:rf.trace/dispatch-id` — the ring groups by it, "
+                          "so the join is the storage and not an inference.")}
+       :says  (if (pos? unnamed)
+                (str unnamed " sub run" (when (not= 1 unnamed) "s")
+                     " in this bundle carried no `:rf.sub/id` and join to no "
+                     "subscription.")
+                "read off the bundle's own sub events.")})))
+
+(defn- link-values
+  [ex]
+  (cond
+    (nil? ex)
+    {:id :values-changed :ordinal 3 :label "values changed"
+     :seam "the cell table's epoch stamps"
+     :basis :observation :evidenced? false
+     :holds hh/unknown :loss nil
+     :joins {:on nil :status :uncorrelated
+             :says (str "no explanation row for this boundary — the census and "
+                        "the slice disagree about what is mounted.")}
+     :says  "no `explain-render` row holds this boundary."}
+
+    (hh/unknown? (:latest-reads ex))
+    {:id :values-changed :ordinal 3 :label "values changed"
+     :seam "the cell table's epoch stamps"
+     :basis :observation :evidenced? false
+     :holds hh/unknown :loss nil
+     :joins {:on nil :status :uncorrelated
+             :says "nothing to join — no epoch moved for this boundary."}
+     :says  (str "this boundary holds no read with an epoch, so no value of "
+                 "its can have moved. That is a fact about the boundary, not "
+                 "a gap in the instrument.")}
+
+    :else
+    {:id :values-changed :ordinal 3 :label "values changed"
+     :seam "the cell table's epoch stamps"
+     :basis :observation :evidenced? true
+     :holds {:latest-reads (:latest-reads ex)
+             :peak-epoch   (:peak-epoch ex)
+             ;; The exact number React compares in `checkIfSnapshotChanged`.
+             :snapshot     (:snapshot ex)}
+     :loss  nil
+     ;; THE UNCORRELATED JOIN. Both sides are solid and nothing links them.
+     :joins {:on nil :status :uncorrelated
+             :says (str "an epoch stamp carries no dispatch id and Hicasso's "
+                        "commit seam records no cascade id, so the recompute "
+                        "above and the movement here CANNOT be joined. They "
+                        "are printed adjacent because the chain runs that way, "
+                        "not because this slice can show one caused the other. "
+                        "Leads live on the Why view.")}
+     :says  (str "every commit re-stamps a moved cell's epoch, so the reads at "
+                 "this boundary's highest epoch are the ones whose values "
+                 "moved most recently — read off the table.")}))
+
+(defn- link-notified
+  [attribution ex]
+  (cond
+    (or (nil? ex) (hh/unknown? (:latest-reads ex)))
+    {:id :boundaries-notified :ordinal 4 :label "boundaries notified"
+     :seam "the cells' reader arrays — the reverse edge `notify!` walks"
+     :basis :derivation :evidenced? false
+     :holds hh/unknown :loss nil
+     :joins {:on nil :status :uncorrelated
+             :says "no moved read to take a reverse edge from."}
+     :says  "there is no moved read whose readers could be named."}
+
+    (not (hh/supported? attribution))
+    {:id :boundaries-notified :ordinal 4 :label "boundaries notified"
+     :seam "the cells' reader arrays — the reverse edge `notify!` walks"
+     :basis :derivation :evidenced? false
+     :holds hh/unknown :loss nil
+     :joins {:on [:frame-id :sub-id] :status :uncorrelated
+             :says "the reverse-edge table is not readable on this host."}
+     ;; NOT substituted from the mounted census. The census carries each
+     ;; boundary's own reads, so a plausible-looking notified set could be
+     ;; assembled from it — and it would be a different fact, assembled
+     ;; from the forward edge, printed under the reverse edge's name.
+     :says  (str "the read-attribution envelope is absent or unparseable, so "
+                 "the reverse edge cannot be read. The mounted census is NOT "
+                 "substituted: it holds the forward edge, and answering a "
+                 "reverse-edge question from it would be a different fact "
+                 "under this one's name.")}
+
+    :else
+    (let [moved   (into #{} (map (juxt :frame-id :sub-id)) (:latest-reads ex))
+          matched (filter #(contains? moved [(:frame-id %) (:sub-id %)]) (:edges attribution))
+          readers (into [] (distinct) (mapcat :readers matched))]
+      {:id :boundaries-notified :ordinal 4 :label "boundaries notified"
+       :seam "the cells' reader arrays — the reverse edge `notify!` walks"
+       :basis :derivation :evidenced? true
+       :holds {:readers  readers
+               :fan-out  (reduce + 0 (map #(or (:fan-out %) 0) matched))
+               :cells    (mapv #(select-keys % [:frame-id :sub-id :query :fan-out]) matched)}
+       :loss  nil
+       :joins {:on [:frame-id :sub-id] :status :evidenced
+               :says (str "the moved reads and the cell table are keyed the "
+                          "same way, so this join is an equality on the "
+                          "producer's own identity rather than a correlation.")}
+       :says  (str "a commit unions the dirty cells' readers and notifies "
+                   "them, and the reader array IS that set — one slot per "
+                   "reading boundary, maintained by the same commit and "
+                   "cleanup that acquire and release the reference. DERIVED, "
+                   "not observed: the notify CALL is not recorded, and this "
+                   "array is read now rather than at commit time, so a "
+                   "boundary that unmounted in between is absent from a set "
+                   "it was in.")})))
+
+(defn- link-host
+  [{:keys [id label says authority]} ordinal]
+  {:id id :ordinal ordinal :label label
+   :seam nil
+   :basis :host-opaque :evidenced? false
+   :holds hh/unknown
+   :loss  {:reason :host-opaque :dropped hh/unknown}
+   :joins {:on nil :status :host-opaque
+           :says (str "not joinable from here — " authority " is the authority.")}
+   :authority authority
+   :says says})
+
+;; ---------------------------------------------------------------------------
+;; The slice
+;; ---------------------------------------------------------------------------
+
+(defn slice
+  "The seven-link causal chain for one dispatch against one boundary.
+
+      (slice {:envelopes envelopes :windows windows
+              :dispatch-id 41 :boundary-key [[:app/main :todo [:todo 7]]]})
+
+  `:dispatch-id` defaults to [[newest-dispatch]] — the most recent
+  interaction the ring still holds. `:boundary-key` has no default here:
+  the panel passes the advisor's top-ranked boundary, so the slice is
+  about the boundary the roster just pointed at.
+
+  The envelope's own `:loss` is `:uncorrelated` and its `:complete?` is
+  false, and neither depends on how well the run went. Three links are
+  host-opaque by construction and the 2→3 join has no id to make; a slice
+  that reported itself complete because its first four links came back
+  green would be claiming the chain, having evidenced its prefix."
+  [{:keys [envelopes windows dispatch-id boundary-key]}]
+  (let [did            (or dispatch-id (newest-dispatch windows))
+        [fid bundle]   (when did (bundle-for windows did))
+        frames         (if did (frames-touched windows did) [])
+        ex             (explanation-for (:explain-render envelopes) boundary-key)
+        attribution    (:read-attribution envelopes)
+        links          (into [(link-event fid bundle did frames)
+                              (link-subs bundle)
+                              (link-values ex)
+                              (link-notified attribution ex)]
+                             (map-indexed (fn [i l] (link-host l (+ 5 i))))
+                             host-opaque-links)]
+    {:schema     causal-schema
+     :producer   causal-producer
+     :read       :causal-slice
+     :scope      {:dispatch-id (or did hh/unknown)
+                  :boundary    boundary-key
+                  :frames      frames}
+     :basis      :derivation
+     :complete?  false
+     :loss       {:reason :uncorrelated :dropped hh/unknown}
+     :links      links
+     :evidenced  (count (filter :evidenced? links))
+     :total      (count links)}))
+
+(defn slice-summary
+  "One line: how much of the chain this run could show.
+
+  Counts links and JOINS separately, because they answer different
+  questions and a reader who conflates them reads four green links as a
+  proven cause. The join count is the one that says whether the arrow
+  between two facts means anything."
+  [s]
+  (when s
+    (let [links (:links s)
+          joins (keep :joins links)]
+      (string/join " · "
+                   [(str (:evidenced s) " of " (:total s) " links evidenced")
+                    (str (count (filter #(= :evidenced (:status %)) joins))
+                         " of " (count joins) " joins evidenced")
+                    (str "dispatch " (hh/format-id (get-in s [:scope :dispatch-id])))]))))

--- a/tools/xray/src/day8/re_frame2_xray/panels/hicasso_causal.cljc
+++ b/tools/xray/src/day8/re_frame2_xray/panels/hicasso_causal.cljc
@@ -190,7 +190,7 @@
       {:id :subs-recomputed :ordinal 2 :label "subscriptions recomputed"
        :seam "the bundle's `:subs` trace events, keyed `:rf.sub/id`"
        :basis :observation
-       :evidenced? (or (seq named) (zero? unnamed))
+       :evidenced? (boolean (or (seq named) (zero? unnamed)))
        ;; An empty roster with no unnamed runs is a genuine survey result:
        ;; this dispatch recomputed nothing. An empty roster WITH unnamed
        ;; runs is not — work happened and joins to no subscription — so the

--- a/tools/xray/src/day8/re_frame2_xray/panels/hicasso_helpers.cljc
+++ b/tools/xray/src/day8/re_frame2_xray/panels/hicasso_helpers.cljc
@@ -246,7 +246,20 @@
     :says (str "There is no mounted boundary to explain. Why answers per "
                "boundary, so an empty roster here follows the mounted census "
                "and carries its qualifications — it is not a statement that "
-               "nothing has re-run.")}})
+               "nothing has re-run.")}
+   :advisor
+   {:testid-suffix "empty-advisor"
+    :says (str "There is no boundary to rank. The advisor ranks the mounted "
+               "census, so an empty roster here follows that census — it is "
+               "not a verdict that nothing is hot, and it says nothing at all "
+               "about lowering, React or layout, which this tab never "
+               "measures.")}
+   :causal
+   {:testid-suffix "empty-causal"
+    :says (str "There is no slice to draw: the advisor named no boundary to "
+               "trace, so there is no chain to walk. A slice needs a mounted "
+               "boundary AND a retained dispatch, and this is the first of "
+               "those two missing.")}})
 
 (def presence-copy
   "The sentence each non-live presence gets, and the testid it renders
@@ -490,8 +503,18 @@
 ;; ---------------------------------------------------------------------------
 
 (def sub-modes
-  "The tab's four views, in order — the four questions Spec SN §10 says a
-  developer actually asks, one sub-view each."
+  "The tab's six views, in order.
+
+  The first four are the questions Spec SN §10 says a developer asks of a
+  view substrate, one sub-view each. The last two are rf2-hic-037's: the
+  ADVISOR, which ranks and classifies and then refuses the routes its
+  evidence cannot support, and the CAUSAL slice, which walks §10's chain
+  link by link and labels every one it cannot evidence.
+
+  They are sub-views of this tab rather than a tab of their own because
+  they are derivations of exactly the same one-turn evidence — a second
+  tab would take a second turn, and a mount landing between the two would
+  give a ranking about a census the slice no longer agrees with."
   [{:id :mounted     :label "Mounted"     :mnem "m"
     :asks "which boundaries are mounted, over which frames"}
    {:id :attribution :label "Reads"       :mnem "r"
@@ -499,7 +522,11 @@
    {:id :intents     :label "Intents"     :mnem "i"
     :asks "what was dispatched, in order, inside the retained window"}
    {:id :explain     :label "Why"         :mnem "w"
-    :asks "which reads changed, and what that can and cannot prove"}])
+    :asks "which reads changed, and what that can and cannot prove"}
+   {:id :advisor     :label "Advisor"     :mnem "a"
+    :asks "which boundary is hot, what owns the pressure, and the smallest route that addresses it"}
+   {:id :causal      :label "Causal"      :mnem "c"
+    :asks "one dispatch, walked link by link from event to paint, with every missing link named"}])
 
 (def sub-mode-ids (into #{} (map :id) sub-modes))
 

--- a/tools/xray/src/day8/re_frame2_xray/panels/hicasso_reads.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/hicasso_reads.cljs
@@ -38,7 +38,8 @@
   Every read is `nil` in a production build: the Hicasso door nil-gates on
   `re-frame.interop/debug-enabled?`, and Xray itself never reaches a
   production bundle (the tools/README bundle-isolation contract)."
-  (:require [re-frame.hicasso.tool :as tool]))
+  (:require [re-frame.hicasso.tool :as tool]
+            [re-frame.trace.tooling :as trace-tooling]))
 
 (defn- soft
   "Call `f`, answering nil on any throw.
@@ -83,3 +84,45 @@
    :read-attribution   (read-attribution)
    :intents            (intents)
    :explain-render     (explain-render)})
+
+(defn trace-windows
+  "Spec 009's retained ring for every frame this Hicasso runtime touches,
+  as `{frame-id [event-bundle …]}` — the advisor's clock and the causal
+  slice's event seam (rf2-hic-037).
+
+  ## Why this read exists beside the four, rather than inside them
+
+  The Hicasso door deliberately carries no duration. Its four reads
+  project the substrate's own tables, and a clock is not one of them: per
+  `lanes/left-field-ideas.md` §Capability receipts, per-boundary self time
+  was KILLED as a decision rather than deferred, because the 0.1 ms timer
+  grain is coarser than the quantity being measured. What Spec 009 does
+  publish is `:rf.sub/elapsed-ms` on the reactive recompute path — the
+  cost of the SUBSCRIPTIONS a boundary reads, which is a different
+  quantity, honestly measured, and the only one of the five pressure
+  classes this tab can weigh.
+
+  So this is a SECOND producer, not a fifth Hicasso read, and it is kept
+  separate for that reason: `hicasso-advisor/sub-timing` stamps it with
+  its own schema and its own `:cap` loss, and a reader can see at a glance
+  which producer vouched for which number.
+
+  ## The frames come from the evidence, not from a guess
+
+  `explain-render`'s `:window :frames` is already the union this needs —
+  the frames the runtime dispatches through PLUS any frame a boundary
+  reads from — computed by the producer for exactly the same reason a
+  per-boundary window is scoped that way. Reading every frame in the
+  process instead would let an unrelated application's activity inflate
+  this one's ranking.
+
+  Answers `{}` when Hicasso is absent, which is the same shape an idle
+  runtime gives — and the advisor renders that as a capped window rather
+  than as a quiet application."
+  [envelopes]
+  (soft
+    (fn []
+      (let [frames (or (get-in envelopes [:explain-render :window :frames])
+                       (get-in envelopes [:intents :scope :frames])
+                       [])]
+        (into {} (map (fn [fid] [fid (trace-tooling/trace-buffer fid)])) frames)))))

--- a/tools/xray/test/day8/re_frame2_xray/panels/hicasso_advisor_cljs_test.cljc
+++ b/tools/xray/test/day8/re_frame2_xray/panels/hicasso_advisor_cljs_test.cljc
@@ -1,0 +1,407 @@
+(ns day8.re-frame2-xray.panels.hicasso-advisor-cljs-test
+  "The advisor's algebra — ranking, classification, and the refusal
+  (rf2-hic-037).
+
+  Pure data → data, so this namespace runs under the JVM target beside the
+  CLJS one. The claims that need a live runtime are in
+  `hicasso_causal_cljs_test`.
+
+  ## The load-bearing row is a PAIR
+
+  [[the-advisor-never-recommends-a-native-route-from-this-evidence]] asserts
+  a property over every classification the classifier can emit, and it
+  would be equally true of a `recommend` that answered `:measure-first`
+  unconditionally — which is a stub, not a finding.
+  [[the-native-ladder-is-real-and-the-refusal-is-about-the-EVIDENCE]] is
+  its non-vacuity control: handed an owner the door cannot measure, the
+  same table returns rungs 3, 4 and 5 with their steps. Read together they
+  say the thing that matters — the refusal comes from the instruments, not
+  from a missing arm."
+  (:require [clojure.string :as string]
+            #?(:clj  [clojure.test :refer [deftest is testing]]
+               :cljs [cljs.test :refer [deftest is testing]])
+            [day8.re-frame2-xray.panels.hicasso-advisor :as advisor]
+            [day8.re-frame2-xray.panels.hicasso-helpers :as hh]))
+
+;; ---------------------------------------------------------------------------
+;; Fixtures — envelopes and windows in the producers' own shapes
+;; ---------------------------------------------------------------------------
+
+(defn- mounted-envelope
+  [boundaries]
+  {:schema     hh/consumed-evidence-schema
+   :producer   hh/consumed-producer
+   :read       :mounted-boundaries
+   :scope      :mounted-boundaries
+   :basis      :observation
+   :complete?  true
+   :loss       nil
+   :boundaries boundaries})
+
+(defn- attribution-envelope
+  [edges]
+  {:schema    hh/consumed-evidence-schema
+   :producer  hh/consumed-producer
+   :read      :read-attribution
+   :scope     :read-edges
+   :basis     :observation
+   :complete? true
+   :loss      nil
+   :edges     edges})
+
+(defn- boundary
+  "One producer boundary row. `reads` is `[[frame-id sub-id] …]`."
+  [reads & {:keys [instances read-orders] :or {instances 1 read-orders 1}}]
+  {:boundary    {:parent nil
+                 :key    (mapv (fn [[f s]] [f s [s]]) reads)}
+   :view        hh/unknown
+   :source      hh/unknown
+   :instances   instances
+   :read-orders read-orders
+   :frame       (ffirst reads)
+   :reads       (mapv (fn [[f s]] {:sub-id s :query [s] :frame-id f :epoch 1}) reads)})
+
+(defn- sub-ev
+  "One `:rf.sub/run` trace event, in Spec 009's own shape."
+  ([sub-id ms] (sub-ev sub-id ms :rf.sub/run))
+  ([sub-id ms op]
+   {:op-type   :rf.sub
+    :operation op
+    :tags      (cond-> {:rf.sub/id sub-id}
+                 (number? ms) (assoc :rf.sub/elapsed-ms ms))}))
+
+(defn- bundle
+  [dispatch-id event-id subs]
+  {:dispatch-id dispatch-id
+   :event       [event-id]
+   :subs        subs})
+
+;; ---------------------------------------------------------------------------
+;; The timing digest
+;; ---------------------------------------------------------------------------
+
+(deftest an-untimed-recompute-is-UNKNOWN-and-never-zero
+  ;; Spec 009 puts `:rf.sub/elapsed-ms` on the reactive recompute path and
+  ;; NOT on the pure `compute-sub` form. A fold that read the missing tag
+  ;; as zero would report a subscription it never timed as instantaneous —
+  ;; and the reader would then rank it LAST, which is the loudest possible
+  ;; version of the `unknown is never zero` mistake.
+  (let [t (advisor/sub-timing {:app/main [(bundle 1 :e [(sub-ev :slow nil)
+                                                        (sub-ev :slow nil)])]})
+        e (get-in t [:by-read [:app/main :slow]])]
+    (is (= 2 (:runs e)) "the runs really happened and are counted")
+    (is (nil? (:timed-runs e)) "none of them carried a duration")
+    (is (= 2 (:untimed-runs e)))
+    (is (nil? (:elapsed-ms e)) "no duration was summed"))
+
+  (testing "and the boundary's time axis states unknown, with the reason"
+    (let [adv (advisor/advise
+                {:mounted-boundaries (mounted-envelope [(boundary [[:app/main :slow]])])}
+                (advisor/sub-timing {:app/main [(bundle 1 :e [(sub-ev :slow nil)])]}))
+          ax  (get-in (first (:rows adv)) [:axes :time])]
+      (is (hh/unknown? (:ms ax)) "unknown, not 0.0")
+      (is (= :uncorrelated (:reason (:loss ax)))
+          (str "the recomputes are observed and it is the DURATION that joins "
+               "to nothing — reporting a cap would send the reader to the "
+               "retention knob, which is not the remedy")))))
+
+(deftest a-memo-hit-is-counted-and-never-summed-as-work
+  (let [t (advisor/sub-timing
+            {:app/main [(bundle 1 :e [(sub-ev :a 2.0)
+                                      (sub-ev :a nil :rf.sub/skip)
+                                      (sub-ev :a nil :rf.sub/skip)])]})
+        e (get-in t [:by-read [:app/main :a]])]
+    (is (= 1 (:runs e)) "a skip is not a run")
+    (is (= 2.0 (:elapsed-ms e)) "and contributes no time")
+    (is (= 2 (:memo-hits e))
+        (str "counted, because a read whose runs are mostly skips is "
+             "well-placed and one that runs every time is not — the single "
+             "most informative topology signal there is"))))
+
+(deftest a-run-with-no-registration-id-is-UNCORRELATED-not-dropped
+  ;; An untagged stream must not be able to read as an idle one.
+  (let [t (advisor/sub-timing {:app/main [(bundle 1 :e [{:op-type :rf.sub
+                                                         :operation :rf.sub/run
+                                                         :tags {}}])]})]
+    (is (= 1 (:unnamed-runs t)))
+    (is (= :uncorrelated (:reason (:unnamed-loss t))))
+    (is (= 1 (:dropped (:unnamed-loss t))))))
+
+(deftest the-window-is-scoped-per-FRAME
+  ;; Two frames are two applications. Summing frame B's clock into frame
+  ;; A's ranking would make an idle boundary look hot because something
+  ;; unrelated was busy next door — the same defect `explain-render`
+  ;; scopes its leads against (audit #7789).
+  (let [t (advisor/sub-timing {:app/a [(bundle 1 :e [(sub-ev :shared 5.0)])]
+                               :app/b [(bundle 2 :e [(sub-ev :shared 50.0)])]})]
+    (is (= 5.0  (get-in t [:by-read [:app/a :shared] :elapsed-ms])))
+    (is (= 50.0 (get-in t [:by-read [:app/b :shared] :elapsed-ms])))
+    (is (nil? (get-in t [:by-read [:shared]]))
+        "there is no frame-free key to sum into")))
+
+;; ---------------------------------------------------------------------------
+;; Ranking — four axes in four units, and the order stated out loud
+;; ---------------------------------------------------------------------------
+
+(deftest the-top-three-match-a-hand-profile
+  ;; The acceptance row. Three boundaries with deliberately different
+  ;; profiles, ranked against a profile computed by hand from the window
+  ;; below — not against whatever the implementation happens to answer.
+  ;;
+  ;;   :hot    reads [:app/main :heavy]  — 3 runs × 4.0 ms = 12.0 ms
+  ;;   :middle reads [:app/main :medium] — 2 runs × 1.0 ms =  2.0 ms
+  ;;   :cheap  reads [:app/main :light]  — 6 runs × 0.05ms =  0.3 ms
+  ;;
+  ;; So by time: hot, middle, cheap. By FREQUENCY the order inverts —
+  ;; cheap runs twice as often as hot — which is why the roster has to say
+  ;; which axis it sorted on.
+  (let [windows {:app/main (concat (repeat 3 (bundle 1 :e [(sub-ev :heavy 4.0)]))
+                                   (repeat 2 (bundle 2 :e [(sub-ev :medium 1.0)]))
+                                   (repeat 6 (bundle 3 :e [(sub-ev :light 0.05)])))}
+        adv     (advisor/advise
+                  {:mounted-boundaries
+                   (mounted-envelope [(boundary [[:app/main :light]])
+                                      (boundary [[:app/main :heavy]])
+                                      (boundary [[:app/main :medium]])])}
+                  (advisor/sub-timing windows))
+        ids     (mapv #(get-in % [:attributable :edges 0 :sub-id]) (:rows adv))]
+    (is (= [:heavy :medium :light] ids)
+        "ranked by attributable subscription time, highest first")
+    (is (= [1 2 3] (mapv :rank (:rows adv))))
+    (is (= :time (get-in adv [:ordered-by :axis])))
+
+    (testing "and the frequency axis really does disagree, so the sort matters"
+      (is (= [3 2 6] (mapv #(get-in % [:axes :frequency :runs]) (:rows adv)))
+          (str "the cheapest boundary recomputes twice as often as the "
+               "hottest — a roster sorted on the wrong axis would put it "
+               "first and be defensible about it")))))
+
+(deftest with-no-clock-the-roster-says-so-rather-than-implying-time
+  (let [adv (advisor/advise
+              {:mounted-boundaries (mounted-envelope [(boundary [[:app/main :a]])
+                                                      (boundary [[:app/main :b]])])}
+              (advisor/sub-timing
+                {:app/main [(bundle 1 :e [(sub-ev :a nil) (sub-ev :b nil) (sub-ev :b nil)])]}))]
+    (is (= :frequency (get-in adv [:ordered-by :axis])))
+    (is (string/includes? (get-in adv [:ordered-by :says]) "NOT by time"))
+    (is (= [:b :a] (mapv #(get-in % [:attributable :edges 0 :sub-id]) (:rows adv)))
+        "ordered by recompute count, the only axis that survived")
+    (is (string/includes? (advisor/advice-summary adv) "NOT by time")
+        "and the summary line carries it too — this is not a footnote")))
+
+(deftest the-advice-envelope-is-never-complete
+  ;; The roster covers every mounted boundary, but the QUESTION is *where
+  ;; is the pressure*, and three of its five answers are outside this
+  ;; door. A `:complete? true` here would be the schema's own fail-open
+  ;; shape, written by the one function best placed to know better.
+  (let [adv (advisor/advise
+              {:mounted-boundaries (mounted-envelope [(boundary [[:app/main :a]])])}
+              (advisor/sub-timing {:app/main [(bundle 1 :e [(sub-ev :a 9.0)])]}))]
+    (is (false? (:complete? adv)))
+    (is (= :host-opaque (:reason (:loss adv))))
+    (is (= advisor/advice-schema (:schema adv)))
+    (is (= :re-frame2/xray (:producer adv))
+        (str "Xray derived it and Hicasso did not — stamping the producer's "
+             "schema would tell a reader Hicasso vouched for a ranking it has "
+             "never seen"))))
+
+;; ---------------------------------------------------------------------------
+;; Classification — four outcomes, driven
+;; ---------------------------------------------------------------------------
+
+(defn- classify-with
+  "Run the classifier over a window built to a named profile."
+  [boundary-row windows]
+  (let [adv (advisor/advise {:mounted-boundaries (mounted-envelope [boundary-row])}
+                            (advisor/sub-timing windows))]
+    (:class (first (:rows adv)))))
+
+(deftest a-dominant-measured-subscription-is-CLASSIFIED-computation
+  (let [c (classify-with (boundary [[:app/main :heavy] [:app/main :trivial]])
+                         {:app/main [(bundle 1 :e [(sub-ev :heavy 8.0)
+                                                   (sub-ev :trivial 0.1)])]})]
+    (is (= :computation (:owner c)))
+    (is (= :observation (:basis c)) "measured, not derived")
+    (is (= :heavy (get-in c [:read :sub-id])))
+    (is (nil? (:loss c)))))
+
+(deftest a-spread-of-time-is-not-a-computation-finding
+  ;; 55/45 across two reads. The remedy is the read SET, not either member
+  ;; of it — so this must not be reported as a hot subscription.
+  (let [c (classify-with (boundary [[:app/main :a] [:app/main :b]])
+                         {:app/main (repeat 2 (bundle 1 :e [(sub-ev :a 5.5)
+                                                            (sub-ev :b 4.5)]))})]
+    (is (not= :computation (:owner c))
+        (str "neither read holds " advisor/dominance " of the total, so naming "
+             "one the owner would be a coin toss printed as a finding"))))
+
+(deftest an-oscillating-read-set-is-a-topology-finding-with-no-clock-at-all
+  (let [c (classify-with (boundary [[:app/main :a]] :read-orders 4)
+                         {:app/main [(bundle 1 :e [(sub-ev :a nil)])]})]
+    (is (= :read-topology (:owner c)))
+    (is (= :derivation (:basis c)))
+    (is (string/includes? (:says c) "oscillating"))))
+
+(deftest repeated-recomputes-for-negligible-work-are-a-topology-finding
+  (let [c (classify-with (boundary [[:app/main :a]])
+                         {:app/main (repeat 5 (bundle 1 :e [(sub-ev :a 0.05)]))})]
+    (is (= :read-topology (:owner c)))
+    (is (= :derivation (:basis c)))
+    (is (string/includes? (:says c) "bringing it back"))))
+
+(deftest a-searched-window-that-explains-nothing-is-HOST-OPAQUE-not-CAPPED
+  ;; The pair a naive advisor collapses. One remedy is free (raise the
+  ;; retention knob); the other is a change of INSTRUMENT. A tool that
+  ;; printed one sentence for both would send half its readers to the
+  ;; wrong place.
+  (let [searched (classify-with (boundary [[:app/main :a]])
+                                {:app/main [(bundle 1 :e [(sub-ev :a 0.05)])]})
+        capped   (classify-with (boundary [[:app/main :a]]) {:app/main []})]
+    (is (= :unattributed (:owner searched)))
+    (is (= :host-opaque (:basis searched)))
+    (is (= :unattributed (:owner capped)))
+    (is (= :cap (:basis capped)))
+    (is (not= (:says searched) (:says capped))
+        "two states, two sentences")
+    (is (string/includes? (:says capped) "absence of evidence"))
+    (is (string/includes? (:says searched) "lowering, React or layout"))))
+
+;; ---------------------------------------------------------------------------
+;; THE REFUSAL — and its non-vacuity control
+;; ---------------------------------------------------------------------------
+
+(def ^:private classification-space
+  "Every classification [[advisor/classify]] can emit, driven from real
+  windows rather than hand-built maps.
+
+  Built from profiles rather than enumerated as literals, because the
+  claim below is about what the CLASSIFIER produces: a hand-written list
+  could silently stop covering an arm the classifier grew."
+  (let [profiles
+        [[(boundary [[:app/main :heavy]])
+          {:app/main [(bundle 1 :e [(sub-ev :heavy 8.0)])]}]
+         [(boundary [[:app/main :a]] :read-orders 4)
+          {:app/main [(bundle 1 :e [(sub-ev :a nil)])]}]
+         [(boundary [[:app/main :a]])
+          {:app/main (repeat 5 (bundle 1 :e [(sub-ev :a 0.05)]))}]
+         [(boundary [[:app/main :a]])
+          {:app/main [(bundle 1 :e [(sub-ev :a 0.05)])]}]
+         [(boundary [[:app/main :a]]) {:app/main []}]
+         [(boundary []) {:app/main []}]
+         [(boundary [[:app/main :a] [:app/b :c]])
+          {:app/main [(bundle 1 :e [(sub-ev :a 0.4)])]
+           :app/b    [(bundle 2 :e [(sub-ev :c 0.4)])]}]]]
+    (mapv (fn [[b w]] (classify-with b w)) profiles)))
+
+(deftest the-advisor-never-recommends-a-native-route-from-this-evidence
+  ;; Spec SN §10: *it recommends native extraction only when it addresses
+  ;; the measured owner.* Every native rung addresses lowering, hooks,
+  ;; vendor behaviour or reconciliation, and this door observes none of
+  ;; them — so the honest consequence is that no classification reachable
+  ;; from this evidence selects one.
+  ;;
+  ;; A property over the classifier's whole output, not three fixtures.
+  (is (seq classification-space) "the space must be non-empty to test anything")
+  (doseq [c classification-space]
+    (let [r (advisor/recommend c)]
+      (is (false? (:native? r))
+          (str "owner " (:owner c) "/" (:basis c) " selected " (:route r)
+               ", a native route, from evidence that cannot say whether it "
+               "helps"))
+      (is (not (contains? #{:direct-element :native-island :native-screen} (:route r))))))
+
+  (testing "and the owners the native rungs answer to are UNREACHABLE from here"
+    (is (= #{:computation :read-topology :unattributed}
+           (into #{} (map :owner) classification-space))
+        (str "if the classifier ever emits :lowering, :react-work or "
+             ":react-shaped, this door has grown an instrument it did not "
+             "have — and the ladder will route to it"))))
+
+(deftest the-native-ladder-is-real-and-the-refusal-is-about-the-EVIDENCE
+  ;; THE NON-VACUITY CONTROL. The row above would be equally true of a
+  ;; `recommend` that answered `:measure-first` unconditionally, which is
+  ;; a stub. Hand the same table an owner the door cannot measure and it
+  ;; answers the ladder — so the refusal is a statement about the
+  ;; instruments, not about a missing arm.
+  (doseq [[owner route rung] [[:lowering     :direct-element 3]
+                              [:react-work   :native-island  4]
+                              [:react-shaped :native-screen  5]]]
+    (let [r (advisor/recommend {:owner owner :basis :observation :loss nil
+                                :says "measured elsewhere"})]
+      (is (= route (:route r)))
+      (is (= rung (:rung r)))
+      (is (true? (:native? r)))
+      (is (seq (:working-loop r)) "with its steps attached")
+      (is (nil? (:refusal r))))))
+
+(deftest the-refusal-names-the-instrument-for-each-candidate
+  ;; A refusal with a next step, not a shrug.
+  (let [c (classify-with (boundary [[:app/main :a]])
+                         {:app/main [(bundle 1 :e [(sub-ev :a 0.05)])]})
+        r (advisor/recommend c)]
+    (is (= :measure-first (:route r)))
+    (is (= [:direct-element :native-island :native-screen]
+           (get-in r [:refusal :refused])))
+    (is (= [:lowering :react :layout]
+           (mapv :class (get-in r [:refusal :next]))))
+    (doseq [n (get-in r [:refusal :next])]
+      (is (string? (:authority n)))
+      (is (not (string/includes? (:authority n) "Xray"))
+          (str "Xray must not be nominated as the authority for a class it "
+               "does not measure")))))
+
+(deftest a-computation-owner-is-routed-BELOW-the-view-substrate
+  ;; The other half of the same rule. The measured owner here is the
+  ;; subscription body, which runs below the boundary — so every native
+  ;; route would move the markup and keep the cost.
+  (let [c (classify-with (boundary [[:app/main :heavy]])
+                         {:app/main [(bundle 1 :e [(sub-ev :heavy 8.0)])]})
+        r (advisor/recommend c)]
+    (is (= :narrow-the-subscription (:route r)))
+    (is (false? (:native? r)))
+    (is (string/includes? (:says r) "keep the cost"))))
+
+(deftest a-topology-owner-is-routed-to-rung-2-and-no-further
+  (let [c (classify-with (boundary [[:app/main :a]] :read-orders 3)
+                         {:app/main [(bundle 1 :e [(sub-ev :a nil)])]})
+        r (advisor/recommend c)]
+    (is (= :tune-topology (:route r)))
+    (is (= 2 (:rung r)))
+    (is (false? (:native? r)))
+    (is (string/includes? (:says r) "Do not split per element mechanically")
+        "the ladder's own warning rides with the advice")))
+
+(deftest a-capped-boundary-is-told-to-widen-the-window-not-to-measure-react
+  (let [r (advisor/recommend (classify-with (boundary [[:app/main :a]]) {:app/main []}))]
+    (is (= :measure-first (:route r)))
+    (is (= :cap (get-in r [:refusal :reason])))
+    (is (string/includes? (:says r) "events-retained"))
+    (is (not (string/includes? (:says r) "DevTools"))
+        (str "a capped window is a knob setting, and sending its reader to "
+             "another tool would waste the free remedy"))))
+
+;; ---------------------------------------------------------------------------
+;; Fan-out and the shape of the roster
+;; ---------------------------------------------------------------------------
+
+(deftest fan-out-is-summed-across-the-cells-a-boundary-reads
+  (let [adv (advisor/advise
+              {:mounted-boundaries (mounted-envelope [(boundary [[:app/main :a] [:app/main :b]])])
+               :read-attribution   (attribution-envelope
+                                     [{:sub-id :a :query [:a] :frame-id :app/main
+                                       :epoch 1 :fan-out 3 :readers []}
+                                      {:sub-id :b :query [:b] :frame-id :app/main
+                                       :epoch 1 :fan-out 4 :readers []}
+                                      {:sub-id :a :query [:a] :frame-id :other
+                                       :epoch 1 :fan-out 99 :readers []}])}
+              (advisor/sub-timing {}))]
+    (is (= 7 (get-in (first (:rows adv)) [:axes :fan-out :total]))
+        "3 + 4 — and never the 99, which is another frame's cell")))
+
+(deftest an-absent-door-yields-an-empty-roster-and-still-states-what-is-unmeasured
+  (let [adv (advisor/advise {:mounted-boundaries nil} (advisor/sub-timing {}))]
+    (is (= [] (:rows adv)))
+    (is (= 3 (count (:unmeasured adv)))
+        (str "the three unmeasured classes are stated whether or not there is "
+             "a roster — a reader who saw them only when the roster was empty "
+             "would read a populated one as complete"))))

--- a/tools/xray/test/day8/re_frame2_xray/panels/hicasso_advisor_cljs_test.cljc
+++ b/tools/xray/test/day8/re_frame2_xray/panels/hicasso_advisor_cljs_test.cljc
@@ -18,6 +18,7 @@
   say the thing that matters — the refusal comes from the instruments, not
   from a missing arm."
   (:require [clojure.string :as string]
+            #?(:cljs [cljs.reader])
             #?(:clj  [clojure.test :refer [deftest is testing]]
                :cljs [cljs.test :refer [deftest is testing]])
             [day8.re-frame2-xray.panels.hicasso-advisor :as advisor]
@@ -397,6 +398,24 @@
               (advisor/sub-timing {}))]
     (is (= 7 (get-in (first (:rows adv)) [:axes :fan-out :total]))
         "3 + 4 — and never the 99, which is another frame's cell")))
+
+(deftest the-advisor-ADVISES-and-carries-nothing-executable
+  ;; The bead's own words: it never rewrites code and never switches
+  ;; semantics. Structurally that is a property of the VALUE — advice made
+  ;; of readable EDN cannot carry a patch, a thunk or a rewrite, and it
+  ;; round-trips through the reader unchanged.
+  (let [envelopes {:mounted-boundaries (mounted-envelope [(boundary [[:app/main :a]])])}
+        timing    (advisor/sub-timing {:app/main [(bundle 1 :e [(sub-ev :a 4.0)])]})
+        adv       (advisor/advise envelopes timing)]
+    (is (= adv #?(:clj (read-string (pr-str adv))
+                  :cljs (cljs.reader/read-string (pr-str adv))))
+        (str "the whole advice round-trips through the reader — so it is "
+             "data a reader can inspect, print and diff, and not a closure "
+             "that could do something"))
+    (testing "and it is deterministic over one turn's evidence"
+      (is (= adv (advisor/advise envelopes timing))))
+    (testing "and reading it does not disturb what it read"
+      (is (= envelopes {:mounted-boundaries (mounted-envelope [(boundary [[:app/main :a]])])})))))
 
 (deftest an-absent-door-yields-an-empty-roster-and-still-states-what-is-unmeasured
   (let [adv (advisor/advise {:mounted-boundaries nil} (advisor/sub-timing {}))]

--- a/tools/xray/test/day8/re_frame2_xray/panels/hicasso_causal_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panels/hicasso_causal_cljs_test.cljs
@@ -1,0 +1,449 @@
+(ns day8.re-frame2-xray.panels.hicasso-causal-cljs-test
+  "ONE causal slice on a REAL interaction, with every evidenced link
+  mutation-tested (rf2-hic-037).
+
+  ## What a mutation test is for here
+
+  A causal display that renders `evidenced` from a seam it is not actually
+  reading is worse than one that renders `unknown`, and on a healthy
+  application the two are indistinguishable from the outside. So each of
+  the four evidenced links has a row below that BREAKS its seam and
+  asserts the link stops being evidenced — degrading to a stated loss,
+  never to a confident wrong answer, and never borrowing a neighbouring
+  seam to keep its colour.
+
+  Every sabotage carries its positive control in the same row. A sabotage
+  that reds a link which was never green proves nothing about the link;
+  it proves the fixture was broken. So each row asserts the link IS
+  evidenced first, on the same runtime, before breaking anything.
+
+  ## The runtime is real
+
+  Boundaries are mounted through the actual commit seam and the events are
+  actual dispatches through the actual router, so the ring below holds
+  bundles the framework put there. Two sabotages act on the SEAM'S OWN
+  DATA rather than on the runtime — the `:rf.sub/id` tag, and the
+  attribution envelope — because those are the seams, and a runtime that
+  could be talked out of stamping a trace tag would be a different bead.
+  The events they carry are otherwise the runtime's own.
+
+  Normative owner: `tools/xray/spec/028-Hicasso-Advisor.md`."
+  (:require [cljs.test :refer [deftest is testing use-fixtures]]
+            [clojure.string :as string]
+            [day8.re-frame2-xray.panels.hicasso :as hicasso]
+            [day8.re-frame2-xray.panels.hicasso-advisor :as advisor]
+            [day8.re-frame2-xray.panels.hicasso-causal :as causal]
+            [day8.re-frame2-xray.panels.hicasso-helpers :as hh]
+            [day8.re-frame2-xray.panels.hicasso-reads :as reads]
+            [day8.re-frame2-xray.registry :as registry]
+            [day8.re-frame2-xray.test-support :as xray-test-support]
+            [re-frame.adapter.uix :as uix-adapter]
+            [re-frame.core :as rf]
+            [re-frame.hicasso :as h]
+            [re-frame.hicasso.impl.collector :as collector]
+            [re-frame.trace.tooling :as trace-tooling]))
+
+(def ^:private app-frame ::causal-app)
+
+(rf/reg-sub :hcaus/left  (fn [db _] (:left db)))
+(rf/reg-sub :hcaus/right (fn [db _] (:right db)))
+(rf/reg-event :hcaus/seed (fn [_ [_ db]] {:db db}))
+(rf/reg-event :hcaus/bump (fn [{:keys [db]} _] {:db (update db :left inc)}))
+
+;; See `hicasso_cljs_test`'s fixture note: the UIx adapter is required
+;; because Hicasso's cell wiring calls `add-watch` on the substrate's
+;; derived value, and the `:once` restore is load-bearing because
+;; `install-adapter!` is process-global.
+(use-fixtures :once
+  (fn [run-tests]
+    (run-tests)
+    ((xray-test-support/make-xray-runtime-fixture) (fn []))))
+
+(use-fixtures :each
+  (xray-test-support/make-xray-runtime-fixture
+    {:adapter    uix-adapter/adapter
+     :post-reset (fn [] (collector/reset-runtime!))}))
+
+;; ---------------------------------------------------------------------------
+;; Harness
+;; ---------------------------------------------------------------------------
+
+(declare expand-fn-component)
+
+(defn- expand-children [node]
+  (cond
+    (vector? node) (mapv expand-fn-component node)
+    (seq? node)    (map  expand-fn-component node)
+    :else          node))
+
+(defn- expand-fn-component [node]
+  (if (and (vector? node) (fn? (first node)))
+    (expand-children (apply (first node) (rest node)))
+    (expand-children node)))
+
+(defn- hiccup-seq [tree]
+  (tree-seq (some-fn vector? seq?) seq (expand-fn-component tree)))
+
+(defn- testids [tree]
+  (into #{}
+        (keep (fn [node]
+                (when (and (vector? node) (map? (second node)))
+                  (:data-testid (second node)))))
+        (hiccup-seq tree)))
+
+(defn- text-of [tree]
+  (->> (hiccup-seq tree) (filter string?) (string/join " ")))
+
+(defn- setup! []
+  (registry/register-xray-handlers!)
+  (rf/make-frame {:id :rf/xray})
+  (set! (.-IS_REACT_ACT_ENVIRONMENT js/globalThis) false)
+  (rf/make-frame {:id app-frame})
+  (rf/with-frame app-frame
+    (rf/dispatch-sync [:hcaus/seed {:left 1 :right 2}]))
+  nil)
+
+(defn- mount!
+  "A real boundary, rendered and committed through the real commit seam."
+  [body-fn]
+  (collector/render-body app-frame body-fn {})
+  (collector/commit-boundary! (collector/last-reads) (fn [])))
+
+(defn- interact!
+  "One real user interaction: a dispatch through the real router, which
+  moves app-db, recomputes the reads that depend on it, and lands in the
+  frame's own Spec 009 ring."
+  []
+  (rf/with-frame app-frame (rf/dispatch-sync [:hcaus/bump])))
+
+(defn- evidence! []
+  (reads/evidence))
+
+(defn- windows! [envelopes]
+  (or (reads/trace-windows envelopes) {}))
+
+(defn- slice!
+  "The slice for the FIRST mounted boundary, on the newest retained
+  dispatch — exactly what the panel draws."
+  ([] (slice! {}))
+  ([{:keys [envelopes windows boundary-key]}]
+   (let [e  (or envelopes (evidence!))
+         w  (or windows (windows! e))
+         bk (or boundary-key
+                (get-in e [:mounted-boundaries :boundaries 0 :boundary :key]))]
+     (causal/slice {:envelopes e :windows w :boundary-key bk}))))
+
+(defn- link [s id]
+  (first (filter #(= id (:id %)) (:links s))))
+
+(defn- show!
+  [view]
+  (rf/with-frame :rf/xray
+    (rf/dispatch-sync [:rf.xray.hicasso/set-view view])
+    (rf/clear-sub-cache! :rf/xray)
+    (hicasso/Panel)))
+
+;; ---------------------------------------------------------------------------
+;; The positive control — the whole chain, on a real interaction
+;; ---------------------------------------------------------------------------
+
+(deftest the-chain-is-seven-links-and-only-its-prefix-is-evidenced
+  (setup!)
+  (let [release (mount! (fn [_] (h/sub [:hcaus/left]) nil))
+        _       (interact!)
+        s       (slice!)]
+    (is (= 7 (:total s)))
+    (is (= [:event :subs-recomputed :values-changed :boundaries-notified
+            :bodies-run :react-commit :paint]
+           (mapv :id (:links s)))
+        "Spec SN §10's chain, in its own order")
+
+    (testing "links 1-4 are evidenced on a real interaction"
+      (doseq [id [:event :subs-recomputed :values-changed :boundaries-notified]]
+        (is (true? (:evidenced? (link s id)))
+            (str id " must be evidenced on a healthy run — otherwise every "
+                 "sabotage below proves only that the fixture is broken"))))
+
+    (testing "links 5-7 are host-opaque, always, and each names its own authority"
+      (doseq [id [:bodies-run :react-commit :paint]]
+        (let [l (link s id)]
+          (is (false? (:evidenced? l)))
+          (is (= :host-opaque (:basis l)))
+          (is (hh/unknown? (:holds l)))
+          (is (string? (:authority l)))))
+      (is (= 3 (count (into #{} (map #(:says (link s %)))
+                            [:bodies-run :react-commit :paint])))
+          (str "three different absences with three different authorities — a "
+               "reader deciding what to open next needs to know which one "
+               "they are missing")))
+
+    (testing "the envelope never claims the chain from its prefix"
+      (is (false? (:complete? s)))
+      (is (= :uncorrelated (:reason (:loss s)))))
+    (release)))
+
+(deftest the-2-to-3-join-is-UNCORRELATED-even-when-both-links-are-solid
+  ;; THE FINDING. A sub really recomputed and a cell's epoch really moved,
+  ;; and nothing joins them: an epoch stamp carries no dispatch id and
+  ;; Hicasso's commit seam records no cascade id. A chain of green links
+  ;; with the join left implicit is exactly the adjacency-as-cause the
+  ;; producer refuses one layer down.
+  (setup!)
+  (let [release (mount! (fn [_] (h/sub [:hcaus/left]) nil))
+        _       (interact!)
+        s       (slice!)]
+    (is (true? (:evidenced? (link s :subs-recomputed))))
+    (is (true? (:evidenced? (link s :values-changed))))
+    (is (= :uncorrelated (get-in (link s :values-changed) [:joins :status]))
+        "two solid facts, joined by nothing")
+    (is (= :evidenced (get-in (link s :subs-recomputed) [:joins :status]))
+        (str "while the 1→2 join IS evidenced — the ring GROUPS by "
+             "dispatch-id, so that join is the storage rather than an "
+             "inference"))
+    (testing "and the summary counts links and joins separately"
+      (let [summary (causal/slice-summary s)]
+        (is (string/includes? summary "links evidenced"))
+        (is (string/includes? summary "joins evidenced")
+            (str "a reader who conflates the two reads four green links as a "
+                 "proven cause"))))
+    (release)))
+
+;; ---------------------------------------------------------------------------
+;; MUTATION 1 — the event seam: Spec 009's retained ring
+;; ---------------------------------------------------------------------------
+
+(deftest breaking-the-ring-stops-the-event-link-being-evidenced
+  (setup!)
+  (let [release (mount! (fn [_] (h/sub [:hcaus/left]) nil))
+        _       (interact!)
+        before  (slice!)]
+    (is (true? (:evidenced? (link before :event)))
+        "POSITIVE CONTROL — the link is green before the sabotage")
+    (is (not (hh/unknown? (get-in (link before :event) [:holds :event-id]))))
+
+    ;; SABOTAGE: release the ring. The dispatch happened; the seam that
+    ;; carried it no longer holds it.
+    (trace-tooling/clear-trace-buffer! app-frame)
+    (let [after (slice!)
+          l     (link after :event)]
+      (is (false? (:evidenced? l)) "the link must stop being evidenced")
+      (is (= :cap (:basis l)))
+      (is (hh/unknown? (:holds l))
+          "and must not fall back to an event id from anywhere else")
+      (is (string/includes? (:says l) "capped window")
+          "a capped window, never a dispatch that did not happen")
+
+      (testing "and link 2 degrades with it rather than inventing a roster"
+        (is (hh/unknown? (:holds (link after :subs-recomputed))))
+        (is (= :cap (get-in (link after :subs-recomputed) [:joins :status])))))
+    (release)))
+
+;; ---------------------------------------------------------------------------
+;; MUTATION 2 — the sub-recompute seam: the `:rf.sub/id` tag
+;; ---------------------------------------------------------------------------
+
+(defn- strip-sub-ids
+  "The runtime's OWN window with one seam broken: every sub event keeps
+  its operation, its duration and its dispatch, and loses the tag that
+  says which subscription it was."
+  [windows]
+  (into {}
+        (map (fn [[fid bundles]]
+               [fid (mapv (fn [b]
+                            (update b :subs
+                                    (fn [evs] (mapv #(update % :tags dissoc :rf.sub/id) evs))))
+                          bundles)]))
+        windows))
+
+(deftest an-untagged-recompute-is-UNKNOWN-and-never-an-empty-roster
+  (setup!)
+  (let [release   (mount! (fn [_] (h/sub [:hcaus/left]) nil))
+        _         (interact!)
+        envelopes (evidence!)
+        windows   (windows! envelopes)
+        before    (slice! {:envelopes envelopes :windows windows})]
+    (is (true? (:evidenced? (link before :subs-recomputed)))
+        "POSITIVE CONTROL")
+    (is (seq (:holds (link before :subs-recomputed)))
+        "and it really named some subscriptions")
+
+    ;; SABOTAGE: the runtime's own events, minus the one tag that joins a
+    ;; run to a subscription.
+    (let [after (slice! {:envelopes envelopes :windows (strip-sub-ids windows)})
+          l     (link after :subs-recomputed)]
+      (is (false? (:evidenced? l)))
+      (is (hh/unknown? (:holds l))
+          (str "UNKNOWN, never `[]` — work happened and joins to nothing, and "
+               "an empty roster would say this dispatch recomputed nothing, "
+               "which is the one substitution the evidence schema exists to "
+               "refuse"))
+      (is (= :uncorrelated (:reason (:loss l))))
+      (is (pos? (:dropped (:loss l))) "with a count of what could not be named")
+
+      (testing "and the runs are still reported as having happened"
+        (is (string/includes? (:says l) "join to no subscription"))))
+    (release)))
+
+;; ---------------------------------------------------------------------------
+;; MUTATION 3 — the value-change seam: the cells' epoch stamps
+;; ---------------------------------------------------------------------------
+
+(deftest a-boundary-with-no-epoch-cannot-have-values-that-changed
+  (setup!)
+  (let [reading (mount! (fn [_] (h/sub [:hcaus/left]) nil))
+        silent  (mount! (fn [_] nil))
+        _       (interact!)
+        e       (evidence!)
+        w       (windows! e)
+        keys*   (mapv #(get-in % [:boundary :key]) (get-in e [:mounted-boundaries :boundaries]))
+        reading-key (first (filter seq keys*))
+        empty-key   (first (filter empty? keys*))]
+    (is (some? reading-key) "the reading boundary is in the census")
+    (is (some? empty-key) "and so is the read-free one — it claims an entry too")
+
+    (testing "POSITIVE CONTROL — the reading boundary's values-changed is evidenced"
+      (let [l (link (slice! {:envelopes e :windows w :boundary-key reading-key})
+                    :values-changed)]
+        (is (true? (:evidenced? l)))
+        (is (number? (get-in l [:holds :peak-epoch])))))
+
+    (testing "the read-free boundary's is not, and says why in ITS OWN terms"
+      (let [s (slice! {:envelopes e :windows w :boundary-key empty-key})
+            l (link s :values-changed)]
+        (is (false? (:evidenced? l)))
+        (is (hh/unknown? (:holds l)))
+        (is (string/includes? (:says l) "not a gap in the instrument")
+            (str "a boundary that holds no read is a FACT about the boundary, "
+                 "and reporting it as a missing instrument would send the "
+                 "reader looking for a knob"))
+
+        (testing "and link 4 follows it down rather than naming readers anyway"
+          (is (false? (:evidenced? (link s :boundaries-notified))))
+          (is (hh/unknown? (:holds (link s :boundaries-notified)))))))
+    (reading)
+    (silent)))
+
+;; ---------------------------------------------------------------------------
+;; MUTATION 4 — the notify seam: the cells' reader arrays
+;; ---------------------------------------------------------------------------
+
+(deftest without-the-reverse-edge-the-notified-set-is-UNKNOWN-not-borrowed
+  ;; The dangerous substitution. The mounted census carries each
+  ;; boundary's own reads, so a plausible-looking notified set could be
+  ;; assembled from it — and it would be the FORWARD edge, printed under
+  ;; the reverse edge's name.
+  (setup!)
+  (let [release (mount! (fn [_] (h/sub [:hcaus/left]) nil))
+        _       (interact!)
+        e       (evidence!)
+        w       (windows! e)
+        before  (slice! {:envelopes e :windows w})]
+    (is (true? (:evidenced? (link before :boundaries-notified)))
+        "POSITIVE CONTROL")
+    (is (seq (get-in (link before :boundaries-notified) [:holds :readers])))
+    (is (= :derivation (:basis (link before :boundaries-notified)))
+        (str "derived rather than observed even when green — the notify CALL "
+             "is not recorded, and the array is read now rather than at "
+             "commit time"))
+
+    ;; SABOTAGE: the reverse-edge table is not readable.
+    (let [after (slice! {:envelopes (assoc e :read-attribution nil) :windows w})
+          l     (link after :boundaries-notified)]
+      (is (false? (:evidenced? l)))
+      (is (hh/unknown? (:holds l)))
+      (is (string/includes? (:says l) "mounted census is NOT substituted"))
+
+      (testing "and the census it could have borrowed from is still right there"
+        (is (seq (get-in e [:mounted-boundaries :boundaries]))
+            (str "the substitution was AVAILABLE and was not taken — which is "
+                 "what makes this row a finding rather than an accident"))))
+    (release)))
+
+;; ---------------------------------------------------------------------------
+;; The loss states reach the SCREEN
+;; ---------------------------------------------------------------------------
+
+(deftest every-unevidenced-link-renders-a-distinguishable-loss-on-the-page
+  (setup!)
+  (let [release (mount! (fn [_] (h/sub [:hcaus/left]) nil))
+        _       (interact!)
+        tree    (show! :causal)
+        ids     (testids tree)]
+    (is (contains? ids "rf-xray-hicasso-causal"))
+    (doseq [id ["event" "subs-recomputed" "values-changed" "boundaries-notified"
+                "bodies-run" "react-commit" "paint"]]
+      (is (contains? ids (str "rf-xray-hicasso-causal-link-" id))
+          (str "link " id " must render")))
+
+    (testing "the three host-opaque links carry the host-opaque chip, by testid"
+      (doseq [id ["bodies-run" "react-commit" "paint"]]
+        (is (contains? ids (str "rf-xray-hicasso-causal-link-" id "-loss-host-opaque"))
+            (str id " must render its loss under a testid a browser assertion "
+                 "can select — `…-loss-host-opaque` can never match "
+                 "`…-loss-cap`"))))
+
+    (testing "the join is its own row, never folded into the link's own basis"
+      (is (contains? ids "rf-xray-hicasso-causal-link-values-changed-join"))
+      (is (string/includes? (text-of tree) "CANNOT be joined")))
+
+    (testing "and a capped ring renders the cap chip instead"
+      (trace-tooling/clear-trace-buffer! app-frame)
+      (let [ids' (testids (show! :causal))]
+        (is (contains? ids' "rf-xray-hicasso-causal-link-event-loss-cap"))
+        (is (not (contains? ids' "rf-xray-hicasso-causal-link-event-loss-host-opaque"))
+            "two genuinely different window states, two different testids")))
+    (release)))
+
+;; ---------------------------------------------------------------------------
+;; The advisor, on the same running application
+;; ---------------------------------------------------------------------------
+
+(deftest the-advisor-answers-on-a-running-app-and-still-refuses-the-native-ladder
+  ;; The end-to-end of the refusal. A real boundary, a real interaction, a
+  ;; real ring — and the advice is still not `extract this to native`,
+  ;; because nothing on this host measured lowering, React or layout.
+  (setup!)
+  (let [release (mount! (fn [_] (h/sub [:hcaus/left]) (h/sub [:hcaus/right]) nil))
+        _       (interact!)
+        _       (interact!)
+        e       (evidence!)
+        adv     (advisor/advise e (advisor/sub-timing (windows! e)))
+        row     (first (:rows adv))]
+    (is (seq (:rows adv)) "the advisor ranked the running census")
+    (is (= 1 (:rank row)))
+    (is (pos? (get-in row [:axes :read-churn :reads])) "with its reads priced")
+    (is (false? (get-in row [:advice :native?]))
+        "no native route from this evidence, on a real application")
+    (is (contains? #{:computation :read-topology :unattributed}
+                   (get-in row [:class :owner])))
+
+    (testing "and the tab renders it, refusal and working loop included"
+      (let [tree (show! :advisor)
+            ids  (testids tree)]
+        (is (contains? ids "rf-xray-hicasso-advisor"))
+        (is (contains? ids (str "rf-xray-hicasso-advice-" (:slug row))))
+        (is (contains? ids (str "rf-xray-hicasso-advice-" (:slug row) "-class")))
+        (is (contains? ids (str "rf-xray-hicasso-advice-" (:slug row) "-route")))
+        (is (contains? ids "rf-xray-hicasso-advisor-unmeasured"))
+        (doseq [c ["lowering" "react" "layout"]]
+          (is (contains? ids (str "rf-xray-hicasso-advisor-unmeasured-" c))
+              (str c " must be named on the page as unmeasured — the reason "
+                   "the top row is not a verdict")))
+        (is (string/includes? (text-of tree) "React DevTools"))))
+    (release)))
+
+(deftest the-advisor-and-the-slice-are-taken-in-ONE-turn
+  ;; The two views are derivations of the same one-turn read. A slice
+  ;; drawn from a second turn could describe a boundary the ranking no
+  ;; longer holds.
+  (setup!)
+  (let [release (mount! (fn [_] (h/sub [:hcaus/left]) nil))
+        _       (interact!)
+        data    (rf/with-frame :rf/xray
+                  (rf/clear-sub-cache! :rf/xray)
+                  @(rf/subscribe [:rf.xray.hicasso/data]))
+        top     (first (get-in data [:advice :rows]))]
+    (is (some? top))
+    (is (= (:key (:boundary top)) (get-in data [:slice :scope :boundary]))
+        "the slice is about the boundary the advisor ranked first")
+    (release)))

--- a/tools/xray/test/day8/re_frame2_xray/panels/hicasso_helpers_cljs_test.cljc
+++ b/tools/xray/test/day8/re_frame2_xray/panels/hicasso_helpers_cljs_test.cljc
@@ -130,16 +130,26 @@
     (is (= (set (map :id hh/sub-modes)) (set (keys hh/empty-copy)))))
 
   (testing "no two views share a sentence or a testid suffix"
+    ;; Counted against the LIVE view list rather than a literal, so a
+    ;; sixth view cannot be added with a fifth view's sentence and still
+    ;; pass. rf2-hic-037 added Advisor and Causal, and the property this
+    ;; row is actually about — pairwise distinctness — is unchanged.
     (let [says     (map :says (vals hh/empty-copy))
-          suffixes (map :testid-suffix (vals hh/empty-copy))]
-      (is (= 4 (count says) (count (set says))))
-      (is (= 4 (count suffixes) (count (set suffixes))))))
+          suffixes (map :testid-suffix (vals hh/empty-copy))
+          n        (count hh/sub-modes)]
+      (is (= n (count says) (count (set says))))
+      (is (= n (count suffixes) (count (set suffixes))))))
 
   (testing "each names ITS OWN scope's fact and remedy"
     (is (string/includes? (:says (:mounted hh/empty-copy)) "read edge"))
     (is (string/includes? (:says (:attribution hh/empty-copy)) "reads nothing"))
     (is (string/includes? (:says (:intents hh/empty-copy)) "CAP"))
-    (is (string/includes? (:says (:explain hh/empty-copy)) "no mounted boundary")))
+    (is (string/includes? (:says (:explain hh/empty-copy)) "no mounted boundary"))
+    (is (string/includes? (:says (:advisor hh/empty-copy)) "not a verdict that nothing is hot")
+        (str "an empty ranking is a consequence of an empty census, and must "
+             "not read as `nothing here is expensive` — which it cannot know, "
+             "having never measured lowering, React or layout"))
+    (is (string/includes? (:says (:causal hh/empty-copy)) "no boundary to trace")))
 
   (testing "the CAPPED window never claims nothing was dispatched"
     (let [says (:says (:intents hh/empty-copy))]
@@ -581,11 +591,20 @@
   (testing "no envelope, no summary — the panel renders a presence note instead"
     (is (nil? (hh/read-summary nil)))))
 
-(deftest the-four-views-are-the-four-questions
-  (is (= [:mounted :attribution :intents :explain] (mapv :id hh/sub-modes)))
+(deftest the-views-are-the-four-questions-plus-the-two-derivations
+  ;; The first four are Spec SN §10's questions, one sub-view each. The
+  ;; last two are rf2-hic-037's derivations over the SAME one-turn read —
+  ;; a tab of their own would take a second turn, and a mount landing
+  ;; between the two would rank a census the slice no longer agrees with.
+  (is (= [:mounted :attribution :intents :explain :advisor :causal]
+         (mapv :id hh/sub-modes)))
   (is (= :mounted hh/default-sub-mode))
   (is (= :mounted (hh/normalise-sub-mode :nonsense))
       "a stale or hand-dispatched id must land on a view that exists")
   (is (= :explain (hh/normalise-sub-mode :explain)))
+  (is (= :advisor (hh/normalise-sub-mode :advisor)))
   (testing "every view says what it asks, so a tooltip is not invented at render"
-    (is (every? (comp seq :asks) hh/sub-modes))))
+    (is (every? (comp seq :asks) hh/sub-modes)))
+  (testing "and no two views share a mnemonic"
+    (let [mnems (map :mnem hh/sub-modes)]
+      (is (= (count mnems) (count (set mnems)))))))


### PR DESCRIPTION
Closes rf2-hic-037.

Spec SN §10's differentiating feature — the cause-aware hot-view advisor — plus
the one complete, mutation-proved causal slice. Both ship as sub-views of the
existing Hicasso tab, so **no governance pin moves**: no new tab, no registry
schema bump, no palette count, no feature-matrix row, no new build id and no new
`:dev-http` port.

## The finding

§10 says the advisor *recommends native extraction only when it addresses the
measured owner*. Enumerating the instruments honestly turns that clause into a
surprising deliverable.

| Pressure class | Instrument at this door | Available? |
|---|---|---|
| application computation | Spec 009 `:rf.sub/elapsed-ms` on the retained ring | **yes** |
| read topology | cell-table fan-out, entry-cache read orders, ring recompute counts | **yes** |
| Hiccup lowering | — | no |
| React reconciliation / commit | — | no |
| DOM layout / paint | — | no |

The three gaps are decisions, not omissions. Per-boundary self time was **killed**
in `lanes/left-field-ideas.md` §Capability receipts (the 0.1 ms timer grain is
coarser than the quantity, so *a ranking built on it orders noise*); commit, paint
and attempt outcome are `:host-opaque` on every envelope `re-frame.hicasso.tool`
emits; Hicasso emits no `:rf.view/render` trace and its User-Timing `:render`
channel is off by default and observer-first.

Ladder rungs 3, 4 and 5 — `n/$`, a named native island, a native screen — each
address a class in the unavailable half. So:

> **from this evidence the advisor never recommends a native route.**

A tool that ranked boundaries by the one clock it has and then pointed at the
native ladder would be recommending an expensive, semantics-changing,
diagnostics-losing change on evidence that cannot say whether it helps. **The
refusal is the product**, and it comes with the instrument that settles each
candidate (React DevTools Profiler; the browser's performance tools) — never Xray,
which is asserted.

`ladder` is a real table keyed on the measured OWNER: hand it `:lowering` and it
answers rung 3 with its working-loop steps. Those owner keys are unreachable from
`classify` on this door, and the suite asserts **both halves** — the property over
every classification the classifier emits, and the non-vacuity control proving the
table is not a stub. Either half alone would be worthless.

## The advisor

- **Four axes in four units, never a composite.** Weighting milliseconds against
  dispatch counts against read orders against reader slots would make the weights
  the ranking. `order-axis` states which one the roster was sorted on, and when no
  read edge carried a duration the summary line says `NOT by time` out loud.
- **Untimed is `:unknown`, never `0.0`** — with loss `:uncorrelated` rather than
  `:cap`, because the recomputes were observed and it is the DURATION that joins
  to nothing; a cap would send the reader to the retention knob, which is not the
  remedy.
- **The window is scoped per frame.** Two frames are two applications.
- **`:cap` and `:host-opaque` stay apart.** One says *raise
  `:rf.trace/events-retained`* (free); the other says *the answer lives in another
  tool* (a change of instrument). Two sentences, two chips.
- Three thresholds, each carrying its reason: `computation-floor-ms` 1.0 (the
  clock grain), `dominance` 0.6 (below a comfortable majority the time is spread
  across the read SET), `repeat-floor` 2 (the smallest count that makes a re-run a
  pattern).

## The causal slice

§10's chain walked for one dispatch against the boundary the advisor ranked first.

**A link's own basis and its JOIN to the previous link are different questions**,
and each renders separately. Links 2 and 3 are both `:observation` — the sub
really recomputed, the cell's epoch really moved — and the join between them is
`:uncorrelated`, because an epoch stamp carries no dispatch id and Hicasso's commit
seam records no cascade id. Two solid facts, printed adjacent, joined by nothing.
The 1→2 join IS evidenced: the ring GROUPS by dispatch-id, so that join is the
storage rather than an inference.

Links 5–7 are three different absences with three different authorities, not three
phrasings of one. The slice's envelope is `:complete? false` with
`{:reason :uncorrelated}` unconditionally — reporting complete because the prefix
came back green would be claiming the chain.

### Evidenced vs labelled, and the mutation evidence for each

| Link | Basis | Sabotage | Degrades to |
|---|---|---|---|
| 1 event | `:observation` | `clear-trace-buffer!` on the frame | `:cap`, `:holds :unknown`, "capped window" — never *a dispatch that did not happen*; link 2 follows it down |
| 2 subs recomputed | `:observation` | the runtime's own events with `:rf.sub/id` stripped | `:holds :unknown` + `{:reason :uncorrelated :dropped n}` — **never `[]`**, which would say this dispatch recomputed nothing |
| 3 values changed | `:observation` | a real read-free boundary | not evidenced, and says *not a gap in the instrument* |
| 4 boundaries notified | `:derivation` | the attribution envelope suppressed | `:holds :unknown`, and the row asserts the mounted census was **available and not substituted** |
| 5 bodies run | `:host-opaque` | — | already `:unknown` |
| 6 React commit | `:host-opaque` | — | already `:unknown` |
| 7 paint | `:host-opaque` | — | already `:unknown` |

**Every sabotage asserts the link is green FIRST, on the same runtime.** A
sabotage that reds a link which was never green proves the fixture was broken and
nothing else. The runtime is real throughout: boundaries mounted through the real
commit seam, events dispatched through the real router, the ring holding bundles
the framework put there. Two sabotages act on the seam's own DATA (the trace tag,
the attribution envelope) because those are the seams.

## Spec

`tools/xray/spec/028-Hicasso-Advisor.md` (new) documents both views, the
instrument table, the refusal and its non-vacuity control, the mutation matrix and
the rendering contract; `tools/xray/spec/README.md` indexes it. `027` is unchanged
— it describes the four evidence reads, which this bead does not touch.

## Quality gates

`gate root:` verified as `C:/Users/miket/code/re-frame2-worktrees/advisor-hic037`
on every run; every exit code below is the one captured on the same command line
as the redirect.

| Gate | Command | Exit |
|---|---|---|
| Node CLJS suite (13702 tests / 69385 assertions) | `npm run test:cljs` | **0** |
| Browser suite (1423 tests / 8767 assertions) | `npm run test:browser` | **0** |
| Xray feature gate (17 scenarios, 14 matrix rows) | `npm run test:xray-feature-gate` | **0** |
| Xray JVM suite (1309 tests / 6154 assertions) | `cd tools/xray && clojure -M:test` | **0** |
| Hicasso production erasure — hic-024, re-verified | `npm run build:hicasso-release` | **0** |
| Doc slugs / anchors (covers `tools/*/spec`) | `python scripts/check_doc_slugs.py` | **0** |

The erasure gate reports *5 sentinels absent, 3 positive controls present* and
bundle isolation *4 absent, 4 present*, so hic-024 is green on this tree. Nothing
under `implementation/` was touched, so that was expected rather than at risk —
it is re-verified because the bead asks for it.

### CI-only lanes this diff arms, deliberately deferred

- `test:bundle-isolation`, `test:perf-bundle`, `test:elision`,
  `test:browser-prod-elision` — release-sized sweeps whose surface is
  `implementation/`, which this diff does not touch. `tools/xray` never reaches a
  production bundle, and the one-way `tools/xray → implementation` dependency is
  unchanged (the new read consumes the public `re-frame.trace.tooling/trace-buffer`).
- `test:hicasso-hmr` — **not run**: another worker holds the `:dev-http` 8061 rig.
- The tool JVM sweep beyond `tools/xray` (`scripts/test-jvm-tools.sh`) — no tool
  other than Xray is in the diff.

## Files

- `tools/xray/src/day8/re_frame2_xray/panels/hicasso_advisor.cljc` (new)
- `tools/xray/src/day8/re_frame2_xray/panels/hicasso_causal.cljc` (new)
- `tools/xray/src/day8/re_frame2_xray/panels/hicasso.cljs` — two sub-views, the
  one-turn sub now also derives the advice and the slice
- `tools/xray/src/day8/re_frame2_xray/panels/hicasso_reads.cljs` — `trace-windows`,
  the second producer's read
- `tools/xray/src/day8/re_frame2_xray/panels/hicasso_helpers.cljc` — two sub-modes,
  two per-view empties
- `tools/xray/test/…/hicasso_advisor_cljs_test.cljc` (new, node + JVM)
- `tools/xray/test/…/hicasso_causal_cljs_test.cljs` (new, node, reactive substrate)
- `tools/xray/test/…/hicasso_helpers_cljs_test.cljc` — the distinctness pin now
  counts against the live view list rather than a literal `4`
- `tools/xray/spec/028-Hicasso-Advisor.md` (new) + `tools/xray/spec/README.md`
