### PR TITLE
docs(EP-0038): record the P2 fork ruling as the addendum the EP promises; decisions.md's preamble states the provenance split (rf2-k6bv)

### DIFF
--- a/docs/EP/EP-0038-the-hicasso-view-layer-programme.md
+++ b/docs/EP/EP-0038-the-hicasso-view-layer-programme.md
@@ -171,9 +171,9 @@ the P2 fork, was given by the operator directly on 2026-08-13** — the decider
 HD-013 reserves that ruling to — and is therefore not a delegated resolution.
 Each entry carries its own rationale and reopen condition in `decisions.md`.
 
-**Future operator rulings made under this EP — the donor-gate ruling and the P2
-fork ruling — are recorded here when made** (per EP-0009 rule 2), with their
-evidence on the standard bead.
+**Operator rulings made under this EP — the donor-gate ruling and the P2 fork
+ruling — are recorded here when made** (per EP-0009 rule 2), with their evidence
+on the standard bead. The P2 fork ruling is the 2026-08-13 addendum below.
 
 ### Addendum, 2026-07-31 — Hicasso is a React adapter; Arm 2 (PATCH) is dropped
 
@@ -353,6 +353,70 @@ Design record: `docs/design/hicasso/validation.md` (the dated note),
 `charter.md` item 4, and the note heading the HD-022 … HD-026 block in
 `decisions.md`. This addendum answers `rf2-825ft`.
 
+### Addendum, 2026-08-13 — the P2 fork is ruled: Hicasso graduates, as a success
+
+**Operator ruling (Mike), verbatim:** *"Make it graduate" … "as success"* — given
+directly in chat on 2026-08-13 at 04:57 AUSEST. That is the decider HD-013
+reserves this ruling to; the recorded adversarial and creative passes advised it
+and did not make it, exactly as that entry provides.
+
+Recorded here per rule 2, and as an addendum rather than an edit per EP-0009 rule
+3 — the wave-2 text and the Graduation section are left as written, because they
+are the proposal that was accepted and the programme they describe did run. Open
+issue 2 is annotated below in the dated style the two prior addenda used, since
+that list states what is open *now*.
+
+- **What is ruled: the Graduation section's "Go" exit.** Hicasso graduates and
+  the programme's outcome is recorded as a **success**. v0 proceeds in
+  `implementation/hicasso/`, which is already the live tree, so HD-017's
+  graduation clause is executed by this ruling rather than pending it. **The
+  adapters remain first-class alongside it** — graduating Hicasso is not a
+  demotion of Reagent, reagent-slim or UIx, which stay supported and stay the
+  standing comparator every Hicasso measurement is taken against (HD-012). Wave
+  3 — donor-surface deletion per HD-018, the real guide superseding the wave-0
+  draft, skill/migration work, and the product-phase roster — becomes fileable
+  from here, on its own stated conditions, which this ruling does not discharge.
+- **The held K1 price is accepted, and ratified by this ruling rather than by a
+  sitting.** Graduating *as a success* with the canonical K1 record on the table
+  is the operator's acceptance of the priced capability premium that record
+  prices. **The published miss is not recoloured and no threshold widens** —
+  acceptance of a price is not a pass, the registered gate is untouched, and no
+  evidence row may cite this ruling to colour K1 green. The accepted price, the
+  use cases it buys, the escape route and the reconsideration trigger are in
+  `docs/design/hicasso/product/k1-price-acceptance.md`, which records this ruling
+  as the ratifying act; the figures are cited from their own record rather than
+  restated here.
+- **The K7 clock closes, satisfied.** The six-week clock (HD-014) ran from the
+  first Hicasso-arm commit that mounted the dogfood screen and the fork was ruled
+  well inside its boundary — satisfied on its own terms rather than extended, and
+  no extension was sought or given. Both endpoints are recorded once, in
+  `validation.md`.
+- **What the ruling does not decide, stated so it is not over-read.** K2's `1.5×`
+  architecture kill is **not waived** and measurement continues under its own
+  protocol; K3's owed disposition is discharged by its own record, not by this
+  ruling; K4's WebKit half of the control matrix is **open and unwitnessed**, an
+  evidence limitation the ruling accepts rather than closes; and K6 stands with
+  its bans on a compiler, an analyzer and a dual mode — the K1 line is *priced,
+  not met by a compiler*, so nothing here reads as licence to build one. The
+  non-kill rows are unchanged too. Dispositions row by row in `validation.md`.
+- **The sitting is pre-empted, not adjourned.** The packet freeze of 2026-08-25
+  and the sitting of 2026-08-27 were scheduled to put this question; the question
+  is answered, and neither is required for the fork. The SSR addendum's
+  one-sitting linkage resolves with it: the production-server-arm choice it bound
+  to that sitting had already been ruled on 2026-08-08 (`rf2-2rtt6.88`) and is
+  untouched by the fork ruling, its five start gates still governing when that
+  arm's implementation begins.
+- **What this EP's own status is not.** The Graduation section makes `final`
+  conditional on v0 *and* the narrow contract graduation landing — the `spec/004`
+  view-family re-homing and EP-0036's supersession — and neither has. This EP
+  stays `accepted`; the fork ruling starts that work rather than completing it.
+
+Evidence and full text on the epic `rf2-2rtt6` (the dated ruling note). Design
+record written by `rf2-2rtt6.144`: `docs/design/hicasso/decisions.md` HD-029,
+`validation.md` §"The kill table at graduation", `product/k1-price-acceptance.md`,
+`product/decision-brief.md`, `production-server-arm.md`. This addendum answers
+`rf2-k6bv`.
+
 ## Open Issues
 
 1. The donor-gate ruling (delegated advisory; expected days after P0 publishes).
