### PR TITLE
fix(ci): scope the Playwright install verdict to what the handler can know (rf2-swos)

### DIFF
--- a/.github/scripts/playwright-install-failed.sh
+++ b/.github/scripts/playwright-install-failed.sh
@@ -19,8 +19,8 @@
 # site: on failure the step now says, on the checks page, that no gate ran.
 #
 # "No gate ran" is the whole of the claim. It is deliberately NOT "not this
-# diff" — see the next section, which is the correction the merged-PR audit of
-# #8061 reopened this bead for.
+# diff" — see "What the annotation can support" below, which is the correction
+# the merged-PR audit of #8061 reopened this bead for.
 #
 # Every call site is one line:
 #

--- a/.github/scripts/playwright-install-failed.sh
+++ b/.github/scripts/playwright-install-failed.sh
@@ -18,6 +18,10 @@
 # CLI, clj-kondo and Babashka installs. This is the same remedy at the fourth
 # site: on failure the step now says, on the checks page, that no gate ran.
 #
+# "No gate ran" is the whole of the claim. It is deliberately NOT "not this
+# diff" — see the next section, which is the correction the merged-PR audit of
+# #8061 reopened this bead for.
+#
 # Every call site is one line:
 #
 #     - name: Install Playwright (Chromium + system deps)
@@ -38,6 +42,62 @@
 # `implementation/scripts/_changed-surfaces.test.cjs` and
 # `tools/template/test/day8/re_frame2_template/release_gate_test.clj` assert
 # on intact, so this change needs no edit outside `.github/`.
+#
+# # What the annotation can support — and why it no longer says "not this diff"
+#
+# The first cut of this file (#8061) titled EVERY nonzero exit "CI
+# infrastructure — not this diff" and said in the body that the red "says
+# nothing whatever about the diff". That is a claim about the diff, and this
+# script has no way to reach it. It knows three things and no more:
+#
+#   * the install exited nonzero — it is the `||` branch, so that is a given;
+#   * therefore the browser is absent, the gate step never started, and NO GATE
+#     RAN IN THIS JOB. True whatever the cause, and worth saying, because the
+#     bare `##[error]Process completed with exit code 1` at the rollup does not;
+#   * its own environment — the working directory it was invoked in, which is
+#     the one fact that tells the reader WHICH Playwright root failed.
+#
+# It cannot see the diff. It cannot even see the install's output: the call
+# site is `npx playwright install … || <this script>`, so the fetcher's stderr
+# goes to the job log and never to this process. A signature classifier of the
+# `resolve-clojure-deps.sh` kind is therefore not available here without
+# changing the call-site shape, and the shape is pinned by the gap-map coupling
+# described above.
+#
+# And the claim was not merely unsupported, it was wrong for a real class. A PR
+# can break this install itself: by editing the browser arguments on the `npx
+# playwright install` line, the step's `working-directory`, `env` or download
+# host, the runner image or `setup-node`/cache inputs, this script, or the
+# Playwright pin the job resolves. Under the old wording all of those reds
+# arrived titled "not this diff" — a confident wrong answer telling the author
+# to look away from the change that caused it. That is the same fault the
+# merged-PR audits of #7132 and #7221 found in `resolve-clojure-deps.sh`, whose
+# comment states the rule this file now follows: the bias is that a fault it
+# cannot classify degrades to "we do not know" rather than to "not your diff".
+#
+# So the title states only what is certain — the install failed, no gate ran —
+# and the body keeps every useful measured fact as CONDITIONAL guidance: first
+# the provisioning inputs a diff can reach, then the re-run remedy for the case
+# where the diff reaches none of them. The reader loses nothing; the annotation
+# stops deciding for them.
+#
+# # The two Playwright roots — the pin depends on which root the step ran in
+#
+# The old caveat named `implementation/package-lock.json` alone. There are two
+# roots, resolving different pins from different lockfiles, and `npx` resolves
+# whichever one the step's working directory sits in:
+#
+#   * `implementation` — `package.json` pins `playwright` to an exact `1.59.1`;
+#     19 of the 21 sites run here, each after an `npm ci` in the same root.
+#   * `docs/tools/playground` — `package.json` asks for `^1.60.0`, and its own
+#     `package-lock.json` resolves `1.60.0`; the two playground smokes run here
+#     (`docs.yml`'s post-merge `build` job and `test.yml`'s `tools-playground`).
+#
+# Different pins fetch different Chrome-for-Testing revisions, which is why
+# rf2-169n (#8065) keys the two browser caches on the two lockfiles separately.
+# The annotation therefore prints `$PWD` and names both locks, leaving the
+# reader one obvious step — match the directory to its lockfile — instead of a
+# caveat that is silently inapplicable in two of twenty-one jobs.
 #
 # # Why there is no retry loop here — the siblings have one and this does not
 #
