### PR TITLE
The no-frame-context diagnostic names the carry repair — an :on-click dispatch is by design, the message was not (rf2-8747)

### DIFF
--- a/docs/core/errors.md
+++ b/docs/core/errors.md
@@ -267,9 +267,9 @@ you'll meet first; the rest read the same way once you have the rhythm.
 
 ### A dispatch with no frame in scope
 
-*You wrote a quick `(rf/dispatch [:cart/add-item {:id 7}])` at the REPL, or in a
-`setTimeout` callback, or in a promise `.then` — and instead of a run you got an
-error.* Nearly everyone trips on this once.
+*You wrote a quick `(rf/dispatch [:cart/add-item {:id 7}])` at the REPL, in a
+`setTimeout` callback, in a promise `.then` — or in a button's `:on-click` — and
+instead of a run you got an error.* Nearly everyone trips on this once.
 
 [`dispatch`](glossary.md#dispatch) and
 [`subscribe`](glossary.md#subscribe--derive) resolve their target
@@ -283,9 +283,18 @@ The fix is always the same: **carry the frame** across the async gap — capture
 `:frame` at fx-handler entry and pass it explicitly on the deferred dispatch
 (`{:frame frame}` in the opts), exactly as [Effects](effects.md) showed.
 `capture-frame` is the same move for app code, and [Frames](frames.md) is the
-pattern's canonical home. In a [view](glossary.md#view) you're already under the
-[frame-provider](glossary.md#frame-provider), so you rarely think about it; at the
-REPL or in a test, `with-frame` / `with-new-frame` pin the scope.
+pattern's canonical home. At the REPL or in a test, `with-frame` /
+`with-new-frame` pin the scope.
+
+Being inside a [view](glossary.md#view) does **not** exempt you, and this is where
+the error is met most often. A view renders under the
+[frame-provider](glossary.md#frame-provider), but its `:on-*` handler runs on a
+fresh stack *after* that render committed — so an `:on-click` is a deferred
+callback like any other, and a fully-qualified `#(rf/dispatch [:cart/add-item])`
+inside one raises. What survives the boundary is the frame captured at render
+time: reach for the `dispatch` / `subscribe` that [`reg-view`](views.md) injects,
+which are exactly that capture. [Views](views.md#the-trap-a-callback-that-fires-after-render-has-no-frame)
+has the WRONG / RIGHT pair.
 
 ### A handler throws
 

--- a/implementation/core/src/re_frame/frame.cljc
+++ b/implementation/core/src/re_frame/frame.cljc
@@ -809,8 +809,23 @@
   never a keyword — `NoFrameContextTags` in spec/Spec-Schemas.md declares the
   slot `:symbol`, and every call site in the corpus emits a quoted symbol.
 
-  `:reason` is always composed, and `:rf.trace/dispatch-id` (the capture-site
-  correlation key) is merged whenever a handler scope is in effect. There is
+  `:reason` is always composed, and names BOTH halves of the repair (rf2-8747).
+  EP-0002 resolves a frame three ways — **scope**, **hold** (carry), and
+  **override** — and the enumerated \"three distinct ways\" cover only scope
+  (1, 2) and override (3). The single most-travelled way to reach this error is
+  a deferred callback — an `:on-click`, a timer, a `.then` — written inside a
+  live scope and run after it unwound, and for that case all three are the wrong
+  advice: the author has not forgotten to establish a scope, they had one and it
+  ended. The composed sentence therefore leads with the **hold** repair (the
+  `reg-view` macro's injected render-time `dispatch` / `subscribe`, or an
+  explicit `(:dispatch (rf/capture-frame))` taken while the scope is live) and
+  keeps the three scope/override ways behind an \"otherwise\". This is prose
+  only: the discriminator is `:rf.error/id` and the machine-readable recovery
+  is `:recovery :supply-frame`, both unchanged — per Spec 009, nothing branches
+  on message bytes.
+
+  `:rf.trace/dispatch-id` (the capture-site correlation key) is merged
+  whenever a handler scope is in effect. There is
   no `:rf.trace/parent-dispatch-id` on this payload: per Spec 009 §Dispatch
   correlation that key is scoped to `:rf.event/dispatched` only, and the
   parent is walked from the dispatch-id through the correlation graph.
@@ -825,7 +840,15 @@
            :recovery    :supply-frame
            :reason      (str "a frame-scoped " (name operation) " ran with no frame "
                              "context — no carried frame stamp and no established "
-                             "scope. Frame identity is carried, not found. Establish a "
+                             "scope. Frame identity is carried, not found. If this fired "
+                             "from an :on-* handler, a timer, a promise or any other "
+                             "deferred callback, the scope it was WRITTEN inside had "
+                             "already unwound by the time it RAN: the repair is to carry "
+                             "the frame across that boundary, not to establish a second "
+                             "scope there. In a view, use the dispatch / subscribe the "
+                             "reg-view macro injects — they are render-time captures; "
+                             "elsewhere hold (:dispatch (rf/capture-frame)) while the "
+                             "scope is still live. Otherwise establish a "
                              "scope one of three distinct ways (do not combine 1 and 2): "
                              "(1) create a frame with rf/make-frame, then scope the "
                              "operation inside it with with-frame or a frame-provider "


### PR DESCRIPTION
Closes `rf2-8747`.

**The API is not the defect, and this PR does not change it.** A qualified `rf/dispatch` from an `:on-click` raising `:rf.error/no-frame-context` is the contract working as designed, it is already pinned as law by a green real-DOM test, and the `reg-view` macro's injected `dispatch` — the fix the reporter named in passing — **already exists** and already works on that exact click path. What was wrong is the sentence the consumer reads at the moment they hit it. That, and one paragraph of `docs/core/errors.md`, is all that changed.

No production behaviour changes. No facade export added, moved or removed — **so there is no export to classify**. No new error id, no new fx, no schema change. `spec/**`, `implementation/shadow-cljs.edn`, `implementation/deps.edn` and `.github/workflows/**` are untouched.

## 1. Reproduced, at the exact error id

`implementation/adapters/reagent/test/re_frame/views_synthetic_event_frame_dom_cljs_test.cljs` (rf2-xzgs3j) already mounts a `reg-view` under a `frame-provider` with two buttons and fires a **real** `.click()` on each. It has pinned both halves of this since it landed. To get the raised id printed verbatim — and to prove the run reached *this* tree rather than a sibling checkout — its expectation was inverted to a keyword that exists nowhere else:

```
FAIL in (synthetic-event-frame-advice-real-dom-proof) (views_synthetic_event_frame_dom_cljs_test.cljs:215:21)
  expected: (= :rf.error/PLANT-8747-expect-me-to-fail (clojure.core/deref raised))
    actual: (not (= :rf.error/PLANT-8747-expect-me-to-fail :rf.error/no-frame-context))
```

Captured exit **`1`**, **exactly 1 failure** out of 1457 tests / 9010 assertions — the planted one. The `actual` side is the reproduction: a real synthetic click on `#(rf/dispatch [:syn/inc])` raised **`:rf.error/no-frame-context`**, quoted by the runner. The plant reached the runtime (the bundle printed a keyword only this tree contains) and the run was this tree's (`shadow-cljs - config: …/clickdispatch-8747/implementation/shadow-cljs.edn`). **The harness reported *"completed (exit code 0)"* for that run; the `.exit` file read `1`.**

The *other* row in the same test — a real click on the injected `#(dispatch [:syn/inc])` — passed in that same planted run. So one click, two spellings, one page: the qualified one raises and the injected one advances `app-db` to `{:n 1}`.

Restored byte-exact: `7dee083ed50178339bb78ea527090502b1b76b4b` → plant `dfeaae1e…` → `7dee083ed50178339bb78ea527090502b1b76b4b`, `git status` clean. The file is **not** in this diff.

## 2. The named fix: exists, and simply was not reached

**Exists.** `implementation/core/src/re_frame/core_reg_view_macro.cljc:186-191` — the macro wraps every view body in

```clojure
(let [handle#    (re-frame.core/make-capture-frame (re-frame.core/current-frame-id) …)
      ~'dispatch  (:dispatch handle#)
      ~'subscribe (:subscribe handle#)]
  ~@body)
```

`current-frame-id` is read **at render**, so the injected `dispatch` is a render-time capture that survives the render boundary. The body is spliced verbatim; nothing is code-walked.

**Why it wasn't reached.** The reporter wrote the confirm dialog on **`reg-view*`** — the plain-fn registration surface (`implementation/core/src/re_frame/core.cljc:737`), for computed ids and Form-3 bodies. It is a function, not a macro; it introduces no lexical bindings and by construction can inject nothing. So the diagnosis is **exists-but-unreached**, and the smaller of the two repairs. The reporter reached the same conclusion before landing: `worker/recipes-hic054`'s shipped `async_nav.cljs` uses the **macro** and unqualified `dispatch`, with a source comment saying why.

## 3. Verdict: by design — and the diagnostic was the defect

**By design**, on four independent witnesses:

- `spec/002-Frames.md` §*Dispatches issued from inside a handler body* — "A bare `(rf/dispatch [:child])` from inside the callback carries no stamp and fails with `:rf.error/no-frame-context` … **the loud failure is the contract working as designed**."
- EP-0002 removed the `:rf/default` floor deliberately; a synthesised frame poisons replay and turns "sole live frame" into a silent semantic change the moment an Xray, Story or SSR frame appears.
- `views-synthetic-event-frame-dom-cljs-test` pins the raise **as expected behaviour**, in the browser lane, with the reagent-slim twin alongside.
- `docs/core/views.md` §*The trap: a callback that fires after render has no frame* already teaches the right spelling, with a WRONG/RIGHT pair and a troubleshooting row.

So no API change, and the honest deliverable would have been a refusal — except for the last question the bead asks: **does the error message teach the right spelling at the moment of failure?** It did not, and the miss is structural rather than stylistic.

EP-0002 resolves a frame **three ways — scope, hold (carry), override**. The composed `:reason` enumerated "three distinct ways": (1) `make-frame` + `with-frame`/`frame-provider`, (2) `frame-root`, (3) explicit `{:frame …}`. Those are **scope, scope, override**. **Hold is absent** — and hold is the only one that repairs the most-travelled case. Worse, for that case the three that *are* named read as *"you forgot to establish a frame"*, which the author did not: they had one, under a provider, and it ended when the render committed. Following (1) or (2) cannot fix a click handler, and (3) asks them to hardcode the frame id the framework's own ergonomics exist to avoid.

`implementation/core/src/re_frame/frame.cljc` — `no-frame-context-payload`'s `:reason` now leads with the hold repair and keeps the existing three behind an *"otherwise"*:

> …Frame identity is carried, not found. **If this fired from an `:on-*` handler, a timer, a promise or any other deferred callback, the scope it was WRITTEN inside had already unwound by the time it RAN: the repair is to carry the frame across that boundary, not to establish a second scope there. In a view, use the dispatch / subscribe the `reg-view` macro injects — they are render-time captures; elsewhere hold `(:dispatch (rf/capture-frame))` while the scope is still live.** Otherwise establish a scope one of three distinct ways (do not combine 1 and 2): (1) … (2) … (3) …

Three things this deliberately does **not** do:

- **No discriminator moves.** `:rf.error/id` and `:recovery :supply-frame` are byte-identical. Per Spec 009 nothing branches on message bytes, and the corpus honours it — `subscribe_opts_arity_cljs_test` says so in as many words ("Branches on the DISCRIMINATOR, never the message bytes"). Nothing in the tree asserts this prose; the sentence exists in exactly one place.
- **No `spec/` row, and none is needed.** `NoFrameContextTags` types the slot `[:reason :string]`. Its adjacent comment describes the sentence as *"the composed `"establish a scope one of three ways"` sentence"* — that phrase is preserved **verbatim**, so the comment stays true. This was a constraint on the wording, not an accident: the new clause is a **carry**, not a fourth *scope*, so the three ways are still three.
- **No new dispatch surface, and no nag.** One conditional clause, on the one error, at the one point where the existing advice sent the reader the wrong way.

## 4. The docs: right on one page, actively misleading on the other

`docs/core/views.md` is good and is untouched. `docs/core/errors.md` §*A dispatch with no frame in scope* was not: it listed the REPL, `setTimeout` and `.then` as where you meet this — **omitting `:on-click`, which is where you actually meet it** — and then closed with

> In a view you're already under the frame-provider, so you rarely think about it

which is precisely the reassurance that fails, inside the section about deferred callbacks. It now names `:on-click` in the opening incident, states plainly that a view does **not** exempt you and that this is where the error is met most often, explains that `:on-*` runs on a fresh stack after the render committed, and links the WRONG/RIGHT pair in `views.md`.

## Quality gates

Each gate redirected to a worktree-named log with `echo $?` captured **on the same command line**, and each run's root line checked against this worktree before its colour was believed. **Every exit code below is read back out of the `.exit` file, never the harness's summary** — which mattered here: the harness reported *"completed (exit code 0)"* for the planted browser run whose captured code was **`1`**.

| Gate | Command | Result | Exit |
|---|---|---|---|
| Browser lane (**decides this**) | `npm run test:browser` | **Ran 1457 tests containing 9010 assertions. 0 failures, 0 errors.** | `0` |
| Node lane (`frame.cljc` compiles here) | `npm run test:cljs` | **Ran 13762 tests containing 69602 assertions. 0 failures, 0 errors.** | `0` |
| Doc slugs (`errors.md` link + anchor) | `python scripts/check_doc_slugs.py` | pass | `0` |
| Browser lane — **planted**, §1 | `npm run test:browser` | 1457 tests / 9010 assertions, **1 failure** (the plant) | `1` |
| Doc slugs — **planted** | `python scripts/check_doc_slugs.py` | `BROKEN ANCHOR: docs\core\errors.md:296 -> views.md#PLANT-8747-no-such-anchor` | `1` |

**Both sabotages are named, because a green sabotage proves nothing.** `check_doc_slugs.py` prints no root banner and passes silently, so it was run against a deliberately broken anchor: it came back **`1`** and quoted the plant by name, which is the only evidence that the green run above read this tree.

**The async-row control comes free.** `rf2-u0j8` — an async row under the wrong fixture can truncate a browser run and read as a pass. The planted and clean browser runs report **identical** counts, 1457 tests / 9010 assertions, differing only in the planted failure. No namespace dropped, and this PR adds no test row at all.

**Not run, deliberately.** `npm run test:hicasso-hmr` binds `:dev-http` 8061 and other workers are live on this machine; nothing in this diff reaches Hicasso. `mkdocs build --strict` does not cover the changed page's neighbours in `docs/design/**`, and `docs/core/errors.md` is validated by the slugs gate above. The JVM tiers are unreached by a `.cljc` docstring/prose edit that changes no shape — the node lane compiles `frame.cljc` and is green.

## Fences

- **Files touched: two.** `implementation/core/src/re_frame/frame.cljc` (the `:reason` sentence + its docstring rationale) and `docs/core/errors.md` (one section).
- **Untouched, per the fence:** the resource/optimistic write path, `implementation/ssr-node/**`, `implementation/package.json`, `.github/workflows/**`, `implementation/routing/test/re_frame/recipes/**`, `docs/EP/**`, `docs/design/hicasso/product/{decision-brief,production-server-arm}.md`, `docs/the-mayor-method/**`.
- **`tools/**` is untouched**, so `tools/xray/spec/*` is unchanged.
- The `reg-view` macro itself needed no change — the injection was already correct.
