### PR TITLE
rf2-36bd: the slice's reset-law row was hollow — take the inert ::h/revision bookkeeping out and withdraw finding 5 in both reports

### DIFF
--- a/docs/design/hicasso/product/authoring-report-slice.md
+++ b/docs/design/hicasso/product/authoring-report-slice.md
@@ -8,7 +8,7 @@ The application is `re-frame.hicasso.examples.slice.*` under `implementation/hic
 
 ## What the application actually needed
 
-The most useful single fact for a facade freeze is the list of doors an ordinary application reaches for. This one reaches four namespaces and, within `re-frame.hicasso`, **nine names and three keywords**:
+The most useful single fact for a facade freeze is the list of doors an ordinary application reaches for. This one reaches four namespaces and, within `re-frame.hicasso`, **nine names and two keywords**:
 
 | Reached | Used for |
 |---|---|
@@ -19,9 +19,9 @@ The most useful single fact for a facade freeze is the list of doors an ordinary
 | `route-link` | two link sites |
 | `reg-state` | one per-row disclosure flag |
 | `root!` / `render!` / `unmount!` | the entry point and its `^:dev/after-load` hook |
-| `::h/value` · `::h/checked` · `::h/revision` | the two controlled text fields, the checkbox, and the discard |
+| `::h/value` · `::h/checked` | the two controlled text fields, and the checkbox |
 
-**Never reached, in an application deliberately chosen to be broad:** `portal`, `as-element`, `as-component`, `defhost`, `hfn`, `hframe`, `motion/presence`, and the whole native tier. Each has a real use case named in the specification; none of them is *ordinary*. `hfn` is the sharpest of these — it is the one callback form, and an application with two text fields, a checkbox, a select and five buttons never needed one, because an intent vector said everything.
+**Never reached, in an application deliberately chosen to be broad:** `portal`, `as-element`, `as-component`, `defhost`, `hfn`, `hframe`, `motion/presence`, and the whole native tier. `::h/revision` belongs on this list too, and the story of how it got there is finding 5: it was reached for, written into two fields and two handlers, and then measured to be doing nothing. Each has a real use case named in the specification; none of them is *ordinary*. `hfn` is the sharpest of these — it is the one callback form, and an application with two text fields, a checkbox, a select and five buttons never needed one, because an intent vector said everything.
 
 The import discipline is asserted mechanically rather than reviewed: `surface-cljs-test` reads each application namespace's `:requires` / `:require-macros` / `:uses` / `:use-macros` off the ClojureScript analyzer and pins that roster of four, so a fifth door cannot arrive quietly.
 
@@ -83,19 +83,28 @@ Mixing the two in one body is legal and unremarked: `use-subs` sets a `grouped` 
 
 Consistent with the operator's standing ruling that grouped `use-subs` sits below the ergonomics bar.
 
-### 5. `::h/revision` works, and the counter behind it is the author's to invent
+### 5. The counter this report asked for was not needed — WITHDRAWN AND REPLACED (rf2-36bd)
 
-The reset law is right and the slice depends on it. What the slice discovered is that the **most ordinary** use of it — a *Discard changes* button — does not work without bookkeeping the application has to add:
+**This finding said the opposite, and it was wrong.** It read:
 
-```clojure
-{:db (-> db
-         (update :drafts dissoc slug)                  ;; the model moves back
-         (update-in [:revision slug] (fnil inc 0)))}   ;; …and this is what the field takes
-```
+> The reset law is right and the slice depends on it. What the slice discovered is that the **most ordinary** use of it — a *Discard changes* button — does not work without bookkeeping the application has to add […] So an `app-db` key, a `(fnil inc 0)` in two handlers and a subscription exist for no reason a reader of the application can see […] The mechanism should stay; what is missing is that nothing on the door says *you will need a counter*. A worked discard in the guide would probably close it.
 
-Dropping the draft moves the model back to a value the field is **already showing**, so React's own value diff sees nothing to do and the typed text stays on the glass. The revision bump is what re-baselines it. So an `app-db` key, a `(fnil inc 0)` in two handlers and a subscription exist for no reason a reader of the application can see, and their absence is a bug that shows up only when a user discards after typing — the exact case a hurried author will not have.
+It rested on a row that could not see its own subject. `flow-dom-cljs-test`'s reset row asserted the field's value after a discard and said, in its own failure message, that *the changed `::h/revision` is what re-baselines it*. rf2-hic-026's slice review deleted the bump from `::discard` — nothing else touched — and the browser lane came back at **1474 tests, 9154 assertions, 0 failures, captured exit 0**, byte-identical to the control. Ten files recompiled, so the plant was in the bundle. The bookkeeping this finding called load-bearing had never been carried by anything.
 
-The mechanism should stay; what is missing is that nothing on the door says *you will need a counter*. A worked discard in the guide would probably close it.
+**Why it is inert, which is the part a guide row actually needs.** `impl/codec`'s `revision-key` states the whole delivery: *the revision is a value the body reads, and its change **re-runs the body***; the re-run re-commits the element and the commit re-asserts the model over whatever the DOM holds. React marks that host update on props-object **identity** (HD-004 refuses prop-object caching), so **any** re-render of the boundary does the same re-assert for free. A discard already moves three of this editor's reads — the draft, the dirty flag, the save status — so the body re-runs whatever the counter does.
+
+That was measured too, and against the hardest case rather than the easy one. A probe drifted a field's DOM by an **eventless value write** — the shape a password manager, an autofill or a translation extension has, and the shape the controlled-input testbed's `revision` arm uses deliberately — and then discarded, with the bump deleted. The drift was repaired. There is no DOM state in this application that can tell the counter's presence from its absence.
+
+So the counter came out: the `:revision` key, `db/revision`, the two `(fnil inc 0)`s, `::subs/revision` and both `::h/revision` props. The slice reaches **two** of the three reserved keyword markers, not three.
+
+**What replaces the finding.** `::h/revision` is the door for a reset that leaves **every other read the body makes `=`**. Two populations get there and the slice is in neither:
+
+- a **normalising or refusing** field whose typed value lands back on the value the model already holds, so nothing moves at all — `examples/editor`'s slug field is written for exactly this;
+- a DOM that **drifted by a route React never saw** — autofill, an extension, a live IME composition — re-asserted by a control that changes no other state. The testbed's `revision` / `revision-strict` arms drive precisely that, with a bare *bump revision* button, and they are the only witnesses in the corpus measured to red on a deleted trigger.
+
+**So the guide row this finding asked for should be inverted.** Not *you will need a counter* — most authors will not, and a row teaching one to the ordinary-discard population would have every reader adding an `app-db` key, a subscription and two `fnil`s that do nothing. The row worth writing gives them the **test**: *if your reset leaves every value your body reads equal, you need `::h/revision`; if it moves any of them, React's own commit has already done it.*
+
+> A caution the corpus earns: `examples/editor`'s `what-the-revision-bump-is-actually-load-bearing-FOR` presents itself as the measured counterpart to this finding, and it stayed green on a deleted bump too (**rf2-5h9k**). Do not write the guide row from it until that is settled.
 
 ### 6. Two clicks on one page settle differently, and nothing says which
 

--- a/docs/design/hicasso/product/authoring-report-slice.md
+++ b/docs/design/hicasso/product/authoring-report-slice.md
@@ -21,7 +21,9 @@ The most useful single fact for a facade freeze is the list of doors an ordinary
 | `root!` / `render!` / `unmount!` | the entry point and its `^:dev/after-load` hook |
 | `::h/value` · `::h/checked` | the two controlled text fields, and the checkbox |
 
-**Never reached, in an application deliberately chosen to be broad:** `portal`, `as-element`, `as-component`, `defhost`, `hfn`, `hframe`, `motion/presence`, and the whole native tier. `::h/revision` belongs on this list too, and the story of how it got there is finding 5: it was reached for, written into two fields and two handlers, and then measured to be doing nothing. Each has a real use case named in the specification; none of them is *ordinary*. `hfn` is the sharpest of these — it is the one callback form, and an application with two text fields, a checkbox, a select and five buttons never needed one, because an intent vector said everything.
+**Never reached, in an application deliberately chosen to be broad:** `portal`, `as-element`, `as-component`, `defhost`, `hfn`, `hframe`, `motion/presence`, and the whole native tier. Each has a real use case named in the specification; none of them is *ordinary*. `hfn` is the sharpest of these — it is the one callback form, and an application with two text fields, a checkbox, a select and five buttons never needed one, because an intent vector said everything.
+
+`::h/revision` belongs on that list too, and it arrived there by a different road: it was reached for, written into two fields and two handlers, believed, and then measured to be doing nothing. That is finding 5.
 
 The import discipline is asserted mechanically rather than reviewed: `surface-cljs-test` reads each application namespace's `:requires` / `:require-macros` / `:uses` / `:use-macros` off the ClojureScript analyzer and pins that roster of four, so a fifth door cannot arrive quietly.
 

--- a/docs/design/hicasso/product/authoring-report-todo.md
+++ b/docs/design/hicasso/product/authoring-report-todo.md
@@ -56,11 +56,9 @@ No body here has a group worth declaring: the largest read set is three, and `to
 
 That is a datum rather than a finding, and it is the same datum twice: two ordinary applications, one grouped read between them. Consistent with the operator's standing ruling that grouped `use-subs` sits below the ergonomics bar.
 
