### PR TITLE
docs(the-mayor-method): name gate artefacts per-attempt, not merely per-worktree (rf2-lbve)

### DIFF
--- a/docs/the-mayor-method/dispatch-prompt-template.md
+++ b/docs/the-mayor-method/dispatch-prompt-template.md
@@ -59,17 +59,24 @@ worktrees, cross-contaminating them. Commit to your branch instead.
 
 Concurrent workers SHARE one session scratchpad directory — its path carries the
 SESSION id, not your worktree — so name every scratch file you write outside your
-worktree FOR that worktree: `pr-body-<worktree>.md`, `gate-fastpr-<worktree>.log`,
-`gate-fastpr-<worktree>.exit`, never the bare names. A generic name is silently
-overwritten by a peer: nothing errors, and the loser can READ the survivor and
-take a PR body with plausible structure and the wrong subject for its own — or a
-gate exit code belonging to another worker's run, which reads as a clean pass and
-fails the merge decision open. Confirm a scratch file is your own before
-believing it, and confirm each gate read YOUR worktree before believing its
-colour — by whichever of two routes that gate affords. The shell gates print
-`gate root: <path>` as their first line; check it names your worktree. A gate
-that prints no banner (no `scripts/check_*.py` does) is discriminated by the red
-from a fault you planted, which exists only in your tree. That worktree check,
+worktree FOR that worktree, and every gate artefact for the ATTEMPT that wrote it
+as well: `pr-body-<worktree>.md`, `gate-fastpr-<worktree>-1.log`,
+`gate-fastpr-<worktree>-1.exit`, never the bare names, and bump that number on
+every re-run. A generic name is silently overwritten by a peer: nothing errors,
+and the loser can READ the survivor and take a PR body with plausible structure
+and the wrong subject for its own — or a gate exit code belonging to another
+worker's run, which reads as a clean pass and fails the merge decision open. The
+attempt number closes the same hole from the other side, which the worktree
+suffix cannot reach because both writers are YOU: a gate the harness kills at the
+ten-minute cap can survive that kill and write its `.log` and `.exit` after your
+restarted run has started using them. One worker shipped `exit 0` that way with
+18 real failures underneath it. Confirm a scratch file is your own — and your
+current attempt's — before believing it, and confirm each gate read YOUR worktree
+before believing its colour — by whichever of two routes that gate affords. The
+shell gates print `gate root: <path>` as their first line; check it names your
+worktree. A gate that prints no banner (no `scripts/check_*.py` does) is
+discriminated by the red from a fault you planted, which exists only in your
+tree. That worktree check,
 not this naming rule, is what has actually caught both observed collisions.
 
 If you create a `node_modules` symlink/junction in your worktree, remove the
@@ -287,22 +294,39 @@ none of them is obvious from the gate command itself.
   rather than closing it, because it is genuine evidence for a narrower claim than
   the worker needs.
 - **Put *every* gate artefact where git ignores it, and name each one FOR your
-  worktree** — the log and the exit-code file both. `*.log`, `*.exit` and
-  `*-exit.txt` are all ignored, and the `-<worktree>` suffix is what stops a
-  sibling worker writing those same two files:
+  worktree AND for the attempt that wrote it** — the log and the exit-code file
+  both. `*.log`, `*.exit` and `*-exit.txt` are all ignored; the `-<worktree>`
+  suffix is what stops a *sibling worker* writing those same two files, and the
+  trailing attempt number is what stops *you* writing them twice:
 
   ```bash
-  sh <ASSIGNED_WORKTREE>/scripts/test-fast-pr.sh > gate-fastpr-<worktree>.log 2>&1; echo "$?" > gate-fastpr-<worktree>.exit
+  sh <ASSIGNED_WORKTREE>/scripts/test-fast-pr.sh > gate-fastpr-<worktree>-1.log 2>&1; echo "$?" > gate-fastpr-<worktree>-1.exit
   ```
 
-  **The suffix is not tidiness — a bare name fails the gate OPEN.** The
+  Bump that number on every re-run — `-2`, `-3` — and never write to one twice.
+
+  **Neither half is tidiness; a name missing either fails the gate OPEN.** The
   scratchpad path carries the SESSION id, not the worktree, so every worker in a
   wave shares one directory. On 2026-08-12 two of six workers in a single wave
   wrote `gate-fastpr.exit` there; one then read a `0` a peer's run had already
   left while its own spine was still running (`ps -ef` showed its pid alive),
   and found its log interleaved by two writers at independent offsets, one line
