### PR TITLE
fix(machines): repair the guide-truth prose and re-pin its guards (rf2-s41i)

### DIFF
--- a/docs/machines/parallel-states.md
+++ b/docs/machines/parallel-states.md
@@ -140,7 +140,9 @@ That means region order can affect action/data accumulation order, but it does
 not affect which transitions are selected.
 
 A region guard cannot see a sibling region's move from the same broadcast event.
-It sees the sibling state as it was at the start of the macrostep.
+It sees the sibling state as that broadcast's selection froze it. One macrostep
+can run several selections — the broadcast, then parent `:always` rounds, then
+any `:raise` re-broadcast — and each one freezes the view afresh.
 
 Use `:raise` if one region's move should trigger a second broadcast inside the
 same macrostep.
@@ -219,8 +221,10 @@ Use `:all-state` only when exact state names are the contract:
   (= :valid (:form all-state)))
 ```
 
-Both keys are frozen for the broadcast. A same-event move in a sibling region
-is not visible until a later microstep or later event.
+Both keys are frozen for the **selection round** that is currently choosing
+transitions, not for the whole macrostep. Between rounds the view is re-frozen,
+so each round sees the completed result of the one before it. A same-event move
+in a sibling region becomes visible on the next round, not on this one.
 
 ## `:always`, `:after`, and `:spawn` are region-scoped
 
@@ -249,6 +253,9 @@ enable a sibling's `:always`, and that sibling waits for the *next* parent
 round. A tiny case: `:source` writes `:ready?`, `:gate`'s `:always` reads it and
 writes `:cleared?`, `:audit`'s `:always` reads `:cleared?` — one event, two
 parent rounds, then the snapshot commits.
+
+The loop is bounded by `:always-depth-limit` (default 16). The limit counts
+parent **rounds** — a round in which five regions move is one round, not five.
 
 ## Tags compose across regions
 

--- a/implementation/machines/test/re_frame/parallel_states_guide_truth_jvm_test.clj
+++ b/implementation/machines/test/re_frame/parallel_states_guide_truth_jvm_test.clj
@@ -136,18 +136,42 @@
    ;;    token within a short window of the `fixed`/`frozen` word — which the
    ;;    negated teaching (`frozen for the selection round … not for the whole
    ;;    macrostep`, `whole` ~80 chars away) never satisfies.
+   ;;
+   ;;    rf2-s41i adds the SEEN-AT axis. The rf2-9d0d rewrite shipped "It sees
+   ;;    the sibling state as it was at the start of the macrostep." on main —
+   ;;    the superseded claim in a paraphrase none of the alternatives above
+   ;;    reached (no `frozen`/`fixed` word at all, and `as it WAS AT` rather
+   ;;    than the pinned `as OF`). Two alternatives close it: the `as of / as it
+   ;;    was at ... the start of the macrostep` family, and an observation verb
+   ;;    (`sees`/`reads`/`observes`) within a short window of `at the start of
+   ;;    the macrostep`. Neither can reach the corrected teaching, which never
+   ;;    dates the frozen view to the macrostep at all.
    [claim-frozen-whole-macrostep
-    #"(?i)(?:frozen\s+for\s+the\s+\*{0,2}whole\s+macrostep|as\s+of\s+the\s+\*{0,2}start\*{0,2}\s+of\s+the\s+macrostep|\b(?:frozen|fixed|constant|unchanged|stable|pinned|immutable|unchanging)\b[^.\n]{0,45}?\b(?:whole|entire|throughout|across|for\s+the\s+(?:duration|life)\s+of|until\s+the\s+end\s+of|macrostep\s+entry)\b[^.\n]{0,30}?\bmacrostep\b|\bfrom\s+macrostep\s+(?:entry|start|begin(?:ning)?)\b[^.\n]{0,45}?\b(?:until|to|through|up\s+to)\b[^.\n]{0,30}?\bmacrostep\s+(?:exit|end|finish|completion)\b)"]])
+    #"(?i)(?:frozen\s+for\s+the\s+\*{0,2}whole\s+macrostep|as\s+(?:of|(?:it|they)\s+(?:was|were)\s+at)\s+the\s+\*{0,2}(?:start|beginning|outset)\*{0,2}\s+of\s+the\s+macrostep|\b(?:sees?|reads?|observes?|gets?)\b[^.\n]{0,60}?\bat\s+the\s+\*{0,2}(?:start|beginning|outset)\*{0,2}\s+of\s+the\s+macrostep\b|\b(?:frozen|fixed|constant|unchanged|stable|pinned|immutable|unchanging)\b[^.\n]{0,45}?\b(?:whole|entire|throughout|across|for\s+the\s+(?:duration|life)\s+of|until\s+the\s+end\s+of|macrostep\s+entry)\b[^.\n]{0,30}?\bmacrostep\b|\bfrom\s+macrostep\s+(?:entry|start|begin(?:ning)?)\b[^.\n]{0,45}?\b(?:until|to|through|up\s+to)\b[^.\n]{0,30}?\bmacrostep\s+(?:exit|end|finish|completion)\b)"]])
 
 ;; ---------------------------------------------------------------------------
 ;; The load-bearing terms the rewrite installed. Absence = the guide lost the
 ;; law, which is the revert this guard exists to catch.
 
+;; rf2-s41i re-pins two of these onto the shorter prose the rf2-9d0d guide
+;; rewrite installed. Both pins move from a phrasing/markup form to the CLAIM
+;; the new prose makes; neither is relaxed. The other four are unchanged,
+;; because the rewritten guide still carries them word for word.
+;;
+;; - freeze → select → apply was pinned on a **bolded** three-step list. The
+;;   rewrite states the same round in running prose, so the pin now anchors on
+;;   the ORDER (freeze the whole configuration → select → apply → freeze again),
+;;   which is the law; the bold markup was never the law.
+;; - birth was pinned on "the same process runs at **birth**". The rewrite says
+;;   the parent settles `:always` across the whole configuration at birth using
+;;   "the same freeze / select / apply rounds used after an event" — the same
+;;   claim, so the pin follows it.
+
 (def ^:private required-terms
   [["the parent owns `:always` stabilization"
     #"(?i)`?:always`?\s+stabilization\s+is\s+parent-owned"]
-   ["the round is freeze → select → apply"
-    #"(?is)\*{2}Freeze\*{2}.{0,400}\*{2}Select\*{2}.{0,400}\*{2}Apply\*{2}"]
+   ["the round is freeze → select → apply, over the whole configuration"
+    #"(?is)parent\s+freezes\s+the\s+whole\s+configuration.{0,250}?\bselects\b.{0,250}?\bapplies\b.{0,120}?\bfreezes\s+again\b"]
    ["the view is re-frozen between rounds"
     #"(?i)between\s+rounds[^\n]{0,80}re-frozen"]
    ["sibling keys are frozen per selection round"
@@ -155,7 +179,7 @@
    ["`:always-depth-limit` counts parent rounds"
     #"(?i)counts\s+parent\s+\*{0,2}rounds"]
    ["birth runs the same parent-owned round process"
-    #"(?i)same\s+process\s+runs\s+at\s+\*{0,2}birth"]])
+    #"(?is)parent\s+settles\s+`?:always`?\s+across\s+the\s+whole\s+configuration.{0,80}?same\s+freeze\s*/\s*select\s*/\s*apply\s+rounds"]])
 
 ;; ---------------------------------------------------------------------------
 ;; Historical / incorrect-example polarity.
@@ -273,7 +297,12 @@
              [claim-frozen-whole-macrostep
               "the sibling configuration as of the *start* of the macrostep."]
              [claim-frozen-whole-macrostep      ; paraphrase (rf2-b0vvu mutation)
-              "Sibling keys remain fixed from macrostep entry until macrostep exit."]]]
+              "Sibling keys remain fixed from macrostep entry until macrostep exit."]
+             ;; rf2-s41i — the paraphrase that actually SHIPPED to main in the
+             ;; rf2-9d0d guide rewrite, verbatim. It carried no `frozen`/`fixed`
+             ;; word, so every alternative above missed it.
+             [claim-frozen-whole-macrostep
+              "It sees the sibling state as it was at the start of the macrostep."]]]
       (is (= [family] (superseded-hits sentence))
           (str "the guard failed to catch (exactly) the claim: " family
                "\n  in: " sentence))))

--- a/implementation/machines/test/re_frame/transition_geometry_terminology_jvm_test.clj
+++ b/implementation/machines/test/re_frame/transition_geometry_terminology_jvm_test.clj
@@ -134,10 +134,27 @@
     spec-self #"(?i)empty-descendant leaf"]
 
    ;; docs/machines/concepts.md
-   ["concepts: runtime `internal?` flag narrower than XState `internal`"
-    concepts-self #"(?is)runtime\s+`internal\?`\s+flag\s+is\s+narrower"]
-   ["concepts: the targetless no-op is named"
-    concepts-self #"(?i)targetless\**\s+no-op alone"]
+   ;;
+   ;; rf2-s41i re-points this surface's two pins. They were anchored on the
+   ;; parenthetical that carried the XState-parity disambiguation — "XState
+   ;; calls that non-reentering shape `internal`; re-frame2's runtime
+   ;; `internal?` flag is narrower — it's the **targetless** no-op alone".
+   ;; The rf2-9d0d guide rewrite deleted that parenthetical and now teaches
+   ;; the three self-transition shapes as a table that never says `internal`
+   ;; at all. That is not the drift this guard exists to catch — the
+   ;; conflation is impossible in prose that does not use the word, and the
+   ;; FORBIDDEN half still scans this same slice, so re-introducing it fails.
+   ;; Re-injecting the deleted parenthetical would revert an operator-authored
+   ;; rewrite, so the pins follow the guide instead: they now hold the SAME
+   ;; distinction the parenthetical carried — targetless is the action-only
+   ;; geometry, and a targeted self on a COMPOUND is not a no-op because it
+   ;; re-resolves descendants. The normative statement of the disambiguation
+   ;; is unaffected: Spec 005 §Self-transitions still carries all four of its
+   ;; pins below, including the `internal?`/XState-parity labels.
+   ["concepts: targetless is the action-only shape"
+    concepts-self #"(?is)\(targetless\).{0,60}?action only"]
+   ["concepts: a targeted self on a compound re-resolves descendants"
+    concepts-self #"(?is)compound\s+re-resolves\s+descendants"]
 
    ;; transition.cljc runtime prose
    ["impl: `compute-cascade-paths` keeps `explicit target is NEVER internal`"


### PR DESCRIPTION
`main` was RED. Five assertions across four deftests in two guide-truth namespaces, all installed by the rf2-9d0d machines-guide rewrite (#8068, commit `6012a7b21a`).

## The five failures, re-run at `origin/main`

```
cd implementation/machines && clojure -M:test \
  -n re-frame.parallel-states-guide-truth-jvm-test \
  -n re-frame.transition-geometry-terminology-jvm-test
