### PR TITLE
fix(ci): widen the clj-kondo and Babashka install envelopes, and fail exhaustion as infrastructure (rf2-gfvy)

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -258,12 +258,56 @@ jobs:
         # placement where the retry policy covers the download that fails,
         # and it drops this step from two network hops to one.
         #
-        # `--retry 5 --retry-all-errors --retry-delay 3` retries transient
-        # failures with a 3s base backoff — the SSL-connect drop above, and
-        # the CDN HTTP-429 that `-f` alone treats as fatal (rf2-cq0s2j; cost
-        # a fix-worker cycle on #5304). GNU curl on ubuntu-24.04 runners
-        # supports `--retry-all-errors` (since 7.71). `-f` additionally means
-        # an error page can never be mistaken for an archive.
+        # `--retry-all-errors` is what makes the retry cover the failures that
+        # actually occur here — the SSL-connect drop above, and the CDN HTTP-429
+        # that `-f` alone treats as fatal (rf2-cq0s2j; cost a fix-worker cycle
+        # on #5304). GNU curl on ubuntu-24.04 runners supports it (since 7.71).
+        # `-f` additionally means an error page can never be mistaken for an
+        # archive.
+        #
+        # THE ENVELOPE (rf2-gfvy). The first cut was `--retry 5 --retry-delay 3`
+        # — about FIFTEEN SECONDS of cover, and it lost twice on 2026-08-13
+        # against github.com 5xx storms. #8009 logged five 503s, which is
+        # exactly curl's five retries and therefore every request this step was
+        # willing to make; job 94263477384 logged four and died `exit code 56`,
+        # curl's own receive-error number. `-f` means the step dies AT the curl
+        # rather than falling through to a missing binary, so the mask is
+        # milder than the one rf2-xsfr fixed one toolchain over — but the red
+        # still aggregates into `Lint required` and reads as a lint failure,
+        # and no exit-code handling can substitute for simply covering the
+        # storm. 24 retries at a 15s delay is six minutes of backoff, hard-
+        # capped at seven by `--retry-max-time`, which is the same envelope
+        # `.github/scripts/install-clojure-cli.sh` now carries and roughly
+        # 3.5x the longest storm measured (1m48s, #8017). The healthy path is
+        # untouched: the first attempt succeeds and none of it costs anything.
+        #
+        # NO OUTER LOOP, AND NO JITTER, both deliberately. An outer `for` loop
+        # is what the sibling installer uses, but it cannot go here: this step's
+        # body is read by `scripts/check_fast_pr_gap.py`, which classifies a
+        # step as SETUP rather than as a gate only when EVERY command line
+        # matches one of its `SETUP_PATTERNS` — so an added loop line, or a
+        # separate `echo ::error` line, would make the gap map report this job
+        # as an UNRUN GATE, a fail-open in the very map that exists to find
+        # them. Widening flags on the existing `curl` line preserves the
+        # classification, and the `|| { … }` below is appended to that SAME
+        # logical line behind the backslash continuations for the same reason.
+        # The sibling's jitter term is not carried over either: it exists there
+        # because ~59 jobs install the Clojure CLI concurrently within a single
+        # run and would arrive as one herd; clj-kondo has ONE call site, so a
+        # literal delay a reader can multiply out is worth more than thinning a
+        # herd of one.
+        #
+        # ON EXHAUSTION THE STEP SAYS SO. `-f` alone reds the step with curl's
+        # own number — 56 here, 22 for a plain HTTP error, and it varies with
+        # the transfer's failure mode, which is precisely why the annotation is
+        # NOT keyed on an exit code. `|| { echo "::error title=…"; exit 1; }`
+        # fires whatever curl returned, surfaces on the PR's checks page, and
+        # makes "the lint gate failed" and "the lint gate never ran"
+        # distinguishable without opening the raw log. Same idiom, and the same
+        # plain `exit 1`, as `install-clojure-cli.sh` and
+        # `resolve-clojure-deps.sh` (rf2-xsfr, rf2-vm036). The title carries no
+        # comma: `,` separates properties in GitHub's workflow-command grammar,
+        # so a comma inside one truncates the rendered title.
         #
         # The URL is written out in full — platform triple and version pin
         # literal, no shell interpolation — so that the string in this file is
@@ -280,9 +324,10 @@ jobs:
         # one this step exists to stop. `/usr/local/bin` is on $PATH and is
         # where the upstream script installed too, so nothing downstream moves.
         run: |
