### PR TITLE
docs(method): scope the gate-root banner claim to the gates that print it, and recalibrate the exit-code disagreement (rf2-804e)

### DIFF
--- a/docs/the-mayor-method/dispatch-prompt-template.md
+++ b/docs/the-mayor-method/dispatch-prompt-template.md
@@ -213,9 +213,15 @@ none of them is obvious from the gate command itself.
   print no such line** — not one of `scripts/check_*.py` emits it,
   `check_doc_slugs.py` included, and several of them print nothing whatever on
   success. There the proof is the same shape drawn from a different source:
-  **the file path the gate names in its own negative control.** Plant a fault,
-  run the gate red, and read the path it reports; if that path is inside your
-  worktree, that gate read your tree. This half is written down because the
+  **the fault the gate names when you plant one.** Plant it at a line you are
+  already editing, run the gate red, and check that the path and line number in
+  the failure are the ones you planted. Do not expect that path to name your
+  worktree — `check_doc_slugs.py` reports repo-relative
+  (`docs\the-mayor-method\dispatch-prompt-template.md:214`), which cannot tell
+  two checkouts apart on its own. The discrimination is the red itself: the
+  fault exists only in your tree, so a run that had wandered into a sibling's
+  would have come back green, and a green sabotage run is a reason to stop, not
+  to proceed. This half is written down because the
   bullet used to claim *every* gate printed the banner, which is an instruction
   a worker on a Python gate cannot satisfy — two hit it in one day, and one of
   them arrived at the negative control's path unprompted, because a worker

--- a/docs/the-mayor-method/dispatch-prompt-template.md
+++ b/docs/the-mayor-method/dispatch-prompt-template.md
@@ -203,15 +203,26 @@ none of them is obvious from the gate command itself.
   that tree as its spine root, its diff root and its classifier input, then
   reported the resulting verdict as its own. A complete, internally consistent
   run about somebody else's work is far harder to catch than a broken one, so
-  every gate now prints `gate root: <path>` as its first line — **check that
-  line against your worktree before believing any colour.** That check, not any
-  naming rule, is what has actually caught this class of defect: both 2026-08-12
-  scratchpad collisions (the artefact bullet below) were caught by a worker
-  reading `gate root:` and finding a sibling's worktree name there, and neither
-  by the file-naming convention its brief had already given it. So treat it as a
-  mandatory step on every gate run rather than an aside — a positive
-  verification performed on evidence you received is a stronger shape than a
-  rule you are asked to remember.
+  the shell gates — every `scripts/test-*.sh` — print `gate root: <path>` as
+  their first line, and some node runners do as well. **Check that line against
+  your worktree before believing any colour.** That check, not any naming rule,
+  is what has actually caught this class of defect: both 2026-08-12 scratchpad
+  collisions (the artefact bullet below) were caught by a worker reading
+  `gate root:` and finding a sibling's worktree name there, and neither by the
+  file-naming convention its brief had already given it. **The Python gates
+  print no such line** — not one of `scripts/check_*.py` emits it,
+  `check_doc_slugs.py` included, and several of them print nothing whatever on
+  success. There the proof is the same shape drawn from a different source:
+  **the file path the gate names in its own negative control.** Plant a fault,
+  run the gate red, and read the path it reports; if that path is inside your
+  worktree, that gate read your tree. This half is written down because the
+  bullet used to claim *every* gate printed the banner, which is an instruction
+  a worker on a Python gate cannot satisfy — two hit it in one day, and one of
+  them arrived at the negative control's path unprompted, because a worker
+  facing an unsatisfiable rule improvises rather than stops. So the check is
+  mandatory on every gate run, by whichever of the two routes that gate affords
+  — a positive verification performed on evidence you received is a stronger
+  shape than a rule you are asked to remember.
 - **Never pipe a gate through `tail`, `head` or `grep`.** A pipeline's exit
   status is its *last* command's, so a red runner reads green and the PR claims
   a pass it never got. Redirect to a log file, echo the runner's own exit code