@@ -92,11 +152,19 @@
 #     understands. There is no working alternative value, so the knob is not
 #     set.
 #
-# So this file ships the (c)-half of the sibling remedy and refuses the
-# (a)-half, on the evidence. If a transient 5xx or ECONNRESET is ever measured
-# at this site — as it was at the other three on 2026-08-13 — Playwright's own
-# five attempts are the thing to widen, and an outer loop belongs here then,
-# sized under the tightest `timeout-minutes` of its call sites.
+# So this file ships the (c)-half of the sibling remedy — an explicit
+# annotation and a non-zero exit, rather than falling through to a later
+# "command not found" — and refuses the (a)-half, the widened retry envelope,
+# on the evidence. It parts company with the siblings on one point only: their
+# annotations classify the failure as infrastructure in the title, which they
+# can nearly support because the only diff-reachable input at those three sites
+# is a constant URL in the very file the caveat names. This site has a dozen
+# such inputs across two roots, so the title classifies nothing.
+#
+# If a transient 5xx or ECONNRESET is ever measured at this site — as it was at
+# the other three on 2026-08-13 — Playwright's own five attempts are the thing
+# to widen, and an outer loop belongs here then, sized under the tightest
+# `timeout-minutes` of its call sites.
 #
 # Exit status stays a plain 1, as in `install-clojure-cli.sh` and
 # `resolve-clojure-deps.sh`: the annotation is the machine-readable carrier
@@ -105,5 +173,5 @@
 #
 set -euo pipefail
 
-echo "::error title=Playwright browser install failed — CI infrastructure — not this diff::NO GATE RAN IN THIS JOB. This step provisions the browser, so the step that would have tested this change never started and this red says nothing whatever about the diff. Playwright already retries the download five times internally (playwright-core browserFetcher.js), so the remedy is a re-run, which lands on a different runner. Two modes have been measured (rf2-swos): a Google Cloud Storage 403 'this service is not available in your location' on the Chrome-for-Testing bucket that cdn.playwright.dev redirects to, which is scoped to this runner's egress IP; and a slow azure.archive.ubuntu.com apt hop under --with-deps. Neither is affected by anything in this PR UNLESS it changes the Playwright pin in implementation/package-lock.json or edits .github/scripts/playwright-install-failed.sh, in which case read those first."
+echo "::error title=Playwright browser install failed — no gate ran::npx playwright install exited nonzero in ${PWD}. This step provisions the browser, so the gate this job exists to run never started: the red reports PROVISIONING and carries no verdict on the code under test. WHICH KIND of failure it is depends on the diff, and this script cannot tell you — it is the || branch of the install and sees neither the diff nor the install's output. BEFORE RE-RUNNING, check whether this PR touches a provisioning input: the browser arguments on the npx playwright install line, the step's working-directory or env or download host, the runner image or setup-node or cache inputs, this script itself, or the Playwright pin in the lockfile of the root shown above — implementation/package-lock.json pins 1.59.1, docs/tools/playground/package-lock.json pins 1.60.0. If it touches any of them, read this step's raw log first: a diff-caused install failure lands here looking exactly like an outage. If it touches none of them, this is infrastructure and the remedy is a re-run, which lands on a different runner. Playwright already retries the download five times internally (playwright-core browserFetcher.js), and both modes measured under rf2-swos need a different runner rather than more attempts: a Google Cloud Storage 403 'this service is not available in your location' on the Chrome-for-Testing bucket that cdn.playwright.dev redirects to, scoped to this runner's egress IP; and a slow azure.archive.ubuntu.com apt hop under --with-deps."
 exit 1


