### PR TITLE
docs(hicasso): retire two stale contract carriers the last two audits found (rf2-l50z, rf2-k1mp)

### DIFF
--- a/docs/design/hicasso/studio/reads-per-boundary-heap-ladder.md
+++ b/docs/design/hicasso/studio/reads-per-boundary-heap-ladder.md
@@ -2715,10 +2715,14 @@ it in *both* segments; it shows in one, to the byte, while the UIx segment
 reproduces `2,115` exactly and its ratio moves from `0.7099×` to `0.7098×`.
 Naming a cause would take ablations this window is not permitted to run — its
 terms are one invocation, and an instrument iterated until it explains itself is
-no longer the instrument the figures were taken on. **`rf2-hic-018` owns the
-attribution, and it now has the same-instrument package baseline that makes an
-attribution possible at all**, which is precisely what this bead existed to
-supply.
+no longer the instrument the figures were taken on. Supplying the
+same-instrument package baseline that makes an attribution possible at all is
+precisely what this bead existed to do, and the attribution was taken on that
+baseline the next day:
+[the `+139 B/read` subsection below](#the-139-bread-attributed-to-one-line-and-the-premise-it-had-to-correct-first-rf2-l50z)
+prices the whole move to a single ratom-only correctness line in `wire-cell!`.
+**No figure moves** — S3 remains `1,417 B/read`, because the attribution names
+what that cost buys rather than removing it.
 
 What it does to the candidate's standing, stated plainly:
 

--- a/implementation/hicasso/src/re_frame/hicasso/impl/mount.cljs
+++ b/implementation/hicasso/src/re_frame/hicasso/impl/mount.cljs
@@ -157,13 +157,19 @@
 ;; this arm. The only thing missing was a way to say the word through
 ;; these doors, and until rf2-hic-046 there was none.
 ;;
-;; **The server half is React's too, and it needs no door here.** A
-;; consumer server-renders through `react-dom/server` itself —
+;; **The PREFIX's server half is React's too, and it needs no door
+;; here.** A consumer server-renders through `react-dom/server` itself —
 ;; `renderToString(element, #js {"identifierPrefix" "a-"})` — which per
 ;; rf2-ggnp's census, re-run, is the only server path this package has.
 ;; So the two sides already meet in React's own vocabulary and what
 ;; matters is that the caller hands BOTH of them the same string.
 ;; Agreement is the contract; presence on one side proves nothing.
+;;
+;; **That settles the prefix and not the pair**, and the difference is
+;; the whole of why no hydrating door is public. `useId` derives from
+;; tree POSITION as well as from the prefix, and a hydrating root's tree
+;; is not the app subtree. [[hydrate-root!]] carries the measurement and
+;; the consequence.
 
 (defn- root-options
   "React's `react-dom/client` root options object, or nil when there is
@@ -404,12 +410,39 @@
   one) resolves every id in the tree differently from the bytes it is
   adopting; React sees the divergence as a mismatch and recovers by
   replacing the subtree, which is a correct repair of a page that should
-  never have shipped. The server side of the pair is React's own
-  `react-dom/server` option and needs nothing from this arm — see the
-  [[root-options]] section comment.
+  never have shipped.
 
   Name neither and [[hydrate-root-options]] answers nil in production, so
   this call is the bare two-argument one it always was.
+
+  ## Matching the prefix is NECESSARY and it is not SUFFICIENT
+
+  The prefix half of the pair does meet in React's own vocabulary, and
+  needs nothing from this arm: a consumer names `identifierPrefix` on
+  `react-dom/server`'s own render and the same string here — the
+  [[root-options]] section comment is where that is set out.
+
+  **Matching root STRUCTURE is the other half, and today nothing on this
+  arm produces it** (`dispositions.md` HS-11, obstruction 2, MEASURED;
+  obstruction 1 was the prefix and rf2-hic-046 cleared it). React derives
+  a `useId` from tree POSITION as well as from the prefix, and a
+  hydrating root's tree is NOT the app subtree: [[tree]] wraps it in a
+  Fragment whose first child is [[adoption-window-closer]], with the
+  adoption-window provider around the app. The only server path this
+  package has — a hand-rolled `renderToString`, rf2-ggnp's census —
+  emits no counterpart to that fork, so bytes a consumer can bake today
+  hydrate into a text mismatch whose two ids agree on the prefix and
+  differ after it. The same fork is where `:adoption` comes from, and the
+  provider presence reads to start an adopted child `:present` rather
+  than `:mounting` has no server counterpart either.
+
+  **So this door is built and witnessed but NOT on the
+  `re-frame.hicasso` facade** (rf2-k1mp), and the section comment there
+  is the roster's own record of the absence. HS-11 names two candidate
+  repairs — a matching server-render entry of this arm's own, or making
+  the closer a wrapper rather than a sibling — and rules on neither.
+  Until one lands, a caller reaching in here is hydrating against bytes
+  no door in this package emits.
 
   ## The handle carries `:adoption` — this root's OWN window (rf2-6tmu)
 


### PR DESCRIPTION
Closes rf2-l50z. Closes rf2-k1mp.

Two merged-PR audits, one branch, a commit each. Both are stale-contract repairs:
in each case the PR that shipped left one document still stating, as the operative
position, something a later record settled the other way.

## rf2-l50z — the ladder's stale attribution ownership (audit of #8039)

`docs/design/hicasso/studio/reads-per-boundary-heap-ladder.md:2718-2721` closed the
`rf2-fe0l` package section with a **present-tense** ownership claim:

> **`rf2-hic-018` owns the attribution, and it now has the same-instrument package
> baseline that makes an attribution possible at all**, which is precisely what this
> bead existed to supply.

The same page, ~180 lines later, records `rf2-l50z` having *completed* the A-B-A
attribution. So a reader met the ownership as live before reaching the section that
discharges it.

**What survives, deliberately.** The preceding sentence — *"The mechanism is not
attributed here, and the asymmetry is why"* — is a legitimate historical statement
about what this measurement window did and did not do, and it is untouched, as is
the whole asymmetry paragraph that follows it. So is the record that supplying the
same-instrument baseline is what the section existed to do; only the *ownership*
clause was stale, not the account of what the bead delivered.

**After:**

> … no longer the instrument the figures were taken on. Supplying the
> same-instrument package baseline that makes an attribution possible at all is
> precisely what this bead existed to do, and the attribution was taken on that
> baseline the next day: [the `+139 B/read` subsection below](…) prices the whole
> move to a single ratom-only correctness line in `wire-cell!`. **No figure
> moves** — S3 remains `1,417 B/read`, because the attribution names what that cost
> buys rather than removing it.

**No measurement re-run and no figure moved.** S3 stays `1,417 B/read`; the ratio
table, the band table and every conditions block are untouched (the diff is 8
insertions / 4 deletions in one paragraph, tables not among them). The forward
pointer is an in-page anchor to the settled subsection, validated by
`check_doc_slugs.py` — and the negative control below proves that validation ran.

Two other mentions of `rf2-hic-018` on this page (`:2594`, `:2754`) were read and
left alone: both are about that bead's *future collector work*, not about who owns
the attribution, and neither is stale.

## rf2-k1mp — the implementation said the opposite of the facade (audit of #8033)

#8033 closed this bead as a **REFUSAL** and recorded on the facade why the hydrating
door is not exported: HS-11's obstruction 2 is measured, and it is not the prefix.
That verdict stands here — nothing is exported, no server-render entry is built, and
the wrapper is not redesigned.

But `impl.mount/hydrate-root!` still told its own reader the opposite:

> The server side of the pair is React's own `react-dom/server` option and needs
> nothing from this arm — see the [[root-options]] section comment.

That asserts precisely the no-Hicasso-counterpart posture HS-11 disproved. And the
section comment it defers to carried the same claim in stronger form — *"**The
server half is React's too, and it needs no door here.** … Agreement is the
contract; presence on one side proves nothing"* — so repairing only the docstring
would have relocated the contradiction rather than removed it. Both are in this
bead's fenced file and both are corrected; nothing else is touched.

**The correction, taking #8033's facade comment as the source of truth** (read
first, matched rather than re-derived — it is *not* edited here). The two necessary
conditions the old text ran together are now separated:

- **Matching `identifierPrefix` — necessary, and needs nothing from this arm.** A
  consumer names it on `react-dom/server`'s own render and hands this door the same
  string. This half of the old sentence was true and is kept.
- **Matching root STRUCTURE — also necessary, and nothing this package ships
  produces it.** `tree` wraps a hydrating root's app subtree in a Fragment whose
  first child is `adoption-window-closer`, with the adoption-window provider around
  the app. React derives a `useId` from tree *position* as well as from the prefix,
  so bytes baked through the package's only server path (a hand-rolled
  `renderToString`, rf2-ggnp's census) hydrate into a text mismatch whose two ids
  agree on the prefix and differ after it. The same fork is where `:adoption` comes
  from, so the provider presence reads — to start an adopted child `:present` rather
  than `:mounting` — has no server counterpart either.

The docstring now closes with the consequence, where a reader of the implementation
meets it: the door is built and witnessed but **not on the `re-frame.hicasso`
facade** (rf2-k1mp), and HS-11's two candidate repairs — a matching server-render
entry, or making the closer a wrapper rather than a sibling — are both unruled.

Docstring and comment only: no behaviour change, no new export, no `spec/` row owed.

## Premises checked

Both audits' premises held at source. The `rf2-hic-018` sentence was present-tense at
`:2718-2721`; the `react-dom/server` sentence was present in `hydrate-root!`. One
addition to the second audit's account: the stale claim had **two** carriers in that
file, not one — the docstring the audit names, and the `root-options` section comment
it points at, which states it more strongly. Both are inside the bead's fence.

