### PR TITLE
test(hicasso): integration accessibility witnesses — keyboard, virtualized, overlay (rf2-hic-049)

### DIFF
--- a/implementation/hicasso/test/re_frame/hicasso/combobox_keyboard_dom_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/combobox_keyboard_dom_cljs_test.cljs
@@ -1,0 +1,499 @@
+(ns re-frame.hicasso.combobox-keyboard-dom-cljs-test
+  "L4 — THE SELECT-ONLY DROPDOWN'S KEYBOARD CONDUCT, AND THE ACTIVE-
+  DESCENDANT MODEL IT RESTS ON (rf2-hic-049; merged-PR audit #7914).
+
+  A dropdown built from `overlay/popover` is the one overlay pattern
+  whose accessibility is entirely the APPLICATION's. The module supplies
+  the top layer, the light dismiss and the anchor; every part a screen
+  reader announces — the role, the expanded state, which option is
+  active, which option is selected — is markup the author writes, and
+  the audit on this bead found the guide's own example writing it
+  wrongly:
+
+  > The focused native button carries `aria-activedescendant` for a
+  > sibling listbox but has neither a combobox role nor
+  > `aria-controls`/ownership, so its active-descendant model is
+  > invalid. `aria-selected` also follows transient `:active` although
+  > the app's committed value changes only on Enter/click.
+  >
+  > — merged-PR audit #7914, on rf2-hic-049
+
+  Both halves are defects a reader cannot see and a click-driven test
+  cannot reach. `aria-activedescendant` is a POINTER, and a pointer is
+  only meaningful if the pointing element owns what it points at: the
+  attribute tells assistive technology *the user's position is on that
+  element over there*, and the platform resolves *over there* through
+  the combobox's `aria-controls`/`aria-owns`. Written on an element with
+  no combobox role and no ownership edge, it names an id in a vacuum —
+  the announcement is simply not made, and the dropdown reads as a
+  button whose label changes for no stated reason.
+
+  ## What this file is, and its relationship to the guide
+
+  [[select-dropdown]] is the guide's example
+  (`docs/design/hicasso/draft-guide/13-overlays-and-focus.md`,
+  *Build a dropdown from a popover*) with the audit's bounded repair
+  applied: the trigger carries `role=\"combobox\"`; `aria-controls`
+  names the listbox and is emitted only while one exists;
+  `aria-activedescendant` names an option INSIDE that listbox; and
+  `aria-selected` follows the COMMITTED value while
+  `aria-activedescendant` follows the keyboard's transient position.
+
+  [[the-guides-dropdown-as-written]] is the same view with the repair
+  taken back out, and it is not decoration: every row below is an
+  emptiness claim or a stability claim, and each one is shown going the
+  other way over that view. It is also what makes this file the audit's
+  *witness covering the exact guide example* rather than a witness over
+  a nearby one.
+
+  **The guide chapters are another worker's fence on this wave** —
+  chapter 13 carries the example and chapter 22 calls it the contract —
+  so this file does not edit them. The follow-up bead named in the PR
+  body carries the text change, with this namespace as its source of
+  truth.
+
+  ## Keyboard conduct is measurable here, and only here
+
+  A synthetic `KeyboardEvent` performs no DEFAULT action — no Tab moves
+  focus, no Escape closes a dialog — which is why
+  `examples.ledger.keyboard-dom-cljs-test` witnesses traversal as the
+  engine's focusability answer rather than as a keypress. But
+  `:on-key-down` is a React handler, and React delivers a synthetic
+  keydown to it exactly as it delivers a trusted one. So the conduct the
+  APPLICATION owns — arrow keys moving the active option, Enter
+  committing it, DOM focus never leaving the trigger — is genuinely
+  driven below, by real key events, and is the one place in this bead
+  where a key press is the instrument rather than the gap.
+
+  Escape remains the platform's: the popover owns light dismiss and the
+  close request, and `overlay-dom-cljs-test` drives it through
+  `HTMLDialogElement.requestClose` for want of trusted input.
+
+  ## Lanes
+
+  The structural rows run everywhere — a role, a pointer and its
+  referent are facts about markup, so they are decided on rf2-hic-043's
+  projections and need no engine. The conduct rows need a real React DOM
+  and state a skip in the node lane. Nothing here is `async` (rf2-u0j8:
+  an async row under a positional fixture aborts the whole run)."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [clojure.string :as str]
+            [re-frame.adapter.uix :as uix-adapter]
+            [re-frame.core :as rf]
+            [re-frame.hicasso :as h]
+            [re-frame.hicasso.overlay :as overlay]
+            [re-frame.hicasso.test :as ht]
+            [re-frame.hicasso.test.mounted :as hm]
+            [re-frame.test-support :as test-support]))
+
+;; ---------------------------------------------------------------------------
+;; The model — the guide's, with a COMMITTED value beside the active one
+;; ---------------------------------------------------------------------------
+
+(def ^:private items
+  [{:value "en" :label "English"}
+   {:value "fr" :label "Français"}
+   {:value "ja" :label "日本語"}])
+
+(def ^:private values (mapv :value items))
+
+(def ^:private label-id "combo-locale-label")
+(def ^:private trigger-id "combo-locale-trigger")
+(def ^:private listbox-id "combo-locale-listbox")
+
+(defn- option-id [v] (str "combo-locale-opt-" v))
+
+(rf/reg-sub ::open? (fn [db _] (boolean (:open? db))))
+(rf/reg-sub ::active (fn [db _] (:active db)))
+(rf/reg-sub ::value (fn [db _] (:value db "en")))
+
+(rf/reg-event ::toggled (fn [{:keys [db]} _] {:db (update db :open? not)}))
+(rf/reg-event ::dismissed (fn [{:keys [db]} _] {:db (assoc db :open? false)}))
+
+(rf/reg-event ::moved
+  {:doc "An arrow key. Opens the list if it is shut and moves the ACTIVE
+  option, which is the keyboard's transient position and not a
+  selection: nothing about `:value` moves here, and that is the audit's
+  *keep active focus distinct from committed selection* stated in the
+  model rather than only in the markup."}
+  (fn [{:keys [db]} [_ step]]
+    (let [at   (:active db)
+          i    (get (zipmap values (range)) at -1)
+          next (nth values (-> (+ i step) (max 0) (min (dec (count values)))))]
+      {:db (assoc db :open? true :active next)})))
+
+(rf/reg-event ::committed
+  {:doc "Enter. The active option becomes the committed value and the
+  list shuts."}
+  (fn [{:keys [db]} _]
+    (let [{:keys [open? active]} db]
+      {:db (cond-> (assoc db :open? false)
+             (and open? active) (assoc :value active))})))
+
+(rf/reg-event ::selected
+  {:doc "A pointer click on an option — the same commit by the other
+  door."}
+  (fn [{:keys [db]} [_ v]]
+    {:db (assoc db :open? false :value v)}))
+
+;; ---------------------------------------------------------------------------
+;; The view — the guide's example with the audit's repair
+;; ---------------------------------------------------------------------------
+
+(h/defview select-dropdown
+  "The guide's *Build a dropdown from a popover*, repaired.
+
+  Four changes, and each is one clause of the audit:
+
+  1. `role=\"combobox\"` on the trigger. Without it the element is a
+     button, and `aria-activedescendant` is not an attribute a button
+     may carry — ARIA allows it on `combobox`, `textbox`, `searchbox`,
+     `listbox`, `menu`, `tree`, `grid`, `group` and `application`, and
+     nowhere else.
+  2. `aria-controls` naming the listbox. This is the OWNERSHIP edge the
+     pointer is resolved through; without it the id in
+     `aria-activedescendant` names an element the combobox has no stated
+     relationship to.
+  3. Both are emitted only while the list is OPEN, because the module's
+     posture is that a closed overlay has no DOM node — so a
+     permanently-emitted `aria-controls` would spend most of its life
+     pointing at nothing, which is the same invalidity by a different
+     route.
+  4. `aria-selected` follows the COMMITTED value. The active option is
+     where the keyboard is; the selected option is what the application
+     will act on. In a list where selection does not follow focus those
+     are two different options for as long as the user is looking
+     around, and collapsing them announces a choice nobody has made."
+  [_]
+  (let [open?  (h/sub [::open?])
+        active (h/sub [::active])
+        value  (h/sub [::value])
+        label  (some #(when (= value (:value %)) (:label %)) items)]
+    [:div.combo
+     [:span {:id label-id} "Language"]
+     [:button
+      {:id                    trigger-id
+       :type                  "button"
+       :role                  "combobox"
+       :aria-labelledby       (str label-id " " trigger-id)
+       :aria-haspopup         "listbox"
+       :aria-expanded         open?
+       :aria-controls         (when open? listbox-id)
+       :aria-activedescendant (when (and open? active) (option-id active))
+       :on-click              [::toggled]
+       :on-key-down           {"ArrowDown" [::h/prevent [::moved 1]]
+                               "ArrowUp"   [::h/prevent [::moved -1]]
+                               "Enter"     [::h/prevent [::committed]]}}
+      label]
+     [overlay/popover {:open?      open?
+                       :on-dismiss [::dismissed]
+                       :anchor     trigger-id
+                       :placement  :bottom-start}
+      [:ul {:id listbox-id :role "listbox" :aria-labelledby label-id}
+       (for [{v :value l :label} items]
+         [:li {:key           v
+               :id            (option-id v)
+               :role          "option"
+               :aria-selected (= v value)
+               :on-click      [::selected v]}
+          l])]]]))
+
+(h/defview the-guides-dropdown-as-written
+  "THE POSITIVE CONTROL — the same dropdown with the repair taken back
+  out, which is the shape the guide ships today.
+
+  Everything a reviewer looks at is here: the trigger is a real button,
+  it is named, `aria-expanded` tracks the flag, the options carry
+  `role=\"option\"` and the panel is a real listbox. What is missing is
+  the pointer's ownership, and what is wrong is which state
+  `aria-selected` follows — neither of which shows on screen, in a
+  click-driven test, or in a structural sweep that only asks whether
+  every control has a name."
+  [_]
+  (let [open?  (h/sub [::open?])
+        active (h/sub [::active])
+        value  (h/sub [::value])
+        label  (some #(when (= value (:value %)) (:label %)) items)]
+    [:div.combo
+     [:span {:id label-id} "Language"]
+     [:button
+      {:id                    trigger-id
+       :type                  "button"
+       :aria-labelledby       (str label-id " " trigger-id)
+       :aria-haspopup         "listbox"
+       :aria-expanded         open?
+       :aria-activedescendant (when (and open? active) (option-id active))
+       :on-click              [::toggled]
+       :on-key-down           {"ArrowDown" [::h/prevent [::moved 1]]
+                               "ArrowUp"   [::h/prevent [::moved -1]]
+                               "Enter"     [::h/prevent [::committed]]}}
+      label]
+     [overlay/popover {:open?      open?
+                       :on-dismiss [::dismissed]
+                       :anchor     trigger-id
+                       :placement  :bottom-start}
+      [:ul {:role "listbox"}
+       (for [{v :value l :label} items]
+         [:li {:key           v
+               :id            (option-id v)
+               :role          "option"
+               ;; The transient position, announced as the selection.
+               :aria-selected (= v active)
+               :on-click      [::selected v]}
+          l])]]]))
+
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture
+    {:adapter       uix-adapter/adapter
+     :ambient-frame nil}))
+
+;; ---------------------------------------------------------------------------
+;; The auditor — an active-descendant model, checked the way a platform
+;; resolves one
+;; ---------------------------------------------------------------------------
+
+(def ^:private activedescendant-roles
+  "The roles ARIA permits `aria-activedescendant` on. A pointer on
+  anything else is not a pointer: the attribute is defined against these
+  roles, so a user agent reading it on a plain button has nothing to do
+  with it."
+  #{"combobox" "textbox" "searchbox" "listbox" "menu" "menubar" "tree"
+    "treegrid" "grid" "radiogroup" "group" "toolbar" "application"})
+
+(defn- attr [node k] (get (ht/attrs node) k))
+
+(defn- ids-of [s] (remove str/blank? (str/split (or s "") #"\s+")))
+
+(defn- activedescendant-findings
+  "Every way `tree`'s active-descendant model can be broken, in the
+  order a platform would trip over them.
+
+  Written as a sweep over the tree rather than as four assertions about
+  one element, so a second combobox added tomorrow is audited the day it
+  lands — the shape rf2-hic-043's `ht/unnamed-controls` established, and
+  the reason this file's claims are `= []` rather than a list of
+  attribute readings.
+
+  | finding | what a platform does with it |
+  |---|---|
+  | `:role-may-not-carry-activedescendant` | ignores the attribute — the position is never announced |
+  | `:no-ownership-edge` | has no stated relationship to resolve the id through |
+  | `:activedescendant-names-nothing` | resolves the id to no element |
+  | `:activedescendant-outside-the-owned-subtree` | resolves it outside what the combobox controls |"
+  [tree]
+  (let [by-id (into {} (map (juxt #(attr % :id) identity))
+                    (ht/find-all tree #(some? (attr % :id))))]
+    (into []
+          (mapcat
+            (fn [node]
+              (let [target (attr node :aria-activedescendant)
+                    owned  (concat (ids-of (attr node :aria-controls))
+                                   (ids-of (attr node :aria-owns)))
+                    owner  (some by-id owned)
+                    referent (get by-id target)]
+                (cond-> []
+                  (not (contains? activedescendant-roles (name (or (ht/role node) :none))))
+                  (conj :role-may-not-carry-activedescendant)
+
+                  (empty? owned)
+                  (conj :no-ownership-edge)
+
+                  (nil? referent)
+                  (conj :activedescendant-names-nothing)
+
+                  (and (some? referent) (some? owner)
+                       (not (some #(identical? referent %)
+                                  (ht/find-all owner (constantly true)))))
+                  (conj :activedescendant-outside-the-owned-subtree)))))
+          (ht/find-all tree #(some? (attr % :aria-activedescendant))))))
+
+(defn- selected-options
+  "The values of the options carrying `aria-selected=\"true\"`, in
+  document order."
+  [tree]
+  (into []
+        (comp (filter #(= :option (ht/role %)))
+              (filter #(true? (attr % :aria-selected)))
+              (map #(attr % :id)))
+        (ht/find-all tree (constantly true))))
+
+(defn- open-tree
+  "The named view, rendered with the list open and the keyboard resting
+  on `active` while `value` is committed."
+  [view {:keys [active value]}]
+  (ht/tree [view {}]
+           {:subs {[::open?] true
+                   [::active] active
+                   [::value] (or value "en")}}))
+
+;; ---------------------------------------------------------------------------
+;; The model, structurally — both views, both ways
+;; ---------------------------------------------------------------------------
+
+(deftest the-repaired-dropdown-has-a-resolvable-active-descendant-model
+  (let [t (open-tree select-dropdown {:active "ja" :value "en"})]
+    (is (= [] (activedescendant-findings t))
+        "THE ACCEPTANCE. The pointer is on a `combobox`, the combobox
+         controls the listbox, and the id it names is an option inside
+         it — the four things a platform needs before it will announce
+         *3 of 3, 日本語* at all")
+
+    (testing "and the pieces, named, so a failure above says which"
+      (let [trigger (ht/find t #(= :combobox (ht/role %)))]
+        (is (= trigger-id (attr trigger :id)))
+        (is (= listbox-id (attr trigger :aria-controls)))
+        (is (= (option-id "ja") (attr trigger :aria-activedescendant)))
+        (is (true? (attr trigger :aria-expanded)))))))
+
+(deftest the-guides-dropdown-fails-the-model-in-exactly-two-ways
+  ;; THE POSITIVE CONTROL, and the audit finding reproduced. Without it
+  ;; the row above is green having proved only that the sweep can return
+  ;; an empty vector, which it would do just as readily over a tree it
+  ;; could not read at all.
+  (let [t (open-tree the-guides-dropdown-as-written {:active "ja" :value "en"})]
+    (is (= [:role-may-not-carry-activedescendant :no-ownership-edge]
+           (activedescendant-findings t))
+        "the two halves of merged-PR audit #7914's first sentence. Note
+         what is NOT reported: the id resolves perfectly — the option
+         really is in the document, with that exact id — which is why
+         this defect survives review and why an `is the referent there?`
+         check alone would call it fine")
+
+    (testing "and the trigger reads as an ordinary button, which is
+              precisely the problem: everything about it is legal markup"
+      (let [trigger (ht/find t #(some? (attr % :aria-activedescendant)))]
+        (is (= :button (ht/role trigger)))
+        (is (nil? (attr trigger :aria-controls)))))))
+
+(deftest aria-selected-follows-the-commitment-and-not-the-keyboard
+  (testing "the repaired view: the keyboard is on `ja`, the application
+            holds `en`, and it is `en` that is announced as selected —
+            exactly one option, and the committed one"
+    (let [t (open-tree select-dropdown {:active "ja" :value "en"})]
+      (is (= [(option-id "en")] (selected-options t)))))
+
+  (testing "moving the keyboard does not move it — the same view, the
+            same commitment, the active option somewhere else again"
+    (let [t (open-tree select-dropdown {:active "fr" :value "en"})]
+      (is (= [(option-id "en")] (selected-options t)))))
+
+  (testing "and committing does: `aria-selected` moves when the value
+            moves, so the row above is a distinction rather than an
+            attribute that never changes"
+    (let [t (open-tree select-dropdown {:active "fr" :value "ja"})]
+      (is (= [(option-id "ja")] (selected-options t)))))
+
+  (testing "THE CONTROL — the guide's view announces the TRANSIENT
+            position as the selection. A screen-reader user arrowing
+            through three options is told they have selected all three,
+            one after another, having chosen none"
+    (is (= [(option-id "ja")]
+           (selected-options (open-tree the-guides-dropdown-as-written
+                                        {:active "ja" :value "en"}))))
+    (is (= [(option-id "fr")]
+           (selected-options (open-tree the-guides-dropdown-as-written
+                                        {:active "fr" :value "en"}))))))
+
+;; ---------------------------------------------------------------------------
+;; The conduct — real key events, on a real React DOM
+;; ---------------------------------------------------------------------------
+
+(defn- browser? []
+  (and (exists? js/document) (some? js/document) (some? (.-body js/document))))
+
+(defn- skip! [why]
+  (is true (str "a keyboard round trip needs a real React DOM — " why)))
+
+(defn- q [m sel] (.querySelector (:container m) sel))
+(defn- active-el [] (.-activeElement js/document))
+(defn- attr-of [m sel a] (some-> (q m sel) (.getAttribute a)))
+
+(defn- key!
+  "A real `keydown` carrying `key`, on the trigger. React's synthetic
+  event system delivers it to `:on-key-down` exactly as it delivers a
+  trusted one — the DEFAULT ACTION is what an untrusted event does not
+  get, and this handler is not one."
+  [m k]
+  (.dispatchEvent (q m (str "#" trigger-id))
+                  (js/KeyboardEvent. "keydown" #js {:key k :bubbles true}))
+  (hm/settle! m)
+  nil)
+
+(deftest the-arrow-keys-move-the-active-option-and-nothing-else
+  (if-not (browser?)
+    (skip! "the arrow keys")
+    (let [m (hm/mount! [select-dropdown {}])]
+      (try
+        (.focus (q m (str "#" trigger-id)))
+        (testing "premise: shut, with no pointer and nothing to point at"
+          (is (= "false" (attr-of m (str "#" trigger-id) "aria-expanded")))
+          (is (nil? (attr-of m (str "#" trigger-id) "aria-activedescendant")))
+          (is (nil? (attr-of m (str "#" trigger-id) "aria-controls")))
+          (is (nil? (q m (str "#" listbox-id)))
+              "and no listbox in the document, which is the module's
+               closed-cost posture and the reason `aria-controls` is
+               conditional"))
+
+        (key! m "ArrowDown")
+        (testing "one arrow opens the list and puts the pointer on the
+                  first option"
+          (is (= "true" (attr-of m (str "#" trigger-id) "aria-expanded")))
+          (is (= listbox-id (attr-of m (str "#" trigger-id) "aria-controls")))
+          (is (= (option-id "en") (attr-of m (str "#" trigger-id) "aria-activedescendant")))
+          (is (some? (q m (str "#" listbox-id)))))
+
+        (key! m "ArrowDown")
+        (key! m "ArrowDown")
+        (testing "two more move it to the last, and stop there — a
+                  clamp rather than a wrap, which is the guide's model
+                  and is asserted so a later wrap is a decision rather
+                  than a drift"
+          (is (= (option-id "ja") (attr-of m (str "#" trigger-id) "aria-activedescendant")))
+          (key! m "ArrowDown")
+          (is (= (option-id "ja") (attr-of m (str "#" trigger-id) "aria-activedescendant"))))
+
+        (testing "AND THE COMMITMENT NEVER MOVED. Three keystrokes later
+                  the selected option is still the one the application
+                  holds, and the trigger still shows its label — the
+                  audit's *keep active focus distinct from committed
+                  selection*, driven rather than described"
+          (is (= "true" (.getAttribute (q m (str "#" (option-id "en"))) "aria-selected")))
+          (is (= "false" (.getAttribute (q m (str "#" (option-id "ja"))) "aria-selected")))
+          (is (= "English" (.-textContent (q m (str "#" trigger-id))))))
+
+        (testing "and DOM focus never left the trigger, which is the
+                  whole reason an active-descendant model is used
+                  instead of moving focus into the list"
+          (is (identical? (q m (str "#" trigger-id)) (active-el))))
+
+        (finally (hm/unmount! m))))))
+
+(deftest enter-commits-the-active-option-and-shuts-the-list
+  (if-not (browser?)
+    (skip! "the commit")
+    (let [m (hm/mount! [select-dropdown {}])]
+      (try
+        (.focus (q m (str "#" trigger-id)))
+        (key! m "ArrowDown")
+        (key! m "ArrowDown")
+        (is (= (option-id "fr") (attr-of m (str "#" trigger-id) "aria-activedescendant"))
+            "premise: the keyboard is on the second option and the
+             application still holds the first")
+        (is (= "English" (.-textContent (q m (str "#" trigger-id)))))
+
+        (key! m "Enter")
+
+        (testing "THE ROUND TRIP: the active option became the committed
+                  one, the list shut, and both attributes that only make
+                  sense while it is open went with it"
+          (is (= "Français" (.-textContent (q m (str "#" trigger-id)))))
+          (is (= "false" (attr-of m (str "#" trigger-id) "aria-expanded")))
+          (is (nil? (attr-of m (str "#" trigger-id) "aria-activedescendant")))
+          (is (nil? (attr-of m (str "#" trigger-id) "aria-controls")))
+          (is (nil? (q m (str "#" listbox-id)))))
+
+        (is (identical? (q m (str "#" trigger-id)) (active-el))
+            "and focus is still on the trigger — nothing had to be
+             restored, because nothing ever moved")
+
+        (finally (hm/unmount! m))))))

--- a/implementation/hicasso/test/re_frame/hicasso/examples/ledger/keyboard_dom_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/examples/ledger/keyboard_dom_cljs_test.cljs
@@ -1,0 +1,508 @@
+(ns re-frame.hicasso.examples.ledger.keyboard-dom-cljs-test
+  "L4 — WHAT A KEYBOARD CAN REACH ON THE TEN-THOUSAND-ROW SCREEN
+  (rf2-hic-049, over rf2-hic-047's ledger).
+
+  > | Accessibility | Semantic Hiccup and native controls | Structural
+  > a11y assertions plus browser focus tests | Names, roles, **keyboard,
+  > virtualized/overlay focus** |
+  >
+  > — product specification §7
+
+  `ledger.a11y-cljs-test` says what the markup CLAIMS: this is a row,
+  that is a textbox, here is its name. `ledger.virtualized-dom-cljs-test`
+  says what happens to a focused node when the window moves under it.
+  Neither asks the question a keyboard user actually has, which is
+  **what can I get to, and does getting to it work** — and that question
+  has an answer only an engine can give, because focusability is decided
+  by the engine from `disabled`, from `tabindex` and from the tag, and
+  none of those three is a fact about a hiccup vector.
+
+  Virtualization makes the question sharp. Ten thousand records exist
+  and forty-eight controls are operable at any instant; the other
+  nineteen thousand nine hundred and fifty-two are not merely off screen
+  but ABSENT, and no amount of tabbing reaches them from where the
+  viewport currently is. That is not a defect — it is the trade a
+  virtualizer is bought for — but it is a fact a screen has to be
+  designed around, and the design is measured here:
+  [[the-keyboard-reachable-set-is-the-window-and-not-the-model]] states
+  the bound, and
+  [[traversing-to-the-window-edge-scrolls-and-extends-the-reachable-set]]
+  states the mitigation that makes the whole model reachable anyway.
+
+  ## The instrument, and why it ASKS rather than infers
+
+  [[focusable?]] blurs whatever holds focus, asks for focus on one
+  element, and reads `document.activeElement` back. Every other way of
+  answering — a `:tabindex` attribute, a selector, a tag table — is a
+  SECOND OPINION about the very thing under test, and the two opinions
+  disagree exactly where it matters: a `role=\"button\"` on a `<div>`
+  looks operable in every projection and is unreachable in fact.
+  `slice.a11y-focus-dom-cljs-test` established the idiom on a static
+  screen; this file is the same instrument on a screen where the
+  candidate set moves.
+
+  ## What is measured here, and what is stated
+
+  **Measured.** Which elements the engine will focus; the complete order
+  they come in; that the order is exactly the mounted window's controls
+  and nothing else; that focusing the window's last row makes the ENGINE
+  scroll the viewport; that the previously-focused node survives the
+  window moving; and that the screen carries no control whose role
+  promises an activation its tag cannot deliver.
+
+  **Stated, because trusted input is not reachable from inside the
+  page.** A synthetic `KeyboardEvent` performs no default action in any
+  engine, so a Tab press moves focus nowhere and an Escape closes
+  nothing — a `pressed Tab` row would be measuring its own dispatcher.
+  Sequential navigation is therefore witnessed as the ENGINE'S OWN
+  focusability answer over the candidate set in document order, which is
+  what Tab consumes, and Enter/Space activation is witnessed as
+  [[every-operable-control-is-one-the-platform-activates]]: the ledger's
+  controls are a real `<input>` and a real `<button>`, so their keyboard
+  activation is the platform's and needs no handler to exist. Driving a
+  real key through a Playwright bridge would need the browser test
+  runner, which this bead does not own — see the PR body.
+
+  ## Browser lane
+
+  Focusability, `document.activeElement` and scroll-into-view have no
+  implementation in the node lane. `:node-test` compiles this namespace
+  too (`cljs-test$` matches `-dom-cljs-test`) and every row degrades
+  there to a STATED skip rather than to a false green.
+
+  Nothing here is `async`: every claim is settled inside one tick, which
+  is deliberate — an async row under a positional fixture aborts the
+  whole `test:browser` run, every later namespace included (rf2-u0j8,
+  and the note on `virtualized-dom-cljs-test`'s fixture)."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [re-frame.adapter.uix :as uix-adapter]
+            [re-frame.hicasso :as h]
+            [re-frame.hicasso.examples.ledger.app :as app]
+            [re-frame.hicasso.examples.ledger.events :as events]
+            [re-frame.hicasso.examples.ledger.vendor :as vendor]
+            [re-frame.hicasso.examples.ledger.views :as views]
+            [re-frame.hicasso.test.mounted :as hm]
+            [re-frame.test-support :as test-support]
+            ["react-dom" :as react-dom]))
+
+;; ---------------------------------------------------------------------------
+;; The control page — the two defects this file's instruments must catch
+;; ---------------------------------------------------------------------------
+
+(h/defview a-page-of-near-misses
+  "Three controls that all LOOK operable, and one of them is.
+
+  It is a page rather than a ledger variant on purpose: what the two
+  instruments below have to be shown finding is a property of one
+  element, and a twenty-four-row screen carrying it would test the
+  instrument through four hundred lines of virtualizer."
+  [_]
+  [:div
+   [:button#real {:type "button"} "A real button"]
+   ;; Reachable — a `tabindex` buys a place in the order — and still not
+   ;; activatable: Enter and Space do nothing on a `<div>`, whatever its
+   ;; role says, unless the author wrote a key handler. The commonest
+   ;; keyboard defect there is, and the one a focus-order check alone
+   ;; reports as fine.
+   [:div#half {:role "button" :tab-index 0} "Looks like a button"]
+   ;; Neither reachable nor activatable.
+   [:div#neither {:role "button"} "Not even a tabindex"]])
+
+;; The fixture snapshots the registrar when THIS form is evaluated, so it
+;; sits below every view above. The MAP shape, for the reason
+;; `virtualized-dom-cljs-test` states: a positional fixture aborts the
+;; entire run on an async row, and the map shape is the one that does
+;; not — kept here even though nothing in this file is async, so the
+;; file cannot acquire the trap by acquiring an async row.
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture
+    {:adapter       uix-adapter/adapter
+     :ambient-frame nil}))
+
+;; ---------------------------------------------------------------------------
+;; The lane
+;; ---------------------------------------------------------------------------
+
+(defn- browser? []
+  (and (exists? js/document) (some? js/document) (some? (.-body js/document))))
+
+(defn- skip! [why]
+  (is true (str "only an engine decides what a keyboard can reach — " why)))
+
+;; ---------------------------------------------------------------------------
+;; Reading the page
+;; ---------------------------------------------------------------------------
+
+(defn- q [m sel] (.querySelector (:container m) sel))
+(defn- q* [m sel] (array-seq (.querySelectorAll (:container m) sel)))
+
+(defn- viewport-in [m] (q m ".ledger-viewport"))
+(defn- note-node [m i] (q m (str "#" (events/note-id i))))
+(defn- active [] (.-activeElement js/document))
+(defn- record-of [^js node] (some-> node (.getAttribute "data-record")))
+
+(defn- label-of
+  "How a failure NAMES an element — its id when it has one, else its
+  first class, else its tag. `slice.a11y-focus-dom-cljs-test`'s, so a
+  reader who knows one focus order can read the other."
+  [^js el]
+  (cond
+    (seq (.-id el))        (.-id el)
+    (seq (.-className el)) (first (.split (.-className el) " "))
+    :else                  (.toLowerCase (.-tagName el))))
+
+(defn- focusable?
+  "Does the ENGINE accept focus on `el`? Asked, not inferred: blur
+  whatever holds focus, ask, and read `document.activeElement` back.
+
+  A `disabled` control, a `tabindex=\"-1\"` control and a `<div>` with
+  nothing but a role all leave focus where it was, and not one of those
+  three facts is legible in the markup."
+  [^js el]
+  (some-> (active) (.blur))
+  (.focus el)
+  (identical? el (active)))
+
+(def ^:private candidates
+  "What Tab consumes: the natural-tab-order tags plus anything carrying
+  a `tabindex`. The ENGINE decides which of them survive — this selector
+  only has to be a superset, and a selector that tried to decide would
+  be the second opinion [[focusable?]] exists to avoid."
+  "a[href],button,input,select,textarea,[tabindex]")
+
+(defn- keyboard-order
+  "The page's sequential-navigation order, as readable names.
+
+  Two pieces of hygiene, both of which the ledger forces and a static
+  screen does not:
+
+  1. **The viewport's scroll offset is restored.** Asking for focus on
+     an element below the fold makes the engine scroll it into view —
+     which is a fact this file measures deliberately elsewhere, and
+     which would silently move the window under any row that merely
+     wanted to read the order.
+  2. **Focus is dropped at the end.** The sweep leaves focus on the last
+     element it asked about, and a row asserting where focus IS must not
+     be reading this function's leftovers."
+  [m]
+  (let [^js vp (viewport-in m)
+        top    (some-> vp .-scrollTop)
+        order  (->> (.querySelectorAll (:container m) candidates)
+                    (array-seq)
+                    (filterv focusable?)
+                    (mapv label-of))]
+    (some-> (active) (.blur))
+    (when vp (set! (.-scrollTop vp) top))
+    order))
+
+(def ^:private activation-roles
+  "The ARIA roles that promise the platform will ACTIVATE the element
+  from the keyboard. A role from this set on an element the platform
+  does not operate is a control that announces itself, takes focus, and
+  then does nothing when a keyboard user presses Enter."
+  #{"button" "link" "checkbox" "radio" "menuitem" "menuitemcheckbox"
+    "menuitemradio" "option" "switch" "tab"})
+
+(defn- natively-operable?
+  "Is `el` an element the PLATFORM gives keyboard activation to?"
+  [^js el]
+  (let [tag (.toLowerCase (.-tagName el))]
+    (or (contains? #{"button" "input" "select" "textarea" "summary"} tag)
+        (and (= "a" tag) (.hasAttribute el "href")))))
+
+(defn- unoperable-controls
+  "Every element whose ROLE promises activation and whose TAG does not
+  deliver it, in document order.
+
+  The sweep [[every-operable-control-is-one-the-platform-activates]]
+  makes, and the counterpart of rf2-hic-043's `ht/unnamed-controls`: one
+  asks whether a control can be NAMED, this asks whether it can be
+  OPERATED, and a screen needs both answers to be empty."
+  [m]
+  (->> (q* m "[role]")
+       (filterv (fn [^js el]
+                  (and (contains? activation-roles (.getAttribute el "role"))
+                       (not (natively-operable? el)))))))
+
+;; ---------------------------------------------------------------------------
+;; Driving the screen
+;; ---------------------------------------------------------------------------
+
+(defn- mount-ledger!
+  ([] (mount-ledger! events/default-total))
+  ([total] (hm/mount! [views/ledger {}] {:initial-events (app/initial-events total)})))
+
+(defn- window-at
+  "The window `views/ledger`'s geometry puts on screen at scroll offset
+  `top`, derived rather than typed — `ledger.l0-cljs-test` is where the
+  arithmetic itself is held."
+  [top total]
+  (vendor/window-from top
+                      {:row-height      views/row-height
+                       :viewport-height views/viewport-height
+                       :overscan        views/overscan
+                       :total           total}))
+
+(defn- tell-the-vendor-it-scrolled!
+  "Deliver a `scroll` event for the offset the viewport is ALREADY at,
+  and let React commit all of it.
+
+  Deliberately not `virtualized-dom-cljs-test`'s `scroll-to!`, which
+  SETS `scrollTop` and then notifies: here the engine moved the viewport
+  itself, in response to a focus move, and what is under test is that
+  the vendor follows the platform. The three mechanics are that file's
+  and its docstring holds their reasons — the event goes inside
+  `flushSync` because a scroll is a continuous-priority event that an
+  empty `flushSync` does not flush, and the settle happens twice because
+  the window report is a passive effect."
+  [m]
+  (let [^js vp (viewport-in m)]
+    (react-dom/flushSync
+      (fn [] (.dispatchEvent vp (js/Event. "scroll" #js {:bubbles true}))))
+    (hm/settle! m)
+    (hm/settle! m)
+    m))
+
+(defn- controls-of-rows
+  "The ids the ledger's rows contribute to a focus order, for the model
+  rows `from`..`to` inclusive: a note field and a flag button each, in
+  that document order.
+
+  Derived from the application's own id function, so an order asserted
+  here and a row rendered there cannot disagree about the spelling."
+  [from to]
+  (into []
+        (mapcat (fn [i] [(events/note-id i) "ledger-flag"]))
+        (range from (inc to))))
+
+;; ---------------------------------------------------------------------------
+;; The instruments answer, and answer both ways
+;; ---------------------------------------------------------------------------
+
+(deftest the-instruments-discriminate
+  ;; THE PREMISE ROW. Every claim below is an emptiness or a membership
+  ;; claim over two sweeps, and a sweep that could not report anything
+  ;; would satisfy all of them at once.
+  (if-not (browser?)
+    (skip! "the instruments")
+    (let [m (hm/mount! [a-page-of-near-misses {}])]
+      (testing "focusability is the ENGINE's answer and it goes both ways"
+        (is (true? (focusable? (q m "#real"))))
+        (is (true? (focusable? (q m "#half")))
+            "a `tabindex` buys a place in the order for an element the
+             tag table would refuse")
+        (is (false? (focusable? (q m "#neither")))))
+
+      (testing "so the ORDER contains the two the engine accepts, in
+                document order, and not the third"
+        (is (= ["real" "half"] (keyboard-order m))))
+
+      (testing "and the activation sweep reports BOTH divs — including
+                the one that is perfectly reachable, which is the defect
+                a focus-order check alone calls fine"
+        (is (= ["half" "neither"] (mapv label-of (unoperable-controls m))))
+        (is (= ["real"] (mapv label-of (q* m "button")))
+            "and the real button is NOT among them, so the sweep is
+             discriminating rather than reporting every element it
+             ranges over"))
+      (hm/unmount! m))))
+
+(deftest the-ledgers-controls-are-reachable-and-its-chrome-is-not
+  (if-not (browser?)
+    (skip! "the candidate set")
+    (let [m (mount-ledger!)]
+      (testing "premise: the screen mounted the window it always mounts"
+        (is (= 24 (count (q* m "[role='row']")))))
+
+      (testing "a row's two controls are both the engine's to focus"
+        (is (true? (focusable? (note-node m 0))))
+        (is (true? (focusable? (q m ".ledger-flag")))))
+
+      (testing "and the virtualizer's own wrappers are not — they carry
+                `role=\"presentation\"`, and an element that is
+                presentational to a screen reader and reachable by Tab
+                is a stop on the journey that announces nothing"
+        (is (false? (focusable? (viewport-in m))))
+        (is (false? (focusable? (q m ".ledger-spacer")))))
+
+      (testing "nor is the grid, nor a cell: `role=\"grid\"` is a
+                container, and the ledger does not implement the
+                roving-tabindex conduct that would make one focusable"
+        (is (false? (focusable? (q m "[role='grid']"))))
+        (is (false? (focusable? (q m "[role='gridcell']")))))
+
+      (hm/unmount! m))))
+
+;; ---------------------------------------------------------------------------
+;; The order, complete — and bounded by the window
+;; ---------------------------------------------------------------------------
+
+(deftest the-keyboard-order-is-the-window-in-document-order
+  (if-not (browser?)
+    (skip! "the order")
+    (let [m         (mount-ledger!)
+          [from to] (window-at 0 events/default-total)]
+      (is (= (controls-of-rows from to) (keyboard-order m))
+          "THE COMPLETE SEQUENCE rather than a membership test — a
+           control that joined the order, left it, or moved within it is
+           invisible to `is this focusable?` and loud here. Forty-eight
+           entries: two per mounted row, note before flag, rows in model
+           order")
+
+      (testing "and nothing buys itself a place out of turn — a positive
+                tabindex hoists a control above everything that has
+                none, which is a reordering nothing on screen shows"
+        (is (= [] (->> (q* m "[tabindex]")
+                       (filterv #(pos? (.-tabIndex ^js %)))
+                       (mapv label-of)))))
+
+      (hm/unmount! m))))
+
+(deftest the-keyboard-reachable-set-is-the-window-and-not-the-model
+  (if-not (browser?)
+    (skip! "the bound")
+    (let [small   (mount-ledger! 100)
+          n-100   (count (keyboard-order small))
+          _       (hm/unmount! small)
+          big     (mount-ledger! 10000)
+          n-10k   (count (keyboard-order big))]
+      (is (= n-100 n-10k)
+          "THE BOUND. A hundred records and ten thousand put the same
+           number of operable controls within reach of a keyboard —
+           which is what `10K-row behavior` costs, stated where an
+           accessibility reviewer can see the cost rather than only the
+           benefit")
+      (is (= 48 n-10k)
+          "forty-eight: two controls on each of twenty-four mounted
+           rows. `virtualized-dom-cljs-test` holds the contrast — the
+           same rows with no virtualizer put the whole model in the
+           document, and the order grows with it")
+
+      (testing "so the last record is not reachable from here at all,
+                and `aria-rowcount` is the whole of what tells a screen
+                reader that it exists"
+        (is (nil? (note-node big 9999)))
+        (is (= "10000" (.getAttribute (q big "[role='grid']") "aria-rowcount"))))
+
+      (hm/unmount! big))))
+
+;; ---------------------------------------------------------------------------
+;; Traversal drives the virtualizer — which is what makes the model reachable
+;; ---------------------------------------------------------------------------
+
+(deftest traversing-to-the-window-edge-scrolls-and-extends-the-reachable-set
+  (if-not (browser?)
+    (skip! "the mitigation")
+    (let [total     events/default-total
+          m         (mount-ledger! total)
+          [_ to]    (window-at 0 total)
+          ^js vp    (viewport-in m)
+          edge      (note-node m to)]
+      (testing "premise: the viewport is at the top, and the last
+                mounted row is below the fold — twenty-four rows of
+                twenty-four pixels against a four-hundred-and-eighty
+                pixel viewport"
+        (is (zero? (.-scrollTop vp)))
+        (is (some? edge))
+        (is (> (* to views/row-height) views/viewport-height)))
+
+      (.focus edge)
+
+      (is (pos? (.-scrollTop vp))
+          "THE ENGINE MOVED THE VIEWPORT. Asking for focus scrolls the
+           element into view, and that is the platform's own behaviour
+           rather than anything this screen or this test arranged — it
+           is also the entire mechanism by which a keyboard user reaches
+           past a virtualizer's window")
+      (is (identical? edge (active)))
+
+      (let [top       (.-scrollTop vp)
+            [from' _] (window-at top total)]
+        (tell-the-vendor-it-scrolled! m)
+
+        (is (identical? edge (active))
+            "and the node the user is on survived the window moving —
+             the same node, so the caret and the selection went
+             nowhere")
+        (is (= (str "rec-" (+ 100000 to)) (record-of (active)))
+            "still that record's field, which is the claim
+             `virtualized-dom-cljs-test`'s unkeyed arm shows can be
+             false while looking true")
+
+        (testing "the window really did move, so the row below is not
+                  green for want of anything happening"
+          (is (pos? from'))
+          (is (nil? (note-node m 0)) "row 0 has left the document"))
+
+        (testing "AND THE REACHABLE SET MOVED WITH IT: records that were
+                  absent a moment ago are now operable from the
+                  keyboard, which is what makes ten thousand rows
+                  reachable by traversal rather than only by mouse"
+          (let [[from'' to''] (window-at (.-scrollTop vp) total)]
+            (is (= (controls-of-rows from'' to'') (keyboard-order m)))
+            (is (> to'' to)
+                "the far edge advanced past where the first window
+                 ended"))))
+
+      (hm/unmount! m))))
+
+(deftest the-field-a-user-was-typing-in-stays-reachable-after-any-scroll
+  ;; The keyboard half of Rule 3. `virtualized-dom-cljs-test` shows the
+  ;; pinned node keeps FOCUS across a scroll that unmounts its
+  ;; neighbours; the question left over is what happens when the user
+  ;; then tabs away — whether they can ever get back.
+  (if-not (browser?)
+    (skip! "the pin's keyboard consequence")
+    (let [total  events/default-total
+          m      (mount-ledger! total)
+          ^js vp (viewport-in m)
+          field  (note-node m 5)]
+      (.focus field)
+      (hm/settle! m)
+      (set! (.-scrollTop vp) (* 500 views/row-height))
+      (tell-the-vendor-it-scrolled! m)
+
+      (is (some? (note-node m 5))
+          "premise: the pin kept row 5 in the document four hundred and
+           ninety-five rows after the window left it")
+
+      (let [order (keyboard-order m)]
+        (is (= (events/note-id 5) (last (butlast order)))
+            "THE PIN'S PLACE IN THE ORDER. The vendor appends the pinned
+             row after the window's rows, so the field the user was
+             typing in is the second-to-last stop rather than the first
+             — off screen, out of visual order, and still REACHABLE,
+             which is the property that matters: a keyboard user who
+             scrolled away can tab back to their own draft without
+             hunting for it with the scrollbar")
+        (is (= 50 (count order))
+            "twenty-four rows plus the pinned one, two controls each"))
+
+      (hm/unmount! m))))
+
+;; ---------------------------------------------------------------------------
+;; Activation — bought by the tag, not by a handler
+;; ---------------------------------------------------------------------------
+
+(deftest every-operable-control-is-one-the-platform-activates
+  (if-not (browser?)
+    (skip! "the activation sweep")
+    (let [m (mount-ledger!)]
+      (is (= [] (unoperable-controls m))
+          "THE SWEEP. Every element on the screen whose role promises
+           activation is an element the platform activates: the note is
+           an `<input>` and the flag is a `<button>`, so Enter and Space
+           work because HTML says they do and not because this
+           application wrote a key handler. A `role=\"button\"` on a
+           `<div>` would be reported here, and
+           [[the-instruments-discriminate]] is the arm that shows the
+           sweep can report one")
+
+      (testing "and the roles the screen DOES carry on plain elements
+                are the ones that promise nothing — a grid, its rows,
+                its cells and a status region are all structure, and
+                none of them is a control"
+        (is (= #{"grid" "row" "gridcell" "presentation" "status"}
+               (into #{} (map #(.getAttribute ^js % "role")) (q* m "[role]")))))
+
+      (hm/unmount! m))))

--- a/implementation/hicasso/test/re_frame/hicasso/examples/ledger/keyboard_dom_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/examples/ledger/keyboard_dom_cljs_test.cljs
@@ -318,11 +318,26 @@
         (is (true? (focusable? (note-node m 0))))
         (is (true? (focusable? (q m ".ledger-flag")))))
 
-      (testing "and the virtualizer's own wrappers are not — they carry
-                `role=\"presentation\"`, and an element that is
-                presentational to a screen reader and reachable by Tab
-                is a stop on the journey that announces nothing"
-        (is (false? (focusable? (viewport-in m))))
+      (testing "and the virtualizer's own wrappers are not in the
+                sequential-navigation order — they carry
+                `role=\"presentation\"`, and an element that announces
+                nothing and is reachable by Tab is a stop on the journey
+                for no reason"
+        (let [order (set (keyboard-order m))]
+          (is (not (contains? order "ledger-viewport")))
+          (is (not (contains? order "ledger-spacer")))))
+
+      (testing "MEASURED, AND WORTH RECORDING: the engine will
+                nonetheless accept a PROGRAMMATIC focus on the scroll
+                container, because a scroller is focusable in its own
+                right (Chromium's keyboard-focusable scrollers). Being
+                focusable and being in the tab order are therefore two
+                different questions, and `.focus()` answers only the
+                first — which is exactly why [[keyboard-order]] filters
+                a CANDIDATE SET rather than sweeping every element on
+                the page. The spacer, which does not scroll, is not
+                focusable at all"
+        (is (true? (focusable? (viewport-in m))))
         (is (false? (focusable? (q m ".ledger-spacer")))))
 
       (testing "nor is the grid, nor a cell: `role=\"grid\"` is a
@@ -453,13 +468,15 @@
   ;; then tabs away — whether they can ever get back.
   (if-not (browser?)
     (skip! "the pin's keyboard consequence")
-    (let [total  events/default-total
-          m      (mount-ledger! total)
-          ^js vp (viewport-in m)
-          field  (note-node m 5)]
+    (let [total     events/default-total
+          m         (mount-ledger! total)
+          ^js vp    (viewport-in m)
+          field     (note-node m 5)
+          top       (* 500 views/row-height)
+          [from to] (window-at top total)]
       (.focus field)
       (hm/settle! m)
-      (set! (.-scrollTop vp) (* 500 views/row-height))
+      (set! (.-scrollTop vp) top)
       (tell-the-vendor-it-scrolled! m)
 
       (is (some? (note-node m 5))
@@ -475,8 +492,14 @@
              which is the property that matters: a keyboard user who
              scrolled away can tab back to their own draft without
              hunting for it with the scrollbar")
-        (is (= 50 (count order))
-            "twenty-four rows plus the pinned one, two controls each"))
+        (is (= (* 2 (inc (inc (- to from)))) (count order))
+            "the window's rows plus the pinned one, two controls each —
+             derived from the geometry rather than typed, because the
+             window here is twenty-seven rows wide and the one at the
+             top of the model is twenty-four: the upper overscan is
+             clamped away at row zero and present everywhere else, and a
+             constant would be asserting about whichever offset it was
+             written at"))
 
       (hm/unmount! m))))
 

--- a/implementation/hicasso/test/re_frame/hicasso/overlay_focus_dom_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/overlay_focus_dom_cljs_test.cljs
@@ -1,0 +1,326 @@
+(ns re-frame.hicasso.overlay-focus-dom-cljs-test
+  "L4 — WHAT A KEYBOARD CAN REACH WHILE AN OVERLAY IS OPEN
+  (rf2-hic-049, over rf2-hic-052's overlay module).
+
+  > | Accessibility | Semantic Hiccup and native controls | Structural
+  > a11y assertions plus browser focus tests | Names, roles, keyboard,
+  > **virtualized/overlay focus** |
+  >
+  > — product specification §7
+
+  `overlay-dom-cljs-test` establishes the module's posture: the top
+  layer, the LIFO stack, light dismiss, the imperative call, the
+  listener census. It also asserts inertness — by focusing ONE control
+  behind an open modal and finding that it will not take focus. This
+  file finishes that claim, because *one control refused focus* and *the
+  page behind is unreachable* are different statements and only the
+  second is the thing a modal is bought for.
+
+  ## The three claims, and why the middle one is what makes the others mean
+  ## anything
+
+  | claim | row |
+  |---|---|
+  | a real `<dialog>` traps focus when it is MODAL, and does not when it is merely shown | [[the-instrument-tells-a-trap-from-its-absence]] |
+  | the module's modal is the trapping kind: the reachable set becomes EXACTLY the panel's controls | [[an-open-modal-is-the-whole-of-what-a-keyboard-can-reach]] |
+  | the module's popover is NOT a trap, and must not be read as one | [[an-open-popover-leaves-the-page-behind-it-reachable]] |
+
+  The middle claim is an emptiness claim about everything outside a
+  dialog, and an emptiness claim is exactly the shape that passes
+  vacuously — an instrument that reported *nothing is focusable* would
+  satisfy it perfectly. So the first row is the SEEDED VIOLATION the
+  bead's acceptance asks for, made permanent rather than run once by
+  hand: the same `<dialog>` element, holding the same controls, opened
+  through `show()` instead of `showModal()`. That is a legal call on the
+  same element which paints the same panel and fires the same events,
+  and the ONE thing it does not do is make the document behind it inert.
+  The row asserts that the page behind stays reachable under `show()`,
+  which is the trap removed, measured.
+
+  The third row is the other direction on the product itself. A popover
+  is deliberately not modal — a filter menu that made the page it
+  filters unreachable would be a defect, not a feature — so a suite that
+  only ever asserted *an overlay makes everything else unfocusable*
+  would be asserting something the module does not claim and must not
+  do.
+
+  ## What is measured, and what a page cannot drive
+
+  Every row asks the ENGINE — blur, request focus, read
+  `document.activeElement` back — because inertness is decided by the
+  engine's own modality and by nothing this module writes. See
+  `examples.ledger.keyboard-dom-cljs-test` on why asking is the only
+  honest instrument.
+
+  A real Escape key is still not reachable from inside the page:
+  Chromium refuses an untrusted `KeyboardEvent` a close request by
+  design, which `overlay-dom-cljs-test` names and drives through
+  `HTMLDialogElement.requestClose` instead — the same `cancel` path
+  Escape takes. Nothing here re-litigates it.
+
+  ## Browser lane
+
+  `<dialog>`, `popover`, the top layer and inertness have no
+  implementation in the node lane at all, so every row states a skip
+  there rather than a false green. Nothing here is `async` (rf2-u0j8:
+  an async row under a positional fixture aborts the whole run)."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [re-frame.adapter.uix :as uix-adapter]
+            [re-frame.core :as rf]
+            [re-frame.hicasso :as h]
+            [re-frame.hicasso.overlay :as overlay]
+            [re-frame.hicasso.test.mounted :as hm]
+            [re-frame.test-support :as test-support]))
+
+;; ---------------------------------------------------------------------------
+;; The application — one flag, and the two overlays over the same panel
+;; ---------------------------------------------------------------------------
+;;
+;; Registered ABOVE `use-fixtures`, for the reason the overlay and motion
+;; suites give: the reset fixture snapshots the registrar when the
+;; `use-fixtures` form is evaluated.
+
+(rf/reg-sub ::open? (fn [db _] (boolean (:open? db))))
+(rf/reg-event ::opened (fn [{:keys [db]} _] {:db (assoc db :open? true)}))
+(rf/reg-event ::closed (fn [{:keys [db]} _] {:db (assoc db :open? false)}))
+(rf/reg-event ::dismissed (fn [{:keys [db]} _] {:db (assoc db :open? false)}))
+
+;; The two pages differ in the OVERLAY and in nothing else: the same
+;; three panel controls, the same three page controls, the same flag.
+
+(h/defview a-page-with-a-modal [_]
+  [:div
+   [:button#before {:type "button"} "Before"]
+   [:button#trigger {:type "button" :on-click [::opened]} "Open"]
+   [overlay/modal {:open?      (h/sub [::open?])
+                   :on-dismiss [::dismissed]
+                   :label      "Confirm deletion"}
+    [:button#confirm {:type "button"} "Delete"]
+    [:input#reason {:type "text" :aria-label "Reason"}]
+    [:button#cancel {:type "button" :on-click [::closed]} "Cancel"]]
+   [:button#after {:type "button"} "After"]])
+
+(h/defview a-page-with-a-popover [_]
+  [:div
+   [:button#before {:type "button"} "Before"]
+   [:button#trigger {:type "button" :on-click [::opened]} "Open"]
+   [overlay/popover {:open?      (h/sub [::open?])
+                     :on-dismiss [::dismissed]
+                     :anchor     "trigger"
+                     :placement  :bottom-start}
+    [:button#confirm {:type "button"} "Delete"]
+    [:input#reason {:type "text" :aria-label "Reason"}]
+    [:button#cancel {:type "button" :on-click [::closed]} "Cancel"]]
+   [:button#after {:type "button"} "After"]])
+
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture
+    {:adapter       uix-adapter/adapter
+     :ambient-frame nil}))
+
+;; ---------------------------------------------------------------------------
+;; The lane
+;; ---------------------------------------------------------------------------
+
+(defn- browser? []
+  (and (exists? js/document)
+       (some? js/document)
+       (some? (.-body js/document))
+       (fn? (.-showModal (.-prototype js/HTMLDialogElement)))))
+
+(defn- skip! [why]
+  (is true (str "modality, inertness and the top layer are the engine's — " why)))
+
+;; ---------------------------------------------------------------------------
+;; The instrument
+;; ---------------------------------------------------------------------------
+
+(defn- active [] (.-activeElement js/document))
+
+(defn- label-of [^js el]
+  (cond
+    (seq (.-id el))        (.-id el)
+    (seq (.-className el)) (first (.split (.-className el) " "))
+    :else                  (.toLowerCase (.-tagName el))))
+
+(defn- focusable?
+  "Does the ENGINE accept focus on `el`? Blur, ask, read
+  `document.activeElement` back. Inertness is invisible in markup — the
+  page behind a modal carries no attribute saying so — which is why
+  every row here asks rather than reads."
+  [^js el]
+  (some-> (active) (.blur))
+  (.focus el)
+  (identical? el (active)))
+
+(defn- reachable
+  "Every element under `root` the engine will focus, in document order,
+  as readable names.
+
+  Scoped to a root rather than to the document because a mount's own
+  container is what a page is here, and because the sabotage row below
+  parks a raw `<dialog>` on `document.body` deliberately outside it."
+  [^js root]
+  (let [order (->> (.querySelectorAll root "a[href],button,input,select,textarea,[tabindex]")
+                   (array-seq)
+                   (filterv focusable?)
+                   (mapv label-of))]
+    (some-> (active) (.blur))
+    order))
+
+(defn- open! [m] (hm/dispatch-and-settle! m [::opened]) m)
+(defn- close! [m] (hm/dispatch-and-settle! m [::closed]) m)
+
+(defn- $ [m sel] (.querySelector (:container m) sel))
+
+;; ---------------------------------------------------------------------------
+;; The seeded violation — one method name apart
+;; ---------------------------------------------------------------------------
+
+(defn- raw-dialog!
+  "A `<dialog>` holding one button, built from raw DOM and parked on
+  `document.body`.
+
+  Raw, and not this module's, on purpose: the claim it settles is about
+  the PLATFORM's two doors, and the shortest honest way to compare them
+  is an element nothing else has touched. It is parked outside the
+  mount's container so that removing it cannot disturb React's
+  reconciliation of a tree it does not own."
+  []
+  (let [d (.createElement js/document "dialog")
+        b (.createElement js/document "button")]
+    (set! (.-id b) "raw-inside")
+    (set! (.-textContent b) "Inside")
+    (.appendChild d b)
+    (.appendChild (.-body js/document) d)
+    d))
+
+(deftest the-instrument-tells-a-trap-from-its-absence
+  ;; THE SEEDED VIOLATION, made permanent. Every row below this one is an
+  ;; emptiness claim about the page behind an overlay, and an instrument
+  ;; that answered `not focusable` to everything would satisfy all of
+  ;; them at once. So the trap is removed here — the same element, the
+  ;; same contents, `show()` where `showModal()` was — and the page
+  ;; behind must be measured STILL REACHABLE.
+  (if-not (browser?)
+    (skip! ":node-test has no <dialog>")
+    (let [m      (hm/mount! [a-page-with-a-modal {}])
+          ^js d  (raw-dialog!)]
+      (try
+        (testing "premise: with nothing open, the page's own controls are
+                  the reachable set"
+          (is (= ["before" "trigger" "after"] (reachable (:container m)))))
+
+        (testing "SHOWN, NOT MODAL — the trap removed. A legal call on
+                  the same element: it paints the same panel, fires the
+                  same events, joins no top layer of its own, and leaves
+                  the document behind it live"
+          (.show d)
+          (is (true? (.-open d)) "premise: it really is open")
+          (is (zero? (.-length (.querySelectorAll js/document ":modal")))
+              "and the engine does not consider it modal")
+          (is (= ["before" "trigger" "after"] (reachable (:container m)))
+              "so every control behind it is still the engine's to focus
+               — which is what a missing focus trap looks like, measured
+               rather than described")
+          (.close d))
+
+        (testing "MODAL — the same element, one method name apart, and
+                  the page behind goes inert"
+          (.showModal d)
+          (is (= 1 (.-length (.querySelectorAll js/document ":modal"))))
+          (is (= [] (reachable (:container m)))
+              "nothing behind it can be focused. The two arms differ in
+               `show` versus `showModal` and in nothing else, so the
+               instrument is measuring modality and not, say, an element
+               it cannot see")
+          (is (true? (focusable? (.querySelector d "#raw-inside")))
+              "while the dialog's own control still takes focus, so the
+               reading above is inertness rather than a page that has
+               stopped answering")
+          (.close d))
+
+        (finally
+          (when (.-open d) (.close d))
+          (.remove d)
+          (hm/unmount! m))))))
+
+;; ---------------------------------------------------------------------------
+;; The module's modal — the trap, complete
+;; ---------------------------------------------------------------------------
+
+(deftest an-open-modal-is-the-whole-of-what-a-keyboard-can-reach
+  (if-not (browser?)
+    (skip! ":node-test has no modality")
+    (let [m (hm/mount! [a-page-with-a-modal {}])]
+      (try
+        (testing "premise: closed, the page is its own three controls and
+                  the panel is not in the document at all"
+          (is (= ["before" "trigger" "after"] (reachable (:container m))))
+          (is (nil? ($ m "dialog"))))
+
+        (open! m)
+
+        (testing "opening moves focus INTO the panel — the platform's own
+                  dialog-focusing steps, which `overlay-dom-cljs-test`
+                  holds in detail; asserted here only as the premise the
+                  next row needs"
+          (is (.contains ($ m "dialog") (active))))
+
+        (is (= ["confirm" "reason" "cancel"] (reachable (:container m)))
+            "THE TRAP, COMPLETE. The reachable set is now EXACTLY the
+             panel's three controls, in the panel's document order —
+             `before`, `trigger` and `after` have all left it. Stated as
+             the whole sequence rather than as `is #before still
+             focusable?`, because a modal that leaked one control of the
+             page behind it is a modal a keyboard user tabs straight out
+             of, and a membership test over one control cannot see the
+             leak in another")
+
+        (close! m)
+
+        (testing "and closing gives the page back — the same three
+                  controls, in the same order, so the reading above was
+                  a state the page was in and not a state it is now
+                  stuck in"
+          (is (nil? ($ m "dialog")))
+          (is (= ["before" "trigger" "after"] (reachable (:container m)))))
+
+        (finally (hm/unmount! m))))))
+
+;; ---------------------------------------------------------------------------
+;; The module's popover — deliberately not a trap
+;; ---------------------------------------------------------------------------
+
+(deftest an-open-popover-leaves-the-page-behind-it-reachable
+  ;; The other direction, on the product rather than on the instrument.
+  ;; A popover is an anchored panel over a live page: a filter menu that
+  ;; made the list it filters unreachable would be a defect. Without
+  ;; this row the suite would have proved only that opening SOMETHING
+  ;; makes everything else unfocusable, which is not what the module
+  ;; claims and not what it does.
+  (if-not (browser?)
+    (skip! ":node-test has no popover")
+    (let [m (hm/mount! [a-page-with-a-popover {}])]
+      (try
+        (is (= ["before" "trigger" "after"] (reachable (:container m)))
+            "premise: closed, the page is its own three controls")
+
+        (open! m)
+
+        (is (some? ($ m "[popover]")) "premise: the panel is in the document")
+
+        (is (= ["before" "trigger" "confirm" "reason" "cancel" "after"]
+               (reachable (:container m)))
+            "THE CONTRAST. The panel's controls JOIN the page's rather
+             than replacing them, and they join at the panel's place in
+             the DOM — which is where the author wrote it, because the
+             top layer changes paint order and not tree order. A
+             keyboard user can tab out of a popover and back into the
+             page, which is exactly the conduct that separates a menu
+             from a dialog")
+
+        (close! m)
+        (is (= ["before" "trigger" "after"] (reachable (:container m))))
+
+        (finally (hm/unmount! m))))))


### PR DESCRIPTION
Closes rf2-hic-049.

Three browser witnesses over products that already exist, asking the engine rather than reading markup. Nothing in `implementation/` or `spec/` changed — this PR is three new test namespaces.

| witness | file |
|---|---|
| keyboard reachability and conduct on the virtualized screen | `implementation/hicasso/test/re_frame/hicasso/examples/ledger/keyboard_dom_cljs_test.cljs` |
| the overlay focus trap, complete, with a permanent seeded violation | `implementation/hicasso/test/re_frame/hicasso/overlay_focus_dom_cljs_test.cljs` |
| the select-only combobox's keyboard conduct and its active-descendant model | `implementation/hicasso/test/re_frame/hicasso/combobox_keyboard_dom_cljs_test.cljs` |

## What #8026 and #8025 already cover, and this PR does not rebuild

PR #8026 (rf2-hic-047) landed the ledger and its structural a11y suite; PR for rf2-hic-052 landed `overlay_dom_cljs_test`. Both were read first, and the following are **theirs**, cited from the new files rather than repeated:

- `aria-rowcount` 10000 beside 24 mounted rows, `aria-rowindex` after a scroll, one body per keystroke at both model sizes, four per three-row scroll — `ledger.virtualized-dom-cljs-test`.
- The unkeyed-window identity defect and the unpinned focus-destruction arm — same file. **The finding it publishes is inherited and respected**: Hicasso's unkeyed-children warning cannot reach a render callback, so the key rule is prose by necessity. Nothing here claims an enforcement the substrate cannot provide.
- Names, roles, `aria-pressed`, the status region — `ledger.a11y-cljs-test`.
- Focus entering a modal, focus restored to the trigger on close, the LIFO stack, light dismiss, the listener census, the close request as an intent — `overlay-dom-cljs-test`. The trap row below asserts focus-entry only as its own premise and says so.
- Focus order, label association, disabled controls leaving and rejoining the order on a static screen — `slice.a11y-focus-dom-cljs-test`, whose `focusable?` idiom the new files reuse deliberately.

## What is new

**Keyboard reachability is a measurement, and virtualization changes it.** The complete focus order of the ledger is the mounted window's 48 controls, note before flag, rows in model order — asserted as a sequence, not a membership test. That number is *identical at a hundred records and at ten thousand*, which is the cost of windowing stated where an accessibility reviewer can see it, not only the benefit: record 9,999 is not reachable from the keyboard at all, and `aria-rowcount` is the whole of what says it exists. The mitigation is measured too — focusing the window's last row makes the **engine** scroll the viewport, the window follows, and the newly-mounted rows join the reachable set while the focused node and its record survive. The pinned row stays reachable after an arbitrary scroll, as the second-to-last stop, so a user who scrolled away can tab back to their own draft.

**Activation is bought by the tag.** `unoperable-controls` sweeps for elements whose ARIA role promises activation and whose tag cannot deliver it — the counterpart of rf2-hic-043's `ht/unnamed-controls`, one asking whether a control can be *named* and this whether it can be *operated*. The ledger reports `[]`; a three-control control page reports the two `<div role="button">`s, including the one with a `tabindex` that a focus-order check alone calls fine.

**The trap, complete.** `overlay-dom-cljs-test` asserts inertness by focusing one control behind an open modal. *One control refused focus* and *the page behind is unreachable* are different statements, and only the second is what a modal is bought for: the new row measures the whole reachable set and finds it is **exactly** the panel's three controls. The popover arm is the other direction on the product — a popover is deliberately not a trap, and its controls *join* the page's rather than replacing them.

**The combobox, per merged-PR audit #7914 on this bead.** The guide's select-only dropdown carries `aria-activedescendant` on a plain button with no `aria-controls`, so the pointer names an id in a vacuum and the position is never announced; `aria-selected` follows the transient active option although the committed value moves only on Enter or click. `select-dropdown` is the guide's example with the bounded repair applied; `the-guides-dropdown-as-written` is the same view with it removed, and the sweep reports its two findings **by name** (`:role-may-not-carry-activedescendant`, `:no-ownership-edge`) while explicitly *not* reporting the id as unresolved — which is why the defect survives review. The conduct is driven, not stated: `:on-key-down` is a React handler, so arrows and Enter are real key events.

## The seeded violation

The bead's acceptance is *one seeded violation (a focus trap removed) reddens the overlay witness*. It is discharged twice.

**Permanently, in the suite.** `the-instrument-tells-a-trap-from-its-absence` opens a raw `<dialog>` through `show()` and then `showModal()` — the same element, the same contents, one method name apart — and requires the page behind to be measured still reachable under the first and unreachable under the second. Without it every trap row below is an emptiness claim an instrument that answered *nothing is focusable* would satisfy.

**Once, against the module.** `impl/overlay.cljs:189` `showModal` → `show`, verified by hash rather than by `git diff`:

```
pristine   7cbd21fda52ab2c5989ced3ea6dfb47e75a00ddd2d1dff12ff952795f76cd1f7
sabotaged  01a6dd4b8b3df7dcc48cae47a2c01d6b1e3e05e9c59d4a2ecaa872e4859f376d
restored   7cbd21fda52ab2c5989ced3ea6dfb47e75a00ddd2d1dff12ff952795f76cd1f7   ← equals pristine
```

The run reddened with **captured exit 1, 9 failures** — and the runtime demonstrably saw the plant, because the new witness's own diagnosis is the right one:

```
FAIL in (an-open-modal-is-the-whole-of-what-a-keyboard-can-reach)
  overlay_focus_dom_cljs_test.cljs:270
  expected: (= ["confirm" "reason" "cancel"] (reachable (:container m)))
    actual: (not (= ["confirm" "reason" "cancel"]
                    ["before" "trigger" "confirm" "reason" "cancel" "after"]))
```

The eight others are `overlay-dom-cljs-test`'s own top-layer, inertness and stacking rows, which that file's docstring already names as this sabotage's reds. Neither the raw-dialog control nor the popover row moved, which is correct: the sabotage touches the modal door only.

## Quality gates

Raw **captured** exit codes, from `.exit` files written on the same command line as the runner. Each run's `Serving …` line named `C:\Users\miket\code\re-frame2-worktrees\a11y-hic049\implementation\out\browser-test` — this worktree.

| gate | exit | result |
|---|---|---|
| `npm run test:browser` (control, pristine tree) | **0** | Ran 1439 tests containing 8897 assertions. 0 failures, 0 errors. |
| `npm run test:browser` (this branch) | **0** | Ran 1454 tests containing 8986 assertions. 0 failures, 0 errors. |
| `npm run test:browser` (seeded violation) | **1** | Ran 1454 tests containing 8986 assertions. 9 failures, 0 errors. |
| `npm run test:cljs` (node lane) | **0** | Ran 13759 tests containing 69590 assertions. 0 failures, 0 errors. |
| `npm run test:hicasso-invariants` | **0** | |
| `npm run test:hicasso-lint` | **0** | |
| `clj-kondo` over the three new files | **0** | errors: 0, warnings: 0 |

> Twice in this session the harness surfaced a completed browser run as *"completed (exit code 0)"* while the captured `.exit` file read **1** — once on a genuine two-assertion failure, once on the seeded-violation run. Every number above is the captured one.

`npm run test:hicasso-hmr` was **not** run: it binds `:dev-http` 8061, which is machine-exclusive. Deferred to CI.

### The async-abort check (rf2-u0j8)

An async row under a positional fixture aborts the whole `test:browser` run, every later namespace included, and a green count that silently dropped namespaces is the failure mode. Two defences:

1. **No row in any of the three files is `async`.** Every claim settles inside one tick. All three fixtures use the MAP shape anyway, so the file cannot acquire the trap by acquiring an async row later.
2. **The counts reconcile exactly against a control run on an unmodified tree.**

```
control  (origin/main, no new files)   1439 tests   8897 assertions
branch                                 1454 tests   8986 assertions
delta                                    +15 tests    +89 assertions
```

+15 is exactly the new rows: 7 (ledger keyboard) + 3 (overlay focus) + 5 (combobox) = 15. Nothing was dropped — the control run's 1439 are all still there.

## Premises in the brief that did not hold

**1. There is no axe in the tree, and this bead did not add one.** The bead's *Deliverables* prose asks for "axe checks across all three surfaces". Refused, source-located:

- The **acceptance** columns do not ask for it. Product specification §7's accessibility row is *Names, roles, keyboard, virtualized/overlay focus*; `requirements-mine.md` assigns rf2-hic-049 *Keyboard, virtualized and overlay focus in a browser* and assigns axe to rf2-hic-043.
- `axe-core` is not in `implementation/package.json`, not in the lockfile, not in `node_modules`. Adding it is a dependency plus a lockfile change, and every worker worktree junctions the mayor's **real** `node_modules`, so the install mutates a shared tree mid-wave.
- The repo's own recorded posture is that axe-core is **not** bundled: `spec/Security.md` and `spec/007-Stories.md` document Story loading it from a public CDN precisely so bundles do not carry it. The browser gate serves from 127.0.0.1 with no egress, so a CDN axe is not available to it either.

Filed as **rf2-5q8o** — a decision bead, not an implementation one: either rule the structural sweeps are the gate and strike the prose, or admit axe-core as a devDependency in its own bead. Three of axe's rule families are already covered structurally (`ht/unnamed-controls`, `unoperable-controls`, `activedescendant-findings`); the genuinely uncovered ones are colour contrast, duplicate ids and required-children.

**2. A real Tab and a real Escape are not reachable from inside the page.** A synthetic `KeyboardEvent` performs no default action, so those two would measure this suite's own dispatcher. Sequential navigation is therefore witnessed as the engine's own focusability answer over the candidate set — which is what Tab consumes — and the gap is stated in all three docstrings rather than papered over. The application-owned half **is** driven for real, through `:on-key-down`. Closing the gap needs a `page.keyboard.press` bridge in `scripts/run-browser-tests.cjs`, the same shape as the GC bridge already there; that file is `worker/asyncabort-u0j8`'s fence on this wave, so it is filed as **rf2-il7b** to be sequenced after it.

**3. The audit's doc half is another worker's fence.** Merged-PR audit #7914 asks to true up the guide example and the chapter that calls it the contract. Those are `docs/design/hicasso/draft-guide/13-overlays-and-focus.md` and `22-accessibility.md`, fenced to the draft-guide worker, so this PR does not touch them. The witness half — *make this owner's browser keyboard witness cover the exact guide example* — is discharged here, and **rf2-56v4** carries the text change with `combobox_keyboard_dom_cljs_test.cljs` named as its source of truth.

**4. `docs/design/hicasso/draft-guide` chapters are renumbered since the audit.** The audit says "chapter 12" and "chapter 21"; today they are 13 (*Overlays and focus*) and 22 (*Accessibility*). Recorded so the follow-up bead is not read against stale numbers.

## One finding, published rather than asserted away

The first browser run reddened on `(is (false? (focusable? (viewport-in m))))`. The engine **will** accept a programmatic `.focus()` on the ledger's scroll container — Chromium's keyboard-focusable scrollers. Being focusable and being in the tab order are therefore different questions, and `.focus()` answers only the first, which is exactly why `keyboard-order` filters a candidate set rather than sweeping every element on the page. The row now measures both facts and says so, instead of asserting the convenient one. The presentational wrappers are still absent from the order, which is the claim that matters.

## Hot zone

Untouched. No `spec/*`, no `implementation/shadow-cljs.edn`, no `implementation/deps.edn`, no `.github/workflows/*`. The three new namespaces end in `-dom-cljs-test`, so `:browser-test`'s existing `ns-regexp` selects them and no build id or `:dev-http` port was needed.
