### PR TITLE
fix(ssr-node): close the response-leg egress, and gate it (rf2-hic-056)

### DIFF
--- a/implementation/ssr-node/README.md
+++ b/implementation/ssr-node/README.md
@@ -40,6 +40,11 @@ operator's ruling names beside the other five, and the **bytes reaching
 the client unaltered**, which is what makes a hydration contract survive
 the crossing (`test/bytes.test.cjs`).
 
+Guarantee 2 has a response leg as well as a request one — **application
+data cannot cross outside body markup** — and it is witnessed separately,
+in `test/egress.test.cjs`, because a fail-closed door on the way in and an
+open one on the way out is not a fail-closed crossing.
+
 ### 1. Per-request state isolation, via immutable snapshots
 
 A request's `state` never crosses as a reference. It crosses as a
@@ -84,6 +89,36 @@ refusal so the message teaches instead of merely declining.
 module publishes. An id the bundle does not carry is refused per request
 (`:rf.ssr-node/unknown-entry`) — the per-request half of the skew detector
 the server-arm pricing named as row B5.
+
+**The response leg's fields.** A fail-closed request door with an open
+response door is not a fail-closed crossing. `COMPLETE_FIELDS` in
+`src/protocol.cjs` is the terminal frame's field list and it is the same
+kind of object as `REQUEST_FIELDS` rather than a comment: `type`,
+`chunks`, `renderMs`, `buildId` and the optional `requestId`. Every one is
+a fact **this service** produced about the crossing it just performed —
+counted here, timed here, or read from the bundle's published table at
+boot — and `requestId` is the caller's own correlation token handed back.
+There is no member the application's render module fills in, and no
+mechanism by which it could: **`emit` is a render module's only output
+channel**, and a module that returns a value is refused
+(`:rf.ssr-node/render-threw`) rather than having the value quietly
+dropped. `test/egress.test.cjs` is the witness.
+
+That door was not there in the first cut of this package, and how it was
+missing is worth keeping on the record. `worker.cjs` forwarded an
+arbitrary `out.meta` from the render module, `isolate.cjs` carried it and
+`service.renderFrames()` published it — and the fixtures under `test/`
+demonstrated the channel carrying application state (`readTodos`,
+`readRoute`). The HTTP transport happened not to serialise it, so nothing
+looked wrong; but "the current transport drops it" is a fact about
+`http.cjs` and not a guarantee about this package, and the protocol is
+documented as transport-independent while `renderFrames()` and
+`renderToString()` are an in-process API that carried it in full. A
+contract asserting a property its code does not enforce is the exact
+fail-open class this repo hunts in its own instruments, so the property is
+now enforced in `worker.cjs` — the one place where the topology *can* be
+enforced, because nothing downstream can carry what it never posts — and
+checked on the FRAMES rather than on the HTTP response.
 
 **The state keys.** Each entry in the table declares its own
 `stateAllowlist`: the top-level app-db keys a render of that entry may
@@ -270,8 +305,13 @@ frames rather than changing semantics.
 ```jsonc
 { "type": "chunk",    "seq": 0, "html": "<div>…" }
 { "type": "complete", "chunks": 1, "renderMs": 1.4, "buildId": "…",
-  "requestId": "…", "meta": {} }
+  "requestId": "…" }
 ```