### PR DESCRIPTION
Reopened by the merged-PR audit of #8061 — the PR that fixed rf2-swos. One file changes: `.github/scripts/playwright-install-failed.sh`. No workflow is touched.

## The defect

#8061 gave every nonzero `npx playwright install` the title **"CI infrastructure — not this diff"** and a body asserting the red *"says nothing whatever about the diff"*. That is a claim about the diff, and the handler has no way to reach it. It is the `||` branch of the install, so it sees neither the diff nor the fetcher's output.

It was not merely unsupported — it is wrong for a real class. A PR can break this install itself by editing the browser arguments on the `npx playwright install` line, the step's `working-directory`/`env`/download host, the runner image or `setup-node`/cache inputs, this script, or the Playwright pin. All of those arrived titled *not this diff*, telling the author to look away from the change that caused the red. The mayor recorded on the bead that they re-ran failed installs on the strength of that verdict.

The repo had already ruled on this class. `resolve-clojure-deps.sh` carries the finding from the merged-PR audits of #7132 and #7221 in its own header: an annotation that categorically declared *"INFRASTRUCTURE, not this diff"* was "a lie for the failures a diff owns", and "the bias is that an unrecognised transient fault degrades to *we do not know* rather than to *not your diff*". This PR applies that existing rule at the fourth site; it does not invent a fifth style.

## The verdict, before and after

**Before** (title / body opening):

> `Playwright browser install failed — CI infrastructure — not this diff`
> NO GATE RAN IN THIS JOB. … **this red says nothing whatever about the diff.** … Neither is affected by anything in this PR UNLESS it changes the Playwright pin in `implementation/package-lock.json` or edits `.github/scripts/playwright-install-failed.sh`.

**After**:

> `Playwright browser install failed — no gate ran`
> `npx playwright install` exited nonzero in `${PWD}`. This step provisions the browser, so the gate this job exists to run never started: the red reports PROVISIONING and carries no verdict on the code under test. WHICH KIND of failure it is depends on the diff, and this script cannot tell you — it is the `||` branch of the install and sees neither the diff nor the install's output. **BEFORE RE-RUNNING, check whether this PR touches a provisioning input:** the browser arguments on the `npx playwright install` line, the step's working-directory or env or download host, the runner image or setup-node or cache inputs, this script itself, or the Playwright pin in the lockfile of the root shown above — `implementation/package-lock.json` pins 1.59.1, `docs/tools/playground/package-lock.json` pins 1.60.0. If it touches any of them, read this step's raw log first: a diff-caused install failure lands here looking exactly like an outage. If it touches none of them, this is infrastructure and the remedy is a re-run … [measured modes and the internal-retry fact retained verbatim].

### Why the new form is one the handler CAN support

Each clause maps to something the process actually holds:

| Claim in the new message | What supports it |
| --- | --- |
| "the install exited nonzero" | it is the `\|\|` branch — a given |
| "no gate ran in this job" | the browser is absent, so the gate step never started. True whatever the cause, and it is the fact the bare `##[error]Process completed with exit code 1` withholds |
| "exited nonzero in `${PWD}`" | its own environment. This is the fact that identifies WHICH Playwright root failed |
| "this script cannot tell you which kind" | it sees neither diff nor install output — stated, not hidden |
| the provisioning-input checklist | a static property of the call sites, not a runtime inference |
| the infrastructure modes + re-run remedy | the two failures measured under rf2-swos, now behind an explicit "if it touches none of them" |

This is hedging with a decision procedure attached, not vagueness: the reader is given the exact list to check and a branch for each outcome. Nothing measured was dropped.

