### PR TITLE
docs(hicasso): record why the hydrating door is not on the facade (rf2-k1mp)

### DIFF
--- a/implementation/hicasso/src/re_frame/hicasso.cljc
+++ b/implementation/hicasso/src/re_frame/hicasso.cljc
@@ -543,6 +543,25 @@
      ;; may hold as many roots as it likes and no call here reaches a root
      ;; the caller did not name. That is the property rf2-31xm restored and
      ;; the reason `release!` is no longer among them.
+     ;;
+     ;; **The HYDRATING door is not here, and the absence is held rather
+     ;; than overlooked** (rf2-k1mp). `impl.mount/hydrate-root!` is built,
+     ;; witnessed, and takes `:identifier-prefix` exactly as `root!` does
+     ;; (rf2-hic-046). What is missing is the OTHER half of the pair: a
+     ;; hydrating door adopts bytes something produced, and this package
+     ;; publishes no server-render door to produce them — `server/render`
+     ;; is taught in the draft guide and rostered in naming-ledger row 22,
+     ;; and `re-frame.hicasso.server` does not exist. `dispositions.md`
+     ;; HS-11 measures what an improvised counterpart does: the adoption
+     ;; closer rides as a SIBLING of the app subtree (`impl.mount/tree`,
+     ;; rf2-6tmu) and React derives a `useId` from tree POSITION as well
+     ;; as from the prefix, so bytes a consumer can bake today hydrate
+     ;; into a text mismatch. Both candidate repairs — a matching
+     ;; server-render entry, or making the closer a wrapper — change
+     ;; behaviour, and neither is ruled. The spelling is open too:
+     ;; naming-ledger row 13 holds `hydrate-root!`→`hydrate!` for the
+     ;; operator's sitting, so an export now would freeze a name the
+     ;; ledger is deliberately keeping open.
 
      (def ^{:doc "Associate a DOM container, a frame keyword and a hiccup
   tree; returns the handle [[render!]] and [[unmount!]] take. HD-021(b)'s
@@ -558,10 +577,12 @@
   page mounting two roots gives them distinct prefixes or watches their
   generated ids collide. A page with one root names none. There is no
   default, no coercion and no validation: React owns the option and this
-  is a pass-through to it. The hydrating twin takes the same key, and a
-  hydrating root must be handed the SAME string its server render used —
-  `react-dom/server`'s own `identifierPrefix`, which is where the other
-  half of the pair is spelled.
+  is a pass-through to it. The hydrating twin takes the same key — but it
+  is `impl.mount/hydrate-root!` and is NOT on this facade, for the reasons
+  the section comment above sets out — and a hydrating root must be handed
+  the SAME string its server render used, `react-dom/server`'s own
+  `identifierPrefix`, which is where the other half of the pair is
+  spelled.
   [[re-frame.hicasso.impl.mount/root!]]."}
        root! impl-mount/root!)
 


### PR DESCRIPTION
Closes rf2-k1mp.

## Verdict: REFUSAL — no hydrating door is added

The bead's fact is confirmed at source. `implementation/hicasso/src/re_frame/hicasso.cljc`'s alias block is the facade roster and it carries `root!`, `render!` and `unmount!` and no hydrating door; `hydrate-root!` is defined at `implementation/hicasso/src/re_frame/hicasso/impl/mount.cljs:357`. So `h/hydrate!` names nothing, and this is a missing door rather than rf2-bjpe's misspelled one.

**The omission is deliberate, and a record already says so.** `docs/design/hicasso/product/dispositions.md` §2.1, note 1 under the surface-inventory table:

> The root lifecycle functions are Client-only by nature, not by default. `h/root!`, `h/render!` and `h/unmount!` — the facade's whole root roster — are client entry points, **as is the hydrating door, which HS-11 spells `h/hydrate!` but which ships only as `impl.mount/hydrate-root!` and is not re-exported to the facade at all** (rf2-bjpe; naming-ledger row 13 holds both spellings open).

The non-export is therefore a recorded state of the roster, not an oversight nobody noticed. Three further facts say it should stay that way for now:

1. **The other half of the pair is not built.** A hydrating door adopts bytes something produced, and this package publishes no server-render door to produce them. `server/render` is taught in `draft-guide/18-ssr-and-hydration.md` and rostered as naming-ledger row 22 (`re-frame.hicasso.server` module, eight options, "keep as taught"), but no such namespace exists under `implementation/hicasso/src/` — the public namespaces are `hicasso`, `.evidence`, `.forms`, `.motion`, `.native`, `.overlay`, `.tool`. Exporting the client half alone hands a consumer a door with no legal counterpart.

2. **The improvised counterpart is measured, and it mismatches.** HS-11's Obstruction 2 (cleared Obstruction 1 was the `:identifier-prefix`, landed by rf2-hic-046): a hydrating root's tree carries the adoption closer as a *sibling* of the app subtree (`impl.mount/tree`, rf2-6tmu), React derives a `useId` from tree position as well as from the prefix, and the package's only server path — a hand-rolled `renderToString`, rf2-ggnp's census — emits no counterpart to that fork. So "bytes a consumer can bake today hydrate into a text mismatch whose two ids agree on the prefix and differ after it." HS-11 names two candidate repairs (a matching server-render entry, or making the closer a wrapper rather than a sibling) **and rules on neither**. Both are behaviour changes, and this bead's brief fences them out explicitly.

3. **The spelling is not settled either.** Naming-ledger row 13 (status *half landed*) rosters the door as three plus impl: "root lifecycle: door has `root!` + `render!` + `unmount!` (impl also holds `hydrate-root!` and `release!`, docstring-unfrozen) … STILL THE SWEEP'S: `root!`→`mount!` and `hydrate-root!`→`hydrate!`, which are taste (React's createRoot/hydrateRoot model) and stay ratified provisional until rf2-84w6." rf2-84w6 closed by routing to the ledger and renaming nothing, so the spelling now waits on the operator's single sitting. Exporting today would freeze a name the ledger is deliberately holding open.

None of this contradicts HD-020's 2026-08-04 addendum making SSR + hydration required Hicasso scope. That ruling is why `hydrate-root!` exists at all (it names the door as one of four pieces landed on `rf2-2rtt6.84`–`.87`) and it requires participation in Spec 011's *existing* SSR story — `re-frame.ssr/hydrate!` is that story's state-payload helper and is a different thing from a Hicasso DOM door. The ruling says the door must exist; it does not say it must be public before its server counterpart is.

## What this PR changes

Only the one document that implied the door was reachable, and it is the facade itself — the single file a consumer actually reads.

- `root!`'s docstring ended "The hydrating twin takes the same key, and a hydrating root must be handed the SAME string its server render used …". A reader of the public door reasonably infers there is a hydrating twin on the public door. It now names `impl.mount/hydrate-root!` and says it is not on this facade.
- The root-lifecycle section comment, which already explains why `release!` is not among the doors (rf2-31xm), now also explains why the roster is three rather than four, with the three reasons above. That is the file's own established pattern for a deliberate absence — cf. the ns docstring's "What this door does NOT carry — the optional modules (rf2-hic-053)".

No behaviour change, no new export, no `spec/` row owed.

**Documents deliberately left alone**, both of which name `h/hydrate!` correctly for what they are:

- `docs/design/hicasso/product/dispositions.md` — already states the non-export (quoted above). Nothing to correct.
- `docs/design/hicasso/draft-guide/18-ssr-and-hydration.md`, `glossary.md`, `15-testing.md` — the draft guide teaches the *target* surface ahead of the code by design; naming-ledger row 16's ruling is the precedent ("the code catches up to the chapter rather than the chapter being rewritten onto the doors that existed"). Rewriting ch18 onto today's roster would invert that.
- `docs/design/hicasso/product/invariants.md:51` (`root lifecycle | h/mount!, h/hydrate!, h/render!, h/unmount!`) — a transcription of specification.md §4, and its own header says "the provisional facade as the specification currently spells it" and "where a row and its owner disagree the owner governs". It is a target row, like HS-11's own Public-surface column. Noted, not touched — it is outside this bead's fence and its `h/mount!` half is rf2-bjpe's territory.

## Quality gates

Run from `implementation/` in `C:\Users\miket\code\re-frame2-worktrees\hydrate-k1mp`. Both shadow-cljs gates printed `config: C:\Users\miket\code\re-frame2-worktrees\hydrate-k1mp\implementation\shadow-cljs.edn`, confirming this worktree as the gate root.

| Gate | Raw exit code | Notes |
|---|---|---|
| `npm run test:cljs` | `0` | 13678 tests, 69188 assertions, 0 failures, 0 errors |
| `npm run test:hicasso-invariants` | `0` | freeze (1 frozen row; the facade is not among them), optional-module reachability, complaint catalogue (74 live), budget ledger (38 rows) |
| `npm run build:hicasso-release` | `0` | `:hicasso-release` 162 files / 107 compiled / 0 warnings; production-erasure 5 sentinels absent + 3 positive controls; bundle-isolation 4 + 4 |

`npm run test:hicasso-hmr` was **not** run: it binds `:dev-http` 8061 and other workers are live on this machine. Deferred to CI. The change is docstring-and-comment only, so it cannot move HMR behaviour.