+
+The `complete` frame's field list is `COMPLETE_FIELDS`, and it is closed
+in the same sense the request's is. Nothing on it originates in the
+application's render module — see
+[the response leg](#2-allowlisted-request-fail-closed).
 
 or, instead of everything:
 
@@ -300,7 +340,7 @@ rather than presenting a well-formed shorter page.
 | `:rf.ssr-node/state-key-not-allowed` | a key the entry does not declare |
 | `:rf.ssr-node/build-identity-mismatch` | caller's `buildId` ≠ the bundle's |
 | `:rf.ssr-node/render-timeout` | deadline expired; the isolate was terminated |
-| `:rf.ssr-node/render-threw` | the render module threw, or emitted nothing |
+| `:rf.ssr-node/render-threw` | the render module threw, emitted nothing, or returned a value |
 | `:rf.ssr-node/isolate-lost` | the worker died mid-render |
 | `:rf.ssr-node/service-saturated` | no isolate free within the admission budget |
 | `:rf.ssr-node/service-closed` | the service is shutting down |
@@ -354,10 +394,10 @@ module.exports = {
   boot() { /* rf.init!(adapter); registerViews(); */ },
 
   // Once per request. `state` is frozen; writing to it throws. Call `emit`
-  // one or more times with body markup.
+  // one or more times with body markup, and return nothing — `emit` is
+  // this module's only channel out of the isolate.
   render({ entry, state, args }, emit) {
     emit(MY_APP_SSR.renderToString(entry, state, args));
-    return { meta: {} };
   },
 };
 ```
@@ -365,6 +405,18 @@ module.exports = {
 `render` may return a promise; the isolate awaits it under the same
 deadline, so a streaming module is governed identically. A module that
 returns without emitting is refused rather than served as an empty page.
+
+**A module that returns a *value* is also refused**
+(`:rf.ssr-node/render-threw`), and that is the response leg's fail-closed
+door rather than fussiness — see
+[the response leg's fields](#2-allowlisted-request-fail-closed) for what
+it is holding and what it cost to find missing. An `async render` that
+falls off its end returns `undefined` and is fine; `return { … }` is a
+module reaching for a second way out, and the refusal says so in as many
+words. Because it can only be discovered *after* the render, a module that
+both emitted and returned produces a **torn** response carrying
+`detail.afterChunks` — the bytes really did leave, and the transport must
+not present them as a page.
 
 The CLJS half — the thing behind `MY_APP_SSR.renderToString` — is the
 existing Hicasso render entry: a per-request `gensym` frame, `:rf/set-db`
@@ -499,10 +551,10 @@ that is out of scope here.
 node implementation/ssr-node/test/run.cjs
 ```
 
-No build, no npm install, no browser, roughly seven seconds. Each suite
-runs in its own process, because several of them deliberately kill worker
-threads and a shared process would let one file's leaked isolate turn the
-next file's clean failure into a hang.
+No build, no npm install, no browser, roughly seven seconds — eight
+suites, 83 rows. Each suite runs in its own process, because several of
+them deliberately kill worker threads and a shared process would let one
+file's leaked isolate turn the next file's clean failure into a hang.
 
 **There is deliberately no npm script and no CI job yet, and the reason is
 measurable rather than aesthetic.** Adding one line to
@@ -521,9 +573,17 @@ affect", answers *nothing* for this package's files.
 
 The suite drives the service against reference render modules under
 `test/fixtures/` — well-behaved, mutating, sloppy-mode, hanging, throwing,
-chunking and byte-hostile — because every guarantee here is a property of
-the *service*, and a fixture that misbehaves on purpose is the only way to
-see a guard fire.
+chunking, byte-hostile and leaky — because every guarantee here is a
+property of the *service*, and a fixture that misbehaves on purpose is the
+only way to see a guard fire.
+
+A fixture reports what it observed by **rendering** it, as a base64
+attribute on markup it was emitting anyway, and the witnesses read it back
+out of the body (`test/observations.cjs`). That is not a workaround for a
+missing channel; it is the response contract holding, in the one place a
+suite would feel it. The observations used to ride the terminal frame,
+which is the egress described above — they were not deleted when it
+closed, because four of the five guarantees are witnessed through them.
 
 **Every guard has a control beside it, and the controls are ordinary rows
 rather than a `--self-test` flag**, so they cannot be skipped by anyone
@@ -533,7 +593,9 @@ false proof of a real guard, which is worse than no proof. So the overlap
 counter is shown reading 2 before it is trusted reading 1; the byte
 comparison is shown moving under a re-encoding before it is trusted
 agreeing; the runaway render is shown still running after 400 ms before a
-200 ms refusal is called a termination; and the absence scan is shown
+200 ms refusal is called a termination; the egress scan is shown finding a
+planted leak — and the leaky fixture shown really returning one — before
+its zero is believed; and the absence scan is shown
 finding a planted reference before its zero is believed.
 
 ---
@@ -577,7 +639,10 @@ the tree, which is what the PR's quality-gate table records.
 ## Provenance
 
 - `rf2-hic-056` — this package. Operator ruling of 2026-08-12
-  (`rf2-xpq9`) lifted the dormancy and set V0 scope.
+  (`rf2-xpq9`) lifted the dormancy and set V0 scope. Reopened at P2 by the
+  merged-PR audit of #8028 for the response-contract escape described
+  under [guarantee 2](#2-allowlisted-request-fail-closed); the remedy is
+  the response-leg field list and `test/egress.test.cjs`.
 - `rf2-hic-046` — the per-surface SSR/hydration witnesses this builds on.
   The client-side hydration contract is that bead's and is already
   mandatory; nothing here waits on this service.

--- a/implementation/ssr-node/src/isolate.cjs
+++ b/implementation/ssr-node/src/isolate.cjs
@@ -168,11 +168,15 @@ class Isolate {
       return;
     }
     if (msg.t === 'complete') {
+      // Named fields, never a spread of `msg`. The worker refuses to put
+      // application data on this message at all (see its header), and
+      // this end declines to carry a field it was not expecting even if
+      // one somehow arrived — two independent readings of the same
+      // property, which is what makes it a boundary rather than a habit.
       this._settle(msg.id, () =>
         p.resolve({
           chunks: msg.chunks,
           renderMs: msg.renderMs,
-          meta: msg.meta,
           buildId: this.buildId,
         }),
       );

--- a/implementation/ssr-node/src/protocol.cjs
+++ b/implementation/ssr-node/src/protocol.cjs
@@ -60,6 +60,18 @@
 //     well-meaning implementer would actually reach for are named in
 //     `REFUSED_FIELDS` with the reason attached to the refusal, so the
 //     message teaches instead of merely declining.
+//
+// ## AND THE RESPONSE LEG IS ALLOWLISTED THE SAME WAY
+//
+// A fail-closed request door with an open response door is not a
+// fail-closed crossing; it is a fail-closed crossing in one direction and
+// a `meta` map in the other. `COMPLETE_FIELDS` is therefore the response
+// leg's field list, and it is the same kind of object as `REQUEST_FIELDS`
+// rather than a comment: every member is a fact the SERVICE owns about
+// the crossing it just performed, and there is no member — and no
+// mechanism — by which the application's render module contributes one.
+// The module's only output channel is `emit`, and `MODULE_RETURN_REFUSAL`
+// is the reason a module that reaches for a second one is told no.
 
 const PROTOCOL_VERSION = 1;
 
@@ -120,6 +132,49 @@ const REFUSED_FIELDS = Object.freeze({
     'stay on the JVM. Anything beyond body markup crossing this contract is the host fork ' +
     'arriving by increments.',
 });
+
+/**
+ * EVERY field a `complete` frame carries. The response leg's half of the
+ * contract, and the same kind of list as `REQUEST_FIELDS` — see the header.
+ *
+ * Read the members as a single claim: each one is a fact about the
+ * CROSSING, produced by this service, and none of them originates in the
+ * application's render module.
+ *
+ *   `type`      — the frame discriminator.
+ *   `chunks`    — how many body chunks preceded this frame. Counted here.
+ *   `renderMs`  — how long the module's render took. Timed here.
+ *   `buildId`   — which bundle answered. Read from the module's published
+ *                 table at boot, not from the render.
+ *   `requestId` — the CALLER's own correlation token, echoed back. It is
+ *                 the one field that did not originate on this side, and
+ *                 it originated with the caller rather than with the
+ *                 application bundle, so echoing it egresses nothing the
+ *                 caller does not already hold.
+ *
+ * Adding a member is a protocol change and should read like one. Adding a
+ * member the render module fills in is the topology change §11 of the
+ * server-arm pricing calls "the host fork arriving by increments", and
+ * `test/egress.test.cjs` is the row that will say so.
+ */
+const COMPLETE_FIELDS = Object.freeze(['type', 'chunks', 'renderMs', 'buildId', 'requestId']);
+
+/**
+ * Why a render module that returns a value is refused rather than having
+ * its value quietly dropped.
+ *
+ * The wording lives here, with the contract, because it IS the contract:
+ * the module has one output channel and dropping a second one silently is
+ * how a second one survives long enough to be depended on. This service
+ * shipped for one commit with the returned value forwarded to the caller
+ * as `meta`, HTTP happened not to serialise it, and "the current transport
+ * drops it" was doing the work a guarantee was supposed to do.
+ */
+const MODULE_RETURN_REFUSAL =
+  'the render module returned a value. `emit` is its only output channel: this contract ' +
+  'carries body markup and nothing else, so a second way out of the isolate is application ' +
+  'data crossing a boundary that has no policy for it — the host fork arriving by increments. ' +
+  'Render what the module has to say, and return nothing.';
 
 /**
  * A top-level app-db key, as its EDN text. Keywords in re-frame2 are what
@@ -377,14 +432,19 @@ function validateRequest(req, tables, limits = {}) {
 /** A body chunk. `seq` is monotonic per response and starts at 0. */
 const chunkFrame = (seq, html) => ({ type: 'chunk', seq, html });
 
-/** The terminal success frame. Everything that is not body markup. */
-const completeFrame = ({ chunks, renderMs, buildId, requestId, meta }) => ({
+/**
+ * The terminal success frame. Everything that is not body markup — and
+ * `COMPLETE_FIELDS` is the whole of it. There is deliberately no rest
+ * parameter and no spread of a caller-supplied object here: a constructor
+ * that copies whatever it is handed is a field list that grows without
+ * anyone editing the field list.
+ */
+const completeFrame = ({ chunks, renderMs, buildId, requestId }) => ({
   type: 'complete',
   chunks,
   renderMs,
   buildId,
   ...(requestId === undefined ? {} : { requestId }),
-  meta: meta ?? {},
 });
 
 module.exports = {
@@ -392,6 +452,8 @@ module.exports = {
   CODE,
   REQUEST_FIELDS,
   REFUSED_FIELDS,
+  COMPLETE_FIELDS,
+  MODULE_RETURN_REFUSAL,
   KEY_TEXT,
   Refusal,
   refuse,

--- a/implementation/ssr-node/src/service.cjs
+++ b/implementation/ssr-node/src/service.cjs
@@ -26,6 +26,17 @@
 // or a streaming module throwing halfway — is a TORN response, carries
 // `detail.afterChunks`, and the transport is required to treat it as
 // unpresentable rather than as a shorter page.
+//
+// ## THE PUBLIC FRAMES CARRY NO APPLICATION DATA
+//
+// `renderFrames` is the widest surface this package has: every transport
+// is an adapter over it and the in-process caller reads it raw, so
+// whatever it yields IS the egress. What it yields is body markup in
+// `chunk` frames and `COMPLETE_FIELDS` in the terminal one — nothing
+// else, and nothing the application's render module authored outside the
+// markup it emitted. `test/egress.test.cjs` is that property's witness,
+// and it checks the frames rather than the HTTP response, because HTTP
+// dropping a field is a fact about HTTP and not a guarantee about this.
 
 const { CODE, Refusal, validateRequest, completeFrame } = require('./protocol.cjs');
 const { Pool } = require('./pool.cjs');
@@ -117,7 +128,6 @@ class Service {
         renderMs: terminal.renderMs,
         buildId: terminal.buildId,
         requestId: req.requestId,
-        meta: terminal.meta,
       });
     } finally {
       // A consumer that abandons the iteration must not strand the

--- a/implementation/ssr-node/src/worker.cjs
+++ b/implementation/ssr-node/src/worker.cjs
@@ -42,9 +42,27 @@
 // arriving here is a bug in the pool rather than a caller's mistake. It is
 // still refused rather than queued: a guard that trusts its one caller is
 // a guard that stops holding the day a second caller appears.
+//
+// ## `emit` IS THE MODULE'S ONLY WAY OUT, AND THIS FILE IS WHERE THAT IS TRUE
+//
+// Everything else in this package can only carry what this file posts, so
+// the topology — *Node returns the body markup, and nothing else* — is
+// enforceable in exactly one place and it is here. The `complete` message
+// below is built from counters and clocks this file owns; the render
+// module's return value contributes nothing to it and cannot.
+//
+// It is REFUSED rather than dropped, and that distinction is the whole
+// finding this file was reopened for. The service shipped with the return
+// value forwarded to the caller as `meta`; the HTTP transport happened not
+// to serialise it, so nothing was observably wrong, and "the current
+// transport drops it" was silently standing in for a guarantee — while the
+// in-process `renderFrames`/`renderToString` API, and any future socket or
+// pipe adapter, carried it in full. A channel that is quietly discarded is
+// a channel someone restores later because nothing appeared to be using
+// it. A channel that refuses is a channel that stays closed.
 
 const { parentPort, workerData } = require('node:worker_threads');
-const { CODE, validateModule } = require('./protocol.cjs');
+const { CODE, validateModule, MODULE_RETURN_REFUSAL } = require('./protocol.cjs');
 
 const post = (msg) => parentPort.postMessage(msg);
 
@@ -119,7 +137,11 @@ async function render(id, request) {
     // `await` even for a synchronous module: a module that returns a
     // promise is the streaming shape's, and the deadline governs both
     // identically because it is the PARENT's timer.
-    const out = (await mod.render(call, emit)) ?? {};
+    // Not defaulted. `undefined` is the contract's own answer here and
+    // coercing it to `{}` would erase the difference between a module
+    // that returned nothing and one that returned an empty object — which
+    // is precisely the difference the egress door below is checking.
+    const out = await mod.render(call, emit);
     const renderMs = Number(process.hrtime.bigint() - started) / 1e6;
 
     if (!emitted) {
@@ -132,12 +154,41 @@ async function render(id, request) {
       });
       return;
     }
+
+    // THE EGRESS DOOR. See the header.
+    //
+    // Discoverable only after the render, so a module that both emitted
+    // and returned produces a TORN response rather than a clean refusal —
+    // `afterChunks` says so and the transport is required to treat it as
+    // unpresentable. That is the honest outcome: the bytes really did
+    // leave, and the alternative is serving a page from a module whose
+    // contract this service does not hold.
+    //
+    // The refusal names the SHAPE and never the value. A diagnostic that
+    // echoed what the module tried to return would be the same egress
+    // wearing a different frame type.
+    if (out !== undefined && out !== null) {
+      post({
+        t: 'error',
+        id,
+        code: CODE.RENDER_THREW,
+        message: MODULE_RETURN_REFUSAL,
+        detail: {
+          entry: request.entry,
+          returned: Object.prototype.toString.call(out),
+        },
+        afterChunks: seq,
+      });
+      return;
+    }
+
+    // Counters and clocks this file owns, and nothing else. There is no
+    // field here for the module to fill in, which is the point.
     post({
       t: 'complete',
       id,
       chunks: seq,
       renderMs,
-      meta: out.meta ?? {},
     });
   } catch (err) {
     post({

--- a/implementation/ssr-node/test/_support.cjs
+++ b/implementation/ssr-node/test/_support.cjs
@@ -4,6 +4,7 @@
 
 const path = require('node:path');
 const { createService } = require('../src/service.cjs');
+const { observationsIn } = require('./observations.cjs');
 
 const fixture = (name) => path.join(__dirname, 'fixtures', `${name}.cjs`);
 
@@ -36,6 +37,17 @@ async function collect(service, request) {
 }
 
 /**
+ * What the render module observed, read back out of the body it rendered.
+ *
+ * The response contract carries body markup and nothing else, so this is
+ * the only channel a fixture has — see `observations.cjs` for why that is
+ * a feature of the witness rather than a workaround. Takes a `collect`
+ * result or a raw body string.
+ */
+const observed = (x) =>
+  observationsIn(typeof x === 'string' ? x : x.chunks.map((c) => c.html).join(''));
+
+/**
  * The refusal a call produced, or `null` if it produced none. Written as a
  * helper because "assert it refused" and "assert it refused with THIS
  * code" are different claims and the second is the one worth making.
@@ -60,4 +72,4 @@ async function post(url, body, headers = {}) {
   return { status: res.status, headers: res.headers, buf, text: buf.toString('utf8') };
 }
 
-module.exports = { fixture, boot, withService, collect, refusalOf, post };
+module.exports = { fixture, boot, withService, collect, observed, refusalOf, post };

--- a/implementation/ssr-node/test/concurrency.test.cjs
+++ b/implementation/ssr-node/test/concurrency.test.cjs
@@ -16,7 +16,7 @@
 const test = require('node:test');
 const assert = require('node:assert');
 const path = require('node:path');
-const { withService, collect, refusalOf } = require('./_support.cjs');
+const { withService, collect, observed, refusalOf } = require('./_support.cjs');
 const { CODE } = require('../src/protocol.cjs');
 const { Isolate } = require('../src/isolate.cjs');
 
@@ -28,11 +28,15 @@ test('CONTROL — the overlap counter can read more than 1', async () => {
   // This is what makes every `overlapMax === 1` below a measurement.
   const mod = require('./fixtures/reference.cjs');
   const call = { entry: 'app/root', state: Object.freeze({ ':delay': '40' }), args: undefined };
-  const [a, b] = await Promise.all([
-    mod.render(call, () => {}),
-    mod.render(call, () => {}),
+  // The module's observations ride the markup it emits — the only channel
+  // a render module has — so the control reads them the same way the
+  // service-driven rows below do.
+  const bodies = [];
+  await Promise.all([
+    mod.render(call, (h) => bodies.push(h)),
+    mod.render(call, (h) => bodies.push(h)),
   ]);
-  const seen = Math.max(a.meta.overlapMax, b.meta.overlapMax);
+  const seen = Math.max(...bodies.map((h) => observed(h).overlapMax));
   assert.strictEqual(seen, 2, 'the counter must be able to see an overlap, or it proves nothing');
 });
 
@@ -45,15 +49,15 @@ test('a pool of N under 2N concurrent requests never overlaps within an isolate'
     );
     for (const r of results) {
       assert.strictEqual(
-        r.complete.meta.overlapMax,
+        observed(r).overlapMax,
         1,
-        `an isolate ran ${r.complete.meta.overlapMax} renders at once`,
+        `an isolate ran ${observed(r).overlapMax} renders at once`,
       );
     }
     // The requests really did contend: three isolates served six requests,
     // so at least one isolate was reused, and the wall time exceeded a
     // single delay.
-    const threads = new Set(results.map((r) => r.complete.meta.threadId));
+    const threads = new Set(results.map((r) => observed(r).threadId));
     assert.strictEqual(threads.size, 3, 'all three isolates should have been used');
   });
 });
@@ -105,10 +109,10 @@ test('a waiter is served the moment an isolate frees, without its own timer firi
       collect(service, req({ state: { ':todos': '"A"', ':delay': '60' } })),
       collect(service, req({ state: { ':todos': '"B"', ':delay': '60' } })),
     ]);
-    assert.strictEqual(a.complete.meta.overlapMax, 1);
-    assert.strictEqual(b.complete.meta.overlapMax, 1);
+    assert.strictEqual(observed(a).overlapMax, 1);
+    assert.strictEqual(observed(b).overlapMax, 1);
     // Serialised through one isolate, so the pair takes both delays.
     assert.ok(Date.now() - started >= 110, 'the two renders should have been serialised');
-    assert.strictEqual(a.complete.meta.threadId, b.complete.meta.threadId);
+    assert.strictEqual(observed(a).threadId, observed(b).threadId);
   });
 });

--- a/implementation/ssr-node/test/egress.test.cjs
+++ b/implementation/ssr-node/test/egress.test.cjs
@@ -1,0 +1,298 @@
+'use strict';
+// THE EGRESS CONTROL — application data cannot cross outside body markup.
+//
+//     node implementation/ssr-node/test/egress.test.cjs
+//
+// The package's stated topology is *Node returns the body markup, and
+// nothing else*, and until this file existed that was a paragraph rather
+// than a property. `worker.cjs` accepted an arbitrary `out.meta` from the
+// application's render module, `isolate.cjs` carried it, and
+// `service.renderFrames()` published it on the public `complete` frame —
+// an unallowlisted, application-controlled channel at precisely the point
+// the contract says there is none. The fixtures in this directory were its
+// demonstration: `readTodos` and `readRoute` are application state, and
+// they were crossing.
+//
+// HTTP happened not to serialise it, which is where the finding gets its
+// teeth. "The transport drops it" is a fact about `http.cjs` and not a
+// guarantee about this package: the protocol is documented as
+// transport-independent, `renderFrames()`/`renderToString()` are the
+// in-process API a JVM host embedding Node would use, and a socket or
+// pipe adapter written tomorrow would carry the field in full. So the
+// property has to be checked where it is actually true — on the FRAMES —
+// and this file checks the transport afterwards as a corollary rather
+// than as the evidence.
+//
+// ## WHAT IS BEING CLAIMED, EXACTLY
+//
+// Not "no data crosses" — chunks are data and that is the whole job.
+// The claim is that on the response leg:
+//
+//   1. the `complete` frame's fields are EXACTLY `COMPLETE_FIELDS`, every
+//      one of which is a fact this service produced about the crossing;
+//   2. nothing the render module authored appears anywhere in the frame
+//      sequence outside `chunk.html`; and
+//   3. a module that reaches for a second channel is REFUSED, not quietly
+//      dropped — and the refusal does not carry the payload either, which
+//      is the failure a diagnostic-shaped leak would take.
+//
+// ## EVERY ROW HAS A CONTROL, AND THE CONTROLS ARE ORDINARY ROWS
+//
+// The suite-wide discipline (see the package README) applies here with
+// particular force, because an absence check is the easiest kind of test
+// to pass by accident: a scanner with a typo'd field name, a sentinel that
+// was never actually planted, or a fixture that quietly stopped producing
+// the thing being hunted would all read green. So `scanForEgress` is
+// exercised against a doctored frame set that DOES leak and is required to
+// find it, the leaky fixture is driven in-process and required to really
+// return its payload, and the roster check is shown rejecting an added
+// field before it is trusted accepting the real one.
+
+const test = require('node:test');
+const assert = require('node:assert');
+
+const { withService, collect, refusalOf, post } = require('./_support.cjs');
+const { CODE, COMPLETE_FIELDS, MODULE_RETURN_REFUSAL } = require('../src/protocol.cjs');
+const { serve } = require('../src/http.cjs');
+const LEAKY = require('./fixtures/leaky.cjs');
+
+// ---------------------------------------------------------------------------
+// The two checkers. Both are ordinary functions so a control can feed them
+// a fault by hand — a checker reachable only through a live service is a
+// checker nobody can prove works.
+// ---------------------------------------------------------------------------
+
+/**
+ * The fields on a `complete` frame that are not in the roster, and the
+ * roster fields that are missing. Both directions: a frame that quietly
+ * LOST `buildId` is a different bug, but it is still one this row should
+ * see rather than a green tick.
+ */
+function rosterDrift(frame) {
+  const got = Object.keys(frame);
+  return {
+    extra: got.filter((k) => !COMPLETE_FIELDS.includes(k)),
+    // `requestId` is optional by contract — present only when the caller
+    // sent one — so its absence is not drift.
+    missing: COMPLETE_FIELDS.filter((k) => k !== 'requestId' && !got.includes(k)),
+  };
+}
+
+/**
+ * Every place a sentinel appears in a frame sequence OUTSIDE body markup.
+ *
+ * Chunks are stripped of `html` rather than skipped whole, because a chunk
+ * frame is a plausible place for a future field to sprout and skipping the
+ * frame would make this scanner blind to exactly that.
+ */
+function scanForEgress(frames, sentinels) {
+  const findings = [];
+  for (const frame of frames) {
+    const rest = { ...frame };
+    delete rest.html;
+    const text = JSON.stringify(rest);
+    for (const s of sentinels) {
+      if (text.includes(s)) findings.push({ type: frame.type, sentinel: s, in: text });
+    }
+  }
+  return findings;
+}
+
+// The state one render is given. Distinctive on purpose: a sentinel that
+// could plausibly occur in framing or in a stack trace would make a zero
+// meaningless.
+const STATE = {
+  ':todos': '"rf2-hic-056-todos-4b19ae"',
+  ':route': '{:name :rf2-hic-056-route-7c02fd}',
+};
+const ARGS = '{:page "rf2-hic-056-args-51d8b0"}';
+const SENTINELS = [
+  STATE[':todos'].replace(/"/g, ''),
+  'rf2-hic-056-route-7c02fd',
+  'rf2-hic-056-args-51d8b0',
+];
+
+const req = (extra = {}) => ({
+  protocol: 1,
+  entry: 'app/root',
+  state: STATE,
+  args: ARGS,
+  ...extra,
+});
+
+// ---------------------------------------------------------------------------
+// 1. The roster
+// ---------------------------------------------------------------------------
+
+test('CONTROL — the roster check rejects an added field and a missing one', () => {
+  // Before any green roster row is believed. A checker that returned an
+  // empty list unconditionally would satisfy every row below it.
+  const honest = { type: 'complete', chunks: 1, renderMs: 0.4, buildId: 'b' };
+  assert.deepStrictEqual(rosterDrift(honest), { extra: [], missing: [] });
+
+  const leaked = { ...honest, meta: { readTodos: 'x' } };
+  assert.deepStrictEqual(rosterDrift(leaked).extra, ['meta'], 'an added field must be seen');
+
+  const truncated = { type: 'complete', chunks: 1, renderMs: 0.4 };
+  assert.deepStrictEqual(rosterDrift(truncated).missing, ['buildId']);
+});
+
+test('the complete frame carries EXACTLY the service-owned roster', async () => {
+  await withService('reference', { isolates: 1 }, async (service) => {
+    const withoutId = await collect(service, req());
+    assert.deepStrictEqual(rosterDrift(withoutId.complete), { extra: [], missing: [] });
+    assert.deepStrictEqual(Object.keys(withoutId.complete).sort(), [
+      'buildId',
+      'chunks',
+      'renderMs',
+      'type',
+    ]);
+
+    const withId = await collect(service, req({ requestId: 'corr-1' }));
+    assert.deepStrictEqual(rosterDrift(withId.complete), { extra: [], missing: [] });
+    assert.strictEqual(withId.complete.requestId, 'corr-1', 'the caller’s token is echoed');
+  });
+});
+
+test('renderToString returns the body and the roster, and nothing besides', async () => {
+  // The other public surface, and the one an embedding JVM host would
+  // reach for first. It spreads the complete frame, so a field that got
+  // onto the frame would arrive here too.
+  await withService('reference', { isolates: 1 }, async (service) => {
+    const out = await service.renderToString(req());
+    assert.deepStrictEqual(Object.keys(out).sort(), [
+      'buildId',
+      'chunks',
+      'html',
+      'renderMs',
+      'type',
+    ]);
+    assert.ok(out.html.includes('<div data-entry="app/root"'), 'the body really did render');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 2. The scan
+// ---------------------------------------------------------------------------
+
+test('CONTROL — the scan finds a planted leak, in each of its two shapes', () => {
+  // Same function, same sentinels, a frame set doctored to carry them.
+  // Without this row a zero below would be evidence of nothing.
+  const onComplete = [
+    { type: 'chunk', seq: 0, html: `<p>${SENTINELS[0]}</p>` },
+    { type: 'complete', chunks: 1, renderMs: 1, buildId: 'b', meta: { readTodos: SENTINELS[0] } },
+  ];
+  assert.strictEqual(scanForEgress(onComplete, SENTINELS).length, 1, 'a leak on the terminal frame');
+
+  const onChunk = [
+    { type: 'chunk', seq: 0, html: '<p>ok</p>', note: SENTINELS[2] },
+    { type: 'complete', chunks: 1, renderMs: 1, buildId: 'b' },
+  ];
+  assert.strictEqual(scanForEgress(onChunk, SENTINELS).length, 1, 'a leak beside body markup');
+
+  // …and the scan is not simply always positive: the same frames with the
+  // sentinel only inside `html` are clean.
+  const clean = [
+    { type: 'chunk', seq: 0, html: `<p>${SENTINELS[0]}${SENTINELS[1]}${SENTINELS[2]}</p>` },
+    { type: 'complete', chunks: 1, renderMs: 1, buildId: 'b' },
+  ];
+  assert.deepStrictEqual(scanForEgress(clean, SENTINELS), []);
+});
+
+test('no value the render module handled crosses outside body markup', async () => {
+  await withService('reference', { isolates: 1 }, async (service) => {
+    const frames = [];
+    for await (const frame of service.renderFrames(req({ requestId: 'corr-2' }))) {
+      frames.push(frame);
+    }
+
+    // The sentinels must be REACHABLE, or the scan is looking for
+    // something the render never had. The reference module renders its
+    // todos into the body, so the first one is in the markup by
+    // construction; the other two it merely observed.
+    const body = frames.filter((f) => f.type === 'chunk').map((f) => f.html).join('');
+    assert.ok(body.includes(SENTINELS[0]), 'the module did read and render the state');
+
+    assert.deepStrictEqual(
+      scanForEgress(frames, SENTINELS),
+      [],
+      'application data reached a public frame outside body markup',
+    );
+  });
+});
+
+test('the HTTP transport carries none of it either — corollary, not evidence', async () => {
+  // Deliberately last of the three, and deliberately framed as a
+  // corollary: this transport dropping a field is what let the leak ship
+  // unnoticed, so a green row HERE has never been the property. It is
+  // still worth having, because headers are their own egress surface.
+  await withService('reference', { isolates: 1 }, async (service) => {
+    const http = await serve({ service, port: 0 });
+    try {
+      const res = await post(`http://127.0.0.1:${http.port}/render`, req({ requestId: 'corr-3' }));
+      assert.strictEqual(res.status, 200);
+      assert.ok(res.text.includes(SENTINELS[0]), 'the body is the channel and it is carrying');
+
+      const headers = JSON.stringify(Object.fromEntries(res.headers.entries()));
+      for (const s of SENTINELS) {
+        assert.ok(!headers.includes(s), `header carried ${s}`);
+      }
+    } finally {
+      await http.close();
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 3. The refusal
+// ---------------------------------------------------------------------------
+
+test('CONTROL — the leaky fixture really does return a payload', () => {
+  // In-process, with no service in the way. This is what makes the
+  // refusal below a measurement: a fixture that had quietly stopped
+  // returning anything would satisfy every assertion in the next row.
+  const emitted = [];
+  const out = LEAKY.render({ entry: 'app/root', state: { ':todos': '[1]' } }, (h) => emitted.push(h));
+  assert.strictEqual(emitted.length, 1, 'it emits body markup like any other module');
+  assert.strictEqual(out.meta.secret, LEAKY.SECRET);
+  assert.strictEqual(out.meta.readTodos, '[1]', 'and it reads application state into the payload');
+});
+
+test('a render module that returns a value is REFUSED, not silently dropped', async () => {
+  await withService('leaky', { isolates: 1 }, async (service) => {
+    const err = await refusalOf(() => collect(service, { protocol: 1, entry: 'app/root', state: { ':todos': '[1]' } }));
+    assert.ok(err, 'the render must not have succeeded');
+    assert.strictEqual(err.code, CODE.RENDER_THREW);
+    assert.strictEqual(err.message, MODULE_RETURN_REFUSAL, 'the contract owns the wording');
+
+    // The tear is named. The module emitted before it returned, so bytes
+    // really did leave and the transport must not present them as a page.
+    assert.strictEqual(err.detail.afterChunks, 1);
+    assert.strictEqual(err.detail.returned, '[object Object]', 'the SHAPE, for a diagnosis');
+  });
+});
+
+test('the refusal does not carry the payload out through the error channel', async () => {
+  // The subtle re-run of the same leak: a diagnostic that echoed what the
+  // module tried to return would be the identical egress wearing a
+  // different frame type, and it would look like helpfulness.
+  await withService('leaky', { isolates: 1 }, async (service) => {
+    const err = await refusalOf(() =>
+      collect(service, { protocol: 1, entry: 'app/root', state: { ':todos': '"secret-state-3ab1"' } }),
+    );
+    const text = `${err.message}${JSON.stringify(err.detail)}${err.stack ?? ''}`;
+    assert.ok(!text.includes(LEAKY.SECRET), 'the refusal echoed the module’s own value');
+    assert.ok(!text.includes('secret-state-3ab1'), 'the refusal echoed the request state');
+  });
+});
+
+test('a well-behaved module returns nothing, and the service is fine with that', async () => {
+  // The positive half of the door: `undefined` is the contract's answer,
+  // and it must not be coerced into an empty object that then trips the
+  // very check above.
+  await withService('reference', { isolates: 1 }, async (service) => {
+    const { chunks, complete } = await collect(service, req());
+    assert.strictEqual(chunks.length, 1);
+    assert.strictEqual(complete.type, 'complete');
+  });
+});

--- a/implementation/ssr-node/test/fixtures/bad-no-allowlist.cjs
+++ b/implementation/ssr-node/test/fixtures/bad-no-allowlist.cjs
@@ -4,5 +4,5 @@ module.exports = {
   protocol: 1,
   buildId: 'bad-1',
   entries: { 'app/root': {} },
-  render(_c, emit) { emit('<p>never</p>'); return {}; },
+  render(_c, emit) { emit('<p>never</p>'); },
 };

--- a/implementation/ssr-node/test/fixtures/bad-no-build-id.cjs
+++ b/implementation/ssr-node/test/fixtures/bad-no-build-id.cjs
@@ -3,5 +3,5 @@
 module.exports = {
   protocol: 1,
   entries: { 'app/root': { stateAllowlist: [] } },
-  render(_c, emit) { emit('<p>never</p>'); return {}; },
+  render(_c, emit) { emit('<p>never</p>'); },
 };

--- a/implementation/ssr-node/test/fixtures/bad-protocol.cjs
+++ b/implementation/ssr-node/test/fixtures/bad-protocol.cjs
@@ -4,5 +4,5 @@ module.exports = {
   protocol: 99,
   buildId: 'bad-2',
   entries: { 'app/root': { stateAllowlist: [] } },
-  render(_c, emit) { emit('<p>never</p>'); return {}; },
+  render(_c, emit) { emit('<p>never</p>'); },
 };

--- a/implementation/ssr-node/test/fixtures/bytes.cjs
+++ b/implementation/ssr-node/test/fixtures/bytes.cjs
@@ -37,6 +37,5 @@ module.exports = {
   BODY,
   render(_call, emit) {
     emit(BODY);
-    return {};
   },
 };

--- a/implementation/ssr-node/test/fixtures/chunked.cjs
+++ b/implementation/ssr-node/test/fixtures/chunked.cjs
@@ -22,6 +22,5 @@ module.exports = {
       await new Promise((r) => setImmediate(r));
       emit(p);
     }
-    return { meta: { emitted: parts.length } };
   },
 };

--- a/implementation/ssr-node/test/fixtures/hang.cjs
+++ b/implementation/ssr-node/test/fixtures/hang.cjs
@@ -7,6 +7,8 @@
 // from outside the thread. An `await`-based hang would be a much weaker
 // test, because a cooperative cancel would have been enough to pass it.
 
+const { encode } = require('../observations.cjs');
+
 module.exports = {
   protocol: 1,
   buildId: 'hang-build-1',
@@ -14,11 +16,13 @@ module.exports = {
 
   render({ entry }, emit) {
     if (entry === 'app/quick') {
-      emit('<p>quick</p>');
       // The thread id is what proves a REPLACEMENT rather than a revival:
       // a terminated isolate is never reused, so the isolate that serves
-      // the request after a timeout must be a different thread.
-      return { meta: { threadId: require('node:worker_threads').threadId } };
+      // the request after a timeout must be a different thread. It rides
+      // the markup, because that is the only channel out of here.
+      const threadId = require('node:worker_threads').threadId;
+      emit(`<p${encode({ threadId })}>quick</p>`);
+      return;
     }
     while (true) {
       // Touch something so no engine can optimise the loop away.

--- a/implementation/ssr-node/test/fixtures/leaky.cjs
+++ b/implementation/ssr-node/test/fixtures/leaky.cjs
@@ -1,0 +1,45 @@
+'use strict';
+// THE FIXTURE THE EGRESS CONTROL EXISTS FOR.
+//
+// A render module that emits perfectly good body markup and then tries to
+// hand the service a second thing on the side — which is exactly what the
+// well-behaved fixtures in this directory used to do, and exactly what
+// this package shipped for one commit forwarding onto the public
+// `complete` frame as `meta`.
+//
+// The payload is deliberately of two kinds, because they fail differently
+// in the field:
+//
+//   THE SECRET is application data that never crossed the wire inbound —
+//   a value the module read out of its own process. Nothing upstream sent
+//   it and nothing upstream can predict it, so a caller receiving it is
+//   receiving something no allowlist ever adjudicated.
+//   THE ECHO is the request's own state read back out. It looks harmless
+//   because the caller already has it, and it is the shape the fixtures
+//   actually had (`readTodos`, `readRoute`). It is here so the control
+//   cannot be satisfied by a guard that only notices unfamiliar strings.
+//
+// `SECRET` is exported so the witness compares against this module's own
+// constant rather than against a second copy of the same literal — the
+// same discipline `bytes.cjs` uses for its corpus.
+
+const SECRET = 'rf2-hic-056-egress-sentinel-8f21c4';
+
+module.exports = {
+  protocol: 1,
+  buildId: 'leaky-build-1',
+  entries: { 'app/root': { stateAllowlist: [':todos'] } },
+
+  SECRET,
+
+  render({ state }, emit) {
+    emit('<p>leaky</p>');
+    return {
+      meta: {
+        secret: SECRET,
+        readTodos: state[':todos'] ?? null,
+      },
+      secret: SECRET,
+    };
+  },
+};

--- a/implementation/ssr-node/test/fixtures/reference.cjs
+++ b/implementation/ssr-node/test/fixtures/reference.cjs
@@ -11,8 +11,12 @@
 // TypeError when it writes to a frozen snapshot, which is what makes the
 // freeze visible. `sloppy.cjs` is its control.
 //
-// Everything this module reports back rides `meta`, which the service
-// passes through untouched.
+// It reports what it observed by RENDERING it — the one channel the
+// contract gives a render module, and the reason `test/observations.cjs`
+// exists. It returns nothing, because a render module has nothing to
+// return.
+
+const { encode } = require('../observations.cjs');
 
 /** Object identities this isolate has already been handed. */
 const seen = new WeakSet();
@@ -20,6 +24,34 @@ const seen = new WeakSet();
 /** Live renders in this isolate, and the high-water mark. Guarantee 3. */
 let inFlight = 0;
 let overlapMax = 0;
+
+/** What a render of this module observed. Shared with its in-process control. */
+function observe({ entry, state, args }) {
+  const seenBefore = seen.has(state);
+  seen.add(state);
+
+  let mutationThrew = false;
+  try {
+    // The snapshot is frozen; in strict mode this throws.
+    state[':todos'] = 'MUTATED';
+  } catch {
+    mutationThrew = true;
+  }
+
+  return {
+    entry,
+    args: args ?? null,
+    seenBefore,
+    frozen: Object.isFrozen(state),
+    mutationThrew,
+    // What the module actually READ — so a test can prove one request
+    // never saw another's state.
+    readTodos: state[':todos'] ?? null,
+    readRoute: state[':route'] ?? null,
+    overlapMax,
+    threadId: require('node:worker_threads').threadId,
+  };
+}
 
 module.exports = {
   protocol: 1,
@@ -34,41 +66,21 @@ module.exports = {
     module.exports.booted = true;
   },
 
-  async render({ entry, state, args }, emit) {
+  async render(call, emit) {
     inFlight += 1;
     overlapMax = Math.max(overlapMax, inFlight);
     try {
-      const seenBefore = seen.has(state);
-      seen.add(state);
-
-      let mutationThrew = false;
-      try {
-        // The snapshot is frozen; in strict mode this throws.
-        state[':todos'] = 'MUTATED';
-      } catch {
-        mutationThrew = true;
-      }
+      const observed = observe(call);
+      const { entry, state } = call;
 
       const delay = Number(state[':delay'] ?? 0);
       if (delay > 0) await new Promise((r) => setTimeout(r, delay));
 
-      emit(`<div data-entry="${entry}">${state[':todos'] ?? ''}</div>`);
+      // The overlap high-water mark has to be read AFTER the delay, or it
+      // could never see an overlap it was measuring.
+      observed.overlapMax = overlapMax;
 
-      return {
-        meta: {
-          entry,
-          args: args ?? null,
-          seenBefore,
-          frozen: Object.isFrozen(state),
-          mutationThrew,
-          // What the module actually READ — so a test can prove one
-          // request never saw another's state.
-          readTodos: state[':todos'] ?? null,
-          readRoute: state[':route'] ?? null,
-          overlapMax,
-          threadId: require('node:worker_threads').threadId,
-        },
-      };
+      emit(`<div data-entry="${entry}"${encode(observed)}>${state[':todos'] ?? ''}</div>`);
     } finally {
       inFlight -= 1;
     }

--- a/implementation/ssr-node/test/fixtures/sloppy.cjs
+++ b/implementation/ssr-node/test/fixtures/sloppy.cjs
@@ -5,7 +5,10 @@
 // its real strength: the FREEZE is a diagnostic that only strict code
 // hears, and the ISOLATION is the structured clone, which holds either
 // way. It reports what it observed after writing, so the witness can show
-// the write reached nothing even though nothing threw.
+// the write reached nothing even though nothing threw — and it reports it
+// by RENDERING it, because that is the only channel a render module has.
+
+const { encode } = require('../observations.cjs');
 
 module.exports = {
   protocol: 1,
@@ -19,7 +22,7 @@ module.exports = {
     } catch {
       threw = true;
     }
-    emit('<i>sloppy</i>');
-    return { meta: { threw, afterWrite: state[':todos'] ?? null, frozen: Object.isFrozen(state) } };
+    const observed = { threw, afterWrite: state[':todos'] ?? null, frozen: Object.isFrozen(state) };
+    emit(`<i${encode(observed)}>sloppy</i>`);
   },
 };

--- a/implementation/ssr-node/test/fixtures/throws.cjs
+++ b/implementation/ssr-node/test/fixtures/throws.cjs
@@ -12,7 +12,7 @@ module.exports = {
   },
 
   render({ entry }, emit) {
-    if (entry === 'app/silent') return {}; // emits nothing at all
+    if (entry === 'app/silent') return; // emits nothing at all
     if (entry === 'app/after') {
       emit('<p>first</p>');
       throw new Error('fell over halfway');

--- a/implementation/ssr-node/test/isolation.test.cjs
+++ b/implementation/ssr-node/test/isolation.test.cjs
@@ -25,18 +25,18 @@
 
 const test = require('node:test');
 const assert = require('node:assert');
-const { withService, collect } = require('./_support.cjs');
+const { withService, collect, observed } = require('./_support.cjs');
 
 const req = (state, extra = {}) => ({ protocol: 1, entry: 'app/root', state, ...extra });
 
 test('the snapshot the module is handed is FROZEN, and a write to it throws', async () => {
   await withService('reference', { isolates: 1 }, async (service) => {
-    const { complete } = await collect(service, req({ ':todos': '[1 2 3]' }));
-    assert.strictEqual(complete.meta.frozen, true, 'the snapshot must be frozen');
-    assert.strictEqual(complete.meta.mutationThrew, true, 'a strict-mode write must throw');
+    const obs = observed(await collect(service, req({ ':todos': '[1 2 3]' })));
+    assert.strictEqual(obs.frozen, true, 'the snapshot must be frozen');
+    assert.strictEqual(obs.mutationThrew, true, 'a strict-mode write must throw');
     // …and the value it read is the one it was sent, so the freeze did not
     // simply hand it an empty object.
-    assert.strictEqual(complete.meta.readTodos, '[1 2 3]');
+    assert.strictEqual(obs.readTodos, '[1 2 3]');
   });
 });
 
@@ -44,11 +44,11 @@ test("a sloppy module's write fails silently — and still reaches nothing", asy
   // The control for the row above. If the suite only ever tested strict
   // modules it would be claiming a TypeError the contract cannot promise.
   await withService('sloppy', { isolates: 1 }, async (service) => {
-    const { complete } = await collect(service, req({ ':todos': 'original' }));
-    assert.strictEqual(complete.meta.frozen, true);
-    assert.strictEqual(complete.meta.threw, false, 'sloppy mode swallows the write');
+    const obs = observed(await collect(service, req({ ':todos': 'original' })));
+    assert.strictEqual(obs.frozen, true);
+    assert.strictEqual(obs.threw, false, 'sloppy mode swallows the write');
     assert.strictEqual(
-      complete.meta.afterWrite,
+      obs.afterWrite,
       'original',
       'the write must have reached nothing even though nothing threw',
     );
@@ -59,15 +59,15 @@ test('each request gets its OWN snapshot object — never one seen before', asyn
   await withService('reference', { isolates: 1 }, async (service) => {
     const first = await collect(service, req({ ':todos': '[1]' }));
     const second = await collect(service, req({ ':todos': '[2]' }));
-    assert.strictEqual(first.complete.meta.seenBefore, false);
+    assert.strictEqual(observed(first).seenBefore, false);
     assert.strictEqual(
-      second.complete.meta.seenBefore,
+      observed(second).seenBefore,
       false,
       'a second request handed the same object would mean the snapshot is shared',
     );
     // One isolate served both, so `seenBefore` is a reading of something:
     // the WeakSet that answers it survived between the two renders.
-    assert.strictEqual(first.complete.meta.threadId, second.complete.meta.threadId);
+    assert.strictEqual(observed(first).threadId, observed(second).threadId);
   });
 });
 
@@ -90,15 +90,16 @@ test('two concurrent requests do not leak into one another, in either direction'
       collect(service, req({ ':todos': '"AAA"', ':route': '{:name :a}', ':delay': '30' })),
       collect(service, req({ ':todos': '"BBB"', ':route': '{:name :b}', ':delay': '30' })),
     ]);
-    assert.strictEqual(a.complete.meta.readTodos, '"AAA"');
-    assert.strictEqual(a.complete.meta.readRoute, '{:name :a}');
-    assert.strictEqual(b.complete.meta.readTodos, '"BBB"');
-    assert.strictEqual(b.complete.meta.readRoute, '{:name :b}');
+    const [obsA, obsB] = [observed(a), observed(b)];
+    assert.strictEqual(obsA.readTodos, '"AAA"');
+    assert.strictEqual(obsA.readRoute, '{:name :a}');
+    assert.strictEqual(obsB.readTodos, '"BBB"');
+    assert.strictEqual(obsB.readRoute, '{:name :b}');
     assert.strictEqual(a.chunks[0].html.includes('AAA'), true);
     assert.strictEqual(b.chunks[0].html.includes('BBB'), true);
     assert.notStrictEqual(
-      a.complete.meta.threadId,
-      b.complete.meta.threadId,
+      obsA.threadId,
+      obsB.threadId,
       'the two renders must have run in different isolates for this row to mean anything',
     );
   });
@@ -111,9 +112,9 @@ test('a key omitted from a request is absent, not inherited from the last one', 
   // manufacture a value by leaving the previous request's behind.
   await withService('reference', { isolates: 1 }, async (service) => {
     const first = await collect(service, req({ ':todos': '"kept"', ':route': '{:name :x}' }));
-    assert.strictEqual(first.complete.meta.readRoute, '{:name :x}');
+    assert.strictEqual(observed(first).readRoute, '{:name :x}');
     const second = await collect(service, req({ ':todos': '"kept"' }));
-    assert.strictEqual(second.complete.meta.readRoute, null, 'the previous route must not persist');
+    assert.strictEqual(observed(second).readRoute, null, 'the previous route must not persist');
   });
 });
 
@@ -124,10 +125,10 @@ test('the module boots once per isolate, not once per request', async () => {
   await withService('reference', { isolates: 1 }, async (service) => {
     const a = await collect(service, req({ ':todos': '[]' }));
     const b = await collect(service, req({ ':todos': '[]' }));
-    assert.strictEqual(a.complete.meta.threadId, b.complete.meta.threadId);
+    assert.strictEqual(observed(a).threadId, observed(b).threadId);
     // `overlapMax` is module-level state; its survival across the two
     // renders is what shows the module was not re-required.
-    assert.strictEqual(a.complete.meta.overlapMax, 1);
-    assert.strictEqual(b.complete.meta.overlapMax, 1);
+    assert.strictEqual(observed(a).overlapMax, 1);
+    assert.strictEqual(observed(b).overlapMax, 1);
   });
 });

--- a/implementation/ssr-node/test/observations.cjs
+++ b/implementation/ssr-node/test/observations.cjs
@@ -1,0 +1,70 @@
+'use strict';
+// TEST-ONLY INSTRUMENTATION — how a fixture reports what it saw, now that
+// the response contract carries body markup and nothing else.
+//
+// ## WHY THIS FILE EXISTS
+//
+// The witnesses in this suite are mostly claims about what happened INSIDE
+// an isolate: was the snapshot frozen, did the write throw, did this
+// render ever overlap another, which thread served it, what state did the
+// module actually read. All of it is knowledge the render module has and
+// the parent does not, so it has to cross the thread boundary somehow.
+//
+// It used to cross on `meta`, a free-form map the module returned and the
+// service forwarded onto the public `complete` frame. That was the
+// egress this package was reopened for: a channel the application fills
+// in, on the response leg of a contract whose stated topology is *Node
+// returns the body markup, and nothing else*. The fixtures were its
+// clearest demonstration — `readTodos` and `readRoute` are application
+// state, and they were crossing.
+//
+// ## THE CHANNEL IS THE MARKUP, AND THAT IS THE POINT
+//
+// The observations are not deleted, because they are witnesses to four of
+// the five guarantees. They come home through the one door the contract
+// names: the fixture RENDERS what it observed, as an attribute on markup
+// it was emitting anyway, and the test reads it back out of the body.
+//
+// So the instrumentation is not merely *allowed* by the contract, it is a
+// standing demonstration of it. If a future change re-opened a second
+// channel, nothing here would need it; if a future change closed the
+// markup channel too, there would be no service left.
+//
+// This file is under `test/`, is required by fixtures and witnesses only,
+// and nothing in `src/` knows it exists.
+//
+// ## BASE64, DELIBERATELY
+//
+// The observations carry EDN text — `"AAA"`, `{:name :a}`, `[1 2 3]` —
+// which is full of quotes and braces, and one of the guarantees this suite
+// checks is that the body's BYTES reach the client unaltered. An
+// instrumentation channel that needed HTML escaping would be an
+// instrumentation channel that could corrupt the thing it is measuring.
+// Base64's alphabet is attribute-safe with no escaping at all, so the
+// blob is inert markup and round-trips exactly.
+
+/** The attribute the blob rides on. One name, spelled once. */
+const ATTR = 'data-rf-test-observations';
+
+const RE = new RegExp(`${ATTR}="([A-Za-z0-9+/=]*)"`);
+
+/**
+ * Render an observation blob as an attribute, with its leading space, so
+ * a fixture can splice it into a tag it was already emitting.
+ */
+const encode = (obj) =>
+  ` ${ATTR}="${Buffer.from(JSON.stringify(obj), 'utf8').toString('base64')}"`;
+
+/**
+ * Read the blob back out of a body. Returns `null` when the markup carries
+ * none — a witness that expected observations and got `null` is reading a
+ * fixture that did not emit them, which is a failure worth seeing plainly
+ * rather than a `{}` it would happily assert against.
+ */
+function observationsIn(html) {
+  const m = RE.exec(html ?? '');
+  if (!m) return null;
+  return JSON.parse(Buffer.from(m[1], 'base64').toString('utf8'));
+}
+
+module.exports = { ATTR, encode, observationsIn };

--- a/implementation/ssr-node/test/run.cjs
+++ b/implementation/ssr-node/test/run.cjs
@@ -31,6 +31,7 @@ const PACKAGE_DIR = path.resolve(HERE, '..');
 // seconds of worker threads and ten of filesystem scanning.
 const FILES = [
   'protocol.test.cjs',
+  'egress.test.cjs',
   'isolation.test.cjs',
   'concurrency.test.cjs',
   'timeout.test.cjs',
@@ -41,6 +42,7 @@ const FILES = [
 
 console.log(`gate root: ${PACKAGE_DIR}`);
 console.log(`gate: re-frame2 ssr-node — ${FILES.length} suites\n`);
+console.log(`gate files: ${FILES.join(' ')}\n`);
 
 const failures = [];
 for (const file of FILES) {

--- a/implementation/ssr-node/test/timeout.test.cjs
+++ b/implementation/ssr-node/test/timeout.test.cjs
@@ -18,7 +18,7 @@
 
 const test = require('node:test');
 const assert = require('node:assert');
-const { withService, collect, refusalOf } = require('./_support.cjs');
+const { withService, collect, observed, refusalOf } = require('./_support.cjs');
 const { CODE } = require('../src/protocol.cjs');
 
 const hang = (extra = {}) => ({ protocol: 1, entry: 'app/root', state: {}, ...extra });
@@ -44,7 +44,7 @@ test('a render that never returns is refused inside its budget', async () => {
 test('the pool recovers, and the replacement is a DIFFERENT thread', async () => {
   await withService('hang', { isolates: 1, admissionTimeoutMs: 10000 }, async (service) => {
     const before = await collect(service, quick());
-    const firstThread = before.complete.meta.threadId;
+    const firstThread = observed(before).threadId;
 
     const err = await refusalOf(() => collect(service, hang({ timeoutMs: 150 })));
     assert.strictEqual(err.code, CODE.RENDER_TIMEOUT);
@@ -53,7 +53,7 @@ test('the pool recovers, and the replacement is a DIFFERENT thread', async () =>
     const after = await collect(service, quick());
     assert.strictEqual(after.chunks.length, 1, 'the service must serve the next request normally');
     assert.notStrictEqual(
-      after.complete.meta.threadId,
+      observed(after).threadId,
       firstThread,
       'a terminated isolate must never be reused — this must be a fresh thread',
     );


### PR DESCRIPTION
Closes the response-contract escape the merged-PR audit of #8028 reopened
`rf2-hic-056` for, and — more to the point — installs the control that
turns the package's stated topology into a property something can fail.

## The finding held, and here is the source

Verified end to end before writing anything. On `origin/main` at
`372cbefc55`:

| Layer | The line |
|---|---|
| `src/worker.cjs` | `post({ t: 'complete', id, chunks: seq, renderMs, meta: out.meta ?? {} })` — `out` is whatever the application's render module returned. Unbounded, unvalidated, unallowlisted. |
| `src/isolate.cjs` | `p.resolve({ chunks, renderMs, meta: msg.meta, buildId })` — carried across the thread boundary. |
| `src/protocol.cjs` | `completeFrame({ …, meta }) => ({ …, meta: meta ?? {} })` — a declared field of the terminal frame. |
| `src/service.cjs` | `yield completeFrame({ …, meta: terminal.meta })` — published on the **public** `complete` frame, and spread again by `renderToString()`. |
| `test/fixtures/reference.cjs` | `meta: { …, readTodos: state[':todos'], readRoute: state[':route'], … }` — the shipped fixtures demonstrated the channel carrying application state, not merely thread diagnostics. |

So: really unbounded, really carried, and really on a public surface. The
audit did not overstate it.

The one premise worth sharpening is the "HTTP drops it" half, because it
turns out to be *stronger* evidence for the finding than it looks. It is
true — `http.cjs` writes the joined body and a fixed header set, and never
touches the terminal frame's `meta`. But that is a fact about one adapter.
`protocol.cjs`'s own header calls itself transport-independent and names a
socket, a length-prefixed pipe and an in-process call as equal citizens;
`renderFrames()`/`renderToString()` are the in-process API an embedding
JVM host would reach for first, and they carried it in full. The
negative-control run below makes the point better than prose can: under
the planted regression, **the HTTP row stays green while five others go
red**. A gate placed on the transport would have witnessed nothing.

## Remedy (a): removed from the production response contract

Chosen over (b), and (b) was genuinely considered rather than dismissed.

The argument that decided it: **the service-owned metadata roster (b)
would ask for already exists, and it is already tightly bound.** The
terminal frame carries `chunks` (counted here), `renderMs` (timed here),
`buildId` (read from the bundle's table at boot) and the caller's own
`requestId` echoed back. Those *are* the facts this service owns about a
crossing, they are already flat, already named, and already impossible for
a render module to reach. Re-adjudicating a `meta` map alongside them
would produce either a duplicate of that list under a second spelling, or
an empty map — and a map is a shape that grows without anyone editing a
field list, which is the failure that produced this bead.

There is also a mechanical reason (b) cannot be done cheaply while
`out.meta` is the source: bounding it means either filtering application
keys — and there is no application key that belongs on this frame — or
ignoring the return value entirely, which is (a) with a vestigial field
left behind.

So the response leg now gets the same treatment the request leg already
had, in the same idiom:

- **`COMPLETE_FIELDS`** in `protocol.cjs`, a sibling of `REQUEST_FIELDS`,
  with each member documented as *why it is a fact the service produced*.
  `completeFrame` builds from named fields with no rest parameter and no
  spread — a constructor that copies what it is handed is a field list
  that grows silently.
- **`emit` is a render module's only output channel.** A module that
  returns a value is **refused** (`:rf.ssr-node/render-threw`), not
  quietly dropped, with `MODULE_RETURN_REFUSAL` carrying the reason —
  matching `REFUSED_FIELDS`' "the message teaches instead of merely
  declining". A silent drop is precisely what let this ship: a channel
  nothing appears to use is a channel someone restores later.
- The refusal names the **shape** (`[object Object]`) and never the value.
  A diagnostic that echoed the payload would be the identical egress
  wearing a different frame type, and it would look like helpfulness.
- Because a returned value is only discoverable *after* the render, a
  module that both emitted and returned produces a **torn** response
  carrying `detail.afterChunks`. That is the honest outcome and the
  package already has the vocabulary for it.

**No new refusal code.** `spec/Conventions.md` enumerates every member of
the `:rf.ssr-node/*` family (landed by #8034) and that file is a
sequenced hot-zone lane this PR is fenced from, so the existing
`render-threw` — "the render module threw, or emitted nothing" — is
widened by one clause rather than a new id being minted. **No spec change
is needed and none was made.**

## The control (`test/egress.test.cjs`, 10 rows)

The deliverable, per the audit. It claims three things and each has a
planted-fault control beside it, as ordinary rows, per this package's
standing discipline:

1. the `complete` frame's fields are **exactly** `COMPLETE_FIELDS`
   (`rosterDrift` is shown rejecting an added field *and* a missing one
   before it is trusted accepting the real one);
2. **nothing the render module handled appears in any frame outside
   `chunk.html`** (`scanForEgress` is shown finding a planted leak in each
   of its two shapes, and shown clean when the same sentinels sit only
   inside `html` — so it is neither blind nor always-positive);
3. a module reaching for a second channel is **refused**, and the refusal
   carries neither its payload nor the request state (the leaky fixture is
   driven in-process first and required to really return one, so the row
   is a measurement rather than a fixture that quietly stopped
   misbehaving).

The HTTP row is deliberately last and deliberately framed as a corollary,
for the reason the red run demonstrates.

### Red with the property removed, green with it restored

Planted the exact shipped regression — `meta` back on `completeFrame`,
carried by `isolate.cjs`, published by `service.cjs`, `out.meta` accepted
by `worker.cjs` with the egress door deleted, and `reference.cjs`
returning its observations on the side as it originally did — across five
files, all five sha256 sums confirmed changed.

```
node implementation/ssr-node/test/egress.test.cjs     -> exit 1
  tests 10 | pass 5 | fail 5
```

| Row | Planted | Restored |
|---|---|---|
| CONTROL — roster check rejects added/missing | ✔ | ✔ |
| complete frame carries EXACTLY the roster | **✖** | ✔ |
| renderToString returns body + roster, nothing besides | **✖** | ✔ |
| CONTROL — scan finds a planted leak, both shapes | ✔ | ✔ |
| no value the module handled crosses outside markup | **✖** | ✔ |
| HTTP carries none of it either — *corollary* | ✔ | ✔ |
| CONTROL — leaky fixture really returns a payload | ✔ | ✔ |
| module returning a value is REFUSED | **✖** | ✔ |
| refusal does not carry the payload | **✖** | ✔ |
| well-behaved module returns nothing | ✔ | ✔ |

Positive evidence the runtime observed the plant — not merely that the
source changed — is the failure output itself, which prints the leaked
frame:

```
'{"type":"complete","chunks":1,"renderMs":0.1574,"buildId":"reference-build-1",
  "requestId":"corr-2","meta":{"entry":"app/root",
  "args":"{:page \"rf2-hic-056-args-51d8b0\"}","seenBefore":false,"frozen":true,
  "mutationThrew":true,"readTodos":"\"rf2-hic-056-todos-4b19ae\"",
  "readRoute":"{:name :rf2-hic-056-route-7c02fd}","overlapMax":1,"threadId":3}}'
```

That is application state on the public terminal frame — the audit's
`readTodos`/`readRoute`, reproduced.

**Restore verified by hashing the bytes**, not by reading a diff. The four
`src/` files returned to their pre-plant sha256 sums exactly. The fifth,
`test/fixtures/reference.cjs`, differs by line endings only, because
git's checkout filter rewrote LF to CRLF; its LF-normalised content hashes
to `3dedc88eefd776ed57f40de5addfc49d5871e0a207999bc11b4ca7d62ead66e4`,
identical to the pre-plant hash and to `git show HEAD:` of the same path,
and `git status` is clean. Full suite re-run green afterwards.

## Where the fixture observations went

They were **not deleted** — they are the witnesses for four of the five
guarantees. They now ride **the body markup**, which is the one channel
the contract names: a fixture reports what it saw by *rendering* it, as a
base64 attribute on markup it was emitting anyway, and the witnesses read
it back out (`test/observations.cjs`, `_support.cjs`'s `observed()`).

That is test-only instrumentation in the audit's sense — it lives entirely
under `test/`, nothing in `src/` knows it exists — but it is better than
merely permitted: it is a standing demonstration of the property. The
suite's own diagnostics now prove, every run, that everything a render
module has to say fits through `emit`. Base64 rather than escaped
attributes because the observations carry EDN text full of quotes and
braces, and an instrumentation channel needing HTML escaping could corrupt
the byte guarantee it sits beside.

## Quality gates

Exit codes below are the ones I captured with `echo $?` on the same
command line as the redirect, never a harness's report. Each gate's
`gate root:` line names this worktree
(`C:\Users\miket\code\re-frame2-worktrees\egress-hic056`).

| Gate | Exit | Result |
|---|---|---|
| `node implementation/ssr-node/test/run.cjs` (baseline, before changes) | 0 | 7 suites, **73 rows**, 0 fail |
| `node implementation/ssr-node/test/run.cjs` (after) | 0 | 8 suites, **83 rows**, 0 fail |
| `npm run lint:js` | 0 | clean |
| `node implementation/ssr-node/test/egress.test.cjs` — **property removed** | **1** | 5 pass / **5 fail** (the control is real) |
| `node implementation/ssr-node/test/run.cjs` — restored | 0 | 8 suites, 83 rows, 0 fail |
| `.github/scripts/report-changed-surfaces.sh` on this diff | — | **every surface `false`** |

**The row count moves 73 → 83, and the +10 are all the new
`egress.test.cjs`.** No pre-existing suite gained or lost a row: the three
files that read the old channel (`isolation`, `concurrency`, `timeout`)
have the same assertions asserting the same things, sourced from the
markup instead of the terminal frame. Suite counts are unchanged at 22 /
7 / 5 / 9 / 15 / 4 / 11.

The classifier answering `false` for every surface is the empirical half
of the package's absence claim, unchanged by this PR: **no CI lane is
armed by this diff**, which is also why no lane is added here —
`rf2-n8vp` owns the missing-lane gap and is in flight. This PR touches
neither `implementation/package.json` nor `.github/workflows/**`.

## Scope

`implementation/ssr-node/**` only — 22 files, no other tree touched. No
`spec/` edit, no hot-zone file, no new `:rf.ssr-node/*` id.
