### PR TITLE
ci: record why the Playwright install cap stays at 5 minutes (rf2-g3lv)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4391,6 +4391,65 @@ jobs:
       # download while turning the lock-wait into a re-runnable FAILURE
       # instead of an open-ended block. Mirrors the identical step-level cap
       # on the hermetic re-frame2-pair-mcp Playwright install.
+      #
+      # rf2-g3lv — DO NOT RAISE THIS NUMBER, and do not thin the apt hop to
+      # make it fit. This is the canonical note; the other two capped sites
+      # (tenant-switcher-testbed-smoke, mcp-conformance-re-frame2-pair) point
+      # here. Measured 2026-08-13, and every claim below is from a CI log or
+      # from `playwright-core` at the pinned version, not from taste:
+      #
+      #   * THE CAP IS NOT TIGHT. 183 samples of this step across 2026-08-10
+      #     to 2026-08-13 (every `Install Playwright*` step of the last ~46
+      #     completed test.yml runs): 183 successes, 0 failures, min 10s,
+      #     p50 13s, p90 21s, max 49s. The 300s cap is 6.1x the observed
+      #     worst case. Raising it re-widens the open-ended window the cap
+      #     exists to bound — the rf2-e6enf failure above, where four PRs
+      #     (#2304/#2311/#2316/#2324) each sat 15-75+ min on a wedged
+      #     apt/dpkg lock and blocked the merge queue. That trade is a
+      #     regression, not a fix.
+      #
+      #   * THE APT HOP IS ALREADY MINIMAL. On ubuntu-24.04 the hop reports
+      #     `0 upgraded, 9 newly installed, 0 to remove` — invariant across
+      #     image versions 20260720.247.2 and 20260810.271.1 and four
+      #     independent jobs. ZERO Chromium shared libraries are installed;
+      #     every one of the 21 entries in nativeDeps' `chromium:` list
+      #     reports "is already the newest version". The 9 are CJK/Thai/
+      #     Cyrillic fonts from the separate `tools:` list plus two
+      #     transitive xfonts packages. They cannot be dropped selectively:
+      #     `Registry.installDeps` does an unconditional `targets.add("tools")`
+      #     (registry/index.js) and `installDependenciesLinux` already passes
+      #     `--no-install-recommends` (registry/dependencies.js). The only
+      #     lever is dropping `--with-deps` wholesale, which trades a loud,
+      #     annotated apt failure for a silent dependency on a runner-image
+      #     property nobody here controls — a removed lib would surface as an
+      #     unlaunchable Chromium, which is strictly worse than a slow apt.
+      #
+      #   * SO THE ONE OBSERVED BLOW-OUT WAS THE MIRROR, NOT THIS WORKFLOW.
+      #     Job 93920468065 (2026-08-11) spent the whole 5 min inside apt and
+      #     never reached the browser download. Those same 21.1 MB of fonts
+      #     fetch in 1s at 17-23 MB/s on a healthy run (job 94306922190,
+      #     2026-08-13: "Fetched 21.1 MB in 1s (18.9 MB/s)"). In the failing
+      #     job they came down at a sustained ~52 kB/s — while `apt-get
+      #     update`'s own metadata had come off the SAME host seconds earlier
+      #     in the SAME step at 7831 kB/s, 150x faster. That is an
+      #     azure.archive.ubuntu.com edge degradation. No cap survives it:
+      #     21.1 MB at 52 kB/s needs ~405s of download alone.
+      #
+      #   * THE BROWSER CACHE IS ORTHOGONAL HERE. rf2-f79t8's cache step
+      #     above scored an exact-key hit in that very job ("Cache restored
+      #     from key: Linux-playwright-96be61e0…") and the step blew the cap
+      #     anyway. A hit skips the DOWNLOAD; this failure is in the apt hop,
+      #     which runs either way.
+      #
+      # One real gap stays open and is deliberately not patched here: a step
+      # the runner guillotines on `timeout-minutes` is killed rather than
+      # failing, so the `|| playwright-install-failed.sh` handler never runs
+      # and this mode prints no "no gate ran" annotation. Moving the cap into
+      # the command (`timeout 270 npx playwright install …`) would fix that,
+      # but it breaks `scripts/check_fast_pr_gap.py`'s `^npx playwright
+      # install\b` setup pattern and would fail-open the gap map — see the
+      # header of .github/scripts/playwright-install-failed.sh. At 0 failures
+      # in 183 samples that trade is not worth taking.
       - name: Install Playwright (Chromium + system deps)
         timeout-minutes: 5
         run: npx playwright install --with-deps chromium || "$GITHUB_WORKSPACE/.github/scripts/playwright-install-failed.sh"