## Quality gates

Run from `C:\Users\miket\code\re-frame2-worktrees\tense-cluster` (`WORKTREE_ROOT`
printed by `scripts/assert-worker-worktree.sh`:
`/c/Users/miket/code/re-frame2-worktrees/tense-cluster`). Every exit code below is
the one captured with `echo $?` on the gate's own command line and read back from a
worktree-named `.exit` file — never the harness's report.

| Gate | Raw exit code | Notes |
|---|---|---|
| `python scripts/check_doc_slugs.py` | `0` | bead 1; validates the new in-page anchor |
| `python scripts/check_provenance_pins.py --changed-since origin/main --verbose` | `0` | bead 1; 1 file, 69 cited pins, 0 unresolvable |
| `python scripts/check_retired_spellings.py` | `0` | not nominated; run because both commits add prose |
| `npm run test:hicasso-invariants` | `0` | bead 2; freeze, optional-module reachability, complaint catalogue (74 live), budget ledger (38 rows) |
| `npm run test:cljs` | `0` | bead 2; 13806 tests, 69817 assertions, **0 failures, 0 errors**; `config:` line named this worktree |

`mkdocs build --strict` is **not** nominated: `mkdocs.yml`'s `exclude_docs` keeps
`docs/design/**` out of the site, so it would have verified nothing about bead 1's
file. Anchors and table column counts were checked by hand instead — the edit adds
one anchor (independently proven live by the negative control) and touches no table
row.

`npm run test:hicasso-hmr` was **not** run: it binds `:dev-http` 8061 and peer
workers are live on this machine. The change cannot move HMR behaviour.

### Negative control (bead 1)

`check_doc_slugs.py` was proven to be reading this worktree by planting a fault at a
line this PR edits — the new anchor replaced with `#NEGATIVE-CONTROL-not-a-real-slug-rf2-l50z`:

```
1 broken anchor link(s) found:
  BROKEN ANCHOR: docs\design\hicasso\studio\reads-per-boundary-heap-ladder.md:2722
      -> #NEGATIVE-CONTROL-not-a-real-slug-rf2-l50z
```

Raw exit **1**. The planted fault exists only in this tree, so the red is itself the
proof the gate ran here (this gate prints no `gate root:` banner and reports
repo-relative). Restored, and the restore verified by **hashing the bytes** rather
than by reading the diff: `sha256` before sabotage and after restore are identical —
`3153212d50f9b177affd88a246a0412757afb810046bd7c96ba816ddc8839644`.

### Negative control (bead 2)

Same treatment for `npm run test:cljs`, planted at a line this PR's docstring adds —
one unescaped `"` inside the new section. Raw exit **1**, and this gate's failure
path does name the tree:

```
------ ERROR ------
 File: C:\Users\miket\code\re-frame2-worktrees\tense-cluster\implementation\hicasso\src\re_frame\hicasso\impl\mount.cljs:429:48
 re_frame/hicasso/impl/mount.cljs [line 429, col 48] Invalid symbol: subtree:.
```

Restored, and the restore verified by hashing the bytes: `sha256` of
`impl/mount.cljs` after restore equals the hash taken before the sabotage —
`a83eb7e7a4b5318d5c78782be874a1c564520fca3570ea106e3f7c1af61481cb` — and
`git status --porcelain` is empty against the committed version.

### One gate-hygiene note, because it produced a false red

An earlier foreground attempt at `npm run test:cljs` hit the harness's 10-minute
ceiling. The shell was killed; the `node out/node-test.js` child was **not**, and it
ran to completion as an orphan, reporting `2 failures, 0 errors` while still writing
into the redirected log at its own file offset. That left a log with a NUL hole in it
and two summaries — one from the orphan, one from the real run — which is exactly the
shape that would let a worker quote a failure count belonging to a killed process.
The captured exit code (`0`, written by this worker's own shell to a worktree-named
`.exit` file) is what is reported above; the orphan's `2 failures` is an artefact of
the kill and reproduced in neither the clean run nor CI. Long gates here are run
detached rather than foreground for this reason.

The `node_modules` junction this worktree created for the npm gates was removed (the
link only, never its target) before reporting done.
