### PR TITLE
fix(ci): make a failed Playwright browser install say that no gate ran (rf2-swos)

### DIFF
--- a/.github/scripts/playwright-install-failed.sh
+++ b/.github/scripts/playwright-install-failed.sh
@@ -1,0 +1,109 @@
+#!/usr/bin/env bash
+#
+# The failure branch of every `npx playwright install` step in CI (rf2-swos).
+#
+# # What this is for
+#
+# Twenty-one CI steps provision browsers with `npx playwright install
+# --with-deps <browsers>`. When that fails the job dies with a bare
+#
+#     ##[error]Process completed with exit code 1
+#
+# which, at the checks rollup, is INDISTINGUISHABLE from the gate the job
+# exists to run having failed. Measured 2026-08-12 on PR #8055, job
+# 94299983393: the diff under test was a corpus fix and a docstring
+# correction, no test ran, and establishing that cost a diagnosis cycle
+# reading the raw log. That is the cost rf2-swos was filed against, and it is
+# the same cost rf2-xsfr (#8030) and rf2-gfvy (#8036) deleted at the Clojure
+# CLI, clj-kondo and Babashka installs. This is the same remedy at the fourth
+# site: on failure the step now says, on the checks page, that no gate ran.
+#
+# Every call site is one line:
+#
+#     - name: Install Playwright (Chromium + system deps)
+#       run: npx playwright install --with-deps chromium || "$GITHUB_WORKSPACE/.github/scripts/playwright-install-failed.sh"
+#
+# Use the $GITHUB_WORKSPACE-absolute form, not a relative path: several jobs
+# set a `defaults.run.working-directory` (e.g. `implementation`), under which
+# `./.github/scripts/...` would not resolve. Keep the `||` on the SAME logical
+# line as the `npx` — `scripts/check_fast_pr_gap.py` classifies a step as
+# toolchain setup only when EVERY logical line of the body matches one of its
+# `SETUP_PATTERNS`, and the pattern that covers these steps is
+# `^npx playwright install\b`. A separate `echo` line, or a `for` loop, would
+# drop the body out of that set and make the gap map report the job as an
+# UNRUN GATE — a fail-open in the very map the merge criterion consults.
+# Appending `|| <script>` behind the existing command keeps the logical line
+# starting with `npx playwright install`, so nothing reclassifies. It is also
+# what keeps the literal `playwright install --with-deps <browsers>` text that
+# `implementation/scripts/_changed-surfaces.test.cjs` and
+# `tools/template/test/day8/re_frame2_template/release_gate_test.clj` assert
+# on intact, so this change needs no edit outside `.github/`.
+#
+# # Why there is no retry loop here — the siblings have one and this does not
+#
+# The bead's premise was that Playwright's browser fetch "has no retry
+# envelope". Read at source, it has one: `playwright-core`'s
+# `lib/server/registry/browserFetcher.js` runs `const retryCount = 5` and
+# loops `for (let attempt = 1; attempt <= retryCount; ++attempt)`. So the
+# (a)-half of the sibling remedy — widen a too-narrow envelope — is already
+# half-present, and the two failures actually measured are not failures a
+# wider envelope would have caught:
+#
+#   * 2026-08-12, job 94299983393 — five attempts in 3.85 seconds, every one
+#     answered `403 AccessDenied` with the body "We're sorry, but this service
+#     is not available in your location". `https://cdn.playwright.dev/builds/
+#     cft/<ver>/linux64/chrome-linux64.zip` is a 307 REDIRECTOR to
+#     `https://storage.googleapis.com/chrome-for-testing-public/...` (verified
+#     by request), so that 403 is Google Cloud Storage denying the runner's
+#     egress IP by region. The IP does not change for the life of a job, so
+#     retrying it — for four seconds or for seven minutes — asks the same
+#     bucket the same question from the same address. What clears it is a
+#     re-run, which lands on a different runner. A jittered backoff loop would
+#     have converted a 4-second red into a 7-minute red and changed nothing
+#     else.
+#
+#   * 2026-08-11, job 93920468065 — `##[error]The action 'Install Playwright
+#     (Chromium + system deps)' has timed out after 5 minutes`, spent entirely
+#     inside the `--with-deps` apt hop fetching 21MB of fonts from
+#     azure.archive.ubuntu.com. The browser download was never reached. Three
+#     of the twenty-one sites carry `timeout-minutes: 5`; an envelope wider
+#     than that cap cannot finish, and a step the runner guillotines never
+#     prints its annotation at all. There, a wider loop is not merely useless
+#     but actively worse than what it replaces.
+#
+# Playwright's own knobs were preferred to hand-rolling, per the brief, and
+# both were checked at source and rejected on measurement, not on taste:
+#
+#   * MIRROR ROTATION. `registry/index.js` normally hands the fetcher three
+#     hosts (`PLAYWRIGHT_CDN_MIRRORS`) and the retry loop rotates them,
+#     `downloadURLs[(attempt - 1) % downloadURLs.length]`. Chromium is the
+#     exception: `cftUrl()` overrides `mirrors` to the single element
+#     `["https://cdn.playwright.dev"]`, which is why all five attempts in the
+#     measured failure hit one URL. Firefox and WebKit keep the rotation.
+#
+#   * `PLAYWRIGHT_CHROMIUM_DOWNLOAD_HOST` / `PLAYWRIGHT_DOWNLOAD_HOST`. The
+#     knob REPLACES the mirror list with one host, and the only other host in
+#     Playwright's own list answers `400` for the Chrome-for-Testing path
+#     (`https://playwright.download.prss.microsoft.com/dbazure/download/
+#     playwright/builds/cft/<ver>/linux64/chrome-linux64.zip`, verified by
+#     request): the ESRP CDN does not carry CfT builds. Nor can the knob be
+#     pointed at the Google bucket directly, because it is prepended to the
+#     path `builds/cft/<ver>/...`, a layout only Playwright's own redirector
+#     understands. There is no working alternative value, so the knob is not
+#     set.
+#
+# So this file ships the (c)-half of the sibling remedy and refuses the
+# (a)-half, on the evidence. If a transient 5xx or ECONNRESET is ever measured
+# at this site — as it was at the other three on 2026-08-13 — Playwright's own
+# five attempts are the thing to widen, and an outer loop belongs here then,
+# sized under the tightest `timeout-minutes` of its call sites.
+#
+# Exit status stays a plain 1, as in `install-clojure-cli.sh` and
+# `resolve-clojure-deps.sh`: the annotation is the machine-readable carrier
+# the checks API exposes, and a bespoke code would be a second convention with
+# no consumer.
+#
+set -euo pipefail
+
+echo "::error title=Playwright browser install failed — CI infrastructure — not this diff::NO GATE RAN IN THIS JOB. This step provisions the browser, so the step that would have tested this change never started and this red says nothing whatever about the diff. Playwright already retries the download five times internally (playwright-core browserFetcher.js), so the remedy is a re-run, which lands on a different runner. Two modes have been measured (rf2-swos): a Google Cloud Storage 403 'this service is not available in your location' on the Chrome-for-Testing bucket that cdn.playwright.dev redirects to, which is scoped to this runner's egress IP; and a slow azure.archive.ubuntu.com apt hop under --with-deps. Neither is affected by anything in this PR UNLESS it changes the Playwright pin in implementation/package-lock.json or edits .github/scripts/playwright-install-failed.sh, in which case read those first."
+exit 1

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -295,7 +295,7 @@ jobs:
       - name: Install Playwright (Chromium + system deps)
         if: github.event_name != 'pull_request'
         working-directory: docs/tools/playground