@@ -4460,6 +4519,16 @@ jobs:
       # job for the dpkg/apt-lock-wedge rationale). A healthy install is
       # ~20s; 5 min covers a slow apt + cold download while turning a lock
       # wait into a re-runnable FAILURE instead of an open-ended block.
+      #
+      # rf2-g3lv — DO NOT RAISE THIS NUMBER. This is the job whose 2026-08-11
+      # run (93920468065) burned the whole 5 min inside the apt hop without
+      # reaching the browser download. That was an azure.archive.ubuntu.com
+      # throughput collapse (~52 kB/s against 17-23 MB/s on a healthy run),
+      # not a cap that is too tight: 183 samples of this step over four days
+      # gave 183 successes with a 49s worst case. The measurement, the
+      # at-source reason the apt hop cannot be thinned, and why the browser
+      # cache does not help this path are all set out at the
+      # cljs-reagent-slim-bundle-isolation site above.
       - name: Install Playwright (Chromium + system deps)
         timeout-minutes: 5
         run: npx playwright install --with-deps chromium || "$GITHUB_WORKSPACE/.github/scripts/playwright-install-failed.sh"
@@ -5525,6 +5594,15 @@ jobs:
       # ~20s; 5 min covers a slow apt + cold (cache-miss) download while
       # turning the lock-wait into a re-runnable FAILURE instead of an
       # open-ended block.
+      #
+      # rf2-g3lv — DO NOT RAISE THIS NUMBER. Measured over 2026-08-10 to
+      # 2026-08-13, this step is 183-for-183 with a 49s worst case against a
+      # 300s cap, and the one recorded blow-out (job 93920468065) was an
+      # azure.archive.ubuntu.com throughput collapse that no cap survives.
+      # The apt hop cannot be thinned either — it installs zero Chromium
+      # libraries and only Playwright's unconditional `tools:` fonts. Full
+      # measurement and the at-source citations are at the
+      # cljs-reagent-slim-bundle-isolation site above.
       - name: Install Playwright chromium (for hermetic browser preload)
         working-directory: implementation
         timeout-minutes: 5


### PR DESCRIPTION
Closes rf2-g3lv.

## Verdict: the cap is right, the apt hop is irreducible — this was a slow-mirror day

rf2-g3lv posed two independent questions. Measured, the answer to both is "no change
warranted", so **this PR changes no behaviour at all**: it is comment-only, and the
PyYAML shape dump of `test.yml` is byte-identical before and after.

The comments exist because the *existing* rationale at the three capped sites reads
"5 min covers a slow apt + cold download" — which invites exactly the wrong fix
(raise it, since the apt was slower still). The new note says why not, with the
measurement, at the three places a reader will look.

### Q1 — is the 5-minute cap wrong, or is the apt hop too fat? **Neither.**

**The cap is not tight.** 183 samples of every `Install Playwright*` step across the
last ~46 completed `test.yml` runs, 2026-08-10 → 2026-08-13 (a window that spans the
day of the reported failure):

| samples | failures | min | p50 | p90 | p99 | max |
|--------:|---------:|----:|----:|----:|----:|----:|
| 183 | **0** | 10s | 13s | 21s | 32s | **49s** |

The 300s cap is 6.1x the observed worst case. Raising it re-widens the open-ended
window the cap exists to bound — the rf2-e6enf failure where #2304/#2311/#2316/#2324
each sat 15-75+ min on a wedged apt/dpkg lock and blocked the merge queue. That trade
is a regression, not a fix.

**The reporter's 9-package observation HOLDS at source** — and it is stronger than
reported. Verified on the runner image these jobs actually use, across **two** image
versions and four independent jobs (93920468065 / 94306922190 / 94283080583 /
94052876160):

- `0 upgraded, 9 newly installed, 0 to remove` — invariant on `ubuntu-24.04`
  **20260720.247.2** and **20260810.271.1**.
