### PR TITLE
records cluster: annotation title comma, budgets.md prose owners, kernel row 2 close-out (rf2-h082, rf2-adda, rf2-5gb6)

### DIFF
--- a/.github/scripts/install-clojure-cli.sh
+++ b/.github/scripts/install-clojure-cli.sh
@@ -88,7 +88,7 @@ while [ "$attempt" -lt "$attempts" ]; do
     https://github.com/clojure/brew-install/releases/latest/download/linux-install.sh \
     && sudo bash /tmp/linux-install.sh && break
   if [ "$attempt" -ge "$attempts" ]; then
-    echo "::error title=Clojure CLI install failed — CI infrastructure, not this diff::Downloading and running the official Clojure CLI installer failed ${attempts} times over roughly seven minutes. NO GATE RAN IN THIS JOB: this step provisions the toolchain, so the step that would have tested this change never started, and this red says nothing whatever about the diff. The usual cause is a github.com 5xx storm on the release download (four PRs on 2026-08-13, rf2-xsfr); the URL fetched is a fixed constant in .github/scripts/install-clojure-cli.sh, so no change can affect it UNLESS this PR edits that file, in which case read it first. Otherwise re-run the job."
+    echo "::error title=Clojure CLI install failed — CI infrastructure — not this diff::Downloading and running the official Clojure CLI installer failed ${attempts} times over roughly seven minutes. NO GATE RAN IN THIS JOB: this step provisions the toolchain, so the step that would have tested this change never started, and this red says nothing whatever about the diff. The usual cause is a github.com 5xx storm on the release download (four PRs on 2026-08-13, rf2-xsfr); the URL fetched is a fixed constant in .github/scripts/install-clojure-cli.sh, so no change can affect it UNLESS this PR edits that file, in which case read it first. Otherwise re-run the job."
     exit 1
   fi
   delay=$((attempt * 20 + RANDOM % 10))

--- a/docs/design/hicasso/product/budgets.md
+++ b/docs/design/hicasso/product/budgets.md
@@ -366,7 +366,7 @@ disagreed about, so a remediation landing there would have been decided by a
 coin-flip. It no longer can be.
 
 **The breach is a property of the design, not of the prototype.** That is the
-substantive finding the package re-pin adds, and it is `rf2-hic-018`'s to
+substantive finding the package re-pin adds, and it is `rf2-0xx2`'s to
 disposition.
 
 ### The record: why the freeze was needed
@@ -420,9 +420,9 @@ decision is the operator's.
 ### The breach is carried, never normalised
 
 The current breach stands at **R=0 = 1,100 B / 1,095 B on the package**, against
