### PR TITLE
ci(classifier): arm the JVM tier for prose that a test.yml suite pins (rf2-61ar)

### DIFF
--- a/.github/scripts/report-changed-surfaces.sh
+++ b/.github/scripts/report-changed-surfaces.sh
@@ -1524,6 +1524,225 @@ else
         cljs_node_test=true
         cljs_browser=true
         ;;
+
+      # ─── PROSE THAT A test.yml SUITE PINS (rf2-61ar) ──────────────────────
+      #
+      # THE HOLE. A docs/spec-only diff classified to NOTHING: measured on
+      # main, `report-changed-surfaces.sh docs/machines/parallel-states.md
+      # docs/machines/concepts.md` printed all 32 outputs `false`. But a
+      # growing family of suites inside test.yml jobs `slurp` repo PROSE and
+      # assert on its text — guide-truth pins, terminology pins, schema
+      # extracts, doc-example evaluators. Every one of them was armed by its
+      # CODE surface and by nothing on the PROSE side, so a prose-only edit
+      # could red them and merge green, with the red landing on `main` for the
+      # next unrelated PR to discover. That is not hypothetical: PR #8068 (the
+      # machines-guide rewrite, 13 files, docs-only) skipped `jvm-machines` —
+      # the very lane pinning the pages it rewrote — and left five assertions
+      # across four deftests red on main until an unrelated PR happened to arm
+      # `implementation_jvm` (rf2-s41i, PR #8082, the prose+test half).
+      #
+      # THE MEASURED ROSTER — the prose each test.yml suite reads, and the job
+      # that reads it. Established by walking every `.clj`/`.cljc` under
+      # implementation/**/test and tools/**/test that both names a repo prose
+      # path and calls a read primitive, then reading each one:
+      #
+      #   docs/machines/parallel-states.md   parallel_states_guide_truth_jvm_test
+      #                                        .clj                  → jvm-machines
+      #   docs/machines/concepts.md          transition_geometry_terminology_jvm_
+      #                                        test.clj              → jvm-machines
+      #   docs/core/freehand/**.md           guide/samples_coverage_jvm_test.clj
+      #                                      (file-seq over the WHOLE tree,
+      #                                       digest-pins every fenced block)
+      #                                                              → jvm-freehand
+      #   docs/api/re-frame.adapter.uix.md   scope_ensure_authority_test.clj
+      #                                                              → jvm-core
+      #   docs/api/re-frame.ssr.md           ssr_doc_example_projector_test.clj
+      #                                                              → jvm-ssr
+      #   docs/design/hicasso/product/       recipes/async_nav_doc_test.clj
+      #     async-routing-recipes.md                                 → jvm-routing
+      #   spec/000-Vision.md                 scope_ensure_authority_test.clj
+      #   spec/012-Routing.md                        "
+      #   spec/013-Flows.md                          "                → jvm-core
+      #   spec/Tool-Pair.md                  spec_elision_registry_tense_
+      #   spec/Security.md                     conformance_test.clj   → jvm-core
+      #   spec/009-Instrumentation.md        error_catalogue_channel_conformance
+      #                                        _test.clj (core), scope_ensure_
+      #                                        authority_test.clj (core),
+      #                                        destroyed_reason_channel_
+      #                                        conformance_test.clj (machines),
+      #                                        spawn_all_schema_extract.clj →
+      #                                        spawn_all_authority_catalogue_
+      #                                        test.clj (machines)
+      #                                              → jvm-core + jvm-machines
+      #   spec/005-StateMachines.md          transition_geometry_terminology_jvm_
+      #                                        test.clj, destroyed_reason_channel
+      #                                        _conformance_test.clj → jvm-machines
+      #   spec/Cross-Spec-Interactions.md    destroyed_reason_channel_conformance
+      #                                        _test.clj             → jvm-machines
+      #   spec/006-ReactiveSubstrate.md      slice_memo_lifetime_census_jvm_test
+      #                                        .clj                  → jvm-ui
+      #   spec/Pattern-FormAction.md         ssr_doc_example_form_action_test.clj
+      #                                                              → jvm-ssr
+      #   spec/Spec-Schemas.md               SIX suites in FIVE artefacts — see
+      #                                        its own arm below.
+      #
+      # WHY `implementation_jvm` AND NOT SOMETHING NARROWER. There is nothing
+      # narrower. `implementation_jvm` is the single output every one of the 22
+      # per-artefact JVM jobs gates on; a per-lane arm would mean 22 new outputs
+      # and 22 `if:` widenings in test.yml for a saving the spec roster above
+      # would not even collect (its pins already span jvm-core, jvm-machines,
+      # jvm-ui, jvm-epoch, jvm-ssr and jvm-routing). The precedent is directly
+      # overhead: rf2-vxgfnd.97.3 armed exactly this output for the S3/S4/S5
+      # profile DOCS "so the jvm-ui job re-runs the S3-S5 profile guards", and
+      # rf2-drpa3.70 arms it for `implementation/freehand/*.md`. So the
+      # narrowing this bead buys is bought on the PATH axis instead: prose a
+      # suite reads arms the JVM tier, and prose nothing reads still arms
+      # nothing, exactly as today.
+      #
+      # NONE of these arms `cljs_browser`, `cljs_prod` or any Playwright
+      # output. Markdown cannot change what React puts on a page — the same
+      # line rf2-drpa3.70 drew for `implementation/freehand/*.md`. The one
+      # exception is `spec/Spec-Schemas.md`, and it is a COMPILE-TIME edge
+      # rather than a runtime one; its own arm below says why.
+      docs/machines/*.md)
+        # The two pinned pages are `concepts.md` (the §Self-transitions
+        # terminology `transition_geometry_terminology_jvm_test.clj` holds to
+        # spec/005) and `parallel-states.md` (the guide-truth walk). The arm is
+        # the TREE rather than those two names, and deliberately:
+        #   * the incident was a 13-file tree-wide rewrite, which is how a
+        #     guide is actually edited — page by page is the exception;
+        #   * `concepts.md` and `parallel-states.md` are the terminology spine
+        #     every other page in the guide restates, so a rewrite that moves a
+        #     definition between pages is the shape most likely to red them;
+        #   * unlike `docs/api/**` below, this tree has NO other gate — it
+        #     reaches docs.yml, which stages it into the site and executes not
+        #     one line of the suites that read it. Under-arming here is what
+        #     cost the red, and TESTING.md's rule for exactly this doubt is
+        #     "when in doubt, over-classify".
+        # `.md` rather than `*`: both pins read Markdown, and the tree carries
+        # no other file today. An image dropped beside a page should not queue
+        # a JVM tier.
+        implementation_jvm=true
+        ;;
+      docs/core/freehand/*.md)
+        # No judgement needed on the scope here — the pin IS the tree.
+        # `guide/samples_coverage_jvm_test.clj` `file-seq`s `docs/core/freehand`
+        # and digest-pins EVERY fenced block on EVERY `.md` page under it
+        # (22 pages today), so every page is genuinely pinned and a new page is
+        # pinned the moment it lands. The suite runs in `jvm-freehand`.
+        #
+        # `implementation_jvm` only — no `cljs_node_test`. The sibling prose arm
+        # `implementation/freehand/*.md` fires both, but that one covers prose
+        # INSIDE the artefact (a README documenting contracts the two host
+        # suites assert). Nothing in the `:node-test` build reads this guide.
+        implementation_jvm=true
+        ;;
+      docs/api/re-frame.adapter.uix.md|docs/api/re-frame.ssr.md)
+        # Named files, NOT `docs/api/*` — the one place in this block where the
+        # narrow answer is the right one, for a reason the other trees lack:
+        # `docs/api/**` is ALREADY on lint.yml's `paths:` filter, so all 25
+        # pages carry the api-manifest `doc-api-check` projection gate. The
+        # tree is not an unwatched surface; the hole is two pages that two
+        # test.yml JVM suites additionally name as literals —
+        # `scope_ensure_authority_test.clj` (jvm-core) reads the uix adapter
+        # page's scope/ensure row, and `ssr_doc_example_projector_test.clj`
+        # (jvm-ssr) EVALUATES the projector example off the ssr page. Arming 25
+        # pages' worth of edits into a 22-job JVM tier when 23 of them have no
+        # JVM pin at all is the "coarse rules clutter the matrix" TESTING.md
+        # warns about. Add the page here when a new JVM suite names one.
+        implementation_jvm=true
+        ;;
+      docs/design/hicasso/product/async-routing-recipes.md)
+        # One named file, and emphatically not its tree: `docs/design/**` is 159
+        # files of working design records, deliberately excluded from the site
+        # build (`exclude_docs` in mkdocs.yml) and validated only by
+        # scripts/check_doc_slugs.py + check_provenance_pins.py. Exactly one of
+        # them is read by a test.yml suite — `recipes/async_nav_doc_test.clj`
+        # (jvm-routing) reads this page's recipe forms and evaluates them — so
+        # exactly one is armed.
+        implementation_jvm=true
+        ;;
+      spec/conformance/freehand/README.md|spec/conformance/freehand/donor-inventory.md)
+        # A MEASURED EXCLUSION, held ahead of the `spec/*` catch-all below so
+        # the catch-all cannot silently reverse it.
+        #
+        # rf2-49upn and rf2-lrtwj each read these two files' consumers and
+        # found neither reachable from a lane: README.md DEFINES the
+        # conformance addressing scheme (it speaks in illustrative ids and is
+        # excluded from the census's own citation scan for exactly that
+        # reason), and donor-inventory.md is an archive of the withdrawn
+        # absorption programme whose checker, check_donor_inventory.py, is a
+        # snapshot-integrity check reading that one file and nothing else — so
+        # it cannot observe a source change at all. Neither can change what a
+        # lane proves.
+        #
+        # `spec/*` below is a POLICY default for spec prose nobody has
+        # measured. These two have been measured, by two beads, and the frozen
+        # mirror pins the result. A general default does not get to overturn a
+        # specific measurement, so the walk stops here. The empty `:` arm is
+        # the same device the story-feature-load launcher case uses further up
+        # for the same purpose.
+        :
+        ;;
+      spec/Spec-Schemas.md)
+        # The widest single miss in the roster, and the only prose file in the
+        # repo that arms a CLJS output.
+        #
+        # SIX suites in FIVE artefacts extract schema forms from this file:
+        #   error_catalogue_channel_conformance_test.clj      (core)
+        #   observation_schema_extract.clj                    (core)
+        #   epoch_silence_contract_test.clj                   (epoch)
+        #   destroyed_reason_channel_conformance_test.clj     (machines)
+        #   spawn_all_schema_extract.clj                      (machines)
+        #   frame_destroyed_op_schema_jvm_test.clj            (ui)
+        # — jvm-core, jvm-epoch, jvm-machines and jvm-ui, all on
+        # `implementation_jvm`.
+        #
+        # `cljs_node_test` as well, and this is the part no other prose arm
+        # needs: `observation_schema_extract.clj` is a JVM MACRO namespace, and
+        # `observation_port_cljs_test.cljc` pulls it in through
+        # `:require-macros`. So the ObservationOnChangeFailedTags schema is
+        # extracted from this Markdown at COMPILE TIME and inlined into the
+        # consolidated `:node-test` build. Editing the def form here changes
+        # what the `cljs` job compiles and asserts, not merely what a JVM suite
+        # slurps — the same macro-expansion-time reasoning the
+        # `spec/conformance/freehand/fixtures/*` arm above is built on.
+        #
+        # Must precede the `spec/*` catch-all below: a POSIX `case` takes the
+        # FIRST match, and the catch-all does not set `cljs_node_test`.
+        implementation_jvm=true
+        cljs_node_test=true
+        ;;
+      spec/*)
+        # The catch-all, and WHOLESALE on purpose.
+        #
+        # Eleven spec documents are pinned today by suites in six artefacts
+        # (the roster above), and every one of them arrived as its own bead —
+        # rf2-qyvyes, rf2-4go8s, rf2-qgsp2o, rf2-vxgfnd.97.3 and friends. A
+        # named list of eleven would therefore be a list that is wrong again by
+        # the next bead, and being wrong is precisely this hole: an unarmed
+        # normative document whose pin runs in no lane. `spec/` is the
+        # artefact of this repo — the implementation is downstream of it — and
+        # it is edited prose-only routinely, which is the exact diff shape that
+        # classified to nothing.
+        #
+        # The cost is explicit and accepted: a typo fix in an unpinned spec
+        # page now queues the JVM tier. That is TESTING.md's "when in doubt,
+        # over-classify", and the tier is 22 cached `clojure -M:test` jobs — no
+        # Chromium, no `:advanced` compile, no Playwright.
+        #
+        # It is a CATCH-ALL, so its POSITION is load-bearing twice over. A
+        # POSIX `case` takes the first match and `*` spans `/`, so this arm
+        # would swallow every narrower `spec/` case if it preceded them. The
+        # four that must stay ahead of it, and do:
+        #   spec/api-manifest{,-metadata}.edn + spec/API.md  (cljs_node_test)
+        #   spec/conformance/S{3,4,5}-view-conformance-profile.md
+        #   spec/conformance/fixtures/*
+        #   spec/conformance/freehand/fixtures/* + conformance-index.md
+        #   spec/Spec-Schemas.md                             (immediately above)
+        # A new narrower `spec/` arm goes ABOVE this one or it is dead code.
+        implementation_jvm=true
+        ;;
       implementation/scripts/serve-and-run-reagent-slim-smoke.cjs|implementation/scripts/_reagent-slim-smoke-policy.test.cjs)
         # rf2-5v0dg7 — false-green fix, mirroring the xray-feature-gate
         # launcher case below. serve-and-run-reagent-slim-smoke.cjs IS the

--- a/implementation/scripts/_changed-surfaces.test.cjs
+++ b/implementation/scripts/_changed-surfaces.test.cjs
@@ -211,13 +211,37 @@ test('Mixed Story spec .md + JVM .clj DOES fan out to tools_jvm (rf2-f79t8)', ()
 // (jvm-core) and cljs_node_test (cljs). The pull_request trigger stays
 // UNFILTERED — gating is job-side, NOT a trigger path filter.
 
-test('Spec-only .md change skips jvm-core + cljs (implementation_jvm + cljs_node_test false) (rf2-f79t8)', () => {
+// rf2-61ar SUPERSEDES the spec half of the case below, and the control it used
+// is the reason why. `spec/006-ReactiveSubstrate.md` was picked here (and in a
+// dozen other cases) as an inert stand-in for "some spec document" — but
+// implementation/ui/test/re_frame/ui/slice_memo_lifetime_census_jvm_test.clj
+// SLURPS that exact file and asserts on its text, inside jvm-ui, which gates on
+// implementation_jvm. So the negative control was itself a false-green witness:
+// the classifier's own mirror asserted that editing a pinned document must skip
+// the lane pinning it. The claim that survives is the one about the CLJS tier —
+// Markdown compiles into nothing, so `cljs_node_test` stays false for spec
+// prose, with `spec/Spec-Schemas.md` the single measured exception (a JVM macro
+// extracts it into the `:node-test` build; it has its own case below).
+test('Spec-only .md change fires implementation_jvm but NOT cljs (rf2-f79t8, rf2-61ar)', () => {
   const result = classify('spec/006-ReactiveSubstrate.md');
-  assert.equal(result.implementation_jvm, 'false');
-  assert.equal(result.cljs_node_test, 'false');
+  assert.equal(
+    result.implementation_jvm,
+    'true',
+    'spec prose arms the JVM tier — jvm-ui slurps this very file (rf2-61ar)',
+  );
+  assert.equal(
+    result.cljs_node_test,
+    'false',
+    'spec prose compiles into nothing, so the consolidated node build stays out',
+  );
 });
 
-test('Docs-only change skips jvm-core + cljs (rf2-f79t8)', () => {
+test('Docs prose with NO pinning suite still skips jvm-core + cljs (rf2-f79t8, rf2-61ar)', () => {
+  // rf2-61ar armed the docs trees a test.yml suite reads (docs/machines,
+  // docs/core/freehand, two docs/api pages, one docs/design page) and left
+  // every other docs page classifying exactly as it did before. That asymmetry
+  // IS the bead's narrowing, so this case keeps its original control — a
+  // docs/core page OUTSIDE docs/core/freehand reaches none of the armed trees.
   const result = classify('docs/core/intro.md');
   assert.equal(result.implementation_jvm, 'false');
   assert.equal(result.cljs_node_test, 'false');
@@ -293,9 +317,28 @@ test('S3 view-conformance profile-doc edit runs jvm-ui (implementation_jvm true)
   assert.equal(result.implementation_jvm, 'true');
 });
 
-test('a NON-profile spec .md does NOT fire implementation_jvm — no over-broadening (rf2-vxgfnd.97.3)', () => {
-  const result = classify('spec/006-ReactiveSubstrate.md');
-  assert.equal(result.implementation_jvm, 'false');
+// rf2-61ar — the over-broadening this case guarded has been REPLACED, not
+// abandoned. rf2-vxgfnd.97.3's worry was that arming implementation_jvm for
+// three profile docs might leak onto the rest of spec/. rf2-61ar then measured
+// eleven MORE pinned spec documents across six artefacts and made the leak
+// deliberate, so "a non-profile spec .md stays false" is no longer a law the
+// classifier holds. The law that replaces it is about OUTPUTS rather than
+// paths, and it is the sharper of the two: the profile docs are Markdown, so
+// they must reach the JVM tier and stop there. A future widening that dragged
+// a CLJS or Chromium lane onto a profile-doc edit is what this now catches.
+test('a profile-doc edit reaches the JVM tier and NO CLJS tier — no over-broadening (rf2-vxgfnd.97.3, rf2-61ar)', () => {
+  for (const file of [
+    'spec/conformance/S3-view-conformance-profile.md',
+    'spec/conformance/S4-view-conformance-profile.md',
+    'spec/conformance/S5-view-conformance-profile.md',
+  ]) {
+    const result = classify(file);
+    assert.equal(result.implementation_jvm, 'true', `${file} must arm implementation_jvm`);
+    assert.equal(result.cljs_node_test, 'false', `${file} must not arm cljs_node_test`);
+    assert.equal(result.cljs_browser, 'false', `${file} must not arm cljs_browser`);
+    assert.equal(result.cljs_prod, 'false', `${file} must not arm cljs_prod`);
+    assert.equal(result.ui_gates, 'false', `${file} must not arm ui_gates`);
+  }
 });
 
 test('shadow-cljs.edn change runs cljs (it defines the node-test build) (rf2-f79t8)', () => {
@@ -3142,9 +3185,17 @@ test('all-required-passed aggregator needs jvm-spec-resource', () => {
 });
 
 test('test-quiet routing does NOT broaden docs/spec-only or unrelated surfaces (rf2-am7grp scope)', () => {
-  // Scoped to src/test/deps.edn under test-quiet; a generic spec/docs
-  // change stays off the implementation gates entirely.
-  const result = classify('spec/006-ReactiveSubstrate.md');
+  // Scoped to src/test/deps.edn under test-quiet; a generic docs change stays
+  // off the implementation gates entirely.
+  //
+  // rf2-61ar — the control moved off `spec/006-ReactiveSubstrate.md`. Not
+  // because this case's claim changed, but because that file stopped being an
+  // inert control: jvm-ui slurps it (slice_memo_lifetime_census_jvm_test.clj),
+  // so spec prose now arms implementation_jvm by design and could no longer
+  // distinguish a test-quiet over-broadening from the spec arm doing its job.
+  // `docs/guide/getting-started.md` is prose no suite reads, which is what this
+  // case always needed.
+  const result = classify('docs/guide/getting-started.md');
   assert.equal(result.implementation_jvm, 'false');
   assert.equal(result.cljs_node_test, 'false');
 });
@@ -5317,6 +5368,181 @@ test('check-beads-pr-boundary.sh is committed executable (rf2-3mh2f)', () => {
     /^100755\s/,
     `check-beads-pr-boundary.sh must be committed 100755, got: ${mode}`,
   );
+});
+
+// ─── rf2-61ar — PROSE THAT A test.yml SUITE PINS ────────────────────────────
+//
+// The hole: a docs/spec-only diff classified to NOTHING while a growing family
+// of suites inside test.yml jobs `slurp` repo prose and assert on its text. PR
+// #8068 (the machines-guide rewrite, 13 files, docs-only) skipped jvm-machines
+// — the lane pinning the pages it rewrote — and left five assertions across
+// four deftests red on `main` until an unrelated PR happened to arm
+// implementation_jvm.
+//
+// The cases below are the two directions the arm has to hold in, and they are
+// deliberately written as one-way claims rather than as a frozen census: a
+// positive case asserts a pinned path DOES arm, a negative case asserts an
+// UNPINNED path does not. Neither shape has to be revisited when the next
+// pinned document lands — only when one is deliberately unarmed.
+
+// The measured roster, path -> the suite that reads it -> the job that runs it.
+// This is documentation for the reader; the assertions consume the paths only.
+const PROSE_PINS_ARMING_JVM = [
+  ['docs/machines/parallel-states.md', 'parallel_states_guide_truth_jvm_test.clj', 'jvm-machines'],
+  ['docs/machines/concepts.md', 'transition_geometry_terminology_jvm_test.clj', 'jvm-machines'],
+  ['docs/core/freehand/index.md', 'guide/samples_coverage_jvm_test.clj', 'jvm-freehand'],
+  ['docs/core/freehand/authoring/composition.md', 'guide/samples_coverage_jvm_test.clj', 'jvm-freehand'],
+  ['docs/api/re-frame.adapter.uix.md', 'scope_ensure_authority_test.clj', 'jvm-core'],
+  ['docs/api/re-frame.ssr.md', 'ssr_doc_example_projector_test.clj', 'jvm-ssr'],
+  ['docs/design/hicasso/product/async-routing-recipes.md', 'recipes/async_nav_doc_test.clj', 'jvm-routing'],
+  ['spec/000-Vision.md', 'scope_ensure_authority_test.clj', 'jvm-core'],
+  ['spec/005-StateMachines.md', 'transition_geometry_terminology_jvm_test.clj', 'jvm-machines'],
+  ['spec/006-ReactiveSubstrate.md', 'slice_memo_lifetime_census_jvm_test.clj', 'jvm-ui'],
+  ['spec/009-Instrumentation.md', 'error_catalogue_channel_conformance_test.clj', 'jvm-core'],
+  ['spec/012-Routing.md', 'scope_ensure_authority_test.clj', 'jvm-core'],
+  ['spec/013-Flows.md', 'scope_ensure_authority_test.clj', 'jvm-core'],
+  ['spec/Cross-Spec-Interactions.md', 'destroyed_reason_channel_conformance_test.clj', 'jvm-machines'],
+  ['spec/Pattern-FormAction.md', 'ssr_doc_example_form_action_test.clj', 'jvm-ssr'],
+  ['spec/Security.md', 'spec_elision_registry_tense_conformance_test.clj', 'jvm-core'],
+  ['spec/Spec-Schemas.md', 'six suites in five artefacts', 'jvm-core/-epoch/-machines/-ui'],
+  ['spec/Tool-Pair.md', 'spec_elision_registry_tense_conformance_test.clj', 'jvm-core'],
+];
+
+test('every measured prose pin arms the JVM tier that runs its suite (rf2-61ar)', () => {
+  for (const [file, suite, job] of PROSE_PINS_ARMING_JVM) {
+    assert.equal(
+      classify(file).implementation_jvm,
+      'true',
+      `${file} is slurped by ${suite}, which runs in ${job} — it must arm implementation_jvm`,
+    );
+  }
+});
+
+test('prose no suite reads still arms NOTHING — the narrowing (rf2-61ar)', () => {
+  // The other direction, and the whole reason this bead did not simply arm the
+  // JVM tier on `docs/**`. A lane that fires on everything costs what a lane
+  // that never fires costs, one tier over.
+  for (const file of [
+    'docs/index.md',
+    'docs/guide/getting-started.md',
+    'docs/hicasso/concepts.md',
+    'docs/core/intro.md',
+    'docs/api/re-frame.core.md', // 23 of the 25 docs/api pages carry no JVM pin
+    'docs/design/hicasso/draft-guide/02-views-and-reads.md', // 159 files, one pinned
+    'migration/from-re-frame-v1/README.md',
+    'README.md',
+  ]) {
+    const result = classify(file);
+    for (const [key, value] of Object.entries(result)) {
+      assert.equal(value, 'false', `${file} must arm nothing, but ${key} fired`);
+    }
+  }
+});
+
+test('prose arms the JVM tier and NO browser/prod/Playwright tier (rf2-61ar)', () => {
+  // Markdown cannot change what React puts on a page — the line rf2-drpa3.70
+  // drew for `implementation/freehand/*.md`, held here for every prose arm.
+  // `spec/Spec-Schemas.md` is the ONE exception and only for cljs_node_test: a
+  // JVM macro extracts its schema forms into the `:node-test` build at
+  // COMPILE time, so its own case below states that separately.
+  const forbidden = ['cljs_browser', 'cljs_prod', 'ui_gates', 'bundle_isolation',
+    'adapter_testbed_smokes', 'story_xray_browser', 'hicasso_controlled', 'playground'];
+  for (const [file] of PROSE_PINS_ARMING_JVM) {
+    const result = classify(file);
+    for (const key of forbidden) {
+      assert.equal(result[key], 'false', `${file} must not arm ${key}`);
+    }
+    if (file !== 'spec/Spec-Schemas.md') {
+      assert.equal(result.cljs_node_test, 'false', `${file} must not arm cljs_node_test`);
+    }
+  }
+});
+
+test('spec/Spec-Schemas.md also arms the node build — a COMPILE-TIME edge (rf2-61ar)', () => {
+  // implementation/core/test/re_frame/observation_schema_extract.clj is a JVM
+  // MACRO namespace that parses the ObservationOnChangeFailedTags def form out
+  // of this Markdown; observation_port_cljs_test.cljc pulls it in through
+  // `:require-macros`, so the schema is inlined into the consolidated
+  // `:node-test` build. Editing the def form changes what the `cljs` job
+  // compiles, not merely what a JVM suite slurps.
+  const result = classify('spec/Spec-Schemas.md');
+  assert.equal(result.implementation_jvm, 'true');
+  assert.equal(result.cljs_node_test, 'true');
+  assert.equal(result.cljs_browser, 'false', 'no mounted surface reads this file');
+});
+
+test('the docs/machines and docs/core/freehand arms cover the whole TREE (rf2-61ar)', () => {
+  // Two trees, two different reasons, and both are wider than the pages named
+  // in the roster above.
+  //
+  // docs/core/freehand — the pin IS the tree: samples_coverage_jvm_test.clj
+  // `file-seq`s the directory and digest-pins every fenced block on every page,
+  // so a page added tomorrow is pinned the moment it lands.
+  //
+  // docs/machines — a judgement, and the incident's own shape: the red came
+  // from a 13-file tree-wide rewrite, concepts.md and parallel-states.md are
+  // the terminology spine every other page restates, and unlike docs/api this
+  // tree has no other gate at all (docs.yml stages it into the site and
+  // executes not one line of the suites that read it).
+  for (const file of [
+    'docs/machines/glossary.md',
+    'docs/machines/history.md',
+    'docs/core/freehand/operate/debugging.md',
+    'docs/core/freehand/get-running/build-a-view.md',
+  ]) {
+    assert.equal(
+      classify(file).implementation_jvm,
+      'true',
+      `${file} rides its tree's arm — see the case comment for which reason`,
+    );
+  }
+});
+
+test('the spec/* catch-all does not shadow the narrower spec arms (rf2-61ar)', () => {
+  // A POSIX `case` takes the FIRST match and `*` spans `/`, so the catch-all
+  // would swallow every narrower spec/ case if it were ever moved above them.
+  // These are the verdicts that prove it has not been.
+  assert.equal(classify('spec/API.md').implementation_jvm, 'false',
+    'spec/API.md keeps its cljs_node_test-only classification (rf2-4ka7c2.1)');
+  assert.equal(classify('spec/API.md').cljs_node_test, 'true');
+  assert.equal(classify('spec/api-manifest.edn').cljs_node_test, 'true');
+  assert.equal(classify('spec/conformance/fixtures/dispatch.edn').cljs_browser, 'true',
+    'the shared conformance corpus keeps all four outputs (rf2-qmiiz)');
+  assert.equal(classify('spec/conformance/freehand/conformance-index.md').cljs_browser, 'true',
+    'the freehand ledger keeps its three lanes (rf2-49upn)');
+});
+
+test('rf2-61ar does not overturn the MEASURED freehand-prose exclusion (rf2-49upn, rf2-lrtwj)', () => {
+  // The `spec/*` catch-all is a POLICY default for spec prose nobody has
+  // measured. These two files HAVE been measured — twice, by beads that read
+  // their consumers — and found unreachable from any lane: README.md defines
+  // the addressing scheme in illustrative ids, and donor-inventory.md is an
+  // archived ledger whose checker reads that one file and nothing else. A
+  // general default does not get to overturn a specific measurement, so the
+  // classifier stops the walk on them ahead of the catch-all.
+  for (const file of [
+    'spec/conformance/freehand/README.md',
+    'spec/conformance/freehand/donor-inventory.md',
+  ]) {
+    const result = classify(file);
+    for (const [key, value] of Object.entries(result)) {
+      assert.equal(value, 'false', `${file} must arm nothing, but ${key} fired`);
+    }
+  }
+});
+
+test('the prose arms reach lanes that are still gated on implementation_jvm (rf2-61ar)', () => {
+  // Arming an output binds nothing unless the jobs it arms are still gated on
+  // it — the same third leg rf2-49upn's index case asserts. These four are the
+  // jobs the roster's suites actually run in.
+  const workflow = fs.readFileSync(WORKFLOW, 'utf8');
+  for (const job of ['jvm-machines', 'jvm-freehand', 'jvm-core', 'jvm-ui']) {
+    assert.match(
+      jobBlock(workflow, job),
+      /if: needs\.detect_changed_surfaces\.outputs\.implementation_jvm == 'true'/,
+      `${job} must stay gated on implementation_jvm, or arming it schedules nothing`,
+    );
+  }
 });
 
 let failed = 0;

--- a/scripts/_test_fixtures/test_fast_pr_docs_gate/run-self-test.sh
+++ b/scripts/_test_fixtures/test_fast_pr_docs_gate/run-self-test.sh
@@ -120,12 +120,42 @@ git -C "$r" add implementation/core/src/re_frame/core.cljc   # staged, not commi
 assert "B staged core code → runtime" "PLAN docs=false jvm=true node=true" "$(plan "$r")"
 
 # ---- Case C: unstaged docs change (tracked, modified, not staged) → docs ----
+#
+# The subject here is the GIT STATE — that a tracked file modified but not
+# staged is gathered into the change set at all — and the path is only a
+# vehicle for it.  It used to be `spec/006.md`, and rf2-61ar retired that
+# choice: the classifier now arms `implementation_jvm` for `spec/*`, because
+# eleven spec documents are slurped and asserted on by suites in six artefacts
+# and a prose-only edit to one used to skip the lane pinning it.  So a spec
+# path is no longer inert here, and `jvm=false` stopped being a statement about
+# the git state.  A markdown page under `docs/guide/` carries the same docs
+# surface (`is_doc_surface_path` matches any `*.md`) and no runtime arm, which
+# is what this case needs.  Keep it that way: an exemplar for a git-state case
+# must be prose NO suite reads — see the roster in
+# `.github/scripts/report-changed-surfaces.sh` before choosing another.
 r="$tmp_root/unstaged-docs"; mkrepo "$r"
-mkdir -p "$r/spec"; printf '# a\n' > "$r/spec/006.md"
-git -C "$r" add spec/006.md; git -C "$r" commit -q -m addmd
+mkdir -p "$r/docs/guide"; printf '# a\n' > "$r/docs/guide/unstaged.md"
+git -C "$r" add docs/guide/unstaged.md; git -C "$r" commit -q -m addmd
 git -C "$r" update-ref refs/remotes/origin/main HEAD
-printf '# a\nmore\n' > "$r/spec/006.md"                       # unstaged modify
+printf '# a\nmore\n' > "$r/docs/guide/unstaged.md"            # unstaged modify
 assert "C unstaged docs → docs only" "PLAN docs=true jvm=false node=false" "$(plan "$r")"
+
+# ---- Case C1: unstaged PINNED prose → docs AND the JVM tier (rf2-61ar) ----
+#
+# The other half of the case above, and the reason it had to move rather than
+# simply have its expectation flipped.  Case C proves an unstaged edit reaches
+# the change set; this one proves the spine's tiering still agrees with CI's
+# once it gets there — a spec page arms the JVM tier locally exactly as
+# `implementation_jvm` arms it in test.yml.  Without this, retargeting case C
+# would have silently deleted the only local evidence that the widening
+# reaches the spine at all.
+r="$tmp_root/unstaged-pinned-prose"; mkrepo "$r"
+mkdir -p "$r/spec"; printf '# a\n' > "$r/spec/006-ReactiveSubstrate.md"
+git -C "$r" add spec/006-ReactiveSubstrate.md; git -C "$r" commit -q -m addmd
+git -C "$r" update-ref refs/remotes/origin/main HEAD
+printf '# a\nmore\n' > "$r/spec/006-ReactiveSubstrate.md"     # unstaged modify
+assert "C1 unstaged pinned spec prose → docs + JVM tier" \
+  "PLAN docs=true jvm=true node=false" "$(plan "$r")"
 
 # ---- Case D: untracked docs file → docs ----
 r="$tmp_root/untracked-docs"; mkrepo "$r"


### PR DESCRIPTION
Closes rf2-61ar.

## The defect

`.github/scripts/report-changed-surfaces.sh` classified a **docs/spec-only diff to nothing**. Measured on `main` before this PR:

```
$ bash .github/scripts/report-changed-surfaces.sh docs/machines/parallel-states.md docs/machines/concepts.md
implementation_jvm=false      (and all 31 other outputs false)
```

But a growing family of suites inside `test.yml` jobs `slurp` repo **prose** and assert on its text — guide-truth pins, terminology pins, schema extracts, doc-example evaluators. Every one of them was armed by its **code** surface and by nothing on the **prose** side, so a prose-only edit could red them and merge green. PR #8068 (the machines-guide rewrite, 13 files, docs-only) skipped `jvm-machines` — the lane pinning the pages it rewrote — and left five assertions across four deftests red on `main` until an unrelated PR happened to arm `implementation_jvm`. That prose+test half is rf2-s41i / PR #8082, already merged; this is the arming half.

`test.yml` is **unchanged**. The jobs already gate on the right output.

## The roster I measured

Established by walking every `.clj`/`.cljc` under `implementation/**/test` and `tools/**/test` that both names a repo prose path *and* calls a read primitive (`slurp` / `io/file` / `file-seq`), then reading each one. A count is a claim, so here is the claim:

| Prose | Pinning suite | Job |
|---|---|---|
| `docs/machines/parallel-states.md` | `parallel_states_guide_truth_jvm_test.clj` | `jvm-machines` |
| `docs/machines/concepts.md` | `transition_geometry_terminology_jvm_test.clj` | `jvm-machines` |
| `docs/core/freehand/**.md` (whole tree, `file-seq`) | `guide/samples_coverage_jvm_test.clj` | `jvm-freehand` |
| `docs/api/re-frame.adapter.uix.md` | `scope_ensure_authority_test.clj` | `jvm-core` |
| `docs/api/re-frame.ssr.md` | `ssr_doc_example_projector_test.clj` | `jvm-ssr` |
| `docs/design/hicasso/product/async-routing-recipes.md` | `recipes/async_nav_doc_test.clj` | `jvm-routing` |
| `spec/000-Vision.md`, `spec/012-Routing.md`, `spec/013-Flows.md` | `scope_ensure_authority_test.clj` | `jvm-core` |
| `spec/Tool-Pair.md`, `spec/Security.md` | `spec_elision_registry_tense_conformance_test.clj` | `jvm-core` |
| `spec/009-Instrumentation.md` | `error_catalogue_channel_conformance_test.clj`, `scope_ensure_authority_test.clj`, `destroyed_reason_channel_conformance_test.clj`, `spawn_all_schema_extract.clj` | `jvm-core` + `jvm-machines` |
| `spec/005-StateMachines.md` | `transition_geometry_terminology_jvm_test.clj`, `destroyed_reason_channel_conformance_test.clj` | `jvm-machines` |
| `spec/Cross-Spec-Interactions.md` | `destroyed_reason_channel_conformance_test.clj` | `jvm-machines` |
| `spec/006-ReactiveSubstrate.md` | `slice_memo_lifetime_census_jvm_test.clj` | `jvm-ui` |
| `spec/Pattern-FormAction.md` | `ssr_doc_example_form_action_test.clj` | `jvm-ssr` |
| `spec/Spec-Schemas.md` | six suites in five artefacts, **plus a compile-time macro edge** | `jvm-core`/`-epoch`/`-machines`/`-ui` **+ `cljs`** |

**Five entries the bead's roster did not carry**, all measured here: `spec/Spec-Schemas.md` (the widest single miss), `spec/006-ReactiveSubstrate.md`, `spec/Cross-Spec-Interactions.md`, `spec/Pattern-FormAction.md`, and `docs/design/hicasso/product/async-routing-recipes.md`.

**One bead premise that did not hold:** `no_rf_default_floor_lint_test.clj` reads as a repo-wide scanner ("docs skills tools implementation spec" in its docstring) but scans only `.clj{,c,s}` under `**/src/`. It is not a prose pin and is not armed.

## Why `implementation_jvm` and not something narrower

There is nothing narrower. `implementation_jvm` is the single output all 22 per-artefact JVM jobs gate on; a per-lane arm would mean 22 new outputs and 22 `if:` widenings in a hot-zone file, for a saving the spec roster would not even collect — its pins already span `jvm-core`, `jvm-machines`, `jvm-ui`, `jvm-epoch`, `jvm-ssr` and `jvm-routing`. The precedent is directly overhead in the same file: rf2-vxgfnd.97.3 armed exactly this output for the S3/S4/S5 profile **docs**, and rf2-drpa3.70 arms it for `implementation/freehand/*.md`.

So **the narrowing is bought on the path axis instead**: prose a suite reads arms the JVM tier; prose nothing reads still arms nothing, exactly as before. No arm sets `cljs_browser`, `cljs_prod` or any Playwright output — Markdown cannot change what React puts on a page.

Per-surface grouping and why:

- **`docs/core/freehand/*.md` — the tree**, no judgement required: the pin *is* the tree. `samples_coverage_jvm_test.clj` `file-seq`s the directory and digest-pins every fenced block on all 22 pages, so a new page is pinned on arrival.
- **`docs/machines/*.md` — the tree**, a judgement: the incident was a 13-file tree-wide rewrite, `concepts.md` + `parallel-states.md` are the terminology spine every other page restates, and unlike `docs/api` this tree has **no other gate at all** (it reaches `docs.yml`, which stages it into the site and executes not one line of the suites reading it). TESTING.md's rule for exactly this doubt is "when in doubt, over-classify".
- **`docs/api/…uix.md|…ssr.md` — two named files**, the one place the narrow answer wins: `docs/api/**` is already on `lint.yml`'s `paths:` filter, so all 25 pages carry the api-manifest `doc-api-check`. The tree is not unwatched; only two pages carry an additional `test.yml` JVM pin.
- **`docs/design/…/async-routing-recipes.md` — one named file**: `docs/design/**` is 159 files of working design records deliberately excluded from the site build. Exactly one is read by a `test.yml` suite.
- **`spec/*` — wholesale**: eleven spec documents are pinned today by suites in six artefacts, each having arrived as its own bead. A named list of eleven is a list that is wrong again by the next bead — and being wrong is precisely this hole. Cost accepted and stated in the comment: a typo in an unpinned spec page now queues 22 cached `clojure -M:test` jobs (no Chromium, no `:advanced` compile).
- **`spec/Spec-Schemas.md` — also `cljs_node_test`**, and it is the only prose file in the repo that arms a CLJS output. `observation_schema_extract.clj` is a JVM **macro** namespace; `observation_port_cljs_test.cljc` pulls it in via `:require-macros`, so the schema is extracted from that Markdown at **compile time** and inlined into the consolidated `:node-test` build.

## Prose with no pinning test — a finding, not a gap

`spec/conformance/freehand/README.md` and `donor-inventory.md` were measured out by rf2-49upn and rf2-lrtwj, which read their consumers and found neither reachable from a lane. My `spec/*` catch-all would have swallowed both — the frozen mirror caught it. **I kept the exclusion rather than inventing an arm**: a policy default does not get to overturn a specific measurement. An explicit `:` arm now stops the walk on them ahead of the catch-all, and the mirror pins that.

## Both directions, demonstrated

Positive — every pinned path arms:

```
docs/machines/parallel-states.md                       implementation_jvm=true
docs/machines/concepts.md                              implementation_jvm=true
docs/machines/glossary.md                              implementation_jvm=true
docs/core/freehand/index.md                            implementation_jvm=true
docs/core/freehand/authoring/composition.md            implementation_jvm=true
docs/api/re-frame.adapter.uix.md                       implementation_jvm=true
docs/api/re-frame.ssr.md                               implementation_jvm=true
docs/design/hicasso/product/async-routing-recipes.md   implementation_jvm=true
spec/Spec-Schemas.md                  implementation_jvm=true cljs_node_test=true
spec/{000,005,006,009,012,013}.md                      implementation_jvm=true
spec/{Tool-Pair,Security,Cross-Spec-Interactions,Pattern-FormAction}.md
                                                       implementation_jvm=true
```

Negative — unrelated prose still arms nothing (all 32 outputs `false`):

```
docs/index.md                docs/guide/getting-started.md   docs/hicasso/concepts.md
docs/core/intro.md           docs/core/api/re-frame.core.md  docs/api/re-frame.core.md
docs/story/api/re-frame.story.md                             docs/machines/README.txt
docs/design/hicasso/product/correction-ledger.md
docs/design/hicasso/draft-guide/02-views-and-reads.md
migration/from-re-frame-v1/README.md                         README.md
spec/conformance/freehand/README.md   spec/conformance/freehand/donor-inventory.md
```

First-match ordering preserved — the `spec/*` catch-all shadows none of the four narrower `spec/` arms:

```
spec/API.md                                      cljs_node_test=true   (only)
spec/api-manifest{,-metadata}.edn                cljs_node_test=true   (only)
spec/conformance/S4-view-conformance-profile.md  implementation_jvm=true (only)
spec/conformance/fixtures/*.edn                  jvm + node + browser + prod
spec/conformance/freehand/conformance-index.md   jvm + node + browser
```

Both directions are now frozen into the mirror as one-way claims rather than a census, so the next pinned document does not need to come back here.

## The frozen mirror

`implementation/scripts/_changed-surfaces.test.cjs`: **330 to 338 cases**, all passing.

Three existing cases are **restated, not deleted**, and the reason is worth recording: all three used `spec/006-ReactiveSubstrate.md` as an inert negative control asserting `implementation_jvm === 'false'` — and `jvm-ui` slurps that exact file (`slice_memo_lifetime_census_jvm_test.clj`). The classifier's own mirror was asserting that editing a pinned document must skip the lane pinning it. Each is rewritten to keep the claim that survives:

- *"Spec-only .md skips jvm-core + cljs"* becomes: spec prose fires `implementation_jvm` but **not** `cljs_node_test` (Markdown compiles into nothing; `Spec-Schemas.md` is the measured exception).
- *"a NON-profile spec .md does not fire implementation_jvm"* (rf2-vxgfnd.97.3's over-broadening guard) becomes the sharper law about **outputs**: a profile doc reaches the JVM tier and stops there — no CLJS, browser, prod or `ui_gates`.
- *"test-quiet routing does not broaden docs/spec-only"* keeps its claim; the control moves to `docs/guide/getting-started.md`, prose no suite reads. The old control could no longer distinguish a test-quiet over-broadening from the spec arm working.

## The CI red, and what it was

The first push reddened one check, `Verify README link slugs (rf2-br5u7)`. It was neither the README slugs nor pre-existing: `check_readme_links.py --self-test`, `--ci` and `check_readme_inventories.py` all pass on this branch (exit **0**), and that job carries **no `if:`** — it is unconditional, so the classifier change never armed it. It always ran; one assertion inside it changed verdict.

Running the job's thirteen steps locally in the foreground: steps 3-12 pass, and the red is **step 13**, `scripts/_test_fixtures/test_fast_pr_docs_gate/run-self-test.sh` — the harness that drives the real fast-PR spine in `--plan` mode.

```
42/43 self-test cases passed.
FAIL C unstaged docs -> docs only:
  expected PLAN docs=true jvm=false node=false
  got      PLAN docs=true jvm=true  node=false
```

**It is my diff, and the exemplar rather than the arm.** Case C's fixture path was `spec/006.md` — a spec path standing in for "docs" (the spine's `is_doc_surface_path` matches any `*.md`), in a disposable fixture repo. Evidence, run against the classifier blob checked out of `origin/main`:

| path | `origin/main` classifier | this branch |
|---|---|---|
| `spec/006.md` | 0 outputs true | `implementation_jvm=true` |
| `spec/006-ReactiveSubstrate.md` | 0 outputs true | `implementation_jvm=true` |
| `docs/machines/parallel-states.md` | 0 outputs true | `implementation_jvm=true` |
| `docs/core/freehand/index.md` | 0 outputs true | `implementation_jvm=true` |

So `jvm=false` held only because the exemplar classified to nothing. It was a side effect of an inert path, not a claim about the git state — and case C's subject **is** the git state: that a tracked file modified but not staged is gathered into the change set at all. Cases A and D use different paths for the committed and untracked states.

The expectation is therefore **not flipped**. Case C keeps asserting "docs-only arms docs only" against `docs/guide/unstaged.md` — same documentation surface, no runtime arm — so it still tests what it was written to test. And because retargeting alone would have deleted the only local evidence that the widening reaches the spine, **case C1 is added beside it**: an unstaged edit to `spec/006-ReactiveSubstrate.md`, a page `jvm-ui` slurps, must plan `docs=true jvm=true node=false`. The harness now runs **44/44**.

This is the same shape as the three restated mirror cases above, and the same shape as rf2-s41i itself: a frozen expectation encoding the old behaviour, surfaced by the change that made the behaviour correct. Three separate frozen artefacts in this repo had picked `spec/006*` as their inert control, and `jvm-ui` reads that file.

## Quality gates

Exit codes are the ones I captured with `echo $?` on the same command line, not the harness's.

| Gate | Command | Exit |
|---|---|---|
| Frozen mirror | `node implementation/scripts/_changed-surfaces.test.cjs` | **0** — 338 passed (was 330) |
| Fast-PR spine tiering self-test (the CI red) | `bash scripts/_test_fixtures/test_fast_pr_docs_gate/run-self-test.sh` | **0** — 44/44 (was 42/43) |
| README link validator | `python scripts/check_readme_links.py --self-test --verbose` then `--ci` | **0**, **0** |
| README inventories | `python scripts/check_readme_inventories.py --self-test --verbose` then `--verbose` | **0**, **0** |
| Test-lane bijection | `python scripts/check_test_lane_bijection.py --self-test` then `--verbose` | **0**, **0** — 1939 test-defining files, 49 lanes |
| JVM roster/CI bijection | `python scripts/check_jvm_lane_rosters.py --self-test` then `--verbose` | **0**, **0** |
| Adapter disposition | `python scripts/check_adapter_disposition.py --self-test --verbose` then `--verbose --ci` | **0**, **0** |
| Fast-PR gap map | `python scripts/check_fast_pr_gap.py --list` | **0** — 96 before, 96 after, output byte-identical (`diff` empty) |
| Gap-map discriminator | planted a bogus non-setup step in `jvm-core`, re-ran `--list` | **0** — count moved **96 to 97** and named `RF2-61AR PLANTED BOGUS DISCRIMINATOR STEP`; `test.yml` then restored and verified by `sha256sum -c` (`OK`), not by reading a diff |
| Gate scheduling | `python scripts/check_gate_scheduling.py` | **0** — 51 gate commands, 43 scheduled, 8 declared, 0 known holes |
| Shellcheck (CI roster's own invocation) | `git ls-files '.github/scripts/*.sh' \| xargs shellcheck` (v0.11.0) | **0** |
| Shellcheck (the retargeted fixture) | `shellcheck scripts/_test_fixtures/test_fast_pr_docs_gate/run-self-test.sh` | **0** |
| Shell parse | `bash -n` on the classifier and on the retargeted fixture | **0**, **0** |
| JS parse | `node --check implementation/scripts/_changed-surfaces.test.cjs` | **0** |
| Workflow YAML validity | `yaml.safe_load` over all 13 `.github/workflows/*.yml` | **0** — 13 workflows, 124 jobs parsed |
| Workflow shape comparison | PyYAML dump of every job's `name` / `needs` / `if` / step names, before vs after | **identical**, `sha256 59da602c…` on both sides, `diff` empty. Decoded UTF-8 explicitly: 24 real U+2014 bytes in the dump, **0** U+FFFD and **0** cp1252 double-encodings, so no phantom em-dash drift |
| Self-classification | classifier over this PR's own diff | 32/32 outputs `true` (`mark_all` — re-tiering the matrix re-runs the matrix) |

**Not run locally:** ESLint. `eslint.config.mjs` imports `globals` from a root `node_modules` this worktree does not carry; `lint.yml`'s ESLint job covers the file. `node --check` passes and the suite executes end to end.

Rebased onto `origin/main` three times as the trunk moved (`7ca6fe8e` -> `75597021` -> `e4857cb6`); `origin/main` is an ancestor of HEAD and nothing landed on any of this PR's three files while it was open (`git log <base>..origin/main -- <files>` empty each time). The roster was re-measured against the rebased tree — `docs/design/hicasso/product/async-routing-recipes.md` and its reader `async_nav_doc_test.clj` both changed on main meanwhile, and the pin still holds — and every gate above was re-run after the final rebase.

## Follow-up not taken (out of fence)

Two comments now describe the old behaviour and are worth a one-line correction by whoever owns them:

- `test.yml` `jvm-core` — "The JVM core suite skips on a spec/docs-only PR, where `implementation_jvm` is false". True only for prose no suite reads, now.
- `TESTING.md`'s classifier table, `implementation_jvm` row — "any JVM artefact under `implementation/` changes". It now also fires for the measured prose roster above.

Neither is required by an arm, and both files are hot-zone or outside this bead's fence, so they are left alone deliberately rather than overlooked.