-### 5. `::h/revision` and the counter the author has to invent — BOUNDED, from the other side
+### 5. Neither application needed a counter — the bound was right, the boundary was not (rf2-36bd)
 
-The slice's report says the *most ordinary* use of the reset law — a **Discard changes** button — needs bookkeeping the application must add. The Todo class contains the most ordinary reset there is, **Escape cancels an edit**, and it needs no counter and no revision at all.
-
-The difference is not the domain, it is whether the field survives its own reset:
+**The datum this report contributed stands; the explanation it gave for it does not.** The Todo class contains the most ordinary reset there is, **Escape cancels an edit**, and it needs no counter and no revision at all:
 
 ```clojure
 ;; Escape removes the draft; a nil draft is what makes the editor absent,
@@ -68,7 +66,15 @@ The difference is not the domain, it is whether the field survives its own reset
 :on-key-down {"Escape" [::h/clear db/draft id]}
 ```
 
-The slice's editor is always on the page, so a discard hands a still-mounted field the value it is already showing, React's own value diff sees nothing to do, and the revision is what re-baselines it. **`::h/revision` is the reset door for a field that outlives the reset**, and finding 5's scope is that narrower statement. The guide row it asks for should say which of the two shapes it is about, because *most* resets in the corpus are probably the unmounting kind and would be taught a counter they do not need.
+What this report then concluded was that the difference is **whether the field survives its own reset** — that the slice's editor is always on the page, so its discard hands a still-mounted field the value it is already showing and the revision is what re-baselines it. It closed: *`::h/revision` is the reset door for a field that outlives the reset*.
+
+That boundary was measured and it is in the wrong place. The slice's counter was deleted and its browser lane did not move (1474 tests, 9154 assertions, captured exit 0, identical to the control), so the slice's field **outlives its reset and still needs nothing**. The counter has since come out of the slice and its own finding 5 is withdrawn.
+
+The line that survives the measurement is drawn elsewhere. `impl/codec`'s `revision-key` states that the whole of a revision's delivery is that its change **re-runs the body**, and React marks the resulting host update on props-object identity — so **any** re-render re-asserts the model over the DOM, drifted or not. Unmounting is therefore just one member of a larger class: every reset that moves *something the body reads* gets the re-assert for free, and an unmount is only the most emphatic way to move it.
+
+**`::h/revision` is the door for a reset that leaves every other read the body makes `=`.** That is a much smaller population than either report supposed — a normalising or refusing field whose typed value lands back on the value the model already holds, or a DOM drifted by a route React never saw and re-asserted by a control that changes no other state.
+
+So the two reports agree after all, and they agree on the opposite of what the slice's report first asked for: **neither of these two ordinary applications needed a counter.** The guide row should give an author the test rather than the counter — *if your reset leaves every value your body reads equal, you need `::h/revision`; if it moves any of them, React's own commit has already done it* — because on the evidence of both applications, most authors reading it will not need one.
 
 ### 6. Two clicks on one page settle differently — CONFIRMED, and it is not about servers
 

