### PR TITLE
fix(hicasso): scope the navigation example's focus recipe to its own root (rf2-hic-042)

### DIFF
--- a/implementation/hicasso/test/re_frame/hicasso/examples/navigation/conduct_dom_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/examples/navigation/conduct_dom_cljs_test.cljs
@@ -37,6 +37,23 @@
   the positives and fails both of these, and would take a user out of the
   field they are still typing in.
 
+  **Focus, third direction: the SCOPE.** Every row here mounts exactly
+  one application, and on a page with one root a recipe scoped to the
+  document and a recipe scoped to its own root are indistinguishable —
+  which is how the document-wide version survived the audits of #7970 and
+  #8031. So one row,
+  [[a-deep-link-focuses-inside-the-applications-own-root]], mounts a
+  marked DECOY heading ahead of the application and asserts both halves:
+  that `document.querySelector` over the shared marker answers the decoy
+  rather than this application's heading, and that focus lands on this
+  application's heading anyway. Without the decoy the scope would be
+  untested; without the first half the decoy might not be in the way.
+
+  Every focus row reads the application's OWN node — `focused-heading`
+  polls on `identical?` against the heading inside this mount's
+  container, never on *something with the marker has focus*, because the
+  weaker predicate is satisfied by exactly the defect above.
+
   **Scroll.** Positive: a forward navigation lands at the top, and Back
   restores the exact offset the page was left at. Too-eager: a
   navigation carrying `:scroll false` must move nothing, and a Back to a
@@ -129,6 +146,24 @@
 
 (defn- read-sub [m query-v] (rf/subscribe-once query-v {:frame (:frame m)}))
 
+(defn- decoy!
+  "A marked heading belonging to something that is NOT this application —
+  a shell header, a banner, a second root — appended to the document
+  BEFORE the application's own root, so it wins document order.
+
+  This is the near-miss the recipe's `:root` scope exists to close, and
+  it is the control that makes the scope's witness mean anything: with
+  the decoy in front of it, a recipe that resolved its selector against
+  the document would focus the decoy, and the row would go red."
+  []
+  (let [h (.createElement js/document "h2")]
+    (.setAttribute h "data-route-heading" "true")
+    (.setAttribute h "tabindex" "-1")
+    (.setAttribute h "id" "navigation-decoy")
+    (set! (.-textContent h) "A shell heading that belongs to no route")
+    (.appendChild js/document.body h)
+    h))
+
 (defn- at!
   "Mount the application with its first navigation already made — the deep
   link, and the shape every other row starts from."
@@ -139,20 +174,27 @@
                                 [:rf.route/navigate (cond-> {:to route}
                                                       params (assoc :params params))]]})))
 
-(defn- finish [m done]
-  (-> (hm/unmount! m) (hm/assert-clean!) (.then done)))
+(defn- finish
+  "Take the mount down and read it clean — and detach anything the row
+  appended to the page ITSELF, which the facade knows nothing about. A
+  decoy left behind would be in the way of every row that followed."
+  ([m done] (finish m nil done))
+  ([m extra-nodes done]
+   (doseq [n extra-nodes] (try (.remove n) (catch :default _ nil)))
+   (-> (hm/unmount! m) (hm/assert-clean!) (.then done))))
 
 (defn- finish-after
   "End the row when `p` settles, reporting a rejection as a failure rather
   than letting a deadline hang the run — and tearing the mount down
   either way, so a stuck row cannot make the next row's reading wrong."
-  [p m done]
-  (-> p
-      (.catch (fn [e]
-                (is false (str "the flow never settled: "
-                               (or (ex-message e) (str e)) " "
-                               (pr-str (ex-data e))))))
-      (.then (fn [_] (finish m done)))))
+  ([p m done] (finish-after p m nil done))
+  ([p m extra-nodes done]
+   (-> p
+       (.catch (fn [e]
+                 (is false (str "the flow never settled: "
+                                (or (ex-message e) (str e)) " "
+                                (pr-str (ex-data e))))))
+       (.then (fn [_] (finish m extra-nodes done))))))
 
 ;; ---------------------------------------------------------------------------
 ;; Waiting for a frame, and waiting long enough to disbelieve
