### PR TITLE
fix(ssr-node): move Reading 1 to loader positions, so a CI lane is not a coupling (rf2-6ovv)

### DIFF
--- a/implementation/ssr-node/test/absence.test.cjs
+++ b/implementation/ssr-node/test/absence.test.cjs
@@ -8,8 +8,10 @@
 // byte-for-byte the client it would have been had this package never
 // existed. Three independent readings, in increasing strength:
 //
-//   1. NOTHING REFERENCES IT. No tracked file in the source trees that
-//      build or configure client artefacts mentions this package.
+//   1. NO LOADER CAN REACH IT. In the source trees that build or configure
+//      client artefacts, no module specifier, no ns `:require`, no
+//      classpath entry and no package-manifest link names this package —
+//      and its refusal-code namespace appears nowhere at all.
 //   2. IT IS ON NO BUILD'S SOURCE PATH. `implementation/shadow-cljs.edn`
 //      names no build reaching it and the top-level `implementation/
 //      deps.edn` has no entry for it, so it is in no module graph and
@@ -66,25 +68,84 @@ const SCANNED = ['implementation', 'examples', 'tools', 'scripts', '.github'];
  * source path, `../ssr-node/src/service.cjs` in a require) and none of the
  * forms that are somebody else's compound name.
  */
-const REFERENCES = [/(?<![\w:-])ssr-node(?![\w-])/g, /(?<![\w-]):rf\.ssr-node\//g];
+const PATH_REFERENCE = /(?<![\w:-])ssr-node(?![\w-])/g;
+const CODE_NAMESPACE = /(?<![\w-]):rf\.ssr-node\//g;
+const REFERENCES = [PATH_REFERENCE, CODE_NAMESPACE];
 
 /**
- * THERE IS NO ALLOWANCE LIST, AND THAT IS A DECISION RATHER THAN AN
- * OVERSIGHT.
+ * THERE IS STILL NO ALLOWANCE LIST. THE READING MOVED INSTEAD — rf2-6ovv.
  *
- * The reading below is an absolute zero: nothing outside this package
- * mentions it, full stop. An earlier draft added a `test:ssr-node` script
- * to `implementation/package.json` and carried a pinned one-string
- * exception for it. The script was dropped for an unrelated and better
- * reason — it arms eleven expensive CI lanes that the package's own files
- * arm none of — and the exception went with it, because an allowance
- * mechanism with nothing in it is the first entry of an allowance list.
+ * ## What this block used to say, and why it could not survive contact
  *
- * If the npm script is wired up later, the answer is one PINNED EXACT
- * STRING deleted from that file before the remainder is scanned — never a
- * broadened pattern and never a skipped file. A pinned string reds on a
- * second reference and reds again if the script value drifts; a widened
- * pattern is how a scan like this stops meaning anything.
+ * Reading 1 was once an absolute zero over raw file text: nothing outside
+ * this package MENTIONS it, full stop. An earlier draft had added a
+ * `test:ssr-node` script to `implementation/package.json` and carried a
+ * pinned one-string exception for it. The script was dropped for an
+ * unrelated and better reason — it arms eleven expensive CI lanes that the
+ * package's own files arm none of — and the exception went with it, because
+ * an allowance mechanism with nothing in it is the first entry of an
+ * allowance list. This block then ruled that if the npm script were ever
+ * wired up, the answer was one PINNED EXACT STRING deleted from that file
+ * before the remainder was scanned — never a broadened pattern and never a
+ * skipped file.
+ *
+ * That ruling anticipated the right event and mis-sized it. The CI lane
+ * (rf2-n8vp, PR #8042) arrived armed by this package's own surface, exactly
+ * as wanted, and it necessarily writes the package's path into FOUR files:
+ * `implementation/package.json`, `.github/workflows/test.yml`,
+ * `.github/scripts/report-changed-surfaces.sh` and
+ * `implementation/scripts/_changed-surfaces.test.cjs`. Not one line but 23
+ * of them, most of which are the prose that explains WHY the lane has its
+ * own output. Pinning 23 exact lines would red this suite on every comment
+ * reflow in four files nobody here owns — a gate people learn to route
+ * around, which is the failure this block was written to prevent.
+ *
+ * ## What moved
+ *
+ * The absolute zero was a PROXY, and the collision showed which part of it
+ * was load-bearing. What the claim needs is that no client can LOAD this
+ * package — that no resolver, compiler or classpath can be led here. What
+ * the old scan asserted was that no file may NAME it, which is a much
+ * larger statement, and the extra territory is prose, shell `case` arms, CI
+ * job names and an npm script that spawns a separate `node` process. None
+ * of those is a way into a module graph.
+ *
+ * So Reading 1 now tests the needles at LOADER POSITIONS: the static
+ * specifier of a `require` / `import`, the body of a ClojureScript ns
+ * `:require`, the classpath and coordinate keys of an EDN build config, and
+ * the linking fields of a package manifest. A format that cannot resolve a
+ * module — YAML, shell, Markdown — offers no loader position and therefore
+ * cannot host a hit.
+ *
+ * ## Why this is not the widened pattern the old ruling forbade
+ *
+ * Because it is the same move this file had ALREADY made, one paragraph
+ * down, and for the same reason. `DOC_EXT` excludes Markdown on the ground
+ * that "a Markdown file cannot be required, compiled, or put on a source
+ * path" — a statement about what the FORMAT can do, never about which paths
+ * are forgiven. `.yml` and `.sh` cannot be required, compiled or put on a
+ * source path either. The old reading had carried the category error for
+ * every format except the one that forced the issue; this finishes the
+ * move rather than starting a new one.
+ *
+ * The prohibitions it was guarding are both intact. There is no allowance
+ * list: no file, path or string is named as forgiven, and the four wiring
+ * files are read exactly as any other file of their format. And the needles
+ * were not widened by a character — `PATH_REFERENCE` and `CODE_NAMESPACE`
+ * are unchanged, and the rows below plant a fault at every loader position
+ * this file knows about and require each one to be found.
+ *
+ * ## What did NOT move
+ *
+ * `CODE_NAMESPACE` keeps the absolute zero, over raw text, everywhere. A
+ * path is a token that legitimately appears in prose and in commands; the
+ * refusal-code namespace is a token that only code producing or consuming
+ * this service's refusals has any use for, so a client that names it has
+ * been changed by this package's existence — which is precisely the claim
+ * under test. Nothing inert has ever spelled it: at the time of writing it
+ * appears in three files inside this package and zero outside.
+ *
+ * Readings 2 and 3 are untouched and remain the strong net.
  */
 
 const SKIP_EXT = new Set([
@@ -126,9 +187,178 @@ function trackedFiles(cwd, roots) {
   return out.split('\0').filter(Boolean);
 }
 
+// ---------------------------------------------------------------------------
+// Loader positions — the places a resolver, compiler or classpath turns a
+// spelling into a module. Everything Reading 1 asserts, it asserts here.
+// ---------------------------------------------------------------------------
+
+const JS_EXT = new Set(['.js', '.cjs', '.mjs', '.jsx', '.ts', '.tsx', '.mts', '.cts']);
+const CLJ_EXT = new Set(['.clj', '.cljs', '.cljc']);
+
+/** A static module specifier: `require('x')`, `import('x')`, `from 'x'`, `import 'x'`. */
+const SPECIFIER = /(?:\b(?:require|import)\s*\(\s*|\bfrom\s+|\bimport\s+)(['"])((?:[^'"\\]|\\.)*)\1/g;
+
 /**
- * Files under `files` that mention any of `needles`, excluding anything
- * inside `excludePrefix`. Returns `[{file, needle, line}]`.
+ * A `require(` / `import(` whose argument is NOT a string literal. The
+ * specifier is then computed, so it cannot be read off the call — and
+ * `require(SERVICE)` two lines under `const SERVICE = '../ssr-node/src/
+ * service.cjs'` is a module-graph edge that a specifier scan alone would
+ * walk straight past. Such a file FAILS CLOSED: every string literal in it
+ * is treated as a candidate specifier.
+ */
+const DYNAMIC_SPECIFIER = /\b(?:require|import)\s*\(\s*(?!['"])/;
+const STRING_LITERAL = /(['"`])((?:[^'"`\\\n]|\\.)*)\1/g;
+
+/** ns forms that put a namespace on the compiler's load path. */
+const CLJ_LOAD_KEYS = [':require', ':require-macros', ':import', ':use', ':load'];
+
+/** EDN keys whose value is a source path or a dependency coordinate. */
+const EDN_LOAD_KEYS = [
+  ':source-paths', ':paths', ':extra-paths', ':replace-paths',
+  ':deps', ':extra-deps', ':replace-deps', ':local/root', ':dependencies',
+];
+
+/**
+ * The `package.json` fields a resolver reads. `scripts` is deliberately not
+ * among them and is not an omission: a script is a COMMAND LINE, and the
+ * process it spawns has its own module graph rooted wherever it is rooted.
+ * `npm run test:ssr-node` no more links this package into a client than
+ * typing the same command into a terminal does.
+ */
+const MANIFEST_LINK_FIELDS = [
+  'dependencies', 'devDependencies', 'peerDependencies', 'optionalDependencies',
+  'bundleDependencies', 'bundledDependencies', 'workspaces', 'imports',
+  'exports', 'main', 'module', 'browser', 'files', 'types', 'typings', 'bin',
+];
+
+const CLOSERS = { '[': ']', '{': '}', '(': ')' };
+
+/** The one balanced form (or quoted string, or bare token) starting at `i`. */
+function balancedFormAt(text, i) {
+  while (i < text.length && /\s/.test(text[i])) i += 1;
+  if (i >= text.length) return '';
+  if (text[i] === '"') {
+    for (let j = i + 1; j < text.length; j += 1) {
+      if (text[j] === '\\') j += 1;
+      else if (text[j] === '"') return text.slice(i, j + 1);
+    }
+    return text.slice(i);
+  }
+  if (CLOSERS[text[i]]) {
+    let depth = 0;
+    let inString = false;
+    for (let j = i; j < text.length; j += 1) {
+      const c = text[j];
+      if (inString) {
+        if (c === '\\') j += 1;
+        else if (c === '"') inString = false;
+      } else if (c === '"') inString = true;
+      else if (CLOSERS[c]) depth += 1;
+      else if (c === ']' || c === '}' || c === ')') {
+        depth -= 1;
+        if (depth === 0) return text.slice(i, j + 1);
+      }
+    }
+    return text.slice(i);
+  }
+  const bare = /^[^\s()[\]{},]+/.exec(text.slice(i));
+  return bare ? bare[0] : '';
+}
+
+/** The form following each occurrence of each key. Returns `[{text, at}]`. */
+function formsAfterKeys(text, keys) {
+  const out = [];
+  for (const key of keys) {
+    let from = 0;
+    for (;;) {
+      const at = text.indexOf(key, from);
+      if (at === -1) break;
+      from = at + key.length;
+      // `:paths` must not fire on `:source-paths`, nor `:deps` on `:extra-deps`.
+      if (at > 0 && /[\w:./-]/.test(text[at - 1])) continue;
+      if (/[\w:./-]/.test(text[from] ?? '')) continue;
+      out.push({ text: balancedFormAt(text, from), at });
+    }
+  }
+  return out;
+}
+
+/**
+ * Every loader position in one file, as `[{text, at}]` where `at` is an
+ * offset into `text` good enough to name a line. A format with no way to
+ * resolve a module contributes none — which is the whole of the narrowing,
+ * and is the `DOC_EXT` argument applied to `.yml` and `.sh` as well.
+ */
+function loaderPositions(rel, text) {
+  const ext = path.extname(rel).toLowerCase();
+  const out = [];
+  if (JS_EXT.has(ext)) {
+    for (const m of text.matchAll(SPECIFIER)) out.push({ text: m[2], at: m.index });
+    if (DYNAMIC_SPECIFIER.test(text)) {
+      for (const m of text.matchAll(STRING_LITERAL)) out.push({ text: m[2], at: m.index });
+    }
+  }
+  if (CLJ_EXT.has(ext)) out.push(...formsAfterKeys(text, CLJ_LOAD_KEYS));
+  if (ext === '.edn') out.push(...formsAfterKeys(text, EDN_LOAD_KEYS));
+  if (path.basename(rel).toLowerCase() === 'package.json') {
+    let manifest = null;
+    try {
+      manifest = JSON.parse(text);
+    } catch {
+      out.push({ text, at: 0 }); // unparseable manifest: fail closed
+    }
+    for (const field of manifest === null ? [] : MANIFEST_LINK_FIELDS) {
+      if (manifest[field] === undefined) continue;
+      const at = text.indexOf(`"${field}"`);
+      out.push({ text: JSON.stringify(manifest[field]), at: at === -1 ? 0 : at });
+    }
+  }
+  return out;
+}
+
+/** Read a tracked file, or `null` if this checkout has no such file. */
+function readTracked(cwd, rel) {
+  const abs = path.join(cwd, rel);
+  let stat;
+  try {
+    stat = fs.statSync(abs);
+  } catch {
+    return null; // a tracked file not present in this checkout
+  }
+  if (!stat.isFile() || stat.size > 2 * 1024 * 1024) return null;
+  return fs.readFileSync(abs, 'utf8');
+}
+
+/**
+ * Files under `files` whose LOADER POSITIONS mention any of `needles`,
+ * excluding anything inside `excludePrefix`. Returns `[{file, needle, line}]`.
+ */
+function scanLoaderPositions(cwd, files, needles, excludePrefix) {
+  const hits = [];
+  for (const rel of files) {
+    if (excludePrefix && rel.startsWith(excludePrefix)) continue;
+    const ext = path.extname(rel).toLowerCase();
+    if (SKIP_EXT.has(ext) || DOC_EXT.has(ext)) continue;
+    const text = readTracked(cwd, rel);
+    if (text === null) continue;
+    for (const position of loaderPositions(rel, text)) {
+      for (const needle of needles) {
+        needle.lastIndex = 0;
+        if (!needle.test(position.text)) continue;
+        hits.push({
+          file: rel,
+          needle: String(needle),
+          line: text.slice(0, position.at).split('\n').length,
+        });
+      }
+    }
+  }
+  return hits;
+}
+
+/**
+ * Files under `files` mentioning any of `needles` ANYWHERE in their raw
+ * text — the older, broader shape, kept for `CODE_NAMESPACE`.
  */
 function scanForReferences(cwd, files, needles, excludePrefix) {
   const hits = [];
@@ -136,15 +366,8 @@ function scanForReferences(cwd, files, needles, excludePrefix) {
     if (excludePrefix && rel.startsWith(excludePrefix)) continue;
     const ext = path.extname(rel).toLowerCase();
     if (SKIP_EXT.has(ext) || DOC_EXT.has(ext)) continue;
-    const abs = path.join(cwd, rel);
-    let stat;
-    try {
-      stat = fs.statSync(abs);
-    } catch {
-      continue; // a tracked file not present in this checkout
-    }
-    if (!stat.isFile() || stat.size > 2 * 1024 * 1024) continue;
-    const text = fs.readFileSync(abs, 'utf8');
+    const text = readTracked(cwd, rel);
+    if (text === null) continue;
     for (const needle of needles) {
       needle.lastIndex = 0;
       const m = needle.exec(text);
@@ -192,18 +415,32 @@ function scratch(files) {
 }
 
 // ---------------------------------------------------------------------------
-// 1. Nothing references it
+// 1. No loader can reach it
 // ---------------------------------------------------------------------------
 
-test('no client-building tree references this package', () => {
+test('no loader in a client-building tree can reach this package', () => {
   const files = trackedFiles(REPO_ROOT, SCANNED);
   assert.ok(files.length > 500, `only ${files.length} tracked files scanned — the scope looks wrong`);
-  const hits = scanForReferences(REPO_ROOT, files, REFERENCES, 'implementation/ssr-node/');
+  const hits = scanLoaderPositions(REPO_ROOT, files, REFERENCES, 'implementation/ssr-node/');
   assert.deepStrictEqual(
     hits,
     [],
-    `something outside the package reaches for it:\n${hits
+    `something outside the package can load it:\n${hits
       .map((h) => `  ${h.file}:${h.line} (${h.needle})`)
+      .join('\n')}`,
+  );
+});
+
+test('the refusal-code namespace appears nowhere outside the package', () => {
+  // The absolute zero that survives, and the reason the narrowing above is
+  // safe rather than merely smaller — see the long note on REFERENCES.
+  const files = trackedFiles(REPO_ROOT, SCANNED);
+  const hits = scanForReferences(REPO_ROOT, files, [CODE_NAMESPACE], 'implementation/ssr-node/');
+  assert.deepStrictEqual(
+    hits,
+    [],
+    `something outside the package names our refusal codes:\n${hits
+      .map((h) => `  ${h.file}:${h.line}`)
       .join('\n')}`,
   );
 });
@@ -213,35 +450,137 @@ test('the layout map DOES name the package, as the README ratchet requires', () 
   // legitimate because the naming is an obligation somewhere else. If this
   // row ever went red, `check_readme_inventories.py` would be red too.
   const readme = fs.readFileSync(path.join(REPO_ROOT, 'implementation', 'README.md'), 'utf8');
-  const needle = REFERENCES[0];
+  const needle = PATH_REFERENCE;
   needle.lastIndex = 0;
   assert.strictEqual(needle.test(readme), true, 'the layout map must carry an ssr-node entry');
 });
 
-test('CONTROL — the documentation exclusion is by EXTENSION, not a hole in the matcher', () => {
-  const body = 'see implementation/ssr-node/src/service.cjs\n';
-  const dir = scratch({ 'notes.md': body, 'boot.cjs': body });
+/**
+ * ONE PLANTED FAULT PER LOADER POSITION. If a shape below stops being
+ * found, Reading 1 has a blind spot in exactly that shape — which is the
+ * only way a narrowed reading can fail quietly.
+ */
+const PLANTED_LOADER_FAULTS = {
+  'app/boot.cjs': "require('../../implementation/ssr-node/src/service.cjs');\n",
+  'app/entry.mjs': "import svc from '../implementation/ssr-node/src/service.cjs';\n",
+  'app/lazy.cjs': "const P = 'implementation/ssr-node/src/service.cjs';\nrequire(P);\n",
+  'app/re_export.mjs': "export { render } from '../ssr-node/src/service.cjs';\n",
+  'app/core.cljs': '(ns app.core\n  (:require [rf.ssr-node/service :as svc]))\n',
+  'build/shadow-cljs.edn': '{:builds {:app {:target :browser\n :source-paths ["ssr-node/src"]}}}\n',
+  'build/deps.edn': '{:deps {day8/ssr-node {:mvn/version "0.1.0"}}}\n',
+  'build/local.edn': '{:aliases {:x {:extra-deps {a/b {:local/root "../ssr-node"}}}}}\n',
+  'build/paths.edn': '{:paths ["src" "../ssr-node/src"]}\n',
+  'pkg/package.json': '{"name": "x", "dependencies": {"svc": "file:../ssr-node"}}\n',
+};
+
+test('CONTROL — every loader position this file knows about finds its planted fault', () => {
+  for (const [rel, body] of Object.entries(PLANTED_LOADER_FAULTS)) {
+    const dir = scratch({ [rel]: body, 'inert/README.md': body });
+    try {
+      const hits = scanLoaderPositions(dir, [rel, 'inert/README.md'], REFERENCES, null);
+      assert.ok(hits.length > 0, `the planted ${rel} fault was NOT found — a blind spot`);
+      for (const hit of hits) {
+        assert.strictEqual(hit.file, rel, `${rel}: documentation must never be a loader position`);
+      }
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  }
+});
+
+test('CONTROL — a format that cannot resolve a module hosts no loader position', () => {
+  // The `DOC_EXT` argument, generalised: the SAME text that reds in a
+  // `.cjs` is inert in Markdown, YAML and shell, because none of the three
+  // has a `require`. This is the narrowing, stated as a control.
+  const body = "require('implementation/ssr-node/src/service.cjs')\n";
+  const files = ['notes.md', 'pipeline.yml', 'run.sh', 'boot.cjs'];
+  const dir = scratch(Object.fromEntries(files.map((f) => [f, body])));
   try {
-    const hits = scanForReferences(dir, ['notes.md', 'boot.cjs'], REFERENCES, null);
-    assert.strictEqual(hits.length, 1, 'exactly one of the two must be found');
-    assert.strictEqual(hits[0].file, 'boot.cjs', 'and it must be the source file');
+    const hits = scanLoaderPositions(dir, files, REFERENCES, null);
+    assert.strictEqual(hits.length, 1, `exactly one of the ${files.length} must be found`);
+    assert.strictEqual(hits[0].file, 'boot.cjs', 'and it must be the one a loader reads');
   } finally {
     fs.rmSync(dir, { recursive: true, force: true });
   }
 });
 
-test('CONTROL — the reference scan finds a planted reference', () => {
-  const dir = scratch({
-    'app/core.cljs': '(ns app.core)\n',
-    'app/boot.cjs': "require('../../implementation/ssr-node/src/service.cjs');\n",
+/**
+ * THE SHAPES A CI LANE WRITES (rf2-n8vp, PR #8042), copied by shape rather
+ * than referenced by path: an npm script, a workflow job name and run step,
+ * a shell `case` arm classifying a changed path, and a gate test asserting
+ * on that mapping. All four name this package. None of the four is a way to
+ * load it.
+ */
+const CI_WIRING_SHAPES = {
+  'implementation/package.json':
+    '{\n  "name": "re-frame2",\n  "scripts": {\n'
+    + '    "test:ssr-node": "node ssr-node/test/run.cjs"\n  }\n}\n',
+  '.github/workflows/test.yml':
+    'jobs:\n  node-ssr-node:\n'
+    + '    name: Node implementation/ssr-node (bounded SSR service suite)\n'
+    + '    steps:\n      - name: Run the ssr-node suite\n'
+    + '        run: node implementation/ssr-node/test/run.cjs\n',
+  '.github/scripts/report-changed-surfaces.sh':
+    '# the ssr-node package\'s own lane — see implementation/ssr-node/\ncase "$file" in\n'
+    + '  implementation/ssr-node/*)\n    ssr_node=true ;;\nesac\n',
+  'implementation/scripts/_changed-surfaces.test.cjs':
+    "const { execFileSync } = require('node:child_process');\n"
+    + "// the ssr-node lane arms on its own tree — implementation/ssr-node/\n"
+    + "const SSR_NODE = {\n  dir: 'implementation/ssr-node',\n"
+    + "  runner: 'implementation/ssr-node/test/run.cjs',\n"
+    + "  src: 'implementation/ssr-node/src/service.cjs',\n};\n"
+    + 'module.exports = { SSR_NODE, execFileSync };\n',
+};
+
+test('CONTROL — a CI lane naming the package is inert, and IS NOT inert once it links', () => {
+  // BOTH DIRECTIONS IN ONE ROW, because the reconciliation is only correct
+  // if both hold. A reading that stopped failing would be worse than the
+  // collision it was narrowed to resolve.
+  const files = Object.keys(CI_WIRING_SHAPES);
+
+  const inert = scratch(CI_WIRING_SHAPES);
+  try {
+    assert.deepStrictEqual(
+      scanLoaderPositions(inert, files, REFERENCES, null),
+      [],
+      'the four CI wiring shapes must not be loader positions',
+    );
+  } finally {
+    fs.rmSync(inert, { recursive: true, force: true });
+  }
+
+  // The same four files, each additionally given a real edge of the kind
+  // its own format supports. Every one of the four must now be found.
+  const linked = scratch({
+    ...CI_WIRING_SHAPES,
+    'implementation/package.json':
+      '{\n  "name": "re-frame2",\n  "scripts": {\n'
+      + '    "test:ssr-node": "node ssr-node/test/run.cjs"\n  },\n'
+      + '  "dependencies": {\n    "ssr-node": "file:./ssr-node"\n  }\n}\n',
+    // A workflow cannot resolve a module, so the edge a CI tree can really
+    // grow is an EDN one beside it — the shape Reading 2 pins for two named
+    // files and this row pins for every other build config in the trees.
+    '.github/build/deps.edn': '{:paths ["../../implementation/ssr-node/src"]}\n',
+    '.github/scripts/report-changed-surfaces.sh': CI_WIRING_SHAPES['.github/scripts/report-changed-surfaces.sh'],
+    'implementation/scripts/_changed-surfaces.test.cjs':
+      CI_WIRING_SHAPES['implementation/scripts/_changed-surfaces.test.cjs']
+      + "require('../ssr-node/src/service.cjs');\n",
+    'implementation/scripts/boot.cljs': '(ns boot\n  (:require [rf.ssr-node/service]))\n',
   });
   try {
-    const hits = scanForReferences(dir, ['app/core.cljs', 'app/boot.cjs'], REFERENCES, null);
-    assert.strictEqual(hits.length, 1, 'the planted reference must be found');
-    assert.strictEqual(hits[0].file, 'app/boot.cjs');
-    assert.match(hits[0].needle, /ssr-node/);
+    const linkedFiles = [...files, '.github/build/deps.edn', 'implementation/scripts/boot.cljs'];
+    const hits = scanLoaderPositions(linked, linkedFiles, REFERENCES, null);
+    const seen = new Set(hits.map((h) => h.file));
+    for (const rel of [
+      'implementation/package.json',
+      '.github/build/deps.edn',
+      'implementation/scripts/_changed-surfaces.test.cjs',
+      'implementation/scripts/boot.cljs',
+    ]) {
+      assert.ok(seen.has(rel), `${rel} grew a real loader edge and Reading 1 missed it`);
+    }
   } finally {
-    fs.rmSync(dir, { recursive: true, force: true });
+    fs.rmSync(linked, { recursive: true, force: true });
   }
 });
 
@@ -250,6 +589,8 @@ test('CONTROL — the exclusion really is what keeps the package itself quiet', 
   // exclusion prefix were wrong, the real scan would be red rather than
   // green — but a scan pointed at a tree with nothing in it would be green
   // too, so this row shows the package DOES match when it is not excluded.
+  // It runs on the raw-text reading because that is the one still asserting
+  // an absolute zero, and so the one an exclusion bug would silently pass.
   const files = trackedFiles(REPO_ROOT, ['implementation/ssr-node']);
   assert.ok(files.length > 5, 'the package should have tracked files by now');
   const unexcluded = scanForReferences(REPO_ROOT, files, REFERENCES, null);


### PR DESCRIPTION
Unblocks **PR #8042** (rf2-n8vp), which needs no edit and merges unchanged on top of this.

## The collision

`implementation/ssr-node/test/absence.test.cjs` Reading 1 asserted an **absolute zero over raw file text**: no tracked file under `implementation/`, `examples/`, `tools/`, `scripts/` or `.github/` may *mention* this package. Giving the package a CI lane necessarily writes its path into four of them, so the act rf2-n8vp exists to perform was the act that redded this suite.

Reproduced at source on this branch, with #8042's five files overlaid on current `main` — `node implementation/ssr-node/test/absence.test.cjs` exits **1** with exactly the four hits the bead names:

```
.github/scripts/report-changed-surfaces.sh:106 (/(?<![\w:-])ssr-node(?![\w-])/g)
.github/workflows/test.yml:5171                (/(?<![\w:-])ssr-node(?![\w-])/g)
implementation/package.json:84                 (/(?<![\w:-])ssr-node(?![\w-])/g)
implementation/scripts/_changed-surfaces.test.cjs:1058 (/(?<![\w:-])ssr-node(?![\w-])/g)
```

Blast radius confirmed as one row: 7 of the 8 suites passed, and inside `absence.test.cjs` Readings 2 and 3 passed **with their controls firing**.

## Premise that did not hold: it is 23 lines, not one

The scanner reports only the *first* match per needle per file, so "four hits" understates the surface. Enumerated properly, #8042's four files carry **23 reference-bearing lines** — 5 in `report-changed-surfaces.sh`, 4 in `test.yml`, 1 in `package.json`, 13 in `_changed-surfaces.test.cjs`. The bead estimated "roughly 6–10 irreducible lines"; the real count is more than double, and most of it is the prose explaining *why* the lane has its own output rather than joining an existing one.

This materially changes the trade-off between the three options.

## Option chosen: narrow Reading 1 to loader positions

Reading 1 now tests the **unchanged** needles at the places a resolver, compiler or classpath turns a spelling into a module:

- the static specifier of a `require` / `import` / `import(...)` / `from '...'`, in JS-family files;
- the body of a ClojureScript ns `:require` / `:require-macros` / `:import` / `:use`;
- the classpath and coordinate keys of an EDN build config (`:source-paths`, `:paths`, `:extra-paths`, `:deps`, `:extra-deps`, `:local/root`, …);
- the linking fields of a package manifest (`dependencies`, `workspaces`, `exports`, `main`, `files`, …). `scripts` is deliberately not among them: a script is a **command line**, and the process it spawns has its own module graph. `npm run test:ssr-node` no more links this package into a client than typing the command into a terminal does.

A format that cannot resolve a module — YAML, shell, Markdown — hosts no loader position and therefore cannot host a hit.

**Why this is not the "broadened pattern" the old note forbade.** It is the same move the file had *already made* one paragraph down, for the same reason. `DOC_EXT` excludes Markdown on the ground that "a Markdown file cannot be required, compiled, or put on a source path" — a statement about what the **format** can do, never about which paths are forgiven. `.yml` and `.sh` cannot be required, compiled or put on a source path either. The old reading carried that category error for every format except the one that forced the issue; this finishes the move rather than starting a new one.

Both prohibitions the old note was guarding are intact:

- **No allowance list.** No file, path or string is named as forgiven. The four wiring files are read exactly as any other file of their format, and would red tomorrow if one of them grew a real edge (demonstrated below).
- **The needles are unchanged by a character.** `PATH_REFERENCE` and `CODE_NAMESPACE` are byte-identical to what they were.

**What did not move.** `CODE_NAMESPACE` (`:rf.ssr-node/…`) keeps the absolute zero over raw text, promoted to its own row. A path is a token that legitimately appears in prose and in commands; the refusal-code namespace is a token only code producing or consuming this service's refusals has any use for, so a client that names it has been changed by this package's existence — which is precisely the claim under test. Measured: it appears in 3 files inside the package and **0** outside.

**A dynamic specifier fails closed.** `require(P)` two lines under `const P = '../ssr-node/src/service.cjs'` is a real module-graph edge that a specifier scan alone would walk past, so any JS file containing a non-literal `require(`/`import(` has *every* string literal in it treated as a candidate specifier. One file in the repo trips this branch — `implementation/freehand/test/re_frame/bench/hicasso/ssr/driver.cjs`, the SSR spike driver whose header the needle comment already discusses — and it stays green because its only spellings are `:hicasso-ssr-node` and `hicasso-ssr-node.js`, compound names the bounded needle correctly refuses.

### Why the other two were rejected

**(1) Pinned exact strings, one per reference.** This is what the file's own note prescribed, and it does not survive the real numbers. 23 pinned lines tracking line-level edits in four files this package does not own means every comment reflow, every renumbered `rf2-` reference and every rewrap in `report-changed-surfaces.sh` reds a suite in a different tree. The note's own justification for pinning — "a pinned string reds on a second reference and reds again if the script value drifts" — is a virtue at n=1 and a defect at n=23, because the signal becomes indistinguishable from noise and people learn to route around the gate. That is the failure the note was written to prevent, arrived at by following the note.

**(2) A pinned path allowance.** Rejected on its merits, not only because the header forbids it. Forgiving `implementation/package.json` wholesale would forgive a real `"dependencies": {"ssr-node": "file:./ssr-node"}` added to the same file — which is exactly the edge Reading 1 exists to catch, and which the both-directions row below plants and requires to be found. A path allowance cannot distinguish the inert line from the fatal one *in the same file*; classifying by construct can, and does.

## Both directions — Reading 1 still fails for the reason it exists

A reading that can no longer fail would be worse than the collision, so this is demonstrated in the real tree, not only in the controls.

**Green with #8042's references present.** With all five of #8042's files overlaid on this branch, `node implementation/ssr-node/test/run.cjs` exits **0**, 8 suites, 85 rows.

**Still red on a real edge.** Two genuine loader edges planted in the repo (a `require('../ssr-node/src/service.cjs')` in a tracked `.cjs` under `implementation/scripts/`, and a `:paths` entry in `tools/story/deps.edn`) — `absence.test.cjs` exits **1**:

```
✖ no loader in a client-building tree can reach this package
  implementation/scripts/__sabotage-6ovv.cjs:3 (/(?<![\w:-])ssr-node(?![\w-])/g)
  tools/story/deps.edn:14                      (/(?<![\w:-])ssr-node(?![\w-])/g)
```

Note that **Reading 2 stayed green** through that run: it pins only `implementation/shadow-cljs.edn` and `implementation/deps.edn`, so the `tools/story/deps.edn` classpath entry was caught by Reading 1 and by nothing else. The narrowed Reading 1 is still carrying load Readings 2 and 3 do not.

**Still red on the namespace.** The refusal-code namespace planted in prose alone — no require, no specifier — reds its own row and only that row:

```
✖ the refusal-code namespace appears nowhere outside the package
  implementation/scripts/__sabotage-6ovv.cjs:4
```

Every plant was removed and the restoration verified by hashing bytes through `git checkout-index` (`git show` bypasses the CRLF smudge filter and reports false differences on Windows). All six touched files hash identical to the index:

```
OK  .github/scripts/report-changed-surfaces.sh          5a88c9c5…
OK  .github/workflows/test.yml                          ddb4c6d3…
OK  implementation/package.json                         3cfdeeac…
OK  implementation/scripts/_changed-surfaces.test.cjs   8bb3db80…
OK  TESTING.md                                          333ef1a9…
OK  tools/story/deps.edn                                217e63ca…
```

### In-suite controls

The file's doctrine is that every check plants its own fault every run, so the narrowing is guarded the same way:

- `CONTROL — every loader position this file knows about finds its planted fault` — ten planted shapes, one per position: `require`, `import … from`, a dynamic `require(P)`, `export … from`, a CLJS ns `:require`, `:source-paths`, an `:mvn/version` coordinate, `:local/root`, `:paths`, and a manifest `dependencies`. A blind spot in any one of them fails this row.
- `CONTROL — a format that cannot resolve a module hosts no loader position` — the *same* `require(…)` text in `.md`, `.yml`, `.sh` and `.cjs`; exactly one hit, and it must be the `.cjs`. This is the narrowing stated as a control.
- `CONTROL — a CI lane naming the package is inert, and IS NOT inert once it links` — both directions inside one row. The four wiring shapes (npm script, workflow job name + run step, shell `case` arm, gate-test path constants) must produce zero hits; the same four files each given a real edge of the kind their format supports must every one be found.

## Files

Only `implementation/ssr-node/test/absence.test.cjs`. **#8042's four wiring files are untouched**, as is `TESTING.md`. No spec change: no new `:rf.ssr-node/*` id is minted, so the sequenced `spec/Conventions.md` lane is not involved.

## Quality gates

| Gate | Command | Exit |
| --- | --- | --- |
| ssr-node suite (final tree) | `node implementation/ssr-node/test/run.cjs` | **0** — 8 suites, 85 rows |
| ssr-node suite, #8042 overlaid | `node implementation/ssr-node/test/run.cjs` | **0** — 8 suites, 85 rows |
| ssr-node suite, pre-change baseline | `node implementation/ssr-node/test/run.cjs` | **0** — 8 suites, 83 rows |
| Reading-1 sabotage (require + `:paths`) | `node implementation/ssr-node/test/absence.test.cjs` | **1** — as required |
| Namespace sabotage (prose only) | `node implementation/ssr-node/test/absence.test.cjs` | **1** — as required |
| JS lint | `npm run lint:js` | **0** |
| JS lint, planted `no-undef` | `npm run lint:js` | **1** — as required |

Every exit code above was captured with `echo $?` on the same command line as the gate, redirected to a per-worktree log; none is the harness's report. The ssr-node runner printed `gate root: …\re-frame2-worktrees\absence-6ovv\implementation\ssr-node` on every run. `lint:js` prints no gate-root line, so it was discriminated by the planted fault instead — it redded on a `no-undef` that exists only in this worktree and named the absolute path under `absence-6ovv`.

Row count moves **83 → 85**: Reading 1's absolute-zero row split into the loader row plus the namespace row (+2), and the three old Reading-1 controls were replaced by three new ones (net 0). The 73 → 83 step was PR #8046's egress suite, already on `main`.

Closes rf2-6ovv.
