### PR TITLE
rf2-u0j8: an aborted browser run now names itself instead of being waited out

### DIFF
--- a/implementation/scripts/_browser-test-report.test.cjs
+++ b/implementation/scripts/_browser-test-report.test.cjs
@@ -3,11 +3,13 @@
 const assert = require('assert/strict');
 const {
   createDiagnosticBuffer,
+  findFixtureAbort,
   formatCompactSummary,
   isVerboseTests,
   parseFailureCounts,
   parseRanCounts,
   summaryPartsFromText,
+  testingNamespaces,
 } = require('./lib/browser-test-report.cjs');
 
 const tests = [];
@@ -240,6 +242,64 @@ test('diagnostic buffer entries() returns a defensive copy', () => {
   // Mutating the returned array must not leak back into the buffer.
   assert.equal(buffer.entries().length, 1);
   assert.deepEqual(buffer.entries(), [{ stream: 'stdout', text: 'a' }]);
+});
+
+// rf2-u0j8 — the fixture abort. The literal below is the one cljs.test 1.12.x
+// rethrows from `test-var-block*`'s `::async-disabled` branch, captured from a
+// real aborted `npm run test:browser` run.
+const REAL_ABORT_TEXT =
+  'Async tests require fixtures to be specified as maps.  Testing aborted.';
+
+test('the cljs.test fixture abort is recognised in the captured page errors (rf2-u0j8)', () => {
+  assert.equal(findFixtureAbort([REAL_ABORT_TEXT]), REAL_ABORT_TEXT);
+  // It is found wherever it sits in the list — the abort is rarely the only
+  // thing a busy page throws.
+  assert.equal(
+    findFixtureAbort(['TypeError: x is not a function', REAL_ABORT_TEXT]),
+    REAL_ABORT_TEXT,
+  );
+});
+
+test('an ordinary uncaught exception is NOT classified as the fixture abort (rf2-u0j8)', () => {
+  // This is the arm that must stay narrow: an ordinary mid-suite throw is not
+  // terminal, and treating it as one would truncate a run that was about to
+  // report its summary.
+  assert.equal(findFixtureAbort([]), null);
+  assert.equal(findFixtureAbort(null), null);
+  assert.equal(
+    findFixtureAbort(['Error: Cannot read properties of null (reading "foo")']),
+    null,
+  );
+  assert.equal(findFixtureAbort(['Async test called done more than one time']), null);
+});
+
+test('either half of the abort sentence is enough to match (rf2-u0j8)', () => {
+  // Two independent substrings, so an upstream reword has to take out BOTH
+  // before immediacy is lost — and even then the matcher-free
+  // no-summary-with-pageerror arm still reports the abort.
+  assert.ok(findFixtureAbort(['… Testing aborted.']));
+  assert.ok(findFixtureAbort(['Async tests require fixtures to be specified as maps.']));
+});
+
+test('the announced namespaces are recovered from the console trail, in order (rf2-u0j8)', () => {
+  // cljs-test-display prints `\nTesting <ns>` at every :begin-test-ns, so a
+  // single console message carries a leading blank line.
+  const lines = [
+    '\nTesting day8.re-frame2-xray.theme.a11y-dom-cljs-test',
+    'some app log',
+    '\nTesting re-frame.aaa-abort-probe-dom-cljs-test',
+  ];
+  assert.deepEqual(testingNamespaces(lines), [
+    'day8.re-frame2-xray.theme.a11y-dom-cljs-test',
+    're-frame.aaa-abort-probe-dom-cljs-test',
+  ]);
+});
+
+test('a "Testing" mention inside a log line is not mistaken for a namespace (rf2-u0j8)', () => {
+  assert.deepEqual(testingNamespaces(['When Testing this, wrap in act(...)']), []);
+  assert.deepEqual(testingNamespaces(['Testing']), []);
+  assert.deepEqual(testingNamespaces([]), []);
+  assert.deepEqual(testingNamespaces(null), []);
 });
 
 test('RF2_VERBOSE_TESTS=1 enables verbose mode', () => {

--- a/implementation/scripts/_impl-browser-runners-verdict-policy.test.cjs
+++ b/implementation/scripts/_impl-browser-runners-verdict-policy.test.cjs
@@ -423,7 +423,7 @@ test('run-browser-tests: an aborted run is named as an abort, not waited out as 
   // without pinning it to a string that lives in another repository.
   assert.match(
     src,
-    /else if\s*\(\s*pageErrors\.length\s*>\s*0\s*\)\s*\{[\s\S]{0,600}?NO cljs\.test SUMMARY/,
+    /else if\s*\(\s*pageErrors\.length\s*>\s*0\s*\)\s*\{[\s\S]{0,600}?THE BROWSER RUN ABORTED/,
     'a summary-less run with page errors must be reported as an abort even when '
       + 'the abort literal did not match',
   );

--- a/implementation/scripts/_impl-browser-runners-verdict-policy.test.cjs
+++ b/implementation/scripts/_impl-browser-runners-verdict-policy.test.cjs
@@ -368,6 +368,67 @@ test('run-browser-tests: navigation has its own explicit, named ceiling (rf2-dcz
   );
 });
 
+test('run-browser-tests: an aborted run is named as an abort, not waited out as a timeout (rf2-u0j8)', () => {
+  const src = read('run-browser-tests.cjs');
+  // cljs.test refuses an `async` row under a POSITIONAL fixture by throwing a
+  // bare string out of `test-var-block*`. Nothing catches it, shadow.test runs
+  // the whole lane inside ONE `run-block`, so every remaining namespace AND the
+  // closing summary are lost. The runner already held the decisive signal — a
+  // `pageerror` — and consulted it only after a summary it was never going to
+  // get, so the observed cost was a full BROWSER_TEST_TIMEOUT_MS burn ending in
+  // "Timed out ... waiting for cljs.test summary. (source: not found)".
+  //
+  // Dormant in a healthy tree, like the floor and the navigation ceiling: no
+  // green run reaches any of this, so it needs a static pin.
+  assert.match(
+    src,
+    /const\s+fixtureAborts\s*=\s*\[\]/,
+    'must track the terminal fixture abort in a dedicated array, not merely in diagnostics',
+  );
+  assert.match(
+    src,
+    /page\.on\(\s*['"]pageerror['"][\s\S]{0,400}?fixtureAborts\.push\(/,
+    'the pageerror handler must classify and record the terminal abort as it arrives',
+  );
+  // The break must be INSIDE the poll loop. After it, the abort has already
+  // cost the whole budget, which is the defect.
+  assert.match(
+    src,
+    /while\s*\([\s\S]{0,80}?TIMEOUT_MS\s*\)\s*\{[\s\S]{0,700}?if\s*\(\s*fixtureAborts\.length\s*>\s*0\s*\)\s*break\s*;/,
+    'the poll loop must stop the moment a terminal abort is seen',
+  );
+  // Narrowness is the point: only the terminal class short-circuits. An
+  // ordinary mid-suite `pageerror` is NOT terminal — the run usually finishes
+  // and the rf2-mwx08 arm fails it on the summary — so breaking on those would
+  // truncate a run that was about to report and mislabel it.
+  assert.doesNotMatch(
+    src,
+    /while\s*\([\s\S]{0,80}?TIMEOUT_MS\s*\)\s*\{[\s\S]{0,700}?if\s*\(\s*pageErrors\.length\s*>\s*0\s*\)\s*break\s*;/,
+    'an ordinary pageerror must NOT short-circuit the poll loop',
+  );
+  // The verdict path must SAY what happened, and name the fix.
+  assert.match(
+    src,
+    /THE BROWSER RUN ABORTED/,
+    'the abort must name itself rather than presenting as a summary timeout',
+  );
+  assert.match(
+    src,
+    /use-fixtures[\s\S]{0,400}?:before/,
+    'the message must name the map-fixture remedy, not merely report the abort',
+  );
+  // And the matcher-free backstop: if the cljs.test literal is ever reworded,
+  // a summary-less run that emitted page errors must STILL be reported as an
+  // abort rather than as a timeout. This is what keeps the guard correct
+  // without pinning it to a string that lives in another repository.
+  assert.match(
+    src,
+    /else if\s*\(\s*pageErrors\.length\s*>\s*0\s*\)\s*\{[\s\S]{0,600}?NO cljs\.test SUMMARY/,
+    'a summary-less run with page errors must be reported as an abort even when '
+      + 'the abort literal did not match',
+  );
+});
+
 // ---- serve-and-run-xray-feature-gate.cjs ----
 
 test('xray-feature-gate: a scenario with a captured pageerror is not marked passed (rf2-mwx08)', () => {

--- a/implementation/scripts/lib/browser-test-report.cjs
+++ b/implementation/scripts/lib/browser-test-report.cjs
@@ -31,11 +31,49 @@
 //   createDiagnosticBuffer()    → an ordered stdout/stderr line buffer
 //                                  flushed verbatim (with stream routing)
 //                                  only when the runner needs the trail.
+//   findFixtureAbort(errors)    → the page error that ENDED the run, or null
+//                                  (rf2-u0j8).
+//   testingNamespaces(lines)    → the namespaces cljs-test-display announced,
+//                                  in order — the trail's own answer to "how
+//                                  far did the run get?" (rf2-u0j8).
 // isVerboseTests(env) is the RF2_VERBOSE_TESTS=1 escape hatch shared
 // with lib/gate-report.cjs.
 
 const RAN_RE = /Ran\s+(\d+)\s+tests?\s+containing\s+(\d+)\s+assertions?\./;
 const FAIL_RE = /(\d+)\s+failures?,\s*(\d+)\s+errors?\.?/;
+
+// rf2-u0j8 — the one uncaught page error that is TERMINAL for the whole run.
+//
+// cljs.test refuses `async` rows in a namespace whose fixtures are POSITIONAL
+// (`(use-fixtures :once (fn [f] … (f)))`) rather than maps. `execution-strategy`
+// picks `:sync` for a namespace whose fixtures are all fns, and the `:sync`
+// branch wraps every test body in `disable-async`, which throws `::async-disabled`
+// the moment a body returns an async object. `test-var-block*` catches that and
+// rethrows a bare STRING:
+//
+//     ::async-disabled (throw "Async tests require fixtures to be specified as
+//                              maps.  Testing aborted.")
+//
+// Nothing catches it after that. `cljs.test/run-block` has no try/catch, and
+// shadow.test runs the ENTIRE lane — every namespace block plus the closing
+// `:summary` / `:end-run-tests` reports — inside ONE `run-block`. So the throw
+// unwinds the whole lane: every namespace sorted after the offender never
+// executes, and the `Ran N tests containing M assertions.` line the runner
+// waits for is never printed.
+//
+// Two independent substrings of the same sentence, so a reword upstream has to
+// take out both before this stops matching. It does NOT have to keep matching
+// for the runner to stay correct: the abort still produces a `pageerror` and no
+// summary, which the generic no-summary-with-pageerror arm reports on its own.
+// This matcher only buys IMMEDIACY (fail in seconds instead of burning the
+// whole BROWSER_TEST_TIMEOUT_MS budget) and the named remedy.
+const FIXTURE_ABORT_RE = /Testing aborted|fixtures to be specified as maps/;
+
+// The `Testing <ns>` line cljs-test-display prints at every `:begin-test-ns`
+// when `cljs-test-display.core/printing` is true (the `:browser-test` build
+// sets it via `:closure-defines`). Anchored to the start of a line because
+// that is where the reporter's own `(println "\nTesting" ns)` puts it.
+const TESTING_NS_RE = /^Testing\s+([^\s]+)\s*$/;
 
 function isVerboseTests(env = process.env) {
   return env.RF2_VERBOSE_TESTS === '1';
@@ -123,6 +161,36 @@ function parseRanCounts(ran) {
   };
 }
 
+// rf2-u0j8: the first captured page error that is the cljs.test fixture abort,
+// or null. Kept pure (and separate from the runner) so the classification is
+// unit-testable without launching a browser.
+function findFixtureAbort(errors) {
+  if (!errors) return null;
+  for (const err of errors) {
+    if (err != null && FIXTURE_ABORT_RE.test(String(err))) return String(err);
+  }
+  return null;
+}
+
+// rf2-u0j8: the namespaces the run announced, in order. `lines` may be raw
+// console texts (which carry embedded newlines) or already-split lines; both
+// are handled. The LAST entry is the namespace that was executing when a
+// terminal error fired, and the COUNT is how far the lane got — the two numbers
+// that turn "the run stopped" into "the run stopped HERE, and N namespaces
+// after it never ran".
+function testingNamespaces(lines) {
+  const out = [];
+  if (!lines) return out;
+  for (const raw of lines) {
+    if (raw == null) continue;
+    for (const line of String(raw).replace(/\r\n/g, '\n').split('\n')) {
+      const match = line.match(TESTING_NS_RE);
+      if (match) out.push(match[1]);
+    }
+  }
+  return out;
+}
+
 function formatCompactSummary({ label = 'Browser tests', ran, failErr, source }) {
   const sourceSuffix = source ? ` (source: ${source})` : '';
   return `${label}: ${ran} ${failErr}${sourceSuffix}`;
@@ -155,6 +223,9 @@ function createDiagnosticBuffer() {
 module.exports = {
   RAN_RE,
   FAIL_RE,
+  FIXTURE_ABORT_RE,
+  findFixtureAbort,
+  testingNamespaces,
   isVerboseTests,
   summaryPartsFromText,
   parseFailureCounts,

--- a/implementation/scripts/run-browser-tests.cjs
+++ b/implementation/scripts/run-browser-tests.cjs
@@ -572,10 +572,11 @@ async function main() {
         // This arm is what keeps the guard correct if the abort literal above
         // is ever reworded upstream — it is matcher-free.
         console.error(
-          `NO cljs.test SUMMARY, and the page emitted ${pageErrors.length} ` +
-            `uncaught error(s) — the suite did not finish (rf2-u0j8). This is an ` +
-            `ABORT, not a slow run: raising ${BROWSER_TEST_TIMEOUT_ENV_VAR} ` +
-            `(${TIMEOUT_MS}ms) will not help.\n` +
+          `THE BROWSER RUN ABORTED — no cljs.test summary, and the page emitted ` +
+            `${pageErrors.length} uncaught error(s) (rf2-u0j8). The suite STOPPED; ` +
+            `no summary was still on its way, so the wait above expired against a ` +
+            `run that had already ended. Read the error(s) below as the cause, not ` +
+            `the wait.\n` +
             `  ${where}`,
         );
         for (const line of pageErrors) console.error(`  ${line}`);

--- a/implementation/scripts/run-browser-tests.cjs
+++ b/implementation/scripts/run-browser-tests.cjs
@@ -31,11 +31,13 @@
 const { chromium } = require('playwright');
 const {
   createDiagnosticBuffer,
+  findFixtureAbort,
   formatCompactSummary,
   isVerboseTests,
   parseFailureCounts,
   parseRanCounts,
   summaryPartsFromText,
+  testingNamespaces,
 } = require('./lib/browser-test-report.cjs');
 // `sleep` is the shared poll primitive — verbatim the same
 // `setTimeout`-backed Promise this runner used to define inline
@@ -427,6 +429,13 @@ async function main() {
     // `pageErrors` is — a fatal signal must not be recoverable only by
     // re-scanning diagnostics that a green run never flushes.
     const fatalConsole = [];
+    // rf2-u0j8: the subset of `pageErrors` that is TERMINAL for the lane —
+    // cljs.test's refusal of an `async` row under a positional fixture, which
+    // unwinds every remaining namespace and the closing summary with it.
+    // Dedicated array for the same reason as the two above, and consulted in
+    // the poll loop rather than after it: there is no summary coming, so
+    // waiting for one only converts a diagnosable failure into a timeout.
+    const fixtureAborts = [];
     diagnostics.add(`URL: ${URL}`);
     page.on('console', (msg) => {
       const text = msg.text();
@@ -436,6 +445,12 @@ async function main() {
     });
     page.on('pageerror', (err) => {
       pageErrors.push(err.stack || err.message);
+      // rf2-u0j8: the cljs.test abort is thrown as a bare STRING, so the
+      // sentence lands in `err.message` and `err.stack` may not carry it.
+      // Classify on both.
+      if (findFixtureAbort([err.message, err.stack])) {
+        fixtureAborts.push(err.message || err.stack);
+      }
       diagnostics.add(`${capturedAt()} [browser:pageerror] ${err.message}`, 'stderr');
       if (err.stack) diagnostics.add(err.stack, 'stderr');
     });
@@ -484,6 +499,13 @@ async function main() {
     };
 
     while (Date.now() - start < TIMEOUT_MS) {
+      // rf2-u0j8: stop waiting for a summary that cannot arrive. This is the
+      // ONLY page error that short-circuits the loop — an ordinary uncaught
+      // exception mid-suite is not terminal (the run usually finishes and the
+      // rf2-mwx08 arm below fails it on the summary), and breaking on those
+      // would truncate a run that was about to report and mislabel it.
+      if (fixtureAborts.length > 0) break;
+
       // Serve a pending deterministic GC request before looking for the test
       // summary: the requesting cljs.test is async and cannot finish until
       // this acknowledgement arrives.
@@ -516,7 +538,50 @@ async function main() {
     }
 
     if (!summary.ran || !summary.failErr) {
-      console.error(`Timed out after ${TIMEOUT_MS}ms waiting for cljs.test summary.`);
+      // rf2-u0j8: a missing summary has THREE causes and they are not read
+      // the same way. Say which one this is, and — when the page threw — say
+      // where the lane stopped, because "no summary" alone sends the reader
+      // hunting a hang or a timeout budget.
+      const reached = testingNamespaces(consoleLines);
+      const stoppedAt = reached.length > 0 ? reached[reached.length - 1] : null;
+      const where =
+        `The run announced ${reached.length} namespace(s) before it stopped` +
+        (stoppedAt ? `, the last being \`${stoppedAt}\`` : '') +
+        `. Every namespace scheduled after that point never executed — ` +
+        `shadow.test runs the whole lane, and the closing summary, inside ONE ` +
+        `\`cljs.test/run-block\`, which has no try/catch.`;
+
+      if (fixtureAborts.length > 0) {
+        console.error(
+          `THE BROWSER RUN ABORTED — it did not time out, and it did not ` +
+            `fail an assertion (rf2-u0j8).\n` +
+            `  cljs.test refused an \`async\` row in a namespace whose fixtures ` +
+            `are POSITIONAL. \`(use-fixtures :once (fn [f] … (f)))\` selects the ` +
+            `\`:sync\` execution strategy, and the \`:sync\` strategy throws the ` +
+            `moment a test body returns an async object. The throw is a bare ` +
+            `string and nothing catches it.\n` +
+            `  ${where}\n` +
+            `  FIX: give that namespace MAP fixtures — ` +
+            `\`(use-fixtures :once {:before (fn [] …) :after (fn [] …)})\` — ` +
+            `which is the only form cljs.test runs async rows under. Positional ` +
+            `fixtures remain fine in a namespace with no async rows.`,
+        );
+        for (const line of fixtureAborts) console.error(`  ${line}`);
+      } else if (pageErrors.length > 0) {
+        // Same shape, unknown cause: the page threw and no summary followed.
+        // This arm is what keeps the guard correct if the abort literal above
+        // is ever reworded upstream — it is matcher-free.
+        console.error(
+          `NO cljs.test SUMMARY, and the page emitted ${pageErrors.length} ` +
+            `uncaught error(s) — the suite did not finish (rf2-u0j8). This is an ` +
+            `ABORT, not a slow run: raising ${BROWSER_TEST_TIMEOUT_ENV_VAR} ` +
+            `(${TIMEOUT_MS}ms) will not help.\n` +
+            `  ${where}`,
+        );
+        for (const line of pageErrors) console.error(`  ${line}`);
+      } else {
+        console.error(`Timed out after ${TIMEOUT_MS}ms waiting for cljs.test summary.`);
+      }
       printSummaryDetails(summary);
       flushDiagnostics(diagnostics);
       return 1;


### PR DESCRIPTION
Closes `rf2-u0j8`.

## 1. It reproduces

Deliberately constructed, in this worktree, against the real `npm run test:browser`:
a namespace with a POSITIONAL fixture (`(use-fixtures :once (fn [f] (f)))`) carrying
one `(async done …)` row, plus a witness namespace sorting immediately after it.

| run | namespaces announced | tests | assertions | captured exit |
|---|---|---|---|---|
| control (clean tree) | **223** | 1428 | 8819 | **0** |
| plant (async row under a positional fixture) | **8** | none | none | **1** |

"none" is literal: no `Ran N tests containing M assertions.` line was printed at all,
so there is no tally to compare — which is the whole shape of the defect.

`shadow.test` sorts namespaces by name, so the probe landed 8th of 225. The seven
`day8.*` namespaces before it ran; the probe's first (sync) row ran; its async row
threw; and **217 namespaces never executed**, the witness among them (`grep -c
aab-abort-witness` over the whole trail: `0`).

The console trail carries the cause once, at `[+11.62s]`, as a `pageerror`:

```
Async tests require fixtures to be specified as maps.  Testing aborted.
```

**What the run said before this PR**, after burning the full budget:

```
Timed out after 45000ms waiting for cljs.test summary.
--- cljs.test summary ---
(source: not found)
(missing "Ran ... assertions." line)
(missing "failures, errors" line)
```

That reproduction run used `BROWSER_TEST_TIMEOUT_MS=45000` to keep it cheap; the
poll loop is bounded by that value and the lane's default is **360 000 ms**, so the
real-world shape is six minutes of nothing followed by a line that names the wrong
phase. The abort itself sat at trail line 2885 of 2892, below ~2700 lines of React
`act(...)` warnings.

### The bead's framing needs one correction

The bead (and the dispatch brief) call this a *fail-open* shape — "a browser run
that LOOKS green while an unknown number of namespaces never ran, and the PR body
then quotes a green it did not earn." **It does not present as green.** No summary
means no `Ran N tests` line, and the runner already refuses to pass without one
(rf2-qqzmf's floor never even gets a number to compare). The run reds.

What it actually costs is *diagnosis*: six minutes, then "Timed out … waiting for
cljs.test summary" — which reads as a hang or an under-sized budget, sends the
reader to `BROWSER_TEST_TIMEOUT_MS`, and buries the one line that says what
happened. That is a real defect and worth fixing; it is a **fail-slow, fail-vague**
shape rather than a fail-open one, and the distinction matters because the remedy
is different (name the cause, don't tighten a floor).

## 2. Where the abort happens

Three files, none of them ours, and one of ours:

1. **`cljs/test.cljs:547`** (ClojureScript 1.12.145) — `execution-strategy` maps a
   namespace whose fixtures are all fns to `:sync`:
   `({:map :async :fn :sync} type :async)`.
2. **`shadow/test.cljs`** (shadow-cljs 3.4.10), `test-vars-grouped-block` — the
   `:sync` branch wraps every test body in `ct/disable-async`.
3. **`cljs/test.cljs:479`** — `test-var-block*` catches the `::async-disabled`
   keyword `disable-async` throws and **rethrows a bare string**:
   `(throw "Async tests require fixtures to be specified as maps.  Testing aborted.")`.

Nothing catches it after that. `cljs.test/run-block` (`cljs/test.cljs:439`) has no
`try`/`catch`, and `shadow.test/run-tests` runs `prepare-test-run` + **every**
namespace block + `finish-test-run` inside **one** `run-block`. So the throw unwinds
the entire lane, and `finish-test-run`'s `:summary` / `:end-run-tests` reports — the
`Ran N tests containing M assertions.` line this runner waits for — never execute.

**Our part**, and the only part we can fix: `implementation/scripts/run-browser-tests.cjs`.
The runner *already captured* the decisive signal — the `pageerror` handler records
it the moment it arrives — but the verdict path only consults `pageErrors` at the
green-summary check, i.e. after a summary it was never going to receive. The poll
loop had no reason to stop, so it didn't.

## 3. What is now loud

**The poll loop stops on one terminal class, and a summary-less run says what it
was.** Two arms, deliberately:

- **Named.** A `pageerror` matching the cljs.test abort breaks the loop at once and
  prints `THE BROWSER RUN ABORTED — it did not time out, and it did not fail an
  assertion`, followed by the namespace it stopped at, the count of namespaces
  reached, why everything after was lost, and the fix (map fixtures).
- **Matcher-free backstop.** Any summary-less run that emitted page errors is
  reported as an abort with the same "stopped at" detail, without matching any
  literal.

The second arm is why the guard's *correctness* does not depend on a string that
lives in another repository. The rf2-u0cy4 duplicate-`done` literal needed a live
drift check because drift there made a guard fail **open** on a defect cljs.test
cannot fail. Drift here costs immediacy and the named remedy, not the verdict — so
**no drift probe was added**, and that is argued rather than assumed. Proved by
sabotage below.

### Why this shape and not the alternatives

- **Not a lint.** Positional fixtures are perfectly legal in a namespace with no
  async rows — three browser-lane namespaces use them today and are correct. A lint
  would have to correlate the *shape* of a `use-fixtures` form with the presence of
  an `async` macro elsewhere in the same namespace, across a fixture that may be a
  var defined in a helper ns. That is a source-regex correlation standing in for a
  runtime fact the runner can simply observe.
- **Not "fail on any pageerror".** Tempting, one line, and wrong: an ordinary
  uncaught mid-suite exception is *not* terminal — the run usually finishes and the
  rf2-mwx08 arm fails it on the summary. Breaking on those would truncate a run
  that was about to report and mislabel it. `_impl-browser-runners-verdict-policy`
  pins the narrowness with an `assert.doesNotMatch`.
- **Not a redesign.** No new gate, no new build id, no workflow change, no
  `:source-paths` entry. Every verdict this runner returns is unchanged; what
  changed is *when* it returns and *what it says*.

## 4. Live blast radius (reported, not changed)

Three namespaces in the `:browser-test` lane use positional fixtures today. Each is
one `(async done …)` row away from taking the whole lane down:

- `implementation/ui/test/re_frame/ui/adapter_conformance_dom_cljs_test.cljs`
- `implementation/ssr/test/re_frame/ssr/multi_root_hydration_dom_cljs_test.cljs`
- `implementation/ssr/test/re_frame/ssr/failed_root_isolation_dom_cljs_test.cljs`

They are correct as written and are **not touched here** — converting them would be
a behaviour change to three suites that this bead did not ask for. Flagged for the
mayor to rule on.

## 5. Sabotage control

Both halves, because a green sabotage run proves nothing without the second.

| step | `browser-test-report.cjs` sha256 | what the run said |
|---|---|---|
| baseline | `da89849d…9588` | `THE BROWSER RUN ABORTED — it did not time out…` + the map-fixture fix |
| `FIXTURE_ABORT_RE` neutered | `bc4643b3…b32e6` | `THE BROWSER RUN ABORTED — no cljs.test summary, and the page emitted 1 uncaught error(s)` — the backstop, no remedy line |
| restored | `da89849d…9588` (byte-identical) | baseline message returns |

The hash proves the source changed; **the runtime observed it** because the run's own
output changed between the two — different arm, different sentence, same plant.

One honest miss worth recording: my first attempt at the sabotage used
`perl -pi -e 's{^const FIXTURE_ABORT_RE = …$}{…}'`, and the `$` anchor did not match
against this checkout's line endings. It edited nothing, silently, and the run came
back with the tier-1 message — which I would have read as "the backstop is
vacuous" had I not hashed first. The hash caught it; the second attempt used an
anchored `Edit`.

## Quality gates

Run from `implementation/` in `C:\Users\miket\code\re-frame2-worktrees\asyncabort-u0j8`;
every browser log names that worktree as its asset root. Exit codes are the ones
captured beside each log, not the harness's.

| gate | exit |
|---|---|
| `npm run test:browser` (final, post-restore) | **0** — `Ran 1428 tests containing 8819 assertions. 0 failures, 0 errors.` |
| `npm run test:browser` (control, pre-change) | **0** — same counts; 223 namespaces announced under `RF2_VERBOSE_TESTS=1` |
| `npm run test:script-policy` | **0** — includes `_impl-browser-runners-verdict-policy` (18 passed) and `_navigation-ceiling-policy` |
| `npm run test:script-helpers` | **0** — includes `_browser-test-report` (23 passed) |

`npm run test:cljs` **not run and not needed**: the diff is three `.cjs` files and one
`.cjs` library under `implementation/scripts/`. Nothing here is on any ClojureScript
classpath, so the node lane compiles none of it.

`npm run test:hicasso-hmr` **deferred to CI** — it binds `:dev-http` 8061 and another
worker owns that rig. This diff arms nothing in it.

### A gate that caught me

`_navigation-ceiling-policy.test.cjs` red on the first pass. The backstop arm had said
"raising `BROWSER_TEST_TIMEOUT_MS` will not help" — true of an abort, but that runner's
navigation ceiling *is* the lane budget, and rf2-dczpv's rule forbids disclaiming the
knob that moves it, precisely because that phrasing was itself a misdiagnosis once.
Reworded to state the positive (the suite stopped; no summary was on its way) rather
than to disclaim the knob. Second commit.
