### PR TITLE
fix(ssr-node): `undefined` is the whole of the render module's accepted return (rf2-hic-056)

### DIFF
--- a/implementation/ssr-node/README.md
+++ b/implementation/ssr-node/README.md
@@ -102,7 +102,9 @@ There is no member the application's render module fills in, and no
 mechanism by which it could: **`emit` is a render module's only output
 channel**, and a module that returns a value is refused
 (`:rf.ssr-node/render-threw`) rather than having the value quietly
-dropped. `test/egress.test.cjs` is the witness.
+dropped. The accepted set is `{ undefined }` — falling off the end and
+nothing else, `null` included in the refusal. `test/egress.test.cjs` is
+the witness.
 
 That door was not there in the first cut of this package, and how it was
 missing is worth keeping on the record. `worker.cjs` forwarded an
@@ -413,10 +415,13 @@ door rather than fussiness — see
 it is holding and what it cost to find missing. An `async render` that
 falls off its end returns `undefined` and is fine; `return { … }` is a
 module reaching for a second way out, and the refusal says so in as many
-words. Because it can only be discovered *after* the render, a module that
-both emitted and returned produces a **torn** response carrying
-`detail.afterChunks` — the bytes really did leave, and the transport must
-not present them as a page.
+words. **`undefined` is the whole of the accepted set** — `return null` is
+refused too, because falling off the end is what absence looks like here
+and `null` is a value someone typed. The door spared it for one commit, on
+the most likely deliberate return a render module has. Because a return
+can only be discovered *after* the render, a module that both emitted and
+returned produces a **torn** response carrying `detail.afterChunks` — the
+bytes really did leave, and the transport must not present them as a page.
 
 The CLJS half — the thing behind `MY_APP_SSR.renderToString` — is the
 existing Hicasso render entry: a per-request `gensym` frame, `:rf/set-db`
@@ -573,7 +578,7 @@ affect", answers *nothing* for this package's files.
 
 The suite drives the service against reference render modules under
 `test/fixtures/` — well-behaved, mutating, sloppy-mode, hanging, throwing,
-chunking, byte-hostile and leaky — because every guarantee here is a
+chunking, byte-hostile, leaky and null-returning — because every guarantee here is a
 property of the *service*, and a fixture that misbehaves on purpose is the
 only way to see a guard fire.
 
@@ -594,9 +599,10 @@ counter is shown reading 2 before it is trusted reading 1; the byte
 comparison is shown moving under a re-encoding before it is trusted
 agreeing; the runaway render is shown still running after 400 ms before a
 200 ms refusal is called a termination; the egress scan is shown finding a
-planted leak — and the leaky fixture shown really returning one — before
-its zero is believed; and the absence scan is shown
-finding a planted reference before its zero is believed.
+planted leak — and the leaky fixture shown really returning one, and the
+null-returning fixture shown really returning `null` rather than drifting
+into falling off its end — before its zero is believed; and the absence
+scan is shown finding a planted reference before its zero is believed.
 
 ---
 

