### PR TITLE
docs(agents): scope the gate-root and BASH_SOURCE claims to the shell gates (rf2-804e)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -52,16 +52,37 @@ sh scripts/remove-worker-worktree.sh <worktree-path>   # POSIX (primary)
 
 ## A Backgrounded Gate Runs by Absolute Path — or in Someone Else's Worktree
 
-Every gate script under `scripts/` derives its repo root from
-`${BASH_SOURCE[0]}`, which is relative when the invocation is — and a
+The shell gates — every `scripts/test-*.sh` — derive their repo root from
+`${BASH_SOURCE[0]}`, which is relative when the invocation is, and a
 `cd <worktree> && sh scripts/…` does not reliably keep that `cd` once
 backgrounded, so the run adopts whatever cwd the shell really has. One did
 exactly that inside *another live worker's* checkout: it took that tree as its
 spine root, its diff root and its classifier input, then reported the resulting
 verdict as its own. A complete, internally consistent run about somebody else's
-work is far harder to catch than a broken one, so every gate prints
-`gate root: <path>` as its first line — check that line against your worktree
-before believing any colour.
+work is far harder to catch than a broken one, so those same gates print
+`gate root: <path>` as their first line, and some node runners emit it too —
+check that line against your worktree before believing any colour. That check,
+not any naming rule, is what has actually caught this class: both 2026-08-12
+scratchpad collisions (next section) were caught by a worker reading
+`gate root:` and finding a sibling's worktree name there.
+
+**Every other gate prints no banner at all** — not one of the
+`scripts/check_*.py` gates, nor their `check-*.sh` siblings, and several print
+nothing whatever on success. Nor do they pin themselves to the script's own
+location the way `${BASH_SOURCE[0]}` does: the Python gates resolve their
+rosters against the **cwd**, so invoking one by absolute path buys no
+protection the `cd` did not already give. There the proof is the same shape
+drawn from a different source — **plant a fault at a line you are already
+editing and run the gate red.** Do not expect the failure to name your
+worktree; `check_doc_slugs.py` reports repo-relative paths, which cannot tell
+two checkouts apart. The discrimination is the red itself: the fault exists
+only in your tree, so a run that had wandered into a sibling's comes back
+**green**, and a green sabotage run is a reason to stop rather than a pass.
+This half is written down because the section used to claim that every gate
+under `scripts/` did both, which is an instruction a worker on a Python gate
+cannot satisfy — two hit it in one day, and one improvised its way to the
+negative control unprompted. So the check is mandatory on every gate run, by
+whichever of the two routes that gate affords.
 
 ## Gate Artefacts Go Where Git Ignores Them
 
@@ -82,9 +103,10 @@ the worktree), so a peer silently overwrites a bare `gate-fastpr.exit`, and the
 loser then reads an exit code belonging to another worker's run: a `0` somebody
 else earned, quoted as its own green. Two of six workers in a single wave
 collided exactly that way. Confirm a scratch file is your own before believing
-it, and check the gate's printed `gate root:` line against your worktree (the
-section above) — that check, not this naming rule, is what caught both
-observed collisions.
+it, and check that the run read *your* worktree — its `gate root:` line where
+the gate prints one, the negative control's red where it does not (the section
+above). That check, not this naming rule, is what caught both observed
+collisions.
 
 A single untracked leftover makes `git worktree remove` refuse the tree from
 then on, and nine worktrees accumulated exactly that way before anyone worked