-          curl -fsSL --retry 5 --retry-all-errors --retry-delay 3 \
+          curl -fsSL --retry 24 --retry-all-errors --retry-delay 15 --retry-max-time 420 \
             -o /tmp/clj-kondo.zip \
-            https://github.com/clj-kondo/clj-kondo/releases/download/v2026.04.15/clj-kondo-2026.04.15-linux-static-amd64.zip
+            https://github.com/clj-kondo/clj-kondo/releases/download/v2026.04.15/clj-kondo-2026.04.15-linux-static-amd64.zip \
+            || { echo "::error title=clj-kondo install failed — CI infrastructure — not this diff::Downloading the pinned clj-kondo release archive failed for roughly seven minutes of retries. NO LINT RAN IN THIS JOB: this step provisions the linter, so the clj-kondo gate never started and this red says nothing whatever about the diff. The usual cause is a github.com 5xx storm on the release download (two PRs on 2026-08-13, rf2-gfvy; four more on the Clojure CLI the same day, rf2-xsfr); the URL fetched is a literal constant in .github/workflows/lint.yml, so no change can affect it UNLESS this PR edits that step, in which case read it first. Otherwise re-run the job."; exit 1; }
           unzip -qq -o /tmp/clj-kondo.zip clj-kondo -d /tmp
           sudo install -m 0755 /tmp/clj-kondo /usr/local/bin/clj-kondo
           clj-kondo --version

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5651,17 +5651,63 @@ jobs:
       - name: Set up Babashka
         # rf2-9sgj8 — resilient Babashka install (same setup-clojure curl-35 /
         # socket-hang-up flake class as the Clojure CLI installs above).
-        # Reuses the repo's clj-kondo curl-retry idiom (lint.yml) + a 3x backoff
+        # Reuses the repo's clj-kondo curl-retry idiom (lint.yml) + a backoff
         # loop; the bb installer pulls from raw.githubusercontent.com, which
         # 429s under rate limiting — hence --retry-all-errors (lint.yml note).
+        #
+        # rf2-gfvy — this was a line-for-line copy of the three-attempt loop
+        # that rf2-xsfr replaced in `.github/scripts/install-clojure-cli.sh`,
+        # and it carried both of that loop's defects:
+        #
+        #   * A ~2 MINUTE ENVELOPE (10s/20s/30s of backoff plus each attempt's
+        #     own `--retry 5 --retry-delay 3`) against github.com 5xx storms
+        #     measured at 1m48s on 2026-08-13 — it would have lost by seconds.
+        #     It also slept 30s after the FINAL attempt, wasting half a minute
+        #     to change nothing.
+        #
+        #   * AN UNGUARDED FALL-THROUGH to `bb --version` on exhaustion. On a
+        #     runner where nothing installed that dies `bb: command not found`,
+        #     exit 127 — which stops the job proceeding on a half-installed
+        #     toolchain, as intended, but reports a red step INDISTINGUISHABLE
+        #     from the structural tests below having failed.
+        #
+        # This step has no measured instances of its own (the job runs only on
+        # changed skill paths), but it fetches from the same hosts on the day
+        # its two siblings lost, so it takes the same repair: six attempts with
+        # a jittered 20s/40s/60s/80s/100s backoff — roughly seven minutes, about
+        # 3.5x the longest storm observed — and an explicit `::error` annotation
+        # in place of the fall-through, so "the gate failed" and "the gate never
+        # ran" are distinguishable without opening the raw log. The exit status
+        # stays a plain 1, as it is in `install-clojure-cli.sh` and
+        # `resolve-clojure-deps.sh`: the annotation is the machine-readable
+        # carrier the checks API exposes, and a bespoke code would be a second
+        # convention with no consumer. The jitter term comes over unchanged from
+        # the sibling — it costs nothing in a loop body, unlike inside a curl
+        # flag list, which is why the clj-kondo step in lint.yml does without
+        # it. The title carries no comma: `,` separates properties in GitHub's
+        # workflow-command grammar, so a comma inside one truncates the title.
+        #
+        # NOT extracted to `.github/scripts/install-babashka.sh`. The Clojure
+        # CLI extraction (rf2-e7ja9) paid for itself by collapsing ~59 copies of
+        # one policy; bb has exactly ONE call site, and a new file plus its
+        # shellcheck-roster and mirror-test obligations to own a single caller
+        # is not a trade worth making.
         run: |
           set -euo pipefail
