### PR TITLE
docs(hicasso): rf2-xpq9 started the Node SSR arm and #8028 landed it — correct the status carriers that say otherwise (rf2-k6bv)

### DIFF
--- a/docs/EP/EP-0038-the-hicasso-view-layer-programme.md
+++ b/docs/EP/EP-0038-the-hicasso-view-layer-programme.md
@@ -406,6 +406,33 @@ that list states what is open *now*.
   to that sitting had already been ruled on 2026-08-08 (`rf2-2rtt6.88`) and is
   untouched by the fork ruling, its five start gates still governing when that
   arm's implementation begins.
+
+  > **Erratum — 2026-08-13 (`rf2-k6bv`, from the merged-PR audit of #8029).** The
+  > last clause above was already false when the PR carrying this addendum
+  > merged, and the original text is kept per rule 3. A **separate and earlier**
+  > ruling had started the service: `rf2-xpq9` (operator, in session, 2026-08-12
+  > 17:36 AUSEST) made every Phase-5 optional product v0 scope and removed
+  > `rf2-hic-056`'s *"when a named caller activates it"* condition; PR #8028 then
+  > landed the bounded Node/React service at `implementation/ssr-node/` **twelve
+  > seconds before** this addendum did — #8028 merged at 2026-08-12T21:29:24Z,
+  > #8029 at 21:29:36Z.
+  >
+  > **What is not corrected is the ruling.** The fork ruling recorded above still
+  > neither chose the production server arm nor started it: the choice was
+  > `rf2-2rtt6.88`'s on 2026-08-08, the start was `rf2-xpq9`'s on 2026-08-12, and
+  > neither is this ruling's act. What moves is only the clause's tense.
+  >
+  > **What the landed service does not discharge**, so that "the service exists"
+  > is not read as "the arm is done": start gate 3's per-application **state
+  > projector**, with its round-trip corpus and its negative fixture proving an
+  > omitted server read fails — the JVM produces that projection and the service
+  > can only refuse what arrives outside the allowlist; and start gate 5's
+  > end-to-end **`JVM → Node → JVM` topology witness**, which has no JVM leg to
+  > witness, because `ssr-ring`'s pipeline still hard-calls
+  > `ssr/render-to-string`, the render seam at `build-full-response*` is
+  > unwritten, and nothing deploys or supervises the process. Gates 1, 2 and 4
+  > are answered inside the package and witnessed by its own suite, which is not
+  > the same as witnessed across the crossing.
 - **What this EP's own status is not.** The Graduation section makes `final`
   conditional on v0 *and* the narrow contract graduation landing — the `spec/004`
   view-family re-homing and EP-0036's supersession — and neither has. This EP

--- a/docs/design/hicasso/product/decision-brief.md
+++ b/docs/design/hicasso/product/decision-brief.md
@@ -45,7 +45,7 @@ Bulk is gated on the Reagent pair only, unresolved and instrument-limited. Heap 
 | Teardown | Zero retained bytes and objects on the pinned heap arms — the proven invariant |
 | Interpreter walk | Faster than stock Reagent — interpretation itself is solved |
 | Controlled input | Strong in Chromium; WebKit matrix open (K4) |
-| SSR | Core per-surface server/hydration contract owed; the Node spike is proven on its fixtures; the deployable service is **v0 scope** — the *"waits for its named caller"* gate this row carried is removed (amended 2026-08-12 by operator ruling, Mike in session 17:36 AUSEST, `rf2-xpq9`; `rf2-hic-056` is awake and the service is not yet built) |
+| SSR | Core per-surface server/hydration contract owed; the Node spike is proven on its fixtures; the deployable service is **v0 scope** — the *"waits for its named caller"* gate this row carried is removed (amended 2026-08-12 by operator ruling, Mike in session 17:36 AUSEST, `rf2-xpq9`). **Amended again 2026-08-13 (`rf2-k6bv`)**: `rf2-hic-056` shipped — PR #8028 landed the bounded Node/React service at `implementation/ssr-node/`, so this row's *"not yet built"* no longer holds. What is still unbuilt is the JVM half of the crossing: the `ssr-ring` render seam at `build-full-response*`, the per-application state projector with its negative fixture, and the end-to-end `JVM → Node → JVM` topology witness; nothing is deployed, and no caller is wired |
 | Correctness isolation | Eleven-risk register open — eight kernel rows plus three native-tier rows; the blocker class |
 
 ---

--- a/docs/design/hicasso/production-server-arm.md
+++ b/docs/design/hicasso/production-server-arm.md
@@ -57,9 +57,10 @@ govern when Arm B implementation begins — graduation did not start it.
 
 **A fourth status fact, added 2026-08-13 (`rf2-k6bv`, from the merged-PR audit
 of #8029): the last sentence above was already false when it was written, and
-Arm B is half-built.** The status fact it corrects is the *only* thing that
-moves; the sentence is left standing so the chronology is legible. **Graduation
-still did not start this arm** — but a *separate and earlier* ruling did.
+Arm B is half-built.** Nothing on this page moves except this paragraph and one
+table-column heading in §5; the sentence above is left standing rather than
+rewritten, because the chronology is the finding. **Graduation still did not
+start this arm** — but a *separate and earlier* ruling did.
 `rf2-xpq9` (operator, in session, 2026-08-12 17:36 AUSEST) made every Phase-5
 optional product v0 scope and removed `rf2-hic-056`'s *"when a named caller
 activates it"* condition, and **PR #8028 landed the bounded Node/React service

--- a/docs/design/hicasso/production-server-arm.md
+++ b/docs/design/hicasso/production-server-arm.md
@@ -55,6 +55,50 @@ written, and no figure, band, table or argument on this page moves. The pricing
 still prices unbuilt work, and the five start gates `rf2-2rtt6.88` named still
 govern when Arm B implementation begins — graduation did not start it.
 
+**A fourth status fact, added 2026-08-13 (`rf2-k6bv`, from the merged-PR audit
+of #8029): the last sentence above was already false when it was written, and
+Arm B is half-built.** The status fact it corrects is the *only* thing that
+moves; the sentence is left standing so the chronology is legible. **Graduation
+still did not start this arm** — but a *separate and earlier* ruling did.
+`rf2-xpq9` (operator, in session, 2026-08-12 17:36 AUSEST) made every Phase-5
+optional product v0 scope and removed `rf2-hic-056`'s *"when a named caller
+activates it"* condition, and **PR #8028 landed the bounded Node/React service
+at `implementation/ssr-node/`** at 2026-08-12T21:29:24Z — twelve seconds before
+the PR carrying the third status fact merged (#8029, 21:29:36Z). So the correct
+reading of the third fact is: *graduation* did not start the arm, and by the
+time it said so the arm had already been started by something else.
+
+What that does **not** change, stated so the page is not over-read in the other
+direction:
+
+- **The arm choice is untouched**, as the third fact says. `rf2-2rtt6.88` ruled
+  the Node sidecar on 2026-08-08 and nothing since has reopened it.
+- **The service is the Node half only.** It returns body markup and nothing
+  else, by its own refusal list; `ssr-ring` remains the HTTP host and still
+  hard-calls `ssr/render-to-string`, exactly as the 2026-08-11 fact above
+  records, and the render seam at `build-full-response*` is unwritten. That
+  fact's *"prices unbuilt work"* half is what has aged; its `ssr-ring` half has
+  not.
+- **Two of the five start gates are undischarged**, and they are the two the
+  crossing owns: gate 3's per-application **state projector** with its
+  round-trip corpus and its negative fixture — the JVM produces that projection,
+  and a service that allowlists what arrives is not a projector — and gate 5's
+  end-to-end **`JVM → Node → JVM` witness**, which has no JVM leg to witness.
+  Gates 1, 2 and 4 are answered inside the package and witnessed by its own
+  suite, which is not the same as witnessed across the crossing.
+- **§3's closing sentence and §5's table still hold where it counts.** The
+  compliant shape — JVM host, JVM payload, JVM shell, Node returning a body
+  string across a contract — now has its Node end built and its JVM end not, and
+  the crossing itself remains **unmeasured**, so *"the single largest unmeasured
+  thing on this page"* stands. §5's table is a reading taken while this page was
+  written and its column now says so; the rows the service changes are *"a
+  callable Node process"* and *"process supervision, pooling, restart"*, and the
+  rows naming the JVM↔Node contract, the JVM-written payload and shell, and the
+  production host in front of it are unchanged.
+- **No figure, band, table or argument moves**, on the same terms the third fact
+  set. The pricing below still prices the work that is still unbuilt, and it is
+  not re-costed here against what shipped.
+
 ## What this document deliberately does not contain, and the tension that produced it
 
 `rf2-2rtt6.88`'s description asks for "both branches priced in beads/weeks,
@@ -462,7 +506,7 @@ produces both sides, so there is nothing for two tables to disagree about.
 
 The render exists and is witnessed. What does not exist is everything around it.
 
-| Piece | State today |
+| Piece | State when this page was written |
 |---|---|
 | The render itself | **built** — the entry's `render`, `renderToString` over the same runtime/mount/codec the browser uses |
 | A root the JVM can name | **no** — `render` takes `:hiccup`, and a Hicasso root is `[<minted head> {props}]` whose head is a JavaScript function with no JVM referent. See below |


### PR DESCRIPTION
The merged-PR audit of #8029 reopened `rf2-k6bv` because the addendum that PR
landed carried forward an operative status statement **merge chronology had
already falsified**. It had, and the chronology is the whole finding.

## The finding, verified at source rather than taken on the audit's word

| | |
|---|---|
| **#8028** — `feat(ssr-node): the bounded Node/React SSR service (rf2-hic-056)` | merged **2026-08-12T21:29:24Z** |
| **#8029** — the graduation addendum carrying the falsified clause | merged **2026-08-12T21:29:36Z** |

**Twelve seconds.** #8028 landed the bounded Node/React service at
`implementation/ssr-node/` under the **separate, earlier** ruling `rf2-xpq9`
(operator, in session, 2026-08-12 17:36 AUSEST), which removed
`rf2-hic-056`'s *"when a named caller activates it"* condition and made every
Phase-5 optional product v0 scope. Twelve seconds later the addendum merged
saying the five start gates still govern *"when Arm B implementation begins"*.

Every premise held. `rf2-xpq9`'s ruling text, `rf2-2rtt6.88`'s five start
gates, `implementation/ssr-node/`'s existence and `ssr-ring`'s still-hard-wired
`ssr/render-to-string` call were each read at source, and the two merge
timestamps came from the merge record. **One premise of the audit needed
sharpening rather than correcting**: it reads as though the graduation ruling
were implicated. It is not — see below.

## The distinction that had to survive, and does

**The graduation ruling still neither chose the arm nor started it**, and all
three files say so after this change. The choice was `rf2-2rtt6.88`'s on
2026-08-08; the start was `rf2-xpq9`'s on 2026-08-12. What was wrong was never
the ruling — only a status clause written beside it, in the present tense,
about a state that had changed minutes earlier.

## What is still unbuilt, named at every site

The service being built does not discharge the arm. Of `rf2-2rtt6.88`'s five
start gates, **two are undischarged and they are the two the crossing owns**:

- **Gate 3 — the per-application state projector**, with its round-trip corpus
  and its negative fixture proving an omitted server read fails. The JVM
  produces that projection; a service that allowlists what arrives is not a
  projector.
- **Gate 5 — the end-to-end `JVM → Node → JVM` topology witness**, which has no
  JVM leg to witness: `ssr-ring`'s pipeline still hard-calls
  `ssr/render-to-string`, the render seam at `build-full-response*` is
  unwritten, nothing deploys or supervises the process, and no caller is wired.

Gates 1, 2 and 4 are answered inside the package and witnessed by its own
suite — **which is not the same as witnessed across the crossing**, and each
site says exactly that rather than scoring the gates green.

## The three carriers, before and after

**`docs/EP/EP-0038-…md`** — a dated erratum **beside** the affected passage,
original text preserved, per EP-0009 rule 3 (*"freeze meaning, not bytes"*) and
in the `> **Erratum — date (bead).**` form the EP corpus already uses in
EP-0002, EP-0031, EP-0035 and EP-0037. The bullet is not rewritten; the erratum
states the chronology, insists on the ruling distinction, and lists the
undischarged gates.

**`docs/design/hicasso/product/decision-brief.md:48`** — the SSR row of the
*"Where it stands"* table.

- *Before*: `… rf2-hic-056 is awake and the service is not yet built)`
- *After*: the `rf2-xpq9` clause is kept and a dated **Amended again
  2026-08-13** clause follows it, recording that #8028 shipped the service, that
  *"not yet built"* no longer holds, and naming the JVM half that is still
  unbuilt.

**`docs/design/hicasso/production-server-arm.md`** — two changes, both in the
page's own idiom.

- *Before* (the third status fact, added 2026-08-13 by `rf2-2rtt6.144`): *"The
  pricing still prices unbuilt work, and the five start gates `rf2-2rtt6.88`
  named still govern when Arm B implementation begins — graduation did not start
  it."*
- *After*: **a fourth dated status fact**, which is the shape this page has used
  three times already. It leaves the third fact standing so the chronology stays
  legible, corrects only its last sentence, and then bounds the correction in
  the other direction: the arm choice is untouched; the service is the Node half
  only; two gates are undischarged; §3's *"single largest unmeasured thing"*
  still stands because the **crossing** remains unmeasured; no figure, band,
  table or argument moves.
- §5's table column `State today` → `State when this page was written`. A
  reading taken at writing time had a header presenting it as current. Nothing
  in the rows moved; the fourth status fact names the two rows the service
  changes (*a callable Node process*; *process supervision, pooling, restart*)
  and the rows that are unchanged.

## What the sweep found and how each was disposed of

`git grep` across `docs/` for *"not yet built"*, *"unbuilt"*, *"not started"*,
*"unstarted"*, *"named caller"*, *"implementation begins"*, *"nothing builds"*
and the five-start-gates phrasing.

**Corrected** (in fence): the four sites above.

**Right as they stand** (in fence — historical, not live):

- `production-server-arm.md:37–41`, the 2026-08-11 status paragraph. Dated,
  true at its date, and its `ssr-ring` half is *still* true today; the fourth
  fact says which half aged.
- `production-server-arm.md:212`, §3's *"has not been built and has not been
  measured"*. An argument in the dossier body, and the **unmeasured** half
  survives intact — annotated by the fourth fact rather than edited, because
  this page's convention is that no argument moves.
- `production-server-arm.md` §5 rows and §10 pricing — priced work, framed by
  the retitled column.
- `decision-brief.md:34, 103, 125, 127` — scope statements, not build status;
  still true.
- `decisions.md`'s HD-020 `rf2-xpq9` addendum — a ruling record, and correct.

**Outside the fence, reported not edited** — filed as **`rf2-a8c5`**:

- `product/requirements-mine.md:42` — *"and not yet built"*, a live cell, now
  false.
- `studio/ssr-spike-witness.md:18` — *"the SSR work it prices is unstarted
  either way"*. The exact sibling of the third status fact, written the same day
  by `rf2-2rtt6.145`, falsified the same way.
- `product/dispositions.md:69` — status column reads *"Claimed — rf2-hic-056"*
  where the bead has shipped and closed. Minor.

`implementation/ssr-node/**` was **read, not touched** — including PR **#8046**,
which removes the application `meta` channel from the response contract. It was
open when this branch was cut and merged at 2026-08-12T22:54:30Z while the gates
were running; the descriptions here were written against it either way and
nothing rests on anything it moves. They rest on *body markup and nothing
else*, which #8046 strengthens — `emit` becomes a render module's only output
channel and a module that returns a value is refused.

## Quality gates

Every exit code below is the one captured with `echo $?` on the **same command
line** as the run, redirected to a worktree-named log — never a number the
harness reported about the run.

| Gate | Command | Captured exit |
|---|---|---|
| Doc slugs / anchors | `python scripts/check_doc_slugs.py` | **0** |
| Site build | `python -m mkdocs build --strict` | **0** |
| Provenance pins | `python scripts/check_provenance_pins.py --changed-since origin/main --verbose` | **0** |
| EP ↔ README status sync | `python scripts/check_ep_status_sync.py` | **0** |

`check_ep_status_sync.py` was run for safety although **no EP header line was
touched** — the `Status: accepted` line is unchanged, and this PR takes no
position on it.

### Negative controls — one per gate, each planted at a line this PR adds

| Planted fault | Gate | Captured exit | What it named |
|---|---|---|---|
| Broken anchor `#nc-planted-anchor-ssrstatus-k6bv` in the new status fact | `check_doc_slugs.py` | **1** | `docs\design\hicasso\production-server-arm.md:74` |
| Broken relative link in the EP erratum | `mkdocs build --strict` | **1** | `Aborted with 1 warnings in strict mode!`, naming `EP/EP-0038-…` |
| Bogus 40-hex pin in the new status fact | `check_provenance_pins.py` | **1** | `production-server-arm.md:66 … [UNRESOLVABLE]` |

Each plant was **confirmed present by `grep` before the gate was read**, and
each restore was verified by **SHA-256**, all three back to their pre-plant
digests with `git status` clean:

```
46811f78…da995  production-server-arm.md
11c9c678…dab8e  EP-0038-the-hicasso-view-layer-programme.md
0190b8fd…0445c  decision-brief.md
```

`check_doc_slugs.py` prints nothing on success and emits no `gate root:` line;
the substitute is the file path its negative control named, which is this
worktree's copy.

### Hand verification, because `mkdocs` does not cover `docs/design/**`

`exclude_docs` keeps `docs/design/**` out of the site, so `mkdocs --strict`
says nothing about two of the three files. Verified by hand instead:

- **Table column counts.** `production-server-arm.md`: 9 tables at
  **2/3/3/4/2/3/3/3/3** columns, every row consistent with its header, 0
  mismatches — the same profile the page's earlier passes recorded, so the
  retitled header changed a cell's text and not the shape.
  `decision-brief.md`: 2 tables at **3/2**, all rows consistent; the edited row
  48 has 2 cells against a 2-column header, and the added prose introduces no
  `|`.
- **Anchors.** The diff adds **no headings and no markdown links** anywhere
  (verified over the whole diff), so no anchor is minted and no link target is
  introduced. No existing heading text was changed, so no inbound anchor moved.

No `site/`, `docs/spec/`, `docs/migration/` or `__pycache__/` residue remains —
`git status` is clean in the worktree. No `node_modules` junction was created.

Closes `rf2-k6bv`. Follow-up filed as `rf2-a8c5`.
