### PR TITLE
rf2-lbve: carry the per-attempt gate-artefact rule into AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -97,23 +97,46 @@ Never pipe a gate through `tail`, `head` or `grep` — a pipeline's exit status 
 its *last* command's, so a red runner reads green. Redirect to a file, capture
 the runner's own exit code, and quote that number in the PR body. **Every**
 artefact that produces — the log *and* the exit-code file — must land on an
-ignored path (`*.log`, `*.exit` and `*-exit.txt` all are) **and carry your
-worktree's name**:
+ignored path (`*.log`, `*.exit` and `*-exit.txt` all are) and carry **your
+worktree's name AND the number of the attempt that wrote it**:
 
 ```bash
-sh <WORKTREE_ROOT>/scripts/test-fast-pr.sh > gate-fastpr-<worktree>.log 2>&1; echo "$?" > gate-fastpr-<worktree>.exit
+sh <WORKTREE_ROOT>/scripts/test-fast-pr.sh > gate-fastpr-<worktree>-1.log 2>&1; echo "$?" > gate-fastpr-<worktree>-1.exit
 ```
 
-The suffix is not tidiness — a bare name fails the gate open. Concurrent
-workers share one scratchpad directory (its path carries the session id, not
-the worktree), so a peer silently overwrites a bare `gate-fastpr.exit`, and the
-loser then reads an exit code belonging to another worker's run: a `0` somebody
-else earned, quoted as its own green. Two of six workers in a single wave
-collided exactly that way. Confirm a scratch file is your own before believing
-it, and check that the run read *your* worktree — its `gate root:` line where
-the gate prints one, the negative control's red where it does not (the section
-above). That check, not this naming rule, is what caught both observed
-collisions.
+Bump that number on every re-run — `-2`, `-3` — and never write to one twice.
+
+**Neither half is tidiness; a name missing either fails the gate OPEN**, and the
+two close different mechanisms.
+
+*The worktree name stops a peer.* Concurrent workers share one scratchpad
+directory (its path carries the session id, not the worktree), so a peer
+silently overwrites a bare `gate-fastpr.exit`, and the loser then reads an exit
+code belonging to another worker's run: a `0` somebody else earned, quoted as
+its own green. Two of six workers in a single wave collided exactly that way on
+2026-08-12.
+
+*The attempt number stops you.* Both writers are the same worktree here, so the
+suffix cannot help: a process the harness could not kill goes on writing to an
+inherited descriptor after its replacement has started. The ten-minute cap kills
+the *shell*; what that shell spawned survives holding the `.log` the redirect
+had already opened, and writes at *its* offset while the restart writes from
+zero — so the artefact is spliced rather than cleanly clobbered, and the tell is
+a NUL hole in the log, or **two summary lines** where there should be one. The
+`.exit` is opened later, by the `echo "$?"` that runs only once the gate has
+returned, so a surviving *child* corrupts the log alone and leaves stale output
+paired with the replacement's exit code; a surviving *wrapper* can write the
+exit file as well. Measured twice independently on 2026-08-13 —
+`worker/trusted-il7b` left with `exit 0` beside 18 real failures, and
+`worker/tense-cluster` finding an orphaned `node out/node-test.js` still
+reporting from a run already killed. Expect this route more often than the peer
+collision, not less: foreground dies at ten minutes and the spine needs about
+twenty-five, so kill-and-restart is routine rather than exceptional.
+
+Confirm a scratch file is your own before believing it, and check that the run
+read *your* worktree — its `gate root:` line where the gate prints one, the
+negative control's red where it does not (the section above). That check, not
+this naming rule, is what caught both observed peer collisions.
 
 A single untracked leftover makes `git worktree remove` refuse the tree from
 then on, and nine worktrees accumulated exactly that way before anyone worked

--- a/scripts/test-fast-pr.sh
+++ b/scripts/test-fast-pr.sh
@@ -618,9 +618,15 @@ fi
 # in the same tree, and two live spines then share that tree.  Two kinds of
 # damage follow, both seen on real runs:
 #
-#   1. TWO WRITERS, ONE FILE.  AGENTS.md has every worker redirect this script
-#      to a FIXED path (`> gate-fastpr.log`), so the two runs interleave into
-#      it and produce NUL-riddled output in which no line can be trusted.
+#   1. TWO WRITERS, ONE FILE.  When both runs were observed, AGENTS.md had
+#      every worker redirect this script to a path fixed per tree, so the two
+#      interleaved into it and produced NUL-riddled output in which no line
+#      could be trusted.  AGENTS.md now names gate artefacts for the ATTEMPT as
+#      well as the worktree (`gate-fastpr-<worktree>-1.log`, bumped on each
+#      re-run), which sends the survivor's writes to a file nobody quotes.
+#      That NARROWS this damage; it does not remove the need for the reap.  The
+#      rule binds a worker who remembers to bump, the survivor keeps burning a
+#      tree's CPU either way, and damage 2 below is untouched by any naming.
 #   2. A SPURIOUS RED IN THE GATE'S OWN ENVIRONMENT CLASS.  The older run's
 #      `npm run test:cljs` unlinks out/node-test.js underneath the younger
 #      run's live per-namespace isolation sweep, which then fails with "the