### PR DESCRIPTION
Closes rf2-804e (reopened by the merged-PR audit of #8047).

## What was wrong

`AGENTS.md` §"A Backgrounded Gate Runs by Absolute Path" made **two** claims about *every gate script under `scripts/`*, and both were false of most of them:

1. **root derivation** — "Every gate script under `scripts/` derives its repo root from `${BASH_SOURCE[0]}`"
2. **the banner** — "every gate prints `gate root: <path>` as its first line"

#8047 fixed the identical drift in `docs/the-mayor-method/dispatch-prompt-template.md` and left it standing here, in what the audit calls the higher-priority live carrier. This is the same rf2-804e drift one carrier over.

## Census, re-run at `origin/main` (af482e567c)

Counts are reported here but deliberately **not** written into the prose — a hard count is what drifted in the first place, so the text states a class.

**Clause 2 — `gate root:` emitters: nine.** Eight shell gates plus one node runner:

```
scripts/test-core-prod-gate.sh          scripts/test-rigorous-local.sh
scripts/test-fast-pr.sh                 scripts/test-routing-prod-gate.sh
scripts/test-freehand-prod-gate.sh      scripts/test-ssr-prod-gate.sh
scripts/test-jvm-implementation.sh      implementation/ssr-node/test/run.cjs:43
scripts/test-jvm-tools.sh
```

That is **unchanged from #8047's re-census of 9** — the node emitter it found had already landed, and nothing has moved since. Zero of the 38 `scripts/check_*.py` emit it; nor do the eight `scripts/check-*.sh` / `install-*.sh` / `assert-*.sh` / `beads-checkpoint.sh` siblings, nor the eight `scripts/*.ps1`.

**Clause 1 — `${BASH_SOURCE[0]}`: eight of the sixteen `scripts/*.sh`** — exactly the same eight `test-*.sh` gates (the only other tracked user under `scripts/` is the fixture `scripts/_test_fixtures/test_fast_pr_docs_gate/run-self-test.sh`, not a gate). The claim is wrong on two independent axes: the other shell gates use `$0` (`check-beads-pr-boundary.sh:75`) or `git rev-parse --show-toplevel` (`check-ai-tracking-ratchet.sh:93`), and Python has no `BASH_SOURCE` at all — `check_doc_slugs.py` / `check_readme_links.py` resolve their rosters **against the cwd**, using `Path(__file__)` only to import a sibling module. So invoking a Python gate by absolute path pins nothing, which is the substantive half the old sentence hid.

## Before / after, per clause

| Clause | Before | After |
|---|---|---|
| `${BASH_SOURCE[0]}` root derivation | "Every gate script under `scripts/`" | "The shell gates — every `scripts/test-*.sh`" — plus an explicit second paragraph: the other gates do not pin to the script's location, and the Python gates resolve against the cwd |
| `gate root:` banner | "every gate prints `gate root: <path>` as its first line" | "those same gates print `gate root: <path>` as their first line, and some node runners emit it too", against "**Every other gate prints no banner at all** — not one of the `scripts/check_*.py` gates, nor their `check-*.sh` siblings" |

The bannerless half now carries the discrimination #8047 established, and specifically **not** the mistake #8047's own first draft made: it does *not* say "read the path the failure reports". `check_doc_slugs.py` and `check_readme_links.py` report **repo-relative** paths, which cannot tell two checkouts apart. The discrimination is *the red itself* — the planted fault exists only in your tree, so a run that wandered into a sibling's comes back **green**, and a green sabotage run is a reason to stop rather than a pass.

One further scoping, in the next section: its cross-reference said "check the gate's printed `gate root:` line", presupposing a banner. It now reads "its `gate root:` line where the gate prints one, the negative control's red where it does not" — same force, no unsatisfiable branch. The account of what caught both 2026-08-12 collisions is unchanged; both were banner gates.

## Sweep — every carrier, and its disposition

`git grep` for both claims across all tracked files:

| Carrier | Claim | Disposition |
|---|---|---|
| `AGENTS.md:55-64` | both | **fixed here** |
| `docs/the-mayor-method/dispatch-prompt-template.md:198-231` | both | **correct as it stands** — #8047's landed text; fenced off by the brief, verified accurate against this census, not touched |
| `implementation/ssr-node/test/run.cjs:43` | emitter, not a claim | not a carrier; counted in the census |
| `.github/scripts/verify-version-lockstep.sh` | uses `BASH_SOURCE`, asserts nothing | not a carrier |
| `.claude/commands/*` | **neither claim present** | the "they cite rather than duplicate" premise **holds** — `git grep "gate root\|BASH_SOURCE" -- .claude/` returns empty |

**No third carrier.** The class does not survive this round.

## Quality gates

`AGENTS.md` is not in the site corpus (`mkdocs.yml` has no entry, no `docs/AGENTS.md`), so `mkdocs build --strict` is not the gate for this change. `check_doc_slugs.py` explicitly excludes repo-root markdown (its own docstring, rf2-znup0) — `check_readme_links.py` is the one that covers it. It was run anyway, as confirmation that nothing else moved.

| Gate | Captured exit |
|---|---|
| `python scripts/check_readme_links.py` (baseline) | **0** |
| `python scripts/check_readme_links.py` (negative control planted) | **1** |
| `python scripts/check_readme_links.py` (after restore) | **0** |
| `python scripts/check_doc_slugs.py` | **0** |

Every number above is the one captured by `echo "$?" > …exit` on the same command line as the redirect, in one shell, into worktree-named artefacts (`gate-links-agents-804e.{log,exit}`, `gate-links-negctl-agents-804e.{log,exit}`, `gate-links-restored-agents-804e.{log,exit}`, `gate-slugs-agents-804e.{log,exit}`) — never a number the harness reported.

### The negative control, and the irony

Every gate this PR could run is **bannerless** — `check_readme_links.py` prints *nothing whatever* on success — so the proof that a gate read my worktree is exactly the thing this PR is documenting: **the red itself**.

A broken relative link was planted at a line this PR edits, inside the new paragraph:

```
BROKEN TARGET: AGENTS.md:77 -> scripts/NO_SUCH_FILE_804e.py
    (missing: scripts\NO_SUCH_FILE_804e.py)
```

Note that the failure names `AGENTS.md:77` — **repo-relative**, naming no checkout. It could be any of the twenty-odd worktrees on this machine. What discriminates is that the fault existed only in *this* tree, so a run that had read a sibling's `AGENTS.md` would have come back green. It came back **1**.

Restore verified by hashing the bytes, not by eye:

```
sha256  599fc8545d989cf04bb0d44d7af039b31b24d01dc1b2be802f7b11f5ec3292cd  AGENTS.md
sha256sum -c  ->  AGENTS.md: OK
```

## Fence

`AGENTS.md` only. `docs/the-mayor-method/dispatch-prompt-template.md` and `.claude/commands/*` deliberately untouched. No hot-zone file touched. No `node_modules` junction created; no scratch residue left in the worktree.

`WORKTREE_ROOT=/c/Users/miket/code/re-frame2-worktrees/agents-804e`