--- a/docs/design/hicasso/product/mcp-runtime-query-spike.md
+++ b/docs/design/hicasso/product/mcp-runtime-query-spike.md
@@ -128,6 +128,8 @@ Every id in the right-hand column was registered by `rf2-hic-025` for another pu
 
 The shell's reads (`::subs/token`) stay held across the route change, which is what makes the roster row a *difference* rather than a reset.
 
+> **The roster row's "answer after" is a measurement and stands as taken, but the application under it has since moved.** rf2-36bd removed `::subs/revision` from the slice — the counter behind it was measured inert and the finding it supported was withdrawn — so the article route now holds three of those reads rather than four. Nothing about the divergence the row demonstrates changes; the read that left was one of the three that stayed different.
+
 ### What the run found that reading the source does not give
 
 The slice's root boundary **holds a string-table edge**. `views/app` reads two theme tokens and the route id; it also reads `[::subs/t :app/pane-error]`, because the `h/error-boundary` fallback is markup written in the root's own body and is therefore evaluated when the root runs, not when a pane throws. So the root re-stamps on every locale change, for a sentence that reaches the screen only after a failure.

--- a/implementation/hicasso/test/re_frame/hicasso/examples/slice/a11y_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/examples/slice/a11y_cljs_test.cljs
@@ -130,7 +130,6 @@
   (ht/tree [views/editor {:slug "intents"}]
            {:subs (merge {[::subs/draft "intents"]      {:title "T" :body "B"
                                                          :published? true}
-                          [::subs/revision "intents"]   0
                           [::subs/dirty? "intents"]     false
                           [::subs/save-state "intents"] save
                           [::subs/token :danger]        "rgb(176, 32, 32)"}

--- a/implementation/hicasso/test/re_frame/hicasso/examples/slice/db.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/examples/slice/db.cljs
@@ -12,7 +12,6 @@
       {:articles {slug {:slug :title :body :published? :tags}}
        :order    [slug …]                ;; publication order, the list's key order
        :drafts   {slug {:title :body :published?}}
-       :revision {slug n}                ;; the controlled fields' reset trigger
        :save     {:status :idle|:saving|:failed|:saved  :slug :problem}
        :digest   {:status :ready|:loading  :blocks [block …]}
        :locale   :en
@@ -47,15 +46,36 @@
   than a flag somebody has to remember to clear, and \"reset\" is a
   `dissoc` rather than a re-copy.
 
-  ## `:revision` is a COUNTER, not a value
+  ## THERE IS NO `:revision` KEY, AND ITS ABSENCE WAS MEASURED (rf2-36bd)
 
-  HD-019's reset law re-baselines a controlled field to its model when
-  `::h/revision` CHANGES. A discard that only removed the draft would
-  leave the field showing what the user typed — the model moved back to
-  where it already was, so React's own value diff sees nothing to do. The
-  counter is what makes the reset observable to the field, and it is
-  bumped by exactly the two handlers that need it (discard, and a
-  successful save)."
+  An earlier draft of this application carried one: a `{slug n}` counter,
+  a `(fnil inc 0)` in two handlers, a subscription, and `::h/revision` on
+  both text fields. It was written from HD-019's reset law and from the
+  sentence that used to stand here — *a discard that only removed the
+  draft would leave the field showing what the user typed*.
+
+  That sentence is false of this application, and the way it was found is
+  the only reason to keep talking about it: the counter's bump was deleted
+  from `::discard` and the browser lane did not move — 1474 tests, 9154
+  assertions, zero failures, exactly the control. The bookkeeping was
+  inert.
+
+  It is inert for a mechanical reason worth carrying, because it decides
+  when a consumer needs one. `impl.codec`'s `revision-key` states the
+  whole delivery: **the revision is a value the body reads, and its change
+  RE-RUNS THE BODY**; the re-run re-commits the element and the commit
+  re-asserts the model over whatever the DOM holds. React marks that host
+  update on props-object identity, so *any* re-render of the boundary does
+  the same re-assert for free. A discard here already moves three of the
+  editor's reads — the draft, [[dirty?]], and the save status — so the
+  body re-runs whatever the counter does.
+
+  **`::h/revision` is therefore the door for a reset that leaves every
+  other read the body makes `=`** — not, as the first report had it, for a
+  field that outlives its reset. This field outlives its reset and needs
+  nothing. `flow-dom-cljs-test`'s reset section witnesses both halves: the
+  discard that works, and a DOM drifted by a write React never saw, which
+  the same re-render repairs."
   (:refer-clojure :exclude [empty?]))
 
 (def page-size
@@ -159,7 +179,6 @@
                             :tags ["routing"]}}
    :order    ["hicasso" "intents" "controls" "keys" "boundaries" "revision" "pages"]
    :drafts   {}
-   :revision {}
    :save     {:status :idle}
    :digest   {:status :ready :blocks digest}
    :locale   :en
@@ -196,14 +215,6 @@
   "Has `slug` been edited since it was last saved or discarded?"
   [db slug]
   (contains? (:drafts db) slug))
-
-(defn revision
-  "The reset trigger for `slug`'s controlled fields. Starts at 0 so the
-  first render carries a value rather than a nil that later becomes a
-  number — a change from nil is a change, and the field would re-baseline
-  on the second render for no reason a reader could see."
-  [db slug]
-  (get-in db [:revision slug] 0))
 
 (defn blank?
   "Is `s` absent, or nothing but whitespace? The one string predicate the
@@ -287,5 +298,4 @@
   [db slug draft]
   (-> db
       (update-in [:articles slug] merge (select-keys draft [:title :body :published?]))
-      (update :drafts dissoc slug)
-      (update-in [:revision slug] (fnil inc 0))))
+      (update :drafts dissoc slug)))