### PR DESCRIPTION
Closes rf2-lbve (reopened by the merged-PR audit of #8064).

## The defect

#8064 fixed `docs/the-mayor-method/dispatch-prompt-template.md`, but the
authoritative worker rule lives in `AGENTS.md`, and there it was still
worktree-scoped. The fixed rule reached the page that RECORDS decisions while
the page that ISSUES them still taught the failure — a worker following the live
instructions reused exactly the paths #8064 says must never be reused.

Verified at source before editing, both claims held:

- `AGENTS.md:100-101` required only "**and carry your worktree's name**", and
  `:104` gave `gate-fastpr-<worktree>.log` / `.exit`. The whole mechanism
  narrative was the two-worker collision.
- `scripts/test-fast-pr.sh:621-623` independently called that AGENTS example a
  FIXED path and named it as the cause of the observed NUL-riddled interleaving.

## What changed

**`AGENTS.md`** — the rule now requires the worktree name **and** the attempt
number (`gate-fastpr-<worktree>-1.log` / `.exit`, bumped on each re-run), and
splits the rationale into the two mechanisms it actually closes:

- *The worktree name stops a peer* — the shared session scratchpad collision,
  two of six workers, 2026-08-12. Existing evidence kept.
- *The attempt number stops you* — a process the harness could not kill
  continuing to write to an inherited descriptor after its replacement has
  started. Both writers are the same worktree, so the suffix cannot help.
  Measured twice on 2026-08-13 (`worker/trusted-il7b`, `worker/tense-cluster`).

One mechanism detail is stated precisely rather than loosely, per the audit: the
redirect opens the `.log` before the gate runs, but `echo "$?"` opens the
`.exit` only once the gate returns. So a surviving **child** splices the log
alone and leaves stale output beside the replacement's exit code; a surviving
**wrapper** can write the exit file as well. The page does not claim the child
holds both descriptors.

**`scripts/test-fast-pr.sh`** — its comment needed to agree, and did not. It
asserted a live fact about AGENTS.md ("has every worker redirect this script to
a FIXED path (`> gate-fastpr.log`)") that was already stale before this PR and
is now doubly so. Reworded to historical, and to keep the reap justified on its
own terms: the naming rule binds only a worker who remembers to bump, the
survivor burns a tree's CPU either way, and damage 2 (the `out/node-test.js`
unlink) is untouched by any naming. Comment-only; `sh -n` clean.

## Sweep

`git grep` for `gate-fastpr` and the bare `-<worktree>` suffix across tracked
files (excluding the `.beads` export). Every hit disposed of:

| Carrier | Disposition |
| --- | --- |
| `AGENTS.md:104`, `:109` | **Fixed** — this PR. |
| `docs/the-mayor-method/dispatch-prompt-template.md:63-64, 299-304, 312` | **Stands** — correct as of #8064; out of fence, deliberately not touched. |
| `scripts/test-fast-pr.sh:622` | **Fixed** — comment made historical. |
| `.claude/commands/*` | **No hits** — they cite the section rather than duplicating it. Confirmed by the sweep, matching rf2-w5pj. |
| `gate-doc-arg` / `gate-doc-args` (`implementation/core/...`, `check-elision.cjs`) | **Stands** — unrelated CLJS macro for prod doc-elision; matched only as a substring. |
| `topology-layout-gate-cljs-test`, `*-prod-gate-lane-pin-test` | **Stands** — unrelated test namespaces. |

## Quality gates

Negative control: a broken anchor planted at `AGENTS.md:108`, a line this PR
adds. Every gate here is bannerless and reports repo-relative paths, so the red
itself is the only proof the gate read this worktree.

| Gate | Raw exit code |
| --- | --- |
| `python scripts/check_readme_links.py` (baseline) | `0` |
| `python scripts/check_readme_links.py` (**negative control planted**) | `1` — `BROKEN ANCHOR: AGENTS.md:108 -> #rf2-lbve-negative-control-no-such-heading` |
| `python scripts/check_readme_links.py` (post-restore) | `0` |
| `python scripts/check_readme_links.py` (post-rebase, pushed tree) | `0` |
| `python scripts/check_doc_slugs.py` | `0` |
| `bash scripts/_test_fixtures/test_fast_pr_docs_gate/run-self-test.sh` | `0` — 43/43 |
| `sh -n scripts/test-fast-pr.sh` | `0` |

All exit codes above are the ones captured in `.exit` files by `echo "$?"` on the
same command line as the gate, not the harness's.

Restore verified by hashing bytes, not by eye:
`81778c656227abf54af98fa3e4b19aaf591f92baabe0abc6cfcb2b8f985324b2` before and
after, `sha256sum -c` exit `0`.

The spine self-test is not in the brief's gate list, but this diff touches
`scripts/test-fast-pr.sh`, which arms it in CI (`is_spine_self_path`) — so it
was run locally rather than left for CI to discover.

Diffed against `origin/main` before pushing: no concurrent rewrite of either
file (`git log HEAD..origin/main -- AGENTS.md scripts/test-fast-pr.sh` empty),
and the commit carries exactly two files, no `.beads`.