@@ -176,14 +218,21 @@
   (.then (next-frame) (fn [_] (next-frame))))
 
 (defn- focused-heading
-  "Wait until the route heading holds focus, then answer it. The positive
-  focus rows poll rather than counting frames, because a deadline reports
-  WHICH heading never arrived and a frame count reports only that a line
-  was false."
+  "Wait until THIS APPLICATION'S OWN route heading holds focus, then answer
+  it. The positive focus rows poll rather than counting frames, because a
+  deadline reports WHICH heading never arrived and a frame count reports
+  only that a line was false.
+
+  The predicate is `identical?` against the node inside this mount's
+  container, and deliberately not *the focused element carries the
+  marker*. The marker is a vocabulary, so a shell heading or another
+  root is free to carry it too — and the weaker predicate is satisfied by
+  a recipe that focused somebody else's heading, which is precisely the
+  document-scoped defect the decoy row exists to catch."
   [m label]
   (-> (test-support/poll-until
-        #(let [el (active)]
-           (and (some? el) (.hasAttribute el "data-route-heading")))
+        #(let [h (heading m)]
+           (and (some? h) (identical? h (active))))
         {:label label})
       (.then (fn [_] (heading m)))))
 
@@ -243,6 +292,37 @@
            and `.focus()` is a silent no-op; with 0 the recipe buys itself
            an extra Tab press for every keyboard user on every page"))))
 
+(deftest the-recipe-names-a-root-and-not-the-document
+  (let [fx           (:fx (events/pane-shown {} [::events/pane-shown]))
+        [fx-id args] (first fx)]
+    (testing "`:on-match` asks for exactly one effect, and it is the focus one"
+      (is (= 1 (count fx)))
+      (is (= ::events/focus-heading fx-id)))
+
+    (testing "the effect carries a ROOT scope alongside the selector"
+      (is (= events/root-selector (:root args))
+          "without `:root` the effect resolves its selector against the whole
+           document and focuses the first marked heading on the page, whoever
+           it belongs to — the defect
+           [[a-deep-link-focuses-inside-the-applications-own-root]] mounts a
+           decoy to catch")
+      (is (= events/heading-selector (:selector args))))
+
+    (testing "and the shell RENDERS that root, so the scope names an element
+              rather than nothing"
+      ;; The other half of the same fact, and the half a `:root` key alone
+      ;; cannot state: a recipe scoped to an id no view writes resolves to
+      ;; nil and focuses nothing at all — a no-op that looks exactly like a
+      ;; working recipe on a page where nothing else competes for the marker.
+      (let [tree (ht/tree [views/app {}] {:subs {[:rf.route/id] routes/feed}})
+            root (ht/find tree #(= events/root-id (:id (ht/attrs %))))]
+        (is (some? root)
+            (str "no element in the shell carries the id "
+                 (pr-str events/root-id) " that " (pr-str events/root-selector)
+                 " names"))
+        (is (= :main (:tag root))
+            "and it is the application's own root element")))))
+
 ;; ---------------------------------------------------------------------------
 ;; Focus — the positives
 ;; ---------------------------------------------------------------------------
@@ -265,6 +345,51 @@
                           the landing is not merely somewhere but somewhere
                           identifiable")))
             (finish-after m done))))))