--- a/implementation/hicasso/test/re_frame/hicasso/examples/slice/events.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/examples/slice/events.cljs
@@ -108,17 +108,17 @@
                    (assoc (db/draft-for db slug) :published? (boolean published?)))}))
 
 (rf/reg-event ::discard
-  {:doc "Throw a draft away and re-baseline its fields — the reset."}
+  {:doc "Throw a draft away — the reset, and it is one move."}
   (fn [{:keys [db]} [_ {:keys [slug]}]]
-    ;; Two moves, and both are needed. Dropping the draft moves the MODEL
-    ;; back to the article; bumping the revision is what tells the
-    ;; controlled fields to take it (HD-019's reset law). Without the bump
-    ;; the fields keep showing what the user typed, because the value they
-    ;; are handed is the one they were handed last render and React sees
-    ;; nothing to do.
+    ;; ONE move on the model, and no `::h/revision` counter beside it.
+    ;; This handler carried one until rf2-36bd deleted the bump and the
+    ;; browser lane did not move: dropping the draft is already three
+    ;; changes the editor's body reads, so the body re-runs and the commit
+    ;; re-asserts the model over the fields without being told to. See
+    ;; `db`'s namespace docstring for the measurement and for the shape
+    ;; that DOES need a counter.
     {:db (-> db
              (update :drafts dissoc slug)
-             (update-in [:revision slug] (fnil inc 0))
              (assoc :save {:status :idle}))}))
 
 ;; ---------------------------------------------------------------------------

--- a/implementation/hicasso/test/re_frame/hicasso/examples/slice/flow_dom_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/examples/slice/flow_dom_cljs_test.cljs
@@ -4,8 +4,9 @@
   One complete pass through the application on a real React root: the
   feed, a real click on a real route-link, the editor's controlled
   fields under real keystrokes, a save the stand-in server REFUSES, the
-  error region, a retry that succeeds, and a discard that re-baselines
-  the field. Every row ends at `hm/assert-clean!`.
+  error region, a retry that succeeds, and a discard that restores the
+  fields — including one the model never agreed to. Every row ends at
+  `hm/assert-clean!`.
 
   ## This file reaches no internal namespace either
 
@@ -375,10 +376,27 @@
         (finish m done)))))
 
 ;; ---------------------------------------------------------------------------
-;; 4 — the reset, in a real field
+;; 4 — the reset, in a real field, and why this application carries no
+;;     `::h/revision` (rf2-36bd)
+;;
+;; The two rows below are a PAIR, and the second is the reason the first can
+;; say what it says.
+;;
+;; This section used to be one row, and it claimed the reset law: "the model
+;; moved back to a value the field was already showing, so React alone sees
+;; nothing to do — the changed `::h/revision` is what re-baselines it". The
+;; claim was measured by deleting the counter's bump from `::discard`, and the
+;; row stayed green. It had never witnessed the revision; it witnesses the
+;; MODEL MOVING, which is a different fact and a true one.
+;;
+;; So the counter came out of the application, and the second row is what
+;; keeps it out: it drifts the DOM by a route React cannot see and shows the
+;; discard repairing that too. `impl.codec`'s `revision-key` says why — the
+;; whole of a revision's delivery is that its change re-runs the body, and a
+;; discard re-runs this body three times over.
 ;; ---------------------------------------------------------------------------
 
