### PR TITLE
rf2-hic-052: the modal trap's last inch — Tab wraps last-to-first, not through <body>

### DIFF
--- a/implementation/hicasso/src/re_frame/hicasso/impl/overlay.cljs
+++ b/implementation/hicasso/src/re_frame/hicasso/impl/overlay.cljs
@@ -48,6 +48,23 @@
   platform's door on the way out rather than letting React drop it. That
   one line is the whole of \"focus restore\".
 
+  ## The one keyboard handler, and why the modal alone carries it
+
+  `showModal` makes the rest of the document inert, so the engine owns
+  everything about the trap except its last inch: the wrap off the
+  panel's final control goes through the document's own end-of-scope
+  step, parking focus on `<body>` — nowhere — for one press. The modal
+  therefore renders one `onKeyDown` prop that closes those two edges and
+  nothing else; see [[wrap-tab!]] for the measurement. The popover
+  renders none, because a popover is deliberately not a trap.
+
+  It costs no idle listener: `keydown` bubbles, so React delegates it at
+  the root it already owns rather than attaching anything to the element,
+  and `:open?` false renders no element to hold a prop in the first
+  place. It also means `:on-key-down` written on the modal ELEMENT is the
+  module's, the way `:on-cancel` there already is — an author's key
+  handling belongs on the controls inside, where this one yields to it.
+
   ## Why the open flag can never acquire a second owner
 
   `:open?` false renders nil, so a closed overlay has no element at all.
@@ -181,6 +198,91 @@
   nil)
 
 ;; ---------------------------------------------------------------------------
+;; The trap's last inch — Tab at the modal's two edges
+;; ---------------------------------------------------------------------------
+;;
+;; THE ONE THING THE ENGINE'S OWN TRAP DOES NOT DO, measured rather than
+;; assumed. `showModal` makes the rest of the document inert, so Tab
+;; cannot reach a control behind the panel — that half is the engine's
+;; and this module adds nothing to it. But the WRAP off the panel's last
+;; control goes through the document's own end-of-scope step, and for one
+;; press `document.activeElement` is `<body>`: focus rests nowhere, the
+;; focus ring vanishes, and in a browser with UI that step is the browser
+;; UI rather than the page. Pressed in this repo's Chromium, headless and
+;; headed alike, over a three-control modal starting at the first:
+;;
+;;     Tab       → reason, cancel, BODY, confirm, reason …
+;;     Shift+Tab → BODY, cancel, reason, confirm …
+;;
+;; Four stops for three controls, and headed Chromium does not even do it
+;; consistently — the second backward lap dropped the waypoint. A modal
+;; is bought for "focus cannot Tab outside it", which the guide promises
+;; and rf2-hic-052 owns, so the two edges are closed here.
+;;
+;; This is a WRAP AT TWO EDGES and not a focus manager. It computes no
+;; order, tracks no state, and does not run for any key but Tab: between
+;; the edges the engine moves focus exactly as it always did.
+
+(def ^:private tab-stop-selector
+  "Everything the engine could make a tab stop of, as a selector.
+
+  A superset on purpose. It is filtered down by [[tab-stop?]] asking the
+  properties the engine itself decides tabbability by, and the two are
+  used only to recognise the panel's FIRST and LAST stop. A candidate
+  this misses therefore costs a wrap that does not fire — the engine's
+  own conduct, unchanged — and never a wrap that fires at the wrong
+  place, because the set can only be too large."
+  (str "a[href],area[href],button,input,select,textarea,summary,"
+       "iframe,object,embed,audio[controls],video[controls],"
+       "[contenteditable],[tabindex]"))
+
+(defn- tab-stop?
+  "Would Tab stop here? Disabled elements take no focus, a negative
+  `tabIndex` is reachable only programmatically, and an element with no
+  client rect is not rendered at all — `display:none`, `hidden`, or
+  inside a closed `<details>`."
+  [^js el]
+  (and (not (.-disabled el))
+       (not (neg? (.-tabIndex el)))
+       (pos? (.-length (.getClientRects el)))))
+
+(defn- tab-stops
+  "`panel`'s own tab stops, in document order."
+  [^js panel]
+  (filterv tab-stop? (array-seq (.querySelectorAll panel tab-stop-selector))))
+
+(defn- wrap-tab!
+  "Tab off the panel's last stop lands on its first; Shift+Tab off its
+  first lands on its last. Every other press falls through untouched.
+
+  **The engine confirms the landing before the default action is taken
+  away.** `HTMLElement.focus()` on an element that cannot be focused —
+  `visibility:hidden`, inert because a nested modal is open above it — is
+  a no-op that leaves `activeElement` where it was, so the move is
+  attempted first and `preventDefault` follows only if it took. A wrap
+  that could not land therefore degrades to exactly the engine's own
+  conduct rather than to a Tab that does nothing.
+
+  A press a control inside the panel has already claimed is left alone:
+  the native event's `defaultPrevented` is read rather than the synthetic
+  event's copy, which React takes at construction and which a child's
+  `preventDefault` during the same dispatch would not update."
+  [^js e]
+  (when (and (= "Tab" (.-key e))
+             (not (.. e -nativeEvent -defaultPrevented)))
+    (let [^js panel (.-currentTarget e)
+          stops     (tab-stops panel)]
+      (when (seq stops)
+        (let [back? (.-shiftKey e)
+              edge  (if back? (first stops) (peek stops))
+              land  (if back? (peek stops) (first stops))]
+          (when (identical? edge (.-target e))
+            (.focus land)
+            (when (identical? land (.. panel -ownerDocument -activeElement))
+              (.preventDefault e)))))))
+  nil)
+
+;; ---------------------------------------------------------------------------
 ;; The two platform doors
 ;; ---------------------------------------------------------------------------
 
