### PR TITLE
docs(hicasso): the h/mount! census across product/ — four hits, four refusals, and the missing §5 row that explains them (rf2-4u7x)

### DIFF
--- a/docs/design/hicasso/product/invariants.md
+++ b/docs/design/hicasso/product/invariants.md
@@ -82,6 +82,7 @@ The prototype-to-product disposition prunes rather than adds ([decision brief](d
 | `subscribe-once` | Internal until a caller proves `sub` inadequate | [§4](specification.md#4-target-programming-model) · [ledger 4](naming-ledger.md) |
 | presence | Moves to its optional motion namespace | [§7](specification.md#7-complete-use-case-coverage) · [ledger 5](naming-ledger.md) |
 | route-link | Moves to its optional routing-integration namespace | [§7](specification.md#7-complete-use-case-coverage) · [ledger 6](naming-ledger.md) |
+| root lifecycle: the prototype's `root!`, and `hydrate-root!` | Become `h/mount!` and `h/hydrate!` — the spellings section 3 carries, ratified provisional until the naming sitting; `h/render!` and `h/unmount!` were promoted from impl under their existing names and are renamed by nothing. **Half landed**: the facade's roster today is `root!` / `render!` / `unmount!`, and the hydrating door ships only as `impl.mount/hydrate-root!`, not re-exported | [§4](specification.md#4-target-programming-model) · [ledger 13](naming-ledger.md) |
 | the two missing conversions | `h/as-element` and the outward bridge — a native React parent rendering a minted Hicasso view under the shared frame — are genuinely absent and are added | [decision brief](decision-brief.md#part-ii--review-hicasso-against-the-goal) · [§4.3](specification.md#43-host-interop) |
 
 ## 6. Names freeze on witnesses


### PR DESCRIPTION
Works `rf2-4u7x` — the `h/mount!` census across the four `product/` files. **The sweep's verdict is a refusal: all four hits are correct as written.** What lands instead is the one thing that was actually missing, and whose absence is why this class keeps being re-found.

## 1. Census re-run at `origin/main` (`92c021dca8`)

Matches the bead exactly — 8 files, 14 hits, no drift.

| File | Bead | Found | Fence |
|---|---|---|---|
| `product/naming-ledger.md` | 2 | **2** | mine |
| `product/dispositions.md` | 1 | **1** | mine |
| `product/invariants.md` | 1 | **1** | mine |
| `product/lanes/ergonomics-api.md` | 1 | **1** | mine |
| `draft-guide/00-installation.md` | 6 | **6** | not mine — left |
| `draft-guide/18-ssr-and-hydration.md` | 3 | **3** | not mine — left |
| `draft-guide/glossary.md` | 2 | **2** | not mine — left |
| `draft-guide/REWRITE-NOTES.md` | 1 | **1** | not mine — left |

(A ninth hit, `.beads/issues.jsonl` ×5, is the tracker export of this bead's own text.)

## 2. The discriminator, and the line that settles it

PR #8023 wrote the rule in its own body while fixing HS-10: **"the table now names what ships and the ledger keeps the open rename."** That is the whole discriminator, stated by the PR this bead extends. `dispositions.md`'s inventory makes *measured claims about code that runs* — every row cites a witness suite and reports what the door does at runtime — so a door name with no referent there is a factual error. The design register makes no runtime claim.

Two more source-located rules govern, both written on the pages themselves:

- `invariants.md` line 5: *"Every row is transcribed from the product specification … **Where a row and its owner disagree the owner governs and the row is the defect** — fix the row; **questions are not settled here**."*
- `naming-ledger.md` line 3: *"nobody renames mid-flow … **its recommendations apply as defaults immediately**"* — so a document carrying row 13's ratified-provisional `mount!` is carrying the recommendation as a default, which is what the header says to do.

## 3. Every hit, with its disposition

**All four LEFT. None fixed.**

| Site | Disposition | Why |
|---|---|---|
| `invariants.md:51` — §3 root-lifecycle row | **left** | §3 is titled *"**Provisional** facade — ordinary surface"* and the preamble says *"the provisional facade **as the specification currently spells it**"*. Its two cited owners — `specification.md` §4 (line 122) and `ergonomics-api.md#proposed-core-surface` (line 16) — both spell `mount!`, so the row **agrees with its owner** and by the page's own governing rule is not the defect. Editing it would settle a naming question the same page forbids settling there. This is the line `rf2-k1mp`'s worker reported; the report was right that the symbol has no referent and wrong that the row is where it is wrong |
| `lanes/ergonomics-api.md:16` | **left** | The section is literally *"## Proposed core surface"* — this is the lane recommendation, the **head of the chain** and the source of the `mount!`/`hydrate!` candidate that ledger row 13 records. It is a proposal of what the door should be called, not an instruction to a consumer. Changing it would (a) settle row 13 by editing a proposal, (b) desynchronise the owner from `specification.md` §4, manufacturing exactly the owner/row disagreement `invariants.md` calls a defect, and (c) apply an inconsistent standard *inside one nine-item list* — line 11 of that same list spells `h/handler`, which #8023 measured as having no referent either (ships as `h/hfn`; ledger row 1, open) |
| `naming-ledger.md:26` — row 20 | **left** | Row 20's subject is the *contract shape*, and it says so: *"Row 13 pins the four verbs; this row is the argument and key contract beneath them."* Substituting `h/root!` would make the row **factually false**: the shipped `h/root!` is positional `(container frame-kw hiccup opts?)` with opts carrying ONE key, `:identifier-prefix` (`hicasso.cljc` :547-566) — not `(node config view)` with `:frame` + `:initial-events`. It would also collapse the row's own Candidate column, which contrasts *"the prototype's positional `root!`"* against the current cell |
| `naming-ledger.md:31` — row 25 | **left** | *"one seeding vocabulary across `h/mount!`, `ht/mount!` and `ht/shadow!` (row 20)"* — an argument about option-name uniformity **as taught**, cross-referencing row 20 and inheriting its frame. `:initial-events` is not a key the shipped `h/root!` accepts, so `h/root!` here would be false on the same ground |

Row 13 (line 19) carries bare `mount!` and is outside the `h/mount!` census; it is the ratified-provisional row everything above defers to, and is untouched.

## 4. `dispositions.md`'s remaining hit — the bead's open question, answered

**It is a legitimate ledger reference, not a miss from #8023.** Line 164 is HS-10's row, and the hit sits inside the sentence #8023 *wrote*:

> **This row's SPELLING is corrected here and its disposition is not touched** (rf2-bjpe): the surface column read `h/mount!`, which never shipped …

That is the provenance record of the correction. Removing the old spelling from a sentence whose subject is that spelling would delete the record. The row's actual Public-surface column reads `h/root!` and is correct.

## 5. What DOES land — one row, using the page's own machinery

`invariants.md` §5 *"Prototype-to-product dispositions"* is the register for exactly this: *"each row is also a naming-ledger row"*, and it carries `h/fn` → `h/handler` (ledger 1), `:&` (ledger 2), `h/reg-state` (ledger 3), presence (ledger 5), route-link (ledger 6). **It had no ledger-13 row.**

That gap is the real defect, and it is why the class is a false-positive magnet: §3's `h/handler` reads correctly as provisional *because* §5 records the `h/fn` → `h/handler` disposition, while §3's `h/mount!` had nothing behind it. A reader of the page that advertises itself as *"one page to check a change against"* had no way to learn that the root-lifecycle spellings are direction-of-travel rather than the current door.

One row added after ledger 6:

> \| root lifecycle: the prototype's `root!`, and `hydrate-root!` \| Become `h/mount!` and `h/hydrate!` — the spellings section 3 carries, ratified provisional until the naming sitting; `h/render!` and `h/unmount!` were promoted from impl under their existing names and are renamed by nothing. **Half landed**: the facade's roster today is `root!` / `render!` / `unmount!`, and the hydrating door ships only as `impl.mount/hydrate-root!`, not re-exported \| [§4] · [ledger 13] \|

It renames nothing, settles nothing, and contradicts no owner — it transcribes ledger row 13, which is what §5 rows are. No spelling anywhere in the tree changes.

**Facade roster verified at source**, not from the bead: `hicasso.cljc` — `root!` :566, `render!` :579, `unmount!` :586; `defview` :97, `hfn` :196, `defhost` :216; `sub`, `use-subs`, `hframe`, `error-boundary`, `reg-state`, `portal`, `route-link`, `as-element`, `as-component`. No `mount!` anywhere in the file; `impl.mount/hydrate-root!` exists (`mount.cljs:357`) and is not re-exported.

## 6. The three things kept apart

1. **`h/mount!` — misspelled door.** This bead. Real in the draft guide (`00-installation.md:82` is a consumer boot line: `(h/mount! (js/document.getElementById "app") …)`), correct in the design register. Fenced half untouched.
2. **`h/hydrate!` — missing door.** `rf2-k1mp` refused it (#8033); `dispositions.md` §2.1 note 1 holds the reasoning. Not touched, and named in the new row only as a fact about what ships.
3. **`rf2-bjpe`'s held operator fork** on HS-10/12/13. Not touched. Nothing here depends on how it resolves.

## Quality gates

`mkdocs build --strict` is **not** nominated and does not apply: `mkdocs.yml`'s `exclude_docs` keeps `docs/design/**` out of the site.

| Gate | Raw exit |
|---|---|
| `python scripts/check_doc_slugs.py` | **0** |
| `python scripts/check_provenance_pins.py --changed-since origin/main --verbose` | **0** — `1 files, 0 cited pins (0 landed, 0 stranded, 0 unresolvable, 0 foreign)` |

Not run: `npm run test:hicasso-hmr` binds `:dev-http` 8061 and other workers are live on this machine. No source under `implementation/` changed, so no CLJS suite is in this PR's blast radius.

### Negative control — gate selection proved

Planted at the line this PR actually adds, so the control tests the gate against *this* change.

1. Hash before plant: `1c1b9a2fb4c3dc5f319ed8cf7c6d5d10b51526a768bbe65c28e056a52ff36a6b`
2. Plant: the new row's `[§4]` target → `specification.md#99-a-heading-that-does-not-exist`. Hash after plant `5ce12feee9b1bc42318885fbc5c213acce1c027d525875bf76eef9ec437770f3` — **different**, so the patch applied rather than silently no-opping. Anchored to a single line.
3. `check_doc_slugs.py` → **exit 1**, observing the plant positively rather than merely going red: `BROKEN ANCHOR: docs\design\hicasso\product\invariants.md:85 -> specification.md#99-a-heading-that-does-not-exist` — line 85 being the added row.
4. Restored. Hash `1c1b9a2fb4c3dc5f319ed8cf7c6d5d10b51526a768bbe65c28e056a52ff36a6b` — **byte-identical to (1), verified by hash and not by reading a diff**. Gate back to **exit 0**.

### Verified by hand, since no gate covers it

`docs/design/**` has no renderer gate, so per `CLAUDE.md` these were checked manually and are stated rather than assumed:

- **Table column counts.** §5's table, header and delimiter included (lines 77–86), carries exactly 4 pipes / 3 columns on every row including the added one. Counted mechanically across the whole table, not spot-checked. The added cell text contains no `|` — the roster is written `root!` / `render!` / `unmount!` with slashes.
- **Anchors.** The added row introduces no new link target. Both its links reuse targets already live elsewhere on the page: `specification.md#4-target-programming-model` (lines 45–54, 79–82) and bare `naming-ledger.md` (lines 75, 79–84). `check_doc_slugs.py` validates both at exit 0.
- **Fence respected.** The diff is one added line in §5. Sections 1–4, 6 and 7 are untouched, and no spelling anywhere in the repo changes.