-          for attempt in 1 2 3; do
+          attempts=6
+          attempt=0
+          while [ "$attempt" -lt "$attempts" ]; do
+            attempt=$((attempt + 1))
             curl -fsSL --retry 5 --retry-all-errors --retry-delay 3 -o /tmp/bb-install \
               https://raw.githubusercontent.com/babashka/babashka/master/install \
               && sudo bash /tmp/bb-install && break
-            echo "Babashka install attempt ${attempt}/3 failed; retrying in $((attempt * 10))s"
-            sleep "$((attempt * 10))"
+            if [ "$attempt" -ge "$attempts" ]; then
+              echo "::error title=Babashka install failed — CI infrastructure — not this diff::Downloading and running the official Babashka installer failed ${attempts} times over roughly seven minutes. NO GATE RAN IN THIS JOB: this step provisions bb, so the skills structural tests that would have exercised this change never started, and this red says nothing whatever about the diff. The usual cause is a raw.githubusercontent.com 429 under rate limiting or a github.com 5xx storm (rf2-9sgj8; six such losses on 2026-08-13, rf2-xsfr and rf2-gfvy); the URL fetched is a literal constant in .github/workflows/test.yml, so no change can affect it UNLESS this PR edits that step, in which case read it first. Otherwise re-run the job."
+              exit 1
+            fi
+            delay=$((attempt * 20 + RANDOM % 10))
+            echo "Babashka install attempt ${attempt}/${attempts} failed; retrying in ${delay}s"
+            sleep "$delay"
           done
           bb --version
 


### PR DESCRIPTION
Closes rf2-gfvy.

The two workflow-YAML siblings PR #8030 could not take. Both were fenced out of
rf2-xsfr's brief as hot zone; both fetch from the hosts that served 503 storms
across six PRs on 2026-08-13; and both reported the loss as though the gate had
run and failed. #8030 is the worked example for the shape and it did the
analysis — this PR applies it, adapted where the two sites differ, and proves
the failure path the same way.

## Site 1 — `lint.yml`, `Install clj-kondo`

**Before** (one logical line, no outer loop):

```
curl -fsSL --retry 5 --retry-all-errors --retry-delay 3 \
  -o /tmp/clj-kondo.zip \
  https://github.com/clj-kondo/clj-kondo/releases/download/v2026.04.15/…zip
```

Five retries at a 3s delay is **fifteen seconds of cover** — strictly narrower
than the two-minute envelope that lost four times on the Clojure CLI, and the
bead's reading holds exactly: #8009's "five 503s" *is* curl's five retries, i.e.
every request the step was willing to make. Job `94263477384` logged four and
died `Process completed with exit code 56`.

**After**:

```
curl -fsSL --retry 24 --retry-all-errors --retry-delay 15 --retry-max-time 420 \
  -o /tmp/clj-kondo.zip \
  https://github.com/clj-kondo/clj-kondo/releases/download/v2026.04.15/…zip \
  || { echo "::error title=clj-kondo install failed — CI infrastructure — not this diff::…"; exit 1; }
```