A signature classifier of the `resolve-clojure-deps.sh` kind is **not** available here and the header says so: the call site is `npx playwright install … || <script>`, so the fetcher's stderr goes to the job log and never to this process. Capturing it would mean changing the call-site shape, which is pinned by the gap-map coupling below.

## The second Playwright root — established at source

The old caveat named `implementation/package-lock.json` alone. There are two roots, and `npx` resolves whichever the step's working directory sits in. Enumerated from the workflow YAML rather than by grep:

| Root | `package.json` | lockfile resolves | sites |
| --- | --- | --- | --- |
| `implementation` | `"playwright": "1.59.1"` (exact) | 1.59.1 | **19** of 21 |
| `docs/tools/playground` | `"playwright": "^1.60.0"` (range) | 1.60.0 | **2** — `docs.yml` job `build` (post-merge playground smoke) and `test.yml` job `tools-playground` |

Both playground jobs run `npm ci` in that root before the install step, so `npx` genuinely resolves 1.60.0 there. Different pins fetch different Chrome-for-Testing revisions, which is why rf2-169n/#8065 keys the two browser caches on the two lockfiles separately — `docs.yml` already carries that in a comment. The annotation now prints `$PWD` and names both locks, so the reader matches directory to lockfile instead of being handed a caveat that is silently inapplicable in two of twenty-one jobs.

## Quality gates

Exit codes below are the ones captured in-shell (`echo $?` on the same command line), not the harness's.

| Gate | Command | Exit |
| --- | --- | --- |
| Failure-path proof (5 cases) | `bash proof-verdict-swos.sh` (scratchpad; see below) | 0 |
| Gap map — before | `python scripts/check_fast_pr_gap.py --list` | 0 (96) |
| Gap map — planted-fault discriminator | as above, with a bogus non-setup line planted | 0 (**97**) |
| Gap map — after | `python scripts/check_fast_pr_gap.py --list` | 0 (**96**, output byte-identical to before) |
| Gate scheduling | `python scripts/check_gate_scheduling.py` | 0 |
| Workflow shape vs `origin/main` | PyYAML compare of job id / `name:` / `needs:` / `if:` / `runs-on` / `strategy` / every step name, 13 files | 0 — **0 drifted** |
| YAML validity | `yaml.safe_load` over `.github/workflows/*.yml` | 0 — 13 parsed |
| shellcheck (CI roster verbatim) | `git ls-files '.github/scripts/*.sh' \| xargs shellcheck` (0.11.0) | 0 |
| `bash -n` on the handler | `bash -n .github/scripts/playwright-install-failed.sh` | 0 |

### Failure-path evidence, and its non-vacuity