→ EXIT 1 · Ran 4 tests containing 53 assertions. 5 failures, 0 errors.
```

| # | Site | deftest | Verdict |
|---|---|---|---|
| 1 | `parallel_states_guide_truth_jvm_test.clj:234` | `parallel-states-guide-keeps-the-parent-owned-round-law` | 3 pins on superseded wording, 1 on a real prose defect |
| 2 | `parallel_states_guide_truth_jvm_test.clj:340` | `guard-has-teeth` | same, surfaced through the meta-test |
| 3 | `transition_geometry_terminology_jvm_test.clj:178` | `transition-geometry-prose-keeps-the-disambiguated-vocabulary` | test pinned a deleted parenthetical |
| 4 | `transition_geometry_terminology_jvm_test.clj:217` | `guard-has-teeth` | same |
| 5 | `transition_geometry_terminology_jvm_test.clj:227` | `guard-has-teeth` | same |

Note: the bead says "five deftests"; it is **five assertions across four deftests** — `guard-has-teeth` in the geometry file fails twice (`:217`, `:227`).

## Verdict per failure

**The prose was WRONG about behaviour — one case, and it is the important one.**

`docs/machines/parallel-states.md` shipped:

> It sees the sibling state as it was at the start of the macrostep.

That is the superseded claim rf2-1rdo4j retired. The sibling view is frozen per **selection round** and re-frozen between rounds: `select-always-matches` (`parallel.cljc:945-948`) recomputes `frozen-all-state` / `frozen-tags` from the *current* snapshot on **every** round. The same file contradicts itself two sections later ("one event, two parent rounds"). The rewrite reacquired the claim in a paraphrase carrying no `frozen`/`fixed` word, so no superseded pattern reached it — the guard was blind to the exact drift it exists to catch.

Fixed: the sentence now says the view is frozen per selection and re-frozen for each; the `:tags` / `:all-state` note is restored to per-selection-round precision. The superseded half gains a SEEN-AT axis, plus a teeth case carrying the shipped sentence **verbatim**.

**The tests pinned superseded wording — the other four.**

- *freeze → select → apply* was pinned on a **bolded** three-step list. The rewrite states the same round in running prose. The pin now anchors the ORDER (freeze the whole configuration → select → apply → freeze again); the bold markup was never the law.
- *birth* was pinned on "the same process runs at **birth**". The rewrite says the parent settles `:always` across the whole configuration using "the same freeze / select / apply rounds used after an event" — same claim, pin follows it.
- *`:always-depth-limit` counts parent rounds* — the rewrite dropped the teaching from this page. Rather than drop the pin, one sentence is restored, because "a round in which five regions move is one round" is a consequence of the parent-owned round law and `acc-micro` is compared against the limit per **round** (`parallel.cljc:1225`), not per regional transition.
- *concepts.md* — both pins held a parenthetical the rewrite deleted wholesale ("re-frame2's runtime `internal?` flag is narrower — it's the **targetless** no-op alone"). The new page teaches the three shapes as a table that never says `internal` at all, and it is behaviourally correct. Re-injecting the parenthetical would revert an operator-authored rewrite, so the pins are re-pointed onto the shipped table, holding the same distinction. Spec 005 keeps all four normative pins; the FORBIDDEN half still scans the same slice.

**No guard is weakened.** Nothing was deleted to go green.

## `guard-has-teeth` reds against planted drift

Three plants, each restored and verified by hashing bytes.

| Plant | Result |
|---|---|
| A — revert the fixed sentence to the shipped wrong one | **EXIT 1**, 2 failures. `guard-has-teeth:368` red on `["sibling keys frozen for the whole macrostep (not per selection round)"]` — the new axis catches what shipped to main |
| B — reword the round / birth / depth-limit prose region-local | **EXIT 1**, 2 failures. `guard-has-teeth:369` red on all three re-pinned terms |
| C — strip the concepts.md geometry table | **EXIT 1**, 3 failures. `guard-has-teeth:234` and `:244` red on both re-pointed pins |

Restore verified byte-identical, not by eye:

```
ce47d61796c1e7a360e160bbec521aff62b1987abfc1decc4ce25fdfe84a772d *docs/machines/parallel-states.md
b2ed8e16ea5d62f13859dce789598a85a3e0466ef60b6ec5d29295762a1cfac9 *docs/machines/concepts.md
```

## The arming defect — CONFIRMED, and wider than the bead says

`jvm-machines` gates on `needs.detect_changed_surfaces.outputs.implementation_jvm == 'true'` (`test.yml:1915`). The classifier is `.github/scripts/report-changed-surfaces.sh`. Run against a docs-only diff:

```
$ bash .github/scripts/report-changed-surfaces.sh \
    docs/machines/parallel-states.md docs/machines/concepts.md