-        run: npx playwright install --with-deps chromium
+        run: npx playwright install --with-deps chromium || "$GITHUB_WORKSPACE/.github/scripts/playwright-install-failed.sh"
 
       - name: Smoke the built bundles under headless Chromium
         if: github.event_name != 'pull_request'

--- a/.github/workflows/expensive-tests.yml
+++ b/.github/workflows/expensive-tests.yml
@@ -68,7 +68,7 @@ jobs:
         run: npm run test:examples-compile
 
       - name: Install Playwright (Chromium + system deps)
-        run: npx playwright install --with-deps chromium
+        run: npx playwright install --with-deps chromium || "$GITHUB_WORKSPACE/.github/scripts/playwright-install-failed.sh"
 
       # rf2-wh5to — the eleven gates below used to be ONE unnamed
       # `set -euo pipefail` step. That structure is why the
@@ -261,7 +261,7 @@ jobs:
       # libraries and nothing earlier in this job installs them.
       - name: Install Playwright chromium (for the emitted browser proofs)
         working-directory: implementation
-        run: npx playwright install --with-deps chromium
+        run: npx playwright install --with-deps chromium || "$GITHUB_WORKSPACE/.github/scripts/playwright-install-failed.sh"
 
       - name: Run template emitted-app smoke
         env:
@@ -336,7 +336,7 @@ jobs:
 
       - name: Install Playwright chromium (for hermetic browser preload)
         working-directory: implementation
-        run: npx playwright install --with-deps chromium
+        run: npx playwright install --with-deps chromium || "$GITHUB_WORKSPACE/.github/scripts/playwright-install-failed.sh"
 
       - name: Run re-frame2-pair live conformance suite (hermetic)
         run: npm run test:re-frame2-pair-live-hermetic-suite

--- a/.github/workflows/freehand-bench.yml
+++ b/.github/workflows/freehand-bench.yml
@@ -418,7 +418,7 @@ jobs:
             ${{ runner.os }}-playwright-
 
       - name: Install Playwright (Chromium + system deps)
-        run: npx playwright install --with-deps chromium
+        run: npx playwright install --with-deps chromium || "$GITHUB_WORKSPACE/.github/scripts/playwright-install-failed.sh"
 
       # The buffered console arrives on stderr; stdout carries the runner's
       # one-line summary. The log is kept whatever the exit code, so a red

--- a/.github/workflows/template-release.yml
+++ b/.github/workflows/template-release.yml
@@ -201,7 +201,7 @@ jobs:
       # none of Chromium's shared libraries.
       - name: Install Playwright chromium (for the emitted browser proofs)
         working-directory: implementation
-        run: npx playwright install --with-deps chromium
+        run: npx playwright install --with-deps chromium || "$GITHUB_WORKSPACE/.github/scripts/playwright-install-failed.sh"
 
       # rf2-ek857f F1 — RF2_TEMPLATE_RUN_EMITTED_TESTS=1 flips the
       # behavioural emitted-app tier ON (default-off for the local fast

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1319,7 +1319,7 @@ jobs:
         run: npm ci
 
       - name: Install pinned Chromium
-        run: npx playwright install --with-deps chromium
+        run: npx playwright install --with-deps chromium || "$GITHUB_WORKSPACE/.github/scripts/playwright-install-failed.sh"
 
       - name: G-13 exact push-economics and advanced-elision gate
         run: npm run test:ui-g13
@@ -1391,7 +1391,7 @@ jobs:
             ${{ runner.os }}-playwright-
 
       - name: Install pinned Chromium + WebKit
-        run: npx playwright install --with-deps chromium webkit
+        run: npx playwright install --with-deps chromium webkit || "$GITHUB_WORKSPACE/.github/scripts/playwright-install-failed.sh"
 
       - name: G-8 controlled-input correctness gate (Chromium + WebKit)
         run: npm run test:ui-g8
@@ -1493,7 +1493,7 @@ jobs:
       # Do not move this step out of `implementation`, and do not reorder it
       # before `npm ci`.
       - name: Install pinned Chromium + Firefox + WebKit
-        run: npx playwright install --with-deps chromium firefox webkit
+        run: npx playwright install --with-deps chromium firefox webkit || "$GITHUB_WORKSPACE/.github/scripts/playwright-install-failed.sh"
 
       - name: I15 three-engine controlled-input gate
         run: npm run test:hicasso-controlled
@@ -1603,7 +1603,7 @@ jobs:
       # this step out of `implementation`, and do not reorder it before
       # `npm ci`.
       - name: Install pinned Chromium + Firefox + WebKit
-        run: npx playwright install --with-deps chromium firefox webkit
+        run: npx playwright install --with-deps chromium firefox webkit || "$GITHUB_WORKSPACE/.github/scripts/playwright-install-failed.sh"
 
       - name: HMR contract gate — 36 real shadow reloads in three engines
         run: npm run test:hicasso-hmr
@@ -3179,7 +3179,7 @@ jobs:
             ${{ runner.os }}-playwright-
 
       - name: Install Playwright (Chromium + system deps)
-        run: npx playwright install --with-deps chromium
+        run: npx playwright install --with-deps chromium || "$GITHUB_WORKSPACE/.github/scripts/playwright-install-failed.sh"
 
       - name: Compile :browser-test, serve, and run Playwright runner
         run: npm run test:browser
@@ -3384,7 +3384,7 @@ jobs:
             ${{ runner.os }}-playwright-
 
       - name: Install Playwright (Chromium + system deps)