@@ -222,9 +233,16 @@ none of them is obvious from the gate command itself.
   yields a plausible zero. That is this bullet's own defeat by a second route,
   so a paraphrase that drops the single line drops the rule. **The number you
   quote is the one you captured** — never one the harness reports about the same
-  run, which is a different measurement and has disagreed: on 2026-08-11 a
-  worker's gate was surfaced as *completed (exit code 0)* while the run's own
-  captured status was 1.
+  run, which is a different measurement and disagrees routinely rather than
+  rarely: at least seven times across five workers in three days. The first was
+  noted on 2026-08-11, a gate surfaced as *completed (exit code 0)* while the
+  run's own captured status was 1; 2026-08-13 alone accounts for six more,
+  across five workers — among them a compile failure from an unbalanced paren, a
+  genuine two-assertion failure, and a browser run standing over three real
+  ones. Every one of them surfaced as exit 0, and every one was caught because
+  the worker quoted the number it had captured. The rule is doing its job; it
+  was the frequency that was understated, and a worker deciding how hard to look
+  reads the frequency, not the rule.
 - **Verify a restore by hashing the bytes, never by reading `git diff`.** A brief
   that proves a guard is *exact* rather than merely present tells the worker to
   plant a fault, run the gate, then restore — and `git diff` misreads that restore

--- a/docs/the-mayor-method/dispatch-prompt-template.md
+++ b/docs/the-mayor-method/dispatch-prompt-template.md
@@ -221,14 +221,14 @@ none of them is obvious from the gate command itself.
   two checkouts apart on its own. The discrimination is the red itself: the
   fault exists only in your tree, so a run that had wandered into a sibling's
   would have come back green, and a green sabotage run is a reason to stop, not
-  to proceed. This half is written down because the
-  bullet used to claim *every* gate printed the banner, which is an instruction
-  a worker on a Python gate cannot satisfy — two hit it in one day, and one of
-  them arrived at the negative control's path unprompted, because a worker
-  facing an unsatisfiable rule improvises rather than stops. So the check is
-  mandatory on every gate run, by whichever of the two routes that gate affords
-  — a positive verification performed on evidence you received is a stronger
-  shape than a rule you are asked to remember.
+  to proceed. This half is written down because the bullet used to claim
+  *every* gate printed the banner, which is an instruction a worker on a Python
+  gate cannot satisfy — two hit it in one day, and one of them arrived at the
+  negative control unprompted, because a worker facing an unsatisfiable rule
+  improvises rather than stops. So the check is mandatory on every gate run, by
+  whichever of the two routes that gate affords — a positive verification
+  performed on evidence you received is a stronger shape than a rule you are
+  asked to remember.
 - **Never pipe a gate through `tail`, `head` or `grep`.** A pipeline's exit
   status is its *last* command's, so a red runner reads green and the PR claims
   a pass it never got. Redirect to a log file, echo the runner's own exit code


### PR DESCRIPTION
Two corrections to the **"How a gate is run, not just which one"** section of
`docs/the-mayor-method/dispatch-prompt-template.md` — the file pasted verbatim into
every editing dispatch, so the wording propagates immediately.

Fixes rf2-804e.

## Drift 1 — the gate-root claim was false, and the rule it grounded unsatisfiable

The bullet said *"every gate now prints `gate root: <path>` as its first line"* and closed
*"treat it as a mandatory step on **every** gate run."*

**Census re-run at `origin/main` (`b32a2db389`), and it has moved since the bead was filed:**

| | bead's census (2026-08-12) | mine (2026-08-13, `b32a2db389`) |
|---|---|---|
| emitters | 8, all shell gates under `scripts/` | **9** |
| shell gates | 8 × `scripts/test-*.sh` | 8 × `scripts/test-*.sh` — unchanged, and that is *exactly* the `test-*.sh` set (8 of 22 `scripts/*.sh`) |
| node runners | none noted | **1 new** — `implementation/ssr-node/test/run.cjs:42`, added by `aa413ab092` |
| Python gates | 0 | **0 of 39** `scripts/check_*.py` |