-the frozen `1,024 B` line. It is a **live pressure owned by `rf2-hic-018`**, not
-a disposition this page may make — that disposition has since been taken, and it
-is [the substrate decision record](substrate-decision.md#52-the-read-free-boundary-shell--the-disposition)'s:
+the frozen `1,024 B` line. It is a **live pressure owned by `rf2-0xx2`**, not a
+disposition this page may make — the substrate arm's disposition has since been
+taken, and it is [the substrate decision record](substrate-decision.md#52-the-read-free-boundary-shell--the-disposition)'s:
 the substrate arm is refused on the evidence, the breach is carried red, and the
 line is not re-registered. The row here is never silently normalised into a
 percentage allowance — §6 says in terms that a relative regression allowance
@@ -556,7 +556,7 @@ and no figure may be scaled from one onto the other.
 |---|---|
 | Deterministic rows D1–D16 | ordinary blocking PR gates; framework in `rf2-hic-089`, full gates in `rf2-hic-071` |
 | Distributional rows S1–S7, U1–U4 | pinned interleaved evidence runs on P-DEV-1; never converted into flaky PR thresholds |
-| Shell breach disposition | `rf2-hic-018` |
+| Shell breach disposition | `rf2-0xx2` |
 | K3 per-read record | `rf2-hic-070` — [`k3-disposition.md`](k3-disposition.md), whose §8 makes the 10% same-witness per-read rule executable for `rf2-hic-071` |
 
 Row by row, with each verdict beside its line, that table is
@@ -792,8 +792,9 @@ points here, and here is what each is waiting on.
 - **`C5` and `C6` are rules whose readings have been dispositioned, and the
   rules have not.** `C5` is the shell rule; its evidence is `S1` and `S2`,
   carried red by the substrate decision's §5.2. `C6` is the per-read rule; its
-  evidence is `S3` and `S4`, and that page's §6 leaves the `S3` move open to
-  `rf2-hic-070`. Neither section adjudicates the *rule*, only the readings
+  evidence is `S3` and `S4`, and that page's §6 has since attributed the `S3`
+  move — `[SETTLED 2026-08-13, rf2-l50z]` — without moving the reading.
+  Neither section adjudicates the *rule*, only the readings
   under it, so the two rows point here rather than borrowing a disposition
   that was not made about them. `C5` is settled the day a shell arm lands
   under `1,024 B` on the package; `C6` the day the K3 record is taken.

--- a/docs/design/hicasso/product/checkpoint-1-kernel.md
+++ b/docs/design/hicasso/product/checkpoint-1-kernel.md
@@ -79,7 +79,7 @@ The verdict vocabulary:
 | # | Kernel risk | Witness set | §2 sabotage control | Row verdict |
 |---|---|---|---|---|
 | 1 | Frame reincarnation and cached operations | complete (`rf2-hic-013`) | executing — `reincarnation_routing`, `reincarnation_paint_dom` | WITNESSED |
-| 2 | Process-global ownership | complete (`rf2-hic-012`, `rf2-hic-017`) | executing — `public_root_lifecycle_dom` W3 | WITNESSED, record in flight |
+| 2 | Process-global ownership | complete (`rf2-hic-012`, `rf2-hic-017`) | executing — `public_root_lifecycle_dom` W3 | WITNESSED |
 | 3 | Speculative render leakage | complete (`rf2-hic-010`, `rf2-hic-014`) | executing — `kernel_commit_owns_cljs` residue-census control | WITNESSED |
 | 4 | Ambient-read extent | complete (`rf2-hic-011`) | executing — exact-refusal-map rows, both-ways witness | WITNESSED |
 | 5 | Controlled-input portability | complete for the synthetic tier (`rf2-hic-016`) | hand-run, **re-run by this checkpoint** | **ASSUMED IN PART** |
@@ -111,14 +111,24 @@ So the row is not a miss against the code and not a pass either. It is a scenari
 decided to assume. That decision is the operator's to make and this record does not reopen it — but six
 documents still describe the session as pending and owed, which is filed as `rf2-aubc`.
 
-### 2.2 Row 2's record is in flight
+### 2.2 Row 2's record has landed
 
 `rf2-hic-017`'s deliverable is the mutable-global sweep's justification — the page that answers "root-scope
-or justify every one". Its witnesses have landed and are green, but the ledger page itself
-(`product/globals.md`, nineteen owners, zero migrations) is on PR **#8066**, which was open at
-`d079143b91`. §1's "every kernel row maps to a landed witness" is therefore satisfied for row 2's *tests*
-and not yet for its *record*. No bead is filed: the PR is live and owned. **The next reader of this page
-re-checks that #8066 landed.**
+or justify every one". Its witnesses had landed and were green when this checkpoint ran, but the ledger
+page itself was still on PR **#8066**, open at `d079143b91`, which is why row 2 was read as *record in
+flight* rather than as witnessed outright.
+
+**#8066 merged as `a2c00417bb`, and the record it landed was then corrected by #8075 (`1f09c701e3`).** The
+merged-PR audit of #8066 found its census short by two: its four searches could not see a ClojureScript
+dynamic var, which is written by `binding` rather than by any mechanism they modelled.
+[`product/globals.md`](globals.md) therefore now publishes **twenty-one** mutable owners and **zero** that
+need migrating, re-derivable from **six** searches, and it carries the nineteen-to-twenty-one correction on
+its own face. §1's "every kernel row maps to a landed witness" is satisfied for row 2's *tests* and for its
+*record*, and the row's verdict above is **WITNESSED**.
+
+The nineteen-owner figure this checkpoint quoted is left named rather than quietly swapped for the current
+one. The reading was taken at a commit where the record did not exist at all, and a later reader is
+entitled to know which roster was in front of the checkpoint when it wrote the row.
 
 ## 3. What was re-run, and what it measures
 


### PR DESCRIPTION
Three small record-keeping beads on three isolated files, one commit each.

- `rf2-h082` — `.github/scripts/install-clojure-cli.sh`
- `rf2-adda` — `docs/design/hicasso/product/budgets.md`
- `rf2-5gb6` — `docs/design/hicasso/product/checkpoint-1-kernel.md`

---

## rf2-h082 — the annotation title, and how the claim was verified

The bead said in terms that its claim was reasoned from the workflow-command
grammar and **not measured on a live runner**, and asked for verification at
source before any edit. The claim holds. It was established by reading the
vendor's own parser and its own test, not by measuring a runner — and the
distinction is stated here rather than glossed.

**What was read.**

1. `actions/runner`, `src/Runner.Common/ActionCommand.cs`, `TryParseV2`. The
   properties segment is split on `','`, each pair on `'='` with `count: 2`, and
   only a pair of length 2 is kept:

   ```csharp
   foreach (string propertyStr in splitProperties)
   {
       string[] pair = propertyStr.Split(new[] { '=' }, count: 2,
           options: StringSplitOptions.RemoveEmptyEntries);
       if (pair.Length == 2)
       {
           command.Properties[pair[0]] = UnescapeProperty(pair[1]);
       }
   }
   ```

   So `title=… — CI infrastructure, not this diff` yields two segments; the
   second, `" not this diff"`, has no `=`, fails the length check and is dropped
   **silently**. There is no `return false`: the command still parses and the
   annotation still renders, with half its title missing. That is the worst of
   the available outcomes, because nothing reds and nothing is logged.

2. The runner's **own unit test** asserts the escaping rule.
   `src/Test/L0/Worker/ActionCommandL0.cs`, `CommandParserV2Test`, requires
   `%2C` for a comma to reach a property value:

   ```csharp
   message = "::do-something k1=;=%2C=%0D=%0A=]=%3A,::;-%0D-%0A-]-:-,";
   test.Properties.Add("k1", ";=,=\r=\n=]=:");
   ```

3. `actions/toolkit`, `packages/core/src/command.ts`, `escapeProperty` escapes
   `,` to `%2C` on every property value it emits — the producer side of the same
   rule.

4. In this repository, `.github/workflows/test.yml:5833` already states it for
   the Babashka sibling: *"The title carries no comma: `,` separates properties
   in GitHub's workflow-command grammar, so a comma inside one truncates the
   title."*

**What could not be measured, and why.** A rendered instance would beat all of
the above, and there is none to find. The annotation fires only after six
consecutive install failures, and #8030 — which introduced it — merged
2026-08-12 21:29Z. Every failed workflow run since (12 runs, all of them; their
failed jobs' annotations were fetched from the checks API) carries clj-kondo,
ESLint, JVM and browser-lane annotations and no Clojure-install one. The
annotation has never rendered, so there is nothing to read.

**The fix is the character class only.** The comma becomes an em-dash, which is
exactly what the three siblings already use, verbatim:

```
clj-kondo install failed — CI infrastructure — not this diff        lint.yml:330
Babashka install failed — CI infrastructure — not this diff         test.yml:5851
Playwright browser install failed — CI infrastructure — not this diff
                                       playwright-install-failed.sh:108
```

No other wording moves, and the *"— not this diff"* verdict is left standing in
all four titles. #8077 argues deliberately that it is nearly supported at these
sites and that restating it is a separate ruling; nothing here disturbs that.

### One premise that did not hold in full

The bead's SCOPE says *"Only this one site"*, having checked the three siblings
it names. There is a **fourth** site it does not mention, and it carries the same
defect:

```
.github/scripts/resolve-clojure-deps.sh:149
  ::error title=Dependency resolution failed — transport-level, cause not established::…
```

That title truncates at *"transport-level"*, and *"cause not established"* — the
half that tells the reader the classification is hedged — is dropped. It is
outside this PR's fence and is **not** touched here. Its sibling at `:138`
(*"— no transient transport signature"*) is clean.

---

## rf2-adda — four prose carriers, and the seven left alone

`rf2-ltmd` repaired the ledger's Authority column under a fence that read *"the
seven non-MET ledger rows, and nothing else on that page"*. Four present-tense
ownership claims in the prose survived that fence, naming beads that have since
closed. Confirmed against the tracker before editing: `rf2-hic-018` **CLOSED**,
`rf2-hic-070` **CLOSED**, `rf2-0xx2` **OPEN**, `rf2-hic-085` **OPEN**,
`rf2-l50z` **CLOSED**.

| Line | Carrier | Disposition |
|---|---|---|
| `:369` | *"it is `rf2-hic-018`'s to disposition"* | → `rf2-0xx2`. hic-018 is closed and its verdict 3 was precisely the refusal to take that disposition. The ledger's S1/S2/C5 rows already read `rf2-0xx2`; this is the same substitution in prose. |
| `:423` | *"a **live pressure owned by `rf2-hic-018`**"* | → `rf2-0xx2`, and the next clause now names **which** disposition was taken — the substrate arm's, by `substrate-decision.md` §5.2. The paragraph self-corrected two lines later, so it was muddled rather than wrong; the sentence a scanner lifts is now the right one. |
| `:559` | §7 routing table, *"Shell breach disposition \| `rf2-hic-018`"* | → `rf2-0xx2`. |
| `:795` | *"that page's §6 leaves the `S3` move open to `rf2-hic-070`"* | → §6 now reads `[SETTLED 2026-08-13, rf2-l50z]` for that move, and the attribution moved no figure. Verified by reading `substrate-decision.md` §6 directly. The bullet's conclusion is unchanged: neither section adjudicates the *rule*, only the readings under it. |

Only the two owners the bead established at source are used — `rf2-0xx2` for the
read-free shell disposition. No owner is invented. `rf2-hic-085` was not needed:
none of the four carriers is a cold-mount or per-read K1/K3 claim.

### The seven exclusions were honoured

`:20`, `:21`, `:259`, `:260`, `:328`, `:539`, `:560` record who **decided**
something or who owns test files. A past-tense record is not stale, and
over-sweeping this page is the failure mode the bead was written to prevent. All
seven are **byte-identical to `origin/main`** — verified by per-line SHA-256
rather than by eye:

```
20   IDENTICAL=True  sha=0f493be75442      328  IDENTICAL=True  sha=756e0ae58775
21   IDENTICAL=True  sha=960ddfee1f00      539  IDENTICAL=True  sha=9d424f53333a
259  IDENTICAL=True  sha=ebf5581058f4      560  IDENTICAL=True  sha=67d36d14936e
260  IDENTICAL=True  sha=31e9fd4b5575
```

The diff is four hunks — `369`, `423-425`, `559`, `795-797` — and touches no
other line.

**Constraint held.** No registered line, current value, status, population,
instrument or disposition link moves. No budget goes red-to-green; no threshold
widens. The ledger gate reads the same 38 rows before and after: *21 MET, 5
BREACH, 2 UNRESOLVED, 10 UNPINNED*.

`rf2-hyp4` (the stated dependency) is still open, and does not gate this: it
concerns `rf2-hic-085`'s scope, while `:559` takes `rf2-0xx2`.

One observation for whoever owns the next ruling, flagged rather than swept:
`:20`'s *Owner* cell still reads `rf2-hic-018` for *"The R=0 shell's breach — remediate,
or disposition it"*. The bead read that line and excluded it as a record of what
the page handed off when it was written. That exclusion is honoured here.

---

## rf2-5gb6 — row 2's record, read as it stands rather than as the checkpoint saw it

**Both PRs landed and both are ancestors of this branch's base**: #8066 as
`a2c00417bb` (2026-08-13 01:15Z), #8075 as `1f09c701e3` (02:15Z).

The bead's second closing condition expected *"the nineteen-owner census with its
four re-derivable searches"*. **That condition is superseded**, and reading
`globals.md` as it stands is what shows it: the merged-PR audit of #8066 found
the census short by two, because its four searches could not see a ClojureScript
dynamic var — written by `binding`, a fourth mutation mechanism none of them
modelled. The page now publishes **twenty-one** owners, **zero** needing
migration, from **six** searches, and carries the correction on its own face.

Because the record was materially changed after it merged, §2.2 **says so** —
the bead's fourth closing condition — rather than reporting a clean landing. It
also keeps the nineteen-owner figure the checkpoint quoted, named as the
pre-audit count, because the reading was taken at a commit where the record did
not exist and a later reader is entitled to know which roster was in front of it.

Row 2's verdict in the §2 table becomes **WITNESSED**. No other row, verdict,
gate table or correction-ledger entry is touched. **The kernel suites were not
re-run** — the witnesses were measured at `d079143b91` and this is a
record-keeping close-out, not a re-audit.

### The stale count

Checked, and it resolves. The file carried exactly one stale count — *"nineteen
owners, zero migrations"* — and it sat **inside §2.2**, at `:118`, so the rewrite
retires it. There is **no "sixteen" anywhere in the file**: `grep` for the word
returns nothing, and the only bare `16/19/21/26` digit runs on the page are the
two `#21-row-5-is-assumed-not-witnessed` anchor links. The sibling's flag was
half right — the nineteen was real, the sixteen was not.

Also flagged, not touched (outside the bead's fence, which is *"§2.2 and its
row-2 line in the §2 table, nothing else on the page"*): §8 `:300` reads *"It is
not a `pass` on row 2's record, which is on an open PR."* That is defensible on
the merits as well as on the fence — §8's closing sentence anchors the whole
section to *"the honest state of Checkpoint 1 on `main`@`d079143b91`"*, so it is
a record of what was true then, not a claim about now. Left standing.

The verdict-vocabulary bullet at `:75` still defines **WITNESSED, record in
flight** although no row now carries it. Deliberate: the new §2.2 explains that
this is the verdict the checkpoint gave row 2 and why, so the definition is still
load-bearing for reading the page.

---

## Quality gates

All exit codes below are the value captured on the same command line that ran the
gate, never the harness's report. No gate was piped through `tail`/`head`/`grep`.

| Gate | Scope | Exit |
|---|---|---|
| `bash -n .github/scripts/install-clojure-cli.sh` | rf2-h082 | **0** |
| `git ls-files '.github/scripts/*.sh' \| xargs shellcheck` (CI's own invocation, `portability.yml:106-116`; shellcheck 0.11.0 via `npx`) | rf2-h082 — 12-file roster, non-empty | **0** |
| `python scripts/check_doc_slugs.py` | rf2-adda + rf2-5gb6 | **0** |
| `python scripts/check_provenance_pins.py --changed-since origin/main --verbose` | rf2-adda + rf2-5gb6 — *2 files, 13 cited pins (13 landed, 0 stranded, 0 unresolvable, 0 foreign)* | **0** |
| `python implementation/hicasso/scripts/check_budget_ledger.py` | rf2-adda — *38 rows: 21 MET, 5 BREACH, 2 UNRESOLVED, 10 UNPINNED* | **0** |

`mkdocs build --strict` is **not** nominated: `mkdocs.yml`'s `exclude_docs` keeps
`docs/design/**` out of the site, so it does not cover either changed page.

### Negative controls

Each was planted at a line this PR actually edits, then restored, and **each
restore was verified by hashing the bytes** — not by re-reading the diff. These
doc gates print no `gate root:` banner and report repo-relative paths, so the
planted red is the only evidence one read this worktree rather than the mayor
checkout.

| Gate | Plant | Red exit | Restore verified |
|---|---|---|---|
| `bash -n` | closing `"` dropped from `install-clojure-cli.sh:91` | **2** — `line 96: unexpected EOF while looking for matching '"'` | SHA-256 `aa796e6d…79c83`, matches pre-plant |
| `shellcheck` | same plant | **123** — SC1078/SC1079/SC1072 **at line 91** | same hash |
| `check_doc_slugs` | anchor on the edited `budgets.md:423` broken | **1** — `BROKEN ANCHOR: …budgets.md:425` | SHA-256 `82348eb7…9f49b` |
| `check_provenance_pins` | bogus `deadbeefcafe` appended to the edited `budgets.md:559` | **1** — `budgets.md:559 deadbeefcafe [UNRESOLVABLE]` | same hash |
| `check_doc_slugs` | `globals.md` link target broken in the new §2.2 | **1** — `BROKEN TARGET: …checkpoint-1-kernel.md:124` | SHA-256 `78396064…422e97` |
| `check_budget_ledger` | Authority of ledger row `S1` (`:704`) made a non-bead-id | **1** — `L3 S1 names authority 'NOT A BEAD ID'` | SHA-256 `82348eb7…9f49b` |

Two notes where a control behaved differently from the naive expectation, stated
rather than buried:

- **`check_budget_ledger` does not read any line this PR edits.** It parses only
  `^\| *([DSUCI]\d+) *\|` ledger rows in §9; all four `budgets.md` edits are prose
  and the §7 routing table. The row-`S1` plant above is therefore proof the gate
  reads *this worktree*, not proof the edit reaches its surface. It is reported
  green because it must not break, not because it covers the change.
- **`check_provenance_pins` correctly exits 0 on a bogus SHA inside the new
  §2.2.** Its rule is that a cited head must be *accompanied in its own block* by
  a SHA that is an ancestor of `origin/main`, and that paragraph cites both
  `a2c00417bb` and `1f09c701e3`. The gate's red was proven at `budgets.md:559`,
  where the bogus pin stands alone in a table row.

### Verified by hand, because no gate covers it

`docs/design/**` has no gate for table shape. Both pages were parsed cell-by-cell
(pipes inside inline code excluded) and every table's header, separator and every
data row were compared:

- **`budgets.md` — 14 tables, all uniform, 0 mismatches.** Column counts in file
  order: 2, 2, 3, 5, 5, 4, 3, 5, 5, 3, **2** (§7, edited), 4, 3, **8** (the §9
  ledger, 38 data rows).
- **`checkpoint-1-kernel.md` — 5 tables, all uniform, 0 mismatches.** Column
  counts: 2, **5** (the §2 kernel table, 8 rows, edited), 3, 3, 4.

Anchors were checked the same way: §2.2's heading was renamed, and nothing links
to it — the two `#2…` intra-page links both target
`#21-row-5-is-assumed-not-witnessed`, and the two inbound references from
`correction-ledger.md` and `README.md` are file-level. `check_doc_slugs` confirms.

### Trunk

Diffed against `origin/main` immediately before pushing. The trunk moved while
this PR was in flight — #8077 landed on
`.github/scripts/playwright-install-failed.sh` — and **none of this PR's three
files is touched by it**, so nothing here reverts a concurrent change.