-  beginning mid-word. The exit code a PR body quotes is exactly the artefact
-  that collision corrupts, and it reads as a clean pass — so this is the merge
+  beginning mid-word.
+
+  **The worktree suffix cannot close the second mechanism, because there both
+  writers are the same worktree.** `worker/trusted-il7b` ran `test:cljs` in the
+  foreground; the harness SIGTERM'd it at the ten-minute cap; the run *survived
+  the kill* and later wrote to the same `.log` and the same `.exit` the restarted
+  run was using — leaving `exit 0` sitting beside 18 real failures. The suffix
+  was present and correct throughout and made no difference. Expect this one
+  more often than the peer collision, not less: detaching a long gate is the
+  sanctioned path (foreground dies at ten minutes, the spine needs about
+  twenty-five), so kill-and-restart is routine rather than exceptional. A fresh
+  number per attempt is what sends the survivor's write somewhere you will never
+  quote.
+
+  The exit code a PR body quotes is exactly the artefact both collisions
+  corrupt, and by either route it reads as a clean pass — so this is the merge
   decision failing open, not a housekeeping slip. The boundary block above
   carries the same rule, and an example here that dropped the suffix is what let
   two workers obey the document and still collide — which is why the two have to
@@ -491,7 +515,7 @@ reports everything.
 - Same-file races between concurrent workers → enumerate in-flight surfaces.
 - Edits leaking into the mayor checkout (esp. silent new-file leaks) → boundary block + post-write both-trees check.
 - Cross-worktree contamination via `git stash` → no-stash rule (stashes are repo-global).
-- A peer silently overwriting a worker's scratch file, or the loser reading the survivor as its own — including a gate exit code belonging to another worker's run, which merges on a green nobody earned → worktree-named scratch files AND gate artefacts, plus the `gate root:` check, which is the half of that pair observed to actually catch it.
+- A peer silently overwriting a worker's scratch file, or a killed gate outliving the run that replaced it and overwriting *that* — either way the loser reads the survivor as its own, including a gate exit code belonging to a different run, which merges on a green nobody earned → scratch files and gate artefacts named for BOTH the worktree and the attempt, plus the `gate root:` check, which is the half of that pair observed to actually catch it.
 - Worktree cleanup deleting *through* a `node_modules` link into the shared tree it points at → the worker unlinks before reporting done, and the cleanup path disarms before removing.
 - "Green locally" merged into a red CI gate → gate the transitive surface; merge on CI, not the hand-off; a real failure gets a fix-worker, never `--admin`.
 - A passing synthetic test that routes around the real bug → reproduce the actual failing path.

--- a/docs/the-mayor-method/dispatch-prompt-template.md
+++ b/docs/the-mayor-method/dispatch-prompt-template.md
@@ -67,17 +67,18 @@ and the loser can READ the survivor and take a PR body with plausible structure
 and the wrong subject for its own — or a gate exit code belonging to another
 worker's run, which reads as a clean pass and fails the merge decision open. The
 attempt number closes the same hole from the other side, which the worktree
-suffix cannot reach because both writers are YOU: a gate the harness kills at the
-ten-minute cap can survive that kill and write its `.log` and `.exit` after your
-restarted run has started using them. One worker shipped `exit 0` that way with
-18 real failures underneath it. Confirm a scratch file is your own — and your
-current attempt's — before believing it, and confirm each gate read YOUR worktree
-before believing its colour — by whichever of two routes that gate affords. The
-shell gates print `gate root: <path>` as their first line; check it names your
+suffix cannot reach because both writers are YOU: the harness's ten-minute cap
+kills the SHELL, not what it spawned, and the orphan keeps writing to the `.log`
+and `.exit` your restarted run is already using. A NUL hole or two summary lines
+in one log is the tell. One worker shipped `exit 0` that way with 18 real
+failures underneath it. Confirm a scratch file is your own — and your current
+attempt's — before believing it, and confirm each gate read YOUR worktree before
+believing its colour — by whichever of two routes that gate affords. The shell
+gates print `gate root: <path>` as their first line; check it names your
 worktree. A gate that prints no banner (no `scripts/check_*.py` does) is
 discriminated by the red from a fault you planted, which exists only in your