@@ -362,7 +426,9 @@ Design record: `docs/design/hicasso/validation.md` (the dated note),
    the SSR addendum above: the sitting additionally takes the X1–X5 SSR spike
    witness (`rf2-2rtt6.87`) as a required feasibility input, and prices + rules
    the production-server-arm choice (`rf2-2rtt6.88`) at the same sitting — one
-   sitting, no separate gate.
+   sitting, no separate gate. **Resolved 2026-08-13** by the addendum above: the
+   operator ruled the fork directly in chat, pre-empting the sitting — Hicasso
+   graduates, as a success (HD-029).
 3. The HD-002 read-mechanism adjudication (resolved by P1 instrumentation).
    **Narrowed 2026-07-31** by the addendum above: the ergonomics half is
    decided — Surface B (the ambient collector) is the only acceptable read

--- a/docs/design/hicasso/decisions.md
+++ b/docs/design/hicasso/decisions.md
@@ -1,9 +1,13 @@
 # Hicasso — decisions (HD-001 … HD-029)
 
 Every design decision for the Hicasso programme, resolved. Each record carries the
-ruling, the decisive rationale, and the condition under which it reopens. These
-were resolved under delegated authority (operator-overturnable, like every ruling
-in this repo); the measured claims cite the studio/bench record. Companion pages:
+ruling, the decisive rationale, and the condition under which it reopens. **HD-001
+through HD-028 were resolved under delegated authority; HD-029 — the P2 fork — was
+given by the operator directly, which is the decider
+[HD-013](#hd-013--governance) reserves that ruling to.** Several of the delegated
+entries have since been superseded or amended by operator ruling, each marked in
+its own record, and every ruling here is operator-overturnable like every ruling
+in this repo. The measured claims cite the studio/bench record. Companion pages:
 [charter.md](charter.md), [architecture.md](architecture.md),
 [validation.md](validation.md), [authoring.md](authoring.md).
 


### PR DESCRIPTION
Closes `rf2-k6bv`.

`EP-0038` promises, in its own Resolved Decisions section, that operator rulings made under it are recorded in the EP when made (EP-0009 rule 2). The P2 fork ruling was given by the operator directly in chat on **2026-08-13 at 04:57 AUSEST** — *"Make it graduate" … "as success"* — and `rf2-2rtt6.144` (PR #8014) wrote it into `docs/design/hicasso/` as **HD-029**, but nothing was written into the EP. The four prior operator rulings under this EP each got a dated `### Addendum`; this one now has the fifth. Separately, `decisions.md`'s preamble blanket-claimed delegated authority for every entry, which over-claims **HD-029**.

## What changed

**1. `docs/EP/EP-0038-…md` — the addendum the page promises (+62 lines).**

New `### Addendum, 2026-08-13 — the P2 fork is ruled: Hicasso graduates, as a success`, in the shape the four prior addenda use: the verbatim operator quote and its decider provenance, the EP-0009 rule-3 note naming what is left as written, then bullets for what is ruled (the Graduation section's "Go" exit; adapters stay first-class; HD-017's graduation clause executed; wave 3 becomes fileable), the K1 price accepted-and-ratified-by-ruling with **the miss not recoloured and no threshold widened**, the K7 clock closing satisfied, **what the ruling does not decide** (K2's `1.5×` kill unwaived, K3's disposition owned by its own record, K4's WebKit half open and unwitnessed, K6 and its compiler/analyzer/dual-mode bans standing), the sitting pre-empted rather than adjourned with the SSR addendum's one-sitting linkage resolved, and this EP's status. Figures are cited from their own records rather than restated.

**2. Same file — the promise sentence, and open issue 2.**

The promise sentence read *"**Future** operator rulings … the donor-gate ruling and the P2 fork ruling — are recorded here when made"*. That is present-tense operative text whose enumeration went stale the moment the fork was ruled, so "Future" is dropped and a pointer to the addendum added. Open issue 2 gains a dated **Resolved 2026-08-13** annotation in exactly the style the 2026-07-31 and 2026-08-04 addenda already used on that same entry — the Open Issues list states what is open *now*.

**3. `docs/design/hicasso/decisions.md` — the preamble states the split.**

Was: *"These were resolved under delegated authority (operator-overturnable, like every ruling in this repo)"*. Now:

> **HD-001 through HD-028 were resolved under delegated authority; HD-029 — the P2 fork — was given by the operator directly, which is the decider [HD-013](#hd-013--governance) reserves that ruling to.** Several of the delegated entries have since been superseded or amended by operator ruling, each marked in its own record, and every ruling here is operator-overturnable like every ruling in this repo.

This is the same over-claim `rf2-nxtt` fixed downstream in `EP-0038`'s header, now fixed in the normative source. The third sentence is new and is its own small honesty fix: HD-002 and HD-007 were later *superseded* by operator ruling (both 2026-07-31), and HD-009, HD-019 and HD-020 later *amended* by one, so "resolved under delegated authority" is true of the original resolution only.

### Provenance, verified by reading rather than inherited

`grep -n "operator ruling\|by the operator"` across the HD-022…HD-028 range returns two hits, both inside HD-028's *reopen disposition* discussion ("what remains open is the disposition, and it is the operator's") — neither is a decider marker. No entry in that range names an operator decider. HD-029's own text does: *"Given by the operator directly in chat on 2026-08-13 at 04:57 AUSEST, which is the decider HD-013 reserves this ruling to."* HD-013 confirms the reservation and confirms the donor gate is the delegated one. So the split the bead asserts holds, independently established.

### Not done, deliberately: `Status: accepted` is unchanged

The bead raises this as a question. **Recommendation: leave it at `accepted`.** The EP's own Graduation section names the trigger — *"This EP goes `final` when v0 and that graduation land"*, where "that graduation" is the `spec/004` view-family re-homing from Freehand-voiced text to Hicasso plus EP-0036 being marked superseded by this EP. Neither has: `spec/004-Views.md` has **116** Freehand mentions and **0** Hicasso mentions, and `EP-0036`'s header still reads `Status: withdrawn`. The P2 ruling is the fork, not the contract graduation — it *starts* the work `final` is conditional on. So `accepted` is the correct status today and the header line is untouched (`check_ep_status_sync.py` run anyway, green). The addendum's last bullet records this reasoning in the EP so the next reader does not have to re-derive it.

### The `rf2-nxtt` discipline, applied

A past-tense record of what was true then is not stale. Line 6's `Resolution:` log, the wave-2 text and the Graduation section are **untouched** — they are the proposal that was accepted and the programme that ran. What was edited is only text describing the operative state *now*: the "Future … rulings" promise and the open-issues entry.

## Quality gates

| Gate | Exit |
|---|---|
| `python scripts/check_doc_slugs.py` | **0** |
| `python -m mkdocs build --strict` | **0** |
| `python scripts/check_ep_status_sync.py` | **0** |

Run from `C:/Users/miket/code/re-frame2-worktrees/epaddendum-k6bv`, redirect + `echo $?` on one line, no pipelines.

### Negative controls, one per gate, both at sites this PR edits

| Plant | Gate | Exit | Caught |
|---|---|---|---|
| `decisions.md:7` — `#hd-013--governance` → `#hd-013--governance-BOGUS` (a link **this PR adds**) | `check_doc_slugs.py` | **1** | `BROKEN ANCHOR: docs\design\hicasso\decisions.md:7 -> #hd-013--governance-BOGUS` |
| `EP-0038` addendum's evidence line → `[rf2-2rtt6](EP-9999-does-not-exist.md)` (a line **this PR adds**) | `mkdocs build --strict` | **1** | `WARNING - Doc file 'EP/EP-0038-…md' contains a link 'EP-9999-does-not-exist.md', but the target … is not found` → `Aborted with 1 warnings in strict mode!` |

Both plants verified applied by SHA-256 (the hashes moved), and both restores verified by SHA-256 against the pre-plant digests, not by reading `git diff`:

- `decisions.md` `10c4db0d…d685` → planted `d0279492…08f5` → restored `10c4db0d…d685` ✅
- `EP-0038` `e735e8be…6547` → planted `7913ecde…99ab` → restored `e735e8be…6547` ✅

Both gates re-run green after restore. `git status --porcelain` empty.

### By-hand verification of `decisions.md`

`docs/design/**` is outside the mkdocs corpus (`exclude_docs`), so **mkdocs says nothing about `decisions.md`** — its link targets and heading anchors are covered by `check_doc_slugs.py` (proven live on this exact file and line by the negative control above), and nothing covers its tables. Verified manually:

- **Anchor** — the one link this PR adds is `[HD-013](#hd-013--governance)`. Confirmed against the repo's own slugifier: `SLUGIFY("HD-013 — Governance", SLUG_SEP)` → `hd-013--governance`, exact match. The heading `## HD-013 — Governance` is present at line 846.
- **Table column counts** — the preamble edit is prose and adds no table. All pipe tables in both edited files were re-counted row-by-row against their header rows (including the blockquoted table inside HD-002): **zero mismatches**. No table row in either file was touched.

`site/`, `docs/spec/`, `docs/migration/` and `__pycache__/` residue from the mkdocs runs removed; `git status --porcelain --ignored` shows no leftovers, so the worktree reaps cleanly. No `node_modules` junction was created.