@@ -194,7 +296,12 @@
    :event     :on-cancel
    ;; `cancel` fires only for a close request — never on the way in, and
    ;; never for a programmatic `close()` — so it needs no filter at all.
-   :closed-only? false})
+   :closed-only? false
+   ;; The modal's alone. A popover is deliberately NOT a trap — a filter
+   ;; menu a keyboard cannot tab out of is a defect — so it takes no
+   ;; keyboard handler at all and `overlay-focus-dom-cljs-test` holds that
+   ;; contrast.
+   :key-down  wrap-tab!})
 
 (def ^:private popover-ops
   {:tag       :div
@@ -289,7 +396,7 @@
       (seq style) (assoc :style style))))
 
 (defn- body
-  [{:keys [tag event closed-only?] :as ops} dismissal-attrs js-props]
+  [{:keys [tag event closed-only? key-down] :as ops} dismissal-attrs js-props]
   (let [props    (or (unchecked-get js-props "rfProps") {})
         ;; Hook 1 — the frame, classified through the shared reader so a
         ;; no-provider sentinel resolves to nil ("no scope") rather than
@@ -314,6 +421,9 @@
               extra    (cond-> (assoc (dismissal-attrs props)
                                       :ref   (unchecked-get cell "ref")
                                       event  (dismissal-handler dispatch (:on-dismiss props) closed-only?))
+                         (some? key-down)
+                         (assoc :on-key-down key-down)
+
                          (some? (:label props))
                          (assoc :aria-label (:label props))
 

--- a/implementation/hicasso/src/re_frame/hicasso/overlay.cljs
+++ b/implementation/hicasso/src/re_frame/hicasso/overlay.cljs
@@ -31,8 +31,9 @@
   IMPERATIVE CALL.**
 
   Every part of an overlay has an owner already. `<dialog>` owns modality
-  — the page behind it goes inert and focus cannot leave it, enforced by
-  the engine and not by a key handler. `popover` owns light dismiss and
+  — the page behind it goes inert, enforced by the engine and not by a
+  key handler, so no Tab can reach a control behind an open modal.
+  `popover` owns light dismiss and
   the auto stack. The top layer owns paint order, so no ancestor's
   `overflow`, `transform` or `z-index` can clip or out-stack an overlay
   and no z-index ladder is needed to try. CSS anchor positioning owns
@@ -54,6 +55,18 @@
   one of them is a failure mode the corpus actually shipped. This is not a
   floating-UI library and is not on its way to becoming one.
 
+  **The one exception is two presses wide, and it was measured rather
+  than assumed.** The engine's inertness is complete — no Tab reaches a
+  control behind an open modal — but its WRAP is not: off the panel's
+  last control, one Tab parks focus on `<body>`, which is `activeElement`
+  saying focus rests nowhere, and in a browser with UI is the browser's
+  own UI rather than the page. So `overlay/modal` renders a single
+  `onKeyDown` that sends Tab off the last stop to the first and Shift+Tab
+  off the first to the last, and does nothing on any other press. It is
+  not a focus-trap loop: it holds no state, computes no traversal, and
+  between those two edges the engine moves focus exactly as it always
+  did. `overlay/popover` has none of it, because a popover is not a trap.
+
   ## What follows from the posture, and is witnessed
 
   `re-frame.hicasso.overlay-dom-cljs-test` is the witness; each claim
@@ -74,7 +87,9 @@
   nothing to `window`, to `document` or to any ancestor — not while
   closed, not while open, not while the page scrolls under an anchored
   panel. Its listeners are the ones React attaches to the overlay element
-  itself for `cancel` / `toggle`, and they leave with the node.
+  itself for `cancel` / `toggle`, and they leave with the node. The
+  modal's Tab wrap adds none of its own: `keydown` bubbles, so React
+  delegates it at the root it already owns.
 
   **Anchor tracking is priced at zero because it is not work.**
   `:placement` becomes a CSS `position-area` against an anchor named on
@@ -132,7 +147,11 @@
   Every other key is an ordinary attribute and reaches the element
   unrenamed, so `:class`, `:style`, `:role`, `:id`, `:data-*` and the
   platform's own event attributes all work exactly as they do at a native
-  tag.
+  tag — with the two the module answers on: `:on-cancel` on a modal and
+  `:on-before-toggle` on a popover are how dismissal is routed, and
+  `:on-key-down` on a MODAL is its Tab wrap. Key handling belongs on the
+  controls inside anyway, and the wrap yields to a press one of them has
+  already claimed with `preventDefault`.
 
   ## Two things this bead deliberately did not do
 
@@ -187,8 +206,11 @@
   A legal hiccup head, marked the same way a `defview` product is. `:open?`
   false renders nothing at all.
 
-  Modality is the engine's: the rest of the document is inert, focus
-  cannot leave the dialog, and `::backdrop` is a real CSS selector. Escape
+  Modality is the engine's: the rest of the document is inert and
+  `::backdrop` is a real CSS selector. Focus cannot Tab out of the dialog
+  — inertness is what stops it reaching the page, and the module's own
+  two-edge wrap is what makes the last control Tab straight back to the
+  first rather than through `<body>`. Escape
   dispatches `:on-dismiss`; a backdrop click does so only with
   `:light-dismiss? true`, because a destructive confirmation must not go
   away on a stray click. Without `:on-dismiss` the dialog honours no close

--- a/implementation/hicasso/test/re_frame/hicasso/overlay_focus_dom_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/overlay_focus_dom_cljs_test.cljs
@@ -24,7 +24,7 @@
   | a real `<dialog>` traps focus when it is MODAL, and does not when it is merely shown | [[the-instrument-tells-a-trap-from-its-absence]] |
   | the module's modal is the trapping kind: the reachable set becomes EXACTLY the panel's controls | [[an-open-modal-is-the-whole-of-what-a-keyboard-can-reach]] |
   | the module's popover is NOT a trap, and must not be read as one | [[an-open-popover-leaves-the-page-behind-it-reachable]] |
-  | a REAL Tab cycles inside the trap, and a REAL Escape lets the page back out | [[a-real-tab-cycles-within-the-modal-and-a-real-escape-gives-the-page-back]] |
+  | a REAL Tab and a REAL Shift+Tab cycle inside the trap, and a REAL Escape lets the page back out | [[a-real-tab-cycles-within-the-modal-and-a-real-escape-gives-the-page-back]] |
 
   The middle claim is an emptiness claim about everything outside a
   dialog, and an emptiness claim is exactly the shape that passes
@@ -64,14 +64,19 @@
   `scripts/run-browser-tests.cjs`) and finds it CYCLING — off the last
   panel control back onto the first, never onto `before`, `trigger` or
   `after` — which is the property a modal is actually bought for and the
-  one an emptiness claim over `reachable` can only approximate. The same
-  row then presses a real Escape and gets the page back.
+  one an emptiness claim over `reachable` can only approximate. It
+  presses BOTH directions, because a wrap is two edges. The same row then
+  presses a real Escape and gets the page back.
 
-  It also found something no amount of asking would have: the wrap goes
-  through the DOCUMENT. `document.activeElement` reads `<body>` for one
-  step between the panel's last control and its first, so the cycle is
-  four stops for three controls. That is recorded on the row itself,
-  because it is the engine's conduct and not this module's.
+  It also found something no amount of asking would have, and rf2-hic-052
+  then fixed rather than blessed: left to itself the engine wraps through
+  the DOCUMENT, and `document.activeElement` reads `<body>` for one press
+  between the panel's last control and its first — focus resting nowhere,
+  which in a browser with UI is the browser's own UI. Inertness was never
+  in question; the WRAP was, and `impl.overlay/wrap-tab!` now closes both
+  edges. The row asserts the three-stop cycle, so it reddens the day that
+  handler stops working — and the version of it that recorded `<body>` as
+  a waypoint is what the audit of #8058 correctly refused to accept.
 
   `overlay-dom-cljs-test` holds the synthetic-versus-trusted comparison
   for Escape itself; this file does not re-litigate it.
@@ -347,52 +352,80 @@
                 (str "premise: on the panel's first control. Active: "
                      (label-of (active))))
 
-            ;; FIVE, so the sequence closes: four presses is a wrap, five is
-            ;; a CYCLE, and only the second rules out a one-off excursion
-            ;; that happened to come back.
+            ;; FIVE, so the sequence closes: three presses is a wrap, five
+            ;; is a CYCLE with its start repeated, and only the second
+            ;; rules out a one-off excursion that happened to come back.
             (trusted/walk!
               "Tab" 5
               (fn [] (some-> (active) label-of))
-              (fn [landings]
+              (fn [forward]
                 (try
-                  (is (= ["reason" "cancel" "body" "confirm" "reason"] landings)
-                      (str "THE CYCLE, AS THE ENGINE ACTUALLY PERFORMS IT. From "
-                           "the panel's first control, Tab runs to its last and "
-                           "then wraps back to its first — never to `before`, "
-                           "`trigger` or `after`, and the fifth press repeats "
-                           "the second, so this closes rather than merely "
-                           "returning once.\n"
-                           "  MEASURED, AND NOT WHAT WAS PREDICTED: the wrap "
-                           "goes through the DOCUMENT. Off the last control, "
-                           "`document.activeElement` is `<body>` for one step — "
-                           "the nothing-is-focused reading — and the step after "
-                           "re-enters the panel. So a modal's cycle is four "
-                           "stops for three controls. That waypoint is not a "
-                           "leak: `<body>` is not a control, it is what "
-                           "`activeElement` says when focus rests nowhere, and "
-                           "the next press proves the scope never widened. A "
-                           "row that had asserted the tidier "
-                           "`[reason cancel confirm]` would have been asserting "
-                           "a guess about the engine. Pressed: " (pr-str landings)))
-                  (is (empty? (filter #{"before" "trigger" "after"} landings))
+                  (is (= ["reason" "cancel" "confirm" "reason" "cancel"] forward)
+                      (str "THE CYCLE, FORWARD. From the panel's first "
+                           "control, Tab runs to its last and then lands "
+                           "DIRECTLY on its first — never on `before`, "
+                           "`trigger` or `after`, and never on `<body>`. "
+                           "Three controls, three stops, and the fourth "
+                           "press repeats the first, so this closes rather "
+                           "than merely returning once.\n"
+                           "  THE THIRD STOP IS THE WHOLE ROW. Left to "
+                           "itself the engine wraps through the document's "
+                           "end-of-scope step, and `document.activeElement` "
+                           "reads `<body>` there for one press — focus "
+                           "resting nowhere, which in a browser with UI is "
+                           "the browser's own UI rather than the page. That "
+                           "is what `impl.overlay/wrap-tab!` closes, and "
+                           "this row is what reddens if it stops. Pressed: "
+                           (pr-str forward)))
+                  (is (empty? (filter #{"before" "trigger" "after" "body"} forward))
                       (str "and not one landing was a control of the page "
-                           "behind — the leak a keyboard user tabs straight "
-                           "out of. Pressed: " (pr-str landings)))
+                           "behind, nor the nowhere between them. Pressed: "
+                           (pr-str forward)))
 
-                  (trusted/press-once!
-                    "Escape"
-                    (fn []
+                  ;; Back to the first control, so the backward lap is
+                  ;; measured from the edge Shift+Tab has to wrap AT rather
+                  ;; than from wherever the forward lap finished.
+                  (.focus ($ m "#confirm"))
+                  (is (= "confirm" (label-of (active)))
+                      "premise: back on the panel's first control")
+
+                  (trusted/walk!
+                    "Shift+Tab" 5
+                    (fn [] (some-> (active) label-of))
+                    (fn [backward]
                       (try
-                        (hm/settle! m)
-                        (testing "AND OUT: the platform's own dismissal, which
-                                  is the only exit a trap has. The panel goes,
-                                  and the page comes back exactly as
-                                  [[an-open-modal-is-the-whole-of-what-a-keyboard-can-reach]]
-                                  found it after a programmatic close"
-                          (is (nil? ($ m "dialog")))
-                          (is (= ["before" "trigger" "after"]
-                                 (reachable (:container m)))))
-                        (finally (finish)))))
+                        (is (= ["cancel" "reason" "confirm" "cancel" "reason"] backward)
+                            (str "THE CYCLE, BACKWARD, and it is a separate "
+                                 "claim: a wrap is two edges and the engine "
+                                 "parks focus on `<body>` at both of them. "
+                                 "Shift+Tab off the panel's FIRST control "
+                                 "lands directly on its last. Pressed: "
+                                 (pr-str backward)))
+                        (is (empty? (filter #{"before" "trigger" "after" "body"} backward))
+                            (str "and the backward lap leaves the panel no "
+                                 "more than the forward one does. Pressed: "
+                                 (pr-str backward)))
+
+                        (trusted/press-once!
+                          "Escape"
+                          (fn []
+                            (try
+                              (hm/settle! m)
+                              (testing "AND OUT: the platform's own dismissal,
+                                        which is the only exit a trap has — and
+                                        it still is, because the wrap answers
+                                        Tab and nothing else. The panel goes,
+                                        and the page comes back exactly as
+                                        [[an-open-modal-is-the-whole-of-what-a-keyboard-can-reach]]
+                                        found it after a programmatic close"
+                                (is (nil? ($ m "dialog")))
+                                (is (= ["before" "trigger" "after"]
+                                       (reachable (:container m)))))
+                              (finally (finish)))))
+                        (catch :default e
+                          (is false (str "the backward cycle assertion threw: "
+                                         (.-message e)))
+                          (finish)))))
                   (catch :default e
                     (is false (str "the cycle assertion threw: " (.-message e)))
                     (finish)))))
@@ -436,3 +469,44 @@
         (is (= ["before" "trigger" "after"] (reachable (:container m))))
 
         (finally (hm/unmount! m))))))
+
+(deftest a-real-tab-leaves-an-open-popover
+  ;; THE FENCE ON THE MODAL'S WRAP, and the row above cannot stand in for
+  ;; it. `reachable` asks each element whether it would take focus, and
+  ;; `impl.overlay/wrap-tab!` changes no element's focusability whatever —
+  ;; it changes where Tab GOES at one edge. So a wrap that had been wired
+  ;; into the popover as well as the modal would leave every assertion in
+  ;; this file green except this one, which presses a real Tab off the
+  ;; panel's last control and requires it to land on the page behind.
+  ;;
+  ;; That is not a defect being tolerated: a filter menu a keyboard user
+  ;; cannot tab out of is the defect, and the module withholds the handler
+  ;; from the popover for exactly that reason.
+  (if-not (browser?)
+    (skip! ":node-test has no popover, and no engine to press a key at")
+    (if-not (trusted/bridge?)
+      (trusted/unwitnessed! "a popover's deliberate lack of a trap")
+      (async done
+        (let [m      (hm/mount! [a-page-with-a-popover {}])
+              finish (fn [] (hm/unmount! m) (done))]
+          (try
+            (open! m)
+            (.focus ($ m "#cancel"))
+            (is (= "cancel" (label-of (active)))
+                (str "premise: on the panel's last control. Active: "
+                     (label-of (active))))
+
+            (trusted/press-once!
+              "Tab"
+              (fn []
+                (try
+                  (is (= "after" (label-of (active)))
+                      (str "A REAL TAB OFF THE PANEL'S LAST CONTROL LEAVES "
+                           "IT, and lands at the panel's own place in the "
+                           "DOM — `after`, the control the author wrote "
+                           "next. The modal's two-edge wrap is the modal's "
+                           "alone. Active: " (label-of (active))))
+                  (finally (finish)))))
+            (catch :default e
+              (is false (str "the popover row threw: " (.-message e)))
+              (finish))))))))


### PR DESCRIPTION
Reopens and closes `rf2-hic-052` on the merged-PR audit of #8058.

## 1. The audit was right, and the measurement holds

#8058 predicted `[reason cancel confirm reason]`, measured
`[reason cancel body confirm]`, and recorded what it measured. That instinct was
correct. What followed was not: the extra waypoint was written up as *"not a
leak"*, and a trap that lets focus reach `<body>` is not a trap.

**Verified at source before touching anything.** A standalone Playwright probe on
a bare page — three controls in a modal `<dialog>`, focus started on the first:

| arm | Tab ×7 | Shift+Tab ×7 |
|---|---|---|
| headless Chromium | `reason cancel` **`body`** `confirm reason cancel` **`body`** | **`body`** `cancel reason confirm` **`body`** `cancel reason` |
| **headed** Chromium | `reason cancel` **`body`** `confirm reason cancel` **`body`** | **`body`** `cancel reason confirm cancel reason confirm` |

Three things this settles:

1. **It is not a headless artefact.** Headed Chromium does it too, so it is the
   engine's real conduct and not the runner's.
2. **Both edges do it, not just the forward one.** Shift+Tab off the panel's
   *first* control parks on `<body>` in exactly the same way. #8058 only pressed
   forward, so this half was never seen.
3. **Headed Chromium is not even consistent about it** — the second backward lap
   dropped the waypoint. So the conduct a row asserts against is not stable, which
   is its own reason to stop asserting it.

And `<body>` here is not a harmless bookkeeping value. It is `activeElement`
saying *focus rests nowhere*: the focus ring vanishes, a screen reader announces
nothing, and in a browser that has UI that step is the browser's own UI rather
than the page. The draft guide promises *"focus cannot Tab outside it"*; the WAI
dialog pattern asks for last-to-first wrapping; this owner's deliverable is a
focus trap. **The witness was right to measure. The behaviour is what changed.**

## 2. The repair, and how small it is

`showModal` makes the rest of the document inert, so the engine already owns the
half that matters most — no Tab reaches a control behind an open modal, and this
diff adds nothing to that. What the engine does *not* own is the **wrap**, which
goes through the document's own end-of-scope step. So `overlay/modal` now renders
one `onKeyDown`:

```clojure
(when (identical? edge (.-target e))
  (.focus land)
  (when (identical? land (.. panel -ownerDocument -activeElement))
    (.preventDefault e)))
```

That is the whole mechanism. It holds no state, computes no traversal, and
returns immediately for every key that is not Tab — between the two edges the
engine moves focus exactly as it always did. It is a **wrap at two edges**, not
the general focus manager the audit warned against.

Three things in it are deliberate rather than incidental:

- **The engine confirms the landing before the default action is taken away.**
  `focus()` on an element that cannot be focused — `visibility:hidden`, or inert
  because a nested modal sits above it — is a no-op that leaves `activeElement`
  where it was, so `preventDefault` runs only once the move has *landed*. A wrap
  that could not land therefore degrades to precisely today's engine conduct, and
  can never degrade to a Tab that does nothing.
- **A press a control inside has already claimed is left alone.** The check reads
  the *native* event's `defaultPrevented`, not the synthetic event's copy, which
  React takes at construction and which a child's `preventDefault` during the same
  dispatch would not update.
- **The tab-stop set can only be too large.** It is used solely to recognise the
  panel's first and last stop, so a candidate the selector misses costs a wrap
  that does not fire — the status quo — and never a wrap that fires at the wrong
  place. Positive `tabindex` and radio-group semantics are the known residuals and
  are stated in the source rather than chased.

**The popover gets none of it**, and that is the point of the fence: a filter menu
a keyboard cannot tab out of is a defect. `:key-down` lives in `modal-ops` alone.

### Zero idle listeners is preserved, not merely claimed

`keydown` bubbles, so React delegates it at the root it already owns — no
`addEventListener` reaches the overlay element, and the census in
`overlay-dom-cljs-test` (`window`, `document`, `<html>`, `<body>`) is untouched.
`:open?` false still renders nil, so a closed modal has no element to hold a prop
in the first place. Native Escape, `closedby`, inertness and the platform's own
focus restoration are all unchanged: the handler answers Tab and nothing else,
and the row presses a real Escape afterwards to prove it.

**The trusted-input bridge is unmodified.** `git diff` touches no file under
`implementation/scripts/` and not
`hicasso/test/re_frame/hicasso/trusted_input_support.cljs`. It stays exactly as
#8058 built it and is the load-bearing witness here.

## 3. The witness

`a-real-tab-cycles-within-the-modal-and-a-real-escape-gives-the-page-back` now
asserts the three-stop cycle in **both** directions:

| lap | asserted |
|---|---|
| Tab ×5 from `#confirm` | `["reason" "cancel" "confirm" "reason" "cancel"]` |
| Shift+Tab ×5 from `#confirm` | `["cancel" "reason" "confirm" "cancel" "reason"]` |

plus, on each lap, that no landing was `before`, `trigger`, `after` **or `body`** —
the waypoint is now named in the forbidden set rather than in the expected one.
Then a real Escape, as before.

One row is added: **`a-real-tab-leaves-an-open-popover`**. It is the fence, and
nothing already in the file could stand in for it — `reachable` asks each element
whether it would take focus, and the wrap changes no element's focusability
whatever. A wrap wired into the popover as well as the modal would leave every
other assertion in this suite green. This row presses a real Tab off the popover's
last control and requires it to land on `after`, the page control behind.

## 4. The control: the corrected row against the old behaviour

The plant is the wiring, removed: `:key-down wrap-tab!` → `:key-down nil` in
`modal-ops`. Scoped to the module under test, and an assertion failure rather than
a crash, so no namespace after it can be truncated — confirmed by identical
test and assertion counts on both runs.

| step | `impl/overlay.cljs` sha256 | captured exit | what the run said |
|---|---|---|---|
| fix | `c81ece6db4b0b3d9` | **0** | `Ran 1474 tests containing 9154 assertions. 0 failures, 0 errors.` |
| plant (`:key-down nil`) | `040f58dc198ee24d` | **1** | `Ran 1474 tests containing 9154 assertions.` / `4 failures, 0 errors.` |
| restored | `c81ece6db4b0b3d9` | — | bytes identical to the pre-plant hash; `git status --porcelain` empty |

The plant reddens on **exactly the waypoint**, and reproduces #8058's own reading:

```
FAIL in (a-real-tab-cycles-within-the-modal-and-a-real-escape-gives-the-page-back)
expected: (= ["reason" "cancel" "confirm" "reason" "cancel"] forward)
  actual: (not (= [...] ["reason" "cancel" "body" "confirm" "reason"]))

expected: (= ["cancel" "reason" "confirm" "cancel" "reason"] backward)
  actual: (not (= [...] ["body" "cancel" "reason" "confirm" "body"]))
```

`1474` tests / `9154` assertions on both runs — the plant truncated nothing, and
the backward lap's `["body" … "body"]` is the second edge no previous row had
ever pressed.

The restore was verified by **hashing the bytes**, not by reading a diff.

## 5. Quality gates

Run from `implementation/` in
`C:\Users\miket\code\re-frame2-worktrees\trap-hic052`; every browser log's
`Serving …` line names that worktree's `out/browser-test` as its asset root.
Exit codes are the ones captured beside each log, **not** the harness's.

| gate | captured exit | result |
|---|---|---|
| `npm run test:browser` (fix) | **0** | `Ran 1474 tests containing 9154 assertions. 0 failures, 0 errors.` |
| `npm run test:browser` (plant, wrap unwired) | **1** | `4 failures, 0 errors.` — all four in the target row, same 1474/9154 |
| `npm run test:cljs` | **0** | `Ran 13815 tests containing 69868 assertions. 0 failures, 0 errors.` |

`npm run test:cljs` was needed: `overlay_focus_dom_cljs_test` also compiles under
`:node-test` (`cljs-test$` matches `-dom-cljs-test`), where the new popover row
degrades to the file's existing stated skip.

`npm run test:hicasso-hmr` **not run** — it binds `:dev-http` 8061 and another
worker owns that rig. This diff arms nothing in it.

**The harness's exit code disagreed with the captured one again, on the planted
run.** The harness reported the plant as *"completed (exit code 0)"* while the
`.exit` file beside the log held **1** — the failure mode the brief names, and the
one that would have read as "the witness doesn't bite" and inverted the
conclusion. The numbers quoted above are the captured ones throughout.

## 6. Two premises that did not hold, and one boundary observed

**The audit's own premise, half-right.** It said *"one Tab leaves the dialog and
makes `document.activeElement` be `<body>`"* and asked for both directions to be
fixed. Correct on both counts — but it inherited #8058's forward-only reading, and
Shift+Tab off the *first* control does the same thing. Fixing only the forward
edge would have satisfied the letter of the finding and left half the defect.

**#8058's "that is the engine's conduct rather than this module's"** was true and
not exculpatory. It *is* the engine's conduct; the module's job was to close it,
because the guide's promise and the module's own posture both claim it is closed.

**`rf2-umjv`'s ground, reported rather than absorbed.** That bead owns the focus
one-shot recipe, and the shipped door in
`implementation/hicasso/src/re_frame/hicasso/overlay.cljs` still teaches
`:autofocus true` under *"Focus: the one-shot, and the recipe"* and still uses it
in `overlay/modal`'s public example — which `rf2-umjv` measured to be wrong (the
hyphenated spelling becomes React's `autoFocus` too early; the unhyphenated one is
rejected outright; tree order is the only working recipe today). **Not touched
here.** Every edit to that file in this diff is about the trap: the posture
paragraph, the zero-idle-listeners paragraph, the modal's own docstring and the
attribute-ownership note.

**The draft guide needs no edit and got none** (three operator worktrees hold it).
Chapter 13's promise — *"focus cannot Tab outside it"* — was the thing that was
false; this diff makes it true. Its opening line about *"a custom focus trap"*
describes the hand-rolled overlay stack it argues against, and remains accurate:
there is still no portal, no document listener, no z-index policy and no
positioning engine here. **If a reviewer disagrees**, the two-edge wrap is worth
one sentence in that chapter, and it belongs to whoever holds the file.

## Files

- `implementation/hicasso/src/re_frame/hicasso/impl/overlay.cljs` — `wrap-tab!`,
  its tab-stop recognition, and `:key-down` in `modal-ops` only.
- `implementation/hicasso/src/re_frame/hicasso/overlay.cljs` — the posture, which
  claimed no key handler at all and now states the one exception and its width.
- `implementation/hicasso/test/re_frame/hicasso/overlay_focus_dom_cljs_test.cljs`
  — the corrected cycle row, both directions, plus the popover fence.

No hot-zone file was touched: no `spec/*`, no `shadow-cljs.edn`, no top-level
`deps.edn`, no workflow. Nothing under `.github/workflows/`,
`docs/the-mayor-method/`, `tools/xray/` or
`docs/design/hicasso/draft-guide/`.