implementation_jvm=false
… every other output false
```

Nothing is armed. `docs/machines/**` matches **no case arm at all** — the only `docs/*` arms in the file are the playground bundle and `migration/**`. So #8068 skipped the lane that pins the pages it rewrote.

It is not just this directory. **No prose surface arms the lane that pins it:**

| Prose surface | Classifier | Test that pins it |
|---|---|---|
| `docs/machines/**` | nothing armed | `parallel_states_guide_truth_jvm_test.clj`, `transition_geometry_terminology_jvm_test.clj` |
| `spec/005-StateMachines.md` | nothing armed | `transition_geometry_terminology_jvm_test.clj` (4 required pins) |
| `docs/core/freehand/**` | nothing armed | `samples_coverage_jvm_test.clj` (digest-pins every fenced block) |
| `spec/{013,012,009,000}*`, `docs/api/*` | nothing armed | `scope_ensure_authority_test.clj` |
| `spec/Tool-Pair.md`, `spec/Security.md` | nothing armed | `spec_elision_registry_tense_conformance_test.clj` |

The general shape: **prose-pinning JVM tests are armed by their CODE surface, never by the PROSE surface they pin**, so a prose-only edit can red them and merge green.

**This PR does not take that lane.** The fix is an edit to `.github/scripts/report-changed-surfaces.sh` — CI control plane, sequential, and `worker/records-cluster` is live in that directory. Filed as a follow-up bead. This PR's own diff touches `implementation/machines/test/**`, so `implementation_jvm=true` and `jvm-machines` does run on it.

## Quality gates

| Gate | Command | Raw captured exit | Result |
|---|---|---|---|
| Guide-truth namespaces, at `origin/main` (reproduction) | `clojure -M:test -n …parallel-states-guide-truth-jvm-test -n …transition-geometry-terminology-jvm-test` | **1** | 4 tests / 53 assertions, **5 failures** |
| Guide-truth namespaces, after fix | same | **0** | 4 tests / 54 assertions, 0 failures |
| Machines artefact, whole | `cd implementation/machines && clojure -M:test` | **0** | **1202 tests / 4189 assertions, 0 failures, 0 errors** |
| Machines artefact, whole, **after rebase onto `944c38ca`** | same | **0** | 1202 tests / 4189 assertions, 0 failures, 0 errors |
| Doc slugs | `python scripts/check_doc_slugs.py` | **0** | pass |
| Planted drift A | `clojure -M:test -n …parallel-states-guide-truth-jvm-test` | **1** | intended red |
| Planted drift B | same | **1** | intended red |
| Planted drift C | `clojure -M:test -n …transition-geometry-terminology-jvm-test` | **1** | intended red |

Exit codes are the values captured from `$?` on the same command line as the redirect, not the harness's report.

Rebased onto `origin/main` @ `944c38ca` and the full artefact re-run there; main's four moved files (`docs/core/effects.md`, a hicasso vendor test, a design doc, `.beads`) touch nothing here.

`mkdocs build --strict` was not run: the edit adds no heading and no link, so no slug moves, and `check_doc_slugs.py` — the fast-PR spine's docs gate — passes.

rf2-s41i