-(deftest discarding-re-baselines-the-field-without-remounting-it
+(deftest discarding-moves-the-model-back-without-remounting-the-field
   (if-not (browser?)
     (skip! ":node-test has no React DOM")
     (async done
@@ -391,15 +409,56 @@
         (let [before (node m ".field-title")]
           (click! m ".discard")
           (is (= "Intents are data" (.-value (node m ".field-title")))
-              "THE RESET LAW (HD-019): the model moved back to a value the
-               field was already showing, so React alone sees nothing to
-               do — the changed `::h/revision` is what re-baselines it")
+              "the draft is gone, so the model is the article's title again
+               — a value DIFFERENT from the one the field was handed last
+               render, which is all React's own commit needs")
           (is (identical? before (node m ".field-title"))
               "and it is the SAME element: re-baselined, not remounted, so
                focus, selection and scroll position survive a discard"))
 
         (is (false? (read-sub m [::subs/dirty? "intents"])))
         (is (true? (.-disabled (node m ".discard"))))
+        (finish m done)))))
+
+(deftest a-discard-repairs-a-field-the-model-never-agreed-to
+  ;; THE ROW THAT KEEPS THE COUNTER OUT. Its control is
+  ;; `(update :drafts dissoc slug)` in `::discard`: delete that and this
+  ;; row reds, because nothing the editor's body reads would move and the
+  ;; body would not re-run. That is the same control the row above has, and
+  ;; it is the whole point — there is no third state for a revision to
+  ;; occupy.
+  (if-not (browser?)
+    (skip! ":node-test has no React DOM")
+    (async done
+      (let [m (at-article! "intents")]
+        ;; Dirty the form through the OTHER field, so the title's MODEL does
+        ;; not move across the discard at all.
+        (type-into! m ".field-body" "rewritten, then regretted")
+
+        ;; An EVENTLESS value write — the shape a password manager, an
+        ;; autofill or a translation extension has. No `input` event, so no
+        ;; handler runs, no subscription fires and no commit is scheduled:
+        ;; the field now shows a string `app-db` has never held. Written
+        ;; through the PROTOTYPE setter for the reason `type-into!` gives.
+        (let [n (node m ".field-title")
+              d (js/Object.getOwnPropertyDescriptor
+                  js/HTMLInputElement.prototype "value")]
+          (.call (.-set d) n "pasted by something else"))
+        (is (= "pasted by something else" (.-value (node m ".field-title")))
+            "the drift landed, and nothing in the application knows")
+        (is (= "Intents are data" (:title (read-sub m [::subs/draft "intents"])))
+            "the model is exactly where it was — this is the state a reset
+             trigger would exist for")
+
+        (click! m ".discard")
+        (is (= "Intents are data" (.-value (node m ".field-title")))
+            "and the discard repairs it with NO `::h/revision` anywhere.
+             The body re-ran because the draft, the dirty flag and the save
+             status all moved; the commit that followed re-asserted the
+             model over a DOM React had never been told about. A counter
+             here would have had nothing left to do — which is why this
+             application does not carry one")
+
         (finish m done)))))
 
 ;; ---------------------------------------------------------------------------

--- a/implementation/hicasso/test/re_frame/hicasso/examples/slice/l0_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/examples/slice/l0_cljs_test.cljs
@@ -172,10 +172,11 @@
   (let [db' (db/commit db/seed "intents" {:title "Renamed" :body "New body" :published? false})]
     (is (= "Renamed" (:title (db/article db' "intents"))))
     (is (false? (db/dirty? db' "intents")))
-    (is (= 1 (db/revision db' "intents"))
-        "the revision moves on a successful save too — the field is now
-         showing a value the model agrees with, and the next discard has
-         to be able to move it again")))
+    (is (= #{:articles :order :drafts :save :digest :locale :theme}
+           (set (keys db')))
+        "a commit moves two keys and mints none — in particular no
+         `:revision` counter, which this application measured and does not
+         carry (rf2-36bd; see db's namespace docstring)")))
 
 ;; ---------------------------------------------------------------------------
 ;; i18n — a hole is visible
@@ -219,17 +220,17 @@
            would land in an empty map and blank them")
       (is (true? (read-sub frame [::subs/dirty? "intents"]))))))
 
-(deftest discarding-restores-the-article-and-bumps-the-revision
+(deftest discarding-restores-the-article
   (with-app
     (fn [frame]
       (rf/dispatch-sync [::events/edit "intents" :title "typed"] {:frame frame})
-      (is (= 0 (read-sub frame [::subs/revision "intents"])))
+      (is (true? (read-sub frame [::subs/dirty? "intents"])))
       (rf/dispatch-sync [::events/discard {:slug "intents"}] {:frame frame})
-      (is (= "Intents are data" (:title (read-sub frame [::subs/draft "intents"]))))
-      (is (false? (read-sub frame [::subs/dirty? "intents"])))
-      (is (= 1 (read-sub frame [::subs/revision "intents"]))
-          "the counter is what re-baselines the controlled field; the model
-           alone moved back to a value the field was already showing"))))
+      (is (= "Intents are data" (:title (read-sub frame [::subs/draft "intents"])))
+          "the MODEL moved, which is the whole of the reset here — the
+           counter this handler used to bump beside it was measured inert
+           and removed (rf2-36bd)")
+      (is (false? (read-sub frame [::subs/dirty? "intents"]))))))
 
 (deftest a-local-problem-never-reaches-the-server
   (with-app

--- a/implementation/hicasso/test/re_frame/hicasso/examples/slice/l2_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/examples/slice/l2_cljs_test.cljs
@@ -343,7 +343,6 @@
 
 (def ^:private editor-base-subs
   {[::subs/draft "intents"]      {:title "T" :body "B" :published? true}
-   [::subs/revision "intents"]   0
    [::subs/dirty? "intents"]     false
    [::subs/t :editor/heading]    "Edit"
    [::subs/t :editor/title]      "Title"
@@ -373,15 +372,20 @@
     (is (= [::events/edit "intents" :body :re-frame.hicasso/value]
            (:on-input (ht/attrs body))))))
 
-(deftest the-reset-trigger-rides-both-fields
+(deftest neither-text-field-carries-a-reset-trigger
+  ;; The ABSENCE, pinned at the tier that can read a marker off an authored
+  ;; form — because an absence nothing asserts is an absence somebody
+  ;; re-adds. rf2-36bd deleted the counter's bump from `::discard` and the
+  ;; browser lane did not move: a discard already re-runs this body three
+  ;; times over, and the commit re-asserts the model on its own.
   (is (= 0 (ht/revision [:input {:value "T" :re-frame.hicasso/revision 0}]))
-      "the kit reads the trigger off an authored form")
-  (let [tree (editor-tree {:status :idle :problem nil} {[::subs/revision "intents"] 3})]
-    ;; The tree records the marker as an ordinary attribute, which is what
-    ;; makes it assertable here: both fields carry the SAME revision, so a
-    ;; discard re-baselines the whole form rather than half of it.
-    (is (= [3 3] (mapv #(:re-frame.hicasso/revision (ht/attrs %))
-                       [(classed tree "field-title") (classed tree "field-body")])))))
+      "the kit CAN read a trigger off an authored form, which is what makes
+       the two readings below a finding rather than a blind spot")
+  (let [tree (editor-tree {:status :idle :problem nil} {})]
+    (is (= [nil nil] (mapv #(:re-frame.hicasso/revision (ht/attrs %))
+                           [(classed tree "field-title") (classed tree "field-body")]))
+        "and neither field authors one — see `views/editor` for the
+         population that does need `::h/revision`")))
 
 (deftest the-checkbox-takes-the-checked-marker
   (let [box (ht/find (editor-tree {:status :idle :problem nil} {})

--- a/implementation/hicasso/test/re_frame/hicasso/examples/slice/subs.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/examples/slice/subs.cljs
@@ -128,10 +128,6 @@
   own fields when nobody has typed yet. See db/draft-for."}
   (fn [db [_ slug]] (db/draft-for db slug)))
 
-(rf/reg-sub ::revision
-  {:doc "The controlled fields' reset trigger for one article."}
-  (fn [db [_ slug]] (db/revision db slug)))
-
 (rf/reg-sub ::dirty?
   {:doc "Has this article been edited since it was last saved or discarded?"}
   (fn [db [_ slug]] (db/dirty? db slug)))

--- a/implementation/hicasso/test/re_frame/hicasso/examples/slice/views.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/examples/slice/views.cljs
@@ -6,11 +6,15 @@
   rf2-hic-074 added for pagination, runtime-selected content and a
   nested error region: a pager, a digest region, its body, and four
   block renderers. Everything they reach for is `h/…`: `defview`, `sub`,
-  `use-subs`, `boundary`, `route-link`, the `::h/value` / `::h/checked` /
-  `::h/revision` markers. There is no `impl` namespace anywhere in the
+  `use-subs`, `boundary`, `route-link`, and the `::h/value` /
+  `::h/checked` markers. There is no `impl` namespace anywhere in the
   `:require` list above, and no `re-frame.core` either — a view neither
   dispatches nor subscribes directly, because an intent is a vector and a
   read is `h/sub`.
+
+  The third marker, `::h/revision`, is **not** here, and its absence is a
+  measurement rather than an oversight — see [[editor]] and `db`'s
+  namespace docstring.
 
   ## The one thing an author has to know that is not in a signature
 
@@ -351,15 +355,22 @@
   local draft, no `onChange` closure and no effect reconciling two copies
   of the text. The model is the only place it lives.
 
-  `::h/revision` is the reset trigger and it carries the ONLY thing that
-  makes *discard* work. Dropping the draft moves the model back to the
-  article — but if the user had typed and then discarded, the value the
-  field is handed is the value it was handed before, and React sees
-  nothing to do. A changed revision re-baselines the field to the model
-  without remounting it (HD-019)."
+  ## NO `::h/revision`, and that is the finding rather than a gap
+
+  Both fields carried one until rf2-36bd measured it. Deleting the
+  counter's bump from `::discard` left the browser lane at exactly its
+  control — the reset law's trigger was inert here, because the whole of
+  what a revision does is re-run the body, and a discard already moves
+  three of the reads below. The commit that follows re-asserts the model
+  over the fields on its own.
+
+  A consumer needs `::h/revision` where a reset leaves every read its body
+  makes `=` — a normalising or refusing field whose typed value lands back
+  on the value the model already holds, or a DOM drifted by something
+  React never saw. This editor is neither, and
+  `flow-dom-cljs-test`'s reset section witnesses both halves."
   [{:keys [slug]}]
   (let [draft            (h/sub [::subs/draft slug])
-        revision         (h/sub [::subs/revision slug])
         dirty?           (h/sub [::subs/dirty? slug])
         {:keys [status problem]} (h/sub [::subs/save-state slug])
         saving?          (= :saving status)]
@@ -368,16 +379,14 @@
 
      [:label {:for "slice-title"} (h/sub [::subs/t :editor/title])]
      [:input#slice-title.field-title
-      {:type         "text"
-       :value        (:title draft)
-       ::h/revision  revision
-       :on-input     [::events/edit slug :title ::h/value]}]
+      {:type     "text"
+       :value    (:title draft)
+       :on-input [::events/edit slug :title ::h/value]}]
 
      [:label {:for "slice-body"} (h/sub [::subs/t :editor/body])]
      [:textarea#slice-body.field-body
-      {:value        (:body draft)
-       ::h/revision  revision
-       :on-input     [::events/edit slug :body ::h/value]}]
+      {:value    (:body draft)
+       :on-input [::events/edit slug :body ::h/value]}]
 
      [:label.published {:for "slice-published"}
       [:input#slice-published

--- a/implementation/hicasso/test/re_frame/hicasso/mcp_runtime_query_spike_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/mcp_runtime_query_spike_cljs_test.cljs
@@ -324,9 +324,11 @@
       (testing "what only the feed holds"
         (is (contains? feed-ids ::subs/feed))
         (is (not (contains? art-ids ::subs/feed))))
-      (testing "what only the article holds — the editor's four reads"
+      ;; THREE, and it was four until rf2-36bd. `::subs/revision` was the
+      ;; fourth, and the slice no longer has one: the counter behind it was
+      ;; measured inert and removed. See the slice's `db` namespace docstring.
+      (testing "what only the article holds — the editor's three reads"
         (is (contains? art-ids ::subs/draft))
-        (is (contains? art-ids ::subs/revision))
         (is (contains? art-ids ::subs/dirty?))
         (is (contains? art-ids ::subs/save-state))
         (is (not (contains? feed-ids ::subs/draft))))


### PR DESCRIPTION
Closes rf2-36bd.

## The finding, reproduced before anything was changed

CHECKPOINT 2 reported that the slice's reset-law row stays GREEN with `::h/revision`'s trigger deleted. That was re-measured from scratch on this worktree, off `origin/main@7aebc6012c`, before a line was edited.

The bump was deleted from `::discard` — `(update-in [:revision slug] (fnil inc 0))` removed, nothing else touched:

```
[:browser-test] Build completed. (1250 files, 10 compiled, 8 warnings, 25.39s)
Browser tests: Ran 1474 tests containing 9154 assertions. 0 failures, 0 errors.
captured EXIT=0
```

Ten files recompiled, so the plant was in the bundle. The control immediately before, same worktree, was the identical **1474 / 9154 / captured exit 0**. The finding holds exactly as filed.

## Replaced, not repaired — and the reason is mechanical

`impl/codec`'s `revision-key` states the whole delivery of a revision:

> the revision is a value the body reads, **its change re-runs the body**, the re-run re-commits the element, and the commit re-asserts the model against the DOM

React marks that host update on props-object **identity** (HD-004 refuses prop-object caching), so **any** re-render of the boundary performs the same re-assert. A discard here already moves three of the editor's reads — the draft, the dirty flag, the save status — so the body re-runs whatever the counter does.

That is a stronger statement than "the field is accepting, so React's value diff covers it", and it is the statement that decides repair-vs-replace: it says the bump is inert for **every** DOM state, not just for the undrifted one. So it was measured against the hardest case rather than assumed. A probe drifted a field's DOM by an **eventless value write** — the password-manager shape the controlled-input testbed's `revision` arm uses deliberately — and then discarded, with the bump deleted:

```
Ran 1475 tests containing 9157 assertions.
1 failures, 0 errors.
captured EXIT=1
```

The drift was repaired; the probe stayed green. (The one failure in that run is the *other* application's counter arithmetic — see the second finding below.)

**No assertion on this application's discard can distinguish the bump's presence from its absence.** The row was therefore not salvageable by strengthening it — the observable does not exist — and patching it would have produced a second row that looked like a control and was not. This PR takes bead acceptance 2: the bookkeeping comes out and finding 5 is withdrawn in both reports with the reason.

Out: the `:revision` app-db key, `db/revision`, the two `(fnil inc 0)`s, `::subs/revision`, and both `::h/revision` props. One consumer outside the slice followed it out — see the note under the gate table.

## What replaces it — two rows and a real control

`flow-dom-cljs-test` §4 is now a pair, and both rows name a trigger that exists:

- `discarding-moves-the-model-back-without-remounting-the-field` — the true half of the old row: the model moves, and React's own commit re-baselines the **same element**.
- `a-discard-repairs-a-field-the-model-never-agreed-to` — the row that keeps the counter out. It drifts the DOM by a route React cannot see, then discards, and shows the repair happening with no revision anywhere.

`l2-cljs-test` pins the absence at the tier that can read a marker off an authored form (`neither-text-field-carries-a-reset-trigger`), because an absence nothing asserts is an absence somebody re-adds.

**The control, run:** `(update :drafts dissoc slug)` deleted from `::discard` — the trigger the new rows actually name — reddens both of them.

```
Ran 1475 tests containing 9158 assertions.
4 failures, 0 errors.
captured EXIT=1
```

```
FAIL in (discarding-moves-the-model-back-without-remounting-the-field) flow_dom_cljs_test.cljs:411
  actual: (not (= "Intents are data" "typed and regretted"))
FAIL in (discarding-moves-the-model-back-without-remounting-the-field) flow_dom_cljs_test.cljs:419
FAIL in (discarding-moves-the-model-back-without-remounting-the-field) flow_dom_cljs_test.cljs:420
FAIL in (a-discard-repairs-a-field-the-model-never-agreed-to) flow_dom_cljs_test.cljs:454
  actual: (not (= "Intents are data" "pasted by something else"))
```

**The plant is an assertion failure, not a crash.** The planted run has the *same* namespace and assertion totals as the green one — 1475 / 9158 both — so no namespace was stopped and no row after the plant went unrun. That is the check the browser lane's single un-caught block makes necessary.

## Both reports' finding 5

Withdrawn and replaced in `authoring-report-slice.md` and `authoring-report-todo.md`. The slice's asked for a guide row teaching every author *you will need a counter*; the todo's bounded it to *a field that OUTLIVES its reset*. The slice's field outlives its reset and needs nothing, so both statements are corrected to the population the evidence supports:

> `::h/revision` is the door for a reset that leaves **every other read the body makes `=`** — a normalising or refusing field whose typed value lands back on the value the model already holds, or a DOM drifted by a route React never saw and re-asserted by a control that changes no other state.

and the guide row is inverted: give the author the **test**, not the counter. The slice report's door table drops `::h/revision` (nine names and **two** keywords, not three), and `::h/revision` joins its "never reached" list with the story of how it got there.

**The runtime is not indicted.** No runtime code is touched. The reset law itself is witnessed by the controlled testbed's `revision` / `revision-strict` arms on three engines; this was a defect in the Phase 2 evidence.

## Filed, not absorbed

**rf2-5h9k (P1)** — `examples/editor`'s `what-the-revision-bump-is-actually-load-bearing-FOR` is hollow too. It is the row the corpus offers as the *correct* counterpart to this one, and with its own bump deleted from `examples/editor/events.cljs:173` it stayed green; the only failure in that run was `a-discard-restores-every-field-and-bumps-the-revision`, i.e. `(not (= 1 0))` — the counter's own arithmetic, not a DOM observable. Outside this bead's fence, and CHECKPOINT 2 was live on the surface, so it is filed rather than fixed. The slice report carries a caution beside finding 5 not to write the guide row from that row until rf2-5h9k settles.

## Quality gates

Every exit code below is the **captured** `$?`, echoed on the same command line as the gate. On two of these runs the harness reported exit 0 while the captured code was 1 — the captured one is what is quoted.

| # | Gate | Tree | Tests | Assertions | Failures | Captured exit |
|---|---|---|---|---|---|---|
| 1 | `npm run test:browser` | `origin/main`, unmodified | 1474 | 9154 | 0 | **0** |
| 2 | `npm run test:browser` | + `::h/revision` bump deleted from slice `::discard` | 1474 | 9154 | 0 | **0** ← the finding |
| 3 | `npm run test:browser` | + both applications' bumps deleted, + drift probe | 1475 | 9157 | 1 | **1** |
| 4 | `npm run test:browser` | the slice change | 1475 | 9158 | 0 | **0** |
| 5 | `npm run test:browser` | run 4's tree + `(update :drafts dissoc slug)` deleted | 1475 | 9158 | 4 | **1** ← the control bites |
| 6 | `npm run test:browser` | **this PR, final tree** | 1475 | 9158 | 0 | **0** |
| 7 | `npm run test:cljs` | **this PR, final tree** | 13824 | 69916 | 0 | **0** |
| 8 | `python scripts/check_doc_slugs.py` | this PR | — | — | — | **0** |
| 9 | `python scripts/check_provenance_pins.py --changed-since origin/main` | this PR | — | — | — | **0** |

The node lane earned its place here rather than being run as ceremony: it caught the one consumer of `::subs/revision` **outside** `examples/slice` — the MCP runtime-query spike asserts the article route's roster holds the editor's "four reads", and the removed sub was the fourth. That test does not compile into the browser lane, so runs 1–5 could not have seen it. It is now three reads, and the spike's own record keeps its measurement as taken with a note that the application moved underneath it. **That is the one premise of mine that did not hold** — a first pass at the blast radius was truncated at twenty lines and missed the file.

Every plant was restored and the restore **verified by hashing the bytes**, not by re-reading the diff:

```
implementation/.../slice/events.cljs   50a552d289bbeb59fc57c11ad6636d164fc55bed80168f07d2ceef89855453e3  (before plant 5 == after)
implementation/.../slice/events.cljs   8fa8d7f26a710edec5886f71e071d5b9755876c9836460f0c987c17b09dab4b1  (before plant 2 == after)
implementation/.../slice/db.cljs       9cb6716f8062f5c880ac0ceb32b412f9475b642eb9a7e4763f207deed7812753
implementation/.../slice/flow_dom_cljs_test.cljs  340f241f2a84a61109ef368cb058d8c4ff20caf33e378b7ac14a1f17b928e704
```

`examples/editor/events.cljs` — planted for run 3, outside this PR's fence — was restored and confirmed byte-identical to `HEAD` by an empty `git status --porcelain`.

`npm run test:hicasso-hmr` was **not** run (it binds `:dev-http` 8061).