-        run: npx playwright install --with-deps chromium
+        run: npx playwright install --with-deps chromium || "$GITHUB_WORKSPACE/.github/scripts/playwright-install-failed.sh"
 
       # Production-mode CLJS smoke for `:rf.schema/at-boundary`
       # (Spec 010 §Production builds, rf2-r2uh / rf2-84e9). Compiles
@@ -3448,7 +3448,7 @@ jobs:
             ${{ runner.os }}-playwright-
 
       - name: Install Playwright (Chromium + system deps)
-        run: npx playwright install --with-deps chromium
+        run: npx playwright install --with-deps chromium || "$GITHUB_WORKSPACE/.github/scripts/playwright-install-failed.sh"
 
       # Production-mode CLJS elision smokes:
       #   - rf2-2zdu: re-frame.trace/emit! must NOT fire under :advanced +
@@ -3972,7 +3972,7 @@ jobs:
             ${{ runner.os }}-playwright-
 
       - name: Install Playwright (Chromium + system deps)
-        run: npx playwright install --with-deps chromium
+        run: npx playwright install --with-deps chromium || "$GITHUB_WORKSPACE/.github/scripts/playwright-install-failed.sh"
 
       # rf2-9grp6 — narrow scope. The orchestrator at
       # implementation/adapters/scripts/serve-and-run-adapter-smokes.cjs supports a
@@ -4057,7 +4057,7 @@ jobs:
             ${{ runner.os }}-playwright-
 
       - name: Install Playwright (Chromium + system deps)
-        run: npx playwright install --with-deps chromium
+        run: npx playwright install --with-deps chromium || "$GITHUB_WORKSPACE/.github/scripts/playwright-install-failed.sh"
 
       - name: Compile the re-frame.ui smoke, serve, and run its Playwright spec
         env:
@@ -4147,7 +4147,7 @@ jobs:
             ${{ runner.os }}-playwright-
 
       - name: Install Playwright (Chromium + system deps)
-        run: npx playwright install --with-deps chromium
+        run: npx playwright install --with-deps chromium || "$GITHUB_WORKSPACE/.github/scripts/playwright-install-failed.sh"
 
       # PR-smoke tier (rf2-wa3oo + rf2-og36y). The full feature-load +
       # full Xray matrix + Story static-export sweep sat on the critical
@@ -4393,7 +4393,7 @@ jobs:
       # on the hermetic re-frame2-pair-mcp Playwright install.
       - name: Install Playwright (Chromium + system deps)
         timeout-minutes: 5
-        run: npx playwright install --with-deps chromium
+        run: npx playwright install --with-deps chromium || "$GITHUB_WORKSPACE/.github/scripts/playwright-install-failed.sh"
 
       - name: Run Reagent Slim client-runtime browser smoke
         run: npm run test:reagent-slim:smoke
@@ -4462,7 +4462,7 @@ jobs:
       # wait into a re-runnable FAILURE instead of an open-ended block.
       - name: Install Playwright (Chromium + system deps)
         timeout-minutes: 5
-        run: npx playwright install --with-deps chromium
+        run: npx playwright install --with-deps chromium || "$GITHUB_WORKSPACE/.github/scripts/playwright-install-failed.sh"
 
       # rf2-h5e3v7 — ARM the tenant-switcher testbed browser smoke in PR CI.
       # The dedicated runner (serve-and-run-tenant-switcher-testbed.cjs)
@@ -5019,7 +5019,7 @@ jobs:
       # properly.
       - name: Install Playwright chromium (for the emitted browser proofs)
         working-directory: implementation
-        run: npx playwright install --with-deps chromium
+        run: npx playwright install --with-deps chromium || "$GITHUB_WORKSPACE/.github/scripts/playwright-install-failed.sh"
 
       # tools/template is a deps-new template (rf2-dolpf §2; clj-new
       # body dropped in §2.5 / rf2-40vmd) — its tests
@@ -5528,7 +5528,7 @@ jobs:
       - name: Install Playwright chromium (for hermetic browser preload)
         working-directory: implementation
         timeout-minutes: 5
-        run: npx playwright install --with-deps chromium
+        run: npx playwright install --with-deps chromium || "$GITHUB_WORKSPACE/.github/scripts/playwright-install-failed.sh"
 
       # rf2-e6enf — backstop the orchestrator's own internal watchdog
       # (HERMETIC_TIMEOUT_MS = 9 min in run-re-frame2-pair-live-hermetic-suite.cjs,