-tree. That worktree check,
-not this naming rule, is what has actually caught both observed collisions.
+tree. That worktree check, not this naming rule, is what has actually caught
+both observed collisions.
 
 If you create a `node_modules` symlink/junction in your worktree, remove the
 LINK (never its target) before you report done: a later `git worktree remove`
@@ -314,16 +315,24 @@ none of them is obvious from the gate command itself.
   beginning mid-word.
 
   **The worktree suffix cannot close the second mechanism, because there both
-  writers are the same worktree.** `worker/trusted-il7b` ran `test:cljs` in the
-  foreground; the harness SIGTERM'd it at the ten-minute cap; the run *survived
-  the kill* and later wrote to the same `.log` and the same `.exit` the restarted
-  run was using — leaving `exit 0` sitting beside 18 real failures. The suffix
-  was present and correct throughout and made no difference. Expect this one
-  more often than the peer collision, not less: detaching a long gate is the
-  sanctioned path (foreground dies at ten minutes, the spine needs about
+  writers are the same worktree.** A process the harness could not kill goes on
+  writing to an inherited descriptor after its replacement has started: the
+  ten-minute cap kills the *shell*, and what that shell spawned survives holding
+  the same open `.log` and `.exit`. It writes at *its* offset while the restart
+  writes from zero, so the artefact is not cleanly clobbered but spliced — the
+  tell is a NUL hole in the log and **two summary lines** where there should be
+  one. Measured twice independently on 2026-08-13: `worker/trusted-il7b` was left
+  with `exit 0` sitting beside 18 real failures, and `worker/tense-cluster`
+  (#8060) found an orphaned `node out/node-test.js` reporting `2 failures, 0
+  errors` from a run that had already been killed. The worktree suffix was
+  present and correct in both, and made no difference to either. Expect this
+  route more often than the peer collision, not less: detaching a long gate is
+  the sanctioned path (foreground dies at ten minutes, the spine needs about
   twenty-five), so kill-and-restart is routine rather than exceptional. A fresh
-  number per attempt is what sends the survivor's write somewhere you will never
-  quote.
+  number per attempt sends the orphan's write somewhere you will never quote.
+  It is belt to the capture rule's braces rather than a replacement for it —
+  `tense-cluster` was saved by quoting its own shell's captured code instead of
+  the log, and that is precisely what the capture rule is for.
 
   The exit code a PR body quotes is exactly the artefact both collisions
   corrupt, and by either route it reads as a clean pass — so this is the merge
@@ -515,7 +524,7 @@ reports everything.
 - Same-file races between concurrent workers → enumerate in-flight surfaces.
 - Edits leaking into the mayor checkout (esp. silent new-file leaks) → boundary block + post-write both-trees check.
 - Cross-worktree contamination via `git stash` → no-stash rule (stashes are repo-global).
-- A peer silently overwriting a worker's scratch file, or a killed gate outliving the run that replaced it and overwriting *that* — either way the loser reads the survivor as its own, including a gate exit code belonging to a different run, which merges on a green nobody earned → scratch files and gate artefacts named for BOTH the worktree and the attempt, plus the `gate root:` check, which is the half of that pair observed to actually catch it.
+- A peer silently overwriting a worker's scratch file, or an orphaned child of a killed gate writing over the run that replaced it — either way a worker reads the survivor as its own, including a gate exit code belonging to a different run, which merges on a green nobody earned → scratch files and gate artefacts named for BOTH the worktree and the attempt, plus the `gate root:` check, which is the half of that pair observed to actually catch it.
 - Worktree cleanup deleting *through* a `node_modules` link into the shared tree it points at → the worker unlinks before reporting done, and the cleanup path disarms before removing.
 - "Green locally" merged into a red CI gate → gate the transitive surface; merge on CI, not the hand-off; a real failure gets a fix-worker, never `--admin`.
 - A passing synthetic test that routes around the real bug → reproduce the actual failing path.


### PR DESCRIPTION
Closes rf2-lbve.

The gate-artefact rule in `docs/the-mayor-method/dispatch-prompt-template.md` closed
exactly one mechanism, and its whole evidence base was that one case: **two different
workers** colliding on one filename in the shared session scratchpad. The `-<worktree>`
suffix is the right answer to that, and it stays.

It does not close **one worker racing itself**, and that route was measured twice,
independently, on 2026-08-13.

## The premise, checked at source first

Read as it stood, the bullet was worktree-scoped only — heading (`name each one FOR
your worktree`), example (`gate-fastpr-<worktree>.log`) and rationale (*"what stops a
sibling worker writing those same two files"*) all name the peer case and nothing else.
The claim held.

## The mechanism, taking the more precise of the two measurements

`worker/tense-cluster` (#8060, body §"One gate-hygiene note") is the sharper account of
*why*, and it is what the new text is written from:

> The shell was killed; the `node out/node-test.js` child was **not**, and it ran to
> completion as an orphan, reporting `2 failures, 0 errors` while still writing into the
> redirected log at its own file offset. That left a log with a NUL hole in it and two
> summaries.

So the generic statement — **a process the harness could not kill goes on writing to an
inherited descriptor after its replacement has started** — covers both instances and
re-drifts less than either specific story. It also explains the artefact's *shape*: the
orphan writes at its own offset while the restart writes from zero, so the file is
spliced rather than clobbered, and the tell (a NUL hole, two summary lines in one log) is
visible in the artefact itself. A worker who sees two summaries previously had no reason
to distrust the file.

Both instances are cited: `trusted-il7b` left `exit 0` beside 18 real failures;
`tense-cluster` found the orphan reporting a failure count from a killed process. **The
worktree suffix was present and correct in both** — it cannot help, because both writers
are the same worktree.

Also recorded: this is **belt to the capture rule's braces, not a replacement**.
`tense-cluster` was saved by quoting its own shell's captured exit code rather than the
log, which is exactly what the existing capture rule is for.

## What changed — three carriers, kept in step

The file's own text says the bullet and the boundary block must be kept in step (an
example that dropped the suffix is what once let two workers obey the document and still
collide), so all carriers of the rule move together:

1. **The fifth gate-mechanics bullet** — heading now `name each one FOR your worktree
   AND for the attempt that wrote it`; the example is `gate-fastpr-<worktree>-1.log` /
   `.exit` with an explicit "bump that number on every re-run"; a new paragraph states
   the orphaned-descriptor mechanism, its tell, both measurements, and why to expect it
   *more* often than the peer collision (detaching a long gate is the sanctioned path —
   foreground dies at ten minutes, the spine needs about twenty-five — so kill-and-restart
   is routine rather than exceptional).
2. **The `WORKTREE BOUNDARY` block** — same rule, block-length: names the attempt suffix,
   states that the cap kills the *shell* and not what it spawned, and names the tell.
3. **The failure-modes index** — the entry now covers both routes.

**The two-worker evidence survives intact.** The 2026-08-12 sentence (two of six workers
in a wave wrote `gate-fastpr.exit`; one read a peer's `0` while its own spine was still
running, `ps -ef` showing its pid alive, its log interleaved at independent offsets with
one line beginning mid-word) is carried through **word for word**. This is an addition,
not a replacement — the peer collision is real, measured, and still the entire reason for
the worktree half. The `gate root:` bullet's reference to it (*"both 2026-08-12 scratchpad
collisions"*) remains accurate and is untouched.

`.claude/commands/*` deliberately **not** touched: `gate-fastpr` appears zero times across
all five, so they cite this section rather than duplicating it, and a second copy is the
same drift one level down (`rf2-w5pj`).

## Rebased onto #8062 — both intents kept

#8062 (`rf2-804e`) landed on this same file while this PR's checks ran, and the two
changes met in the *same paragraph* of the pasted `WORKTREE BOUNDARY` block. Rebased
onto `origin/main`; two conflicts, both resolved by **reading both intents**, never
`--ours`/`--theirs`.

They turned out to be complementary rather than competing — #8062's half answers *how do
you know a gate read your worktree*, this PR's half answers *which artefact are you
reading*:

> …The attempt number closes the same hole from the other side, which the worktree suffix
> cannot reach because both writers are YOU: the harness's ten-minute cap kills the SHELL,
> not what it spawned, and the orphan keeps writing to the `.log` and `.exit` your
> restarted run is already using. A NUL hole or two summary lines in one log is the tell.
> One worker shipped `exit 0` that way with 18 real failures underneath it. Confirm a
> scratch file is your own — and your current attempt's — before believing it, **and
> confirm each gate read YOUR worktree before believing its colour — by whichever of two
> routes that gate affords. The shell gates print `gate root: <path>` as their first line;
> check it names your worktree. A gate that prints no banner (no `scripts/check_*.py` does)
> is discriminated by the red from a fault you planted, which exists only in your tree.**
> That worktree check, not this naming rule, is what has actually caught both observed
> collisions.

(Bold is #8062's text, carried through intact.) The two rules also compose in practice:
the negative control below is exactly the no-banner route #8062 documents.

**#8062's mechanism correction survives, checked explicitly.** Its third carrier corrected
a false claim #8054 had introduced — that the Python gates resolve their rosters against
the cwd, when in fact they default to `Path(__file__).resolve().parent.parent`, so the
absolute path matters *more*, not less (`python scripts/check_….py` resolves that relative
path against the cwd first, handing the interpreter a sibling's copy). That text is intact
at `dispatch-prompt-template.md:210-214`; this PR's net diff is three hunks (≈line 59, ≈295,
≈524) and none of them touch it. `AGENTS.md`, #8062's other file, is not in this diff at all.

## Quality gates

Re-run **after** the rebase, not trusted from before it. Run from
`re-frame2-worktrees/attempt-lbve`; exit codes are this worker's own shell's capture
(`echo "$?"` on the same command line), not the harness's. Artefacts named per **attempt**
as well as per worktree — attempt `-3` for these, since that is the rule this PR writes.

| Gate | Exit | Notes |
|---|---|---|
| `python scripts/check_readme_links.py` | **0** | Ran green; not discriminating for this change — see the note below. |
| `python scripts/check_doc_slugs.py` | **0** | Validates this file's link targets and anchors. |
| `python -m mkdocs build --strict` | **0** | `exclude_docs` does not exclude `the-mayor-method/`. Built in 32.60s, **0 warnings**. |

Green taken at post-rebase hash `3b16c3f6441ec53cd13370a02b76a60b34a3e1119d04a7ec666e44c9eeab3b4b`,
which is the committed content.

### Negative control — re-planted after the rebase

Every gate here is bannerless, so the planted red is the only proof a gate read *this*
tree: the fault exists only here, so a run that had wandered into a sibling checkout would
have come back green. Repo-relative paths in the failure output cannot make that
distinction, which is why the red itself is the evidence.

Re-planted rather than carried over, because this checkout is not the one the first control
ran in — the worktree was reaped and recreated at the same path mid-task, and a proof from a
destroyed tree does not transfer. A broken link target was planted on a line this PR adds:

- pre-plant `3b16c3f6441ec53cd13370a02b76a60b34a3e1119d04a7ec666e44c9eeab3b4b`
- planted   `85019d669350e1357e0d532bfffd3eb447c1ae5538d0ab03f005bec95924ac74`

Hashes differ, so the plant applied rather than silently no-opping.

| Gate | Exit under plant | Fault named |
|---|---|---|
| `check_doc_slugs.py` | **1** | `BROKEN TARGET: docs\the-mayor-method\dispatch-prompt-template.md:307 -> negctrl2-lbve-does-not-exist.md` |
| `mkdocs build --strict` | **1** | `WARNING - … contains a link 'negctrl2-lbve-does-not-exist.md', but the target … is not found` → `Aborted with 1 warnings in strict mode!` |

**Restore verified by hashing the bytes**: back to
`3b16c3f6441ec53cd13370a02b76a60b34a3e1119d04a7ec666e44c9eeab3b4b`, byte-identical to
pre-plant, and `git status --porcelain` empty.

**Honesty note on `check_readme_links.py`:** green, but **not** discriminating here — it
validates README links and this PR touches no README, so no plant on this file could red
it. Reported as run, not as evidence.

`site/`, `docs/spec/`, `docs/migration/` and both `__pycache__/` trees left by mkdocs were
removed; worktree clean. No `node_modules` junction created.

## Premises that did not hold

None from the bead. Two corrections of substance came from measurements that landed after
the brief was written:

1. **The mechanism's description.** The brief said the killed run "survived the kill";
   `tense-cluster`'s measurement (#8060) corrects this to *the shell died and its child was
   orphaned holding the inherited descriptor* — which is what explains the NUL hole and the
   two summaries rather than a clean overwrite. The generic form is what the doc now states.
2. **The `gate root:` half of the boundary block** was rewritten by #8062 between this PR
   opening and merging, and its version is the one that survives here.