--- a/implementation/ssr-node/src/protocol.cjs
+++ b/implementation/ssr-node/src/protocol.cjs
@@ -169,12 +169,22 @@ const COMPLETE_FIELDS = Object.freeze(['type', 'chunks', 'renderMs', 'buildId', 
  * shipped for one commit with the returned value forwarded to the caller
  * as `meta`, HTTP happened not to serialise it, and "the current transport
  * drops it" was doing the work a guarantee was supposed to do.
+ *
+ * THE ACCEPTED SET IS `{ undefined }` and nothing else. The door's first
+ * cut spared `null` as well, on the reading that `null` is a kind of
+ * nothing; it is not. Falling off the end of a function produces
+ * `undefined`, so `undefined` is what absence looks like here, while
+ * `return null` is a sentence someone wrote — and it is the likeliest
+ * deliberate return this contract will ever be handed, because it reads
+ * as "nothing to say". A guarantee that admits one value is fail-closed
+ * except, with the exception on the most probable path.
  */
 const MODULE_RETURN_REFUSAL =
   'the render module returned a value. `emit` is its only output channel: this contract ' +
   'carries body markup and nothing else, so a second way out of the isolate is application ' +
   'data crossing a boundary that has no policy for it — the host fork arriving by increments. ' +
-  'Render what the module has to say, and return nothing.';
+  'Falling off the end — `undefined` — is the only accepted return; `null` is a value, not ' +
+  'an absence. Render what the module has to say, and return nothing.';
 
 /**
  * A top-level app-db key, as its EDN text. Keywords in re-frame2 are what

--- a/implementation/ssr-node/src/worker.cjs
+++ b/implementation/ssr-node/src/worker.cjs
@@ -164,10 +164,20 @@ async function render(id, request) {
     // leave, and the alternative is serving a page from a module whose
     // contract this service does not hold.
     //
+    // `undefined` IS THE WHOLE OF THE ACCEPTED SET, and `null` is not in
+    // it. A function that falls off its end returns `undefined`; every
+    // other value arriving here was typed by someone, and `return null`
+    // most of all — it is the spelling a render module reaches for to
+    // mean "nothing to say", which is the sentence `emit` has already
+    // finished. So the one value this door admitted for a commit was the
+    // one most likely to actually arrive. A door with a single exception
+    // is not fail-closed, it is fail-closed EXCEPT, and the exception was
+    // sitting on the most probable path rather than an exotic one.
+    //
     // The refusal names the SHAPE and never the value. A diagnostic that
     // echoed what the module tried to return would be the same egress
     // wearing a different frame type.
-    if (out !== undefined && out !== null) {
+    if (out !== undefined) {
       post({
         t: 'error',
         id,

--- a/implementation/ssr-node/test/egress.test.cjs
+++ b/implementation/ssr-node/test/egress.test.cjs
@@ -36,6 +36,14 @@
 //      dropped — and the refusal does not carry the payload either, which
 //      is the failure a diagnostic-shaped leak would take.
 //
+// Claim 3 is about the ACCEPTED SET as much as about the refusal, and the
+// set is exactly `{ undefined }`. The door shipped reading
+// `out !== undefined && out !== null`, so `return null` — a value someone
+// typed, and the likeliest deliberate return a render module has — went
+// through as a clean success. A guarantee one value short is fail-closed
+// except, so the null rows below are ordinary members of this section
+// rather than an appendix to it.
+//
 // ## EVERY ROW HAS A CONTROL, AND THE CONTROLS ARE ORDINARY ROWS
 //
 // The suite-wide discipline (see the package README) applies here with
@@ -55,6 +63,7 @@ const { withService, collect, refusalOf, post } = require('./_support.cjs');
 const { CODE, COMPLETE_FIELDS, MODULE_RETURN_REFUSAL } = require('../src/protocol.cjs');
 const { serve } = require('../src/http.cjs');
 const LEAKY = require('./fixtures/leaky.cjs');
+const NULL_RETURN = require('./fixtures/null-return.cjs');
 
 // ---------------------------------------------------------------------------
 // The two checkers. Both are ordinary functions so a control can feed them
@@ -286,10 +295,50 @@ test('the refusal does not carry the payload out through the error channel', asy
   });
 });
 
+test('CONTROL — the null fixture really does return null, and not nothing', () => {
+  // In-process, with no service in the way, and for the same reason the
+  // leaky control exists: the row below is only a measurement if the two
+  // values it has to tell apart are genuinely both on the table. `null`
+  // and `undefined` are `==`, so a fixture that had drifted into falling
+  // off its end would look identical from the outside — and would turn
+  // the refusal row into a test of nothing.
+  const emitted = [];
+  const out = NULL_RETURN.render({ entry: 'app/root', state: { ':todos': '[1]' } }, (h) =>
+    emitted.push(h),
+  );
+  assert.strictEqual(emitted.length, 1, 'it emits body markup like any other module');
+  assert.strictEqual(out, null, 'the return really is null…');
+  assert.notStrictEqual(out, undefined, '…and null is not undefined, which is the whole distinction');
+});
+
+test('a module that returns null is REFUSED too — `undefined` is the whole accepted set', async () => {
+  // The door read `out !== undefined && out !== null` for one commit, so
+  // this exact module emitted, returned, and was reported as a clean
+  // success. `undefined` is what falling off the end produces and is
+  // therefore what ABSENCE looks like; `null` is a value someone typed,
+  // and `return null` is the spelling a render module reaches for to mean
+  // "nothing to say". A guarantee that admits one deliberate value is not
+  // fail-closed, and that one value sat on the likeliest path of all.
+  //
+  // Same code, same wording: reaching for a second channel is one offence
+  // and it keeps one refusal.
+  await withService('null-return', { isolates: 1 }, async (service) => {
+    const err = await refusalOf(() =>
+      collect(service, { protocol: 1, entry: 'app/root', state: { ':todos': '[1]' } }),
+    );
+    assert.ok(err, 'returning null must not pass as a clean success');
+    assert.strictEqual(err.code, CODE.RENDER_THREW, 'the existing refusal, not a new member');
+    assert.strictEqual(err.message, MODULE_RETURN_REFUSAL, 'the contract owns the wording');
+    assert.strictEqual(err.detail.afterChunks, 1, 'it emitted first, so the response is torn');
+    assert.strictEqual(err.detail.returned, '[object Null]', 'the SHAPE, for a diagnosis');
+  });
+});
+
 test('a well-behaved module returns nothing, and the service is fine with that', async () => {
-  // The positive half of the door: `undefined` is the contract's answer,
-  // and it must not be coerced into an empty object that then trips the
-  // very check above.
+  // The positive half of the door, and — since the row above closed the
+  // null gap — the ONLY half: `undefined` is the contract's answer, it is
+  // now the entire accepted set, and it must not be coerced into an empty
+  // object that then trips the very check above.
   await withService('reference', { isolates: 1 }, async (service) => {
     const { chunks, complete } = await collect(service, req());
     assert.strictEqual(chunks.length, 1);

--- a/implementation/ssr-node/test/fixtures/null-return.cjs
+++ b/implementation/ssr-node/test/fixtures/null-return.cjs
@@ -1,0 +1,34 @@
+'use strict';
+// THE ONE VALUE THE EGRESS DOOR USED TO ADMIT.
+//
+// It emits perfectly good body markup and then returns `null` — and for
+// one commit that passed as a clean success, because the door read
+// `out !== undefined && out !== null` and `null` fell through the gap
+// between the two clauses.
+//
+// The gap matters more than its width. A function that falls off its end
+// returns `undefined`, so `undefined` is what ABSENCE looks like here;
+// `null` is a value someone typed, and `return null` is the spelling a
+// render module reaches for to mean "nothing to say" — the most likely
+// deliberate return this contract will ever be handed, not an exotic one.
+// The single exception was sitting on the most probable path.
+//
+// It carries no payload at all, and that is deliberate. `leaky.cjs`
+// already proves the door refuses a module that hands over application
+// data; this fixture isolates the OTHER half of the claim — that the
+// refusal is about a module reaching for a second channel, not about what
+// happened to be found on it — so the rows it drives cannot be read as a
+// second run of the leak.
+
+module.exports = {
+  protocol: 1,
+  buildId: 'null-return-build-1',
+  entries: { 'app/root': { stateAllowlist: [':todos'] } },
+
+  render(_call, emit) {
+    emit('<p>null-return</p>');
+    // Written out rather than left implicit, because the whole point is
+    // that this is not the same event as falling off the end.
+    return null;
+  },
+};


### PR DESCRIPTION
Closes the third reopening of **rf2-hic-056**, filed by the merged-PR audit of #8046 — the PR that built the egress door in the first place.

## The finding, verified at source

`implementation/ssr-node/src/worker.cjs` read

```js
if (out !== undefined && out !== null) {   // before
```

so a render module that emitted its markup and then executed an explicit `return null` fell through the gap between the two clauses and was reported as a clean `complete`. The audit's claim held exactly as written.

```js
if (out !== undefined) {                   // after
```

## Why this was worth fixing rather than closing as a nit

The point of #8046 was to make `emit` the **only** channel out of the isolate, fail-closed. A guarantee that admits exactly one value is not fail-closed; it is fail-closed *except*. And the exception was not sitting on an exotic path: falling off the end of a function produces `undefined`, so `undefined` is what absence genuinely looks like here, while `null` is a value someone typed — and `return null` is precisely the spelling a render module reaches for to mean "nothing to say". The single admitted value was the most likely deliberate return the contract will ever be handed.

## No new refusal id

Reaching for a second channel is one offence and keeps one refusal. The null path takes the existing `:rf.ssr-node/render-threw` with the existing `MODULE_RETURN_REFUSAL` message — the same precedent #8046 set when it widened `render-threw` by a clause rather than minting a member. `spec/Conventions.md` is untouched; the `:rf.ssr-node/*` roster is unchanged.

The refusal's wording gained one clause — *"Falling off the end — `undefined` — is the only accepted return; `null` is a value, not an absence"* — because this package's refusals are written to teach rather than merely decline, and this is the exact confusion a reader hitting it will have. The refusal still names the **shape** (`[object Null]`) and never the value; `test/egress.test.cjs`'s existing "the refusal does not carry the payload out through the error channel" row still holds.

## The control is the deliverable

Matching this file's idiom — every claim has a planted-fault control beside it as an ordinary row, never behind a flag — two rows landed:

| Row | What it is |
| --- | --- |
| `CONTROL — the null fixture really does return null, and not nothing` | In-process, no service in the way. `null` and `undefined` are `==`, so a fixture that had drifted into falling off its end would look identical from outside and would turn the row below into a test of nothing. |
| `a module that returns null is REFUSED too — `undefined` is the whole accepted set` | The witness. Same code, same wording, `detail.afterChunks: 1` (it emitted first, so the response is torn), `detail.returned: '[object Null]'`. |

New fixture `implementation/ssr-node/test/fixtures/null-return.cjs`, deliberately carrying **no** payload — `leaky.cjs` already proves the door refuses a module handing over application data; this one isolates the other half of the claim, that the refusal is about reaching for a second channel rather than about what was found on it.

### The null control, run both ways

Predicate reverted to `out !== undefined && out !== null`, `node implementation/ssr-node/test/egress.test.cjs` run in this worktree:

```
✔ CONTROL — the null fixture really does return null, and not nothing (0.3671ms)
✖ a module that returns null is REFUSED too — `undefined` is the whole accepted set (45.0074ms)
  AssertionError: returning null must not pass as a clean success
    actual: null, expected: true
ℹ tests 12  ℹ pass 11  ℹ fail 1        → exit 1
```

The stack frames name this worktree, so the red is this tree's. Predicate restored, and the restore verified by **hashing the bytes** rather than by reading a diff:

```
sha256 before sabotage : 5bb8f1aace13f1626afec12326ff8ce1a2ad5c5608853b897666c16aac20f6d2
sha256 after restore   : 5bb8f1aace13f1626afec12326ff8ce1a2ad5c5608853b897666c16aac20f6d2  (sha256sum -c: OK)
```

## Quality gates

Exit codes captured with `echo $?` on the same command line as the gate, redirected to a per-worktree log — never read off the harness banner.

| Gate | Command | Exit | Notes |
| --- | --- | --- | --- |
| ssr-node suite (baseline, before any edit) | `node implementation/ssr-node/test/run.cjs` | **0** | 8 suites, **83** rows. `gate root:` named this worktree. |
| ssr-node suite (final, post-restore) | `node implementation/ssr-node/test/run.cjs` | **0** | 8 suites, **85** rows. `gate root:` named this worktree. |
| Null control, predicate reverted | `node implementation/ssr-node/test/egress.test.cjs` | **1** | 1 fail — the new witness, and only it. |
| JS lint | `npm run lint:js` | **0** | No banner; eslint installed locally into the worktree's gitignored `/node_modules/` (no junction — see below). |

**83 → 85** is the two new rows in `egress.test.cjs` (10 → 12) and nothing else; the other seven suites are unmoved at 22/7/5/9/15/4/11. #8049 independently takes the baseline to 85 by splitting a row in `absence.test.cjs`; both landed, the total is 87.

## Fence

`implementation/ssr-node/test/absence.test.cjs` is **untouched** — #8049 is open on it. No new refusal id was minted. `spec/*`, `implementation/shadow-cljs.edn`, `implementation/deps.edn` and `.github/workflows/*` are untouched. No `node_modules` junction was created anywhere: the worktree root's `/node_modules/` is a real, gitignored `npm install` of the two lint devDependencies, so nothing points at the mayor checkout's tree.

## Premises that did not hold

None. The audit's claim was accurate in every particular — the predicate, the value that escaped, and the missing witness.
