### PR TITLE
ci: cache the Playwright browser binary at the last eight install sites (rf2-169n)

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -292,6 +292,32 @@ jobs:
       # events: on a PR the docs build is a regression check that never deploys,
       # and tools-playground already smokes the bundle at PR time. This also
       # keeps main-push CI at ONE heavy bundle build instead of two.
+      #
+      # rf2-169n — cache the Playwright browser binary. This step runs under
+      # docs/tools/playground, so `npx` resolves THAT tree's Playwright
+      # (^1.60.0 → 1.60.0), not implementation's pinned 1.59.1 — so the key
+      # hashes the playground's own lockfile. Keying it on
+      # implementation/package-lock.json would bust this cache on a bump it
+      # does not care about and leave it stale across the bump that matters.
+      # No bare `-playwright-` restore fallback here, so an implementation
+      # browser tree is never restored into this job. (The reverse can happen
+      # on an implementation-lock bump; it is harmless — the install step
+      # always runs, and Playwright only ever uses the exact revision
+      # directory its own version asks for.) On a hit that install still runs
+      # `--with-deps`: the apt system libraries live outside
+      # ~/.cache/ms-playwright and are not cacheable. Only the browser
+      # DOWNLOAD is skipped — which is the hop that failed in rf2-swos.
+      # Same `if:` as the install step it fronts, so PR runs neither restore
+      # nor save a cache for a smoke they do not run.
+      - name: Cache Playwright browser binary
+        if: github.event_name != 'pull_request'
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
+        with:
+          path: ~/.cache/ms-playwright
+          key: ${{ runner.os }}-playwright-playground-${{ hashFiles('docs/tools/playground/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-playwright-playground-
+
       - name: Install Playwright (Chromium + system deps)
         if: github.event_name != 'pull_request'
         working-directory: docs/tools/playground

--- a/.github/workflows/expensive-tests.yml
+++ b/.github/workflows/expensive-tests.yml
@@ -67,6 +67,17 @@ jobs:
       - name: Compile every standalone example build (nightly coverage net)
         run: npm run test:examples-compile
 
+      # rf2-169n — cache the Playwright browser binary (see `cljs-browser` in
+      # test.yml for the scheme). On a hit the install below still runs
+      # `--with-deps`; only the browser download is skipped.
+      - name: Cache Playwright browser binary
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
+        with:
+          path: ~/.cache/ms-playwright
+          key: ${{ runner.os }}-playwright-${{ hashFiles('implementation/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-playwright-
+
       - name: Install Playwright (Chromium + system deps)
         run: npx playwright install --with-deps chromium
 
@@ -259,6 +270,19 @@ jobs:
       # (`browser-proofs-required?` in `emitted_test_run_test.clj`).
       # `--with-deps` because the runner carries none of Chromium's shared
       # libraries and nothing earlier in this job installs them.
+      #
+      # rf2-169n — and cache that binary (see `cljs-browser` in test.yml for
+      # the scheme). A hit skips the browser download but NOT `--with-deps`:
+      # the apt system libraries are not cacheable, which is exactly why the
+      # flag stays.
+      - name: Cache Playwright browser binary
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
+        with:
+          path: ~/.cache/ms-playwright
+          key: ${{ runner.os }}-playwright-${{ hashFiles('implementation/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-playwright-
+
       - name: Install Playwright chromium (for the emitted browser proofs)
         working-directory: implementation
         run: npx playwright install --with-deps chromium
@@ -333,6 +357,19 @@ jobs:
       - name: Install implementation deps (for Playwright)
         working-directory: implementation
         run: npm install --no-audit --no-fund
+
+      # rf2-169n — cache the Playwright browser binary (see `cljs-browser` in
+      # test.yml for the scheme). Keyed on implementation/package-lock.json
+      # because the install step below runs under `implementation`, which is
+      # what pins the Playwright `npx` resolves. On a hit the install still
+      # runs `--with-deps`; only the browser download is skipped.
+      - name: Cache Playwright browser binary
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
+        with:
+          path: ~/.cache/ms-playwright
+          key: ${{ runner.os }}-playwright-${{ hashFiles('implementation/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-playwright-
 
       - name: Install Playwright chromium (for hermetic browser preload)
         working-directory: implementation

--- a/.github/workflows/template-release.yml
+++ b/.github/workflows/template-release.yml
@@ -199,6 +199,20 @@ jobs:
       # Chromium now fails the job (`browser-proofs-required?` in
       # `emitted_test_run_test.clj`). `--with-deps` because the runner has
       # none of Chromium's shared libraries.
+      #
+      # rf2-169n — and cache that binary (see `cljs-browser` in test.yml for
+      # the scheme). This is the RELEASE gate, so a network flake on the
+      # Chrome-for-Testing bucket reds a tag rather than a PR; a cache hit
+      # removes the download hop entirely. It does not remove `--with-deps`,
+      # whose apt system libraries are not cacheable.
+      - name: Cache Playwright browser binary
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
+        with:
+          path: ~/.cache/ms-playwright
+          key: ${{ runner.os }}-playwright-${{ hashFiles('implementation/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-playwright-
+
       - name: Install Playwright chromium (for the emitted browser proofs)
         working-directory: implementation
         run: npx playwright install --with-deps chromium

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1318,6 +1318,17 @@ jobs:
       - name: npm install
         run: npm ci
 
+      # rf2-169n — cache the Playwright browser binary (see `cljs-browser` for
+      # the scheme). On a hit the install below still runs `--with-deps`; only
+      # the browser download is skipped.
+      - name: Cache Playwright browser binary
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
+        with:
+          path: ~/.cache/ms-playwright
+          key: ${{ runner.os }}-playwright-${{ hashFiles('implementation/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-playwright-
+
       - name: Install pinned Chromium
         run: npx playwright install --with-deps chromium
 
@@ -5017,6 +5028,22 @@ jobs:
       # present and nothing earlier in the job installs them; a
       # half-provisioned browser would now red the job, so provision it
       # properly.
+      #
+      # rf2-169n — and cache that binary (see `cljs-browser` for the scheme).
+      # This job is where rf2-swos was filed from: run 94299983393 died on the
+      # browser DOWNLOAD, a Google Cloud Storage 403 geo-denial on the
+      # Chrome-for-Testing bucket. A cache hit skips that download outright.
+      # It does NOT skip `--with-deps` — the apt system libraries live outside
+      # ~/.cache/ms-playwright and are not cacheable, so the apt hop still runs
+      # on every run, hit or miss.
+      - name: Cache Playwright browser binary
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
+        with:
+          path: ~/.cache/ms-playwright
+          key: ${{ runner.os }}-playwright-${{ hashFiles('implementation/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-playwright-
+
       - name: Install Playwright chromium (for the emitted browser proofs)
         working-directory: implementation
         run: npx playwright install --with-deps chromium
@@ -5932,6 +5959,28 @@ jobs:
       # bundle build is reproducible — required for the drift gate below.
       - name: npm ci (bootstrap deps)
         run: npm ci
+
+      # rf2-169n — cache the Playwright browser binary. This job's
+      # working-directory is docs/tools/playground, so `npx` resolves THAT
+      # tree's Playwright (^1.60.0 → 1.60.0), not implementation's pinned
+      # 1.59.1 — so the key hashes the playground's own lockfile. Keying it on
+      # implementation/package-lock.json would bust this cache on a bump it
+      # does not care about and leave it stale across the bump that matters.
+      # No bare `-playwright-` restore fallback here, so an implementation
+      # browser tree is never restored into this job. (The reverse can happen
+      # on an implementation-lock bump; it is harmless — the install step
+      # always runs, and Playwright only ever uses the exact revision
+      # directory its own version asks for.) On a hit that install still runs
+      # `--with-deps`: the apt system libraries live outside
+      # ~/.cache/ms-playwright and are not cacheable. Only the browser
+      # DOWNLOAD is skipped — which is the hop that failed in rf2-swos.
+      - name: Cache Playwright browser binary
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
+        with:
+          path: ~/.cache/ms-playwright
+          key: ${{ runner.os }}-playwright-playground-${{ hashFiles('docs/tools/playground/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-playwright-playground-
 
       - name: Install Playwright (Chromium + system deps)
         run: npx playwright install --with-deps chromium


### PR DESCRIPTION
Closes rf2-169n.

## What

Twenty-one CI steps run `npx playwright install --with-deps <browsers>`. Eight had no `actions/cache` of `~/.cache/ms-playwright` in front, so every run re-downloaded Chromium from the network. This adds the cache at those eight. **21 of 21 sites are now fronted by a cache.**

One of the eight was `test.yml:jvm-tools-template` — the job rf2-swos was filed from, whose run `94299983393` died on that exact download with a GCS 403 geo-denial on the Chrome-for-Testing bucket. rf2-swos shipped only the annotation half of the remedy, on the measurement that neither observed failure was one a retry envelope would have caught. A cache hit skips the download entirely, so it *removes* the exposure rather than surviving it.

The diff is **126 insertions, 0 deletions** — pure addition.

## The census: the bead's 21/4 was stale; the real figure was 21/13

The bead reports 4 cached / 17 uncached, citing `test.yml:1384, 1472, 1586` and `freehand-bench.yml:412`. Re-run at source (PyYAML walk of every job's step list, matching `actions/cache` with `path: ~/.cache/ms-playwright` preceding a `playwright install` step **in the same job**):

| | bead | measured on `origin/main` | after this PR |
|---|---|---|---|
| install sites | 21 | **21** (confirmed) | 21 |
| cached | 4 | **13** | **21** |
| uncached | 17 | **8** | **0** |

The site count is exactly right. The cache count moved because rf2-f79t8, rf2-e6enf and rf2-5v0dg7 landed nine more cache steps between the measurement and now. **So this PR is 8 sites, not 17.**

## The key shape: there are TWO Playwright pins, and one key cannot serve both

The bead flags the key as the real judgement. Resolving each install step's effective working directory (step-level `working-directory`, else the job's `defaults.run.working-directory`) splits the 21 sites:

- **19 sites run under `implementation/`** — `implementation/package-lock.json` resolves `playwright@1.59.1`.
- **2 sites run under `docs/tools/playground/`** (`docs.yml:build`, `test.yml:tools-playground`) — `docs/tools/playground/package-lock.json` resolves `playwright@1.60.0`.

Those are **different Playwright versions**, hence different browser revisions. The 19 implementation-rooted sites take the established key **verbatim**:

```yaml
key: ${{ runner.os }}-playwright-${{ hashFiles('implementation/package-lock.json') }}
restore-keys: |
  ${{ runner.os }}-playwright-
```

Keying the two playground sites on `implementation/package-lock.json` would have been the wrong-key failure in both directions at once: busted on a bump they do not care about, and **not** busted on the bump that matters — precisely the "stale browser build against a newer Playwright" case. They take a scope segment in the **same** `<os>-playwright-<scope>-<hash>` spelling that `cw`/`cfw` already use, hashing their own lockfile:

```yaml
key: ${{ runner.os }}-playwright-playground-${{ hashFiles('docs/tools/playground/package-lock.json') }}
restore-keys: |
  ${{ runner.os }}-playwright-playground-
```

This is not a fifth spelling — it is the existing spelling with the scope slot filled, and the version input derived from where that job's Playwright is actually pinned rather than hardcoded. Deliberately **no** bare `${{ runner.os }}-playwright-` fallback, so an implementation browser tree is never restored into a playground job. The reverse overlap (an implementation job's bare fallback prefix-matching a `-playwright-playground-` entry on an implementation-lock bump) is possible and is harmless: the install step always runs, and Playwright only ever uses the exact revision directory its own version asks for, so a foreign tree can cost download time but never correctness.

I enumerated every cache key and restore-key prefix in `.github/workflows/**` before choosing. Note `${{ runner.os }}-playground-` is already taken (the tools-playground Maven cache), which is why the scope segment goes *after* `playwright`, not before.

## `--with-deps` on a cache hit: still required, and this is the honest limit of the change

A cache hit does **not** let the flag go. `--with-deps` runs `sudo apt-get install` for Chromium's shared libraries, which land in `/usr/lib` — outside `~/.cache/ms-playwright`, the only path cached. So on a hit the install step still runs in full and only the **browser download** is skipped. The flag stays at all 21 sites, unconditional. (The repo already reached this conclusion at `test.yml:3170-3172`; I follow it rather than re-deciding it.)

The consequence is worth stating plainly, because it is where "just add cache everywhere" quietly stops working. Of rf2-swos's **two** measured failures this change removes **one**:

- **GCS 403 geo-denial** — a download failure. A cache hit skips the download. **Removed.**
- **Timeout inside the apt hop** — `--with-deps` runs on every run, hit or miss. **Not removed.** rf2-e6enf's `timeout` capping remains the only lever there.

A cache **miss** still goes to the network, so this narrows the window rather than closing it.

## Quality gates

| Gate | Exit | Result |
|---|---|---|
| `python <abs>/scripts/check_fast_pr_gap.py --list` (before) | `0` | `REQUIRED CHECKS THIS SPINE DOES NOT RUN (96)` |
| `python <abs>/scripts/check_fast_pr_gap.py --list` (after) | `0` | `REQUIRED CHECKS THIS SPINE DOES NOT RUN (96)` |
| `diff` of the two `--list` outputs | `0` | **byte-identical, 0 lines of diff** |
| `python <abs>/scripts/check_gate_scheduling.py` (before) | `0` | `51 gate commands, 43 scheduled, 8 declared` |
| `python <abs>/scripts/check_gate_scheduling.py` (after) | `0` | `51 gate commands, 43 scheduled, 8 declared` |
| PyYAML parse — `docs.yml` | `0` | valid |
| PyYAML parse — `expensive-tests.yml` | `0` | valid |
| PyYAML parse — `template-release.yml` | `0` | valid |
| PyYAML parse — `test.yml` | `0` | valid |
| PyYAML parse — `freehand-bench.yml` (untouched, control) | `0` | valid |
| PyYAML parse — `lint.yml` (untouched, control) | `0` | valid |
| Structural shape comparison (before vs after) | `0` | **8 steps added, 0 problems** |
| Census re-run (after) | `0` | `21 install sites, 21 CACHED, 0 UNCACHED` |
| Post-rebase re-run of gap map + scheduling + census | `0` | unchanged |

Exit codes are the ones captured with `echo $?` on the same command line as the redirect, not the harness's.

### Gap-map classification: unchanged, and proven so

`scripts/check_fast_pr_gap.py` derives gate steps as `[s for s in self.steps if s.run and not s.is_setup]`. Every step this PR adds is a pure `uses: actions/cache` step with **no `run:` body**, so it cannot enter the derivation — confirmed at source, then measured: the `--list` output is byte-identical before and after (96 unrun both sides, `diff` exit 0). No job became an unrun gate; no inversion.

**Planted-fault discriminator.** These Python gates print no `gate root:` line, so I proved they read *this* worktree rather than a sibling: I inserted a bogus non-setup step (`run: npm run test:planted-fault-rf2-169n`) into `test.yml`'s `cljs-ui-g13`. The gap map moved **96 → 97** and named the planted step by its command. Restored with `git checkout HEAD --`, verified by `sha256sum -c` against the hash taken before planting: `OK`, `git status` clean. Both gates were re-run on the restored tree and returned to 96 / 51-43-8.

Honest note: `check_gate_scheduling.py` did **not** move under the plant (51/43/8 throughout). It scans npm gate commands, which this diff does not touch, so it is inert against a workflow-only fault by construction — its green here is a real pass but not a discriminated one.

### Shape comparison: only the intended steps changed

Parsed both trees with PyYAML into a normalised structure (per workflow: trigger; per job: `name`, `needs`, `if`, `runs-on`, `defaults`, `strategy`; per step in order: `name`, `uses`, `if`, `working-directory`, `run`, `with`, `env`), then walked the step lists in order requiring every original step to survive **unchanged and in position**:

```
=== ADDED STEPS ===
  + docs.yml             build                            name='Cache Playwright browser binary' uses=actions/cache@27d5ce7f... run=None if="github.event_name != 'pull_request'"
  + expensive-tests.yml  browser-bundle-and-story-gates   name='Cache Playwright browser binary' uses=actions/cache@27d5ce7f... run=None if=None
  + expensive-tests.yml  mcp-live                         name='Cache Playwright browser binary' uses=actions/cache@27d5ce7f... run=None if=None
  + expensive-tests.yml  template-emitted-app             name='Cache Playwright browser binary' uses=actions/cache@27d5ce7f... run=None if=None
  + template-release.yml test-template                    name='Cache Playwright browser binary' uses=actions/cache@27d5ce7f... run=None if=None
  + test.yml             cljs-ui-g13                      name='Cache Playwright browser binary' uses=actions/cache@27d5ce7f... run=None if=None
  + test.yml             jvm-tools-template               name='Cache Playwright browser binary' uses=actions/cache@27d5ce7f... run=None if=None
  + test.yml             tools-playground                 name='Cache Playwright browser binary' uses=actions/cache@27d5ce7f... run=None if=None
  TOTAL ADDED: 8
=== STRUCTURAL PROBLEMS ===
  TOTAL PROBLEMS: 0
```

Job count 124 before and after; step count 848 to 856, exactly +8.

**No required check was renamed.** The comparison asserts equality of every job's `name`, `needs`, `if`, `runs-on`, `defaults` and `strategy`, and of the workflow-level trigger — zero differences. Combined with 0 deletions in the diff, nothing that a branch-protection rule names by string can have moved.

### `docs.yml` detail

Its install step is scoped `if: github.event_name != 'pull_request'`. The cache step mirrors that condition, so a PR neither restores nor saves a cache for a smoke it does not run. It is the only one of the eight with a step-level `if:` (verified across all 21 sites).

## Fence

Touches `.github/workflows/**` only. `.github/scripts/install-clojure-cli.sh`, `.github/scripts/playwright-install-failed.sh` and its call sites, and the clj-kondo/Babashka steps are untouched — the added steps sit strictly *before* the install lines #8061 wraps, so the two changes compose. Rebased cleanly on `origin/main`; gates re-run green after the rebase.