`npx` was shimmed on a sanitised `PATH` (`env -i`) and the CI step's command was run **verbatim** —
`npx playwright install --with-deps chromium || "$GITHUB_WORKSPACE/.github/scripts/playwright-install-failed.sh"` — against the OLD handler (`git show HEAD:…`, i.e. the form #8061 merged) and the NEW one, under two fault regimes.

**Non-vacuity, asserted before believing anything** (#8030's first control ran an empty file and "passed"):

- both handler bodies sized and pattern-checked: old **7090 bytes**, new **11876 bytes**, each containing an `echo "::error title=Playwright browser install failed…` line — else `exit 90/91`;
- the shim must resolve on the sanitised PATH — else `exit 92`;
- the shim must actually emit the measured 403 body when probed — else `exit 93`;
- any case whose stderr contains `command not found` aborts the run — else `exit 94`.

That last guard earned its keep: the **first** run of this proof was vacuous. On Git Bash a `C:/…` element inside a `:`-separated `PATH` splits at the drive colon, the shim never resolved, and all four cases failed identically with `npx: command not found` — the handler ran, but no fault regime was ever simulated, so the negative control proved nothing. Re-run with `cygpath -u` PATH entries; the log then shows each regime's distinct stderr.

**Results** (raw exit code 1 in every case — the handler's plain `exit 1`, unchanged):

| Case | stderr from the shimmed install | Handler | Says "not this diff" | Title says "no gate ran" | Names both locks |
| --- | --- | --- | --- | --- | --- |
| **Positive control** — outage (403 `service is not available in your location`) | GCS AccessDenied | old (#8061) | **YES** | no | no |
| Positive control — same outage | GCS AccessDenied | new | no | YES | YES |
| **Negative control** — diff-caused: `Unknown browser 'chormium'` | Playwright arg error | old (#8061) | **YES** ← the defect | no | no |
| Negative control — same | Playwright arg error | new | **no** | YES | YES |
| Second root — outage under `docs/tools/playground` | GCS AccessDenied | new | no | YES | YES, and prints `…/playground` as the root |

Row 3 is the reopen, reproduced hermetically: a failure a PR owns outright, labelled *CI infrastructure — not this diff*. Row 4 is the negative control the bead asked for.

### Gap-map coupling — measured, with a discriminator

`scripts/check_fast_pr_gap.py` classifies a step as toolchain setup only when **every** logical line matches `SETUP_PATTERNS`, and the pattern covering these steps is `^npx playwright install\b`. Adding a line to one of these setup steps turns its job into an unrun gate.

- **before:** `REQUIRED CHECKS THIS SPINE DOES NOT RUN (96)`
- **discriminator:** a bogus second command line (`echo PLANTED-FAULT-DISCRIMINATOR`) added to `test.yml`'s `cljs-browser` install step → **(97)**, with the newly-reported step named in the diff. The gate reads this worktree.
- **after** (planted fault removed, restore verified by hashing bytes — `md5 82f4b762fb62792f6cc25448dbcf2330` identical before and after, not by reading `git diff`): **(96)**, and the whole 373-line `--list` output is byte-identical to the "before" capture.

This change adds no line to any step: the annotation lives entirely inside the already-invoked script, and no call site moves. The 21 sites are untouched, so the literals that `implementation/scripts/_changed-surfaces.test.cjs` and `tools/template/test/…/release_gate_test.clj` assert on are untouched too.

### Shape comparison

A renamed required check silently un-requires the old one, so the 13 workflows were compared structurally against `origin/main`, not by `--stat`: job ids, job `name:`, `needs:`, `if:`, `runs-on`, `strategy` and every step name. **Zero drift.** (The first run of that comparison reported 8 files drifted; it was a harness bug — `subprocess(text=True)` decoded `git show` with the Windows ANSI codepage, mojibaking every em-dash in a job name. Fixed to decode UTF-8 explicitly, then 0.)

## What was deliberately NOT done

- **No retry envelope.** #8061 refused an outer retry on measurement — a region-scoped GCS 403 that a different IP fixes and a `--with-deps` apt timeout under a 5-minute cap — and rf2-169n confirmed the cap is 6.1× the observed worst case across 183 samples. That refusal stands, unedited; the header's "why there is no retry loop here" section is preserved and only its opening sentence is extended to say where this file now parts company with the siblings.
- **No runtime diff inspection**, and no second classifier framework.
- **No edit to the sibling handlers** (`install-clojure-cli.sh` #8030, the clj-kondo/Babashka steps #8036, the cache steps #8065, the timeout comment #8067) — out of this lane. See the finding below.

## One finding outside this fence, not actioned here

`install-clojure-cli.sh:91` emits `::error title=Clojure CLI install failed — CI infrastructure, not this diff::…`. Per the workflow-command grammar, annotation properties are **comma-separated** `key=value` pairs and the toolkit escapes a literal comma in a value as `%2C`; a raw comma therefore terminates `title=` early, so the rendered title is expected to be `Clojure CLI install failed — CI infrastructure` with the rest dropped. The three other sites use em-dashes and are unaffected, and the new Playwright title contains no comma. This is reasoned from the grammar, **not measured on a live runner**, and the file is outside this PR's lane — filed for triage rather than fixed here.
