### PR TITLE
docs(machines): rewrite the machines guide from the findings draft

### DIFF
--- a/docs/machines/actors.md
+++ b/docs/machines/actors.md
@@ -1,418 +1,370 @@
 # Actors: spawning child machines
 
-Long-lived singletons are only half the story. **Actors** are machines started for
-a job — a per-request protocol, a worker, a wizard step — via declarative
-`:spawn` / `:spawn-all` (or imperative fx). Assumes the [flat model](concepts.md);
-child completion often uses [final states](concepts.md#final-states) and parent
-`:on-done`.
+A machine can start another machine and bind that child's lifetime to a state.
 
-When a state needs self-contained async work — an HTTP request, a websocket session,
-a worker on a shard — **spawn a child machine** scoped to that state's lifetime. The
-child is a full machine instance with its own `:state` and `:data`; we call it an
-**actor**.
+The child is a live machine instance with its own snapshot. re-frame2 calls that
+instance an **actor**. Use one when work should start on state entry and be
+cleaned up on every exit path: a request protocol, a websocket, a worker, a
+cancellable job, a sub-flow that reports a result.
 
-The point is lifetime matching: start on entry, and tear down on **every** way out —
-including the exits you forgot. Declare the binding once; the runtime enforces it.
-Hand-rolling that is where leaks hide.
+Assumes the [flat model](concepts.md). Child completion often uses
+[final states](concepts.md#final-states).
 
-A spawned child can be **state-bound** (alive while a state is active) or
-**dynamically created**; both spell **`:spawn`**. There is **no actor object**:
-liveness *is* the snapshot at
-`[:rf.runtime/machines :snapshots <actor-id>]` in
-[runtime-db](glossary.md#snapshot). Address it with `dispatch` to its id; it reverts
-with the frame on time-travel.
+## State-bound spawn
 
-Assumes the transition table and [guards and actions](concepts.md#guards-and-actions),
-plus [`:after` timers](automatic-transitions.md) for the timeout story below.
-
----
-
-## Your first spawned actor — declarative `:spawn`
-
-Put a `:spawn` map on a state node. While the machine sits in that state, a child actor of the named machine exists; on any transition out of the state, it's destroyed.
-
-From the [websocket example](../../examples/patterns/websocket/): a connection
-machine whose `:active` state owns a live socket. The socket is its own machine
-(`:websocket/socket`), spawned on the `:active` *parent* so one socket spans the
-`:connecting` → `:authenticating` → `:connected` leaves nested inside it.
+Put `:spawn` on a state node. Entering the state creates the child. Leaving the
+state — by any transition — destroys it.
 
 ```clojure
+;; cf. examples/patterns/websocket
 (rf/reg-machine :ws/connection
   {:initial :disconnected
    :data    {:url nil :auth-token nil}
    :states
    {:disconnected
-    {:on {:ws/connect {:target :active :action :record-opts}}}
+    {:on {:ws/connect {:target :active
+                       :action :record-options}}}
 
     :active
     {:spawn {:machine-id :websocket/socket
-             ;; :data can be a fn — evaluated on entry against the
-             ;; post-action snapshot, so it reads whatever's current.
              :data       (fn [{snap :snapshot}]
                            {:url        (-> snap :data :url)
                             :auth-token (-> snap :data :auth-token)})}
-     :on    {:ws/closed {:target :reconnecting}
-             :ws/fatal  {:target :failed}}
-     ;; ... compound :initial / nested leaves omitted ...
-     }}})
+     :on {:ws/closed :reconnecting
+          :ws/fatal  :failed}
+     :initial :connecting
+     :states  {:connecting     {:on {:ws/opened :authenticating}}
+               :authenticating {:on {:ws/auth-ok :connected}}
+               :connected      {}}}}})
 ```
 
-Enter `:active` → the runtime spawns a `:websocket/socket` actor. Leave `:active` by *any* door — `:ws/closed`, `:ws/fatal`, a frame teardown — and the runtime destroys it. The parent never wrote "spawn" or "destroy"; `:spawn` is **registration-time sugar** that rewrites the state's `:entry`/`:exit` into the imperative spawn/destroy effects you'll meet below. From the outside it's indistinguishable from a machine that wired those slots by hand.
+The socket is spawned on the `:active` *parent*, so one actor spans
+`:connecting` → `:authenticating` → `:connected`. Cleanup is tied to the
+statechart, not to hand-written cancel branches.
 
-### The spawn-spec keys
-
-The map under `:spawn` accepts:
-
-| key | what it does |
-|---|---|
-| `:machine-id` **or** `:definition` | which machine to spawn — a registered machine id, or an inline transition table. Supply **exactly one** (both, or neither, is a registration error). |
-| `:data` | initial `:data` for the child — a literal map, or `(fn [{:keys [snapshot event]}] data)` evaluated at entry against the **post-action** snapshot (the transition's own `:action` has already run, so its writes are visible). |
-| `:id-prefix` | base for the allocated actor id (`:websocket/socket#0`); defaults to `:machine-id`. Ids are deterministic counters, never `gensym`. |
-| `:start` | an event vector dispatched to the newborn as its first event (see [the synthetic kick-off](#the-synthetic-spawned-event-and-start) below). |
-| `:system-id` | bind the actor to a per-frame **name** so other code can address it without knowing the allocated id (see [Messaging](#cross-machine-messaging)). |
-| `:on-spawn` | `(fn [{:keys [data id]}] _)` — an **advisory** observation hook; **its return is dropped** (see [Recording the id](#recording-the-spawned-id)). |
-| `:on-done` | `(fn [{:keys [data result]}] new-data)` — success notification when the child reaches a non-error `:final?` leaf. |
-| `:on-error` | an `:on`-shaped **transition** — fires when the child fails (an `:error?` final leaf, or a thrown action). The parent changes state. |
-| `:fixed-actor-id` | an explicit actor id instead of counter allocation, for a per-state singleton actor. |
-
-`:on-done` / `:on-error` are the completion story — they pair with the child declaring a `:final?` leaf, and they get [their own section below](#when-a-child-finishes). The [API reference](../api/re-frame.machines.md) lists the exact shapes.
-
-!!! note "One `:spawn` per state"
-
-    A state node carries at most one `:spawn` — for multiple children, use a compound state with one actor per substate, or [`:spawn-all`](#fan-out-and-join-with-spawn-all) for parallelism. Events aren't auto-forwarded to children — forward them explicitly with `:fx [[:dispatch [child-id ev]]]`. To observe a child's snapshot, read it with the `[:rf/machine actor-id]` subscription.
-
----
-
-## Runtime stamps: how a child knows who it is
-
-When the runtime builds a declaratively-spawned child's initial snapshot, it stamps three framework-reserved keys into the child's `:data` — so the child can address itself and its parent without the parent having to thread that information through:
-
-| key | value |
-|---|---|
-| `:rf/self-id` | the actor's own address (e.g. `:websocket/socket#0`) |
-| `:rf/parent-id` | the parent machine's registration id |
-| `:rf/invoke-id` | the absolute path of the `:spawn`-bearing state node |
-
-The child reads these as ordinary `:data` lookups inside its actions. Here's the socket actor reporting back to its parent on open (simplified from the [websocket example](../../examples/patterns/websocket/)):
+A state carries at most one `:spawn`. For several children, use a compound
+state with one actor per substate, or [`:spawn-all`](#fan-out-and-join-with-spawn-all).
+Events are not forwarded to children; dispatch to the child id yourself. To
+read a child's snapshot:
 
 ```clojure
-(rf/reg-machine :websocket/socket
-  {:initial :opening
-   :data    {:url nil :auth-token nil}
-   :actions
-   {:open-socket
-    (fn [{data :data}]
-      (let [self-id   (:rf/self-id data)       ;; my own address
-            parent-id (:rf/parent-id data)      ;; who spawned me
-            socket    (open-host-socket! self-id (:url data))]
-        (store-socket! self-id socket)
-        ;; Report up to the parent, tagging the message with my socket id.
-        {:fx [[:dispatch [parent-id [:ws/opened {:source-socket-id self-id}]]]]}))}
-   :states
-   {:opening {:entry :open-socket
-              :always [{:target :open}]}
-    :open    {:on {:send {:action :send-via-socket}}}}})
+@(rf/subscribe [:rf/machine actor-id])
 ```
 
-!!! note "Addressing the parent"
+## Spawn spec keys
 
-    A child can address its parent without being told who it is — the runtime stamps `:rf/parent-id` and the child reads it. **Caveat:** the stamp is written **only on the declarative `:spawn` / `:spawn-all` path**. A *hand-emitted* `[:rf.machine/spawn …]` (next section) records only `:rf/self-id` — there's no structural parent — so a hand-spawned child must be handed a correspondent address through its `:data`.
+Supply `:machine-id` or `:definition`, not both.
 
----
+| Key | Meaning |
+|---|---|
+| `:machine-id` | registered machine type to spawn |
+| `:definition` | inline machine definition instead of a registered id |
+| `:data` | child's initial data — a map, or `(fn [{:keys [snapshot event]}] …)` evaluated on entry against the **post-action** snapshot |
+| `:id-prefix` | base for the allocated id (`:websocket/socket#0`); defaults to `:machine-id`. Ids are counters, never `gensym` |
+| `:system-id` | stable role name for lookup and messaging |
+| `:start` | first event sent to the newborn |
+| `:on-spawn` | advisory hook; **its return is dropped** (see [Recording the spawned id](#recording-the-spawned-id)) |
+| `:on-done` | data-fold when the child reaches a successful final state |
+| `:on-error` | transition when the child reaches an error final state or fails |
+| `:timeout` / `:on-timeout` | wall-clock deadline on this child's lifetime; lowers onto the state's `:after` |
+| `:fixed-actor-id` | explicit actor id for a per-state singleton |
 
-## The synthetic spawned event, and `:start`
+The [API reference](../api/re-frame.machines.md) lists the exact shapes.
 
-A freshly-spawned actor needs a first nudge. Two ways:
+## Child runtime stamps
 
-- **No `:start` (the common case).** The runtime dispatches a synthetic `[:rf.machine.spawn/spawned]` into the newborn. The child's initial-state `:entry` cascade fires first regardless, so the **canonical** shape is to do the actor's first work in `:entry` (as `:open-socket` does above). A generic child can also listen for the kick-off explicitly:
+A **declaratively** spawned child gets three reserved keys in its `:data`:
 
-  ```clojure
-  ;; A child springing into action the instant it's spawned (no :start needed).
-  ;; The runtime conjures [:rf.machine.spawn/spawned] when there's nothing to :start.
-  :idle {:on {:rf.machine.spawn/spawned :processing}}
-  ```
+| Key | Meaning |
+|---|---|
+| `:rf/self-id` | this actor's live id |
+| `:rf/parent-id` | the parent actor's id (the address you dispatch to) |
+| `:rf/invoke-id` | the path of the state that spawned it (e.g. `[:active]`) |
 
-  Both work; new code prefers `:entry` (it fires for every kick-off mode). An unhandled `:rf.machine.spawn/spawned` is a benign no-op — it's reserved framework lifecycle traffic, exempt from the [unhandled-event trace](concepts.md#one-thing-that-wont-throw-the-unhandled-event) (see [See one run](concepts.md#see-one-run)).
+```clojure
+:actions
+{:notify-open
+ (fn [{data :data}]
+   {:fx [[:dispatch [(:rf/parent-id data)
+                     [:ws/opened {:source-socket-id (:rf/self-id data)}]]]]})}
+```
 
-- **With `:start [:begin url]`.** Hand the child a specific first event payload. The two paths are mutually exclusive — an actor gets the synthetic kick-off *or* your `:start`, never both.
+A hand-emitted `[:rf.machine/spawn …]` stamps only `:rf/self-id`. There is no
+structural parent, so pass a correspondent address through `:data` yourself.
 
----
+## Starting the child
+
+The child always runs its initial `:entry` cascade first. Prefer putting startup
+work there.
+
+If you omit `:start`, the runtime also dispatches a synthetic
+`[:rf.machine.spawn/spawned]`. Most children can ignore it. If you set
+`:start`, that event is sent **instead** — never both.
+
+```clojure
+:spawn {:machine-id :worker
+        :start      [:worker/start {:shard :a}]}
+```
+
+## Messaging
+
+There is one messaging primitive: `dispatch` to the actor id.
+
+```clojure
+{:fx [[:dispatch [child-id [:worker/cancel]]]]}
+```
+
+A parent gets the id from `:rf/spawned` or from a `:system-id`.
+A child gets the parent from `:rf/parent-id`. There is no separate *send* verb.
+
+### `:system-id`
+
+Bind the actor to a role name when you want to address the role, not a generated
+instance id.
+
+```clojure
+:spawn {:machine-id :request/protocol
+        :system-id  :primary-request
+        :data       {:url "/api/user"}}
+```
+
+From an action (which cannot read app-db):
+
+```clojure
+{:fx [[:rf.machine/dispatch-to-system
+       [:primary-request [:request/cancel]]]]}
+```
+
+That fx is a no-op if the name is unbound. Outside an action, resolve the id
+and dispatch to it:
+
+```clojure
+(when-let [actor (re-frame.machines/machine-by-system-id :primary-request)]
+  (rf/dispatch [actor [:request/cancel]]))
+```
 
 ## Recording the spawned id
 
-You will reach for `:on-spawn` to "capture the child's id into `:data`" — and it won't work. `:on-spawn` is an **advisory observation hook**: the runtime calls it with `{:data <parent-data> :id <new-id>}` and **drops its return value**. Writing `(assoc data :pending id)` records nothing (and emits a `:rf.warning/on-spawn-return-ignored` in dev). The runtime already tracks the id for you — so there's no self-dispatch dance to write, and no side-channel atom either.
-
-There are **two** mechanisms; reach for whichever fits.
-
-### 1. The `:rf/spawned` `:data` slot (read the id in-snapshot)
-
-On every declarative `:spawn` / `:spawn-all`, the pure transition reducer binds the new actor's id into the *spawning* machine's own `:data` under the reserved per-invoke map `:rf/spawned` — `{:rf/spawned {<invoke-id> <actor-id>}}`, keyed by the absolute path of the `:spawn`-bearing state. A later action reads it straight off its own `:data`:
+`:on-spawn` is an observation hook. The runtime calls
+`(fn [{:keys [data id]}] …)` and **drops the return**. Writing the id back
+into `:data` records nothing, and a dev build emits
+`:rf.warning/on-spawn-return-ignored`.
 
 ```clojure
-:active
-{:spawn {:machine-id :websocket/socket
-         :data       (fn [{snap :snapshot}] {:url (-> snap :data :url)})}
- ;; ... nested leaves; a leaf action reads the spawned socket's id:
- :states
- {:authenticating
-  {:entry (fn [{data :data}]
-            ;; the socket actor's id — no :on-spawn, no atom
-            (let [socket (get-in data [:rf/spawned [:active]])]
-              {:fx [[:dispatch [socket [:send {:type :auth}]]]]}))}}}
+;; Don't do this
+:on-spawn (fn [{:keys [data id]}]
+            (assoc data :child-id id))
 ```
 
-This is re-frame2's spelling of XState v5's `spawn(...)`-into-`context` capture, except the id rides the **revertible, SSR-survivable snapshot** rather than a live object reference. It's keyed by `<invoke-id>` (the same path the child records under `:rf/invoke-id`), so multiple `:spawn`-bearing states don't collide.
-
-**The slot clears itself on teardown.** When the actor is destroyed — leaving the state by any door, a completing `:final?`, a frame teardown — the runtime dissocs `[:rf/spawned <invoke-id>]` from the parent's `:data`, so it mirrors the runtime registry exactly. A read after the child is gone returns `nil`, never a dead id. That's what makes the [websocket example](../../examples/patterns/websocket/) treat the slot as its *connection clock*: the live socket's id **is** the epoch, and it goes `nil` the instant the socket dies — no `:exit` action nulling anything.
-
-### 2. `:system-id` (address the actor by a stable name)
-
-Give the spawn a `:system-id` and message it by that *role name* instead of the allocated id — best when you want a stable correspondent rather than to hold the id yourself. See [Addressing by name with `:system-id`](#addressing-by-name-with-system-id) below.
-
-!!! note "The runtime registry, for outside-the-machine reads"
-
-    The id is *also* always at `[:rf.runtime/machines :spawned <parent-id> <invoke-id>]` in the frame's runtime-db — the same value the `:rf/spawned` `:data` slot mirrors. Read it there when you're *outside* the machine's own action context (mechanism 1 needs the action's `:data`); inside an action, prefer the `:rf/spawned` slot.
-
----
-
-## Cross-machine messaging
-
-There is **one** mechanism: `dispatch` by id. **A machine *is* an event handler** — you message it the way you message anything, by dispatching to the id you hold. A spawned actor's id is a handler address, so a parent messages a child — and a child messages its parent — the same way:
+On every declarative `:spawn` / `:spawn-all`, the runtime already writes the
+new id into the **parent's** `:data` under `:rf/spawned`, keyed by the
+`:spawn`-bearing state's path:
 
 ```clojure
-;; parent → child, or child → parent: same primitive.
-{:fx [[:dispatch [some-machine-id [:some-event payload]]]]}
+;; cf. examples/patterns/websocket
+:authenticating
+{:entry (fn [{data :data}]
+          (let [socket (get-in data [:rf/spawned [:active]])]
+            {:fx [[:dispatch [socket [:send {:type :auth}]]]]}))}
 ```
 
-You get the id where the actor was created and carry it as an ordinary value: read the parent's `:rf/spawned` `:data` slot, observe it in `:on-spawn`, or read it from the snapshot — then dispatch to it. There is no machine-specific *send* verb; there is only `dispatch`.
+The slot clears itself when the actor is destroyed. A later read returns `nil`,
+not a dead id.
 
-### Addressing by name with `:system-id`
-
-When you don't want to thread the allocated id around, name the actor at spawn with `:system-id`, then message it by that name. The canonical action-side surface is the reserved `:rf.machine/dispatch-to-system` fx (a machine action can't read app-db, so it can't look the id up itself):
-
-```clojure
-;; spawn under a role-name:
-:spawn {:machine-id :request/protocol
-        :system-id  :primary-request
-        :data       {:url "/api/foo"}}
-
-;; later, from any action's :fx — message it by name (no-op if unbound):
-{:fx [[:rf.machine/dispatch-to-system [:primary-request [:cancel]]]]}
-```
-
-From a non-action call site you can resolve the id directly with `(re-frame.machines/machine-by-system-id :primary-request)` and `dispatch` to it. The binding lives in the frame's runtime-db, so it reverts with everything else.
-
-!!! note "`:rf.machine/dispatch-to-system` is a parked parity escape"
-
-    This fx has **zero in-repo consumers** as of 2026-07-10 — the everyday send is plain `dispatch` to the id you hold (above). It is retained as the one named-addressing escape for **XState v6 actor-system parity** (`systemId` addressing — behavioural parity, not API-mimicry); the facade audit at API-freeze rules on whether it ships. Reach for it only when you genuinely need role-name addressing from *inside* an action (which can't read app-db to resolve the id itself). There is no separate machine *send* verb.
-
-### Including a reply address
-
-There's no `sender`/`sendTo`-reply special form. Put the reply event *in the request* (the standard re-frame2 reply convention): address the request by name, but carry the reply id in the payload, so the reply lands in a specific actor rather than whoever currently owns the name.
-
----
+Use `:system-id` instead when you only need role-based messaging. The same id
+is also at `[:rf.runtime/machines :spawned <parent-id> <invoke-id>]` for reads
+*outside* a machine action.
 
 ## When a child finishes
 
-A spawned child that genuinely *completes* — a one-shot protocol, a finished handshake — declares a **`:final?` leaf**. Entering it terminates the child: the runtime reads the child's result, notifies the parent, then destroys the actor. The child names its result with **`:output-key`** — the slot of its final `:data` to hand up — and the parent's `:spawn` declares **`:on-done`**, which receives that value as `result`:
+A one-shot child reports success by entering a **root-level** `:final?` leaf
+and naming the `:data` slot to hand up with `:output-key`. The parent folds
+that value in `:on-done`:
 
 ```clojure
-;; Child — a one-shot auth handshake that reports its token, then ends.
-(rf/reg-machine :auth-flow
+(rf/reg-machine :auth/request
   {:initial :running
    :data    {}
    :states
    {:running {:on {:server-ok {:target :done
-                               :action (fn [{data :data ev :event}]
-                                         {:data (assoc data :token (second ev))})}}}
+                               :action (fn [{data :data [_ token] :event}]
+                                         {:data (assoc data :token token)})}}}
     :done    {:final?     true
-              :output-key :token}}})       ;; report :data's :token back to the parent
+              :output-key :token}}})
 
-;; Parent — :on-done folds the child's result into its own :data.
 :authenticating
-{:spawn {:machine-id :auth-flow
-         :on-done    (fn [{data :data result :result}]   ;; result = the child's :token
+{:spawn {:machine-id :auth/request
+         :on-done    (fn [{:keys [data result]}]
                        (assoc data :token result))
-         :on-error   :idle}                               ;; child failed → a transition
- :on    {:auth/cancelled :idle}}
+         :on-error   :idle}
+ :on    {:cancel :idle}}
 ```
 
-When `:auth-flow` enters `:done`, the runtime reads its `:token`, hands it to the
-parent's `:on-done` as `result`, then tears the child down — no stale id left
-behind:
-
-- **`:on-done` is a data-fold, not a transition.** `(fn [{:keys [data result]}] new-data)`
-  — returns the parent's next `:data`; the parent's state doesn't move.
-- **`:on-error` IS a transition.** A child that fails — `:final?` leaf flagged
-  `:error? true`, or a thrown action — routes the parent through the `:on`-shaped
-  `:on-error` spec. Failure is control flow, not just observability.
-- **Completion is event-shaped.** `:output-key` flows to `:on-done` at completion,
-  then the child is gone — no long-lived output slot. Want a *computed* output?
-  Write it into the final state's `:data` with a transition `:action`; no
-  `:output-fn`.
-- **Final means final — even for a singleton.** A root-level `:final?` leaf
-  auto-destroys *any* machine. A resting end-screen (`:authed`) is an ordinary leaf
-  with `:final?` omitted.
-- **Nested finals are different.** A `:final?` leaf *inside a compound* signals
-  "this sub-flow is done" to the compound's `:on-done`; the machine keeps running.
-  See [Hierarchical states → When a sub-flow finishes](hierarchical-states.md#when-a-sub-flow-finishes-nested-final-states).
-
----
+- **`:on-done` is a data-fold**, not a transition:
+  `(fn [{:keys [data result]}] new-data)`. The parent's state does not move.
+- **`:on-error` is a transition.** A child that fails — a `:final?` leaf
+  flagged `:error? true`, or a thrown action — routes the parent through that
+  `:on`-shaped spec.
+- Entering a root-level `:final?` destroys the child after the parent is
+  notified. A nested `:final?` only tells the compound "this sub-flow is
+  done"; see [Hierarchical states](hierarchical-states.md#when-a-sub-flow-finishes-nested-final-states).
 
 ## Imperative spawn and destroy
 
-`:spawn` desugars to two reserved effects you can also emit by hand from any `:fx` vector. They are **fx-ids inside `:fx`**, not top-level effect keys:
+Declarative `:spawn` lowers to reserved fx you can also emit from any `:fx`
+vector:
 
 ```clojure
-;; Spawn from an event handler (e.g. a boot-time bootstrap event):
-(rf/reg-event :session/start-logger
-  (fn [_ _]
-    {:fx [[:rf.machine/spawn {:machine-id :machines/log-shipper
-                              :id-prefix  :logger
-                              :system-id  :logger        ;; address it later by name
-                              :data       {:buffer []}
-                              :start      [:logger/connect]}]]}))
+{:fx [[:rf.machine/spawn
+       {:machine-id :logger
+        :system-id  :logger
+        :data       {:buffer []}
+        :start      [:logger/connect]}]]}
 
-;; Tear it down later:
-(rf/reg-event :session/stop-logger
-  (fn [_ _]
-    {:fx [[:rf.machine/dispatch-to-system [:logger [:logger/flush]]]
-          [:rf.machine/destroy (re-frame.machines/machine-by-system-id :logger)]]}))
+{:fx [[:rf.machine/destroy actor-id]]}
 ```
 
-`[:rf.machine/spawn <spec>]` and `[:rf.machine/destroy <actor-id>]` are the surface;
-the [API reference](../api/re-frame.machines.md) documents them in full:
+Inside a machine state, prefer declarative `:spawn`. From an ordinary event
+handler — when the number or timing of children is not one state node — emit
+the fx.
 
-- **Spawning an unregistered `:machine-id` fails closed.** No snapshot, no id, no
-  `:start` — rejects with `:rf.error/machine-spawn-unregistered-type`. There is no
-  "spec-less spawn."
-- **Destroy is silently idempotent.** Destroying an already-gone actor is a no-op —
-  no error, no second trace. Exactly one Active → Stopped transition.
+An unregistered `:machine-id` (and no `:definition`) fails closed:
+**no** snapshot, **no** id, **no** `:start`. The runtime raises
+`:rf.error/machine-spawn-unregistered-type`.
 
-For the rare case of spawning from outside a handler (true boot time), wrap the `:rf.machine/spawn` in a one-shot event and `dispatch-sync` it. Inside a machine, prefer declarative `:spawn`; inside an ordinary handler, the imperative fx is the canonical surface.
+Destroy is silently idempotent. Destroying an already-gone actor is a no-op.
 
----
+## Cancellation
 
-## Cooperative cancellation — teardown on every exit path
+A spawned actor is destroyed when:
 
-This is why `:spawn` is worth using instead of firing an HTTP request from a plain handler: **the child's death is guaranteed on every code path out of its state.** The runtime destroys a spawned actor on *any* of these triggers:
+- the parent exits the spawn-bearing state;
+- a timeout or `:after` transition exits that state;
+- a `:spawn-all` join cancels surviving siblings;
+- you emit `[:rf.machine/destroy actor-id]`;
+- the **frame** is torn down with `destroy-frame!`. A view unmount or a
+  route change does **not** destroy the frame — tear one down only when you
+  mean to.
 
-1. **Parent state exit** — any transition out of the `:spawn`-bearing state.
-2. **The parent's `:after` firing** — a wall-clock timeout (next section) is just a state exit.
-3. **`:spawn-all` join resolution** — surviving siblings are unconditionally torn down when the join resolves.
-4. **Imperative `[:rf.machine/destroy <id>]`**.
-5. **Frame destroy** — when the [frame is torn down](glossary.md#snapshot) by an explicit `destroy-frame!`, every surviving machine in it is destroyed. Note that **a frame is not destroyed by a view unmounting or by navigating away** — frames [survive unmount by design](../core/frames.md) (tearing one down is a deliberate `destroy-frame!`, not a cleanup effect). So this trigger fires when a component that *owns* a frame's whole lifetime destroys it (a modal with a throwaway world torn down on close), or when a per-request SSR frame is disposed at end-of-request — not on every route change. Cross-route teardown of a machine's resources rides its `:exit` cascade (triggers 1–4 above), which is why you don't wire abort calls into route-leave handlers even though the frame itself lives on.
+Destroy releases exactly three framework-managed kinds:
 
-### What auto-cancels — and what you wire by hand
+- in-flight `:rf.http/managed` requests this actor issued (the reply is
+  `{:kind :rf.http/aborted :reason :actor-destroyed}`);
+- this actor's armed `:after` timers;
+- `:rf.resource/*` owners this actor holds.
 
-The runtime knows how to release exactly **three** framework-managed resource kinds on destroy, by any trigger:
-
-- **In-flight `:rf.http/managed` requests** the actor issued — aborted automatically. The reply path sees `{:kind :rf.http/aborted :reason :actor-destroyed}`. *This is the headline:* an HTTP request issued from inside a spawned actor is bound to that actor's lifetime; a request fired from a plain `reg-event` handler has no such peg and is **not** cancelled. If you want lifetime-bound HTTP, spawn a child that issues it.
-- **Armed `:after` timers** the actor scheduled — cancelled, so a killed worker won't wake up later.
-- **`:rf.resource/*` owners** the actor holds.
-
-!!! note "Auto-cancel covers three resource kinds"
-
-    re-frame2 auto-cancels exactly the three kinds above — the ones the framework manages, and so knows how to release. **Anything else** the child holds — a raw `setInterval`, a `js/WebSocket`, a Web Worker, a third-party SDK subscription — you release yourself, in the child's **`:exit` action**. It runs on every destroy cascade, so one line covers all five triggers:
+Anything else — a raw `js/WebSocket`, a `setInterval`, a Worker — you close
+yourself in the child's `:exit`. That action runs on every destroy path:
 
 ```clojure
-{:connected
- {:entry :open-socket
-  :exit  :close-socket          ;; runs on EVERY exit, including parent-destroy
-  :on    {:disconnect :idle}}}
+:connected
+{:entry :open-socket
+ :exit  :close-socket
+ :on    {:disconnect :idle}}
 ```
 
-The destroy path runs the actor's `:exit` *before* dissociating its snapshot, so cleanup gets to read the final `:data`. There is no `core.async` in this path — close the host handle directly, don't reach for a channel close. (The websocket example keeps its mock socket in a host-side atom and leans on actor-destroy plus a mock that holds no real OS resource; a real `js/WebSocket` would `.close()` in `:exit`.)
+The [long-running-work example](../../examples/patterns/long_running_work/)
+cancels by leaving `:working`: that exit destroys every surviving child,
+pending `:after` yield-timers included.
 
-The [long-running-work example](../../examples/patterns/long_running_work/) shows the cascade end-to-end: the user hitting **Cancel** dispatches `:cancel`, which leaves the `:working` state, and *that exit* fires a `:rf.machine/destroy` for every still-running child — pending `:after` yield-timers and all. The author wrote no per-child teardown.
+## Timeouts
 
----
+There is no `:timeout-ms` on `:spawn` or `:spawn-all`. Registration rejects
+it with `:rf.error/spawn-timeout-ms-removed`.
 
-## Wall-clock timeouts — use the parent state's `:after`
-
-"The whole activity must finish within N seconds, spanning any internal retries." There is **no `:timeout-ms` slot** on `:spawn` (it's rejected at registration). The answer is the [`:after`](automatic-transitions.md) primitive on the `:spawn`-bearing state — one timer mechanism, not two:
+`:timeout` / `:on-timeout` **on the spawn spec** is fine. It lowers onto the
+spawn-bearing state's `:after`, so the deadline is anchored to that state's
+entry and spans the child's internal retries:
 
 ```clojure
-{:authenticating
- {:spawn {:machine-id :login-request                  ;; a child MACHINE that issues the request and retries internally
-          :data       {:request {:method :post :url "/api/login" :body credentials}}}
-  :after {30000 :auth-failed}      ;; wall-clock guard — spans the child's retries
-  :on    {:succeeded      :authenticated
-          :user/cancelled :idle}}}
+:authenticating
+{:spawn {:machine-id :auth/request
+         :timeout    "PT30S"
+         :on-timeout {:target :auth-failed}}
+ :on    {:cancel :idle
+         :auth-ok :authenticated}}
 ```
 
-The timer is anchored to `:authenticating`'s **entry**, so it bounds the child's whole lifetime no matter how many times the child retries internally. When it fires, the state exits and the standard cancellation cascade destroys the in-flight child (aborting its HTTP). Three independent triggers — the user cancels, 30s elapses, or the frame is torn down — all route through the *same* teardown.
+The same deadline as a state-level `:after`:
 
-> The same guard has a named-intent spelling, `:timeout "PT30S"` + `:on-timeout {:target :auth-failed}` (ISO-8601 durations), which **lowers onto the same `:after` timer**. Use whichever reads better; they're one mechanism. (Durations are ISO-8601 or integer milliseconds; a bare `"5s"` shorthand isn't accepted.)
+```clojure
+:authenticating
+{:spawn {:machine-id :auth/request}
+ :after {30000 :auth-failed}
+ :on    {:cancel :idle
+         :auth-ok :authenticated}}
+```
 
----
+One timer mechanism. When it fires, the state exits and the child is
+destroyed. Durations are a positive integer (ms) or an ISO-8601 string
+(`"PT30S"`). A `"5s"` shorthand is rejected.
 
 ## Fan-out and join with `:spawn-all`
 
-When a state needs to spawn **N children in parallel** and resume on a join condition — boot hydration, parallel asset loads, a swarm of workers — use `:spawn-all`. The [long-running-work example](../../examples/patterns/long_running_work/) is the canonical case: one parent coordinator spawns a worker per shard and joins when all are done.
+Use `:spawn-all` when one state starts **N children in parallel** and
+resumes on a join.
 
 ```clojure
-(rf/reg-machine :work/flow
-  {:initial :idle
-   :data    {:progress {}}
-   :states
-   {:idle
-    {:on {:start {:target :working :action :reset-progress}}}
+;; cf. examples/patterns/long_running_work
+:working
+{:spawn-all
+ {:children
+  [{:id :s1 :machine-id :work/processor :data {:shard :s1 :total 100}}
+   {:id :s2 :machine-id :work/processor :data {:shard :s2 :total 100}}
+   {:id :s3 :machine-id :work/processor :data {:shard :s3 :total 100}}]
 
-    :working
-    {:spawn-all
-     {:children        [{:id :s1 :machine-id :work/processor :data {:shard :s1 :total 100}}
-                        {:id :s2 :machine-id :work/processor :data {:shard :s2 :total 100}}
-                        {:id :s3 :machine-id :work/processor :data {:shard :s3 :total 100}}]
-      :join            :all                   ;; :all (default) or :any
-      :on-child-done   :work/child-done       ;; keyword each child dispatches on success
-      :on-child-error  :work/child-error      ;; ...and on failure
-      :on-all-complete [:work/all-done]        ;; parent event when :all resolves
-      :on-any-failed   [:work/any-failed]}     ;; parent event when a child fails
-     :on {;; A child checking in — no :target makes it an internal self-transition,
-          ;; so the children aren't re-spawned and aren't torn down.
-          :progress        {:action :record-progress}
-          ;; The join landing back in the parent as an ordinary event:
-          :work/all-done   {:target :complete  :action :stamp-outcome}
-          :work/any-failed {:target :error     :action :stamp-outcome}
-          ;; The user pulling the plug — leaving :working destroys every child:
-          :cancel          {:target :cancelled :action :stamp-outcome}}}
+  :join            :all
+  :on-child-done   :work/child-done
+  :on-child-error  :work/child-error
+  :on-all-complete [:work/all-done]
+  :on-any-failed   [:work/any-failed]}
 
-    :complete  {:on {:reset {:target :idle}}}
-    :cancelled {:on {:reset {:target :idle}}}
-    :error     {:on {:reset {:target :idle}}}}})
+ :on
+ {:progress        {:action :record-progress}   ;; no :target — don't respawn
+  :work/all-done   {:target :complete}
+  :work/any-failed {:target :failed}
+  :cancel          {:target :cancelled}}}
 ```
 
-**The child completion protocol.** Each child is an ordinary machine. When it finishes, its terminal state dispatches the parent's `:on-child-done` keyword, carrying its own `:id`:
+Each child is an ordinary machine. When it finishes, it dispatches the
+parent's `:on-child-done` keyword, carrying its own `:id`:
 
 ```clojure
-;; In the child (:work/processor), at its terminal state:
 :done {:entry (fn [{data :data}]
                 {:fx [[:dispatch [:work/flow [:work/child-done (:shard data)]]]]})}
 ```
 
-The runtime intercepts these at the parent's boundary, updates join state, and once the condition resolves, fires the parent event (`:on-all-complete` here) **and** unconditionally cancels any siblings still in flight. The bookkeeping — who's done, who failed, the resolution latch — is **runtime-owned** at `[:rf.runtime/machines :spawned <parent-id> <invoke-id>]`; the parent keeps none of it in `:data`.
+The runtime owns the join bookkeeping. When the join resolves it fires the
+parent event **and** destroys any siblings still in flight.
 
 Rules:
 
-- **Each child needs a unique `:id`** (the join key) on top of the usual spawn keys.
-  Duplicate ids are a registration error.
-- **Join discriminators:** `:all` (default) or `:any`. `:on-all-complete` is
-  required for `:all`; `:on-some-complete` is required for `:any`. A quorum
-  ("N of M") join uses the data-only `:after` + `:done-guard` idiom, not a `:join`
-  mode.
-- **Sibling cancellation on join resolution is unconditional** — when the join
-  resolves, surviving siblings are torn down. A late result from an already-decided
-  join fires no further parent event. Independently valuable children: N single
-  `:spawn`s (fire-and-forget), not a non-cancelling join.
-- **An unregistered child type fails the whole invoke closed, atomically.** The
-  runtime seeds a childless reject marker and suppresses registered siblings too —
-  malformed fan-out spawns nothing rather than leaving orphans. A child that can
-  never run can never deadlock an `:all` join.
-- **Wall-clock timeout:** same as single `:spawn` — an `:after` on the
-  `:spawn-all`-bearing state. When it fires, the exit cascade cancels every
-  surviving child.
+- **Each child needs a unique `:id`** (the join key) on top of the usual
+  spawn keys. Duplicates are `:rf.error/machine-spawn-all-duplicate-id`.
+- **`:join` is only `:all` or `:any`.** There is no `{:n n}` and no
+  predicate. Quorum ("N of M") is `:after` / `:always` plus a
+  `:done-guard` that reads the join's done count — not a `:join` mode.
+- **`:on-all-complete` is required for `:all`.** **`:on-some-complete` is
+  required for `:any`.** Missing either is
+  `:rf.error/machine-spawn-all-bad-shape`.
+- **An unregistered child type fails the whole invoke**, atomically —
+  nothing is spawned, so an `:all` join cannot hang on a child that never
+  runs (`:rf.error/machine-spawn-unregistered-type`).
+- A wall-clock bound on the join is the same as single `:spawn`: `:after`
+  or `:timeout` / `:on-timeout` on the spawn-all-bearing state.
 
-`:spawn-all` packages fan-out, join, and cancel-on-resolution into one declaration.
+Independently valuable children — fire-and-forget, no cancel-the-rest — are
+N separate `:spawn`s, not a non-cancelling join.
 
----
+## Troubleshooting
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| Parent `:data` never gets the child id; `:rf.warning/on-spawn-return-ignored` | `:on-spawn` return is dropped | Read `(get-in data [:rf/spawned invoke-path])`, or use `:system-id` |
+| No snapshot, no id; `:rf.error/machine-spawn-unregistered-type` | `:machine-id` is not registered and there is no `:definition` | Register the child type first |
+| Registration throws `:rf.error/spawn-timeout-ms-removed` | `:timeout-ms` on `:spawn` / `:spawn-all` | Use `:timeout` / `:on-timeout`, or `:after` on the parent state |
+| Registration throws `:rf.error/machine-spawn-all-bad-shape` on `:join` | `:join` was `{:n n}`, a predicate, or another non-enum | `:join` is only `:all` or `:any`. Quorum is `:after` / `:always` + `:done-guard` |
+| `:join :all` rejected | missing `:on-all-complete` | Give `:on-all-complete` an event vector |
+| `:join :any` rejected | missing `:on-some-complete` | Give `:on-some-complete` an event vector |
+| Socket / interval / Worker still open after destroy | not a framework-managed resource | Close it in the child's `:exit` |
+| Children torn down (or respawned) on a progress event | the parent's `:on` had a `:target` | Omit `:target` so the transition is internal |

--- a/docs/machines/automatic-transitions.md
+++ b/docs/machines/automatic-transitions.md
@@ -1,274 +1,250 @@
 # Automatic transitions
 
-Not every move is a user click. This page is the grammar for transitions the
-**table** takes on its own: eventless `:always`, choice nodes, delayed `:after`,
-and named timeouts.
+Most transitions wait for an event. Some transitions are driven by the machine itself:
 
-You already met `:after` on the [login tutorial](tutorial.md#step-4--talk-to-a-real-server)
-(8s server deadline). The same keys work on **flat** machines
-([the model](concepts.md)) and nest inside
-[hierarchical](hierarchical-states.md) / [parallel](parallel-states.md) states.
+- a guard becomes true;
+- a decision node resolves immediately;
+- a delay expires;
+- a deadline is missed.
 
-Most [transitions](glossary.md#transition) wait for the world — a click, an HTTP
-reply, a hand-rolled timer. An **automatic transition** is one the
-[machine](glossary.md#machine) takes *on its own*: when a condition holds or a
-deadline passes, the [snapshot](glossary.md#snapshot) moves. Without them you re-
-invent the same brittle pattern — `setTimeout` plus a cancel flag, or a synthetic
-`dispatch` from every place that could enable the next step. Each of those is one
-declarative key on a state node.
+re-frame2 has four authoring forms for this, built on two engines.
 
-Four authoring grammars, **two engines**:
-
-| You want… | Reach for | Fires when |
+| Intent | Form | Engine |
 |---|---|---|
-| "the instant condition X holds, go to Y" | `:always` | a guard turns true, re-checked after every transition into the state |
-| "a decision node that routes on entry and never lingers" | `:type :choice` | entry — first guard-passing candidate wins |
-| "after N ms in this state, do Z" | `:after` | a wall-clock delay measured from state entry elapses |
-| "this state (or its child) must finish in time" | `:timeout` / `:on-timeout` | a fixed deadline from entry passes |
+| "Whenever this condition holds, move." | `:always` | guard-driven microstep loop |
+| "Enter a decision node and immediately route." | `:type :choice` + `:choice` | desugars to `:always` |
+| "After N ms in this state, move." | `:after` | wall-clock timer |
+| "This state or child must finish in time." | `:timeout` + `:on-timeout` | desugars to `:after` |
 
-!!! note "Four grammars, two engines"
+## Eventless `:always`
 
-    `:type :choice` **desugars to `:always`**; `:timeout` / `:on-timeout`
-    **desugars to `:after`**. Guard-driven microstep loop vs wall-clock timer. The
-    extra grammars *name intent* so tools and diagrams can read it.
-
-Assumes [the model](concepts.md#register-and-drive): `reg-machine`, table as data,
-[guard](glossary.md#guard) → boolean, [action](glossary.md#action) →
-`{:data … :fx …}` (`:data` merged), snapshot `{:state … :data … :tags …}`. New to
-that? [Guards and actions](concepts.md#guards-and-actions) first.
-
-## Eventless `:always` — fire the instant a condition holds
-
-`:always` is a state-node key holding a vector of guarded transitions. It is checked **after entry** — and after *any* transition that lands in the state — and the first guard that passes fires immediately, no event required. It answers "the snapshot just changed; if X is now true, move on" without you hand-raising a synthetic event from every action that could enable X.
-
-Here is the canonical shape — a quiz that ends the moment enough answers are correct:
+`:always` is checked after a state is entered and after transitions that remain in, or land in, that state.
 
 ```clojure
 (rf/reg-machine :quiz
   {:initial :asking
-   :data    {:correct-count 0}
-   :guards  {:enough-correct? (fn [{:keys [data]}] (>= (:correct-count data) 10))}
-   :actions {:count-correct   (fn [{:keys [data]}]
-                                {:data {:correct-count (inc (:correct-count data))}})}
+   :data    {:correct 0}
+
+   :guards
+   {:enough? (fn [{data :data}]
+               (>= (:correct data) 10))}
+
+   :actions
+   {:count-correct (fn [{data :data}]
+                     {:data {:correct (inc (:correct data))}})}
+
    :states
-   {:asking {:always [{:guard :enough-correct? :target :winner}]
-             :on     {:answer-correct {:action :count-correct}   ;; no :target — stays :asking
-                      :answer-wrong   {:target :loser}}}
+   {:asking
+    {:always [{:guard :enough?
+               :target :winner}]
+     :on     {:answer-correct {:action :count-correct}
+              :answer-wrong   :loser}}
+
     :winner {}
     :loser  {}}})
 ```
 
-When you `(rf/dispatch [:quiz [:answer-correct]])`, two things happen inside **one** machine event:
+The `:answer-correct` transition has no `:target`, so it updates `:data` while staying in `:asking`. Then `:always` is checked. If the count has reached ten, the machine moves to `:winner` in the same macrostep.
 
-1. `:asking`'s `:answer-correct` transition runs `:count-correct`, which bumps `:correct-count`. There is no `:target`, so this is an internal transition — the snapshot stays at `:asking`.
-2. The runtime immediately re-checks `:asking`'s `:always`. If `:correct-count` has now reached 10, `:enough-correct?` is true and the machine transitions to `:winner`.
+External observers see the settled result, not each internal microstep.
 
-External observers see `:asking → :winner` in one step. The "answer counted, still asking" intermediate state is **invisible** — exactly the property `:always` exists to provide.
+## Run to completion
 
-### Settle, then commit once
+A machine processes one event to a stable configuration before the next event is observed.
 
-`:always` extends the event [pipeline](../core/run-to-completion.md): after the
-triggering transition, a **microstep loop** keeps taking enabled `:always`
-transitions (and draining any [`:raise`](../api/re-frame.machines.md)d internal
-events) until a **fixed point** — no `:always` matches, no raised event pending.
-Only then does the snapshot commit **once, atomically**, with the accumulated `:fx`.
+Inside that one macrostep, the runtime:
 
-That is statechart **macrostep** semantics: observers see the *settled* result.
-Time-travel, [Xray](../core/observability.md), and undo see one committed
-transition; inner microsteps ride the trace stream for tools.
+1. takes the event-driven transition;
+2. applies exit/action/entry effects;
+3. checks `:always`;
+4. drains any `:raise`d internal events;
+5. repeats until no `:always` is enabled and no raised event remains;
+6. commits the final snapshot once.
 
-!!! note "It runs at birth, too"
+The loop is bounded. The default depth limit is 16. A runaway `:always` or `:raise` cycle raises `:rf.error/machine-always-depth-exceeded` and aborts the macrostep atomically; the previous snapshot remains visible.
 
-    The same settle loop runs when the machine first starts. If the [`:initial`](concepts.md#register-and-drive) state cascades into a leaf whose `:always` guard already holds, that transition is taken *before* the birth commit — so a transient initial state is settled past, unobserved, on start. (This is also why `:always` lives on a state node, never on the root: the root's cascade entry-point is `:initial`.)
+## `:always` rules
 
-### Ordering, depth, and self-loops
-
-A few rules keep the loop well-behaved — and keep your typos loud at registration time, not on the unlucky dispatch:
-
-- **`:always` settles before the next raised event.** If an action both `:raise`s an event `R` and lands in a state whose `:always` is enabled, the `:always` is taken **first**; `R` is then handled in the post-`:always` state. Raised events otherwise drain FIFO. (This matches SCXML exactly.)
-- **Bounded depth.** The loop is capped (default **16** microsteps, configurable per machine via `:always-depth-limit`). A non-converging cycle trips `:rf.error/machine-always-depth-exceeded` and **fails the whole macrostep** — the snapshot is never written, so the transition rolls back atomically. It is a failure, not a silent no-op, so a runaway cycle is distinguishable from an ordinary guard-blocked decline.
-- **No self-target.** An `:always` whose `:target` resolves to its own declaring state is **rejected at `reg-machine` time** (`:rf.error/machine-always-self-loop`) — guarded or not. An eventless transition back into the state you just entered either loops to the depth limit or is a no-op; either way the author meant something else.
-
-!!! note "Looping until a condition clears"
-
-    The legitimate "keep going while there's work" shape is a **targetless** guarded `:always` with an `:action` — `{:guard :more? :action :drain-one}`. Its action flips the guard false and the loop settles. That is *not* a self-loop (there's no `:target`), so it's allowed.
-
-### `:always` in the wild
-
-The [WebSocket example](../../examples/patterns/websocket/README.md) uses `:always` for two distinct jobs on two different states:
+`:always` takes a candidate vector:
 
 ```clojure
-:reconnecting
-{:always [{:guard :max-retries-exceeded? :target :failed}]   ;; out of retries → give up
- :after  {…}                                                  ;; otherwise back off and retry
- :on     {…}}
-
-:connected
-{:entry  :flush-queue-and-resubscribe
- :always [{:guard :has-queued-messages? :action :flush-queue}]  ;; drain the offline queue on entry
- :on     {…}}}
+:resolving
+{:always [{:guard :empty?    :target :empty}
+          {:guard :too-many? :target :too-many}
+          {:target :some}]}
 ```
 
-`:reconnecting` carries **both** `:always` and `:after` — they're independent state-node slots and coexist freely. And `:connected`'s `:always` is the targetless-action form: its `:flush-queue` action clears the queue, the guard goes false, and the microstep loop settles — no extra state needed.
+The first candidate whose guard passes wins. Include an unguarded default when the state must always resolve.
 
-`:always` is **not** a substitute for `:after`: `:always` fires on guard *truth*, `:after` fires on elapsed *time*.
-
-## `:type :choice` — a decision node that never lingers
-
-A **choice state** is a routing node: enter it, walk its guarded candidates in order, take the first whose guard passes, and leave — all within the same macrostep, no event needed. It's how you draw "decide which way to go" as an explicit node on the chart.
+An `:always` transition may be targetless:
 
 ```clojure
-(rf/reg-machine :submission
-  {:initial :idle
-   :data    {}
-   :guards  {:valid? (fn [{:keys [data]}] (boolean (:form-ok? data)))}
-   :states
-   {:idle     {:on {:submit :checking}}
-    :checking {:type   :choice
-               :choice [{:guard :valid? :target :accepted}
-                        {:target :rejected}]}     ;; unguarded final = the default / else branch
-    :accepted {}
-    :rejected {}}})
+:draining
+{:always [{:guard :has-more?
+           :action :drain-one}]}
 ```
 
-Dispatching `[:submission [:submit]]` enters `:checking`, which resolves **immediately**: if `:valid?` passes the machine settles at `:accepted`, otherwise it falls through to the default `:rejected`. External observers never see `:checking` — it's a transient routing node. (A choice state may also be the machine's `:initial` state, in which case it resolves at birth.)
+This is the safe "loop until done" pattern. The action changes `:data`; once the guard becomes false, the loop settles.
 
-Under the hood, `:type :choice` / `:choice` **desugars to an ordinary state with an `:always` slot** carrying the same candidate vector. The candidate walk, first-guard-pass select, and macrostep settle are all the `:always` machinery you just met — reused, not reinvented. `:choice` exists to *name the intent* so a visualiser renders a decision diamond and validation gives a clearer grammar.
+An `:always` transition may not target its own declaring state. That shape either loops forever or does nothing useful, so `reg-machine` throws `:rf.error/machine-always-self-loop`.
 
-### Divergence: a declarative array, not a `choice` function
+## Choice states
 
-re-frame2 requires a choice node's routing to be a **declarative guarded-candidate array** `[{:guard … :target …}]`, never a function — a function may never be the edge. The edge topology stays *data*, so diagrams, model tests, conformance fixtures, and AI tools can read the routing without executing it. A function-valued `:choice` fails loud at registration with `:rf.error/machine-bad-choice`.
+A choice state is a named decision node. The machine enters it and immediately leaves through the first passing candidate.
 
-### What the runtime checks
+```clojure
+:checking
+{:type   :choice
+ :choice [{:guard :valid? :target :accepted}
+          {:target :rejected}]}
+```
 
-`reg-machine` validates the choice grammar on the raw spec, so a mistake is caught before the machine ever runs:
+It is equivalent in behaviour to an `:always` decision, but it communicates intent to readers and diagram tools.
 
-- `:type :choice` and `:choice` **require each other** — one without the other is meaningless.
-- The `:choice` value **must be a non-empty vector of candidate maps** (not a fn, keyword, or empty vector).
-- The vector **must include an unguarded default** candidate. Without one, a `:checking` entered with every guard failing would have nowhere to go — a stuck transient node. A present default is the only static guarantee the state always resolves.
-- A choice state **only routes** — it may not also declare `:entry`, `:on`, `:after`, `:timeout`, `:spawn`, and so on. (So a choice state can never carry a `:timeout`; the two named-intent grammars don't combine.)
-- A candidate targeting the choice state's own state is a self-loop and is rejected, exactly as for `:always`.
+Choice rules:
 
-## Delayed `:after` — transition after a wall-clock delay
+- `:type :choice` and `:choice` must appear together.
+- `:choice` is a non-empty vector of transition candidates.
+- The vector must include an unguarded default.
+- A choice state only routes; it does not also declare `:on`, `:entry`, `:after`, `:spawn`, and so on.
+- The topology stays data. A function-valued `:choice` fails at registration with `:rf.error/machine-bad-choice`.
 
-`:after` is a state-node key mapping a **delay** to a transition. Entering the state arms every timer; leaving the state cancels them. On expiry, the matching transition fires (subject to its guard). It replaces the `dispatch-later`-plus-cancel-flag pattern that sits behind most timeout, debounce, and reconnect bugs.
+## Delayed `:after`
 
-The simplest case — a splash screen that dismisses itself after three seconds, or sooner if the user skips:
+`:after` maps a delay to a transition. Entering the state arms the timer. Leaving the state cancels it.
+
+The [login tutorial](tutorial.md#step-4--talk-to-a-real-server) uses an 8-second `:after` as a server deadline. The same key works for any wall-clock wait:
 
 ```clojure
 (rf/reg-machine :boot
   {:initial :splash
    :states
-   {:splash {:after {3000 :main}        ;; 3000 ms → :main
-             :on    {:skip :main}}       ;; …or the user clicks "skip"
-    :main   {:on {:restart :splash}}}})
+   {:splash {:after {3000 :main}
+             :on    {:skip :main}}
+    :main   {}}})
 ```
 
-`{3000 :main}` is sugar for `{3000 {:target :main}}` — the delay's value uses the **same** transition grammar as an `:on` clause.
-
-### What goes in the `:after` map
-
-Each entry is `<delay> → <transition>`. Both halves take several forms.
-
-**The delay (the key) — three forms:**
-
-- **Integer milliseconds** — `{30000 :timeout}`. The common fixed delay. (Note: a literal `:after` delay is **integer ms only** — not an ISO-8601 string, and *never* the `"5s"` shorthand. ISO-8601 durations belong to `:timeout`, below; the `"5s"` shorthand re-frame2 rejects everywhere.)
-- **A [subscription](../core/subscriptions.md) vector** — `[:sub-id & args]`, resolved like any `subscribe`. The canonical form for an **app-state-derived** delay (a user preference, a feature-flag config). It *re-resolves* when its value changes (see below).
-- **A function** — `(fn [{:keys [snapshot]}] ms)`, called **once** at state entry. The escape valve for a delay computed from the machine's own `:data`.
-
-!!! note "Watch the shape"
-
-    Guards and actions receive `:data` at the top level of their context map; an `:after` delay-fn instead receives `{:keys [snapshot]}` and reaches *inside* it — `(-> snapshot :data :retry-count)`. The snapshot is the familiar `{:state … :data … :tags …}` value.
-
-**The transition (the value) — identical to an `:on` clause:** a bare keyword (sugar for `{:target kw}`), a full transition map `{:guard … :target … :action … :meta …}`, or a first-guard-pass-wins candidate vector. If a `:guard` is present and false at expiry, the transition is **suppressed** — the timer is "fired and discarded", the snapshot is unchanged, a `:rf.machine.timer/fired` trace records `:fired? false`, and *other in-flight timers keep running*.
+The transition value uses the same grammar as `:on`:
 
 ```clojure
-;; All three delay forms, on one state node:
-{:loading
- {:after {30000                        {:target :timeout :guard :no-progress?}   ;; literal ms
-          [:sub :timeout-config :slow] {:target :warn :action :log-slow}          ;; subscription
-          (fn [{:keys [snapshot]}] (* 1000 (-> snapshot :data :retry-count)))
-                                       :retry}                                     ;; local fn
-  :on    {:loaded :ready
-          :failed :error}}}
+:loading
+{:after {30000 {:target :timeout
+                :guard  :still-loading?
+                :action :record-timeout}}
+ :on    {:loaded :ready
+         :failed :error}}
 ```
 
-### One timer per entry, counted from entry
+If the guard is false when the timer fires, the timer is discarded and the snapshot does not move.
 
-Every `:after` timer counts independently from the moment the machine **enters the state**. A state with `{:after {5000 :warn 30000 :timeout}}` arms *both* timers at entry, concurrently — the 5 s timer is not chained off the 30 s one. Re-entering the state restarts every timer fresh; there's no preserved "elapsed-so-far".
+## Delay forms
 
-A state can have several triggers racing at once — multiple `:after` timers, the state's `:on` events, an `:always`, a [spawned](glossary.md#spawn) child completing. **Whichever fires first wins**; the resulting state exit cancels the rest as part of the normal exit cascade.
+An `:after` delay can be:
 
-!!! note "A same-tick tie has no document-order guarantee"
+```clojure
+30000
+```
 
-    When two `:after` timers with different delays happen to fire in the same scheduler tick, the order they reach the router is the *host scheduler's* order — not document order. SCXML resolves simultaneously-enabled transitions by document order; re-frame2 `:after` timers are real host-clock deferred events, so it's "first valid timer to arrive wins; the transition makes the rest stale." Don't rely on declaration order to break a same-tick `:after` tie.
+A positive integer, in milliseconds. Not an ISO-8601 string — those belong to `:timeout` below.
 
-### No cancel flag: epoch-based staleness
+```clojure
+[:settings/login-timeout-ms]
+```
 
-re-frame2 ships **no `:cancel-dispatch-later` fx**, and you never write one. That's safe — and the headline reason to prefer `:after` over hand-rolled timers.
+A subscription vector. The delay re-resolves while the state is active. If the subscription value changes, the timer restarts from now.
 
-Every scheduled timer carries an **epoch** — a per-state-entry counter — captured when it's armed. Leaving the state advances that state's epoch. When a timer eventually fires, the runtime compares the carried epoch against the state's current one:
+```clojure
+(fn [{:keys [snapshot]}]
+  (* 1000 (-> snapshot :data :retry-count)))
+```
 
-- **Match** → the state is still the one that armed this timer; fire the transition.
-- **Mismatch** → the state was exited (or re-entered, arming a fresh timer); **silently drop it** and emit a `:rf.machine.timer/stale-after` trace.
+A function, evaluated once when the state is entered. It does not re-resolve. Delay functions receive `{:snapshot …}`, not the usual guard/action context (`{:data :event :state :meta}`).
 
-So a timer armed on an earlier visit can never "wander in" and fire against a state you've since left. There's nothing to remember and nothing to clean up: the epoch makes a late timer self-cancelling. The epoch is tracked **per scheduling node** (the declaring state's path), so a parent's long `:after` survives a leaf-to-sibling transition underneath it, while the exited leaf's timers go stale — a parent's 30 s hard-timeout ticks happily alongside a child's 5 s progress timeout.
+## Timer staleness
 
-### Delays that track app state
+You do not cancel `:after` timers yourself.
 
-A **subscription-vector** delay re-resolves while it's in flight. If the underlying sub value changes, the runtime cancels the current timer and **restarts from now** with the freshly-resolved delay (it does *not* extend or shorten the running timer — restart-from-now keeps the countdown always reflecting the current value). The epoch mechanism backstops the cancellation, and a paired `:rf.machine.timer/cancelled` (`:reason :on-resolution`) → `:rf.machine.timer/scheduled` shows up on the trace stream.
+Every timer carries the state-entry epoch that armed it. When it fires, the runtime checks whether that epoch is still current. If the state has been exited or re-entered, the timer is stale and ignored.
 
-A **function** delay does **not** re-resolve — it's computed once at entry. If you need a `:data`-derived delay that re-resolves on change, use the subscription form (over a sub that reads the machine's `:data`) and pay the subscription cost; the fn form is the cheap "compute once at entry" valve.
+This avoids the usual `setTimeout` plus cancel-flag bug. A late timer from a previous visit cannot move the current state.
 
-### Worked example: exponential backoff
+## Several timers can race
 
-The WebSocket example's `:reconnecting` state computes its backoff from the retry count, using the function-delay form:
+```clojure
+:loading
+{:after {5000  :slow-warning
+         30000 :timeout}
+ :on    {:loaded :ready}}
+```
+
+Both timers count from state entry. If `:loaded` arrives before either, leaving the state cancels both. If the 5 second timer fires, it takes its transition; if that transition exits the state, the 30 second timer is cancelled.
+
+Do not rely on declaration order to break a same-tick tie. Host scheduling decides which timer event arrives first.
+
+## Exponential backoff
 
 ```clojure
 :reconnecting
-{:tags   #{:websocket/reconnecting}
- :always [{:guard :max-retries-exceeded? :target :failed}]
- :after  {(fn [{:keys [snapshot]}]
-            (let [{:keys [retries base-ms max-backoff-ms]} (:data snapshot)]
-              (min (* base-ms (Math/pow 2 retries)) max-backoff-ms)))
-          {:target :active}}                       ;; …wait, then retry the connection
- :on     {:ws/connect {:target :active :action :record-and-reset}
-          …}}
+{:after {(fn [{:keys [snapshot]}]
+           (let [{:keys [retries base-ms max-backoff-ms]} (:data snapshot)]
+             (min (* base-ms (Math/pow 2 retries)) max-backoff-ms)))
+         {:target :connecting}}   ;; cf. examples/patterns/websocket
+ :on    {:give-up :failed}}
 ```
 
-Each visit to `:reconnecting` reads the *current* `:retries` and waits longer than the last (200 ms, 400, 800, … capped at `max-backoff-ms`). The `:always` short-circuits straight to `:failed` once retries are exhausted. And because leaving `:reconnecting` cancels the timer via the epoch mechanism, a backoff armed on an earlier visit can never fire late — no flag, no cleanup. See [`connection.cljs`](../../examples/patterns/websocket/README.md) for the whole machine.
+Each visit to `:reconnecting` computes a fresh delay from the current snapshot.
 
-### The clock, SSR, and what `:after` is *not*
+For recurring timers, re-enter the state. There is no separate recurring-timer primitive.
 
-`:after` timers go through `re-frame.interop` (`now-ms`, `schedule-after!`, `cancel-scheduled!`) — `setTimeout`/`clearTimeout` on CLJS, a `ScheduledExecutorService` on the JVM. There's no framework-level clock-config API; tests swap the interop layer with the usual fixture patterns. Under SSR, `:after` **no-ops** — the server renders the current `:state` statically and the client re-arms timers after hydration.
+## SSR
 
-`:after` deliberately does **not** include: recurring timers (re-enter the state to re-arm), calendar/wall-clock-time scheduling (it's relative to *entry*, not "9 AM tomorrow"), or pause/resume (transition out and back in).
+On the server, `:after` does not run wall-clock timers. The server renders the current state. The client re-arms timers after hydration.
 
-## `:timeout` / `:on-timeout` — a named deadline
+Design SSR-visible states so they are meaningful without depending on a timer firing server-side.
 
-A state — or a [`:spawn`](glossary.md#spawn) spec — may declare a `:timeout` duration plus an `:on-timeout` transition. It names a single fact: "this state (or its spawned child) must finish before this time." It reads more clearly than a bare `:after` entry when the intent really is a deadline.
+## `:timeout` and `:on-timeout`
+
+Use `:timeout` when the intent is a deadline.
 
 ```clojure
-{:states
- {:waiting
-  {:timeout    "PT5S"                       ;; ISO-8601: 5 seconds
-   :on-timeout {:target :timed-out}}
-
-  :loading
-  {:spawn {:machine-id :fetch-user          ;; spawn a child machine
-           :timeout    "PT10S"              ;; the child must finish within 10 s…
-           :on-timeout {:target :timed-out}}}}}  ;; …or we bail
+:waiting
+{:timeout    "PT5S"
+ :on-timeout {:target :timed-out}}
 ```
 
-`:timeout` **requires** `:on-timeout` (and vice versa); a lone one of either is a registration error. The pair **desugars to an `:after` entry** keyed by the resolved-ms duration — so entering the state arms it, leaving cancels it, and all the `:after` epoch/staleness/trace machinery drives it unchanged. For a spawn timeout, the timer is anchored to the spawn-bearing state's entry, so it bounds the child's whole lifetime (across any internal retries); when it fires, the exit cascade tears the child down.
+The pair lowers onto the same timer mechanism as `:after`.
 
-`:timeout` and `:after` express different intent and **may coexist** on one state node. (A `:final?` state can't declare a `:timeout` — final means final.)
+It also works on a [spawn](glossary.md#spawn) spec:
 
-### Duration grammar: integer-ms or ISO-8601
+```clojure
+:authenticating
+{:spawn {:machine-id :auth/request
+         :timeout    "PT10S"
+         :on-timeout {:target :auth-failed}}}
+```
 
-A `:timeout` duration is **exactly one of**:
+`:timeout` on a spawn spec is valid. The retired `:timeout-ms` slot is not — `reg-machine` throws `:rf.error/spawn-timeout-ms-removed`.
 
-- a **positive integer** — literal milliseconds (`5000`); or
-- an **ISO-8601 duration string** — `"PT5S"`, `"PT2M"`, `"PT1H30M"`, `"PT0.5S"`, `"P1D"`, … (the `PnYnMnWnDTnHnMnS` form; case-insensitive; fractional seconds allowed).
+When the timeout fires, the parent state exits, and the spawned child is destroyed as part of the normal exit cascade.
 
-A readable shorthand like `"5s"` / `"10ms"` is **not** accepted: such a string — or any other malformed duration (a non-positive integer, a fn, a vector, the bare `"P"`) — fails **loud** at registration with `:rf.error/machine-bad-timeout-duration`. And unlike `:after`, a `:timeout` admits **no** subscription-vector or fn dynamic delays — a timeout is a fixed wall-clock deadline. The integer-ms-or-ISO-8601 rule is the single duration grammar; the shorthand string is rejected on purpose.
+`:timeout` requires `:on-timeout`, and `:on-timeout` requires `:timeout`.
+
+## Timeout durations
+
+A timeout duration is one of:
+
+```clojure
+5000
+```
+
+Positive integer milliseconds.
+
+```clojure
+"PT5S"
+"PT1H30M"
+"PT0.5S"
+```
+
+An ISO-8601 duration string.
+
+Readable shorthands such as `"5s"` or `"10ms"` are not accepted, nor are subscription vectors or delay functions. A bad duration fails at registration with `:rf.error/machine-bad-timeout-duration`. Use integer milliseconds or ISO-8601.

--- a/docs/machines/coming-from-xstate.md
+++ b/docs/machines/coming-from-xstate.md
@@ -1,496 +1,302 @@
 # Coming from XState
 
-This page is a **translation**, not a tutorial. For a first machine in re-frame2,
-use the [login tutorial](tutorial.md) and [the model](concepts.md). Here: how
-XState v5/v6 concepts map, and where re-frame2 deliberately diverges.
+This page is a translation, not a tutorial. It maps XState v5/v6 ideas onto
+re-frame2.
 
-If you've built statecharts with [XState](https://stately.ai/docs) — v5, or the v6
-alpha — most of your mental model ports straight across. re-frame2's
-[machines](concepts.md) borrow XState's grammar on purpose: transition tables as
-data, guards, actions, tags, delayed transitions, final states, run-to-completion,
-internal-by-default self-transitions. You can read a re-frame2 machine table and a
-re-frame2 author can read yours. The *behaviour* is the contract; what changes is
-the *expression* and one piece of *plumbing*.
+If you know XState, the statechart ideas transfer well:
 
-Two things transfer almost untouched:
+- states and transitions;
+- guards and actions;
+- nested states;
+- parallel regions;
+- tags;
+- delayed and eventless transitions;
+- final states;
+- history;
+- run-to-completion.
 
-- **The statechart itself.** States, nested states, parallel regions, guards,
-  entry/exit actions, `after` timers, final states, history — same concepts,
-  idiomatic spelling. If you can draw it, you can write it.
-- **The semantics you rely on.** Run-to-completion, internal-vs-external
-  self-transitions, eventless (`always`) transitions on guard flips, an unknown
-  event as a no-op rather than a crash. re-frame2 matches XState here deliberately,
-  including the v5/v6 drop of strict mode.
+The biggest change is not the chart. It is where the running machine lives.
 
-And one thing genuinely shifts:
+In XState, you create an actor, start it, and send to it.
 
-- **A machine is not an actor.** This is the real difference, and the rest of this
-  page keeps coming back to it. In XState you `createActor(machine)`, `.start()` it,
-  and `.send()` events to a living object that owns its own state. In re-frame2 a
-  machine is an [event handler](../core/glossary.md#event-handler) — registered like
-  any other, fed by the same [`dispatch`](../core/glossary.md#dispatch), with its
-  state living in the [frame](../core/glossary.md#frame) rather than in an object
-  you hold a reference to. There's no `send`, no mailbox, no actor ref. There's one
-  queue, and machines ride it like everything else.
-
-Get that last bullet and the table below is mostly vocabulary.
-
-!!! note "Parity reference: the XState v6 direction"
-
-    Where this page says "XState," the behavioural baseline is the **v6** design direction (plain guard/action functions over a declarative topology, broader optional schemas, explicit timeouts, choice states, private internal events, event-shaped completion) — not v5's helper-creator API. The posture is *behavioural parity, not API mimicry*: re-frame2 aligns semantics and records each intentional divergence rather than cloning JavaScript runtime shapes. When your training recalls a v5 helper (`assign`, `sendTo`, `raise`, `and`/`or`/`not`/`stateIn`, `setup()`), reach for the data-first re-frame2 form below.
-
-## The mapping
-
-Skim this, then read the worked build-up in [The grammar, concept by concept](#the-grammar-concept-by-concept). The exhaustive API contract is the [`re-frame.machines` reference](../api/re-frame.machines.md) — this page teaches; that page enumerates.
-
-| XState (v6 direction) | re-frame2 | Notes |
-|---|---|---|
-| `createMachine({ ... })` / `setup().createMachine()` | a transition-table map passed to [`reg-machine`](concepts.md#register-and-drive) | Plain Clojure data. No builder, no fluent API. |
-| `context` (extended state) | [`:data`](#context-becomes-data) | Same idea. "Context" was already taken (interceptor context, React context); `:data` tracks FSM / `gen_statem` "state data". |
-| `state.value` | the snapshot's `:state` | Flat → keyword; compound → vector path; parallel → region-name→state map (each region's value is itself a keyword or path). |
-| `states: { idle: { on: { ... } } }` | `:states {:idle {:on {...}}}` | Near-identical shape. `on` → `:on`, target strings → state keywords. |
-| nested states (`initial` + `states`) | [`:initial` + `:states` on a state node](#compound-nested-states) | Deepest-wins resolution, parent fall-through. Keyword target = sibling; vector target = absolute path. |
-| `guard: 'canRetry'` | `:guard :under-retry-limit` | Named; defined in the spec's [`:guards`](#guards) map. Idiomatic Clojure name (`?`-suffixed predicate), not a JS boolean string. |
-| `actions: assign({...})` / effectful actions | [`:action :record-error`](#actions-assign-and-the-effect-map) returning `{:data ... :fx ...}` | An action **returns** an [effect map](../core/glossary.md#effect-map) — it doesn't mutate. More below. |
-| `setup({ guards, actions })` registry | per-spec `:guards` / `:actions` maps | Each machine carries its own. Cross-machine reuse is an ordinary Clojure var, not a string registry. |
-| `tags: ['busy']` + `state.hasTag('busy')` | [`:tags #{:auth/busy}`](#tags) + `[:rf.machine/has-tag? id :auth/busy]` | A Clojure set; the membership question is a [subscription](../core/glossary.md#subscription). See [state tag](glossary.md#state-tag). |
-| `after: { 5000: 'next' }` | [`:after {5000 {:target :next}}`](#delayed-transitions-after-and-timeout) | Same declarative timer; same auto-cancel on exit. ISO-8601 strings (`"PT5S"`) accepted; XState's `"5s"` shorthand is **not**. |
-| `always: [{ guard, target }]` | [`:always [{:guard … :target …}]`](#eventless-transitions-always) | Eventless transitions, same firing rule. |
-| state/actor `timeout` / `onTimeout` | [`:timeout`/`:on-timeout`](#delayed-transitions-after-and-timeout) | A named deadline that lowers onto `:after`. ms or ISO-8601; `"5s"` shorthand rejected. |
-| `type: 'choice'` / a `choice` **function** | [`:type :choice` + `:choice [...]`](#choice-states) | A declarative candidate **array**, never a function. See divergence #4. |
-| v6 `internalEvents: [...]` | [`:internal-events #{...}`](#internal-events) | A Clojure **set**, not an array. Private events the machine raises and handles itself. |
-| `reenter: true` | `:reenter? true` | External self-transition. Same semantics; Clojure `?`. |
-| `type: 'parallel'` | [`:type :parallel` + `:regions {...}`](#parallel-states) | Regions, not `states`. `:data` shared, `:tags` unioned, `:state` becomes a region→state map. |
-| `type: 'history'` (`history: 'deep'`) | [`:type :history` (`:deep? true`)](#history-states) | A pseudo-state under a compound's `:states`. Shallow by default. |
-| `type: 'final'` + `output` | [`:final? true`](#final-states-and-output) + `:output-key` | A finishing leaf reports a value to its parent's `:on-done`. `output` is a *key*, not a fn. |
-| `invoke: { src: childMachine }` | [`:spawn {:machine-id …}`](#invoke-becomes-spawn) | Start a child on entry, tear down on exit. Renamed; see below. |
-| `invoke … onError` (a transition) | `:spawn`'s `:on-error` transition + `:error? true` leaf | First-class control flow, not observability-only. |
-| multiple `invoke` per state / fan-out | `:spawn-all` (named children + join + cancel policy) | One `:spawn` per state; fan-out is its own surface. |
-| `raise({ type: ... })` | `:fx [[:raise [:event …]]]` | Loop an event back into *this* machine, atomically, pre-commit. |
-| `sendTo` / `sender` (reply to a request) | the reply event carried in the request vector | No new API; the request names its own reply target. |
-| TypeScript `types` / v6 `schemas` | [`:schemas {:data … :output …}`](#schemas-types-that-actually-run) | A [Malli schema](../core/glossary.md#schema) — but one that **actually runs in dev** and rolls a bad transition back, not erased-at-compile types. |
-| three creation modes (`createActor` / `invoke` / `spawn`) | one mechanism: singleton via `reg-machine`, dynamic via `:spawn` / `[:rf.machine/spawn …]` | Lifetime is the snapshot's presence in [runtime-db](../core/glossary.md#runtime-db), not which constructor you called. |
-| **`createActor(m).start()` → `actor.send(ev)`** | **the machine is an event handler → `(rf/dispatch [machine-id [event]])`** | **The big one.** No actor object; one [`dispatch`](../core/glossary.md#dispatch), one [pipeline run](../core/glossary.md#run). |
-| `actor.getSnapshot()` | [`@(rf/subscribe [:rf/machine id])`](#reading-the-snapshot) | The [snapshot](glossary.md#snapshot) is a value in [runtime-db](../core/glossary.md#runtime-db), read like any other derived state. |
-
-This table is the long form; the worked build-up and the *why* essays below are the part worth your attention.
-
-## The grammar, concept by concept
-
-The table is the map; this section is the territory. Each piece below shows the XState shape you know, then the re-frame2 shape it becomes, built from one running example — the login flow from the [machines guide](concepts.md). Every snippet is real API; nothing here is invented.
-
-### The machine definition
-
-In XState you build a machine with `createMachine` — and in v6 a `setup()` registry holds the guards/actions and types:
-
-```js
-import { setup, assign } from 'xstate';
-
-const loginMachine = setup({
-  guards:  { underRetryLimit: ({ context }) => context.attempts < 2 },
-  actions: { /* … */ },
-}).createMachine({
-  initial: 'idle',
-  context: { attempts: 0, error: null },
-  states:  { idle: { on: { SUBMIT: 'submitting' } } /* … */ },
-});
-```
-
-In re-frame2 the definition is *just data* — one map, with its `:guards` and `:actions` tables carried inline, registered with [`reg-machine`](concepts.md#register-and-drive):
+In re-frame2, a machine is an event handler. You register it, dispatch to it, and
+read its snapshot from the frame. There is no actor object, no `send`, and no
+second event system.
 
 ```clojure
-(rf/reg-machine :auth.login/flow
+(rf/reg-machine :auth.login/flow login-flow)
+
+(rf/dispatch [:auth.login/flow [:auth.login/submit creds]])
+
+@(rf/subscribe [:rf/machine :auth.login/flow])
+```
+
+Require `[re-frame.machines]` once at boot. The first `reg-machine` without it is
+`:rf.error/machines-artefact-missing`.
+
+The behavioural baseline is XState v6 — plain guard and action functions, optional
+schemas, explicit timeouts, choice states, private events, event-shaped
+completion. v5 helpers such as `assign`, `sendTo`, `raise`, and `setup()` map
+onto the data-first forms below.
+
+## Mapping
+
+| XState idea | re-frame2 |
+|---|---|
+| `createMachine(...)` / `setup().createMachine()` | `(rf/defmachine …)` then `(rf/reg-machine id …)`, or an inline `reg-machine` literal |
+| `context` | `:data` |
+| `state.value` | snapshot `:state` |
+| `state.context` | snapshot `:data` |
+| `actor.getSnapshot()` | `@(rf/subscribe [:rf/machine id])` |
+| `actor.send(event)` | `(rf/dispatch [machine-id [event …]])` |
+| `states` | `:states` |
+| `initial` | `:initial` |
+| nested states | compound states with `:initial` + `:states` |
+| `type: "parallel"` | `:type :parallel` + `:regions` |
+| `type: "history"` | `:type :history` |
+| `type: "final"` | `:final? true` (auto-destroys; omit it on a resting leaf) |
+| `reenter: true` | `:reenter? true` |
+| `tags` | `:tags #{…}` |
+| `state.hasTag(tag)` | `@(rf/subscribe [:rf.machine/has-tag? id tag])` |
+| `guard` | `:guard` named in `:guards` |
+| `actions` / `assign` | `:action` returning `{:data … :fx …}` |
+| `always` | `:always` |
+| `after` | `:after` |
+| timeout / onTimeout | `:timeout` + `:on-timeout` |
+| choice state | `:type :choice` + a declarative `:choice` vector |
+| `invoke` | `:spawn` |
+| `invoke` `onError` | `:spawn`'s `:on-error` transition |
+| multiple invokes / fan-out | `:spawn-all` |
+| `raise` | `:fx [[:raise [:tick]]]` |
+| `sendTo` | `:fx [[:dispatch [other-id [:their/event]]]]` or `[:rf.machine/dispatch-to-system [system-id [:their/event]]]` |
+| `output` | `:output-key` on a final state |
+| `internalEvents` | `:internal-events #{…}` |
+| TypeScript types / v6 `schemas` | `:schemas {:data … :output …}` |
+
+## Machine definition
+
+XState commonly separates machine shape from a `setup()` registry. re-frame2
+keeps the table, guards, and actions in one map. Prefer `defmachine` (or an
+inline `reg-machine` literal). A plain `(def m {…})` then `reg-machine` leaves
+source stamps empty (`:rf.warning/machine-source-unstamped`).
+
+```clojure
+(rf/defmachine login-flow
   {:initial :idle
    :data    {:attempts 0 :error nil}
 
    :guards
-   {:under-retry-limit (fn [{:keys [data]}] (< (:attempts data) 2))}
+   {:under-retry-limit (fn [{data :data}]
+                         (< (:attempts data) 2))}
 
    :actions
-   {:clear-error  (fn [_] {:data {:error nil}})
-    :issue-request (fn [{[_ creds] :event}] {:fx [[:rf.http/managed { … }]]})
-    :record-error  (fn [{data :data [_ {:keys [error]}] :event}]      ;; failure map under :error
-                     {:data (-> data (update :attempts inc)
-                                     (assoc :error (or (:message error) "Login failed.")))})
-    :store-session (fn [{[_ {:keys [value]}] :event}]
-                     {:fx [[:auth.session/store {:token (:token value)}]]})}
+   {:record-error
+    (fn [{data :data [_ {:keys [error]}] :event}]
+      {:data (-> data
+                 (update :attempts inc)
+                 (assoc  :error (or (:message error) "Login failed.")))})}
 
    :states
-   {:idle        {:on {:auth.login/submit {:target :submitting :action :clear-error}}}
-    :submitting  {:tags  #{:auth/busy}
-                  :entry :issue-request
-                  :on    {:auth.login/success {:target :authed :action :store-session}
-                          :auth.login/failure [{:target :error-shown
-                                                :guard  :under-retry-limit
-                                                :action :record-error}
-                                               {:target :locked-out}]}}
-    :error-shown {:on {:auth.login/dismiss :idle
-                       :auth.login/submit  :submitting}}
-    :authed      {}
-    :locked-out  {}}})
+   {:idle
+    {:on {:auth.login/submit :submitting}}
+
+    :submitting
+    {:on {:auth.login/failure [{:target :error-shown
+                                :guard  :under-retry-limit
+                                :action :record-error}
+                               {:target :locked-out
+                                :action :record-error}]}}}})
+
+(rf/reg-machine :auth.login/flow login-flow)
 ```
 
-In XState the definition is built by a function call and a `setup()` registry; in re-frame2 it's a literal map with no builder and no global registry — `reg-machine` is sugar over `reg-event`, so the machine *is* an [event handler](../core/glossary.md#event-handler). That single fact (divergence [#1](#1-a-machine-is-an-event-handler-not-an-actor) below) is why you drive it with `dispatch`, not `actor.send`, and why the whole thing being *data* means it [tests on the JVM](#reading-the-snapshot) as pure function calls. Source-coord stamping for tooling is why you reach for the `reg-machine` macro over the plain `reg-machine*` fn — see the [API reference](../api/re-frame.machines.md).
+The guard reads the pre-action `:attempts`, so `< 2` is three attempts. The
+failure payload sits under `:error`. Cross-machine reuse is ordinary Clojure
+reuse: put a guard or action function in a var and reference it from several
+specs.
 
-### Context becomes :data
+## Context becomes :data
 
-A snapshot is the live value of a machine — the XState `{ value, context }` pair:
-
-```js
-// state.value   === 'submitting'
-// state.context === { attempts: 1, error: null }
-```
+The concept is the same: extended state attached to the finite state.
 
 ```clojure
-;; the re-frame2 snapshot:
-{:state :submitting :data {:attempts 1 :error nil}}
+{:state :submitting
+ :data  {:attempts 1 :error nil}}
 ```
 
-Same split — a discrete `:state` (XState's `state.value`) plus extended memory `:data` (XState's `context`). In XState this slot is `context`; in re-frame2 it is `:data`, because re-frame already spends the word "context" on the interceptor context and React context, and `:data` tracks the FSM / Erlang `gen_statem` "state data" tradition. The divergence is name-only.
+The name differs because "context" already has other meanings in Clojure,
+re-frame, and React, and `:data` makes the action return shape match an event
+handler's.
 
-### Actions, assign, and the effect map
+## Actions return effects
 
-This is the deepest behavioural shift. XState's `assign(...)` is an action *creator* that imperatively updates `context`, and an effectful action *runs* its side effect when invoked:
+This is the most important behavioural difference.
 
-```js
-actions: assign({ attempts: ({ context }) => context.attempts + 1 }),  // the "assign"
-// and, separately, an effectful action that performs a fetch when invoked.
-```
-
-re-frame2 inverts this. An action is a pure function that **returns** the same data-shaped [effect map](../core/glossary.md#effect-map) a `reg-event` handler returns — `:data` (merged into the snapshot) and/or `:fx` (a *description* of work the effects machinery runs):
+An XState action may perform work or use `assign` to update context. A re-frame2
+action returns a value:
 
 ```clojure
-:record-error
-(fn [{data :data}] {:data (update data :attempts inc)})       ;; this IS the "assign"
-
-:issue-request
-(fn [{[_ creds] :event}]
-  {:fx [[:rf.http/managed {:request    {:method :post :url "/api/login" :body creds}
-                           :on-success [:auth.login/flow [:auth.login/success]]
-                           :on-failure [:auth.login/flow [:auth.login/failure]]}]]})
+(fn [{data :data}]
+  {:data {:attempts (inc (:attempts data))}
+   :fx   [[:analytics/track {:event :login-failed}]]})
 ```
 
-In XState you reach for the `assign` helper-creator; in re-frame2 returning `{:data ...}` *is* the assignment — there is no `assign`, and no `[:assign {...}]` form (full *why* in divergence [#3](#3-actions-return-effects-they-dont-perform-them) below). XState v6 is itself moving away from `assign`'s special status toward plainer functions, which is roughly where re-frame2 started. Note `:on-success [:auth.login/flow [:auth.login/success]]` above: the HTTP reply lands back *inside the machine* as an ordinary event ([the uniform reply](../core/glossary.md#the-uniform-reply) appends the payload), so a machine and an async surface compose with no `invoke`-promise bridge.
+Returning `{:data …}` is the assignment. Returning `{:fx …}` describes effects
+for re-frame2's effect machinery to perform. The action itself stays pure, so a
+transition is easy to test and replay.
 
-### Guards
+## The topology stays data
 
-A guard is a yes/no test gating a transition. In XState v5 you name it and define it in `setup()`:
+In re-frame2, functions live in guards and actions. The graph stays declarative.
+
+That means:
+
+- targets are data;
+- candidate lists are data;
+- `:choice` is a vector of guarded candidates, not a routing function;
+- guard composition happens inside named guard functions, not a separate
+  combinator DSL.
+
+A declarative graph can be rendered, diffed, inspected, tested, and edited by
+tools.
+
+## Events and dispatch
+
+XState event objects commonly look like:
 
 ```js
-on: { FAILURE: [{ guard: 'underRetryLimit', target: 'errorShown' }, { target: 'lockedOut' }] }
+{ type: "SUBMIT", credentials }
 ```
+
+re-frame2 machine events are vectors:
 
 ```clojure
-:guards {:under-retry-limit (fn [{:keys [data]}] (< (:attempts data) 2))}
-;; …on the :submitting node:
-:on {:auth.login/failure [{:guard :under-retry-limit :target :error-shown :action :record-error}
-                          {:target :locked-out}]}
+[:auth.login/submit credentials]
 ```
 
-Same guarded candidate vector, first-pass-wins — identical to XState's transition array. Both sides read `2` for this three-attempt login because a guard is evaluated *before* the transition's action — ahead of the `assign` in XState, ahead of `:record-error` here — so each sees the not-yet-bumped counter and the boundary sits one below the total ([Guards](concepts.md#guards)). A guard (like an action) receives **one context map** and destructures what it needs: `(fn [{:keys [data event state meta]}] …)`. **Divergence:** there is no `{and: [...]}` / `stateIn` data combinator (XState v6 dropped the v5 `and`/`or`/`not`/`stateIn` creators, which re-frame2 never had) — a compound condition goes in one *named* function, so the *name* is what a diagram arrow and an AI read; cross-region coordination uses [tags](#tags). A guard or action that needs a host fact (the clock, a random draw) [declares it as a coeffect](concepts.md#guards-and-actions) rather than calling `(js/Date.now)`, so the decision replays identically under time-travel.
+Dispatch wraps the machine event in the outer re-frame2 event:
 
-### Reading the snapshot
-
-In XState you reach into the actor object; in re-frame2 you subscribe, because the snapshot is a plain value in the frame's [runtime-db](../core/glossary.md#runtime-db):
-
-```js
-const snap = actor.getSnapshot();   // { value, context, tags, … }
+```clojure
+(rf/dispatch [:auth.login/flow [:auth.login/submit credentials]])
 ```
+
+The outer id chooses the machine. The inner event is what the machine sees.
+
+## Reading the snapshot
 
 ```clojure
 @(rf/subscribe [:rf/machine :auth.login/flow])
-;; => {:state :submitting :data {:attempts 1 :error nil} :tags #{:auth/busy}}
-;;    (nil before the first event; :tags present only when active states declare tags)
+;; => {:state :submitting
+;;     :data  {:attempts 1 :error nil}
+;;     :tags  #{:auth/busy}}
 ```
 
-`[:rf/machine <id>]` is an ordinary [query vector](../core/glossary.md#query-vector) — chain named projections off it and it joins your [derivation graph](../core/glossary.md#the-derivation-graph) like any sub (divergence [#2](#2-the-snapshot-is-a-value-in-the-frame-not-state-owned-by-an-object) below explains the dividend). Because the whole definition and snapshot are data, the pure transition fn `(machines/machine-transition definition snapshot event)` returns a `Result` — `::result/snap` and `::result/fx` (or `result/ok?` / `result/fail?`) — with no frame, DOM, or network — the same value that renders in a browser unit-tests on the JVM ([machines API §`machine-transition`](../api/re-frame.machines.md), worked example at [`examples/.../state_machine_walkthrough/`](../../examples/capabilities/machines/state_machine_walkthrough/)).
+This is an ordinary subscription, so projections are ordinary subscriptions too:
 
-### Eventless transitions: always
+```clojure
+(rf/reg-sub :auth.login/error
+  :<- [:rf/machine :auth.login/flow]
+  (fn [snap _]
+    (get-in snap [:data :error])))
+```
 
-An eventless (`always`) transition fires the instant its guard becomes true — no event needed:
+Because the snapshot is data in the frame, time-travel and SSR do not need a
+separate actor serialization story.
+
+## Tags
+
+XState:
 
 ```js
-resolving: { always: [{ guard: 'isEmpty', target: 'empty' }, { target: 'some' }] }
+state.hasTag("busy")
 ```
+
+re-frame2:
 
 ```clojure
-:resolving {:always [{:guard :empty? :target :empty}
-                     {:target :some}]}
+:submitting {:tags #{:auth/busy}}
+
+@(rf/subscribe [:rf.machine/has-tag? :auth.login/flow :auth/busy])
 ```
 
-Same firing rule, same microstep semantics: the whole cascade (the seed transition, every `:always` microstep, every raised event) commits **once, atomically** — XState/SCXML macrostep semantics, which re-frame2 matches including the "settle `:always` before dequeuing the next `:raise`" ordering. `:always` is a state-node slot (beside `:on`, `:entry`, `:after`), not a mid-transition key.
+Tags are sets of keywords. Use namespaced tags for intent: `:auth/busy`,
+`:mode/read-only`, `:ws/connected`.
 
-### Delayed transitions: after and timeout
+## Delays and timeouts
 
-A delayed transition fires after a wall-clock delay; entering the state arms the timer, leaving it cancels (a stale timer from a prior visit is detected by epoch and ignored):
-
-```js
-loading: { after: { 5000: 'timeout', 30000: { guard: 'stillLoading', target: 'hardError' } } }
-```
+`after` maps to `:after`:
 
 ```clojure
-:loading {:after {5000  :timeout
-                  30000 {:guard :still-loading? :target :hard-error}}
-          :on    {:loaded :ready :failed :error}}
+:loading
+{:after {5000 :timeout}
+ :on    {:loaded :ready}}
 ```
 
-`:after`'s value uses the same transition grammar as an `:on` clause, and the delay can be a literal `pos-int?` ms, a subscription vector (app-state-derived), or `(fn [{:keys [snapshot]}] ms)` (computed from this machine's `:data`). XState's named/delayed-actor `timeout` maps to `:timeout` + `:on-timeout`, a named deadline that lowers onto the same `:after` machinery. **Divergence:** durations are integer ms **or** an ISO-8601 string (`"PT5S"`); XState's readable `"5s"` / `"10ms"` shorthand is **rejected** at registration. And when two `:after` timers fire in the same scheduler tick, ordering follows host-clock arrival, not XState/SCXML document order — re-frame2 timers are real deferred events (first valid timer to arrive wins; the rest go stale), so don't lean on declaration order to break a same-tick tie. (Recurring timers and pause/resume are out of scope for v1.)
-
-### Compound (nested) states
-
-A state with its own `:initial` + `:states` is a compound state, exactly as in XState:
-
-```js
-playing: { initial: 'atStart', states: { atStart: { on: { SEEK: 'midTrack' } }, midTrack: {} } }
-```
+A named deadline uses `:timeout` and `:on-timeout`:
 
 ```clojure
-:playing {:initial :at-start
-          :states  {:at-start  {:on {:seek :mid-track}}
-                    :mid-track {}}}
+:waiting
+{:timeout    "PT5S"
+ :on-timeout {:target :timed-out}}
 ```
 
-Same semantics: deepest-wins transition resolution with parent fall-through (an event the leaf doesn't handle bubbles to the compound), and `state.value` for a compound becomes a vector path — the snapshot's `:state` reads `[:playing :mid-track]`. A keyword `:target` names a **sibling**; a vector target is an **absolute path** from the (region) root, for cross-level jumps.
+Durations are integer milliseconds or ISO-8601 strings. Shorthand strings such as
+`"5s"` are `:rf.error/machine-bad-timeout-duration` at registration.
 
-### Parallel states
+## `invoke` becomes `:spawn`
 
-For orthogonal axes of one domain, XState uses `type: 'parallel'` with sub-`states`; re-frame2 uses `:type :parallel` with `:regions`:
-
-```clojure
-(rf/reg-machine :ui/nine-states
-  {:type    :parallel
-   :data    {:items [] :error nil}                 ;; shared across all regions
-   :guards  {:empty? (fn [{d :data}] (zero? (count (:items d))))}
-   :regions
-   {:data {:initial :nothing
-           :states  {:nothing   {:tags #{:data/idle} :on {:fetch :loading}}
-                     :loading   {:tags #{:data/loading} :on {:loaded :resolving :failed :error}}
-                     :resolving {:always [{:guard :empty? :target :empty} {:target :some}]}
-                     :empty     {:tags #{:data/empty}}
-                     :some      {:tags #{:data/some}}
-                     :error     {:tags #{:data/error}}}}
-    :form {:initial :neutral
-           :states  {:neutral   {:tags #{:form/neutral} :on {:submit-valid :correct}}
-                     :correct   {:tags #{:form/success} :on {:edit :neutral}}}}}})
-```
-
-In XState the parallel node's children sit under `states`; in re-frame2 they sit under `:regions`, each a `{:initial … :states …}` body. The snapshot's `:state` becomes a **region-name → state** map, `:tags` is the **union** across active regions, and `:data` is **shared** (there is no per-region `:data` — if your axes need encapsulated data, that's the substrate telling you to register N separate machines):
-
-```clojure
-@(rf/subscribe [:rf/machine :ui/nine-states])
-;; => {:state {:data :nothing :form :neutral} :data {:items [] :error nil} :tags #{:data/idle :form/neutral}}
-```
-
-Cross-region coordination — one region guarding on another region's active state
-(XState v5's `stateIn` / SCXML `In()`) — is expressed by predicating on a sibling
-region's [tag](#tags), not a combinator. (A region whose own tree is itself
-`:type :parallel` is rejected in v1 — nested parallel is a **deferred** divergence.)
-Worked example: [`examples/patterns/nine_states/`](../../examples/patterns/nine_states/).
-
-### History states
-
-To re-enter a compound at the substate it last occupied, XState declares a `type: 'history'` child; re-frame2 declares a `:type :history` pseudo-state under the compound's `:states`:
-
-```clojure
-{:player
- {:initial :stopped
-  :states {:stopped {:on {:play [:player :playing :hist]}}   ;; target the pseudo-state to restore
-           :playing {:initial :at-start
-                     :on      {:stop [:player :stopped]}
-                     :states {:hist      {:type :history
-                                          :deep? true              ;; omit => SHALLOW
-                                          :default-target :at-start} ;; omit => compound's :initial
-                              :at-start  {:on {:seek :mid-track}}
-                              :mid-track {}}}}}}
-```
-
-Same concept, idiomatic spelling: XState's `history: 'deep'` becomes `:deep? true`
-(shallow is the default — a missing `:deep?` reads as shallow), and
-`:default-target` is the never-yet-entered fallback. The pseudo-state is never
-occupiable — a transition *to* `:hist` resolves to the recorded (or default) leaf,
-which is what the snapshot records. The recording rides the snapshot's
-framework-owned `:rf/history` slot, so undo, time-travel, and SSR get history
-without extra wiring — no hand-rolled stash.
-
-### Final states and output
-
-A leaf marked `:final?` terminates the machine; if it was spawned, the parent is notified — the XState `done` / `onDone` pattern:
-
-```clojure
-;; Child — designates its terminal state and what it reports out.
-(rf/reg-machine :auth-flow
-  {:initial :running
-   :states  {:running {:on {:server-ok {:target :done
-                                         :action (fn [{data :data ev :event}]
-                                                   {:data (assoc data :token (second ev))})}}}
-             :done    {:final?     true
-                       :output-key :token}}})       ;; ← this :data value flows to the parent
-
-;; Parent — :on-done reads the child's reported result.
-(rf/reg-machine :login
-  {:initial :idle
-   :states  {:idle           {:on {:submit :authenticating}}
-             :authenticating {:spawn {:machine-id :auth-flow
-                                      :on-done    (fn [{:keys [data result]}] (assoc data :token result))
-                                      :on-error   :idle}}}})    ;; child failed → transition
-```
-
-In XState `output` is a *function* of context; in re-frame2 `:output-key` names a **key** into the child's `:data` (compute it with an `:action` into the final state if you need to — there is no `:output-fn`). **Divergence:** completion is *event-shaped*, not a long-lived `snapshot.output` slot you read later — `:output-key`'s value flows to the parent's `:on-done` as `result` *at the moment of completion*, then the child auto-destroys. A `:final?` leaf may add `:error? true` to be the designated error terminal that drives the parent's `:on-error` **transition** (XState's `invoke onError` as control flow, not observability). And a **singleton** machine reaching `:final?` also auto-destroys — "final means final"; omit `:final?` for a persistent terminal state (`:authed` / `:locked-out` above are plain leaves).
-
-### Invoke becomes spawn
-
-Starting a child actor on state entry and tearing it down on exit is XState's `invoke`; in re-frame2 it's `:spawn`:
+State-bound child work is `:spawn`:
 
 ```clojure
 :authenticating
-{:spawn {:machine-id :http/post
-         :data       (fn [{snap :snapshot}] {:url "/api/login" :body (-> snap :data :credentials)})
-         :system-id  :auth-actor                ;; address the child by role, not allocated id
-         :on-done    (fn [{:keys [data result]}] (assoc data :result result))
-         :on-error   :idle}
- :on    {:auth/cancelled :idle}}
+{:spawn {:machine-id :auth/request
+         :data       {:url "/api/login"}
+         :on-done    (fn [{:keys [data result]}]
+                       (assoc data :token result))
+         :on-error   {:target :idle}}
+ :on    {:cancel :idle}}
 ```
 
-The job is identical; the **name diverges on purpose** — "invoke" reads like a synchronous call, whereas the thing created is a spawned child actor's worth of lifecycle, so the declarative key aligns with the imperative fx `[:rf.machine/spawn …]`. **Divergences to know:** one `:spawn` per state (fan-out is the separate `:spawn-all`, with named children, a `:join` condition, and unconditional sibling cancellation on join resolution); no `:onSnapshot` (subscribe to `[:rf/machine <child-id>]` instead); no per-actor mailbox (events route through the one queue); no `autoForward` (forward explicitly via `:fx [[:dispatch [child-id ev]]]`). To address a spawned child from a machine action, emit `[:rf.machine/dispatch-to-system [:auth-actor [:event]]]`. Where XState splits child/parent messaging into four primitives (`sendTo`, `sendParent`, the returned child ref, `system.get`), re-frame2 folds them into `dispatch`-by-id: `:rf.machine/dispatch-to-system` resolves a `:system-id`-named child (the `system.get` analog), and a child reaches its parent through the runtime-stamped `:rf/parent-id` (XState's `sendParent`). See the [API reference](../api/re-frame.machines.md).
+The child is destroyed automatically when the parent leaves `:authenticating`.
+`:on-done` folds the child's result into the parent's `:data`. `:on-error` is a
+transition.
 
-### Choice states
+`spawn` is the same lifecycle idea as `invoke`, renamed because a child actor
+exists while the state is active.
 
-A choice (transient) state routes immediately on entry to the first guard that passes:
+## Completion is event-shaped
+
+A child reports a result by reaching a root-level final state:
 
 ```clojure
-:checking {:type   :choice
-           :choice [{:guard :valid? :target :accepted}
-                    {:target :rejected}]}      ;; unguarded final = the default / else branch
+:done {:final? true
+       :output-key :token}
 ```
 
-In XState v6 a `choice` state's routing can be a `choice`-**function**. re-frame2 **rejects** that: `:choice` is a declarative guarded-candidate **array** — a function may never be the edge (the *why* is divergence [#4](#4-the-transition-topology-stays-data--functions-are-confined-to-guards-and-actions) below; a fn-valued `:choice` fails loud at registration). The array must include an unguarded default so the node always resolves, and a choice state *only routes* (no `:entry` / `:on` / `:after`). It desugars onto `:always` — distinct authoring intent, one mechanism — so external observers never see `:checking`.
+The parent receives that value as `result` in `:on-done`.
 
-### Internal events
+There is no long-lived `snapshot.output` to read later. Completion happens,
+reports, and the child is destroyed. A singleton that reaches `:final?` is
+destroyed too — omit `:final?` on a resting leaf such as `:authed` or
+`:locked-out`.
 
-A private event the machine raises and handles itself — never part of its public surface:
+## Schemas
+
+XState types are mostly compile-time. re-frame2 schemas are optional runtime
+checks in development.
 
 ```clojure
-{:initial :waiting
- :internal-events #{:tick}                            ;; a SET, not an array
- :actions {:arm (fn [_] {:fx [[:raise [:tick]]]})}    ;; raised internally…
- :states  {:waiting {:on {:go {:target :armed :action :arm}}}
-           :armed   {:on {:tick {:target :checking}}} ;; …and handled by an ordinary :on clause
-           :checking {}}}
+:schemas {:data   [:map [:attempts :int]]
+          :output :string}
 ```
 
-XState v6's `internalEvents` is an **array**; re-frame2 declares them as a Clojure **set** — membership is the natural shape, order is irrelevant, duplicates are impossible. The `:on {:tick …}` clause is *how* the machine handles the raised event (expected, not a collision); what `:internal-events` adds is the boundary — an *external* `(rf/dispatch [:my/gate [:tick]])` from a view or test is **refused** at the machine dispatch boundary (a benign no-op with an error trace), while the internal `:raise` is handled normally.
+A `:data` schema violation rolls back the transition before the bad snapshot
+commits. Production builds can elide the checks.
 
-### Tags
+## What stays quiet and what fails loud
 
-Once a machine has several "loading-ish" states, views should ask a predicate (*is it busy?*) rather than match exact state names. XState tags a state and asks `state.hasTag('busy')`; re-frame2 tags with a set and asks a subscription:
+| Situation | What happens |
+|---|---|
+| An event the current state does not handle | Quiet no-op, matching modern XState. Trace: `:rf.machine.event/unhandled-no-op`. |
+| Broken definition — unresolved target, missing guard or action, invalid `:choice`, `"5s"` duration, … | Fail at registration. |
 
-```clojure
-:submitting {:tags #{:auth/busy} :entry :issue-request :on { … }}
-```
-```clojure
-(when @(rf/subscribe [:rf.machine/has-tag? :auth.login/flow :auth/busy])
-  [spinner])
-```
-
-At every transition the runtime stamps the union of active states' tags onto the snapshot's `:tags`. The framework ships `[:rf.machine/has-tag? <id> <tag>]` — a derived predicate sub that re-renders only when *this* tag's bit flips. Add a fifth busy state later and it's one `:tags` entry, zero view changes (*ask, don't tell*).
-
-### Schemas: types that actually run
-
-XState v6 declares shapes via `setup({ types })` / `schemas`; re-frame2 declares a machine-level `:schemas` map:
-
-```clojure
-(rf/reg-machine :session/auth
-  {:initial :anon
-   :data    {:retries 0 :token nil}
-   :schemas {:data   [:map [:retries :int] [:token [:maybe :string]]]   ;; XState's typed context
-             :output :string}                                            ;; the :output-key payload
-   :states  { … }})
-```
-
-XState's typed context maps to `[:schemas :data]` (re-frame2 calls the slot `:data`, so the schema names exactly what it validates), and `output` maps to `[:schemas :output]`. **Divergence in enforcement:** XState's typed context is compile-time-only and erased at runtime; re-frame2's `[:schemas :data]` is an *actually-running* [Malli](../core/glossary.md#schema) validation in dev — it checks at every macrostep-commit, bootstrap, and spawn, and a violation **rolls the whole cascade back** (`:output` is best-effort fail-loud, since the machine has already finished). Validation is optional and library-agnostic, and DCE's to nothing in production. A visualiser renders the context shape authoritatively from a declared schema instead of inferring it from one sample.
-
-## Where it diverges — and why
-
-The renames are noise. These four are the real differences, each made on purpose, and knowing the *why* is what lets you stop fighting the framework.
-
-### 1. A machine is an event handler, not an actor
-
-In XState the unit of life is the actor. You instantiate a machine, start it, hold the reference, and `send` it messages; it owns its state and you ask it for a snapshot. That's a clean model, and it's a *second* messaging system living alongside whatever else your app uses to move data around.
-
-re-frame2 already has exactly one of those — the [event pipeline](../core/glossary.md#event-pipeline). Every state change in the entire app is a [`dispatch`](../core/glossary.md#dispatch) flowing through one router queue. So a machine doesn't get to be special:
-
-```clojure
-(rf/reg-machine :auth.login/flow login-flow)            ;; register, like any handler
-(rf/dispatch [:auth.login/flow [:auth.login/submit creds]])  ;; send, like any event
-```
-
-[`reg-machine`](../core/glossary.md#registration) is sugar over `reg-event`: the registered handler interprets the table — read the current [snapshot](glossary.md#snapshot), compute the transition, write the new snapshot, return the [action](glossary.md#action)'s effects. The outer `:auth.login/flow` routes to the machine; the inner `[:auth.login/submit creds]` is the event the machine sees. No actor object to thread through your components, no parallel `send` API, no question of "where do I keep the running machine?" — the answer is the same place every other piece of state lives.
-
-**Why:** one mechanism is cheaper than two. An XState actor is a thing you must wire
-into your component tree, keep alive, and bridge to your data layer. A re-frame2
-machine is reachable from anywhere `dispatch` is, traceable on the same
-[trace stream](../core/glossary.md#trace-stream), and composes with every other
-handler. The cost — and it's real — is that you give up `actor.send(...)` ergonomics
-and the sense of a machine as a tangible object. In exchange the machine stops being
-a special case.
-
-### 2. The snapshot is a value in the frame, not state owned by an object
-
-`actor.getSnapshot()` reaches into an object. In re-frame2 the snapshot — `{:state :submitting :data {...}}` — is a plain value living in the frame's [runtime-db](../core/glossary.md#runtime-db), the framework's half of [the two partitions](../core/glossary.md#the-two-partitions). You read it with an ordinary subscription:
-
-```clojure
-@(rf/subscribe [:rf/machine :auth.login/flow])
-;; => {:state :submitting :data {:attempts 1 :error nil}}   (nil before the first event)
-```
-
-`[:rf/machine <id>]` is a normal [query vector](../core/glossary.md#query-vector). You can chain named projections off it, and it shows up in your [derivation graph](../core/glossary.md#the-derivation-graph) like any sub.
-
-**Why:** because the machine's entire state is *just a value riding the frame*, everything the frame can do, the machine gets for nothing. [Time-travel](../core/glossary.md#time-travel), undo, persistence, and SSR hydration all work on machines with zero extra code — rewind the frame and the machine rewinds with it. An actor that owns its own mutable state can't be rolled back by an outside force without a bespoke serialization story; a value in a database rolls back by definition. This is the quiet dividend of refusing to make the machine an object: it can't hide state where replay can't reach.
-
-That same refusal is why an action sees **only the snapshot, event, and any declared coeffects (`:data` / `:state` / `:event` / `:meta` / `:rf.cofx`) — never app-db**, and why returning `:db` from an action is a hard error. State that escaped into app-db wouldn't ride the snapshot, and the free rollback would silently develop a hole. To touch a sibling slice you [`dispatch`](../core/glossary.md#dispatch) a named event; the reach becomes a traced, reusable event instead of a quiet cross-write.
-
-### 3. Actions return effects; they don't perform them
-
-XState's `assign(...)` is an action *creator* that imperatively updates context, and an effectful action runs its side effect when invoked. re-frame2 inverts this. An action is a pure function that **returns** the same data-shaped [effect map](../core/glossary.md#effect-map) a `reg-event` handler returns:
-
-```clojure
-:record-error
-(fn [{data :data [_ {:keys [error]}] :event}]        ;; failure map rides under :error
-  {:data (-> data (update :attempts inc)
-                  (assoc :error (or (:message error) "Login failed.")))})
-
-:issue-request
-(fn [{[_ creds] :event}]
-  {:fx [[:rf.http/managed {:request {:method :post :url "/api/login" :body creds}
-                           :on-success [:auth.login/flow [:auth.login/success]]
-                           :on-failure [:auth.login/flow [:auth.login/failure]]}]]})
-```
-
-The returned `:data` is merged into the snapshot; the returned `:fx` is a *description* of work, handed to the effects machinery to actually run. No `assign` helper — re-frame2 never needed one, because returning `{:data ...}` is the assignment. ([XState v6 is removing `assign`'s special status](https://stately.ai/docs) and leaning toward plainer functions, which is roughly the shape re-frame2 started from.)
-
-**Why:** ["effects are data"](../core/glossary.md#effects-are-data) is a core rule,
-not a machines feature. An action that *returns* a description of its side effects
-is pure, testable, and replayable; an action that *performs* them is none of those.
-Because an effect is just data, a machine and an async surface compose with no glue.
-Note `:on-success [:auth.login/flow [:auth.login/success]]` above — the HTTP reply
-lands back *inside the machine* as an ordinary event
-([the uniform reply](../core/glossary.md#the-uniform-reply) appends the payload to
-the inner vector). No `invoke`-promise bridge, no callback adapter — the reply is
-just the next event the machine handles.
-
-### 4. The transition topology stays data — functions are confined to guards and actions
-
-This is the most opinionated divergence, and the most easily missed. In XState you can put functions in a lot of places — and v6 adds a `choice` function for dynamic target selection. re-frame2 draws a hard line: **guards and actions are functions, but the transition topology is not.** Targets, `:always`, `:after`, `:choice` candidates — the *shape of the graph* — must be declarative data. So re-frame2 rejects function-valued transitions, and its [`:type :choice`](#choice-states) takes a declarative candidate array, not v6's `choice` function. There's also deliberately no `{:and ...}` guard-combinator DSL: compound conditions go in one *named* function.
-
-**Why:** the spec is the artefact. A machine whose topology is data can be pretty-printed, rendered as a live diagram, diffed in review, and handed whole to an AI with "add a two-factor state" — and the tool sees the entire graph in one form. The moment a target is computed by an opaque function, the diagram has a hole the visualiser can only draw as a shrug, and the AI loses the thread. Names are the same bet: a guard called `:under-retry-limit` renders legibly on the arrow; an inline `{:and [...]}` blob renders as noise. re-frame2 spends a little expressive flexibility to keep the graph *readable by machines other than itself* — which, given that re-frame2 is built AI-first, is the whole point.
-
-### Two smaller deliberate differences
-
-- **`invoke` → `:spawn`.** Same job — start a child machine on state entry, tear it down on exit, collect its result via `:on-done`. Renamed because "invoke" reads like a synchronous call, whereas the thing actually being created is a spawned child actor's worth of lifecycle. See [invoke becomes spawn](#invoke-becomes-spawn) and [spawn](glossary.md#spawn).
-- **Completion is event-shaped.** A finishing child's [`:final? true`](#final-states-and-output) leaf selects a value with `:output-key`, and that value flows to the parent's `:on-done` as `result` — at the moment of completion. There's no long-lived `snapshot.output` slot to read later, the way you'd read XState's `output`. Completion is a thing that *happens* (an event), not a thing that *sits there* (state), which keeps it on the same event rails as everything else.
-
-## What stays loud, what stays quiet
-
-One last alignment, because it trips people who expect re-frame2 to be stricter than it is. An **unknown event is a no-op** — exactly as in XState v5/v6 after strict mode was dropped. Dispatch an event the current state doesn't handle and nothing throws; the snapshot doesn't move; a benign `:rf.machine.event/unhandled-no-op` trace records that it arrived and was dropped.
-
-Almost everything *else* that's wrong [fails loud](../core/glossary.md#fail-loud-not-silent) — a guard referencing an undefined name, a target naming a missing state, a `:schemas` sub-key that isn't real, a function where a `:choice` array belongs, an `:internal-events` vector instead of a set — but at **registration** time, not on the unlucky dispatch that first reaches the bad arrow. And a runaway `:always`/`:raise` cycle (which XState *throws* on) is a bounded, atomically-aborted [error record](../core/glossary.md#error-record), not a hang — deliberately distinct from the silent no-op, because a non-converging loop is a bug you want surfaced.

--- a/docs/machines/concepts.md
+++ b/docs/machines/concepts.md
@@ -2,92 +2,141 @@
 
 <a id="state-machines"></a>
 
-This page is the **flat machine model** — everything you need for a single-level
-state machine. Nested states, parallel regions, history, and actors grow the same
-grammar; each has its own page.
+This page is the **flat machine model** — a single-level transition table, how
+you register and drive it, and the contracts guards and actions live under.
+Nested states, parallel regions, history, and actors grow the same grammar;
+each has its own page.
 
-To *build* a login machine step by step (guard → action → HTTP → view → test), use
-the [tutorial](tutorial.md). Here the goal is understanding the pieces and their
-contracts.
+To *build* a login machine step by step (guard → action → HTTP → view → test),
+use the [tutorial](tutorial.md).
 
 !!! note "Where should this value live?"
 
-    A machine fits when a value has a *lifecycle* of named states — not when it is
-    only data to store. See [Where should this value live?](../core/where-state-lives.md).
+    A machine fits when a value has a *lifecycle* of named states — not when it
+    is only data to store. See [Where should this value live?](../core/where-state-lives.md).
 
 ## The idea
 
 <a id="a-machine-at-a-glance"></a>
 <a id="the-same-flow-as-a-transition-table"></a>
 
-You already write state machines: a `:status` keyword in app-db plus informal rules
-in handlers about what may follow what. A machine writes those rules down as **one
-value** — a transition table — so you can read, draw, test, and change the flow in
-one place.
+You already write state machines: a `:status` keyword in app-db plus informal
+rules in handlers about what may follow what. A machine writes those rules down
+as **one value** — a transition table — so you can read, test, and change the
+flow in one place.
+
+A table has five everyday parts:
 
 ```clojure
-(rf/defmachine turnstile
-  {:initial :locked
-   :data    {:coins 0}
-   :actions {:take-coin (fn [{data :data}] {:data (update data :coins inc)})}
+;; cf. examples/capabilities/machines/state_machine_walkthrough/
+(rf/defmachine login-flow
+  {:initial :idle
+   :data    {:attempts 0 :error nil}
+
+   :guards
+   {:form-valid?
+    (fn [{[_ creds] :event}]
+      (and (seq (:email creds)) (seq (:password creds))))
+    :under-retry-limit
+    (fn [{data :data}]
+      (< (:attempts data) 2))}          ;; three attempts; see Guards
+
+   :actions
+   {:clear-error
+    (fn [_] {:data {:error nil}})
+    :record-error
+    (fn [{data :data [_ {:keys [error]}] :event}]
+      {:data (-> data
+                 (update :attempts inc)
+                 (assoc  :error (or (:message error) "Login failed.")))})
+    :store-session
+    (fn [{[_ {:keys [value]}] :event}]
+      {:fx [[:dispatch [:auth.session/store {:token (:token value)}]]]})}
+
    :states
-   {:locked   {:on {:coin {:target :unlocked :action :take-coin}
-                    :push {:target :locked}}}     ;; blocked: stays locked
-    :unlocked {:on {:push {:target :locked}
-                    :coin {:target :unlocked :action :take-coin}}}}})
+   {:idle
+    {:on {:auth.login/submit {:target :submitting
+                              :guard  :form-valid?
+                              :action :clear-error}}}
+
+    :submitting
+    {:tags #{:auth/busy}
+     :on   {:auth.login/success {:target :authed :action :store-session}
+            :auth.login/failure [{:target :error-shown
+                                  :guard  :under-retry-limit
+                                  :action :record-error}
+                                 {:target :locked-out
+                                  :action :record-error}]}}
+
+    :error-shown
+    {:on {:auth.login/dismiss {:target :idle}
+          :auth.login/submit  {:target :submitting
+                               :guard  :form-valid?
+                               :action :clear-error}}}
+
+    :authed     {:meta {:terminal? true}}
+    :locked-out {:meta {:terminal? true}}}})
 ```
 
-Two words do most of the work ([glossary](glossary.md)):
+- `:initial` — where the machine starts.
+- `:data` — private working memory.
+- `:guards` — yes/no predicates.
+- `:actions` — return `{:data … :fx …}`; they never perform side effects.
+- `:states` — the nodes and their outgoing transitions.
 
-- A **[guard](glossary.md#guard)** — yes/no gate on a transition.
-- An **[action](glossary.md#action)** — side work that returns effects, never performs them.
+`:authed` and `:locked-out` are resting leaves. They keep the snapshot around
+so a view can still render them. They are **not** `:final?` — that flag
+destroys the machine ([Final states](#final-states)).
 
 ## Register and drive
 
+<a id="register-and-drive"></a>
 <a id="registering-and-running-it"></a>
 
-**A machine is an event handler.** `reg-machine` is sugar over `reg-event` whose body
-interprets the table: read the live [snapshot](glossary.md#snapshot), take a
-transition, write the new snapshot, return action effects.
+A machine **is** an event handler. `reg-machine` compiles the table into a
+`reg-event` whose body reads the live [snapshot](glossary.md#snapshot), takes a
+transition, writes the new snapshot, and returns the action's effects.
 
 ```clojure
 (:require [re-frame.core :as rf]
-          [re-frame.machines])   ;; opt-in: forget this → :rf.error/machines-artefact-missing
+          [re-frame.machines])   ;; forget this → :rf.error/machines-artefact-missing
 
-(rf/reg-machine :turnstile turnstile)
+(rf/reg-machine :auth.login/flow login-flow)
 ```
 
-Two blessed registration shapes:
+Two registration shapes:
 
 | Shape | Use when |
-|---|---|
-| `defmachine` + `reg-machine` | Named, reusable specs (Xray click-to-source on guards/actions) |
+| --- | --- |
+| `defmachine` + `reg-machine` | Named, reusable specs (Xray click-to-source on guards and actions) |
 | Inline `reg-machine` with a **literal** map | Small local machines |
 
-Avoid `(def m {…})` then `(reg-machine :id m)` — the macro never sees the literal, so
-source stamps are empty (dev warns `:rf.warning/machine-source-unstamped`).
+Avoid `(def m {…})` then `(reg-machine :id m)`. The macro never sees the
+literal, so source stamps are empty and dev warns
+`:rf.warning/machine-source-unstamped`.
 
 **Dispatch** addresses the machine id; the *inner* vector is the machine event:
 
 ```clojure
-(rf/dispatch [:turnstile [:coin]])
+(rf/dispatch [:auth.login/flow [:auth.login/submit credentials]])
 ```
 
-**Subscribe** with the framework sub:
+**Subscribe** with the framework sub — there is no function sugar:
 
 ```clojure
-@(rf/subscribe [:rf/machine :turnstile])
-;; => {:state :unlocked :data {:coins 1}}   ; nil before the first event
+@(rf/subscribe [:rf/machine :auth.login/flow])
+;; => {:state :submitting :data {:attempts 0 :error nil} :tags #{:auth/busy}}
+;;    nil before the first event
 ```
 
-The snapshot lives in [runtime-db](../core/glossary.md#runtime-db) (framework half of
-the frame), so undo, time-travel, and SSR hydration work without extra wiring.
+The snapshot lives in [runtime-db](../core/glossary.md#runtime-db), so undo,
+time-travel, and SSR hydration work without extra wiring.
 
 !!! note "Async composes"
 
     Point managed HTTP replies at the machine:
-    `:on-success [:auth.login/flow [:auth.login/success]]` (outer id, inner event).
-    The reply is *appended* into the inner event — no adapter. Full walk-through in
+    `:on-success [:auth.login/flow [:auth.login/success]]` (outer id, inner
+    event). The reply is *appended* into the inner event. Full walk-through in
     the [tutorial](tutorial.md#step-4--talk-to-a-real-server).
 
 ## See one run
@@ -130,7 +179,59 @@ Click into the cell and press **`Ctrl-Enter`** (**`Cmd-Enter`** on macOS):
     `:rf.machine.event/unhandled-no-op` trace). Almost every *other* mistake
     (bad target, missing guard name) fails loud at **registration**.
 
-<a id="one-thing-that-wont-throw-the-unhandled-event"></a>
+## The snapshot
+
+<a id="the-snapshot--state-data-tags"></a>
+
+```clojure
+{:state :submitting
+ :data  {:attempts 1 :error nil}
+ :tags  #{:auth/busy}}   ;; omitted when no active state declares tags
+```
+
+| Slot | Role |
+| --- | --- |
+| `:state` | Discrete state — keyword (flat), path vector (hierarchy), or region map (parallel) |
+| `:data` | Machine-private memory |
+| `:tags` | Runtime-projected union of active states' tags |
+
+`[:rf/machine id]` is `nil` until the first event. A view that renders earlier
+should fall back to the definition's `:initial` and `:data`.
+
+Do not build views that switch on detailed `:state` shapes unless the exact
+state is the product decision. For "busy", "read-only", "connected", use
+[state tags](tags.md).
+
+## Transition forms
+
+An `:on` entry can be written in three forms.
+
+```clojure
+:on {:auth.login/submit :submitting}
+```
+
+A bare keyword is sugar for `{:target :submitting}`.
+
+```clojure
+:on {:auth.login/submit {:target :submitting
+                         :guard  :form-valid?
+                         :action :clear-error}}
+```
+
+A map gives the transition a guard, an action, and other options.
+
+```clojure
+:on {:auth.login/failure [{:target :error-shown
+                           :guard  :under-retry-limit
+                           :action :record-error}
+                          {:target :locked-out
+                           :action :record-error}]}
+```
+
+A vector is a first-match-wins **candidate list**. The runtime tries each
+candidate in order and takes the first whose guard passes. Put an unguarded
+default last when the event must be handled. The lockout candidate also runs
+`:record-error`, so the terminal failure is counted.
 
 ## Guards and actions
 
@@ -140,57 +241,70 @@ Click into the cell and press **`Ctrl-Enter`** (**`Cmd-Enter`** on macOS):
 Every callback receives one context map:
 
 ```clojure
-{:data  {:attempts 1 :error nil}   ;; machine-private memory
- :event [:auth.login/failure …]    ;; inbound event vector
+{:data  {:attempts 1 :error nil}
+ :event [:auth.login/failure …]
  :state :submitting
  :meta  {…}}
 ```
 
-There is **no `:db`**. A machine cannot see [app-db](../core/app-db.md). That is
-[strict encapsulation](#strict-encapsulation) — the rule that keeps the whole
-machine inside one snapshot for time-travel.
+There is **no `:db`**. A machine cannot see [app-db](../core/app-db.md). That
+is [strict encapsulation](#strict-encapsulation).
 
 ### Guards
 
 <a id="a-guard-is-a-yesno-gate"></a>
 
-Return truthy/falsey. No combinator DSL — compound logic is ordinary Clojure:
+Return truthy or falsey. There is no combinator DSL — compound logic is
+ordinary Clojure:
 
 ```clojure
 :guards
-{:under-retry-limit (fn [{data :data}] (< (:attempts data) 2))   ;; three attempts total
+{:under-retry-limit (fn [{data :data}] (< (:attempts data) 2))
  :form-valid?       (fn [{[_ creds] :event}]
                       (and (seq (:email creds)) (seq (:password creds))))}
 ```
 
-A guard sees the snapshot as it stands *before* the transition's action runs, so
-`:under-retry-limit` reads the count from the two failures already recorded and
-the boundary sits one below the total you want — `2` for the
-[tutorial](tutorial.md)'s three-attempt lockout. XState guards evaluate in the
-same place, ahead of the `assign`, so the off-by-one reads the same there.
+A guard sees the snapshot *before* the transition's action runs. On a
+three-attempt lockout, `:under-retry-limit` therefore reads the count from
+failures already recorded, and the boundary sits one below the total you
+want — `< 2` for three attempts. The first two failures pass and land in
+`:error-shown`; the third fails the guard and the fallback candidate locks
+out.
 
 <a id="name-them-or-inline-them"></a>
 
-Reference by id (`:guard :form-valid?`) or inline a one-liner. Prefer named ids —
-trace rows and Xray can address them.
-
-A list of transition candidates is tried in order; first guard that passes wins.
+Reference by id (`:guard :form-valid?`) or inline a one-liner. Prefer named
+ids — traces and Xray can address them.
 
 ### Actions
 
 <a id="an-action-returns-effects"></a>
 
-Return **descriptions**, same idea as `reg-event`:
+Return **descriptions**, the same idea as `reg-event`:
 
 ```clojure
 :actions
 {:clear-error  (fn [_] {:data {:error nil}})
  :issue-request
  (fn [{[_ creds] :event}]
-   {:fx [[:rf.http/managed {… :on-success [:auth.login/flow [:auth.login/success]]}]]})}
+   {:fx [[:rf.http/managed
+          {:request    {:method :post :url "/api/login" :body creds
+                        :request-content-type :json}
+           :decode     :json
+           :on-success [:auth.login/flow [:auth.login/success]]
+           :on-failure [:auth.login/flow [:auth.login/failure]]}]]})}
 ```
 
-Also: `:entry` / `:exit` on a state (run when the state is entered / left).
+Require `[re-frame.http.managed]` wherever `:rf.http/managed` appears, or the
+effect is `:rf.error/no-such-fx`. `:on-success` / `:on-failure` are one
+element short on purpose — managed HTTP **appends** the reply envelope:
+
+```clojure
+[:auth.login/success {:status :ok    :value {:token "…"} …}]
+[:auth.login/failure {:status :error :error {:message "…"} …}]
+```
+
+`:record-error` reads `:error`. `:store-session` reads `:value`.
 
 ### The effect map `{:data :fx}`
 
@@ -198,39 +312,66 @@ Also: `:entry` / `:exit` on a state (run when the state is entered / left).
 <a id="the-effect-map-data-fx"></a>
 
 | Key | Meaning |
-|---|---|
+| --- | --- |
 | `:data` | **Merged** into the snapshot's current `:data` (not replaced). Explicit `nil` sets a key to nil; it does not remove keys. |
 | `:fx` | Ordinary effects vector (`:dispatch`, `:rf.http/managed`, …). Machine-only ids: `:raise`, `:rf.machine/spawn`, `:rf.machine/destroy`. |
 
-Both keys optional; `nil` / `{}` means no effects. Returning `:db` is an error
-(`:rf.error/machine-action-wrote-db`) — machines must not scribble on app-db.
+Both keys are optional; `nil` / `{}` means no effects. Returning `:db` is
+`:rf.error/machine-action-wrote-db`.
 
 !!! warning "`:fx` cannot read this action's own `:data` write"
 
-    Both keys are returned together. Bind fresh values in a `let` and use the local
-    in both places, or write in the transition action and read in the target's
-    `:entry`.
+    Both keys are returned together. Bind fresh values in a `let` and use the
+    local in both places, or write in the transition action and read in the
+    target's `:entry`.
 
-Unresolved `:guard` / `:action` / `:target` names throw at `reg-machine` time
-(`:rf.error/machine-unresolved-guard`, etc.), not on first dispatch.
+Unresolved `:guard` / `:action` / `:target` names throw at `reg-machine`
+(`:rf.error/machine-unresolved-guard`,
+`:rf.error/machine-unresolved-action`,
+`:rf.error/machine-unresolved-target`), not on first dispatch.
+
+### Entry, exit, and transition actions
+
+A transition can run up to three action slots, in this order:
+
+1. source state's `:exit`
+2. transition's `:action`
+3. target state's `:entry`
+
+Their `:data` updates accumulate in order; their `:fx` vectors concatenate in
+order.
+
+```clojure
+:submitting
+{:tags  #{:auth/busy}
+ :entry :issue-request
+ :on    {:auth.login/success {:target :authed :action :store-session}
+         :auth.login/failure […]}}
+```
+
+Use `:entry` for work that should happen whenever the state is entered —
+issuing the request, so every path into `:submitting` fires it. Use `:exit`
+for cleanup.
 
 ## Strict encapsulation
 
+<a id="strict-encapsulation"></a>
 <a id="strict-encapsulation--a-machine-sees-only-its-own-data"></a>
 
 A guard or action gets `{:data :event :state :meta}` (plus `:rf.cofx` when it
-declares a coeffect, below) — never app-db. That is what keeps a machine's whole
-state inside one snapshot for time-travel and SSR.
+declares a coeffect) — never app-db. Parallel regions also see `:tags` /
+`:all-state`; that is a later page.
 
 | Need | How |
-|---|---|
+| --- | --- |
 | Fact from outside | Put it on the **event** when you dispatch |
 | Write outside the machine | Return `:fx [[:dispatch […]]]` — a real, named event |
-| Clock / random / host fact | Declare a [coeffect](../core/coeffects.md) on the guard or action — do **not** call `(js/Date.now)` |
+| Clock / random / host fact | Declare a [coeffect](../core/coeffects.md) on the named guard or action — do **not** call `(js/Date.now)` |
 
-A declared coeffect arrives under **`:rf.cofx`** on the callback map — the causal
-token the router recorded, so the decision replays deterministically. Read it there,
-`(:rf/time-ms (:rf.cofx ctx))`; it is *not* a top-level `rf/time-ms` key.
+A declared coeffect arrives under **`:rf.cofx`** on the callback map. Read it
+there, `(:rf/time-ms (:rf.cofx ctx))` — it is *not* a top-level `:rf/time-ms`
+key. Inline callbacks cannot declare requirements
+(`:rf.error/machine-cofx-requires-inline`).
 
 ```clojure
 :guards
@@ -240,53 +381,35 @@ token the router recorded, so the decision replays deterministically. Read it th
         (< (- time-ms (:first-attempt-at data)) 60000))}}
 ```
 
-Returning `:db` from an action is a hard error
-(`:rf.error/machine-action-wrote-db`) — the key is dropped and the failure is
-loud. Actions also never choose the next state; only the transition's `:target`
-moves the machine.
+Actions never choose the next state. Only the transition's `:target` moves
+the machine.
 
-## The snapshot
+## Unhandled events are no-ops
 
-<a id="the-snapshot--state-data-tags"></a>
+<a id="one-thing-that-wont-throw-the-unhandled-event"></a>
 
-```clojure
-{:state :submitting
- :data  {:attempts 1 :error nil}
- :tags  #{:auth/busy}}   ;; optional — union of active states' tags
-```
+If the current state has no transition for an event, the machine ignores it.
+The snapshot does not move. A benign `:rf.machine.event/unhandled-no-op`
+trace records the drop.
 
-| Slot | Role |
-|---|---|
-| `:state` | Discrete state — keyword (flat), path vector (hierarchy), or region map (parallel) |
-| `:data` | Machine-private memory |
-| `:tags` | Runtime-projected set of active tags (omit when empty) |
-
-`[:rf/machine id]` is `nil` until the first event; views should fall back to
-`:initial` / default `:data` if they render earlier.
-
-Optional **`:schemas {:data …}`** (Malli) validates `:data` at commit in dev and
-rolls back a bad transition.
-
-<a id="validating-a-machines-data"></a>
-<a id="validating-a-machines-completion-output"></a>
-
-Full rules: schemas section of the
-[`re-frame.machines` API](../api/re-frame.machines.md).
+That does not hide mistakes. Broken definitions fail at registration: missing
+targets, undefined guards or actions, invalid timeout shapes, illegal
+`:final?` combinations. The unhandled event is the one intentionally quiet
+case.
 
 ## Self-transitions and wildcards
 
+<a id="self-transitions-and-wildcards"></a>
 <a id="self-transitions-internal-by-default-external-on-demand"></a>
 <a id="wildcard-transitions-handle-a-whole-class-of-events"></a>
 
-Self-moves **don't re-enter by default** — the turnstile's push-while-locked counts a
-push without leaving `:locked`. (XState calls that non-reentering shape "internal";
-re-frame2's runtime `internal?` flag is narrower — it's the **targetless** no-op alone,
-never a targeted self/ancestor move.) Three shapes:
+Self-moves do not re-enter by default. The turnstile's push-while-locked
+counts a push without leaving `:locked`. Three shapes:
 
 | Shape | Effect |
-|---|---|
-| No `:target` (targetless) | The `internal?` no-op: action only — no exit/entry; timers and spawns undisturbed; descendants preserved |
-| `:target` same state, no `:reenter?` | Non-reentering: the target survives, but **compounds** re-resolve descendants to `:initial` (a leaf self-target has none, so it's action-only) |
+| --- | --- |
+| No `:target` (targetless) | Action only — no exit/entry; timers and spawns undisturbed |
+| `:target` the same state, no `:reenter?` | Same on a leaf (action only). A compound re-resolves descendants to `:initial` |
 | `:reenter? true` | Full exit → action → entry (timers reset, spawns restart) |
 
 A self-rescheduling poll uses the external form so `:entry` re-fires:
@@ -294,82 +417,156 @@ A self-rescheduling poll uses the external form so `:entry` re-fires:
 ```clojure
 :polling
 {:entry :start-fetch
- :after {30000 {:target :polling :reenter? true}}   ;; every 30s: re-enter → fetch again
- :on    {:got-data {:action :merge}                  ;; internal: merge without resetting the clock
+ :after {30000 {:target :polling :reenter? true}}
+ :on    {:got-data {:action :merge}
          :stop     :idle}}
 ```
 
-!!! note "Targeted self ≠ re-enter"
-
-    A self-target without `:reenter? true` does **not** re-run `:entry`. If you meant
-    to re-arm a timer or re-spawn a child, say so explicitly.
+A self-target without `:reenter? true` does **not** re-run `:entry`. If you
+meant to re-arm a timer, say so.
 
 **Wildcards** on `:on` keys, most-specific first: exact id → `:ns/*` → `:*`.
 
 ```clojure
 :tracking
-{:on {:mouse/down {:action :begin-drag}   ;; exact wins for :mouse/down
-      :mouse/*    {:action :note-move}     ;; any other :mouse/…
-      :*          {:action :log-unknown}}} ;; anything else
+{:on {:mouse/down {:action :begin-drag}
+      :mouse/*    {:action :note-move}
+      :*          {:action :log-unknown}}}
 ```
 
-A **forbidden** handler — `{:on {:E {}}}` or `{:on {:E nil}}` — **consumes** the
-event and stops the search (how a child opts out of a parent transition). A
-**missing** key is a silent no-op. A bare id like `:go` has no `:ns/*` tier — only
-exact or `:*`.
+A **forbidden** handler — `{:on {:E {}}}` or `{:on {:E nil}}` — **consumes**
+the event and stops the search (how a child opts out of a parent
+transition). A **missing** key is a silent no-op. A bare id like `:go` has
+no `:ns/*` tier — only exact or `:*`. A guard-blocked exact match can fall
+through to a wildcard.
 
 ## Final states
 
 <a id="final-states"></a>
 <a id="final-states-when-a-machine-is-done"></a>
 
-- **Ordinary leaf** with no outgoing transitions — machine **persists** (login's
-  `:authed`). Do **not** set `:final?`.
-- **`:final? true`** — machine **terminates** and is destroyed. Use for spawned
-  protocols that finish, not for "last screen of a long-lived machine."
+- **Ordinary leaf** with no outgoing transitions — the machine **persists**
+  (login's `:authed`). Do **not** set `:final?`. Optional
+  `{:meta {:terminal? true}}` is documentation for you and for tools; it
+  does not destroy anything.
+- **`:final? true`** — the machine **terminates** and is destroyed. Use for
+  spawned protocols that finish, not for "last screen of a long-lived
+  machine."
 
 Nested finals and parent `:on-done` live in
 [Hierarchical states](hierarchical-states.md) and [Actors](actors.md).
 
-## Tags and automatic moves (pointers)
+## Schemas
 
-<a id="tags-and-timers"></a>
+<a id="validating-a-machines-data"></a>
+<a id="validating-a-machines-completion-output"></a>
 
-- **Tags** — label intent on states (`:tags #{:auth/busy}`); views ask
-  `[:rf.machine/has-tag? id :auth/busy]` instead of enumerating state names.
-  → [Tags](tags.md)
-- **`:after` / `:always` / choice / timeout** — moves the table takes without a
-  user event. → [Automatic transitions](automatic-transitions.md)
+A machine can validate its private `:data` in development:
+
+```clojure
+(rf/reg-machine :auth.login/flow
+  {:initial :idle
+   :data    {:attempts 0 :error nil}
+   :schemas {:data [:map
+                    [:attempts :int]
+                    [:error [:maybe :string]]]}
+   :states  {…}})
+```
+
+A failed data validation rolls the transition back before the bad snapshot
+reaches runtime-db (`:where :machine-data`).
+
+`:schemas {:output …}` validates the value a `:final?` leaf reports through
+`:output-key`. Full rules: [`re-frame.machines` API](../api/re-frame.machines.md).
+
+## Testing
+
+<a id="testing-transitions-are-pure-function-calls"></a>
+
+The table is a value. Drive it with no frame, no browser, no network:
+
+```clojure
+(ns app.login-test
+  (:require [clojure.test :refer [deftest is]]
+            [re-frame.machines :as machines]
+            [re-frame.machines.result :as result]
+            [app.login :refer [login-flow]]))
+
+(deftest login-flow-test
+  (let [r (machines/machine-transition
+            login-flow
+            {:state :idle :data {:attempts 0 :error nil}}
+            [:auth.login/submit {:email "a@b.com" :password "secret"}])]
+    (is (result/ok? r))
+    (is (= :submitting (:state (result/snap r)))))
+
+  ;; Two failures already recorded; the third is terminal.
+  (let [r (machines/machine-transition
+            login-flow
+            {:state :submitting :data {:attempts 2 :error nil}}
+            [:auth.login/failure {:error {:message "bad creds"}}])]
+    (is (result/ok? r))
+    (is (= :locked-out (:state (result/snap r))))
+    (is (= 3 (get-in (result/snap r) [:data :attempts])))
+    (is (= "bad creds" (get-in (result/snap r) [:data :error])))))
+```
+
+Discriminate with `result/ok?` / `result/fail?`; read the next snapshot and
+the emitted effects with `result/snap` / `result/fx`. More, including Xray:
+[Inspecting and testing](inspecting-machines.md).
+
+## Troubleshooting
+
+| Symptom | Cause | Fix |
+| --- | --- | --- |
+| First `reg-machine` throws `:rf.error/machines-artefact-missing` | `[re-frame.machines]` not required | Require it once at boot |
+| Dev warning `:rf.warning/machine-source-unstamped` | `(def m {…})` then `reg-machine` | Use `defmachine`, or pass a literal map |
+| Registration throws `:rf.error/machine-unresolved-guard` (or `-action`, `-target`) | Named ref missing from the table | Add the name, or fix the typo |
+| Action fails `:rf.error/machine-action-wrote-db` | Returned `:db` | Update the snapshot via `:data`; write app-db through a named event in `:fx` |
+| Dispatch does nothing | Current state has no matching `:on` | Expected no-op (`:rf.machine.event/unhandled-no-op`). Bad names fail at registration |
+| `:rf.error/no-such-fx` on `:rf.http/managed` | HTTP artefact not loaded | Require `[re-frame.http.managed]` |
 
 ## When the table grows
 
 <a id="when-the-machine-grows"></a>
-<a id="testing-transitions-are-pure-function-calls"></a>
+<a id="tags-and-timers"></a>
 
 Same model, more keys — each page assumes this one:
 
 | Need | Page |
-|---|---|
+| --- | --- |
+| Label intent so views don't enumerate states | [Tags](tags.md) — `@(rf/subscribe [:rf.machine/has-tag? id :auth/busy])` |
+| Moves the table takes without a user event | [Automatic transitions](automatic-transitions.md) (`:after` / `:always` / choice / timeout) |
 | Nested sub-flows | [Hierarchical states](hierarchical-states.md) |
 | Independent axes at once | [Parallel regions](parallel-states.md) |
 | Resume mid-compound | [History](history.md) |
 | Per-request / worker children | [Actors](actors.md) |
 | Prove the table / watch live | [Inspecting and testing](inspecting-machines.md) |
 
-**`:raise`** in an action's `:fx` re-enters *this* machine atomically before commit.
-**`:internal-events`** marks event ids that external dispatch must not send.
-
-Eventless loops and raise storms are depth-bounded (default 16); tripping aborts the
-macrostep with a loud error — not a silent no-op.
+**`:raise`** in an action's `:fx` re-enters *this* machine atomically before
+commit. **`:internal-events`** is the set of event ids that external
+`dispatch` must not send
+(`:rf.error/machine-internal-event-external-dispatch`). Eventless loops and
+raise storms are depth-bounded (default 16);
+`:rf.error/machine-always-depth-exceeded` /
+`:rf.error/machine-raise-depth-exceeded` abort the whole step — not a silent
+no-op.
 
 ## When to reach for a machine
 
 <a id="when-to-reach-for-a-machine--and-when-not"></a>
 
-**Yes:** named mutually exclusive stages; conditional transitions scattered as
-`when`s; the flow is worth drawing on a whiteboard.
+**Yes:** named mutually exclusive stages; legal and illegal events;
+timers, cancellation, retries, or cleanup; the flow is easier to draw than
+to describe; tests should assert `(state, event) → next state + effects`.
 
-**No:** plain data; two-state flags; server cache lifecycles ([resources](../resources/concepts.md));
-mere operation sequences (chained events).
+**No:**
 
-**Named states are the concept — not named operations.**
+| Situation | Prefer |
+| --- | --- |
+| A counter, list, or form field | app-db + events |
+| A two-state flag | a keyword or boolean |
+| Server cache lifecycle | [resources](../resources/concepts.md) |
+| A fixed sequence of operations | chained events |
+
+Named states are the concept — not named operations.

--- a/docs/machines/examples.md
+++ b/docs/machines/examples.md
@@ -2,13 +2,16 @@
 
 <a id="machines-examples"></a>
 
-Runnable apps that exercise the machine grammar. Build a machine yourself first
-([tutorial](tutorial.md) — ends with a complete login table), then skim
-[the model](concepts.md). Work these apps in order — each adds machinery.
+Runnable machines in the repo. Pair each app with the guide pages that
+name the same machinery.
 
-| Example | What it shows | Read first |
+| Example | What it shows | Pair with |
 |---|---|---|
-| [state_machine_walkthrough](../../examples/capabilities/machines/state_machine_walkthrough) | Flat login-style table; guards and actions co-located; pure `machine-transition` tests — the tutorial's cousin in-repo | [The model](concepts.md) |
-| [nine_states](../../examples/patterns/nine_states) | One parallel machine, three regions; tags collapse 3×3×3 UI into one view decision | [Tags](tags.md), [Parallel regions](parallel-states.md) |
-| [long_running_work](../../examples/patterns/long_running_work) | Parent spawns N workers with `:spawn-all`; cooperative cancel on every exit path | [Actors](actors.md) |
-| [websocket](../../examples/patterns/websocket) | Hierarchical connection machine; spawned socket actor; `:after` backoff; `:always` flush | [Hierarchical states](hierarchical-states.md), [Automatic transitions](automatic-transitions.md), [Actors](actors.md) |
+| [state_machine_walkthrough](../../examples/capabilities/machines/state_machine_walkthrough) | A small transition table; guards and actions kept with the spec; pure `machine-transition` tests; the same machine value in the browser and on the JVM | [Tutorial](tutorial.md), [The model](concepts.md) |
+| [nine_states](../../examples/patterns/nine_states) | Parallel regions for orthogonal UI axes; tags as render semantics; a `render-priority` table; one view branch instead of a cross-product | [Parallel regions](parallel-states.md), [State tags](tags.md) |
+| [long_running_work](../../examples/patterns/long_running_work) | A parent `:spawn-all` of N workers; `:join :all`; progress as an internal self-transition; cooperative cancel and teardown on every exit | [Actors](actors.md), [Automatic transitions](automatic-transitions.md) |
+| [websocket](../../examples/patterns/websocket) | Hierarchical connection states; a `:spawn`ed socket actor; `:after` exponential backoff; `:always` queue flush; tags for status; `:current-socket?` drops events from a replaced socket | [Hierarchical states](hierarchical-states.md), [Actors](actors.md), [Automatic transitions](automatic-transitions.md) |
+
+## Not a machine example: `process_monitor_helix`
+
+Useful for seeing another rendering substrate consume subscriptions, but it is not a machine example. Do not use it to learn the FSM API.

--- a/docs/machines/glossary.md
+++ b/docs/machines/glossary.md
@@ -1,114 +1,99 @@
 # Machines glossary
 
-re-frame2's optional state-machine capability. One term, definition first; short
-code when the spelling matters; *See* / Related points at the teaching page.
+One term, short definition, tiny code when the spelling matters. *See* points
+at the teaching page.
 
-Grouped by role: [the core loop](#the-core-loop), [state structure](#state-structure),
-[transitions and timing](#transitions-and-timing), [actors and composition](#actors-and-composition),
-[tags](#tags), and [the runtime model](#the-runtime-model).
-
-## The core loop
+## Core terms
 
 ### **machine**
 
-A statechart registered as an [event handler](../core/glossary.md#event-handler) with
-`reg-machine`. Models a feature's lifecycle as explicit [states](#state) and
-[transitions](#transition) — driven by `dispatch`, with [guards](#guard),
-[actions](#action), timers, and optional child machines ([spawn](#spawn)) — instead
-of boolean flags in [app-db](../core/glossary.md#app-db).
-
-Live value is a [snapshot](#snapshot) in [runtime-db](../core/glossary.md#runtime-db).
+A statechart registered as an event handler. It models a feature lifecycle as
+named states and transitions.
 
 ```clojure
+(rf/defmachine login-flow {…})
 (rf/reg-machine :auth.login/flow login-flow)
 ```
 
-Related: [Machines](concepts.md); [`reg-machine`](../api/re-frame.machines.md#reg-machine).
+See [The model](concepts.md).
 
 ### **transition table**
 
-The data a machine *is*: `:initial`, starting [`:data`](#data), machine-local
-[`:guards`](#guard) / [`:actions`](#action), optional `:schemas`, and the `:states`
-tree. Event keys under each state's `:on` move it. [`reg-machine`](../api/re-frame.machines.md#reg-machine)
-compiles the map into an ordinary event handler at registration.
-
-```clojure
-{:initial :idle
- :data    {:attempts 0 :error nil}
- :guards  {:under-retry-limit (fn [{d :data}] (< (:attempts d) 2))}
- :actions {:clear-error (fn [_] {:data {:error nil}})}
- :states  {:idle       {:on {:submit {:target :submitting :action :clear-error}}}
-           :submitting {...}}}
-```
+The map that defines a machine: `:initial`, `:data`, optional `:guards`,
+optional `:actions`, optional `:schemas`, and `:states` or `:regions`.
 
 See [The idea](concepts.md#the-idea).
 
 ### **snapshot**
 
-A machine's live value — current [state](#state) plus `:data` (and optional `:tags`).
-Lives in [runtime-db](../core/glossary.md#runtime-db); read via subscription.
+The machine's live value.
 
 ```clojure
-@(rf/subscribe [:rf/machine :auth.login/flow])   ;; {:state :authed :data {...}}
+{:state :submitting
+ :data  {:attempts 1}
+ :tags  #{:auth/busy}}
 ```
 
-Plain printable value (no functions or atoms), so undo, [time-travel](../core/glossary.md#time-travel),
-persistence, and SSR hydration work without extra wiring. `:state` is a keyword
-(flat), a path vector (compound), or a region → state map (parallel).
+It lives in [runtime-db](../core/glossary.md#runtime-db). Read it with
+`[:rf/machine id]`:
 
-Related: [Machines](concepts.md); [`[:rf/machine machine-id]`](../api/re-frame.machines.md#rfmachine-machine-id).
+```clojure
+@(rf/subscribe [:rf/machine :auth.login/flow])
+```
+
+`nil` until the first event. `:state` is a keyword, a path vector, or a
+region map.
+
+See [The snapshot](concepts.md#the-snapshot).
 
 ### **:data**
 
-Machine-private working memory — counters, error strings, captured credentials —
-riding beside the named [state](#state) in every [snapshot](#snapshot). Guards and
-actions read it from their context map; an action updates it by returning
-`{:data …}` (see [action effect map](#action-effect-map)). Must be printable. A
-machine sees **only its own** `:data` — never [app-db](../core/glossary.md#app-db).
+A machine's private working memory. Guards and actions read it. Actions update
+it by returning `{:data …}`. Merged, not replaced — `{:data {:error nil}}` sets
+that key to nil.
 
-Taught in [The idea](concepts.md#the-idea).
+See [The idea](concepts.md#the-idea).
 
 ### **state**
 
-One fixed, named, mutually exclusive mode — `:idle`, `:submitting`, `:authed`.
-With [parallel regions](#parallel-state), one per region. Leaf = no nested
-`:states`; [compound](#compound-state) = nests its own `:states`.
+One named mode of a machine, such as `:idle`, `:submitting`, or `:authed`.
 
 ### **transition**
 
-Move from one [state](#state) to another on a dispatched [event](../core/glossary.md#event),
-optionally gated by a [guard](#guard) and running an [action](#action). Written under
-a state's `:on`. Also *eventless* ([`:always`](#eventless-transition-always)) or
-*timed* ([`:after`](#delayed-transition-after)).
+A move from one state to another, usually in response to an event under a
+state's `:on` map.
 
 ### **guard**
 
-Pure yes/no predicate on a [transition](#transition). Named in `:guards`, referenced
-from the table. Receives `{:data :event :state :meta}` (**no** app-db); returns a
-boolean. No `{:and …}` combinator — compound logic is one named function.
+A predicate that gates a transition.
 
-Runs *before* the transition's [action](#action), so it sees the pre-action snapshot
-— `(< (:attempts d) 2)` for a three-attempt policy. See [Guards](concepts.md#guards).
+```clojure
+:guard :form-valid?
+```
+
+Defined in `:guards`, or written inline for a one-liner. A three-attempt
+policy is `(< (:attempts data) 2)` — the guard sees the count *before* the
+action increments it.
+
+See [Guards](concepts.md#guards).
 
 ### **action**
 
-Side work on a [transition](#transition): returns `{:data … :fx …}` like an
-[event handler](../core/glossary.md#event-handler); never writes [app-db](../core/glossary.md#app-db)
-directly. Named in `:actions`. Slots: source `:exit`, transition `:action`, target
-`:entry`.
+A function that returns `{:data … :fx …}`. It may update the machine's private
+data or describe effects. It never writes app-db (`:rf.error/machine-action-wrote-db`).
+
+See [Actions](concepts.md#actions).
 
 ### **action effect map**
 
-What an [action](#action) returns. `:data` is **merged** into the snapshot (explicit
-`nil` sets a key to nil; does not remove keys); `:fx` is a vector of `[fx-id args]`.
-`nil` / `{}` means no effects. Describes work rather than performing it.
+The return value from an action.
 
 ```clojure
-:record-error
-(fn [{data :data [_ {:keys [error]}] :event}]
-  {:data (-> data (update :attempts inc)
-                  (assoc :error (:message error)))})
+{:data {:error nil}
+ :fx   [[:dispatch [:session/clear]]]}
 ```
+
+`:data` is merged into the machine data. `:fx` is the ordinary effects vector.
 
 See [The effect map](concepts.md#the-effect-map-data-fx).
 
@@ -116,274 +101,251 @@ See [The effect map](concepts.md#the-effect-map-data-fx).
 
 ### **compound state**
 
-A [state](#state) with its own `:states` map and required `:initial` — parent mode
-with child modes. Snapshot `:state` becomes a **vector path**
-(`[:authenticated :cart :browsing]`). Event resolution walks leaf → root
-(**deepest-wins with parent fallthrough**). Child can [opt out](#forbidden-transition)
-or override.
+A state with nested `:states` and its own `:initial`. The snapshot's `:state`
+becomes a vector path, such as `[:authenticated :cart :paying]`.
 
 See [Hierarchical states](hierarchical-states.md).
 
-### **parallel state**
+### **parallel machine**
 
-Root `:type :parallel` with a **`:regions`** map — all [regions](#region) active at
-once. Snapshot `:state` is a region-name → state map; one shared [`:data`](#data);
-[tags](#state-tag) union across regions. If axes don't share data, use N machines.
+A machine with `:type :parallel` and `:regions`. All regions are active at the
+same time. The snapshot's `:state` is a map of region name to region state.
 
-See [Parallel states](parallel-states.md); [nine_states](../../examples/patterns/nine_states/).
+See [Parallel regions](parallel-states.md).
 
 ### **region**
 
-One orthogonal axis of a [parallel state](#parallel-state) — independent
-sub-state-tree, concurrent with siblings, sharing the machine's [`:data`](#data).
-Events broadcast to every region; each resolves independently. Cross-region
-coordination reads sibling [tags](#state-tag).
+One orthogonal axis of a parallel machine. Each region has its own `:initial`
+and `:states`, but all regions share one machine `:data`.
+
+See [Parallel regions](parallel-states.md).
 
 ### **final state**
 
-Leaf marked **`:final? true`**: entering it **terminates the machine** (auto-destroy,
-including top-level singletons). For a resting end-screen (`:authed`), omit
-`:final?`. May name [`:output-key`](#on-done-and-output-key); may set `:error? true`.
-A final *nested in a compound* ends the sub-flow, not the machine.
+A leaf marked `:final? true`. At the root, it ends and destroys the machine.
+Inside a compound state, it marks that sub-flow as done. A resting end-screen
+(`:authed`) omits `:final?`.
 
-See [Actors → When a child finishes](actors.md#when-a-child-finishes);
-[Hierarchical states → nested finals](hierarchical-states.md#when-a-sub-flow-finishes-nested-final-states).
+See [Final states](concepts.md#final-states);
+[nested finals](hierarchical-states.md#when-a-sub-flow-finishes-nested-final-states).
 
 ### **history state**
 
-`:type :history` **pseudo-state** targeted to re-enter a [compound](#compound-state)
-at the last active substate. Shallow = immediate child; deep = full path;
-`:default-target` for never-visited. Recording rides the [snapshot](#snapshot).
+A `:type :history` pseudo-state inside a compound state. Target it to re-enter
+the compound where it last exited.
 
 See [History states](history.md).
 
-## Transitions and timing
+### **state tag**
+
+A semantic label on a state.
+
+```clojure
+:tags #{:auth/busy}
+```
+
+Read it with `[:rf.machine/has-tag? id tag]`:
+
+```clojure
+@(rf/subscribe [:rf.machine/has-tag? :auth.login/flow :auth/busy])
+```
+
+See [Tags](tags.md).
+
+## Transition forms
+
+### **candidate vector**
+
+A first-match-wins list of transitions.
+
+```clojure
+:on {:auth.login/failure [{:guard :under-retry-limit :target :error-shown
+                           :action :record-error}
+                          {:target :locked-out :action :record-error}]}
+```
 
 ### **self-transition**
 
-Transition back into the current state. re-frame2 is **internal-by-default**:
+A transition that stays in the same state.
 
-- **Targetless** (omit `:target`) — action only; no exit/entry; timers and spawns undisturbed.
-- **Self-target, no `:reenter?`** — own exit/entry still skip; compounds re-resolve descendants to `:initial`.
-- **`:reenter? true`** — full exit → action → entry (timers reset, spawns restart).
+Targetless self-transitions run an action without exit/entry. `:reenter? true`
+forces exit and re-entry.
 
 See [Self-transitions and wildcards](concepts.md#self-transitions-and-wildcards).
 
 ### **wildcard transition**
 
-`:on` key matching a class of events. Three tiers, most-specific first: exact id →
-`:ns/*` → `:*`. Guard-blocked exact falls through to coarser tiers.
+An `:on` key that handles a family of events:
 
 ```clojure
-:tracking {:on {:mouse/down {:action :begin-drag}
-                :mouse/*    {:action :note-move}
-                :*          {:action :log-unknown}}}
+:mouse/*
+:*
 ```
+
+Resolution is exact id, namespace wildcard, then total wildcard.
 
 See [Self-transitions and wildcards](concepts.md#self-transitions-and-wildcards).
 
 ### **forbidden transition**
 
-Present `:on` key with value `{}` or `nil` — consumes the event and stops
-deepest-wins search without changing state. How a child opts out of a parent
-transition. Distinct from unhandled (missing key), which falls through.
+A present no-op transition, such as `{:on {:logout {}}}` or
+`{:on {:logout nil}}`. It consumes the event and prevents parent fallthrough.
 
-Covered with [wildcards](concepts.md#self-transitions-and-wildcards).
+See [Self-transitions and wildcards](concepts.md#self-transitions-and-wildcards).
 
-### **eventless transition (`:always`)**
+### **:always**
 
-State-node key: vector of guarded transitions that fire **with no event** —
-checked on entry and after any landing transition; first-passing-guard wins. Must
-not target its own state (registration reject). Fixed-point form: targetless
-guarded `:always` whose action flips the guard.
+An eventless transition checked after entry and after transitions into the
+state.
 
 ```clojure
-:checking-form {:always [{:guard :form-valid?   :target :submitting}
-                         {:guard :form-invalid? :target :show-errors}]}
+:always [{:guard :done? :target :complete}]
 ```
-
-Settled inside the [microstep](#microstep) loop. See [Automatic transitions](automatic-transitions.md).
-
-### **delayed transition (`:after`)**
-
-Declarative timer: delay → transition. Enter arms; leave cancels. Epoch-tagged so
-late firings from earlier visits are ignored. Delay: positive-int ms, subscription
-vector, or `(fn [{:keys [snapshot]}] ms)`.
-
-```clojure
-:reconnecting {:after {5000 {:target :connecting}}
-               :on    {:net/give-up :failed}}
-```
-
-ISO-8601 / `"5s"` shorthand belong to [`:timeout`](#timeout), not `:after`. See
-[Automatic transitions](automatic-transitions.md).
-
-### **timeout**
-
-Named deadline: `:timeout` + `:on-timeout`. Lowers onto [`:after`](#delayed-transition-after).
-Duration: integer-ms or ISO-8601 (`"PT5S"`); `"5s"` rejected at registration.
 
 See [Automatic transitions](automatic-transitions.md).
 
 ### **choice state**
 
-`:type :choice` transient routing node: resolves immediately on entry to the first
-candidate whose guard passes. Declarative candidate **array** (must include unguarded
-default); no ordinary state keys. Desugars to [`:always`](#eventless-transition-always).
+A transient decision node.
+
+```clojure
+{:type :choice
+ :choice [{:guard :valid? :target :accepted}
+          {:target :rejected}]}
+```
 
 See [Automatic transitions](automatic-transitions.md).
 
-### **run-to-completion**
+### **:after**
 
-One event processes to a settled configuration before the next is seen — every
-[`:always`](#eventless-transition-always) microstep and [`:raise`](#raise) drains,
-then the snapshot [commits](#commit) once. External observers never see mid-cascade
-intermediates. Non-converging loops are depth-bounded (default 16) and abort with
-the snapshot unchanged.
+A delayed transition. Entering the state arms the timer; leaving cancels it.
 
-See [microstep](#microstep), [macrostep](#macrostep).
+```clojure
+:after {5000 :timed-out}
+```
+
+See [Automatic transitions](automatic-transitions.md).
+
+### **timeout**
+
+A named deadline using `:timeout` and `:on-timeout`.
+
+```clojure
+{:timeout "PT5S"
+ :on-timeout {:target :timed-out}}
+```
+
+See [Automatic transitions](automatic-transitions.md).
 
 ## Actors and composition
 
-### **spawn**
+### **actor**
 
-Declarative key that starts a child machine on state entry and tears it down on
-exit; result returns via [`:on-done`](#on-done-and-output-key). (`:spawn-all` starts
-several in parallel and joins.) Under the hood: reserved
-[`[:rf.machine/spawn …]`](../api/re-frame.machines.md#rfmachinespawn-spawn-spec)
-effect. Running instance is an [actor](#actor).
+A live machine instance. A singleton machine and a spawned child are both
+actors. Liveness is the presence of a snapshot in runtime-db.
 
 See [Actors](actors.md).
 
-### **actor**
+### **spawn**
 
-Live machine instance — a [snapshot](#snapshot) at
-`[:rf.runtime/machines :snapshots <id>]` in [runtime-db](../core/glossary.md#runtime-db).
-Two kinds: long-lived **singleton** (`reg-machine` id) and dynamically
-**[spawned](#spawn)** child. Liveness *is* snapshot presence. Address by allocated
-id (`<prefix>#<n>`, never `gensym`) or [system-id](#system-id).
+A state-node key that starts a child actor on entry and destroys it on exit.
+
+```clojure
+:spawn {:machine-id :worker}
+```
+
+See [Actors](actors.md).
 
 ### **spawn-all**
 
-Fan-out sibling of [`:spawn`](#spawn): starts **N children in parallel** and
-**joins** on completion (or first failure with cooperative cancel).
+A state-node key that starts several children and joins on their completion.
+`:join` is `:all` or `:any`.
 
-See [long_running_work](../../examples/patterns/long_running_work/);
-[Actors → Fan-out and join](actors.md#fan-out-and-join-with-spawn-all).
-
-### **:on-done and :output-key**
-
-How a finishing child reports back. Final state names **`:output-key`** (slot of
-[`:data`](#data) to surface). Parent's [`:spawn`](#spawn) declares **`:on-done`**
-`(fn [{:keys [data result]}] new-data)`; runtime then tears the child down.
-Completion is event-shaped — it *happens*, not a long-lived `output` slot.
-
-```clojure
-:done {:final? true :output-key :token}
-:authenticating {:spawn {:machine-id :auth-flow
-                         :on-done (fn [{:keys [data result]}]
-                                    (assoc data :token result))}}
-```
-
-See [Actors → When a child finishes](actors.md#when-a-child-finishes).
+See [Fan-out and join](actors.md#fan-out-and-join-with-spawn-all).
 
 ### **system-id**
 
-Stable role name (`:logger`, `:websocket`) bound to a spawned [actor](#actor).
-Action-side: `[:rf.machine/dispatch-to-system [system-id event]]` — actions can't
-read app-db, so the fx is how they message a named child.
+A stable role name bound to a spawned actor. Use it to message a child without
+threading its generated id.
 
-```clojure
-{:fx [[:rf.machine/dispatch-to-system [:logger [:logger/flush]]]]}
-```
+See [Actors](actors.md).
 
-Parked XState v6 parity escape (`systemId`); everyday send is plain `dispatch` to
-the id you hold. See [`machine-by-system-id`](../api/re-frame.machines.md#re-framemachinesmachine-by-system-id).
+### **:on-done**
+
+A callback or transition that runs when a child or compound sub-flow completes.
+
+See [When a child finishes](actors.md#when-a-child-finishes).
+
+### **:output-key**
+
+A key on a final state naming which value from `:data` is reported to the
+parent.
+
+See [When a child finishes](actors.md#when-a-child-finishes).
 
 ### **:raise**
 
-Machine-only fx-id. Inside an action's `:fx`, `[:raise [:some-event …]]` loops an
-event into *this* machine — **atomically, pre-commit**, FIFO inside one handler
-invocation (never the router queue). Contrast `:fx [[:dispatch [self-id …]]]`
-(separate post-commit event / [epoch](../core/glossary.md#epoch)).
+A machine-only effect that loops an event back into the same machine before
+the macrostep commits.
 
 ```clojure
-{:actions {:kick (fn [_] {:fx [[:raise [:tick]]]})}}
+{:fx [[:raise [:check-complete]]]}
 ```
 
-See [`[:raise event-vec]`](../api/re-frame.machines.md#raise-event-vec);
-[When the machine grows](concepts.md#when-the-machine-grows).
+See [When the table grows](concepts.md#when-the-table-grows).
 
 ### **:internal-events**
 
-Top-level **set** of event ids that are machine plumbing — raised at itself, not
-for external dispatch. External dispatch is refused
-(`:rf.error/machine-internal-event-external-dispatch` trace).
+A top-level set of event ids that may be raised internally but are refused
+when dispatched from outside the machine.
 
-```clojure
-{:internal-events #{:check-complete}
- :states {...}}
-```
+See [When the table grows](concepts.md#when-the-table-grows).
 
-See [When the machine grows](concepts.md#when-the-machine-grows).
+## Runtime terms
 
-## Tags
+### **run-to-completion**
 
-### **state tag**
-
-Label like `:auth/busy` on several [states](#state); active tags ride the
-[snapshot](#snapshot). Views ask
-[`[:rf.machine/has-tag? …]`](../api/re-frame.machines.md#rfmachinehas-tag-machine-id-tag)
-instead of enumerating names. Across [parallel regions](#region), tags union onto
-one snapshot.
-
-```clojure
-(when @(rf/subscribe [:rf.machine/has-tag? :auth.login/flow :auth/busy])
-  [spinner])
-```
-
-See [Tags](tags.md).
-
-## The runtime model
-
-Vocabulary for ordering and atomicity — and what the [trace stream](../core/glossary.md#trace-stream)
-shows. You can ship machines without memorising these.
-
-### **drain**
-
-Deterministic ordering of effects at four levels: within one action's `:fx`
-(`:data` before `:fx`); across `:exit` → `:action` → `:entry`; within one machine
-event ([microstep](#microstep) over [`:always`](#eventless-transition-always) and
-[`:raise`](#raise)); across the per-frame queue (FIFO, with machine continuations
-leap-frogging so a [macrostep](#macrostep) settles first). Source order is runtime
-order.
+The guarantee that one machine event settles all `:always` transitions and
+raised events before the next external event is observed.
 
 ### **microstep**
 
-One settle-loop iteration inside a machine event: prefer an enabled
-[`:always`](#eventless-transition-always); else dequeue one [`:raise`](#raise)
-(FIFO). Loops to fixed point. Not separately observable; composes one
-[macrostep](#macrostep). Bounded at depth 16.
+One internal step inside a macrostep: an `:always` transition or a raised
+event.
 
 ### **macrostep**
 
-Whole machine event — resolving transition plus every microstep and raise — as
-**one** logical step outside: one [commit](#commit), one trace row, one
-[epoch](../core/glossary.md#epoch). External observers see only the post-commit
-snapshot. This is [run-to-completion](#run-to-completion).
+The full processing of one machine event, including all microsteps, ending in
+one committed snapshot.
 
 ### **commit**
 
-Single deferred [runtime-db](../core/glossary.md#runtime-db) write of a
-[macrostep](#macrostep)'s settled [snapshot](#snapshot) at
-`[:rf.runtime/machines :snapshots <id>]` — once per transition. Boundary for
-[`:schemas :data`](concepts.md#validating-a-machines-data) (violation rolls back)
-and for subscription re-fire. (Framework [commit](../core/glossary.md#commit).)
+The single runtime-db write that stores the settled snapshot.
 
-### **LCCA (least common compound ancestor)**
+### **LCA / LCCA**
 
-Also **LCA**. For a [transition](#transition) from path A to B inside a
-[compound](#compound-state), the deepest state that stays active — neither exits
-nor enters. Exit cascade: leaf up to (not including) LCCA, deepest-first. Entry:
-just below LCCA down to B's leaf, shallowest-first. Transition `:action` once at
-the boundary. Flat machine: LCCA is the root → plain exit → action → entry.
+Least common compound ancestor. The deepest state that remains active while
+moving from one hierarchical path to another. Exit actions run up to it; entry
+actions run down from it.
+
+See [Entry/exit cascading](hierarchical-states.md#entryexit-cascading-along-the-lca).
+
+### **runtime-db**
+
+The framework-owned state partition where machine snapshots live. It is
+separate from app-db.
+
+See [runtime-db](../core/glossary.md#runtime-db).
+
+### **unhandled event**
+
+An event the current machine configuration does not handle. It is a no-op, not
+an exception.
+
+### **fail loud**
+
+The design posture for invalid definitions: unresolved targets, missing
+guards/actions, bad timeout shapes, invalid final states, and similar mistakes
+fail at registration rather than later.
+
+See [fail loud](../core/glossary.md#fail-loud-not-silent).

--- a/docs/machines/hierarchical-states.md
+++ b/docs/machines/hierarchical-states.md
@@ -1,424 +1,246 @@
-# Hierarchical (compound) states
+# Hierarchical states
 
-Flat machines ([the model](concepts.md)) put every state at one level. A
-**compound** state holds sub-states — factor shared transitions into a parent,
-cascade entry into an `:initial` child, and finish a sub-flow without ending the
-whole machine.
+A flat machine has one active state at a time. A hierarchical machine lets a
+state contain its own child states.
 
-A flat list of states, one active at a time, carries most flows. Some states are
-really a *cluster*: three leaves that share a resource, a sub-flow with its own
-beginning and end, a family that should answer the same event the same way. A
-**compound state** contains its own `:states` map — a little machine nested inside
-one state of the bigger one.
+Use hierarchy when several states form a sub-flow or share a lifecycle — every
+authenticated screen handles `:logout` the same way, or checkout is a nested
+flow inside shopping.
 
-Reach for hierarchy when:
+## A compound state
 
-- **Several leaves share a lifecycle or a resource.** A WebSocket's
-  `:connecting → :authenticating → :connected` happy path all ride *one* live
-  socket — three phases of being *connected*. Nest them under one `:active` parent
-  and the socket spans all three.
-- **You want to factor a transition to a parent.** Every authenticated screen
-  should honour `:logout` the same way. Declare it *once* on the parent; every
-  descendant inherits it ([parent-fallthrough](#transition-resolution-deepest-wins-with-parent-fallthrough)).
-  No restating, no drift.
-- **A sub-flow has a clear "done."** A checkout collects, submits, confirms — then
-  the outer flow moves on. Mark the sub-flow's terminal leaf and the parent
-  advances ([done signal](#when-a-sub-flow-finishes-nested-final-states)).
-
-The grammar recurses: a substate is a **leaf** (no `:states`) or another
-**compound** (has `:states` and must declare `:initial`). You only pay for
-hierarchy where you use it.
-
-Canonical example: the connection machine in
-[`../../examples/patterns/websocket/`](../../examples/patterns/websocket) — `:active`
-parents the three happy-path leaves. Snippets below are simplified from it. Flat
-grammar: [The model](concepts.md). Spawned sockets on a parent: [Actors](actors.md).
-
----
-
-## Anatomy of a compound state
-
-Here is the shape, lifted and trimmed from the WebSocket connection machine.
-The three happy-path leaves live *inside* `:active`, because they share the one
-thing they can't do without: the live socket, spawned on the parent.
+A state with `:states` is a compound state. It must declare `:initial`.
 
 ```clojure
-(rf/reg-machine :ws/connection
-  {:initial :disconnected
-   :data    {:url nil :socket-id nil :queue []}
-
-   :actions
-   {:record-opts (fn [{data :data [_ {:keys [url]}] :event}]
-                   {:data (assoc data :url url)})
-    :send-now    (fn [{data :data [_ msg] :event}]
-                   {:fx [[:dispatch [(:socket-id data) [:send msg]]]]})
-    :enqueue     (fn [{data :data [_ msg] :event}]
-                   {:data (update data :queue conj msg)})}
-
-   :states
-   {:disconnected
-    {:on {:ws/connect {:target :active :action :record-opts}}}
-
-    :active                                   ;; ← compound: the socket's home
-    {:initial :connecting                     ;; required — every compound declares it
-
-     ;; One socket actor, spawned on the PARENT, so it spans all three leaves
-     ;; below without re-spawning on each leaf transition. (See Actors.)
-     :spawn {:machine-id :websocket/socket}
-
-     ;; Transitions every leaf inherits. A leaf may override any of them; what
-     ;; a leaf doesn't handle falls through to here.
-     :on    {:ws/closed     {:target :reconnecting}
-             :ws/send       {:action :enqueue}    ;; default: queue while not yet connected
-             :ws/disconnect {:target :disconnected}}
-
-     :states
-     {:connecting     {:tags #{:ws/connecting}
-                       :on   {:ws/opened {:target :authenticating}}}
-
-      :authenticating {:tags  #{:ws/authenticating}
-                       :on    {:ws/auth-ok     {:target :connected}
-                               :ws/auth-failed {:target [:failed]}}}  ;; ← vector! (root-level)
-
-      :connected      {:tags #{:ws/connected}
-                       :on   {:ws/send {:action :send-now}}}}}        ;; ← overrides parent :ws/send
-
-    :reconnecting {:on {:ws/connect {:target :active}}}
-    :failed       {:on {:ws/connect {:target :active}}}}})
-```
-
-Three things to notice, each expanded below:
-
-1. `:active` declares `:initial :connecting` — entering `:active` lands you in
-   `:connecting`, never in `:active` "bare."
-2. `:ws/auth-failed` targets `[:failed]` (a **vector**), because `:failed` lives
-   at the root, not as a sibling inside `:active`.
-3. `:connected` redeclares `:ws/send` — it **overrides** the parent's default
-   for that one event while it's the active leaf.
-
----
-
-## The snapshot becomes a path
-
-A flat machine's snapshot `:state` is a single keyword (`:disconnected`). For a
-**compound** machine, `:state` is a **vector path** from the root down to the
-active leaf:
-
-```clojure
-@(rf/subscribe [:rf/machine :ws/connection])
-;; flat-ish state:   {:state :disconnected         :data {…} :tags #{}}
-;; compound state:   {:state [:active :connected]  :data {…} :tags #{:ws/connected}}
-```
-
-`:data` is the machine's extended state — one shared map, not per-state. `:tags`
-is the **union** of the `:tags` sets on every active node along the path. A
-single keyword `:K` read against a hierarchical definition is treated as the
-path `[:K]` (it must name a leaf at the root).
-
-The practical upshot: **views ask about tags, not paths.** Don't unfold the
-`:state` vector in a view to discover "are we connected?" — ask the tag:
-
-```clojure
-(when @(rf/subscribe [:rf.machine/has-tag? :ws/connection :ws/connected])
-  [send-box])
-```
-
-The view doesn't care *which* leaf carries the `:ws/connected` intent, only that
-the tag is present — so you can re-shape the hierarchy later without touching
-the view. (See the [snapshot](glossary.md#snapshot) and
-[state tag](glossary.md#state-tag) glossary entries; the snapshot lives in the
-framework's [runtime-db](../core/glossary.md#runtime-db), read like any other
-[subscription](../core/subscriptions.md).)
-
----
-
-## Initial-state cascading
-
-**Every compound state MUST declare `:initial`** — the substate to enter when
-control reaches the compound without a deeper target. Entering a compound
-*cascades down its `:initial` chain* until it reaches a leaf:
-
-```clojure
-{:initial :outer
- :states  {:outer {:entry   :enter-outer        ;; fires first
-                   :initial :mid
-                   :states  {:mid  {:entry   :enter-mid     ;; then this
-                                    :initial :leaf
-                                    :states  {:leaf {:entry :enter-leaf}}}}}}}
-;; Targeting :outer lands the snapshot at [:outer :mid :leaf].
-;; Entry actions fire shallowest-first: :enter-outer, :enter-mid, :enter-leaf.
-```
-
-So in the WebSocket machine, `{:target :active}` resolves to `[:active :connecting]`,
-and the cascade fires `:active`'s entry slots (including its `:spawn`) and then
-`:connecting`'s — shallowest-first — as the path lengthens.
-
-A compound state *without* `:initial` is a registration error
-(`:rf.error/machine-compound-state-missing-initial`) — it fails loud at
-`reg-machine` time, not on the unlucky dispatch.
-
-!!! note "The initial cascade also runs at birth"
-
-    When a machine first comes to
-    life — a singleton on its first dispatched event, or a spawned actor — the
-    whole `:initial` chain's `:entry` actions fire once, shallowest-first, as part
-    of bringing it into existence — *every* level along the chain, not just the
-    leaf.
-
----
-
-## Targets: vector vs keyword
-
-A transition's `:target` admits two forms, and the difference is *where the
-target is resolved from*:
-
-| Form | Means | Example |
-|---|---|---|
-| **Vector** `[:a :b]` | **Absolute path from the root**, no matter where the transition is declared. Unambiguous; the recommended form for cross-level jumps. | `:ws/auth-failed {:target [:failed]}` |
-| **Keyword** `:b` | **Relative — a sibling** of the state that *declares* the transition (resolved against the declaring state's parent's `:states`). | `:ws/opened {:target :authenticating}` |
-
-The "declaring state" is the node that **owns the `:on` map** — not whatever
-leaf the machine happens to sit in at runtime. It's a static rule you can read
-straight off the transition table.
-
-This is exactly the WebSocket gotcha. From inside `:authenticating` (a child of
-`:active`), a bare `:auth-failed {:target :failed}` would resolve to the
-*sibling* `[:active :failed]` — which doesn't exist. The absolute vector
-`[:failed]` says "from the root, please":
-
-```clojure
-:authenticating
-{:on {:ws/auth-ok     {:target :connected}       ;; keyword: sibling inside :active → [:active :connected]
-      :ws/auth-failed {:target [:failed]}}}       ;; vector: root-level [:failed]
-```
-
-A target naming a **compound** state implicitly cascades through its `:initial`
-chain (above). To land on a *specific* leaf inside a compound, name it with a
-vector: `:target [:active :connected]`.
-
-Flat-machine targets you've already written (`{:target :editing}`) are keyword
-form, root-relative — unchanged, because in a flat machine the declaring state's
-parent *is* the root.
-
----
-
-## Transition resolution: deepest-wins with parent fallthrough
-
-When an event arrives, the runtime walks the active path **from the leaf up to
-the root**, and the first node that *enables* a transition for the event wins.
-Within each node it tries three descriptor tiers in priority order before moving
-up: the **exact** key, then the namespace wildcard `:ns/*`, then the total
-wildcard `:*`. A guard-blocked candidate is **not** enabled, so it doesn't end
-the search — resolution keeps falling through.
-
-Two consequences make hierarchy pay off:
-
-- **A child overrides a parent.** `:connected` redeclares `:ws/send` to send
-  immediately; while connected, that leaf wins and the parent's "enqueue"
-  default never runs. Same event, different answer depending on where you are.
-- **A parent factors a common transition.** `:active` declares `:ws/closed`,
-  `:ws/disconnect`, and the `:ws/send` default *once*; every leaf that doesn't
-  handle them inherits them. Add a fourth leaf and it inherits them too, for
-  free.
-
-```clojure
-;; While the snapshot is [:active :connected], dispatching :ws/disconnect:
-;;   :connected   — no :ws/disconnect  → keep walking up
-;;   :active       — match!             → {:target :disconnected}
-;; Dispatching :ws/send instead resolves at :connected (override → :send-now).
-```
-
-### Opting a child OUT of an inherited transition
-
-Sometimes a child needs the *inverse* of inheritance — to **block** a
-factored-to-parent transition while it's active, without replacing it. Because
-the walk stops at the first *enabled* match, a child can declare a matching
-**internal no-op** that consumes the event so the parent is never reached:
-
-```clojure
-:modal {:on {:logout {}            ;; FORBIDDEN: matching internal no-op, halts the walk
-             ;; equivalently:  :logout nil
-             :close  :dashboard}}
-```
-
-While the machine rests in `:modal`, `:logout` resolves *at* `:modal` to a no-op
-and the parent's `:logout` is **not** inherited. Leave `:modal` and it's
-inherited again. Both spellings — the empty map `{}` and a present key with
-`nil` value — normalise to the same blocking no-op.
-
-The block turns entirely on the key being **present**. A child with *no*
-`:logout` entry keeps falling through (absence means "I don't handle this");
-a deliberately-`nil` key blocks (presence means "I consume this here").
-
-### Unhandled events are a benign no-op
-
-If *no* level enables a transition for an unknown event, the snapshot is
-unchanged and the runtime emits a benign `:rf.machine.event/unhandled-no-op`
-trace. Nothing throws — but benign is not invisible: the trace lets a debugger
-report that an event arrived and was ignored. To "fail loud on unknown," declare
-a `:*` wildcard whose action throws.
-
----
-
-## Entry/exit cascading along the LCA
-
-Moving from one path to another isn't a single hop — it fires a *cascade* of
-`:exit` and `:entry` actions for every state you actually leave and enter. The
-runtime computes the **LCA** (least common compound ancestor — the deepest
-compound state that is a proper ancestor of both the source leaf and the target
-node), then fires three boundaries in order:
-
-1. **Exit cascade** — walk the source path from the leaf back toward the LCA,
-   firing each state's `:exit` action, **deepest-first**. Stop *below* the LCA
-   (you aren't leaving it).
-2. **Transition `:action`** — runs once, at the LCA boundary, between exit and
-   entry.
-3. **Entry cascade** — walk the target path from just below the LCA down to the
-   target node, firing each `:entry` action, **shallowest-first**. If the target
-   is itself compound, keep cascading through its `:initial` chain.
-
-For the common case — source and target in disjoint subtrees — the LCA is simply
-the longest common prefix of the two paths.
-
-Take this auth-flow machine (a compound `:authenticated` over a `:dashboard` /
-`:settings` / `:cart` sub-tree, with `:cart` itself compound):
-
-```clojure
-(rf/reg-machine :shop
+(rf/defmachine shop
   {:initial :unauthenticated
+
    :states
    {:unauthenticated
-    {:on {:login [:authenticated]}}              ;; vector target — absolute from root
+    {:on {:login [:authenticated]}}
 
     :authenticated
     {:initial :dashboard
-     :on      {:logout [:unauthenticated]}       ;; factored to the parent — every descendant inherits
+     :tags    #{:auth/logged-in}
+     :on      {:logout [:unauthenticated]}  ;; inherited by descendants
+
      :states
-     {:dashboard {:on {:open-settings :settings  ;; keyword target — sibling of :dashboard
-                       :open-cart     :cart}}
-      :settings  {:on {:close :dashboard}}
-      :cart      {:initial :browsing
-                  :on      {:close :dashboard}
-                  :states  {:browsing  {:on {:checkout :paying}}
-                            :paying    {:on {:success :confirmed
-                                             :failure :browsing}}
-                            :confirmed {}}}}}}})
+     {:dashboard
+      {:on {:open-settings :settings
+            :open-cart     :cart}}
+
+      :settings
+      {:on {:close :dashboard}}
+
+      :cart
+      {:initial :browsing
+       :on      {:close :dashboard}
+       :states
+       {:browsing  {:on {:checkout :paying}}
+        :paying    {:on {:success :confirmed
+                         :failure :browsing}}
+        :confirmed {}}}}}}})
+
+(rf/reg-machine :shop shop)
 ```
 
-| Event | Source path | Target path | What fires |
-|---|---|---|---|
-| `:login` | `[:unauthenticated]` | `[:authenticated :dashboard]` | LCA is the root: exit `:unauthenticated`. Target `[:authenticated]` cascades `:initial :dashboard`, so entry is `:authenticated`, then `:dashboard`. |
-| `:open-cart` | `[:authenticated :dashboard]` | `[:authenticated :cart :browsing]` | Keyword `:cart` = sibling of `:dashboard`; cascades `:initial :browsing`. LCA is `:authenticated`: exit `:dashboard`; enter `:cart`, `:browsing`. |
-| `:checkout` | `[:authenticated :cart :browsing]` | `[:authenticated :cart :paying]` | Sibling hop inside `:cart`. LCA `:cart`: exit `:browsing`; enter `:paying`. |
-| `:logout` | `[:authenticated :cart :paying]` | `[:unauthenticated]` | Deepest-wins walks `:paying` (no match), `:cart` (no), `:authenticated` (match). LCA is the root: exit `:paying → :cart → :authenticated` (deepest-first); enter `:unauthenticated`. |
+Entering `:authenticated` does not stop at the parent. The machine follows the
+`:initial` chain to `[:authenticated :dashboard]`.
 
-> This generalises the flat `exit → action → entry` rule: in a flat machine the
-> path length is 1 and the LCA is always the root.
+## The snapshot state becomes a path
 
-Actions are **pure returns**, not imperative writes: an `:entry` /
-`:exit` / transition `:action` is `(fn [{:keys [data event state]}] effects)`
-returning `{:data … :fx …}`. The `:fx` flow through the ordinary
-[event pipeline](../core/introduction.md) like any handler's.
+A hierarchical snapshot uses a vector path from the root to the active leaf:
 
----
+```clojure
+@(rf/subscribe [:rf/machine :shop])
+;; => {:state [:authenticated :cart :paying]
+;;     :data  {...}
+;;     :tags  #{:auth/logged-in}}
+```
+
+A flat root state is treated as a one-element path internally, but flat machines
+still present a single keyword. `:data` is one shared map, not per-state.
+`:tags` is the union of every active node along the path.
+
+Avoid matching long paths in views. Put `:tags` on states and ask semantic
+questions:
+
+```clojure
+(when @(rf/subscribe [:rf.machine/has-tag? :shop :auth/logged-in])
+  [account-menu])
+```
+
+## Initial cascading
+
+Every compound state declares the child to enter when it is targeted without a
+deeper path.
+
+```clojure
+:authenticated
+{:initial :dashboard
+ :states  {:dashboard {}
+           :settings  {}}}
+```
+
+Targeting `[:authenticated]` lands at `[:authenticated :dashboard]`.
+
+If there are several nested compounds, the cascade continues until a leaf is
+reached. Entry actions fire shallowest first.
+
+```clojure
+{:initial :outer
+ :states
+ {:outer {:entry   :enter-outer
+          :initial :inner
+          :states  {:inner {:entry   :enter-inner
+                            :initial :leaf
+                            :states  {:leaf {:entry :enter-leaf}}}}}}}
+```
+
+Birth follows the same rule. When a machine first starts, the whole initial
+path is entered.
+
+A compound without `:initial` is a registration error:
+`:rf.error/machine-compound-state-missing-initial`.
+
+## Target forms
+
+A target can be a keyword or a vector.
+
+| Form | Meaning |
+|---|---|
+| `:settings` | sibling of the state that declares the transition |
+| `[:authenticated :settings]` | absolute path from the root |
+
+Use vector targets for cross-level jumps. They are unambiguous. In the shop
+machine, `:open-settings :settings` is a sibling of `:dashboard`;
+`:login [:authenticated]` is an absolute path from the root.
+
+A keyword target is resolved relative to the declaring state's parent, not the
+currently active leaf. That is a static rule. A target that names a compound
+enters its `:initial` child; to land on a particular leaf, use a vector path.
+
+## Deepest wins, then parent fallthrough
+
+When an event arrives, the runtime starts at the active leaf and walks up
+toward the root.
+
+The first state that handles the event wins.
+
+That gives two useful patterns:
+
+```clojure
+:authenticated
+{:on {:logout :unauthenticated}     ;; factored to parent
+ :states
+ {:dashboard {}
+  :settings  {}
+  :modal     {:on {:logout {}}}}}    ;; child consumes and blocks logout
+```
+
+- A parent can factor common transitions.
+- A child can override or block them.
+
+The empty map `{}` is a [forbidden transition](glossary.md#forbidden-transition)
+— a deliberate internal no-op. It consumes the event so the parent does not see
+it. A present `nil` value means the same thing.
+
+If no level handles the event, it is an unhandled no-op
+(`:rf.machine.event/unhandled-no-op`).
+
+## Wildcards and hierarchy
+
+At each level, event resolution checks:
+
+1. exact event id;
+2. namespace wildcard, such as `:mouse/*`;
+3. total wildcard `:*`.
+
+Only then does it move to the parent.
+
+A guard-blocked candidate does not count as handled, so the search can continue
+to a coarser wildcard or parent transition. A deliberate no-op block does count
+as handled.
+
+<a id="entryexit-cascading-along-the-lca"></a>
+
+## Entry/exit cascading along the LCA
+
+Moving from one path to another fires exits and entries along the least common
+compound ancestor.
+
+From `[:authenticated :cart :paying]` to `[:authenticated :dashboard]`, the
+least common active ancestor is `:authenticated`.
+
+The cascade is:
+
+1. exit `:paying`;
+2. exit `:cart`;
+3. run the transition action;
+4. enter `:dashboard`.
+
+The ancestor that remains active is not exited or re-entered.
+
+For a flat machine this collapses to the familiar `exit → action → entry`.
+
+## Parent lifecycle spans child states
+
+Put lifecycle work on the parent when it should span several child states.
+
+```clojure
+;; cf. examples/patterns/websocket
+:active
+{:spawn {:machine-id :websocket/socket}
+ :on    {:ws/disconnect :disconnected}
+
+ :states
+ {:connecting     {:on {:ws/opened :authenticating}}
+  :authenticating {:on {:ws/auth-ok :connected}}
+  :connected      {:on {:ws/send {:action :send-now}}}}}
+```
+
+The socket actor is spawned when `:active` is entered and destroyed when
+`:active` is left. Moving from `:connecting` to `:connected` does not restart
+it. See [Actors](actors.md).
+
+<a id="when-a-sub-flow-finishes-nested-final-states"></a>
 
 ## When a sub-flow finishes: nested final states
 
-A compound state often *is* a sub-flow with a clear end: collect, submit, paid.
-re-frame2 ships the statechart pattern for "the sub-flow finished, now advance
-the outer flow" — and **the machine keeps running**.
-
-Mark the sub-flow's terminal leaf `:final? true`. The moment a compound's active
-child becomes that final leaf, the engine raises a synthetic, transitionable
-event `[:rf.machine/done <compound-path>]`, and the compound's **`:on-done`**
-takes it:
+A `:final?` leaf inside a compound means the compound's sub-flow is complete.
+The machine itself keeps running.
 
 ```clojure
 (rf/reg-machine :checkout
   {:initial :flow
    :states
-   {:flow {:initial :collecting
-           :on-done :next                        ;; ← fires when :flow reaches its :final? child
-           :states  {:collecting {:on {:submit :submitting}}
-                     :submitting {:on {:ok :paid}}
-                     :paid       {:final? true}}} ;; ← embedded final = "sub-flow done"
-    :next {:on {:reset [:flow]}}}})
+   {:flow
+    {:initial :collecting
+     :on-done :next
+     :states  {:collecting {:on {:submit :submitting}}
+               :submitting {:on {:ok :paid}}
+               :paid       {:final? true}}}
+
+    :next
+    {:on {:reset [:flow]}}}})
 ```
 
-When `:flow` reaches `[:flow :paid]`, `:on-done :next` advances the machine to
-the sibling `:next` — **in the same macrostep**, no teardown. `:on-done` on a
-compound is an ordinary `:on`-shaped transition spec (a keyword sibling target,
-a vector path, or a full `{:target :guard :action}` / candidate vector), and a
-keyword target resolves as a **sibling of the compound** — the natural "advance
-the outer flow" placement.
+When the active child reaches `[:flow :paid]`, the runtime raises an internal
+done event for `:flow`, and `:on-done` moves to `:next` in the same macrostep.
+A keyword `:on-done` target is a sibling of the compound.
 
-> The node id rides as the raised event's single argument so the `:on` table
-> stays keyed on one reserved keyword. The raise lands in the same internal FIFO
-> queue an action's `[:raise …]` uses, drained before the macrostep settles.
-
-There's also a lower-level escape hatch: if the done node declares no `:on-done`,
-the raised `[:rf.machine/done <path>]` walks the active path leaf→root like any
-event, so an **ancestor** can catch it with an explicit
-`:on {:rf.machine/done {:guard … :target …}}` — a guard reads the raised path off
-`:event` to disambiguate *which* node is done.
-
-### Depth decides the meaning — embedded vs whole-machine final
-
-The same `:final?` key means two different things depending on **how deep the
-leaf sits:**
-
-| `:final?` leaf placement | Meaning | Effect |
-|---|---|---|
-| **Embedded inside a compound** (path length ≥ 2) | the *compound* is done | raises `[:rf.machine/done <compound>]`; the enclosing `:on-done` advances; **the machine keeps running** |
-| **Direct child of the root** (path length 1) | the *whole machine* is done | **auto-destroys** (a singleton tears itself down; a spawned child notifies its parent — below) |
-
-So you do **not** have to *avoid* `:final?` to keep a machine alive after a
-sub-flow completes — you put the final leaf *inside* the compound. A final leaf
-at the root, by contrast, ends the actor.
-
-!!! note "Final means final"
-
-    A *singleton* (top-level, un-spawned) machine that
-    reaches a **root-level** `:final?` leaf auto-destroys — the snapshot is gone.
-    If you want a state the machine rests in indefinitely (an `:authed`
-    end-screen), use an ordinary leaf and **omit `:final?`**. `:final?` is for
-    "this run is over," not "this is the last screen."
-
-### Reporting a result to a spawning parent: `:output-key`
-
-The *whole-machine* final case is how a **spawned child** reports back: the
-child marks its terminal leaf `:final?` and names the `:data` slot to hand up
-with `:output-key`; the parent's **`:spawn :on-done`** callback receives it as
-`result`, and the runtime then tears the child down. That protocol — including
-the `:on-error` failure path — is worked in
+A root-level `:final?` leaf is different: it means the whole machine is done
+and should be destroyed. For a resting end-screen, omit `:final?`. A spawned
+child's root-level `:final?` is how it reports back — see
 [Actors → When a child finishes](actors.md#when-a-child-finishes).
 
-Two distinct `:on-done` hooks, then, named the same on purpose because they're
-the same idea at two scopes:
+## Troubleshooting
 
-- **`:on-done` on a compound node** — the *transitionable in-machine* signal
-  (`done.state.<compound>`). Advances the outer flow; machine survives.
-- **`:on-done` on a parent's `:spawn` map** — the *actor-teardown notification*
-  `(fn [{:keys [data result]}] new-data)` a parent gets when a spawned child
-  reaches a root-level `:final?` and is then destroyed.
-
-### `:final?` constraints
-
-A `:final?` state fails loud at registration if you break these:
-
-- **Leaf-only.** No `:states` / `:initial` on a final state — a compound can't
-  be final; its finality is a leaf *inside* it. (`:rf.error/machine-final-state-compound`)
-- **No further transitions.** No `:on` / `:always` / `:after` / `:spawn` /
-  `:spawn-all` on a final state — final means final. (`:rf.error/machine-final-state-has-transitions`)
-  `:entry` and `:exit` *are* allowed (entry runs in the cascade; exit runs from
-  teardown).
-- **`:output-key` requires `:final?`.** A non-final state declaring
-  `:output-key` is an error (`:rf.error/machine-output-key-without-final`). On a
-  final leaf it's optional — absent, the parent's `result` is `nil`.
-
-(Inside a parallel-region machine, a `:final?` leaf means "*this region* is
-done"; the machine as a whole is done only when *every* region is final.
-Parallel regions are a separate axis — they're for orthogonal concerns that
-*don't* share a sub-tree — covered in [Parallel states](parallel-states.md).)
-
----
+| Symptom | Cause | Fix |
+|---|---|---|
+| `reg-machine` throws `:rf.error/machine-compound-state-missing-initial` | A `:states` map with no `:initial` | Name the child to enter when the compound is targeted |
+| `reg-machine` throws `:rf.error/machine-unresolved-target` | A keyword target that is not a sibling of the declaring state | Use a vector path for a cross-level jump |
+| Landed in the wrong leaf | The target named a compound, so `:initial` cascaded | Target the leaf with a vector path |
+| `:logout` does nothing in one child | That child declares `:logout {}` or `:logout nil` | Remove the key to inherit; keep it only to block |
+| View broke after reshaping the tree | The view matched a long `:state` path | Ask a tag: `@(rf/subscribe [:rf.machine/has-tag? id tag])` |
+| Machine vanished after the "last screen" | A root-level `:final?` auto-destroys | Omit `:final?` on a resting leaf |

--- a/docs/machines/history.md
+++ b/docs/machines/history.md
@@ -1,215 +1,189 @@
 # History states
 
-Re-enter a [compound](hierarchical-states.md) at the substate you left — a media
-player resumes mid-track. History is a transition *target*, not a state you occupy.
+A history state lets a [compound](hierarchical-states.md) remember where it was
+when you left it.
 
-Without it you stash the last substate in `:data` on the way out, read it back on
-the way in, and wire the restore yourself. A **history state** is that pattern as
-one node — `:type :history` — and because record/restore live *inside the
-snapshot*, they ride undo, time-travel, persistence, and SSR without extra wiring.
+Use it to resume where you left off:
 
-> History only applies to a **compound** state — a state with its own `:states` and
-> `:initial`. If "which tab" is a single flat value, keep it in
-> [`:data`](concepts.md#the-same-flow-as-a-transition-table). History earns its keep
-> when a *non-trivial nested* configuration is worth remembering across a leave/return.
+- a media player resumes mid-track
+- a wizard returns to the last step
+- a settings panel reopens on the same tab
+- a nested editor returns to the last active mode
 
-## A history state is a transition *target*, not a state you occupy
+History is only for compound states. If the remembered thing is a flat value,
+store it in [`:data`](glossary.md#data).
 
-A history state is a **pseudo-state**. You declare it under a compound's `:states`
-alongside real substates, but the machine *never sits in it*. Its only job is to be
-the **target of a transition** — when a transition resolves to it, it stands for
-"the substate this compound was in when control last left it." The runtime resolves
-it to a real leaf, the entry cascade enters *that* leaf, and the
-[snapshot](glossary.md#snapshot)'s `:state` records the resolved leaf — never the
-pseudo-state.
+## A history state is a target, not a place you sit
 
-Write `[:player :hist]` as a target the same way you'd write any state path; it
-resolves to a recorded (or default) configuration.
+A history state is a pseudo-state declared under a compound's `:states`.
 
-## A worked example — a media player that resumes
+The machine never occupies it. A transition targets it, and the runtime resolves
+that target to a real child. The [snapshot](glossary.md#snapshot)'s `:state`
+records the resolved leaf — never the pseudo-state.
 
-A player with a `:tray` (no disc) and a `:player` compound (disc inserted). The
-`:player` compound owns a `:type :history` pseudo-state. `:eject` leaves `:player`
-for `:tray`; `:insert` comes back *through history*, restoring whatever the player
-was doing when ejected:
+## Example: media player
 
 ```clojure
-(rf/reg-machine :media-player
+(rf/reg-machine :media/player
   {:initial :tray
+
    :states
-   {;; No disc. :insert re-enters :player THROUGH the history pseudo-state.
-    :tray
+   {:tray
     {:on {:insert [:player :hist]}}
 
-    ;; Disc inserted — the compound whose configuration we remember.
-    ;; :eject leaves :player entirely, which is what makes it record.
     :player
     {:initial :stopped
      :on      {:eject :tray}
+
      :states
-     {:hist    {:type :history
-                :deep? true                 ;; omit ⇒ SHALLOW (see below)
-                :default-target :stopped}   ;; where the FIRST :insert lands
-      :stopped {:on {:play [:player :playing]}}
-      :playing {:initial :at-start
-                :on      {:stop  [:player :stopped]
-                          :pause [:player :paused]}
-                :states  {:at-start  {:on {:seek :mid-track}}
-                          :mid-track {}}}
-      :paused  {:on {:resume [:player :playing]}}}}}})
+     {:hist
+      {:type :history
+       :deep? true
+       :default-target :stopped}
+
+      :stopped
+      {:on {:play [:player :playing]}}
+
+      :playing
+      {:initial :at-start
+       :on      {:pause [:player :paused]
+                 :stop  [:player :stopped]}
+       :states
+       {:at-start  {:on {:seek :mid-track}}
+        :mid-track {}}}
+
+      :paused
+      {:on {:resume [:player :playing]}}}}}})
 ```
 
-Drive it with ordinary dispatched events; read it with an ordinary subscription:
+Drive it with `dispatch-sync` so each line has settled before the next. Read it
+with the ordinary machine subscription:
 
 ```clojure
-(rf/dispatch [:media-player [:insert]])  ;; :tray → nothing recorded yet → :default-target → [:player :stopped]
-(rf/dispatch [:media-player [:play]])    ;; → [:player :playing :at-start]
-(rf/dispatch [:media-player [:seek]])    ;; → [:player :playing :mid-track]
-(rf/dispatch [:media-player [:eject]])   ;; → :tray   AND records :player's last config
-(rf/dispatch [:media-player [:insert]])  ;; → restores [:player :playing :mid-track] — resumes mid-track
+(rf/dispatch-sync [:media/player [:insert]]) ;; [:player :stopped]
+(rf/dispatch-sync [:media/player [:play]])   ;; [:player :playing :at-start]
+(rf/dispatch-sync [:media/player [:seek]])   ;; [:player :playing :mid-track]
+(rf/dispatch-sync [:media/player [:eject]])  ;; :tray, recording :player
+(rf/dispatch-sync [:media/player [:insert]]) ;; restores [:player :playing :mid-track]
 
-@(rf/subscribe [:rf/machine :media-player])
+@(rf/subscribe [:rf/machine :media/player])
 ;; => {:state      [:player :playing :mid-track]
 ;;     :data       {}
 ;;     :rf/history {[:player] [:player :playing :mid-track]}}
-;; (no :tags key here — this machine declares no tags, and an empty tag
-;;  union is omitted from the snapshot rather than stored as #{})
 ```
 
-You wrote no capture code. The `[:player :hist]` target does the work.
+The target `[:player :hist]` means "enter `:player` through its history
+pseudo-state."
 
-## The three keys — and nothing else
-
-A `:type :history` pseudo-state carries **exactly** three keys:
-
-| Key | Value | Meaning |
-|---|---|---|
-| `:type` | `:history` | Marks this node as a history pseudo-state. **Required.** |
-| `:deep?` | boolean | `true` ⇒ **deep** (full recorded leaf path). `false` or **absent** ⇒ **shallow** (recorded *direct child*, then that child's `:initial` chain). Default is shallow. |
-| `:default-target` | child keyword *or* absolute vector | Where the **first** entry lands before anything is recorded. **Absent** ⇒ owning compound's `:initial`. |
-
-It MUST NOT declare `:on` / `:entry` / `:exit` / `:always` / `:after` / `:spawn` /
-`:spawn-all` / `:states` / `:initial` / `:tags` / `:final?` — the machine never
-occupies it. Any such key is a **registration error** at `reg-machine` time, not on
-first dispatch.
-
-## Shallow vs deep — how *much* of the path is restored
-
-Eject from deep inside — `[:player :playing :mid-track]`:
-
-- **Deep** (`:deep? true`) records the **full leaf path**. On `:insert` it re-enters
-  every level back to that leaf — `[:player :playing :mid-track]`.
-- **Shallow** (omit `:deep?`) records only the compound's **direct child** — here
-  `:playing`. On `:insert` it restores that child and cascades through *its*
-  `:initial` — so `[:player :playing :at-start]` (right branch, initial inner position).
+## The keys
 
 ```clojure
-;; after :eject, DEEP:
-:rf/history {[:player] [:player :playing :mid-track]}   ;; full absolute leaf path
-;; after :eject, SHALLOW:
-:rf/history {[:player] :playing}                        ;; just the direct child keyword
+:hist
+{:type :history
+ :deep? true
+ :default-target :stopped}
 ```
 
-Reach for **deep** when the precise nested position matters; **shallow** when only
-the top-level branch matters (which tab, not the tab's inner scroll).
+| Key | Meaning |
+|---|---|
+| `:type :history` | Marks the node as a history pseudo-state. Required. |
+| `:deep? true` | Restore the full nested path. Absent or `false` means shallow. |
+| `:default-target` | Where to go before anything has been recorded. Absent ⇒ the owning compound's `:initial`. |
 
-## Recording happens on exit — the compound must actually be *left*
+A history pseudo-state cannot declare `:on`, `:entry`, `:exit`, `:always`,
+`:after`, `:spawn`, `:spawn-all`, `:states`, `:initial`, `:tags`, or `:final?`.
+It is not a real state. Any extra key is `:rf.error/machine-history-extra-keys`
+at `reg-machine` time.
 
-Recording is automatic on the way **out**: when the exit cascade *leaves* a compound
-that owns a history pseudo-state, the runtime writes that compound's last-active
-configuration into the snapshot. You never write capture code.
+A keyword `:default-target` names a direct child of the owning compound. Use a
+vector for an absolute path.
 
-The owning compound must be **genuinely exited**. This is the
-[W3C SCXML](https://www.w3.org/TR/scxml/#history) exit-set rule: a `<history>` value
-is written only for states in the exit set. A transition that merely moves *between
-two children* of the compound keeps the compound as the
-[least-common ancestor](hierarchical-states.md#entryexit-cascading-along-the-lca) —
-the compound **survives**, was never left, and records nothing.
+## Shallow vs deep
 
-That is why `:eject` targets `:tray` (a *sibling of* `:player`, outside it) rather
-than some inner state: only leaving `:player` puts it in the exit set. A common
-mistake is putting the history node on a compound that nothing ever exits — then it
-silently never records and "restore" always falls to the default. If history isn't
-sticking, check that *something leaves the owning compound.*
+Suppose the player leaves from:
 
-Symmetrically, restoring through `[:player :hist]` records nothing for that
-compound; re-entry leaves the recorded slot untouched.
+```clojure
+[:player :playing :mid-track]
+```
 
-## Restoring — recorded, else default-target, else `:initial`
+Deep history records the full leaf path:
 
-When a transition resolves to the pseudo-state, the runtime picks a leaf in this
-order:
+```clojure
+:rf/history {[:player] [:player :playing :mid-track]}
+```
 
-1. **A valid recording exists** → restore it (deep = full leaf path; shallow =
-   recorded child then its `:initial` cascade).
-2. **No recording** → resolve `:default-target`; if absent, the compound's
-   `:initial` and cascade from there.
-3. **Recording exists but is no longer a valid path** (hot reload removed a
-   substate) → discard it and fall back per (2). Never enters a dead path; benign,
-   no error.
+Restoring returns to `[:player :playing :mid-track]`.
 
-Once resolved to a concrete leaf, history is just target resolution: standard LCA
-computation, exit/entry cascade, `:always` settling, and `:after` scheduling apply
-as if you'd written that leaf as a literal `:target`.
+Shallow history records only the direct child of the owning compound:
+
+```clojure
+:rf/history {[:player] :playing}
+```
+
+Restoring enters `:playing` and then follows `:playing`'s `:initial`, landing at
+`[:player :playing :at-start]`.
+
+Use deep when the precise nested position matters. Use shallow when only the
+top-level branch matters.
+
+## Recording happens on exit
+
+History records when the owning compound is actually exited.
+
+In the example, `:eject` leaves `:player` for `:tray`, so the runtime records
+`:player`'s last configuration.
+
+A transition between children of `:player` does not record history, because
+`:player` was never exited. It remained the
+[least common ancestor](hierarchical-states.md#entryexit-cascading-along-the-lca).
+
+If history is not sticking, check that the transition leaves the compound that
+owns the history node.
+
+## Restore order
+
+When a transition targets a history pseudo-state, the runtime resolves it in
+this order:
+
+1. use a valid recording, if one exists
+2. otherwise use `:default-target`, if present
+3. otherwise use the owning compound's `:initial`
+
+If a hot reload removes the recorded target, the runtime discards the stale
+recording and falls back to the default. That is not an error.
+
+Once resolved, the normal exit/entry cascade runs. History is target resolution,
+not a separate transition mechanism.
 
 ## The `:rf/history` snapshot slot
 
-Recording lives in a reserved framework-owned slot at the snapshot root:
+History recordings live in a runtime-owned snapshot slot:
 
 ```clojure
 {:state      [:player :stopped]
- :data       {…}
- :rf/history {[:player] [:player :playing :mid-track]}}   ;; compound decl-path → recorded config
+ :data       {...}
+ :rf/history {[:player] [:player :playing :mid-track]}}
 ```
 
-`:rf/history` is a **map**, keyed by the compound's **declaration path** (keyword
-vector) → recorded configuration (full leaf path for deep, direct-child keyword for
-shallow). A machine can own several history-bearing compounds. The slot is:
+The key is the compound's declaration path. The value is either a full path for
+deep history or a direct child keyword for shallow history.
 
-- **read-only for you** — runtime writes it during the exit cascade; app code MUST
-  NOT write under it;
-- **allocated lazily** — absent until a history-bearing compound is first exited;
-- **EDN-clean** — vectors and keywords only, so it round-trips with the rest of the
-  snapshot.
+You do not write this slot. It is part of the snapshot, so it participates in
+undo, time-travel, persistence, and SSR hydration.
 
-Because the recording is *part of the snapshot value*, it rides every path the
-snapshot rides: undo and [time-travel](../core/glossary.md#time-travel), persistence,
-SSR hydration. The snapshot lives in [runtime-db](../core/glossary.md#runtime-db).
+## Parallel regions
 
-## Per-region history under `:type :parallel`
-
-Under a [parallel](parallel-states.md) machine each region runs an independent
-state-tree, so **history is per-region**: a history node inside a region's compound
-records and restores *that region's* configuration on the region's own exit cascade.
-`:rf/history` keys are **region-qualified** — region name is the head segment — so
-structurally identical paths in two regions never collide:
+Inside a [parallel](parallel-states.md) machine, history is scoped to the region
+that owns it. The `:rf/history` key is region-qualified so recordings do not
+collide.
 
 ```clojure
-;; Two regions, each with a history-bearing :on compound at the same shape.
-;; The region name heads the KEY; the recorded VALUE is the within-region path:
 {:rf/history {[:left  :group :on] [:group :on :bright]
               [:right :group :on] [:group :on :dim]}}
 ```
 
-Restoring history in one region leaves the others untouched — same per-region
-scoping as `:spawn`, `:after`, and `:always` under parallel.
-
-## Advanced
-
-You *could* hand-roll the equivalent: an `:exit` action that copies the current
-sub-path into `:data`, an entry that reads it back, plus bookkeeping for which
-compound (and region). re-frame2 ships the declarative node instead:
-
-- **One node** — `{:type :history :deep? true}` is readable in review and to tools;
-  stash-and-restore is bespoke per machine.
-- **Composition falls out of the grammar** — per-region history, deep nesting,
-  shallow-vs-deep, without re-implementing cascade rules.
-- **Tooling** — a `:type :history` node is visible to the inspector and diagram
-  exporters; hand-rolled `:data` shuffling is not.
-- **SCXML parity** — `<history>` keeps the conformance corpus aligned.
-
-The recording rides the snapshot so revertibility is cheap; that is the foundation,
-not a reason to skip the feature.
+The region name heads the key; the value is the within-region path. Restoring
+history in one region leaves the others alone.
 
 ## Troubleshooting
 
@@ -217,6 +191,7 @@ not a reason to skip the feature.
 |---|---|---|
 | History never restores; always hits default | Owning compound never left (sibling moves keep it as LCA) | Give the compound an off-state outside it (the `:tray` pattern) |
 | View `case`s on `:hist` | Pseudo-state is never in `:state` | Transition to `:hist` resolves to a real leaf — case on that |
-| Registration error at root / bare parallel | History needs an enclosing compound | Nest under a compound with `:states` + `:initial` |
-| Two history children under one compound | At most one history node per compound | Use one node; deep-vs-shallow is `:deep?` |
-| Unresolvable `:default-target` | Keyword form must name a *direct child* | Use a direct-child keyword, or vector form for an absolute path |
+| Registration error at root / bare parallel | History needs an enclosing compound | Nest under a compound with `:states` + `:initial`. Error: `:rf.error/machine-history-misplaced` |
+| Two history children under one compound | At most one history node per compound | Use one node; deep vs shallow is `:deep?`. Error: `:rf.error/machine-history-duplicate` |
+| Unresolvable `:default-target` | Keyword form must name a *direct child* | Use a direct-child keyword, or a vector for an absolute path. Error: `:rf.error/machine-history-bad-default-target` |
+| Extra keys on the history node | The pseudo-state is never occupied | Only `:type`, `:deep?`, `:default-target`. Error: `:rf.error/machine-history-extra-keys` |

--- a/docs/machines/index.md
+++ b/docs/machines/index.md
@@ -1,43 +1,53 @@
-# Hierarchical state machines
+# State machines
 
 <a id="theyre-everywhere"></a>
 
-Some state is not a number in app-db — it is **which named stage you are in**, and
-which events may legally leave it. Login is idle, then submitting, then authed or
-error or locked-out. A websocket is connecting, open, reconnecting, closed. Those
-flows usually hide as enums and booleans scattered across handlers.
+Some state is not a number in app-db — it is **which named stage you are in**,
+and what may legally move it. Login is idle, then submitting, then authed or
+error or locked-out. A websocket is connecting, open, reconnecting, closed.
+Those flows usually hide as enums and booleans scattered across handlers.
 
 <a id="first-class-support"></a>
 
-A **machine** makes that shape explicit: one data table of states and transitions,
-driven by ordinary `dispatch`, read by ordinary `subscribe`, living in the same
-[frame](../core/frames.md) as the rest of re-frame2. No second runtime.
+A **machine** makes that shape explicit: one data table of states and
+transitions, driven by ordinary `dispatch`, read by ordinary `subscribe`,
+living in the same [frame](../core/frames.md) as the rest of re-frame2.
 
-**Prerequisites.** The [Core introduction](../core/introduction.md) — events, app-db,
-subscriptions, effects. Machines plug into those; they do not replace them.
-
-## A machine in four lines
+**Prerequisites.** The [Core introduction](../core/introduction.md) — events,
+app-db, subscriptions, effects. Machines plug into those; they do not replace
+them. This page says when a machine fits and shows the smallest working form.
 
 ```clojure
 (:require [re-frame.core :as rf]
-          [re-frame.machines])   ;; opt-in artefact
+          [re-frame.machines])   ;; opt-in; forget this → :rf.error/machines-artefact-missing
 
-(rf/defmachine door
-  {:initial :closed
-   :states  {:closed {:on {:open :open}}
-             :open   {:on {:close :closed}}}})
+(rf/defmachine login-flow
+  {:initial :idle
+   :states  {:idle        {:on {:auth.login/submit :submitting}}
+             :submitting  {:on {:auth.login/success :authed
+                                :auth.login/failure :error-shown}}
+             :error-shown {:on {:auth.login/dismiss :idle}}
+             :authed      {}}})
 
-(rf/reg-machine :door door)
+(rf/reg-machine :auth.login/flow login-flow)
 
-(rf/dispatch [:door [:open]])
-@(rf/subscribe [:rf/machine :door])
-;; => {:state :open :data {}}
+(rf/dispatch [:auth.login/flow [:auth.login/submit]])
+@(rf/subscribe [:rf/machine :auth.login/flow])
+;; => {:state :submitting :data {}}
 ```
+
+The outer id routes to the machine. The inner vector is the event the table
+handles.
 
 <a id="deeply-integrated"></a>
 
-`reg-machine` is sugar over `reg-event`. The snapshot rides runtime-db — undo, Xray,
-SSR, and tests share the same pipeline as the rest of the app.
+`reg-machine` is sugar over `reg-event`. There is one event system — you
+`dispatch`, you do not `send` — and one state model: the snapshot rides
+[runtime-db](../core/glossary.md#runtime-db), so undo, Xray, SSR, and tests
+share the same pipeline as the rest of the app.
+
+A keyword in app-db is enough for two stages. Use a machine when the table is
+the source of truth — which events are legal where, and what happens next.
 
 ## When *not* to use a machine
 
@@ -48,5 +58,10 @@ SSR, and tests share the same pipeline as the rest of the app.
 | Server fetch / cache / invalidate | [resources](../resources/concepts.md) |
 | A fixed sequence of operations | chained events / effects |
 
-Reach for a machine when **named stages and legal transitions** are the thing you
-are modelling — not when the thing is a value or a network cache.
+Reach for a machine when **named stages and legal transitions** are the thing
+you are modelling — not when the thing is a value or a network cache.
+[Where should this value live?](../core/where-state-lives.md) has the full
+decision table.
+
+Already using XState? [Coming from XState](coming-from-xstate.md) is the
+translation.

--- a/docs/machines/inspecting-machines.md
+++ b/docs/machines/inspecting-machines.md
@@ -1,200 +1,126 @@
 # Inspecting and testing machines
 
-You can [author](tutorial.md) and [understand](concepts.md) machines. This page is
-how you **watch** one and **prove** the table.
+Machines are ordinary re-frame2 state and ordinary re-frame2 events.
 
-A machine is [an event handler](concepts.md#register-and-drive) whose body
-interprets a transition table; its whole state is a plain value in runtime-db.
-There is **no parallel machine runtime** and **no second store**. Subscribe like
-any re-frame2 state; watch events in Xray; unit-test with a pure function call.
+That gives you four inspection surfaces:
 
-Two situations:
+| Surface | Use it to answer |
+|---|---|
+| `[:rf/machine id]` | What state is this machine in now? |
+| `[:rf.machine/has-tag? id tag]` | Is this semantic state true? |
+| [Xray Machine Inspector](../xray/08-machine-inspector.md) | What did this event do? |
+| `machine-transition` | Is this transition table correct? |
 
-- **A flow misbehaves and you need to see *why*.** Which transition fired? Did the
-  guard pass? What did the action write? Open Xray's Machine Inspector, or drop to
-  the trace stream for the exact guard/action records.
-- **Headless confidence the table is correct.** Feed a snapshot and an event to
-  `machine-transition` and assert on what comes back — no frame, no browser, no
-  network, microseconds per case on the JVM.
+## Read the live snapshot
 
-Four surfaces, from "read the value" to "prove the logic":
-
-| Surface | Question it answers | Tool |
-|---|---|---|
-| `[:rf/machine id]` subscription | *What state is it in right now?* | `rf/subscribe` |
-| Xray Machine Inspector | *What did this event do?* / *What's the chart?* | Xray (Dynamic + Static) |
-| `:rf.machine/*` trace events + `handler-meta` | *Did this guard pass? Where is that action defined?* | trace bus / source-jump |
-| `machine-transition` | *Is the table correct?* (headless test) | pure function call |
-
----
-
-## Read the live snapshot — `[:rf/machine id]`
-
-The canonical window onto a machine is the framework-registered subscription `[:rf/machine machine-id]`. It returns the [snapshot](glossary.md#snapshot) — the whole `{:state :data :tags}` value — and you subscribe to it exactly like anything else:
+The primary read is the framework subscription. There is no named-read-sugar function:
 
 ```clojure
-(let [{:keys [state data tags]} @(rf/subscribe [:rf/machine :auth.login/flow])]
-  [:div
-   [:p "state: " (name state)]            ;; the discrete FSM keyword, e.g. :submitting
-   [:p "attempts: " (:attempts data)]     ;; :data — the machine's private memory
-   (when (contains? tags :auth/busy)      ;; :tags — union of active states' tags
-     [spinner])])
+@(rf/subscribe [:rf/machine :auth.login/flow])
+;; => {:state :submitting
+;;     :data  {:attempts 1 :error nil}
+;;     :tags  #{:auth/busy}}
 ```
 
-`:state` and `:data` are always present; `:tags` shows up only when an active state declares tags, and some machines add their own runtime-owned keys (a machine with history states carries `:rf/history`, for example):
+The [snapshot](glossary.md#snapshot) is `nil` before the first event addressed to a singleton machine.
 
-- **`:state`** — the discrete FSM keyword (`:idle`, `:submitting`, …). For a hierarchical machine it's a path vector (`[:authenticated :cart :browsing]`); for a parallel machine, a region map.
-- **`:data`** — the machine's extended state: a plain map, distinct from app-db; it's named `:data` to avoid the already-overloaded word "context". Read the fields a view needs by destructuring (above) or through a named projection sub (below).
-- **`:tags`** *(optional)* — the runtime-projected union of every active state's `:tags`, omitted entirely when no active state declares a tag. Ask membership questions against it rather than hard-coding state names (see below).
-
-!!! note "The snapshot is `nil` until the first event"
-
-    A machine bootstraps itself on the first event addressed to it, so `[:rf/machine id]` reads `nil` before then. A view that renders pre-bootstrap should fall back to the definition's `:initial`:
-
-    ```clojure
-    (or @(rf/subscribe [:rf/machine :turnstile/flow])
-        {:state (:initial turnstile) :data (:data turnstile)})
-    ```
-
-### Named projections off the snapshot
-
-`[:rf/machine id]` is the raw value; chain ordinary `reg-sub`s off it so a view reads a small, named slice instead of re-destructuring the whole snapshot:
+For views, prefer projection subscriptions:
 
 ```clojure
-(rf/reg-sub :auth.login/state
-  :<- [:rf/machine :auth.login/flow]
-  (fn [machine _] (:state machine)))
-
 (rf/reg-sub :auth.login/error
   :<- [:rf/machine :auth.login/flow]
-  (fn [machine _] (get-in machine [:data :error])))
+  (fn [m _]
+    (get-in m [:data :error])))
 ```
 
-A sub that reads a machine this way is an ordinary derivation node — it does not become a "second kind" of subscription.
+Now the view reads `[:auth.login/error]` instead of destructuring the whole machine everywhere.
 
-### Ask by tag, not by state name
-
-Once a machine has several "loading-ish" states, views stop asking *which exact state?* and start asking a predicate — *is it busy?* That's what [state tags](glossary.md#state-tag) are for. The framework ships a derived predicate sub you read like any other:
+## Ask by tag
 
 ```clojure
-(when @(rf/subscribe [:rf.machine/has-tag? :auth.login/flow :auth/busy]) [spinner])
+@(rf/subscribe [:rf.machine/has-tag? :auth.login/flow :auth/busy])
+;; => true or false
 ```
 
-This sub re-renders only when *this* tag's membership bit flips, so adding a fifth busy state later is one `:tags` entry on the new node — zero view changes.
+Use this for busy, read-only, connected, terminal, and similar semantic questions. It returns `false` for an unknown or not-yet-started machine.
 
-!!! note "The snapshot is a value, not a live object"
+See [Tags](tags.md) for collapsing several states into one render decision.
 
-    It lives at `[:rf.runtime/machines :snapshots :auth.login/flow]` in runtime-db
-    and is read through the ordinary subscription graph. Time-travel, undo,
-    persistence, and SSR hydration extend to machines without extra wiring — the
-    snapshot rides the frame like any other state.
+## Use Xray
 
-See [`[:rf/machine machine-id]`](../api/re-frame.machines.md#rfmachine-machine-id) and [`machine-has-tag?`](../api/re-frame.machines.md) in the API reference.
+When a flow misbehaves, the useful question is often not "what is the current state?" but "which event moved it there?"
 
----
+[Xray's Machine Inspector](../xray/08-machine-inspector.md) answers that from the trace stream.
 
-## Watch a transition happen — the Xray Machine Inspector
+A good debugging loop:
 
-Your bug is usually not a value; it's a *process* — the wrong transition fired, or the right one didn't. [Xray](../xray/index.md)'s Machine Inspector reads that process. It has two modes, and the trick is knowing which question each answers.
+1. reproduce the behaviour;
+2. click the event row in Xray;
+3. open the machine inspector;
+4. compare before-state and after-state;
+5. inspect the guard and action records;
+6. if the topology is surprising, inspect the static machine definition.
 
-**Dynamic Machine — the transition history.** This tab is *event-coupled*: click an event row in the spine, and it shows what that one epoch did to a machine — the affected machine, the active state **before and after**, the transition that fired, the guards and actions that ran, entry/exit activity, any spawned or destroyed actors, and `:after` timers and their cancellations. It is the black-box recorder for one transition. If the focused epoch touched no machine, the tab stays quiet — that's honest scope, not a failure. Stepping through the epoch spine (with [time-travel](../xray/03-time-travel.md)) replays the machine's history one transition at a time.
+The dynamic view explains one transition. The static view explains the table.
 
-**Static Machines — the state-chart on the wall.** This tab is *event-independent*: browse every registered machine id, inspect its topology, read its states and transitions, and compare the definition's shape to the live snapshot. Reach for it when you need the map rather than a single step.
+## Trace records
 
-A reliable machine-debugging loop:
+Machines emit trace records through the standard trace bus. There is no separate machine log.
 
-1. Reproduce the action.
-2. Click the event row in the spine.
-3. Open **Dynamic Machine** and read the transition before → after.
-4. If the transition is surprising, flip to **Static Machines** and inspect the definition.
-5. Drop to the **Epoch** or **Trace** tab for the exact guard/action records.
+You will most often see records for:
 
-That loop keeps you out of the commonest machine trap: staring at the *current* state while forgetting the *event* that moved it there. Because a machine has a small, named state space, Xray can say something a generic logger never could — not "something updated a map" but "this event moved `:door/main` from `:closed` to `:opening`, ran this guard, scheduled this timer, and cancelled that prior branch." That's the difference between seeing state and seeing behavior.
+- transition selected (`:rf.machine/transition`);
+- guard evaluated (`:rf.machine/guard-evaluated`);
+- action ran (`:rf.machine/action-ran`);
+- timer scheduled, fired, cancelled, or stale;
+- actor spawned or destroyed;
+- unhandled event no-op (`:rf.machine.event/unhandled-no-op`).
 
-!!! note
-
-    **Xray's Machine Inspector reads the same trace bus every event handler already uses**, not a machine-special channel. (A note on scope: there is *no* framework-level chart or JSON export — visualisation exporters live in the separate `re-frame2-machines-viz` library, not the framework.)
-
-The full tour is in [Xray — Machine Inspector](../xray/08-machine-inspector.md).
-
----
-
-## The trace events a machine emits
-
-Because a machine is an event handler, every guard evaluation, action run, and transition flows through the standard [trace bus](../core/observability.md) — the same one Xray renders. There's no separate event log to consult. Three machine-specific records (all under the reserved `:rf.machine/*` namespace) are worth recognising:
+A guard trace tells you:
 
 ```clojure
-;; one trace record per user-declared guard call site
 {:operation :rf.machine/guard-evaluated
- :tags {:actor-id :auth.login/flow             ;; the LIVE instance (a singleton's id == its type)
+ :tags {:actor-id :auth.login/flow
         :guard-id :under-retry-limit
-        :input    {:data {:attempts 2} :event [:auth.login/failure {…}]}
-        :state    :submitting                  ;; the active state the guard ran against
-        :outcome  :fail}}                       ;; :pass | :fail | :threw  (rejects on the third failure)
+        :state    :submitting
+        :outcome  :pass}}   ;; :pass | :fail | :threw
+```
 
-;; one trace record per user-declared action invocation
+An action trace tells you:
+
+```clojure
 {:operation :rf.machine/action-ran
  :tags {:actor-id  :auth.login/flow
         :action-id :issue-request
-        :phase     :entry                       ;; :exit | :transition | :entry | :always | …
-        :input     {:data {…} :event [:auth.login/submit {…}]}
-        :outcome   :ok}}                         ;; the return value, or :ok, or :rf.error/action-threw
+        :phase     :entry
+        :outcome   :ok}}    ;; return value, :ok, or :rf.error/action-threw
 ```
 
-A few things to read off these:
+Those records are what Xray renders. You can also tap the stream yourself in development with `(rf/register-listener! :trace …)`.
 
-- **`:actor-id` is the live instance; `:machine-id` is reserved for the registered *type*.** For a singleton the two coincide; for a [spawned](glossary.md#spawn) actor `:actor-id` is the allocated instance id (`<prefix>#<n>`).
-- **`:state` on the guard trace is the source discriminator.** Two states declaring the same event with the same guard are otherwise indistinguishable; the active `:state` tag attributes a block to the right edge.
-- **`:phase` on the action trace** tells cascade actions apart from transition actions — `:exit` / `:entry` for the LCA cascade, `:transition` for an `:on`-driven action, `:always` for an eventless step, and so on.
+## Jump to source with `handler-meta`
 
-The headline `:rf.machine/transition` trace additionally carries a structured **`:cascade`** field — the ordered exit → action → entry (+ initial-descent) step sequence that explains *how* the transition reached its after-state. That single field is what powers Xray's before → after rendering, so you rarely need to re-walk the geometry by hand.
-
-You can tap the stream yourself; Xray is just the richest consumer of it:
+Machine guards and actions are addressable through handler metadata.
 
 ```clojure
-;; dev-only: print every machine transition the runtime emits (DCE'd in production)
-(rf/register-listener! :trace :my-app/machine-tap
-  (fn [trace-event]
-    (when (= :rf.machine/transition (:operation trace-event))
-      (js/console.log (pr-str (:tags trace-event))))))
+(rf/handler-meta :machine-guard
+                 [:auth.login/flow :under-retry-limit])
+
+(rf/handler-meta :machine-action
+                 [:auth.login/flow :issue-request])
 ```
 
-The [Trace tab](../xray/04-trace-stream.md) is the UI over exactly this feed.
+In development this can include captured source, file, line, and handler function metadata. Production builds elide development-only source details.
 
-### Jump from a snapshot to the guard/action source — `handler-meta`
+## Unit-test with `machine-transition`
 
-When you've found the guard that blocked a transition and want to *read it*, ask `handler-meta`. Machine guards and actions aren't a registry kind of their own — their dev-only source is derived on demand from the machine's `:event` registration spec — but the addressing is uniform with every other handler kind, keyed by a `[machine-id id]` pair:
+A transition table is a value. A transition is a pure function of:
 
 ```clojure
-(rf/handler-meta :machine-guard [:auth.login/flow :under-retry-limit])
-;; => {:rf/guard-id        :under-retry-limit
-;;     :rf/machine-id      :auth.login/flow
-;;     :rf.handler/source  "(fn [{data :data}] (< (:attempts data) 2))"
-;;     :handler-fn         #<fn>
-;;     :ns … :line … :file …}
-
-(rf/handler-meta :machine-action [:auth.login/flow :issue-request])
-;; => {:rf/action-id :issue-request :rf/machine-id :auth.login/flow
-;;     :rf.handler/source "(fn [{[_ creds] :event}] {:fx [[:rf.http/managed …]]})" …}
+(definition, snapshot, event)
 ```
 
-This is the surface Xray's focused-transition lens and the re-frame2 pair MCP use to render guard/action source inline under their declared id. (`reg-machine` captures that source at macro-expansion time; the `:source`-bearing slots are dev-only and elide under `:advanced` + `goog.DEBUG=false`.) See [`handler-meta`](../api/re-frame.core.md#handler-meta) for the general contract.
-
-!!! note "A guard that throws aborts the macrostep — the spec calls this out"
-
-    re-frame2 emits one `:rf.machine/guard-evaluated` with `:outcome :threw`, then aborts transition selection — no candidate falls through to a sibling, no transition fires, and the snapshot rolls back **atomically** (nothing reaches runtime-db). A thrown *action* and a runaway `:always`/`:raise` depth-abort converge on the same failed-macrostep semantics. The runtime does not silently demote a thrown guard to a lower-priority candidate.
-
----
-
-## Unit-test transitions as pure function calls — `machine-transition`
-
-A transition is a pure function of *(definition, snapshot, event)*, exposed as
-`re-frame.machines/machine-transition`. No frame, no browser, no mocks, no clock —
-table in, snapshot in, event in; result out. These tests run on the JVM in
-microseconds.
-
-Use the same `login-flow` value from the [tutorial](tutorial.md#the-complete-machine)
-(the `defmachine` binding, not the registered id):
+Import `login-flow` from the tutorial's [`defmachine`](tutorial.md#the-complete-machine) value and call it directly:
 
 ```clojure
 (ns app.login-test
@@ -204,60 +130,63 @@ Use the same `login-flow` value from the [tutorial](tutorial.md#the-complete-mac
             [app.login :refer [login-flow]]))
 
 (deftest login-flow-test
-  ;; :idle --submit--> :submitting; :entry fires the HTTP fx description
+  ;; cf. examples/capabilities/machines/state_machine_walkthrough
+  ;; :idle --submit--> :submitting; :entry describes the HTTP fx
   (let [r (machines/machine-transition
             login-flow
             {:state :idle :data {:attempts 0 :error nil}}
-            [:auth.login/submit {:email "a@b.com" :password "secret"}])]
+            [:auth.login/submit {:email "a@b.com"
+                                 :password "secret"}])]
     (is (result/ok? r))
     (is (= :submitting (:state (result/snap r))))
     (is (= :rf.http/managed (ffirst (result/fx r)))))
 
-  ;; at the retry limit (two failures already recorded) the first failure
-  ;; candidate is skipped → the third failure records its error and locks out
+  ;; two failures already recorded; the third locks out and is still counted
   (let [r (machines/machine-transition
             login-flow
             {:state :submitting :data {:attempts 2 :error nil}}
             [:auth.login/failure {:error {:message "bad creds"}}])]
+    (is (result/ok? r))
     (is (= :locked-out (:state (result/snap r))))
     (is (= 3 (get-in (result/snap r) [:data :attempts])))))
 ```
 
-The return value is a **Result map**. Discriminate with `result/ok?` / `result/fail?`;
-read the post-transition snapshot and emitted effects with `result/snap` /
-`result/fx` (or destructure `::result/snap` / `::result/fx`).
+The result contains:
 
-Two things make this pleasant:
+- the next snapshot (`result/snap`);
+- the effects vector (`result/fx`);
+- success/failure (`result/ok?` / `result/fail?`);
+- failure diagnostics (`result/info`) if a guard or action throws.
 
-- **Effects are asserted as data, not intercepted.** `(result/fx r)` is the ordinary re-frame `:fx` vector the action returned — you check its *shape* (`(ffirst …)` is `:rf.http/managed`) without ever performing the request. The action describes an effect; the test reads the description.
-- **A throwing action is a *failure value*, not an exception out of your test.** A guard or action that throws yields `(result/fail? r)` with `(result/info r)` carrying the diagnostic, so one assertion style covers both the happy and the broken path. (This is the pure-surface face of the atomic-rollback semantics above.)
+Effects are asserted as data. The HTTP request is not performed in this test; the returned `:fx` description is inspected.
 
-If the machine is already registered and you want to drive its *registered* definition rather than the raw value, pull it back with `machine-meta`:
+`machine-transition` and `machine-meta` live on `re-frame.machines`, not the `rf/` facade.
+
+## Testing registered definitions
+
+If a machine is already registered and you want its registered definition, use machine metadata:
 
 ```clojure
-(machines/machine-transition (machines/machine-meta :auth.login/flow) snapshot event)
+(machines/machine-transition
+  (machines/machine-meta :auth.login/flow)
+  snapshot
+  event)
 ```
 
-### The same value runs in the browser *and* the JVM
+Most tests should import the transition table value directly. Use registered metadata when the registration itself is part of what you are testing.
 
-The `login-flow` table above is plain data, so the very same value that renders a live Reagent form also unit-tests headless. The trick is a `.cljc` source file: it compiles under shadow-cljs for the browser demo *and* loads on the JVM for these tests. The worked example at [`examples/capabilities/machines/state_machine_walkthrough/`](../../examples/capabilities/machines/state_machine_walkthrough/) does exactly this — one table, two lives — and its headless scenarios run on every CI pass.
+## Three useful test levels
 
-### Three test levels
+| Level | What it tests | When to use |
+|---|---|---|
+| `machine-transition` | table logic, guards, action effects | default |
+| unregistered handler | lowering and handler-level integration | rare |
+| registered test frame | dispatch, tracing, spawn/destroy, actor messaging | actor-heavy integration |
 
-`machine-transition` is the fastest of three levels that fall out of the machine being a pure factory — no new test primitive needed:
+Keep most tests at the first level. It is fast, deterministic, and does not require a browser.
 
-| Level | What you test | Speed | Can't reach |
-|---|---|---|---|
-| **1 — `machine-transition`** | FSM logic, guards, action effect *shapes* | fastest | snapshot/db plumbing, fx integration |
-| **2 — unregistered handler fn** | handler-level wiring, `:data`-to-`:db` lowering | fast | dispatch pipeline, spawn lifecycle |
-| **3 — registered in a test frame** | full integration: trace events, drain, spawn/destroy, cross-actor messaging | slowest | nothing |
+## What failure means
 
-Most logic lives at Level 1. Reach for Level 3 only for spawned-actor patterns, where the whole point is that a handler gets registered dynamically and the parent can `dispatch` to it.
+A throwing guard or action becomes a failure result at the pure testing surface. It does not escape as an exception from the test call: `(result/fail? r)` is true and `(result/info r)` carries the diagnostic.
 
-!!! note "The test *is* the transition function"
-
-    A `machine-transition` test is literally `(fn definition snapshot event)` — nothing to instantiate, you assert the behavioural contract *(state, event) → next state + effects* directly.
-
-See [`machine-transition`](../api/re-frame.machines.md#re-framemachinesmachine-transition) and [`machine-meta`](../api/re-frame.machines.md#re-framemachinesmachine-meta) in the API reference.
-
----
+At runtime, the same failure aborts the macrostep atomically. The previous snapshot remains visible. The error is reported as `:rf.error/machine-action-exception` (a thrown guard does not fall through to the next candidate).

--- a/docs/machines/parallel-states.md
+++ b/docs/machines/parallel-states.md
@@ -1,368 +1,273 @@
 # Parallel regions
 
-One machine, several **orthogonal** axes active at once — form validity × load
-state × mode — without exploding a cross-product of flat states. Assumes the
-[flat model](concepts.md); pairs naturally with [tags](tags.md).
+Sometimes one feature has several independent state axes active at the same time.
 
-Some lifecycles aren't *one* question — they're several, all live at once. A todos
-screen is *somewhere in its fetch*, *somewhere in its form*, and *somewhere in its
-page mode*. Those three axes are **orthogonal**: each moves on its own, and any
-combination is legal.
+A todos page might be:
 
-Model that flat and the states multiply — three axes of three states each is
-`3 × 3 × 3 = 27` cross-product states named things like
-`:loading-and-invalid-and-active`. **Parallel regions** keep the axes apart: one
-machine, `:type :parallel`, a `:regions` map; each region is a full little
-state-tree; all regions active simultaneously. Three axes of three states becomes
-**nine states across three regions**, not twenty-seven flat ones.
+- in a data state: `:nothing | :loading | :empty | :some | :error`;
+- in a form state: `:neutral | :valid | :invalid`;
+- in a mode state: `:active | :archived`.
 
-## When to reach for parallel regions
+Those axes are orthogonal. A flat machine would have to name the cross-product.
+Parallel regions keep the axes separate.
 
-Reach for them when you have **multiple orthogonal axes of one feature** that share
-a domain: one form with data / validity / display-mode axes, one connection with
-auth + lifecycle + request-queue. The giveaway is a single conceptual thing whose
-state is naturally a *tuple* of independent sub-states.
+## When to use parallel regions
 
-The axes share a single
-[`:data`](concepts.md#the-same-flow-as-a-transition-table) map *because they're
-facets of one domain*. If your axes are genuinely separate features that share
-nothing (websocket + unrelated auth + route), that's **N separate machines** in
-[runtime-db](../core/glossary.md#runtime-db). Per-region `:data` is **not**
-supported; if axes need encapsulated data, register N machines instead.
+Use parallel regions when:
 
-## The shape: one machine, several regions
+- the axes belong to one conceptual feature;
+- they share one `:data` map;
+- more than one axis can transition in response to the same event;
+- the cross-product would be awkward to name.
 
-Here's the canonical three-region machine — the "[Nine States of UI](../../examples/patterns/nine_states)" pattern, trimmed to its bones. Three axes, one declaration:
+Do not use parallel regions when the axes are separate features that do not share
+data. Register separate machines instead.
+
+There is no per-region `:data`. A parallel machine has one shared `:data` map.
+
+## The shape
+
+A parallel machine has `:type :parallel` and `:regions` at the root.
 
 ```clojure
-(rf/reg-machine :ui/nine-states
+;; cf. examples/patterns/nine_states
+(rf/defmachine nine-states
   {:type :parallel
-   :data {:items [] :error nil :archived-at nil}     ;; shared across every region
+   :data {:items [] :error nil}
 
-   :guards  {:empty?    (fn [{:keys [data]}] (zero? (count (:items data))))
-             :too-many? (fn [{:keys [data]}] (> (count (:items data)) 7))}
+   :guards
+   {:empty? (fn [{data :data}]
+              (zero? (count (:items data))))}
 
-   :actions {:set-items (fn [{data :data [_ {:keys [items]}] :event}]
-                          {:data (assoc data :items (vec items))})}
+   :actions
+   {:set-items (fn [{data :data [_ {:keys [items]}] :event}]
+                 {:data (assoc data :items (vec items))})}
 
    :regions
-   {:data {:initial :nothing
-           :states  {:nothing   {:tags #{:data/nothing}
-                                 :on   {:fetch-started :loading}}
-                     :loading   {:tags #{:data/loading}
-                                 :on   {:fetch-succeeded {:target :resolving
-                                                          :action :set-items}}}
-                     :resolving {:always [{:guard :empty?    :target :empty}
-                                          {:guard :too-many? :target :too-many}
-                                          {:target :some}]}
-                     :empty     {:tags #{:data/empty}}
-                     :some      {:tags #{:data/some}}
-                     :too-many  {:tags #{:data/too-many}}}}
+   {:data
+    {:initial :nothing
+     :states
+     {:nothing   {:tags #{:data/nothing}
+                  :on   {:fetch-started :loading}}
+      :loading   {:tags #{:data/loading}
+                  :on   {:fetch-succeeded {:target :resolving
+                                           :action :set-items}
+                         :fetch-failed    :error}}
+      :resolving {:always [{:guard :empty? :target :empty}
+                           {:target :some}]}
+      :empty     {:tags #{:data/empty}}
+      :some      {:tags #{:data/some}}
+      :error     {:tags #{:data/error}}}}
 
-    :form {:initial :neutral
-           :states  {:neutral   {:tags #{:form/neutral}
-                                 :on   {:submit-valid   :correct
-                                        :submit-invalid :incorrect}}
-                     :incorrect {:tags #{:form/invalid}}
-                     :correct   {:tags #{:form/success}}}}
+    :form
+    {:initial :neutral
+     :states
+     {:neutral {:tags #{:form/neutral}
+                :on   {:submit-valid   :valid
+                       :submit-invalid :invalid}}
+      :valid   {:tags #{:form/valid}}
+      :invalid {:tags #{:form/invalid}}}}
 
-    :mode {:initial :active
-           :states  {:active {:tags #{:mode/active}
-                              :on   {:archive :done}}
-                     :done   {:tags #{:mode/done :mode/read-only}}}}}})
+    :mode
+    {:initial :active
+     :states
+     {:active   {:tags #{:mode/active}
+                 :on   {:archive :archived}}
+      :archived {:tags #{:mode/archived :mode/read-only}}}}}})
+
+(rf/reg-machine :ui/nine-states nine-states)
 ```
 
-Each region body — `:data`, `:form`, `:mode` — is itself an ordinary transition table: its own `:initial`, its own `:states`, with `:on` / `:tags` / `:always` / `:after` / `:spawn` on each node, exactly as a flat machine. The only structural rule at the top: `:type :parallel` is **mutually exclusive** with a root `:initial` / `:states` — you declare *regions* there instead (registration throws `:rf.error/machine-parallel-bad-shape` if you write both).
+Each region body looks like a small machine: it has `:initial` and `:states`.
 
-## The snapshot: `:state` becomes a map
+At the top level, a parallel machine does not also declare root `:initial` and
+root `:states`. Registration throws `:rf.error/machine-parallel-bad-shape` if
+the root has both, or if a region is missing its own `:initial`.
 
-A flat machine's [snapshot](glossary.md#snapshot) `:state` is a single keyword. A parallel machine's `:state` is a **map of region-name → that region's current state**:
-
-```clojure
-;; flat region — the value is a keyword
-{:state {:data :loading :form :neutral :mode :active}
- :data  {:items [] :error nil :archived-at nil}
- :tags  #{:data/loading :form/neutral :mode/active}}
-
-;; a COMPOUND region — that region's value is a vector path INSIDE the region
-{:state {:auth [:authenticated :dashboard] :lifecycle :idle} ...}
-```
-
-Three things to read off that snapshot:
-
-- **`:state`** is the per-region map. A flat region contributes a keyword; a compound region (one whose own tree nests sub-states) contributes the in-region vector path.
-- **`:data`** is **shared** — one map, seen and written by every region. There is no per-region `:data` slot, on the region body or in the snapshot.
-- **`:tags`** is the **union** of every active state's tags across every region (covered [below](#tags-compose-across-regions)).
-
-You read the `:state` map through one ordinary subscription — `@(rf/subscribe [:rf/machine :ui/nine-states])`. The [`[:rf/machine machine-id]`](../api/re-frame.machines.md#rfmachine-machine-id) sub returns the whole snapshot; named projections chain off it like any other [subscription](../core/subscriptions.md).
-
-## Each region has its own `:initial`
-
-Every region declares its own `:initial`, just like a flat machine — a region missing `:initial` is a registration-time error. At machine boot the initial snapshot's `:state` is the map of each region's initial cascade: a flat region lands on its `:initial` keyword; a compound region descends its `:initial` chain to a leaf. Every region's `:entry` cascade runs once, for every region, *before* any eventless work begins. Only then does the machine settle its `:always` transitions — and it settles them the same way it settles them after an event: the parent runs [frozen rounds](#always-stabilization-is-parent-owned) across the whole configuration until nothing more is enabled. A region's birth `:always` guard can therefore read where its siblings landed, because every sibling has already entered.
-
-So immediately after the machine above starts, before any event:
+## The snapshot state is a region map
 
 ```clojure
 @(rf/subscribe [:rf/machine :ui/nine-states])
-;; => {:state {:data :nothing :form :neutral :mode :active}
-;;     :data  {:items [] :error nil :archived-at nil}
-;;     :tags  #{:data/nothing :form/neutral :mode/active}}
+;; => {:state {:data :loading
+;;             :form :neutral
+;;             :mode :active}
+;;     :data  {:items [] :error nil}
+;;     :tags  #{:data/loading :form/neutral :mode/active}}
 ```
 
-All three regions are alive at their initial states, and the `:tags` set already carries one tag per region.
+A compound region contributes a path as its region value:
 
-## Broadcast: one event reaches every region
+```clojure
+{:state {:auth [:authenticated :dashboard]
+         :mode :active}
+ :data  {...}}
+```
 
-Every event dispatched at a parallel machine is **broadcast to every region**. Each
-region's *currently-active* state independently decides whether the event matches
-one of its `:on` keys:
+## Every region starts
 
-- **The region has a matching transition whose guard passes** → that region transitions (exit cascade → action → entry cascade), and any `:fx` its action returns joins the macrostep.
-- **The region has no matching transition** (or its guard returns false) → that region stays put. No per-region complaint is raised.
-- **No region anywhere handled the event** → the machine consults the [root `:on` fallback](#the-root-on-an-ancestor-fallback), and only if *that* also declines does it emit the benign `:rf.machine.event/unhandled-no-op` trace, exactly once. An unhandled event is a no-op, not an error.
+At machine birth, every region enters its own initial state. If a region is
+hierarchical, it follows its own `:initial` cascade to a leaf.
 
-In the nine-states machine, dispatching `:fetch-started` reaches all three regions, but only `:data` lists it, so only `:data` moves:
+Every region's entry actions run first. Then the parent settles `:always` across
+the whole configuration — the same freeze / select / apply rounds used after an
+event. See [`:always` stabilization](#always-stabilization-is-parent-owned).
+
+## Event broadcast
+
+Every event dispatched at a parallel machine is broadcast to every region.
+
+For each region:
+
+- if the active state has a matching transition whose guard passes, that region
+  transitions;
+- otherwise that region stays where it is.
 
 ```clojure
 (rf/dispatch-sync [:ui/nine-states [:fetch-started]])
-;; :data → :loading ; :form and :mode have no :fetch-started, so they hold.
-;; :state {:data :loading :form :neutral :mode :active}
-
-(rf/dispatch-sync [:ui/nine-states [:fetch-succeeded {:items [{:id 1} {:id 2}]}]])
-;; :data handles it: :loading → :resolving (running :set-items). The event set
-;; having applied, the first eventless round reads the now-2 :items and the
-;; :resolving cascade lands on :some — all within this one macrostep.
-;; :state {:data :some :form :neutral :mode :active}  ·  :data {:items [{:id 1} {:id 2}] ...}
+;; only the :data region handles it
+;; {:data :loading, :form :neutral, :mode :active}
 ```
 
-(`dispatch-sync` runs the transition synchronously, so the snapshot is readable on the next line — handy in the REPL and tests; in views you dispatch the usual async way.)
+If several regions handle the same event, their actions run in region
+declaration order and write to the shared `:data` in that order.
 
-### Shared `:data` flows through each region's action
+## Select first, then apply
 
-When *several* regions handle the same event, each one's action runs against the **shared** `:data` — and an [action](glossary.md#action) returns the same data-shaped effect map a `reg-event` handler does, `{:data ... :fx ...}`. The selected transitions apply in **region-declaration order**, so each region's action sees the prior region's `:data` writes:
+Transition selection is done against the frozen pre-event configuration. Then
+the selected transitions are applied.
+
+That means region order can affect action/data accumulation order, but it does
+not affect which transitions are selected.
+
+A region guard cannot see a sibling region's move from the same broadcast event.
+It sees the sibling state as it was at the start of the macrostep.
+
+Use `:raise` if one region's move should trigger a second broadcast inside the
+same macrostep.
+
+## Shared data
+
+Because all regions share `:data`, two regions handling one event can both
+update it. `:data` merges, so an action that returns `{:data {:count n}}` writes
+only `:count`.
 
 ```clojure
-(rf/reg-machine :ui/example
-  {:type    :parallel
-   :data    {:count 0}
-   :actions {:bump-count (fn [{d :data}] {:data (update d :count inc)})}
-   :regions
-   {:left  {:initial :a
-            :states  {:a {:tags #{:left/a} :on {:reset {:target :a :action :bump-count}}}}}
-    :right {:initial :x
-            :states  {:x {:tags #{:right/x} :on {:reset {:target :x :action :bump-count}}}}}}})
-
-(rf/dispatch-sync [:ui/example [:reset]])
-;; Both regions handle :reset. :bump-count runs ONCE PER REGION against the
-;; shared :data — :count goes 0 → 1 → 2.
-;; => {:state {:left :a :right :x} :data {:count 2} :tags #{:left/a :right/x}}
+:actions
+{:bump (fn [{data :data}]
+         {:data {:count (inc (:count data))}})}
 ```
 
-If you wanted that event to count *once*, you'd register the coordinating action at the parent-machine level, or shape the regions so only one handles it.
+If two regions run `:bump`, `:count` increments twice.
 
-!!! note "Selection is order-independent"
+If that is not what you meant, put the update in one region, or model the
+coordination as a root transition.
 
-    The broadcast is **select-then-apply**: every region's enabled transition is
-    *selected* against **one frozen pre-broadcast snapshot**, and only *then* are
-    the selected transitions *applied* in declaration order. Declaration order
-    governs apply order (action / `:fx`, `:data` accumulation) — **never** which
-    transitions are selected. Reorder the regions and you get the *same* selected
-    set; the new configuration is computed **atomically** old→new — no region
-    observes an intermediate where some siblings have moved and others haven't.
-    Matches SCXML: a parallel macrostep selects against the pre-event configuration.
+## Root `:on` fallback
 
-    The same select-then-apply shape governs `:always` once the event set has
-    landed — the parent repeats it per [round](#always-stabilization-is-parent-owned)
-    until the machine is quiescent.
-
-## The root `:on`: an ancestor fallback
-
-A `:type :parallel` machine may declare its **own** `:on` at the root — alongside `:regions`, not instead of them. This is the **ancestor fallback**: the parallel analog of a flat or compound machine's root `:on` fallthrough.
+A parallel machine may declare root `:on` alongside `:regions`.
 
 ```clojure
-(rf/reg-machine :ui/board
+(rf/reg-machine :board
   {:type :parallel
    :data {}
    :regions
-   {:a {:initial :one
-        :states  {:one     {:on {:reset :special}}   ;; region :a handles :reset ITSELF
-                  :two     {}
-                  :special {}}}
-    :b {:initial :one
-        :states  {:one {} :two {}}}}
-   :on {:go-all {:target [[:a :two] [:b :two]]}      ;; no region declares :go-all
-        :reset  {:target [[:a :one] [:b :two]]}}})   ;; region :a DOES declare :reset
+   {:left  {:initial :one :states {:one {} :two {}}}
+    :right {:initial :one :states {:one {} :two {}}}}
+
+   :on
+   {:go-all {:target [[:left :two] [:right :two]]}}})
 ```
 
-The rule has two halves, and the second is the whole point:
+The root transition fires only when no region handles the event.
 
-**When no region handled the event, the root fires.** Nothing else lists `:go-all`, so the root catches it and moves the regions it targets:
+If any region handles the event, the root fallback is suppressed entirely. It
+is not applied to only the regions that did not handle it.
+
+Root targets are region-qualified:
 
 ```clojure
-(rf/dispatch-sync [:ui/board [:go-all]])
-;; No region declares :go-all → root ancestor fallback fires.
-;; :state {:a :two :b :two}
+[:left :two]
+[[:left :two] [:right :two]]
 ```
 
-**When *any* region handled the event, the root is suppressed *entirely* — atomic, all-or-nothing.** It is *not* "fire the root for the regions that didn't handle it." Region `:a` declares `:reset` locally, so on `:reset` the root transition is dropped wholesale, and regions the root *would* have moved are left untouched:
-
-```clojure
-;; from the initial {:a :one :b :one}:
-(rf/dispatch-sync [:ui/board [:reset]])
-;; :a has a local :reset (:one → :special) → :a competes → the WHOLE root :reset
-;; is suppressed → :b is left UNCHANGED (stays :one), even though the root's :reset
-;; targeted :b → :two.
-;; :state {:a :special :b :one}
-```
-
-That last result is the **non-decomposable** case. A naive broadcast decomposition (region `:a`: `reset → special`; region `:b`: `reset → :two`) would fire both independently and give `{:a :special :b :two}`. The atomic suppression instead leaves `:b` untouched — a coordination a *per-region* `:on` simply cannot express, because per-region transitions have no cross-region suppression.
-
-**Target grammar.** A root `:on` target is one of: **targetless / action-only** (runs `:action` / `:fx`, moves no region); a **single region-qualified target** `[<region> & <in-region-path>]` (e.g. `[:a :two]`, or `[:a :compound :leaf]`); or **multiple** `[[<region> …] [<region> …]]` (e.g. `[[:a :x] [:b :y]]`). A bare-keyword target, or one whose head isn't a declared region, is rejected at registration with `:rf.error/machine-parallel-root-on-bad-target` — a root-only parallel machine has no flat sibling state to land a non-region-qualified target on.
-
-A `:type :parallel` root may also declare its own **`:after`** — the timer-driven twin of the root `:on`. It's scheduled at machine birth, owned by the root (alive for the machine's whole life rather than tied to any one region's lifecycle), and uses the very same region-qualified target grammar.
+A bare keyword target at the root of a parallel machine is rejected at
+registration with `:rf.error/machine-parallel-root-on-bad-target`.
 
 ## Coordinating regions: tags as `stateIn`
 
-Orthogonal regions are independent — but sometimes one region's transition should depend on *where a sibling is*. The classic case: a `:checkout` region's `:submit` should only fire when the `:form` region is `:valid`.
+A region guard or action gets two extra context keys. They appear only inside a
+parallel region; a flat machine's context stays `{:data :event :state :meta}`.
 
-re-frame2 lets one region's guard or action read where a sibling sits — no separate combinator needed. When a guard or action runs **inside a region** of a parallel machine, its context map carries two extra cross-region keys alongside the usual `:data` / `:event` / `:state` / `:meta`:
+| Key | Meaning |
+|---|---|
+| `:tags` | the machine-wide tag union from the pre-event snapshot |
+| `:all-state` | the full region → active-state map from the pre-event snapshot |
 
-| ctx key | value | use |
-|---|---|---|
-| **`:tags`** | the machine-wide active-configuration tag union | the **coarse** read — a sibling advertises a tag, you ask `(contains? tags :form/valid)`. The idiomatic choice: a tag is a *named* render-state that survives a sibling renaming its internal states. |
-| **`:all-state`** | the full region → active-state map, e.g. `{:form :valid :checkout :idle}` | the **precise** read — `(= :valid (:form all-state))` matches a sibling's discrete state value directly. |
-
-```clojure
-;; :checkout's :submit fires only while the :form region
-;; advertises :form/valid — read via the cross-region :tags key.
-(rf/reg-machine :ui/checkout
-  {:type   :parallel
-   :data   {}
-   :guards {:form-valid? (fn [{:keys [tags]}] (contains? tags :form/valid))}
-   :regions
-   {:form     {:initial :editing
-               :states  {:editing {:tags #{:form/editing} :on {:complete :valid}}
-                         :valid   {:tags #{:form/valid}}}}
-    :checkout {:initial :idle
-               :states  {:idle       {:on {:submit {:target :submitting
-                                                    :guard  :form-valid?}}}
-                         :submitting {:tags #{:checkout/submitting}}}}}})
-
-(rf/dispatch-sync [:ui/checkout [:submit]])
-;; :form is still :editing → :form/valid is NOT in the union → :submit BLOCKED.
-;; :state stays {:form :editing :checkout :idle}
-
-(rf/dispatch-sync [:ui/checkout [:complete]])   ;; :form → :valid (advertises :form/valid)
-(rf/dispatch-sync [:ui/checkout [:submit]])
-;; :checkout's guard now reads :form/valid in (:tags ctx) → :submit FIRES.
-;; :state → {:form :valid :checkout :submitting}
-```
-
-The precise variant reads the sibling's state value directly:
+Prefer tags:
 
 ```clojure
-:guards {:form-is-valid? (fn [{:keys [all-state]}] (= :valid (:form all-state)))}
+:guards
+{:form-valid?
+ (fn [{:keys [tags]}]
+   (contains? tags :form/valid))}
 ```
 
-Prefer the **tag** query: a tag is a named, tool-legible render-state, and it holds up when a sibling region refactors its internal state names.
+Use `:all-state` only when exact state names are the contract:
 
-!!! note "Both keys are frozen — per selection round"
+```clojure
+(fn [{:keys [all-state]}]
+  (= :valid (:form all-state)))
+```
 
-    `:tags` and `:all-state` are frozen for the **selection round** that is currently choosing transitions, not for the whole macrostep. Within a round every co-selected region reads the *same* sibling view, so no region can observe a sibling's move from the set being selected alongside it — which is exactly why selection is declaration-order-independent. Between rounds the view is **re-frozen**, so each round sees the complete result of the one before it. A region reading its *own* state uses `:state`; `:tags` / `:all-state` are the mechanism for reading *siblings*. These two keys appear **only** for region guards/actions — a flat / compound machine's ctx stays exactly `{:data :event :state :meta}`, because it has no siblings to read; its own `:state` already answers *where am I?*.
+Both keys are frozen for the broadcast. A same-event move in a sibling region
+is not visible until a later microstep or later event.
 
-The two `dispatch-sync` calls above are **separate events**, which is why each `:submit` reads the prior committed config. If you need a *single* event to flip `:form` to `:valid` **and** advance `:checkout` in the same breath, two statechart-idiomatic paths re-couple them. Both converge inside the one macrostep; they differ in *which* mechanism carries the dependency:
+## `:always`, `:after`, and `:spawn` are region-scoped
 
-- **`:raise` — the region announces the news.** `:form`'s `:complete` action returns `:fx [[:raise [:form-valid]]]`; that internal event re-broadcasts across every region on the next microstep, and `:checkout`'s `:on {:form-valid …}` resolves it against the now-`:valid` `:form`. Reach for it when the sibling should react to an *event* — something happened — and when you want the dependency written down as a name.
-- **A guarded `:always` reading the sibling — the region notices the condition.** `:checkout` carries `{:always {:target :submitting :guard :form-valid?}}`. Once the event set has applied, the parent's first eventless round evaluates that guard against the updated configuration and `:checkout` moves — in the **same** macrostep, before it commits. Reach for it when the sibling should track a *condition* — the world now looks like this — without the announcing region needing to know anyone is listening.
+A region chooses *where* its `:always` targets — those targets stay inside that
+region. The parent owns settle; see
+[below](#always-stabilization-is-parent-owned).
 
-Both are bounded by the `:always-depth-limit` / `:raise-depth-limit` (default 16), so neither can spin.
+A region state's `:after` timer belongs to that region state. Sibling
+transitions do not cancel it.
 
-## Per-region `:always` / `:after` / `:spawn` — and the `:raise` exception
+A region state's `:spawn` child is bound to that region state. Sibling
+transitions do not destroy it.
 
-Each region's state-node keys are **scoped to that region**:
-
-- **`:always`** — a region's `:always` entries target states *inside that region*: the `:resolving → :empty | :some | :too-many` cascade in the nine-states `:data` region can only land on `:data`'s own states, never on a sibling's. But **targeting is not stabilization**. *Which* `:always` transitions fire, and *when* the loop is finished, is decided by the **parent** across the whole configuration — see [below](#always-stabilization-is-parent-owned). Keep those two ideas apart and the rest of this section follows.
-- **`:after`** — a timer arms / cancels on *its region's* state entry / exit. A sibling region transitioning does **not** cancel this region's in-flight `:after` timer; each region keeps its own timer epoch.
-- **`:spawn`** — a region's [`:spawn`](glossary.md#spawn)-bearing state starts and tears down child actors bound to *that region's* state; siblings never see the spawn / destroy cascade.
-- **`:entry` / `:exit`** — fire on the region's own transitions, never on a sibling's.
-
-!!! note "`:raise` is the exception — it BROADCASTS"
-
-    A `[:raise [:event]]` emitted by any region's action does **not** stay local. It re-enters the parallel machine's single internal-event queue and re-broadcasts across **every** region — exactly as SCXML delivers a `raise`d internal event to the whole machine, every active parallel state included. Each re-broadcast is its own microstep (a fresh frozen sibling view that already reflects the prior microstep's moves, while the in-flight `:data` flows through), the queue drains FIFO, and the whole macrostep — external event + every raised event + every eventless round — commits **once, atomically**, bounded by the `:raise-depth-limit`. Eventless work has priority: the parent settles `:always` to a fixed point before it dequeues the next raise.
+The exception is `:raise`: a raised event is broadcast to every region, just
+like an external event, but still inside the current macrostep.
 
 ## `:always` stabilization is parent-owned
 
-A region chooses *where* its `:always` transitions go. The **parent** decides *when* they fire. After the selected event transitions have applied, the parent repeats one **round** until nothing is left to do:
+A region chooses *where* its `:always` targets. The **parent** owns settle.
+After the event set has applied, the parent freezes the whole configuration,
+selects every enabled regional `:always` against that one frozen view, applies
+the selected set, and freezes again. It repeats until a round selects nothing.
 
-1. **Freeze** the current whole configuration and `:data`.
-2. **Select** every regional `:always` transition enabled against that one frozen view.
-3. **Apply** the whole selected set, in region-declaration order.
-
-Then it freezes again and goes round once more, until a round selects nothing. Only then does the macrostep commit. So the loop is not *"each region settles itself"* — it is *"the machine settles, one whole-configuration round at a time"*.
-
-That distinction is worth one worked example. Three regions, one dispatch:
-
-```clojure
-(rf/reg-machine :ui/gate
-  {:type :parallel
-   :data {:ready? false :cleared? false}
-
-   :guards  {:ready?   (fn [{:keys [data]}] (:ready? data))
-             :cleared? (fn [{:keys [data]}] (:cleared? data))}
-
-   :actions {:mark-ready (fn [{d :data}] {:data (assoc d :ready? true)})
-             :clear      (fn [{d :data}] {:data (assoc d :cleared? true)})}
-
-   :regions
-   {:source {:initial :idle
-             :states  {:idle {:on {:go {:target :sent :action :mark-ready}}}
-                       :sent {}}}
-
-    :gate   {:initial :closed
-             :states  {:closed {:always [{:guard :ready? :target :open :action :clear}]}
-                       :open   {}}}
-
-    :audit  {:initial :waiting
-             :states  {:waiting {:always [{:guard :cleared? :target :logged}]}
-                       :logged  {}}}}})
-
-(rf/dispatch-sync [:ui/gate [:go]])
-;; => {:state {:source :sent :gate :open :audit :logged}
-;;     :data  {:ready? true :cleared? true}}
-```
-
-One event; all three regions moved. Here is how, round by round:
-
-**The event set applies first.** `:go` is broadcast; only `:source` handles it, and its `:mark-ready` action sets `:ready?`. Every selected event action runs to completion **before** any `:always` is considered — so the first round already sees the finished work of the event.
-
-**Round 1 — selection is frozen.** The parent freezes the configuration and `:data` (`:ready?` true, `:cleared?` false) and asks every region what is enabled. `:gate` is: its `:ready?` guard passes, so `:closed → :open` is selected. `:audit` is **not**: its `:cleared?` guard reads the frozen `:data`, where `:cleared?` is still false. The parent then applies the selected set — `:gate` moves and its `:clear` action sets `:cleared?`. Note what *didn't* happen: `:audit` did not move in this round, even though by the time the round finished applying, its guard's condition held. Selection was decided before any of it applied.
-
-**Round 2 — the view is re-frozen.** A new round, a new freeze: `:cleared?` is now true. `:audit`'s guard passes, and `:waiting → :logged` is selected and applied. This is the payoff of re-freezing — each round sees the previous round's completed result.
-
-**Round 3 — the fixed point.** Nothing is enabled. The loop stops and the macrostep commits, publishing `{:source :sent :gate :open :audit :logged}` as one atomic step. External observers never see the intermediate rounds; they see one dispatch and one new configuration.
-
-The same process runs at **birth**, once every region's `:entry` cascade has completed — which is why a birth `:always` guard can read where its siblings landed.
-
-Two consequences worth naming:
-
-**Within one round, reordering the regions cannot change what is selected.** Because each round selects against a frozen view, no region's guard can ever observe a sibling's move from the set being selected alongside it — declaration order never changes *which* transitions a single round chooses. What it does govern is the *apply* order within that round: action and `:fx` order, and the order in which the selected actions accumulate `:data`. That apply-order reaches *across* rounds, because the `:data` a round accumulates is exactly the view the *next* round freezes. When two regions' actions write the same `:data` key with non-commuting values, reordering them changes what a later round sees, and can therefore change which `:always` that later round selects. So order independence is a guarantee about *selection within one frozen round*, not an unconditional guarantee about the final outcome. Write regions whose actions touch disjoint `:data` keys — those writes commute, so their order stops mattering entirely.
-
-**Failure is bounded and atomic.** `:always-depth-limit` (default 16) counts parent **rounds**, not transitions — a round in which five regions move is one round. If a machine spins past the limit, or a guard or action throws, the **whole** macrostep fails and rolls back: no snapshot is published and no effects run. There is no half-settled configuration to reason about, which is what makes the fixed point safe to lean on.
+The loop is not "each region settles itself." One region's `:always` action can
+enable a sibling's `:always`, and that sibling waits for the *next* parent
+round. A tiny case: `:source` writes `:ready?`, `:gate`'s `:always` reads it and
+writes `:cleared?`, `:audit`'s `:always` reads `:cleared?` — one event, two
+parent rounds, then the snapshot commits.
 
 ## Tags compose across regions
 
-A parallel machine's `:tags` is the **union of every active state's tags across every active region** — walk each region's active configuration (root → leaf for compound regions), union the tags, then union across regions. So in the nine-states machine at boot, `:data`'s `:nothing` contributes `#{:data/nothing}`, `:form`'s `:neutral` contributes `#{:form/neutral}`, `:mode`'s `:active` contributes `#{:mode/active}`, and the snapshot's `:tags` is `#{:data/nothing :form/neutral :mode/active}`.
+The snapshot's `:tags` is the union of every active state in every region.
 
-The framework [`machine-has-tag?`](../api/re-frame.machines.md) sub works unchanged — it asks "does the union contain this tag?", and the answer is yes iff *any* active state in *any* region declared it. That's what lets a view disable itself with `@(rf/subscribe [:rf.machine/has-tag? :ui/nine-states :mode/read-only])` without caring which region (or which state of it) carries the read-only intent — *ask, don't tell* ([state tag](glossary.md#state-tag)).
+That lets a view ask one question without knowing which region owns the tag:
 
-The composed tag union also delivers the headline payoff: **collapsing N live axes down to one render decision**. Several tags are live at once, but the page draws one thing, so a plain-data priority table picks the winner and the root view branches with a single `case`. Three regions, nine states, one branch site. That pattern — the priority table, the selector sub, the one-`case` root view — is worked in [Tags → Collapsing many states into one render decision](tags.md#collapsing-many-states-into-one-render-decision).
+```clojure
+@(rf/subscribe [:rf.machine/has-tag? :ui/nine-states :mode/read-only])
+```
 
-## A divergence to know: no nested parallel regions
+It also lets you build a single render-priority table across all axes. See
+[State tags](tags.md#collapsing-many-states-into-one-render-decision).
 
-**Nested parallel regions are not supported in v1.** A region whose own tree
-declares `:type :parallel` is rejected at registration with
-`:rf.error/machine-parallel-nested-not-supported`. Model a would-be two-level
-cross-product as a flatter set of regions, or as multiple top-level parallel
-machines. A region *may* still be a compound (hierarchical) state-tree; it just
-can't itself be parallel. This is a **deferred** divergence — reconsidered if a
-real two-level cross-product appears that genuinely cannot flatten.
+## Limitations
+
+Nested parallel regions are not supported. A region may be hierarchical, but it
+may not itself declare `:type :parallel`. Registration throws
+`:rf.error/machine-parallel-nested-not-supported`.
+
+If you find yourself wanting nested parallel, flatten the axes into one
+parallel root or split the feature into several machines.

--- a/docs/machines/tags.md
+++ b/docs/machines/tags.md
@@ -1,87 +1,104 @@
 # State tags
 
-You know the [flat model](concepts.md): states, transitions, snapshot. This page is
-how views ask **what is true** without hard-coding state names.
+A view often does not care which exact state a machine is in. It cares about a
+semantic question:
 
-Some questions are not "which state?" but "is it *busy*?" across `:loading`,
-`:retrying`, `:reconnecting`, and whatever you add next month. A
-**[state tag](glossary.md#state-tag)** is a label on a state so a view asks for
-intent — busy, read-only, terminal — instead of enumerating names. *Ask, don't
-tell.*
+- is this flow busy?
+- is this screen read-only?
+- is this state terminal?
+- should the root view render loading, empty, error, or content?
 
-Reach for tags when:
+A **[state tag](glossary.md#state-tag)** is a label on a state that answers those
+questions without forcing the view to enumerate state names.
 
-- several states share a meaning a view cares about;
-- render decisions slice across more than one axis (see also
-  [parallel regions](parallel-states.md));
-- a guard in one parallel region needs a sibling region's *intent* without private
-  state.
-
-If a label would only ever match one state, skip it — compare `:state` directly.
-
-## Declaring tags on a state
-
-`:tags` is a state-node key whose value is a **set of keywords**. No separate
-registration — just another slot on the state, alongside `:on`, `:entry`, and
-`:after`:
+## Declare tags on states
 
 ```clojure
 (rf/reg-machine :todos/loader
   {:initial :idle
    :states
-   {:idle     {:on {:fetch :loading}}
+   {:idle
+    {:on {:fetch :loading}}
 
-    :loading  {:tags #{:data/in-flight}
-               :on   {:ok :ready :fail :retrying}}
+    :loading
+    {:tags #{:data/in-flight}
+     :on   {:ok :ready
+            :fail :retrying}}
 
-    :retrying {:tags #{:data/in-flight}            ;; same intent as :loading
-               :on   {:ok :ready :give-up :error}}
+    :retrying
+    {:tags #{:data/in-flight}
+     :on   {:ok :ready
+            :give-up :error}}
 
-    :ready    {:tags #{:data/ready}}
-    :error    {:tags #{:data/error}}}})
+    :ready
+    {:tags #{:data/ready}}
+
+    :error
+    {:tags #{:data/error}}}})
 ```
 
-Both `:loading` and `:retrying` wear `:data/in-flight`. A view that wants "show the
-spinner while a request is in flight" consumes that one tag — and a third in-flight
-state is one `:tags` entry with no view change.
+Both `:loading` and `:retrying` advertise `:data/in-flight`. A third in-flight
+state later is one more `:tags` entry; the view that asks for that tag does not
+change.
 
-Two rules:
+`:tags` is a **set of keywords** on a state node. A vector or a lone keyword is
+rejected at registration with `:rf.error/machine-bad-tags`.
 
-- **Tags label *intent*, not *identity*.** `:tags #{:data/in-flight}` is good; `:tags #{:todos.loader/loading-state}` just re-encodes the state name and earns nothing. Use a per-axis namespace (`:data/…`, `:form/…`, `:mode/…`) so one tag-question can span several states.
-- **The `:rf/*` / `:rf.*/*` namespaces are framework-reserved.** Tag with your own feature prefix — `:auth/busy`, `:cart/dirty`, `:ws/disconnected`. Any unreserved namespace is fair game, dotted forms (`:ui.state/loading`) included.
+Tags label **intent**, not identity. Good tags name what the state means to the
+rest of the program:
 
-!!! note "Tags ride on *states*, never on transitions"
+```clojure
+:tags #{:auth/busy}
+:tags #{:mode/read-only}
+:tags #{:ws/connected}
+```
 
-    `:tags` is a state-node slot only — there is no tag on an `:on` entry, an `:always`, or an `:after`. "Was this transition tagged?" is already answered by the trace vocabulary, so a transition carries no tag. (Adding transition tags later would be non-breaking — but today, tags are not on transitions.)
+Weak tags repeat the state's identity:
 
-## The snapshot's `:tags` slot
+```clojure
+:tags #{:auth-login/submitting-state}
+```
 
-At every transition the runtime walks the machine's active states, unions their tag sets, and stamps the result onto the [snapshot](glossary.md#snapshot) at `:tags`. The snapshot gains one optional slot:
+Use a per-axis namespace (`:data/…`, `:form/…`, `:mode/…`) so one question can
+span several states. The `:rf/*` and `:rf.*/*` namespaces are reserved; tag with
+your own feature prefix. Dotted forms such as `:ui.state/loading` are fine.
+
+If a tag will only ever match one state, skip it and read `:state` directly.
+
+## The snapshot's `:tags`
+
+The runtime unions the tags on every active state and writes the result onto the
+[snapshot](glossary.md#snapshot):
 
 ```clojure
 @(rf/subscribe [:rf/machine :todos/loader])
-;; => {:state :retrying :data {…} :tags #{:data/in-flight}}
+;; => {:state :retrying
+;;     :data  {...}
+;;     :tags  #{:data/in-flight}}
 ```
 
 How the union is computed depends on the machine's shape:
 
-- **Flat machine** — the single active state's `:tags`.
-- **[Compound (hierarchical)](hierarchical-states.md) machine** — the union along the active path: root → every compound ancestor → leaf.
-- **[Parallel](parallel-states.md) machine** — the union across *every* active state in *every* region. (This is what makes tags the cross-region signal in the last section.)
+| Machine shape | Tag projection |
+|---|---|
+| Flat | tags on the active state |
+| [Hierarchical](hierarchical-states.md) | union along the active path, root to leaf |
+| [Parallel](parallel-states.md) | union of every active state in every region |
 
-`:tags` is **read-only** for you. It's a pure projection of `:state` — set the state, the tags follow — so an action can't return `:tags` in its `{:data :fx}` effect map; the runtime owns the slot. And when the union is **empty** (no active state declares any tag), the runtime **elides** the key entirely: a tag-free machine carries no `:tags` slot at all, so `(contains? snap :tags)` can be `false` even after the machine has settled. Don't declare an empty `:tags #{}` to "have the slot" — just omit it.
+The runtime owns `:tags`. An action cannot return `{:tags …}` — the slot is a
+projection of `:state`. When no active state declares tags, the runtime
+**elides** the key. Do not declare `:tags #{}` to force the slot; omit it.
 
-## Querying with `[:rf.machine/has-tag? …]`
+## Query one tag
 
 <a id="querying-with-machine-has-tag"></a>
 
-The framework ships one **derived subscription** for the containment question — *does this machine's snapshot carry this tag?* There is no separate function sugar; every runtime-db read is a subscription vector:
+The query is this subscription:
 
 ```clojure
-@(rf/subscribe [:rf.machine/has-tag? :todos/loader :data/in-flight])   ;; => true | false
+@(rf/subscribe [:rf.machine/has-tag? :todos/loader :data/in-flight])
+;; => true or false
 ```
-
-In a view that's all you need to render on intent:
 
 ```clojure
 (rf/reg-view spinner-or-list []
@@ -90,44 +107,50 @@ In a view that's all you need to render on intent:
     [todo-list]))
 ```
 
-Because the sub is **derived directly off the snapshot's `:tags` slot** — it reads the containment bit with `get-in` rather than chaining the whole `[:rf/machine id]` snapshot — a view that asks one tag re-renders only when *that bit* flips, not on every `:data` mutation or unrelated transition. It returns `false` for an unknown or not-yet-initialised machine, so there's no nil-guard to write.
+It returns `false` for an unknown or not-yet-initialised machine. The sub is
+derived: a view that asks one tag re-renders when that membership flips, not on
+every `:data` write.
 
-Need the whole set rather than one bit? That's the ordinary snapshot read:
+There is no `machine-has-tag?` function and no `[:rf/machine-has-tag? …]`
+vector. The membership question is `[:rf.machine/has-tag? machine-id tag]`.
+
+Need the whole set? Read the snapshot:
 
 ```clojure
-(:tags @(rf/subscribe [:rf/machine :todos/loader]))   ;; => #{:data/in-flight}
+(:tags @(rf/subscribe [:rf/machine :todos/loader]))
+;; => #{:data/in-flight}
 ```
 
-!!! note "Reading tags inside an event handler"
-
-    A snapshot lives in [runtime-db](../core/glossary.md#runtime-db), not app-db, so a handler that needs to branch on a tag reads it from the `:rf.db/runtime` coeffect rather than from `:db`:
-
-    ```clojure
-    (fn [{rt :rf.db/runtime} _]
-      (get-in rt [:rf.runtime/machines :snapshots :todos/loader :tags]))
-    ```
+Use that form for selectors and render-priority tables.
 
 ## Collapsing many states into one render decision
 
-This is where tags pay off hardest. The [Nine States example](../../examples/patterns/nine_states) models a page as one [`:type :parallel`](parallel-states.md) machine with three orthogonal regions — `:data` (request lifecycle + cardinality), `:form` (validation), `:mode` (active / archived). Every state wears a per-axis tag:
+Several tags can be live at once in a [parallel](parallel-states.md) machine, but
+a page can render only one main view.
+
+The [Nine States example](../../examples/patterns/nine_states) is one
+`:type :parallel` machine with three regions — `:data`, `:form`, `:mode`. Each
+state advertises a per-axis tag:
 
 ```clojure
-;; (excerpt from the three regions) — each state announces its intent
-:loading   {:tags #{:data/loading :data/transient}        :on {…}}
-:empty     {:tags #{:data/empty}                           :on {…}}
-:incorrect {:tags #{:form/invalid}                         :on {…}}
-:correct   {:tags #{:form/success :form/transient}         :on {…}}
+;; cf. examples/patterns/nine_states
+:loading   {:tags #{:data/loading :data/transient} :on {...}}
+:empty     {:tags #{:data/empty}                   :on {...}}
+:incorrect {:tags #{:form/invalid}                 :on {...}}
+:correct   {:tags #{:form/success :form/transient} :on {...}}
 :done      {:tags #{:mode/done :mode/read-only :mode/terminal}}
 ```
 
-Three axes run at once, so several tags are live simultaneously — `:data/loading` *and* `:form/invalid` *and* `:mode/active`. The page can only draw one thing, so it needs a tie-breaker. Make it **plain data**: a render-priority table read top to bottom, plus one selector sub that returns the first matching tag's render-model keyword.
+Make the tie-breaker **plain data**: a table read top to bottom, plus a selector
+sub that returns the first matching tag's render keyword.
 
 ```clojure
-(def render-priority             ;; excerpt — the runnable example carries all ten rows
-  [{:tag :mode/done    :render :done}        ;; archived trumps everything
-   {:tag :form/success :render :correct}     ;; transient form acks next
+;; cf. examples/patterns/nine_states — the example carries all ten rows
+(def render-priority
+  [{:tag :mode/done    :render :done}
+   {:tag :form/success :render :correct}
    {:tag :form/invalid :render :incorrect}
-   {:tag :data/loading :render :loading}     ;; then the data lifecycle
+   {:tag :data/loading :render :loading}
    {:tag :data/error   :render :error}
    {:tag :data/empty   :render :empty}
    {:tag :data/some    :render :some}])
@@ -141,7 +164,7 @@ Three axes run at once, so several tags are live simultaneously — `:data/loadi
             render-priority))))
 ```
 
-The root view's entire branching logic is then one `case` — the only place the UI ever forks:
+The root view branches once:
 
 ```clojure
 (rf/reg-view root-view []
@@ -156,9 +179,9 @@ The root view's entire branching logic is then one `case` — the only place the
     [:p "(unrecognised state)"]))
 ```
 
-Nine states, three regions, one branch site. The priority order is a *product decision* — "an archived page beats a form acknowledgement beats the data bucket" — living in one readable table, not smeared across nine views. Adding a tenth render case is one row in `render-priority` plus one `case` clause; the machine and the other views don't move.
-
-And the controls disable themselves the same ask-don't-tell way — they ask for the *intent*, not the state:
+The order is a product decision — archived beats a form acknowledgement beats
+the data bucket — living in one table. Adding a render case is one row plus one
+`case` clause.
 
 ```clojure
 (rf/reg-view new-todo-form []
@@ -166,25 +189,82 @@ And the controls disable themselves the same ask-don't-tell way — they ask for
     [:button {:disabled read-only?} "Add"]))
 ```
 
-Notice what the form *doesn't* ask: "is the `:mode` region in `:done`?" It asks "is this read-only?" Move `:mode/read-only` onto a different state tomorrow and this view doesn't change a line.
+The form does not ask whether `:mode` is `:done`. It asks whether the screen is
+read-only.
 
 ## Tags as a cross-region signal
 
-In a [parallel machine](parallel-states.md) the tag union spans *all* regions, which makes it the channel one region uses to read what a sibling is doing — the classic statechart coordination primitive, shipped without a dedicated operator. A sibling region advertises a tag; any region's guard reads the machine-wide union off its context map and predicates on it — `(fn [{:keys [tags]}] (contains? tags :form/valid))`.
+In a [parallel machine](parallel-states.md) the tag union spans every region. One
+region can advertise a tag; another region's guard reads it.
 
-Two things to hold onto:
+```clojure
+(rf/reg-machine :checkout/page
+  {:type :parallel
+   :data {}
 
-- **A tag is a guard *input*, not a *trigger*.** A tag flipping on does not *fire* anything — there is no "on this tag appearing" transition. The dependent region still moves on its next event (or an eventless `:always`); the guard merely *reads* the sibling's advertised tag when it runs.
-- **The cross-region keys are parallel-only.** A flat or compound machine's guard/action context stays exactly `{:data :event :state :meta}` — it has no sibling to coordinate with.
+   :guards
+   {:form-valid?
+    (fn [{:keys [tags]}]
+      (contains? tags :form/valid))}
 
-The worked example — a `:checkout` region whose `:submit` waits for the `:form` region to advertise `:form/valid` — plus the precise `:all-state` variant and the frozen-snapshot selection rules are in [Parallel states → Coordinating regions](parallel-states.md#coordinating-regions-tags-as-statein).
+   :regions
+   {:form
+    {:initial :editing
+     :states  {:editing {:tags #{:form/editing}
+                         :on   {:complete :valid}}
+               :valid   {:tags #{:form/valid}}}}
 
-## What tags are *not*
+    :checkout
+    {:initial :idle
+     :states  {:idle       {:on {:submit {:target :submitting
+                                          :guard  :form-valid?}}}
+               :submitting {:tags #{:checkout/submitting}}}}}})
+```
 
-- **Not transition labels.** `:tags` is a state-node slot; transitions carry no tags.
-- **Not an autonomous driver.** A tag appearing never fires a transition by itself — it's read by guards, it doesn't trigger them. For a state change that should follow a `:data` condition on its own, use a guarded eventless `:always`.
-- **Not user-writable.** An action can't return `:tags` in its `{:data :fx}` map — the slot is runtime-owned and derived from `:state`.
-- **Not the `:meta` slot.** A state's `:meta` (e.g. `{:terminal? true}`) is static, tooling-visible metadata; `:tags` is the runtime projection of the *active* configuration. Both can sit on the same state; they are not synonyms.
-- **Not a replacement for `[:rf/machine id]`.** When a view needs the whole snapshot
-  it still subscribes to `:rf/machine`; `machine-has-tag?` is for the
-  predicate-shaped question.
+The checkout region does not need the form region's state names. It reads
+`:form/valid`.
+
+A region guard or action also receives `:all-state`, the region → state map,
+when the precise sibling state matters:
+
+```clojure
+(fn [{:keys [all-state]}]
+  (= :valid (:form all-state)))
+```
+
+Prefer tags. They survive a sibling refactor.
+
+Two rules:
+
+- **A tag is a guard input, not a trigger.** A tag appearing does not fire a
+  transition. The dependent region still moves on its next event or a guarded
+  `:always`; the guard only reads the sibling's tag when it runs.
+- **`:tags` and `:all-state` are parallel-only.** A flat or compound machine's
+  guard/action context is `{:data :event :state :meta}`. There is no sibling to
+  coordinate with.
+
+The frozen-snapshot selection rules live in
+[Parallel states → Coordinating regions](parallel-states.md#coordinating-regions-tags-as-statein).
+
+## What tags are not
+
+- **Not transition labels.** `:tags` is a state-node slot. Transitions carry
+  none.
+- **Not a trigger.** A tag appearing never fires a transition by itself. For a
+  move that should follow a condition on its own, use a guarded `:always`.
+- **Not user-writable.** An action cannot return `:tags`. The runtime projects
+  the slot from active state.
+- **Not `:meta`.** A state's `:meta` (for example `{:terminal? true}`) is static,
+  tooling-visible metadata. `:tags` is the live projection of the active
+  configuration. Both can sit on the same state; they are not the same thing.
+- **Not a replacement for `[:rf/machine id]`.** When a view needs the whole
+  snapshot it still subscribes to `:rf/machine`. `[:rf.machine/has-tag? …]` is
+  the predicate-shaped question.
+
+## Troubleshooting
+
+| Symptom | Cause | Fix |
+| --- | --- | --- |
+| Registration throws `:rf.error/machine-bad-tags` | `:tags` is a vector or a lone keyword | Write a set: `#{:data/in-flight}` |
+| Snapshot has no `:tags` key | No active state declares tags; the empty union is elided | Omit the key; `(contains? (:tags snap) x)` is still false |
+| Guard ctx has no `:tags` / `:all-state` | The machine is flat or compound | Those keys exist only inside a parallel region |

--- a/docs/machines/tutorial.md
+++ b/docs/machines/tutorial.md
@@ -1,30 +1,37 @@
 # Tutorial: build a login machine
 
-Build one machine end to end — idle → submitting → authed / error / locked-out —
-one idea per step. By the end you have a **complete, copy-pasteable** table
-(guards, actions, HTTP, timeout, tags, lock-out) plus a view and a pure test.
+This tutorial builds one login flow, adding one idea at a time.
 
-**Prerequisites.** [Core introduction](../core/introduction.md) (events, app-db,
-effects). Vocabulary for later pages: [The model](concepts.md).
+By the end you will have:
+
+- a registered machine;
+- a guard that refuses an empty form;
+- actions that update machine `:data` and return effects;
+- an HTTP request started on state entry, with a timeout that cancels on exit;
+- a view that reads the snapshot and a tag;
+- a pure unit test for the transition table.
+
+The example is small on purpose. The goal is the shape, not a production auth system.
+
+**Prerequisites.** [Core introduction](../core/introduction.md) (events, app-db, effects). Vocabulary for later pages: [The model](concepts.md).
 
 ## Step 0 — turn machines on
 
-Machines are an optional artefact. Require them once in a boot or feature namespace:
+Machines are an optional artefact. Require the namespace once from a boot or feature namespace:
 
 ```clojure
 (ns app.login
   (:require [re-frame.core :as rf]
-            [re-frame.machines]))   ;; loads the capability
+            [re-frame.machines]))
 ```
 
-Forget this and the first `reg-machine` throws
-`:rf.error/machines-artefact-missing`.
+Skip this and the first `reg-machine` throws `:rf.error/machines-artefact-missing`.
 
-## Step 1 — a table and a registration
+## Step 1 — write the transition table
 
 <a id="step-1--your-first-machine"></a>
 
-A machine is data: named states and which triggers move where.
+A machine is a map. It names an initial state, some private `:data`, and the states plus transitions. Define it with `defmachine` (not `def` — a plain `def` leaves source stamps empty and warns `:rf.warning/machine-source-unstamped`), then register it:
 
 ```clojure
 (rf/defmachine login-flow
@@ -32,21 +39,27 @@ A machine is data: named states and which triggers move where.
    :data    {:attempts 0 :error nil}
 
    :states
-   {:idle        {:on {:auth.login/submit  {:target :submitting}}}
-    :submitting  {:on {:auth.login/success {:target :authed}
-                       :auth.login/failure {:target :error-shown}}}
-    :error-shown {:on {:auth.login/dismiss {:target :idle}
-                       :auth.login/submit  {:target :submitting}}}
-    :authed      {}}})   ;; resting — no outgoing transitions
-```
+   {:idle
+    {:on {:auth.login/submit :submitting}}
 
-Register a **singleton** under an event id (`reg-machine` ≈ specialised `reg-event`):
+    :submitting
+    {:on {:auth.login/success :authed
+          :auth.login/failure :error-shown}}
 
-```clojure
+    :error-shown
+    {:on {:auth.login/dismiss :idle
+          :auth.login/submit  :submitting}}
+
+    ;; Resting leaf. Do not set :final? — that destroys the machine.
+    :authed
+    {:meta {:terminal? true}}}})
+
 (rf/reg-machine :auth.login/flow login-flow)
 ```
 
-Drive it by dispatching to that id; the **inner** vector is the machine event:
+Targets here are bare keywords. The next two steps turn those into maps, then into candidate vectors.
+
+`reg-machine` is machine-shaped `reg-event`. The machine id is the event id you dispatch to; the **inner** vector is the machine event:
 
 ```clojure
 (rf/dispatch [:auth.login/flow [:auth.login/submit {:email "a@b.com" :password "x"}]])
@@ -60,86 +73,122 @@ Read the live [snapshot](glossary.md#snapshot):
 ;;    nil before the first event — the machine boots on first dispatch
 ```
 
-Outer handlers stay ordinary. They only wrap the machine address:
-
-```clojure
-(rf/reg-event :login/submit
-  (fn [_ [_ credentials]]
-    {:fx [[:dispatch [:auth.login/flow [:auth.login/submit credentials]]]]}))
-```
-
-## Step 2 — a guard
+## Step 2 — add a guard
 
 <a id="step-2--a-guard-refuse-an-invalid-submit"></a>
 
-Refuse empty credentials. Name the guard once; reference it from every arrow that
-needs it:
+Right now any submit moves to `:submitting`, even with empty credentials.
+
+A guard is a predicate that gates a transition. It receives one context map and returns truthy or falsey. Once a transition needs more than a target, write it as a map:
 
 ```clojure
-:guards
-{:form-valid?
- (fn [{[_ creds] :event}]
-   (and (seq (:email creds)) (seq (:password creds))))}
+(rf/defmachine login-flow
+  {:initial :idle
+   :data    {:attempts 0 :error nil}
 
-;; on the arrows:
-:idle        {:on {:auth.login/submit {:target :submitting :guard :form-valid?}}}
-:error-shown {:on {:auth.login/submit {:target :submitting :guard :form-valid?}
-                   :auth.login/dismiss {:target :idle}}}
+   :guards
+   {:form-valid?
+    (fn [{[_ creds] :event}]
+      (and (seq (:email creds))
+           (seq (:password creds))))}
+
+   :states
+   {:idle
+    {:on {:auth.login/submit {:target :submitting
+                              :guard  :form-valid?}}}
+
+    :submitting
+    {:on {:auth.login/success :authed
+          :auth.login/failure :error-shown}}
+
+    :error-shown
+    {:on {:auth.login/dismiss :idle
+          :auth.login/submit  {:target :submitting
+                               :guard  :form-valid?}}}
+
+    :authed
+    {:meta {:terminal? true}}}})
 ```
 
+The guard reads credentials from `:event`, not from app-db. Machine callbacks see `{:data :event :state :meta}`. They do not see app-db. ([Encapsulation](concepts.md#strict-encapsulation).)
+
+Try it:
+
 ```clojure
-(rf/dispatch [:auth.login/flow [:auth.login/submit {:email "" :password ""}]])
+(rf/dispatch-sync [:auth.login/flow [:auth.login/submit {:email "" :password ""}]])
 @(rf/subscribe [:rf/machine :auth.login/flow])
-;; => still :idle  (guard said no)
-```
+;; => still :idle
 
-The guard reads credentials from **`:event`**, not app-db —
-[encapsulation](concepts.md#strict-encapsulation).
+(rf/dispatch-sync [:auth.login/flow [:auth.login/submit {:email "a@b.com"
+                                                         :password "secret"}]])
+@(rf/subscribe [:rf/machine :auth.login/flow])
+;; => :submitting
+```
 
 ## Step 3 — actions and candidate lists
 
 <a id="step-3--an-action-and-the-data-fx-it-returns"></a>
 
-An **action** returns `{:data … :fx …}` like a pure event handler — it never calls
-HTTP itself.
+A guard decides whether a transition may fire. An action describes what else should happen. It returns the same shape as a re-frame2 event handler, scoped to the machine:
 
-- `:clear-error` — wipe the last error on a fresh submit
-- `:record-error` — bump `:attempts` and store a message
-- `:store-session` — dispatch an ordinary effect on success
-- **Candidate list** on failure — the first two failures show the error; the third
-  records it and locks out (three attempts total)
+```clojure
+{:data {...}        ;; merged into this machine's private :data
+ :fx   [[id args]]} ;; ordinary effects vector
+```
+
+Add actions for clearing an old error, recording a failed attempt, and storing a session token. On failure, write a **vector of candidates** — first guard that passes wins.
 
 ```clojure
 :guards
-{:form-valid?       …
- :under-retry-limit (fn [{data :data}] (< (:attempts data) 2))}
+{:form-valid?
+ (fn [{[_ creds] :event}]
+   (and (seq (:email creds)) (seq (:password creds))))
+
+ :under-retry-limit
+ (fn [{data :data}]
+   (< (:attempts data) 2))}
 
 :actions
 {:clear-error
  (fn [_] {:data {:error nil}})
+
  :record-error
+ ;; Live HTTP appends {:status :error :error …}; pull the failure map from :error.
  (fn [{data :data [_ {:keys [error]}] :event}]
    {:data (-> data
               (update :attempts inc)
               (assoc  :error (or (:message error) "Login failed.")))})
+
  :store-session
- ;; HTTP appends {:status :ok :value …}; pull the decoded body from :value.
+ ;; Live HTTP appends {:status :ok :value …}; pull the decoded body from :value.
  (fn [{[_ {:keys [value]}] :event}]
    {:fx [[:auth.session/store {:token (:token value)}]]})}
 
+:idle
+{:on {:auth.login/submit {:target :submitting
+                          :guard  :form-valid?
+                          :action :clear-error}}}
+
 :submitting
-{:on {:auth.login/success {:target :authed :action :store-session}
+{:on {:auth.login/success {:target :authed
+                           :action :store-session}
       :auth.login/failure [{:target :error-shown
                             :guard  :under-retry-limit
                             :action :record-error}
                            {:target :locked-out
                             :action :record-error}]}}
+
+:error-shown
+{:on {:auth.login/dismiss :idle
+      :auth.login/submit  {:target :submitting
+                           :guard  :form-valid?
+                           :action :clear-error}}}
+
+:authed     {:meta {:terminal? true}}
+:locked-out {:meta {:terminal? true}}
 ```
 
-A **vector of candidates** is tried in order; first guard that passes wins. The
-guard reads the *pre-action* `:attempts`, so it passes for the first two failures;
-on the third it fails and the fallback candidate records that final error before
-locking out — so the terminal failure is counted, not discarded.
+`:under-retry-limit` reads the *pre-action* `:attempts`, so it passes for the first two failures. On the third it fails and the unguarded default records that error too, then locks out — three attempts total, and the terminal failure is counted.
 
 !!! note "`:data` merges"
 
@@ -147,24 +196,24 @@ locking out — so the terminal failure is counted, not discarded.
     Details: [The model → effect map](concepts.md#the-effect-map-data-fx).
 
 ```clojure
-(rf/dispatch [:auth.login/flow [:auth.login/failure {:error {:message "nope"}}]])
+(rf/dispatch-sync [:auth.login/flow [:auth.login/failure {:error {:message "nope"}}]])
 @(rf/subscribe [:rf/machine :auth.login/flow])
 ;; => {:state :error-shown :data {:attempts 1 :error "nope"}}
 ```
 
 ## Step 4 — talk to a real server
 
-Add an **`:entry`** action on `:submitting` that fires [managed HTTP](../async/http.md),
-and an **`:after`** deadline if the server stalls. Tag the state so views can ask
-"busy?" without naming it. Managed HTTP is its own artefact — require
-`[re-frame.http.managed]` at boot (it registers `:rf.http/managed`), or the effect
-resolves to `:rf.error/no-such-fx`:
+The machine should issue the login request when it enters `:submitting`. Put that work in an `:entry` action, arm an `:after` deadline if the server stalls, and tag the state so a view can ask "busy?" without naming it.
+
+Managed HTTP is its own artefact. Require `[re-frame.http.managed]` at boot (it registers `:rf.http/managed`), or the effect resolves to `:rf.error/no-such-fx`.
 
 ```clojure
 :issue-request
 (fn [{[_ creds] :event}]
   {:fx [[:rf.http/managed
-         {:request    {:method :post :url "/api/login" :body creds
+         {:request    {:method :post
+                       :url    "/api/login"
+                       :body   creds
                        :request-content-type :json}
           :decode     :json
           :on-success [:auth.login/flow [:auth.login/success]]
@@ -172,7 +221,9 @@ resolves to `:rf.error/no-such-fx`:
 
 :record-timeout
 (fn [{data :data}]
-  {:data (-> data (update :attempts inc) (assoc :error "Server took too long."))})
+  {:data (-> data
+             (update :attempts inc)
+             (assoc  :error "Server took too long."))})
 
 :submitting
 {:tags  #{:auth/busy}
@@ -182,23 +233,30 @@ resolves to `:rf.error/no-such-fx`:
                 :action :record-timeout}
                {:target :locked-out
                 :action :record-timeout}]}
- :on    {…}}   ;; success / failure as in step 3
+ :on    {:auth.login/success {:target :authed :action :store-session}
+         :auth.login/failure [{:target :error-shown
+                               :guard  :under-retry-limit
+                               :action :record-error}
+                              {:target :locked-out
+                               :action :record-error}]}}
 ```
 
-`:on-success [:auth.login/flow [:auth.login/success]]` is written one element short
-on purpose — managed HTTP **appends** the [canonical reply envelope](../async/http.md)
-onto the inner event, so `:store-session` sees
-`[:auth.login/success {:status :ok :value {:token "…"} …}]`.
+`:entry :issue-request` runs when the machine enters `:submitting`. `:after` arms an 8-second timer and cancels it automatically when the state exits. If the server replies first, the machine leaves `:submitting` and the timeout becomes stale.
 
-`:after` arms on entry and cancels on exit. A stall counts as an attempt too: the
-timeout carries the **same guarded candidate list** as a rejected login (an `:after`
-value takes the same shape as an `:on` clause), so the third stall — or the third
-failure — records its error and locks out. Deeper timer grammar:
-[Automatic transitions](automatic-transitions.md).
+The timeout uses the **same guarded candidate list** as failure (an `:after` value takes the same shape as an `:on` clause), so the third stall — or the third failure — records its error and locks out.
 
-## Step 5 — render every state
+`:on-success [:auth.login/flow [:auth.login/success]]` is written one element short on purpose. The outer vector routes to the machine; the inner event is what the machine handles. Managed HTTP **appends** the reply envelope onto that inner event:
 
-Project the snapshot; ask **tags** for shared intent:
+```clojure
+[:auth.login/success {:status :ok    :value {:token "…"} …}]
+[:auth.login/failure {:status :error :error {:message "…"} …}]
+```
+
+So `:store-session` reads `:value` and `:record-error` reads `:error`. Deeper timer grammar: [Automatic transitions](automatic-transitions.md). Full HTTP: [Managed HTTP](../async/http.md).
+
+## Step 5 — render the states
+
+Project the snapshot. Ask **tags** for shared intent. The credential draft is ordinary app-db form state — read it through a plain sub, not out of the machine.
 
 ```clojure
 (rf/reg-sub :auth.login/state
@@ -209,11 +267,12 @@ Project the snapshot; ask **tags** for shared intent:
   :<- [:rf/machine :auth.login/flow]
   (fn [m _] (get-in m [:data :error])))
 
-;; The credential draft is ordinary app-db form state — read through a plain
-;; sub, never reached out of the view. The inputs that WRITE it are a form-slice
-;; concern; build one in [Build a form](../core/how-to/build-a-form.md).
 (rf/reg-sub :auth.login/draft
   (fn [db _] (get-in db [:auth :login-form :draft])))
+
+(rf/reg-event :login/submit
+  (fn [_ [_ credentials]]
+    {:fx [[:dispatch [:auth.login/flow [:auth.login/submit credentials]]]]}))
 
 (rf/reg-view login-view []
   (let [state @(subscribe [:auth.login/state])
@@ -221,26 +280,28 @@ Project the snapshot; ask **tags** for shared intent:
         draft @(subscribe [:auth.login/draft])
         busy? @(rf/subscribe [:rf.machine/has-tag? :auth.login/flow :auth/busy])]
     (case state
+      nil          [:button {:on-click #(dispatch [:login/submit draft])}
+                    "Sign in"]          ;; before the first machine event
       :idle        [:button {:disabled busy?
                              :on-click #(dispatch [:login/submit draft])}
                     "Sign in"]
       :submitting  [:p "Signing in…"]
-      :error-shown [:div [:p error]
+      :error-shown [:div
+                    [:p error]
                     [:button {:on-click #(dispatch [:auth.login/flow [:auth.login/dismiss]])}
                      "Try again"]]
       :authed      [:h1 "Welcome back"]
       :locked-out  [:h1 "Account locked"]
-      [:p "…"])))   ;; nil before first event
+      [:p "Unknown login state"])))
 ```
 
-Add another in-flight state later with the same `:auth/busy` tag and this view keeps
-working. Pattern: [Tags](tags.md).
+The busy decision asks for the `:auth/busy` tag, not "is state exactly `:submitting`?". Add another in-flight state later with the same tag and this view keeps working. Pattern: [Tags](tags.md). The inputs that write the draft are a form-slice concern — [Build a form](../core/how-to/build-a-form.md).
 
-## Step 6 — test a transition as a pure function
+## Step 6 — test the transition table
 
 <a id="step-6--test-it-a-transition-is-a-pure-function"></a>
 
-No frame, no browser, no network:
+A transition is a pure function of *(definition, snapshot, event)*. No browser, frame, router, HTTP client, or clock.
 
 ```clojure
 (ns app.login-test
@@ -253,7 +314,8 @@ No frame, no browser, no network:
   (let [r (machines/machine-transition
             login-flow
             {:state :idle :data {:attempts 0 :error nil}}
-            [:auth.login/submit {:email "a@b.com" :password "secret"}])]
+            [:auth.login/submit {:email "a@b.com"
+                                 :password "secret"}])]
     (is (result/ok? r))
     (is (= :submitting (:state (result/snap r))))
     (is (= :rf.http/managed (ffirst (result/fx r)))))   ;; :entry ran :issue-request
@@ -267,12 +329,11 @@ No frame, no browser, no network:
             [:auth.login/failure {:error {:message "bad creds"}}])]
     (is (result/ok? r))
     (is (= :locked-out (:state (result/snap r))))
-    ;; the terminal failure is still counted — attempts bumped, message stored
     (is (= 3 (get-in (result/snap r) [:data :attempts])))
     (is (= "bad creds" (get-in (result/snap r) [:data :error])))))
 ```
 
-More on Result accessors and Xray: [Inspecting and testing](inspecting-machines.md).
+Discriminate with `result/ok?`. Read the next snapshot and the effects vector with `result/snap` and `result/fx`. More on Result accessors and Xray: [Inspecting and testing](inspecting-machines.md).
 
 ## The complete machine
 
@@ -283,6 +344,8 @@ Everything above in one registration — the form you copy into a real app:
   (:require [re-frame.core :as rf]
             [re-frame.machines]
             [re-frame.http.managed]))   ;; registers :rf.http/managed — the :issue-request fx
+
+;; cf. examples/capabilities/machines/state_machine_walkthrough
 
 (rf/defmachine login-flow
   {:initial :idle
@@ -363,6 +426,4 @@ Everything above in one registration — the form you copy into a real app:
     {:fx [[:dispatch [:auth.login/flow [:auth.login/submit credentials]]]]}))
 ```
 
-When a flat table is no longer enough — nested checkout under auth, parallel form
-axes, spawned workers — open [The model](concepts.md) for vocabulary, then the
-matching growth page (hierarchy, parallel, actors, …).
+When a flat table is no longer enough — nested checkout under auth, parallel form axes, spawned workers — open [The model](concepts.md) for vocabulary, then the matching growth page.


### PR DESCRIPTION
Replace the published `docs/machines` corpus with a shorter, tutorial-first rewrite of the `ai/findings/machines` draft.

The draft voice and one-job pages stay. The rewrite teaches what ships: `@(rf/subscribe [:rf/machine id])` and `@(rf/subscribe [:rf.machine/has-tag? id tag])`, `defmachine` + `reg-machine`, the managed-HTTP reply envelope, and a three-attempt lockout (guard sees pre-action `:attempts`, `(< n 2)`). The login tutorial ends with a complete, copy-pasteable machine and a view that actually dispatches. Index is a home page (prerequisites + when-not table), not a syllabus.

Inbound anchors from the published pages are kept (explicit ids or matching heading slugs), including `#register-and-drive`, `#final-states`, glossary `#machine` / `#snapshot` / `#state-tag`, and the tutorial step ids.

## Quality gates

Worktree: `C:\Users\miket\code\re-frame2-worktrees\machines-guide-rewrite`.

| Gate | Captured exit | How |
| --- | --- | --- |
| `scripts/check_doc_slugs.py --repo-root <worktree>` | **0** | Redirected to `gate-docslugs-machines-guide-rewrite.log` / `.exit` |
| `mkdocs build --strict` | **0** | Redirected to `gate-mkdocs-machines-guide-rewrite.log` / `.exit` |

`mkdocs build --strict` does not cover `docs/design/**`; this PR does not touch that tree. Slug/anchor check covers the machines pages and inbound links from the rest of the corpus. Tables on the new pages were checked by hand for column counts. No implementation tests change — this is docs only.

rf2-9d0d