- **Zero Chromium shared libraries are installed.** Every one of the 21 entries in
  `nativeDeps`' `chromium:` list reports "is already the newest version".
- The 9 are `fonts-freefont-ttf fonts-ipafont-gothic fonts-tlwg-loma-otf
  fonts-unifont fonts-wqy-zenhei xfonts-cyrillic xfonts-scalable` from Playwright's
  separate `tools:` list, plus transitive `xfonts-encodings xfonts-utils`.

**But the inference drawn from it does not hold.** Those 21.1 MB cost **one second**
on a healthy mirror — job 94306922190, today: `Fetched 21.1 MB in 1s (18.9 MB/s)`;
also 21.5 MB/s, 23.4 MB/s and 17.2 MB/s on the other sampled jobs. Trimming them would
save about one second of a thirteen-second step. It cannot be what blew a 300s cap.

And they cannot be trimmed anyway, read at source in the pinned `playwright-core`
1.59.1:

- `Registry.installDeps` (`lib/server/registry/index.js`) does an **unconditional**
  `targets.add("tools")`. There is no flag, env var or invocation that installs the
  `chromium:` libraries without the `tools:` fonts.
- `installDependenciesLinux` (`lib/server/registry/dependencies.js`) already emits
  `apt-get install -y --no-install-recommends`. The 08-11 log corroborates it:
  `Recommended packages: fonts-ipafont-mincho fonts-tlwg-loma` were declined.

So the only lever is dropping `--with-deps` wholesale. The libraries genuinely are all
present today, so it would work — but it converts a loud, correctly-annotated apt
failure into a silent dependency on a runner-image property nobody here controls, and
a removed library surfaces as an unlaunchable Chromium. The bead's own warning applies
and I agree with it: strictly worse than a slow apt, to save one second.

**So what actually happened on 2026-08-11 (job 93920468065)** is a mirror-throughput
collapse, not a workflow defect. Per-package rates read off the log timestamps:

| package | size | elapsed | rate |
|---|---:|---:|---:|
| `fonts-ipafont-gothic` | 3513 kB | 63.3s | 55.5 kB/s |
| `fonts-freefont-ttf` | 5641 kB | 106.9s | 52.8 kB/s |
| `fonts-tlwg-loma-otf` | 107 kB | 2.4s | 44.6 kB/s |
| `fonts-unifont` | 2993 kB | 58.2s | 51.4 kB/s |
| `fonts-wqy-zenhei` | 7472 kB | guillotined 73s in | — |

The smoking gun is inside the same step, seconds earlier: that job's own
`apt-get update` fetched **11.3 MB in 1s (7831 kB/s)** from the same
`azure.archive.ubuntu.com`. Metadata at 7.8 MB/s, .deb payloads at ~52 kB/s — 150x
apart, same host, same step. That is an archive-edge degradation. No cap survives it:
21.1 MB at 52 kB/s is ~405s of download alone, so even a 10-minute cap only clears
*this* instance and buys a worse one next time.

### Q2 — does #8065's cache change this? **No, and it is measured, not assumed.**

Two independent confirmations:

1. **#8065 does not touch this path.** Read its diff: it adds `Cache Playwright
   browser binary` at `test.yml` 1318 / 5017 / 5933 plus docs.yml,
   expensive-tests.yml and template-release.yml — the *last eight* sites. All three
   `timeout-minutes: 5` sites (4395, 4464, 5530) already carry that cache step on
   `main`. No overlap, and no rebase conflict with this PR.
2. **Far stronger — the cache was already a HIT in the failing job.** Job
   93920468065 logs `Cache restored from key:
   Linux-playwright-96be61e0eb50f637bf665a0c07066f8c072637f9c7d245e33ff296411a4a2a7a`
   at 20:39:07 — an exact-key hit — and blew the cap anyway, 100% inside apt. A hit
   skips the *download*; the download was never reached. The cache is orthogonal to
   this failure mode by direct measurement in the very job under investigation.

### What I deliberately did NOT do

- **No retry loop on the apt hop.** The reporter's reasoning stands and I found nothing
  to overturn it.
- **No cap raise.** See above.
- **One real gap stays open, and I argue against patching it.** A step guillotined by
  `timeout-minutes` is *killed*, not failed, so `|| playwright-install-failed.sh`
  never runs and this mode prints no "no gate ran" annotation. The obvious fix —
  moving the cap into the command as `timeout 270 npx playwright install ...` — breaks
  `check_fast_pr_gap.py`'s `^npx playwright install\b` setup pattern and would
  **fail-open the gap map**, the exact trap documented in the header of
  `.github/scripts/playwright-install-failed.sh`. At 0 failures in 183 samples, and
  with #8061 already covering the common `exit 1` mode, that trade is not worth
  taking. Recorded in the comment rather than actioned.

## Quality gates

Every exit code below is the value I captured with `echo $?` on the same command line,
not the harness's report.

| gate | exit | note |
|---|---:|---|
| `python scripts/check_fast_pr_gap.py --list` (before) | 0 | `REQUIRED CHECKS THIS SPINE DOES NOT RUN (96)` |
| `python scripts/check_fast_pr_gap.py --list` (**planted fault**) | 0 | **(97)** — discriminator, see below |
| `python scripts/check_fast_pr_gap.py --list` (after) | 0 | `(96)` — `diff` vs before is **0 lines** |
| `python scripts/check_fast_pr_gap.py --self-test` | 0 | |
| `python scripts/check_fast_pr_gap.py --check` | 0 | `fast-PR gap map clean: 85 required jobs across 3 workflows; 29 fully covered by the spine, 5 partly, 51 not at all (96 required checks unrun locally).` |
| `python scripts/check_gate_scheduling.py` (before) | 0 | `51 gate commands, 43 scheduled, 8 declared` |
| `python scripts/check_gate_scheduling.py` (after) | 0 | identical; `diff` vs before is **0 lines** |
| `python scripts/check_gate_scheduling.py --self-test --verbose` | 0 | |
| `python scripts/check_gate_scheduling.py --verbose` | 0 | |
| `yaml.safe_load('.github/workflows/test.yml')` | 0 | `YAML OK` |
| PyYAML shape comparison | 0 | **byte-identical**, see below |

Both Python gates were invoked by **absolute path**
(`python C:/.../aptcap-g3lv/scripts/check_*.py`) so a leaked cwd could not run a
sibling worktree's copy. No gate was piped through `tail`/`head`/`grep`; each was
redirected to a log and `$?` echoed on the same command line, in one shell.

### Gap-map discriminator (these gates print no `gate root:` banner)

Planted a bogus non-setup step in `tenant-switcher-testbed-smoke`:

```yaml
- name: PLANTED FAULT discriminator aptcap-g3lv
  run: echo planted-fault-aptcap-g3lv
```

The count moved **96 → 97** and the step appeared by name in the map:

```
- tenant-switcher-testbed-smoke: "Tenant-switcher testbed browser smoke (rf2-h5e3v7)"
    step "PLANTED FAULT discriminator aptcap-g3lv"
      $ cd implementation && echo planted-fault-aptcap-g3lv
```

So the gate genuinely reads this worktree. The plant was then removed and the restore
**verified by hashing bytes**, not by reading `git diff`:

```
$ sha256sum -c testyml-pristine-aptcap-g3lv-1.sha256
.github/workflows/test.yml: OK
# 20fef9e5c72a2ce93f5a30af124ac7f076d5aa152daa9a51d052a0d9827e726e
```

### Shape comparison — proving nothing structural moved

A canonical dump of every job (`name`, `needs`, `if`, `runs-on`, `timeout-minutes`,
`defaults`, `outputs`) and every step (`name`, `uses`, `run`, `if`, `with`, `env`,
`timeout-minutes`, `working-directory`, `continue-on-error`), before and after:

```
5e3439ea08ac1c78cf6139472d953b3b53b650fe22e91223a63772b6529aedca  shape-before.json
5e3439ea08ac1c78cf6139472d953b3b53b650fe22e91223a63772b6529aedca  shape-after.json
diff -> 0 lines, exit 0
```

**Byte-identical.** No job name, check name, `needs:`, `if:`, step name, step body or
`timeout-minutes` value moved, so no required check is silently un-required. The diff
itself corroborates it: `1 file changed, 78 insertions(+)`, zero deletions, and
filtering the added lines for anything that is not a `#` comment or blank returns
**nothing**.

No `run:` line, no `timeout-minutes:` value, and no part of
`.github/scripts/playwright-install-failed.sh` or its 21 call sites was touched.