@@ -5934,7 +5934,7 @@ jobs:
         run: npm ci
 
       - name: Install Playwright (Chromium + system deps)
-        run: npx playwright install --with-deps chromium
+        run: npx playwright install --with-deps chromium || "$GITHUB_WORKSPACE/.github/scripts/playwright-install-failed.sh"
 
       # Build BOTH bundles from source — the committed esbuild bootstrap
       # (playground.js + playground.css) and the untracked, generated


### PR DESCRIPTION
Closes rf2-swos.

The fourth site in the class rf2-xsfr (#8030) and rf2-gfvy (#8036) fixed at the
Clojure CLI, clj-kondo and Babashka installs. It gets **half** their remedy, and
the other half is refused on measurement rather than shipped on spec.

## The bead's premise did not hold: Playwright already retries

The bead reads "Playwright's browser fetch has no retry envelope". Read at
source in the pinned `playwright-core@1.59.1`, it has one —
`lib/server/registry/browserFetcher.js:56`:

```js
const retryCount = 5;
for (let attempt = 1; attempt <= retryCount; ++attempt) {
  const url = downloadURLs[(attempt - 1) % downloadURLs.length];
  ...
  if (attempt >= retryCount) throw error;
}
```

So the (a)-half of the sibling remedy — *widen a too-narrow envelope* — is
aimed at something that is already half-present. What the envelope lacks is
**backoff**: the five attempts in job `94299983393` ran at 23:56:45.44,
:46.23, :47.00, :47.77 and :48.53 — **3.85 seconds end to end**.

## What actually failed, both times

Read at source from the logs, not from the job titles.

**1. `94299983393` (PR #8055, the bead's instance) — a Google Cloud Storage
403 geo-denial.** Every one of the five attempts got:

```
Error: Download failed: server returned code 403 body '<Error><Code>AccessDenied</Code>
<Details>We're sorry, but this service is not available in your location</Details></Error>'.
URL: https://cdn.playwright.dev/builds/cft/147.0.7727.15/linux64/chrome-linux64.zip
```

That URL is a **307 redirector**. Verified by request:

| request | result |
|---|---|
| `cdn.playwright.dev/builds/cft/147.0.7727.15/linux64/chrome-linux64.zip` | `206`, final URL **`storage.googleapis.com/chrome-for-testing-public/...`** |

So the 403 is Google Cloud Storage denying the runner's egress IP by region,
and `cdn.playwright.dev` is only the signpost. A runner's egress IP does not
change for the life of a job, so retrying it — for four seconds or for seven
minutes — asks the same bucket the same question from the same address. What
clears it is a **re-run**, which lands on a different runner. A jittered
backoff loop would have turned a 4-second red into a 7-minute red and changed
nothing else.

**2. `93920468065` (2026-08-11) — a step timeout that never reached the
download.** `##[error]The action 'Install Playwright (Chromium + system deps)'
has timed out after 5 minutes`, spent **entirely inside the `--with-deps` apt
hop**: `Get:2` 20:39:16, `Get:3` 20:40:19, `Get:4` 20:42:06, `Get:6` 20:43:07,
guillotined 20:44:20, fetching 21.1 MB of fonts from
`azure.archive.ubuntu.com`. Three of the twenty-one sites carry
`timeout-minutes: 5` (`test.yml:4395, 4464, 5530`). An envelope wider than
that cap cannot finish, and a step the runner guillotines never prints its
annotation at all — so there a wider loop is not merely useless, it is worse
than what it replaces.

(A third job matched a `Playwright` step-name grep and is **not** an install
failure: `93895565426` failed in `Compile :browser-test, serve, and run
Playwright runner` on planted-throw assertions. Stated so the count is not
inflated.)

## Playwright's own knobs were preferred to hand-rolling, then rejected on measurement

The brief asks for upstream tooling ahead of a hand-rolled loop. Both knobs
were read at source and probed:

- **Mirror rotation.** `registry/index.js` normally hands the fetcher three
  hosts (`PLAYWRIGHT_CDN_MIRRORS`) and the retry loop rotates them,
  `downloadURLs[(attempt - 1) % downloadURLs.length]`. **Chromium is the
  exception**: `cftUrl()` (index.js:150-159) overrides `mirrors` to the single
  element `["https://cdn.playwright.dev"]`. That is why all five attempts hit
  one URL while Firefox and WebKit would have rotated. This is the real reason
  the envelope is so shallow, and it is not reachable from the workflow.

- **`PLAYWRIGHT_CHROMIUM_DOWNLOAD_HOST` / `PLAYWRIGHT_DOWNLOAD_HOST`.** The
  knob *replaces* the mirror list with one host. There is no working value to
  give it:

  | candidate host, CfT path | result |
  |---|---|
  | `playwright.download.prss.microsoft.com/dbazure/download/playwright/...` | **400** — the ESRP CDN does not carry Chrome-for-Testing builds |
  | `storage.googleapis.com/chrome-for-testing-public` | unusable — the knob is prepended to the path `builds/cft/<ver>/...`, a layout only Playwright's redirector understands |

  So the knob is not set. Not on taste — on two requests.

## What this PR ships: the (c) half, at all twenty-one sites

Twenty-one steps across six workflows run `npx playwright install --with-deps
<browsers>`. Each gains exactly one thing:

```diff
-        run: npx playwright install --with-deps chromium
+        run: npx playwright install --with-deps chromium || "$GITHUB_WORKSPACE/.github/scripts/playwright-install-failed.sh"
```

`.github/scripts/playwright-install-failed.sh` emits an
`::error title=Playwright browser install failed — CI infrastructure — not this
diff::…` annotation and exits 1. The annotation surfaces on the checks page, so
**"the gate failed" and "the gate never ran" are distinguishable without
opening the raw log** — the manual step the bead was filed to delete. It names
both measured modes, says the remedy is a re-run, and names the two things that
*could* make the diff responsible (a Playwright pin change; an edit to that
script).

Three judgements, all recorded in the script's header:

- **One script, not twenty-one copies of a 900-character string.** rf2-e7ja9's
  rule: many call sites → extract. #8036 declined extraction for Babashka
  because it had *one* call site; this has twenty-one, so the same rule points
  the other way. Exit status stays a plain 1, as in `install-clojure-cli.sh`
  and `resolve-clojure-deps.sh`.
- **`||` stays on the same logical line**, for the `SETUP_PATTERNS` reason
  #8036 found — see below.
- **No retry loop**, for the reasons measured above. The header says what would
  change that: a transient 5xx or ECONNRESET measured *at this site*, at which
  point an outer loop belongs there, sized under the tightest `timeout-minutes`
  of its call sites.

## The `check_fast_pr_gap.py` coupling — measured, with planted-fault controls

`Step.is_setup` (line 358) classifies a step as setup only when **every**
logical line of `join_continuations(run)` matches a `SETUP_PATTERNS` entry; the
one covering these steps is `^npx playwright install\b`. Appending `|| <script>`
keeps the logical line starting with `npx playwright install`, so nothing moves.

`python scripts/check_fast_pr_gap.py --list` before and after is **byte-for-byte
identical** — same SHA-256 both times:

```
5920beed635e2911e8104dd53c510fbae7745d52f258a3ce334a54b37e2ac1a9  before (373 lines)
5920beed635e2911e8104dd53c510fbae7745d52f258a3ce334a54b37e2ac1a9  after
```

An identical listing could in principle be vacuous, so the classifier was
probed directly, **with the two shapes #8036 warned about as planted faults**:

| step body | `is_setup` |
|---|---|
| `origin/main` form (control) | `True` |
| **this PR's form** | **`True`** |
| PLANTED FAULT — separate `echo ::error` line | **`False`** |
| PLANTED FAULT — `for attempt in 1 2 3` wrapper | **`False`** |
| this PR's form, 3-browser site | `True` |

The faults really do flip it, so the `True` on this PR's form is a measurement.
Every one of the **21** real steps parsed out of the working-tree YAML
classifies as setup; **0** do not.

`scripts/check_gate_scheduling.py`: `51 gate commands, 43 scheduled, 8 declared
(0 of them known holes with beads)` — unchanged.

## Nothing else in any workflow moved

Both revisions parsed with PyYAML and compared on job ids, job `name`,
`needs`, `if`, `runs-on`, job `timeout-minutes`, and per step
`(name, uses, if, working-directory, timeout-minutes)`, plus the `on:` blocks:

```
docs.yml             jobs  5-> 5  on: identical=True  SHAPE identical=True  run: bodies changed=1
expensive-tests.yml  jobs  5-> 5  on: identical=True  SHAPE identical=True  run: bodies changed=3
freehand-bench.yml   jobs  3-> 3  on: identical=True  SHAPE identical=True  run: bodies changed=1
template-release.yml jobs  3-> 3  on: identical=True  SHAPE identical=True  run: bodies changed=1
test.yml             jobs 78->78  on: identical=True  SHAPE identical=True  run: bodies changed=15
```

Exactly 21 `run:` bodies changed and nothing else, so **no job name, `needs:`,
`if:` or required-check name moved** and nothing was silently un-required. The
diff is 21 insertions / 21 deletions plus the new script — one line per site.

## No edit outside `.github/` was needed

Keeping the literal `playwright install --with-deps <browsers>` text intact is
what buys that. Both consumers that pin it pass **unmodified**:

- `implementation/scripts/_changed-surfaces.test.cjs` — 330 assertions, eight
  of which match that literal.
- `tools/template/.../release_gate_test.clj:117` — `#"playwright install
  --with-deps chromium"` against `template-release.yml`.

`_changed-surfaces.test.cjs` needed no widening, so `implementation/**` is
untouched by this PR.

## Evidence that the failure path behaves as intended

A GCS geo-denial cannot be summoned, so `npx` was shimmed onto the front of a
sanitised `PATH` (asserted: `command -v npx` resolves to the shim; no real
`playwright` on the path) and **the step body was run verbatim** — extracted
from the YAML with PyYAML from the `jvm-tools-template` job's `Install
Playwright chromium` step, at `origin/main` for the control and at HEAD for the
new form. Nothing was hand-typed and no test hook was added to any workflow.
Bodies executed under `/usr/bin/bash -e`, matching the runner's `shell: /usr/bin/bash -e {0}`.

**Non-vacuity, asserted before any case ran** (#8030's first control ran an
empty file and "passed"): the control body is **44 bytes** and must contain
`npx playwright install --with-deps chromium` and must **not** contain
`playwright-install-failed.sh`; the new body is **112 bytes** and must contain
it. Both printed in the log.

| case | outage | exit | npx invocations | `::error` annotations |
|---|---|---|---|---|
| **CONTROL** — `origin/main` form | 403 | **1** | 1 | **0** |
| **CONTROL** — `origin/main` form | healthy | **0** | 1 | 0 |
| A — this PR | 403 | **1** | 1 | **1** |
| B — this PR, healthy | healthy | **0** | 1 | 0 |
| **CONTROL** — this PR's form, handler path wrong | 403 | **127** | 1 | **0** |

The control reproduces today's symptom exactly: dead with the log ending
`Error: Download failure, code=1` and **no annotation**, which is what the
runner then reports as `##[error]Process completed with exit code 1`. Case A is
the same outage, same exit code, now carrying the annotation. Case B shows the
healthy path costs nothing and never reaches the handler.

**The executable bit was a live bug this harness caught.** `git add` staged the
new script **100644** while all eleven siblings are **100755**; on the Linux
runner the handler would have died `Permission denied` (126) and the annotation
would never have printed — the entire change silently inert, with `ls -l`
reporting `-rwxr-xr-x` on this NTFS checkout the whole time. Fixed with
`git update-index --chmod=+x`; the index mode is now asserted by the harness
(`100755`), read from `git ls-files -s`, never from `ls`.

**One control is omitted, and it is omitted rather than faked**: the
un-executable case cannot be reproduced here, because `chmod -x` is a *measured*
no-op on this filesystem (the harness runs the probe and prints the note). The
reachable half of the same risk — handler present but not **found**, the
likelier regression across twenty-one call sites — is reproduced instead and
gives exit **127** with no annotation.

Plus a static sweep: all **21** call sites reference the handler, and **0**
name a path that does not resolve.

**The `tools/template` gate is non-vacuous too.** `clojure -M:test` passes
(60 tests, 633 assertions, 0 failures) against the edited
`template-release.yml`. To prove it reads *this* tree, `chromium` was replaced
with `PLANTED_FAULT` in that file: the suite went **1 failure**, at
`release_gate_test.clj:117`, and its output printed the job block **including
the new `|| "$GITHUB_WORKSPACE/.github/scripts/playwright-install-failed.sh"`
tail**. Restored and verified by hashing bytes —
`5b644e6c4a1c56bfc58dce404d4b354709fa5614e5ae74093f28104a2c94875a`, `sha256sum
-c` → `OK` — not by reading a diff.

## Quality gates

Every exit code below is the one captured next to the command in the same
shell, never the harness's report of it.

| gate | raw exit code |
|---|---|
| `python scripts/check_fast_pr_gap.py --list` (before) | **0** |
| `python scripts/check_fast_pr_gap.py --list` (after) | **0** — identical SHA-256 |
| `python scripts/check_fast_pr_gap.py` | **0** — `fast-PR gap map clean: 85 required jobs…` |
| classifier probe, 5 cases incl. 2 planted faults + all 21 real steps | **0** |
| `python scripts/check_gate_scheduling.py` | **0** — `51 gate commands, 43 scheduled, 8 declared`, unchanged |
| `python -c "yaml.safe_load(open('.github/workflows/docs.yml'))"` | **0** |
| `… expensive-tests.yml` | **0** |
| `… freehand-bench.yml` | **0** |
| `… template-release.yml` | **0** |
| `… test.yml` | **0** |
| PyYAML job/step shape + `on:` comparison vs `origin/main`, 5 files | **0** |
| `git ls-files '.github/scripts/*.sh' \| xargs shellcheck` — CI's own roster command, shellcheck 0.11.0 | **0** (12 scripts, incl. the new one) |
| rf2-swos failure-path harness (2 controls + 2 cases + reachability control + static sweep) | **0** — `HARNESS_VERDICT: PASS` |
| `node implementation/scripts/_changed-surfaces.test.cjs` | **0** (330) |
| `node implementation/scripts/_lint-workflow-policy.test.cjs` | **0** (4) |
| `node implementation/scripts/_docs-workflow-policy.test.cjs` | **0** (5) |
| `node implementation/scripts/_path-policy.test.cjs` | **0** |
| `node implementation/scripts/_script-spawn-policy.test.cjs` | **0** (168) |
| `node implementation/scripts/_mcp-conformance-install-policy.test.cjs` | **0** (5) |
| `node implementation/scripts/_navigation-ceiling-policy.test.cjs` | **0** (4) |
| `node implementation/scripts/_resolve-clojure-deps-classifier.test.cjs` | **0** (6) |
| `clojure -M:test` in `tools/template` | **0** (60 tests, 633 assertions) |
| same, with `PLANTED_FAULT` — the non-vacuity control | **1** (`release_gate_test.clj:117`) |

`sh scripts/test-fast-pr.sh` was **not** run: this is a fresh worker worktree
with no `implementation/node_modules`, the brief forbids junctioning the
mayor's, and the spine's `CLJS node integration` lane needs it. This PR
contains no CLJS, no JS and no Clojure — twenty-one `run:` bodies in workflow
YAML plus one shell script — so that lane cannot be affected either way, and CI
runs it regardless. The spine lanes that *do* cover this change were run
individually and are in the table.

`shellcheck` came from `npx shellcheck@4.1.0`, the npm wrapper that downloads
**shellcheck v0.11.0** (the version CI's image carries — the log line naming
the release URL is in the gate output). `npx shellcheck@0.11.0`, the invocation
#8030's body quotes, does not resolve: no such npm version exists.

## What is not covered, stated plainly

- **No run against the live endpoint.** The install hops are `sudo`-into-apt on
  Linux; this is a Windows checkout. The command, its browsers and its
  `working-directory` are byte-for-byte unchanged at all twenty-one sites —
  only a failure branch was appended — and this PR's own CI runs many of them
  for real.
- **The `--with-deps` timeout mode is not fixed by this PR, and cannot be.** A
  step the runner guillotines never runs its own handler. Filed as **rf2-g3lv**
  with the log timings.
- **Caching, the lever that would actually remove the exposure, is out of
  scope.** Only 4 of the 21 sites cache `~/.cache/ms-playwright`; the job that
  failed is one of the seventeen that do not, and a cache hit would have
  skipped the download entirely. That is 17 new steps across 6 workflow files
  and a real design question about key shape, not a one-line change. Filed as
  **rf2-169n**.
- **No jitter term, and no herd argument.** #8030 needed jitter because ~59
  jobs retry in lockstep; with no retry loop here there is nothing to
  desynchronise.

## One divergence from a sibling, flagged

This annotation title uses ` — CI infrastructure — not this diff` (em dashes),
matching #8036 rather than `install-clojure-cli.sh`'s comma. GitHub's
workflow-command grammar is `::error name=value,name=value::message`, so a
comma inside a property value ends it and that sibling's rendered title very
likely truncates at `… — CI infrastructure`. #8036 raised this and left the
file alone; it is still true, still cosmetic, and still out of this fence.