The bead's count was right when written; a node gate landed since. Because a hard count is what
drifted in the first place, the new text names the **class** (`every scripts/test-*.sh`, "and some
node runners do as well") rather than a number that will re-drift next week.

The claim is now scoped to the gates that print it, and — the half the bead insisted on — the text
names **what to do where it is not printed**, which is the substitute workers had already arrived at
unprompted: plant a fault, run the gate red, and read the fault it names.

**A correction the negative control forced on my own first draft.** I wrote "read the path it
reports; if that path is inside your worktree, that gate read your tree" — then ran it, and
`check_doc_slugs.py` reports **repo-relative**:

```
  BROKEN TARGET: docs\the-mayor-method\dispatch-prompt-template.md:214 -> no-such-file-planted-fault-804e.md
      (missing: docs\the-mayor-method\no-such-file-planted-fault-804e.md)
```

That path cannot tell two checkouts apart, so my first draft was unsatisfiable for precisely the
reason the original claim was. Corrected in `b379a777b9`: what discriminates is **the red itself** —
the planted fault exists only in your tree, so a run that had wandered into a sibling's comes back
green. Which makes a green sabotage run a reason to stop, consistent with the vacuous-control trap
the restore bullet already describes.

## Drift 2 — the exit-code disagreement was understated

The bullet cited **one** instance (2026-08-11), which reads as a rare anomaly and invites a worker to
treat the harness number as usually fine. Measured, it is routine: **at least seven times across five
workers in three days** — `worker/routing-hic042` (a real compile failure from an unbalanced paren,
surfaced as exit 0), `worker/ssrsvc-hic056`, `worker/cliretry-xsfr`, `worker/a11y-hic049` twice (one
a genuine two-assertion failure), and `worker/slice-hic074` twice (one standing over three real
failures). A conservative floor is written rather than an exact tally.

The bullet is **not restructured** and the rule is **not strengthened** — it is already mandatory,
and every one of these was caught by a worker obeying it. Only the evidence needed correcting, since
a worker deciding how hard to look reads the frequency, not the rule.

## Quality gates

Run from `C:/Users/miket/code/re-frame2-worktrees/gateroot-804e`. Every exit code below is the one I
**captured** (`echo "$?" > *.exit`, redirect and echo on one command line in one shell), never the
harness's — which is drift 2's own subject.

| Gate | Exit | Note |
|---|---|---|
| `python scripts/check_readme_links.py` | **0** | repo-root + `.claude/commands` markdown |
| `python scripts/check_doc_slugs.py` | **0** | `docs/**`; silent on success |
| `python -m mkdocs build --strict` | **0** | `exclude_docs` does not exclude `the-mayor-method/`; built in 19.07s |
| `python scripts/check_doc_slugs.py` *(negative control)* | **1** | planted fault, named below |

### Gate selection proved, and the irony used as its own evidence

`check_doc_slugs.py` is itself one of the gates that prints **no `gate root:` banner** — its clean run
printed *nothing at all*. So my proof it read my worktree is exactly the substitute this PR
documents: the fault it named. A broken link planted at line 214 — a line this PR edits — took it to
**exit 1**, reporting
`docs\the-mayor-method\dispatch-prompt-template.md:214 -> no-such-file-planted-fault-804e.md`:
my file, my line, a fault present in no other checkout.

**Restore verified by hashing the bytes**, not by reading `git diff`:

```
before   26e0a6c5b0c74ae21ec1e9c1af43578353a2ab54d6cad50b5181f8d881916a98
planted  991faf2b4561bcd497501e450fe26228b11d2c59b1c7fb98c161d038425cbc95
restored 26e0a6c5b0c74ae21ec1e9c1af43578353a2ab54d6cad50b5181f8d881916a98   sha256sum -c → OK
```

The planted hash differs from the baseline, so the plant genuinely applied rather than silently
no-opping; the restored hash is byte-identical to the baseline.

Residue from the mkdocs runs (`site/`, `docs/spec/`, `docs/migration/`, `__pycache__/`) cleared —
`git status --porcelain --ignored=traditional` is empty.

## Fence

`docs/the-mayor-method/dispatch-prompt-template.md` only. `.claude/commands/*` deliberately **not**
touched: they cite this section rather than duplicating it, and a second copy is the same drift one
level down (rf2-w5pj).