24 retries × 15s is **360 seconds of backoff, hard-capped at 420** by
`--retry-max-time` — the same seven-minute envelope
`.github/scripts/install-clojure-cli.sh` now carries, and ~3.5× the longest
storm measured (1m48s, #8017). The healthy path is untouched: first attempt
succeeds, nothing costs anything.

Three judgements, all source-located in the step's comment:

- **No outer loop and no separate `echo` line.** Forced by the classifier
  coupling below.
- **No jitter term.** The sibling carries one because ~59 jobs install the
  Clojure CLI concurrently *within a single run* and would arrive as one herd.
  clj-kondo has **one** call site, and inside a curl flag list a `$((…RANDOM…))`
  costs the reader a literal they can multiply out. Stated in the comment so
  the asymmetry with the sibling is not a mystery.
- **The annotation is not keyed on an exit code.** 56 here, 22 for a plain HTTP
  error, 127 on the path #8030 fixed — the number varies with the failure mode,
  the annotation does not. `|| { … }` fires on whatever curl returned.

## Site 2 — `test.yml`, `Set up Babashka`

A line-for-line copy of the three-attempt loop rf2-xsfr replaced, carrying both
of its defects: a ~2 minute envelope, and an unguarded fall-through to
`bb --version` whose `bb: command not found` (exit 127) is indistinguishable
from the structural tests below it having failed. It also slept 30s *after* the
final attempt, wasting half a minute to change nothing.

**After**: six attempts, `delay=$((attempt * 20 + RANDOM % 10))`, guarded so the
last attempt does not sleep, and on exhaustion an `::error` annotation plus
`exit 1` instead of the fall-through. Exit status stays a plain **1**, as in
`install-clojure-cli.sh` and `resolve-clojure-deps.sh` — the annotation is the
carrier the checks API exposes, and a bespoke code would be a second convention
with no consumer. Jitter **is** carried over here: it costs nothing in a loop
body, which is precisely the difference from site 1.

**Not extracted** to `.github/scripts/install-babashka.sh`. rf2-e7ja9's
extraction paid for itself by collapsing ~59 copies of one policy; bb has
exactly one call site, and a new file plus its shellcheck-roster and
mirror-test obligations to own a single caller is not a trade. #8030's worker
declined to pre-land that script and that judgement stands for the same reason
from the other side.

## The `SETUP_PATTERNS` coupling — verified at source

`scripts/check_fast_pr_gap.py` classifies a step as setup only when **every**
logical command line in its body matches one of `SETUP_PATTERNS`
(`Step.is_setup`, line 358: `all(any(rx.search(ln) for rx in _SETUP_RE) for ln in lines)`,
over `join_continuations(self.run)`). The patterns are `^`-anchored and compiled
without `re.M`, so `search` can only match at position 0. Adding a `for` loop
line or a separate `echo ::error` line would drop the body out of the set and
the gap map would report the **lint job as an unrun gate** — a fail-open in the
map the briefs cite.

Appending `|| { … }` behind the existing backslash continuations keeps it on the
*same logical line*, so the line still begins `curl ` and still contains
`clj-kondo/releases/download/`. Measured directly against the module, not
inferred:

| | before | after |
|---|---|---|
| `Step("Install clj-kondo").is_setup` | `True` | `True` |
| `_KONDO_PIN_RE` pin read off the step | `2026.04.15` | `2026.04.15` |
| `clj-kondo` job's `gate_steps` (non-setup) | `['Run clj-kondo', 'Hicasso lint export — fixture witness']` | *(identical)* |

And end-to-end, `python scripts/check_fast_pr_gap.py --list` before vs after is
**identical except for the echoed text of the Babashka step body** — the entire
`lint.yml` section is byte-for-byte unchanged, and the `skills-structural` entry
still lists `Set up Babashka` exactly as it did (it was already a gate step, and
still is):

```
253c253,256
<                 for attempt in 1 2 3; do
---
>                 attempts=6
>                 attempt=0
>                 while [ "$attempt" -lt "$attempts" ]; do
>                   attempt=$((attempt + 1))
257,260c260
<                   echo "Babashka install attempt ${attempt}/3 failed; retrying in $((attempt * 10))s"
<                   sleep "$((attempt * 10))"
<                 done
<                 ... (1 more lines -- see .github/workflows/test.yml)
---
>                 ... (9 more lines -- see .github/workflows/test.yml)
```

No classification moved. `scripts/lint_kondo.py` reads the same pin through the
same parser and is unaffected.

## Nothing else in either file moved

Parsed both files with PyYAML at `origin/main` and at HEAD and compared the
structural shape — job ids, job `name`, `needs`, `if`, `runs-on`, and per step
`(name, uses, if, working-directory)` — plus the `on:` trigger blocks:

```
.github/workflows/lint.yml | jobs: 6 -> 6  | on: identical: True
   job/step SHAPE identical: True
   run: body changed -> job=clj-kondo step='Install clj-kondo'
.github/workflows/test.yml | jobs: 77 -> 77 | on: identical: True
   job/step SHAPE identical: True
   run: body changed -> job=skills-structural step='Set up Babashka'
```

Exactly two `run:` bodies changed and nothing else, so no required-check name
moved and nothing was silently un-required.

## Evidence that the failure path behaves as intended

A 503 storm cannot be summoned, so `curl`, `sudo`, `sleep`, `unzip`, `install`
and the installer hop were shimmed onto the front of a sanitised `PATH` (no real
`clj-kondo` and no real `bb` on it, asserted before each run) and **the step
bodies were run verbatim** — extracted from the YAML with PyYAML, no test hooks
and no env knobs added to the workflows.

The outage is modelled in **simulated seconds, not request counts**, because the
thing under test is an envelope. A shared clock advances by every retry delay
curl waits and every outer backoff the step sleeps; any request issued before
the storm clears is served a 503. So `storm=108s` is literally "the longest
storm measured on 2026-08-13".

Two non-vacuity guards, because #8030's first control ran an empty file and
"passed": each control asserts it loaded the real `origin/main` body (`for
attempt in 1 2 3` / `--retry 5 …--retry-delay 3`) and that it carries **no**
`::error`; each new-form run asserts the opposite. The sanitised PATH is checked
for a pre-existing `clj-kondo`/`bb` before every run, or `command not found`
could never happen and the control would be toothless.

### `Install clj-kondo`

| case | storm | exit | HTTP requests | envelope covered | `::error` |
|---|---|---|---|---|---|
| **CONTROL** — `origin/main` form | 108s | **56** | 6 (t=0,3,6,9,12,15s) | **15s** | 0 |
| **CONTROL** — `origin/main` form | never clears | **56** | 6 | 15s | 0 |
| A — this PR | 108s | **0** | 9 (recovered at t=120s) | 120s | 0 |
| B — this PR, healthy | 0s | **0** | 1 | 0s | 0 |
| C — this PR | 300s | **0** | 21 | 300s | 0 |
| D — this PR | never clears | **1** | 25 | **360s** | **1** |
| E — this PR | 400s | **1** | 25 | 360s | 1 |

The control reproduces today's symptom exactly — dead at t=15s with curl's own
exit 56 and no annotation — and case A is the same storm survived. Case B shows
the healthy path costs one request and reaches `clj-kondo --version` (the shim
prints `clj-kondo (installed by the shim)`, so the `unzip` → `sudo install` →
`--version` tail really ran). E pins the boundary where the flags say it is.

### `Set up Babashka`

| case | storm | exit | HTTP requests | outer backoffs | envelope | `::error` |
|---|---|---|---|---|---|---|
| **CONTROL** — `origin/main` form | 108s | **127** | **18** | `[10, 20, 30]` | **105s** | 0 |
| **CONTROL** — `origin/main` form | never clears | **127** | 18 | `[10, 20, 30]` | 105s | 0 |
| **CONTROL** — installer hop fails | 0s | **127** | 3 | `[10, 20, 30]` | 60s | 0 |
| A — this PR | 108s | **0** | 14 (recovered at t=109s) | `[28, 48]` | 109s | 0 |
| B — this PR, healthy | 0s | **0** | 1 | `[]` | 0s | 0 |
| C — this PR | 300s | **0** | 31 | `[26,41,65,81,108]` | 396s | 0 |
| D — this PR | never clears | **1** | 36 | `[29,41,67,82,100]` | **409s** | **1** |
| E — this PR, installer hop fails | 0s | **1** | 6 | `[29,49,62,87,101]` | 328s | **1** |

The control's **eighteen** HTTP requests are #8017's eighteen 503s, arrived at
independently: 3 outer attempts × (1 + curl's `--retry 5`). Its envelope is
**105 seconds against a 108-second storm** — it lost by three. It exits **127**,
the `bb: command not found` mask, with no annotation. The third control row
shows the unguarded trailing sleep: three attempts, three sleeps.

Case E covers the second network hop — the installer script is piped into
`sudo bash`, and that fetch is inside the retried unit, so it is covered too.
Every jitter draw lands in `[attempt*20, attempt*20+9]`, which is the arithmetic
the step declares.

## Quality gates

| gate | raw exit code |
|---|---|
| `python scripts/check_fast_pr_gap.py --list` | **0** (before and after; diff quoted above) |
| `python scripts/check_gate_scheduling.py` | **0** — `50 gate commands, 42 scheduled, 8 declared`, unchanged |
| `python -c "import yaml;yaml.safe_load(open('.github/workflows/lint.yml'))"` | **0** |
| `python -c "import yaml;yaml.safe_load(open('.github/workflows/test.yml'))"` | **0** |
| `node implementation/scripts/_changed-surfaces.test.cjs` (the frozen mirror, 325 assertions) | **0** |
| `node implementation/scripts/_lint-workflow-policy.test.cjs` | **0** (4) |
| `node implementation/scripts/_docs-workflow-policy.test.cjs` | **0** (5) |
| `node implementation/scripts/_mcp-conformance-install-policy.test.cjs` | **0** (5) |
| `node implementation/scripts/_resolve-clojure-deps-classifier.test.cjs` | **0** (6) |
| `node implementation/scripts/_path-policy.test.cjs` | **0** |
| `node implementation/scripts/_script-spawn-policy.test.cjs` | **0** (168) |
| `node implementation/scripts/_navigation-ceiling-policy.test.cjs` | **0** (4) |
| rf2-gfvy failure-path harness (2 sites × control + 4–5 cases) | **0** |
| `sh scripts/test-fast-pr.sh` (`gate root: /c/Users/miket/code/re-frame2-worktrees/wfinstall-gfvy`) | **1** — one environmental lane, see below |

**The spine's 1 is one lane, and it cannot be reached by this diff.** Classified
`docs=false jvm=true node=true`; exactly one `FAIL` line in the whole run:

```
==> CLJS node integration
compile-node-test: could not resolve shadow-cljs: Cannot find module 'shadow-cljs/cli/runner.js'
FAIL CLJS node integration
```

That is a fresh worker worktree with no `implementation/node_modules`. This PR
contains **no CLJS, no JS and no Clojure** — two `run:` bodies in workflow YAML —
so `npm run test:cljs` cannot be affected either way, and CI runs it regardless.
I did not junction the mayor's `node_modules` to re-prove a lane my change cannot
reach; flagging it rather than quietly quoting a green. Everything else passed,
including `JVM implementation/core`, the whole always-on static block, and
`implementation JS harness helpers` — which is where this PR's own coverage lives
(`changed-surfaces tests: 325 passed`, `lint-workflow-policy tests: 4 passed`).

Worth one extra line: the spine's `clj-kondo (pinned, CI's own command)` lane
passed, and it printed `clj-kondo 2026.04.15`. That lane is
`scripts/lint_kondo.py`, which reads the pin **off the step this PR edits** —
so the pin-reading consumer is exercised end to end against the new body, not
just asserted against the regex.

**The frozen mirror needed no edit.** The brief warned that
`implementation/scripts/_changed-surfaces.test.cjs` pins installer text as
literal assertions and might have to be widened — it does, but only for
`.github/scripts/install-clojure-cli.sh` (the `rf2-e7ja9`/`rf2-xsfr` block) and
for the *shape* of `Set up Clojure CLI` steps. Neither of this PR's two steps is
pinned there, and all 325 assertions pass unmodified. `implementation/**` is
untouched by this PR.

### Both steps ran green on this PR's own CI, against the live endpoints

The shims prove control flow; the live run settles the rest. Both edited steps
executed on this PR — and both were re-armed by the diff itself, so neither
needed contriving:

| job | step | conclusion | duration |
|---|---|---|---|
| `clj-kondo (fail on errors, warnings informational)` ([94274658159](https://github.com/day8/re-frame2/actions/runs/31644181110/job/94274658159)) | `Install clj-kondo` | **success** | <1s |
| `Skills structural tests (changed skill paths only)` ([94274630991](https://github.com/day8/re-frame2/actions/runs/31644181023/job/94274630991)) | `Set up Babashka` | **success** | 1s |

`Lint required` is green, and the three structural-test steps downstream of the
Babashka install all ran and passed — so the install really produced a working
`bb`, not just a zero exit.

### What is not covered, stated plainly

- **No wall-clock run with real `sleep`.** #8030 did one; here it would prove
  less. All of the clj-kondo widening lives *inside* curl's own retry loop,
  which is real curl in production — making my shim sleep for six minutes would
  measure the shim, not the fix. The Babashka backoff is the step's own
  arithmetic and is observed directly in the tables above (every draw inside
  `[attempt*20, attempt*20+9]`).
- **No run against the live endpoints.** This is a Windows checkout and the
  install hops are `sudo`-into-`/usr/local` on Linux. The URLs, the `-f`, the
  `--retry-all-errors` and the `sudo` lines are unchanged; only the retry
  budget, the loop bound and the exhaustion boundary moved. This PR's own CI
  runs both steps for real.
- **`--retry-max-time 420` is not exercised as the binding constraint** in the
  clj-kondo table — 24 × 15s = 360s stops first. It is the ceiling, not the
  schedule.

## One divergence from the sibling, flagged

Both new annotation titles read `… — CI infrastructure — not this diff`, with an
em dash where `install-clojure-cli.sh` has a comma. GitHub's workflow-command
grammar is `::error name=value,name=value::message`, so a comma inside a
property value ends it — the sibling's rendered title very likely truncates at
`… — CI infrastructure`. Its message body carries everything that matters, so
this is cosmetic and `install-clojure-cli.sh` is out of my fence; raising it
here rather than editing that file.
