### PR TITLE
docs(hicasso): refresh substrate-decision.md's opening summary now the +139 B/read attribution is settled

### DIFF
--- a/docs/design/hicasso/product/substrate-decision.md
+++ b/docs/design/hicasso/product/substrate-decision.md
@@ -16,6 +16,7 @@
 | **[DERIVED]** | Follows by direct reading of quoted normative text or of source in this repository. Overturn the reading and the conclusion goes. |
 | **[INFERRED]** | This page's conclusion from evidence the record does not itself draw. Weakest class — check it before relying on it. |
 | **[OPEN]** | Not adjudicable from the current evidence. What would settle it is named. |
+| **[SETTLED]** | Was **[OPEN]**; a later bead ran what this page named and settled it. The bead, the ablation and the result are named — including when nothing this page decided changes. |
 
 Governing documents: [specification §3.4](specification.md#34-capability-pays-rent)
 and [§6](specification.md#6-performance-contract), the
@@ -45,9 +46,13 @@ and [§6](specification.md#6-performance-contract), the
    three routes that could close it are priced below for the operator.
 
 What this page does **not** decide is in [§6](#6-what-this-page-does-not-decide).
-The largest item there is the mechanism of a `+139 B/read` move the package
-re-pin found; it is not needed for any verdict above, and the ablation that would
-name it is stated rather than guessed at.
+The `+139 B/read` move the package re-pin found is no longer on that list: the
+ablation §6 named has since been run (`rf2-l50z`), and it attributed the whole
+move to a single ratom-only correctness line in `wire-cell!`. **No figure above
+moves** — S3 is still `1,417 B/read` — because the attribution names what that
+cost buys rather than removing it. What §6 still leaves open is the ratom
+family's missing clock and migration contrasts, and whether a Hicasso-owned
+derived-value container could beat the spine.
 
 ---
 


### PR DESCRIPTION
## What this is

`rf2-l50z` was reopened by the merged-PR audit of **#8020** with a narrow charge. #8020 changed §6 of `docs/design/hicasso/product/substrate-decision.md` to `[SETTLED]` and recorded the completed A–B–A attribution, but the opening summary at the top of the page still called that mechanism the largest undecided item in §6 and called the ablation merely *stated*. The page contradicted itself before the reader reached the repaired section.

This PR refreshes the opening summary only. **The measurement was not re-run**, and no figure moves.

## The change

**Before** (`substrate-decision.md:48–50`):

> What this page does **not** decide is in [§6](#6-what-this-page-does-not-decide).
> The largest item there is the mechanism of a `+139 B/read` move the package
> re-pin found; it is not needed for any verdict above, and the ablation that would
> name it is stated rather than guessed at.

**After** (`substrate-decision.md:48–55`):

> What this page does **not** decide is in [§6](#6-what-this-page-does-not-decide).
> The `+139 B/read` move the package re-pin found is no longer on that list: the
> ablation §6 named has since been run (`rf2-l50z`), and it attributed the whole
> move to a single ratom-only correctness line in `wire-cell!`. **No figure above
> moves** — S3 is still `1,417 B/read` — because the attribution names what that
> cost buys rather than removing it. What §6 still leaves open is the ratom
> family's missing clock and migration contrasts, and whether a Hicasso-owned
> derived-value container could beat the spine.

Three things the replacement is careful about:

- **Settled is not resolved.** The sentence says in terms that no figure above moves and that S3 is still `1,417 B/read`. The attribution names a correctness repair's price; it does not remove it.
- **It names no suspect.** In particular it does not name the `rf2-2rtt6.60` disposal-hook precedent the bead originally floated, which could not have been the cause: that shape costs `+36 B` on the spine and this move costs zero there.
- **It replaces the "largest item" claim rather than deleting it**, so the reader is still told what §6 holds — the two remaining `[OPEN]` rows.

## Second carrier found in this file, and fixed

§6 now opens with the marker `**[SETTLED 2026-08-13, rf2-l50z]**`, but this page's own marker legend listed only RULED / DERIVED / INFERRED / OPEN. The preamble says the page uses [`hd-002-adjudication.md`](docs/design/hicasso/hd-002-adjudication.md)'s markers *"because a reader has to be able to tell what the record decided from what this page concluded"* — and hd-002's table does define `[SETTLED]` (line 37). One row added, worded for this page's case (a later bead ran what the page named, and nothing the page decided changes).

## Sweep — every other carrier, and its disposition

`git grep` over `docs/` for `139 B/read` / `+139 B`, and over the target file for *mechanism*, *ablation*, *bisection*, *owed*, *stated rather than*, *largest item*:

| Location | Status | Disposition |
|---|---|---|
| `substrate-decision.md:48-50` | live contradiction | **fixed** (this PR) |
| `substrate-decision.md` marker legend | `[SETTLED]` used, undefined | **fixed** (this PR) |
| `substrate-decision.md:456` "stated rather than glossed" | inside the §6 `[SETTLED]` block, about what the cost buys | correct as it stands |
| `substrate-decision.md:506` "names the ablation rather than estimating one" | provenance, general posture; two `[OPEN]` rows still make it true | correct as it stands |
| `k3-disposition.md:415-424, 445` | already `[SETTLED elsewhere]`, cites this page | correct as it stands |
| `budgets.md:269-283` | already records the attribution and that S3 does not move | correct as it stands |
| `reads-per-boundary-heap-ladder.md:2896+` | the new attribution section itself | correct as it stands |
| `reads-per-boundary-heap-ladder.md:2712-2721` | **reported, not edited** — see below | out of fence |

The one residual is on the ladder, in the `rf2-fe0l` run record. *"The mechanism is not attributed here, and the asymmetry is why"* is legitimately past-tense and scoped by "here" — a measurement window may not run ablations, and that is the record of the window. But the paragraph closes **"`rf2-hic-018` owns the attribution, and it now has the same-instrument package baseline that makes an attribution possible at all"**, which is present-tense and now stale: `rf2-l50z` took the attribution. It is only mildly misleading, because the later section at 2896 opens by citing this one as having left the mechanism `[OPEN]`, so the two are not in contradiction — a reader who continues is corrected. A one-clause forward pointer would close it. The ladder is outside this PR's fence, so it is reported rather than edited.

## Quality gates

Run from `C:/Users/miket/code/re-frame2-worktrees/settled-l50z` (worktree confirmed by `scripts/assert-worker-worktree.sh`), each redirected to a per-worktree log with `$?` echoed on the same command line.

| Gate | Exit |
|---|---|
| `python scripts/check_doc_slugs.py` | **0** |
| `python scripts/check_provenance_pins.py --changed-since origin/main --verbose` | **0** |
| negative control — anchor broken at line 48, `check_doc_slugs.py` | **1** (expected) |
| `check_doc_slugs.py` re-run after restore | **0** |
| `check_provenance_pins.py` re-run after restore | **0** |

Pins gate output: `1 files, 1 cited pins (1 landed, 0 stranded, 0 unresolvable, 0 foreign)`.

**Negative control.** Line 48 is a line this PR edits. Its anchor `#6-what-this-page-does-not-decide` was changed to a non-existent target; the gate failed with `BROKEN ANCHOR: docs\design\hicasso\product\substrate-decision.md:48`, proving it reads this worktree and covers the edited region. **The restore was verified by hashing the bytes**, not by `git diff`: `sha256` was `b0f2eaa91e33e83df1a5ae792eab0ececd16c1664bec9d6299b4895486ee6cbc` before planting and identical after restoring.

**`mkdocs build --strict` is not applicable** — `exclude_docs` keeps `docs/design/**` out of the site — so **anchors and table column counts were verified by hand**: the only link in the changed text is `[§6](#6-what-this-page-does-not-decide)`, matching the heading `## 6. What this page does not decide` (and `check_doc_slugs.py` validates it, as the negative control demonstrates); the marker table is two columns in its header, its delimiter row and all five body rows, the new row included, and its cell text contains no pipe characters.

## What was not done

- **The measurement was not re-run.** The audit forbids it, and the machine is carrying several other workers, so any number taken here would be unattributable.
- **No figure moved.** S3 reads `1,417 B/read` everywhere it appears in this file, before and after; the `+698` premium and the `1,417 – 2,115` bracket are untouched.