+
+(deftest a-deep-link-focuses-inside-the-applications-own-root
+  (if-not (browser?)
+    (skip! ":node-test has no focus model")
+    (async done
+      ;; The decoy is appended BEFORE the mount, so it precedes the
+      ;; application's container in document order and a document-wide
+      ;; lookup reaches it first. Binding order is the whole mechanism.
+      (let [decoy (decoy!)
+            m     (at! routes/article {:slug (:slug first-article)})]
+        (-> (js/Promise.resolve
+              (testing "the near-miss is LIVE — a document-wide lookup does NOT
+                        answer this application's heading"
+                (is (some? (heading m))
+                    "precondition: the pane rendered a marked heading of its own")
+                (is (some? (.querySelector js/document events/root-selector))
+                    (str "precondition: the shell rendered "
+                         (pr-str events/root-selector) ", the root the recipe
+                         scopes to. A scope that resolves to nothing focuses
+                         nothing, which on a page with no decoy is
+                         indistinguishable from a recipe that works"))
+                (is (not (identical? (heading m)
+                                     (.querySelector js/document events/heading-selector)))
+                    "the decoy precedes the application in document order, so
+                     `document.querySelector` over the shared marker answers
+                     something that is not this application's heading. The
+                     recipe as it stood ran exactly that lookup — and would
+                     still have left `activeElement` on a marked heading, which
+                     is why every assertion below is written against the
+                     application's OWN node rather than against the marker")))
+            (.then (fn [_] (focused-heading m "the deep link's landing focus")))
+            (.then (fn [h]
+                     (is (identical? h (active))
+                         (str "focus is on " (active-label) ", not the article's
+                              own heading"))
+                     (is (not (identical? decoy (active)))
+                         "and NOT on the decoy. The `:root` scope is the only
+                          thing that decides this: drop it from the recipe and
+                          the decoy takes the landing focus of every navigation
+                          in this application")
+                     (is (= (:title first-article) (.-textContent h))
+                         "and the heading names the article that was opened, so
+                          the landing is not merely somewhere but somewhere
+                          identifiable")))
+            (finish-after m [decoy] done))))))
 
 (deftest going-back-lands-focus-on-the-pane-it-returned-to
   (if-not (browser?)

--- a/implementation/hicasso/test/re_frame/hicasso/examples/navigation/events.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/examples/navigation/events.cljs
@@ -37,15 +37,34 @@
     completeness audit's explicit refusals). A view could not run this
     even if it wanted to.
 
-  ## Why the effect waits a frame, which is the only subtle line in it
+  ## Why the effect names a root, which is the line most recipes omit
+
+  An application shares its document. A shell header above the mount, a
+  banner an embedder injected, a second application beside it: any of
+  them may carry the same marker this recipe selects on, and
+  `document.querySelector` answers the FIRST match in document order
+  whoever it belongs to. A page that mounts exactly one application is
+  the one page where that never shows — so the defect is legal, silent,
+  and green under every single-root witness ever written for it.
+
+  So [[pane-shown]] names this application's own root ([[root-selector]],
+  the `<main>` the shell view renders) and [[focus-heading]] resolves the
+  heading INSIDE it. The scope is the correction the merged-PR audits of
+  #7970 and #8031 asked for, and it is load-bearing rather than
+  decorative: the browser witness mounts a marked DECOY heading ahead of
+  the application and asserts both halves — that a document-wide lookup
+  answers the decoy, and that focus lands on this application's own
+  heading anyway.
+
+  ## Why the effect waits a frame, which is the other subtle line in it
 
   `:on-match` dispatches DURING the navigation cascade. The route slice
   has moved, but React has not re-rendered yet, so at the instant the
-  effect runs the heading it wants to focus **does not exist** — and
-  `document.querySelector` would answer nil, and the recipe would be a
-  silent no-op that looked exactly like a working one. One
-  `requestAnimationFrame` is after the commit and after paint, which is
-  the first moment the new pane is on the page.
+  effect runs the heading it wants to focus **does not exist** — the
+  lookup would answer nil, and the recipe would be a silent no-op that
+  looked exactly like a working one. One `requestAnimationFrame` is
+  after the commit and after paint, which is the first moment the new
+  pane is on the page.
 
   It is worth being plain that this ordering is not a Hicasso property:
   it is React's, and any substrate that commits asynchronously has it.
@@ -102,8 +121,30 @@
 ;; The focus-on-route recipe
 ;; ---------------------------------------------------------------------------
 
+(def root-id
+  "The id of this application's own root element — the `<main>` the shell
+  view renders — and the SCOPE the focus recipe resolves its heading
+  inside.
+
+  The application declares its own root rather than borrowing whatever
+  node it happened to be mounted into, because the recipe has to work
+  wherever the application is embedded: a host page's shell, a portal, a
+  second root beside it. See the namespace docstring §Why the effect
+  names a root."
+  "navigation-root")
+
+(def root-selector
+  "[[root-id]] as the selector the effect takes.
+
+  Derived rather than written out a second time. A root the view names
+  and a root the recipe looks for are the two halves of one fact, and two
+  string literals that must agree is the same class of silent near-miss
+  one level up from the one this scope exists to close."
+  (str "#" root-id))
+
 (def heading-selector
-  "The one element per pane that a completed navigation focuses.
+  "The one element per pane that a completed navigation focuses, resolved
+  WITHIN [[root-selector]] and never against the document.
 
   A data attribute rather than an id: the marker says *this is the
   heading the route arrived at*, which is a claim about the pane's role
@@ -111,25 +152,58 @@
   Each pane carries exactly one, and the views put `:tab-index -1` beside
   it so the engine will accept focus on a heading — a heading is not
   natively focusable, and without the tabindex `.focus()` is a no-op that
-  leaves `<body>` holding focus and nothing on screen to say so."
+  leaves `<body>` holding focus and nothing on screen to say so.
+
+  Being a marker rather than an id is also exactly why the root scope is
+  needed: a marker is a vocabulary, so anything else on the page is free
+  to use it, and one that only ever means *this* application's heading is
+  a convention nothing enforces."
   "[data-route-heading]")
+
+(defn pane-shown
+  "The routes' `:on-match` handler, written as a plain fn so a structural
+  witness can read what it returns without a browser.
+
+  It names `:root` beside `:selector`, and that one key is the whole of
+  the scoping: [[focus-heading]] resolves the heading inside this
+  application's own root, so a marked heading belonging to anything else
+  on the page cannot take the landing focus."
+  [_ _]
+  ;; `:fx`, not a top-level effect key: re-frame2's effect map is CLOSED at
+  ;; `{:db … :fx …}`, so a classic `{::focus-heading …}` return is not an
+  ;; effect at all.
+  {:fx [[::focus-heading {:root     root-selector
+                          :selector heading-selector}]]})
 
 (rf/reg-event ::pane-shown
   {:doc "The routes' `:on-match`. A navigation committed, so ask for focus
   to move to whichever pane is now on screen."}
-  ;; `:fx`, not a top-level effect key: re-frame2's effect map is CLOSED at
-  ;; `{:db … :fx …}`, so a classic `{::focus-heading …}` return is not an
-  ;; effect at all.
-  (fn [_ _]
-    {:fx [[::focus-heading {:selector heading-selector}]]}))
+  pane-shown)
 
 (rf/reg-fx ::focus-heading
-  {:doc       "Move focus to the element `:selector` names, on the first
-  frame after the commit that put it there, WITHOUT scrolling. A selector
-  that matches nothing is a no-op — a route whose pane has no heading is
-  an application's choice, not a failure this effect can act on."
+  {:doc       "Move focus to the element `:selector` names WITHIN the element
+  `:root` names, on the first frame after the commit that put it there, and
+  WITHOUT scrolling. Either selector matching nothing is a no-op — a route
+  whose pane has no heading is an application's choice, not a failure this
+  effect can act on.
+
+  Two lines carry the whole recipe.
+
+  `:root` is the scope. Resolving `:selector` against the DOCUMENT takes
+  the first match in document order, which is whichever marked heading the
+  page renders first — a shell heading, a banner, another application's
+  root. That version passes every witness that mounts one application and
+  sends the user somewhere else the moment a second root exists.
+
+  `:preventScroll` is what lets this recipe and scroll restoration COMPOSE.
+  Focusing an element scrolls it into view, and this effect runs one frame
+  AFTER `:rf.nav/scroll` has already restored the offset a Back button
+  asked for — so a plain `.focus()` here silently undoes scroll
+  restoration, on exactly the navigation restoration exists for, and both
+  features look installed the whole time. The two recipes have to be
+  written to compose; this is where they do."
    :platforms #{:client}}
-  (fn [_ {:keys [selector]}]
+  (fn [_ {:keys [root selector]}]
     ;; See the namespace docstring §Why the effect waits a frame. The
     ;; lookup happens INSIDE the callback, not outside it: resolving the
     ;; element now would resolve the OLD pane's heading, which is the
@@ -137,13 +211,6 @@
     ;; the harder one to see.
     (js/requestAnimationFrame
       (fn []
-        ;; `:preventScroll` is not a nicety, and leaving it out is the
-        ;; sharpest bug in this file. Focusing an element scrolls it into
-        ;; view, and this effect runs one frame AFTER `:rf.nav/scroll`
-        ;; has already restored the offset a Back button asked for — so a
-        ;; plain `.focus()` here silently undoes scroll restoration, on
-        ;; exactly the navigation restoration exists for, and both
-        ;; features look installed the whole time. The two recipes have
-        ;; to be written to compose; this is where they do.
-        (some-> (.querySelector js/document selector)
+        (some-> (.querySelector js/document root)
+                (.querySelector selector)
                 (.focus #js {:preventScroll true}))))))

--- a/implementation/hicasso/test/re_frame/hicasso/examples/navigation/events.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/examples/navigation/events.cljs
@@ -47,9 +47,9 @@
   the one page where that never shows — so the defect is legal, silent,
   and green under every single-root witness ever written for it.
 
-  So [[pane-shown]] names this application's own root ([[root-selector]],
-  the `<main>` the shell view renders) and [[focus-heading]] resolves the
-  heading INSIDE it. The scope is the correction the merged-PR audits of
+  So [[::pane-shown]] names this application's own root
+  ([[root-selector]], the `<main>` the shell view renders) and
+  [[::focus-heading]] resolves the heading INSIDE it. The scope is the correction the merged-PR audits of
   #7970 and #8031 asked for, and it is load-bearing rather than
   decorative: the browser witness mounts a marked DECOY heading ahead of
   the application and asserts both halves — that a document-wide lookup
@@ -165,7 +165,7 @@
   witness can read what it returns without a browser.
 
   It names `:root` beside `:selector`, and that one key is the whole of
-  the scoping: [[focus-heading]] resolves the heading inside this
+  the scoping: [[::focus-heading]] resolves the heading inside this
   application's own root, so a marked heading belonging to anything else
   on the page cannot take the landing focus."
   [_ _]

--- a/implementation/hicasso/test/re_frame/hicasso/examples/navigation/views.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/examples/navigation/views.cljs
@@ -18,6 +18,16 @@
   asked for would be a regression to every keyboard user in exchange for
   the same recipe.
 
+  ## Why the shell carries an id
+
+  Because the focus recipe is scoped to it. `events/root-selector` names
+  this element, and the effect resolves `:data-route-heading` INSIDE it
+  rather than over the document — so a marked heading belonging to a
+  shell header, a banner or a second application cannot take the landing
+  focus. Without an id on the root there is nothing for the recipe to
+  scope to, and the document-wide version is green on every page that
+  hosts one application and wrong on the first page that hosts two.
+
   ## Why the shell is four thousand pixels tall
 
   Because scroll restoration is not observable on a page that cannot
@@ -110,10 +120,16 @@
 
 (h/defview app
   "The whole application: whichever pane the route selects, plus the
-  blocked-leave region. See the namespace docstring on the height."
+  blocked-leave region. See the namespace docstring on the height and on
+  the root id.
+
+  The id is `events/root-id` rather than a second literal, because the
+  element the shell names and the element the focus recipe looks for are
+  the two halves of one fact — see `events/root-selector`."
   [_]
   (let [route (h/sub [:rf.route/id])]
-    [:main.navigation {:style {:min-height "4000px"}}
+    [:main.navigation {:id    events/root-id
+                       :style {:min-height "4000px"}}
      [leave-prompt {}]
      (if (= route routes/article)
        [article-page {}]


### PR DESCRIPTION
Reopened by the merged-PR audit of #8031 (rf2-hic-042).

#8031 landed a corrected, root-scoped focus recipe — but only as a **copy**, under `implementation/routing/test/re_frame/routing_conduct_dom_cljs_test.cljs`. The consumer example programmers are meant to copy stayed document-global, so the two disagreed and the wrong one was the one on display.

## The audit's premises, verified at source

Both held at `origin/main`, in `implementation/hicasso/test/re_frame/hicasso/examples/navigation/events.cljs`:

- `::pane-shown` returned `{:fx [[::focus-heading {:selector heading-selector}]]}` — `:selector` and nothing else.
- `::focus-heading` resolved it with `(.querySelector js/document selector)`.

## Before / after, at both sites

| | before | after |
|---|---|---|
| `::pane-shown` fx args | `{:selector "[data-route-heading]"}` | `{:root "#navigation-root" :selector "[data-route-heading]"}` |
| `::focus-heading` lookup | `(.querySelector js/document selector)` | `(.querySelector js/document root)` → `(.querySelector selector)` |

`views/app`'s shell gains `{:id events/root-id}` on its `<main>`, because a `:root` the view never renders resolves to nil and focuses nothing — a no-op indistinguishable from a working recipe on a page where nothing competes for the marker. `root-id` and `root-selector` are one def and its derivation rather than two literals that must agree: a root the view names and a root the recipe looks for drifting apart is the same class of silent near-miss one level up.

The application declares **its own** root rather than borrowing the node it was mounted into — the recipe has to work wherever the application is embedded, and `hm/mount!` mints an anonymous container.

## The decoy is the control

A repair without it just moves the same untested code, so the witness gains #8031's shape:

- `decoy!` appends a marked `<h2 data-route-heading tabindex="-1">` to `document.body` **before** the mount, so it wins document order.
- `a-deep-link-focuses-inside-the-applications-own-root` asserts both halves — that `document.querySelector` over the shared marker answers something that is **not** this application's heading (so the near-miss is live), and that focus lands on the application's own heading anyway.
- `focused-heading` now polls `identical?` against the node inside this mount's container, not *the focused element carries the marker*. The weaker predicate is satisfied by a recipe that focused somebody else's heading — precisely the defect being fixed — so every focus row in the file is now written against the application's own node.
- `the-recipe-names-a-root-and-not-the-document` reads the recipe without a browser (it runs in the node lane too): `pane-shown` is now a plain fn, and the row checks the `:root` key **and** that `views/app` really renders that id.

`finish` / `finish-after` gained an extra-nodes arity so the decoy is detached on both the success and the failure path.

### Red/green demonstration

The scoping was reverted in `::focus-heading` (back to `(.querySelector js/document selector)`) and `npm run test:browser` re-run:

| run | tests | assertions | failures | raw captured exit |
|---|---|---|---|---|
| fix in place | 1469 | 9104 | 0 | `0` |
| scoping reverted | 1469 | **9102** | **1** | `1` |

The single failure is the decoy row and nothing else:

```
FAIL in (a-deep-link-focuses-inside-the-applications-own-root)
the flow never settled: poll-until timed out — the deep link's landing focus
[:rf.error/poll-until-timeout] {... :elapsed-ms 2003 ...}
```

Focus went to the decoy, so the poll for the application's own heading never resolved. Every other row stayed green, which is the point: the decoy row is the only thing in the file that can see this defect. The two missing assertions are the two that follow the poll.

The plant was then reverted and the restore verified by hashing the bytes — `sha256 563118f6482a52c8e445e9a926e80f46a7b2046ba7338e77c88b17b8e7d54692` before and after, and `git status` clean.

## Scope

`implementation/routing/test/re_frame/routing_conduct_dom_cljs_test.cljs` — #8031's landed file — is **not touched**; it is correct and merged. The diff is three files, all under `implementation/hicasso/test/re_frame/hicasso/examples/navigation/`. No spec, no workflow, no `deps.edn`, no `shadow-cljs.edn`, no `.beads`.

## Quality gates

Run from `implementation/` in `re-frame2-worktrees/navscope-hic042` (both logs open with a `gate cwd:` line naming that worktree; neither npm script prints `gate root:`, so the sabotage red above is the discriminator — a run that had wandered into a sibling checkout would have come back green).

| gate | tests | assertions | failures / errors | raw captured exit |
|---|---|---|---|---|
| `npm run test:cljs` | 13808 | 69824 | 0 / 0 | `0` |
| `npm run test:browser` | 1469 | 9104 | 0 / 0 | `0` |
| `npm run test:browser` (sabotage control) | 1469 | 9102 | 1 / 0 | `1` |

Exit codes are the values captured with `echo $?` into a per-worktree `.exit` file, not the harness's report — the harness reported the sabotage run as "exit code 0" while the captured status was `1`.

Both gates ran on base `d4df2e2b05`; the branch was then rebased onto `origin/main`, whose intervening commits touch `.beads`, docs, `ssr-node/`, CI wiring, and one `frame.cljc` diagnostic message — nothing on this diff's surface.

`test:cljs` is included because the new structural row runs in the node lane. `test:hicasso-hmr` was not run (machine-exclusive port 8061).

Closes rf2-hic-042.
