### PR TITLE
test(hicasso): make examples/editor's revision row witness the revision (rf2-5h9k)

### DIFF
--- a/implementation/hicasso/test/re_frame/hicasso/examples/editor/events.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/examples/editor/events.cljs
@@ -56,12 +56,25 @@
 
   [[::discard]] bumps `:revision` with `(fnil inc 0)`, which is
   rf2-hic-025's finding 5. What this application adds is the measurement
-  the report could not make: `editor.flow-dom-cljs-test`
-  §the-discard-row states, at its own assertion, which of the four fields
-  can drift far enough for the bump to be load-bearing and which cannot.
-  The `fnil` is not optional in either case — the seed carries no
-  `:revision` key, so a first discard on a plain `inc` is a
-  `nil` arithmetic error rather than a reset."
+  the report could not make, and it took two attempts to get one
+  (rf2-5h9k).
+  `editor.flow-dom-cljs-test/what-the-revision-bump-is-actually-load-bearing-FOR`
+  names the one state in which the bump is the only thing that repairs a
+  field — a value written onto the glass by something that fired no
+  change event, so nothing converged it — and that row REDS BY NAME when
+  the `update` below is deleted.
+
+  A keystroke's own divergence is not that state, and the row that
+  assumed it was stayed green with the counter gone: `impl.controlled`
+  converges a field in the turn that typed into it, so a reset row built
+  on typing re-reads a value that has been on screen since before the
+  reset. Which is also the useful sentence for a consumer: `::h/revision`
+  is not what makes a normalising field echo — it is what re-baselines a
+  field the application never heard from.
+
+  The `fnil` is a second and smaller claim. The seed carries no
+  `:revision` key, so a first discard on a plain `inc` is a `nil`
+  arithmetic error rather than a reset."
   (:require [clojure.string :as str]
             [re-frame.core :as rf]))
 

--- a/implementation/hicasso/test/re_frame/hicasso/examples/editor/flow_dom_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/examples/editor/flow_dom_cljs_test.cljs
@@ -9,8 +9,17 @@
   - a keystroke's echo lands in the turn that typed it;
   - a NORMALISED value echoes as the committed one rather than as what
     was typed;
-  - a discard re-baselines a field that has drifted, which is the whole
-    of what `::h/revision` buys.
+  - a discard re-baselines a field that some OTHER agent drifted without
+    firing an event, which is the whole of what `::h/revision` buys.
+
+  The word *eventless* in that third claim is load-bearing rather than
+  descriptive, and it cost this file a row (rf2-5h9k). A keystroke's own
+  divergence is converged in the turn that typed it — the second claim
+  above IS that mechanism — so a reset row built on typing asserts a
+  value that has been on the glass since before the reset and stays green
+  with the counter deleted.
+  [[what-the-revision-bump-is-actually-load-bearing-FOR]] carries the
+  reasoning and the measurement.
 
   ## The per-keystroke measurement lives here (§13)
 
@@ -201,46 +210,82 @@
 (deftest what-the-revision-bump-is-actually-load-bearing-FOR
   ;; rf2-hic-025's finding 5 says the bump is needed because dropping a
   ;; draft "moves the model back to a value the field is already
-  ;; showing". This application is the place to say WHICH fields can
-  ;; reach that state, because it has one of each policy.
+  ;; showing". This application is the place to say what can reach that
+  ;; state, because it has one field of each policy on one page.
   ;;
-  ;; MEASURED, and it refines the finding rather than repeating it. A
-  ;; field the model ACCEPTED from has no drift: the model is what the
-  ;; field shows, so a discard moves the value React compares and the
-  ;; wall opens whether a revision moved or not. The bump is load-bearing
-  ;; where the model DID NOT take what was typed — a refusal, or a
-  ;; normalisation whose result the field is already displaying — and it
-  ;; is those fields whose discard is silently broken without it.
+  ;; ## What was here before, and why it was replaced rather than fixed
   ;;
-  ;; The row below is the reachable half at this tier: type a value the
-  ;; slug policy normalises to the value the model already holds, so the
-  ;; model does not move at all, then discard. Without the revision the
-  ;; wall has value-equality on both sides and bails.
+  ;; The first row written here (rf2-5h9k) typed into the slug a value
+  ;; its policy normalises back to what the model already held, discarded,
+  ;; and asserted the field showed the model. It was measured with
+  ;; `::events/discard`'s `(update :revision (fnil inc 0))` DELETED, and it
+  ;; stayed GREEN — so it was never asserting the counter at all.
+  ;;
+  ;; The reason is mechanical and is one file away. A keystroke's
+  ;; divergence is not drift: `impl.controlled/converge!` runs at the end
+  ;; of the change handler, in the same discrete event, and writes the
+  ;; model's value onto the glass — which is exactly what
+  ;; [[a-normalised-keystroke-echoes-the-COMMITTED-value]] asserts three
+  ;; rows above, on this same field with this same setup. By the time that
+  ;; row clicked `#discard` the field had shown `"intents-are-data"` since
+  ;; the keystroke, and the closing assertion re-read a value nothing had
+  ;; disturbed. A row that cannot see its own subject is not patched into
+  ;; seeing it; the stimulus was wrong, so the stimulus is what changed.
+  ;;
+  ;; ## The drift the reset law is about is the drift NO HANDLER RAN FOR
+  ;;
+  ;; A password manager, an autofill, a browser extension assigning
+  ;; `.value`. No change event, so no handler, so the in-turn converge
+  ;; never sees it — and React's own end-of-event restore is not on this
+  ;; path either. The only thing that repairs it is React's per-commit
+  ;; controlled re-assert, and that runs when the BOUNDARY RE-RENDERS.
+  ;; (`impl.codec/revision-key` states the whole delivery in those terms.)
+  ;;
+  ;; Which makes this a claim about the read set of ONE BOUNDARY rather
+  ;; than about the form. `views/text-field` reads exactly two addresses,
+  ;; its own field and the counter, so a discard that leaves this field's
+  ;; value where it is can notify it through `::subs/revision` and through
+  ;; nothing else. The form is therefore dirtied from ANOTHER field: that
+  ;; makes `#discard` live and gives the discard real work — `:draft
+  ;; :title` moves and `::subs/dirty?` moves — while neither address is
+  ;; read by the boundary under measurement. `::subs/dirty?` feeds
+  ;; `views/buttons`, which is a separate boundary for the separate reason
+  ;; [[the-per-keystroke-body-count-is-one-and-does-not-grow]] measures,
+  ;; and that separation is what makes this row reachable at all.
   (if-not (browser?)
     (skip! "the drift case")
-    (let [m (mount-editor!)
-          n (field-node m :slug)]
-      (set-native-value! n "")
-      (type-into! n "Intents Are Data")
+    (let [m     (mount-editor!)
+          title (field-node m :title)
+          slug  (field-node m :slug)]
+      (type-into! title "!")
       (hm/settle! m)
-      (is (= "intents-are-data" (model m :slug))
-          "the normalisation landed on the value the article already
-           holds, so the MODEL is where it started")
-      (is (false? (rf/with-frame (:frame m) (deref (rf/subscribe [::subs/dirty?]))))
-          "and the form is not even dirty — the draft equals the article")
+      (is (true? (rf/with-frame (:frame m) (deref (rf/subscribe [::subs/dirty?]))))
+          "dirtied from the OTHER field, so `#discard` is live and the
+           slug's own address is not among what the discard will move")
 
-      ;; The field, however, is not necessarily where it started: what it
-      ;; shows is whatever the converge last wrote, and a discard from
-      ;; here asks the wall to re-assert a value equal to the one it last
-      ;; rendered. That is precisely the state the revision exists for.
+      ;; The drift, and it is EVENTLESS on purpose.
+      (set-native-value! slug "typed-by-nobody")
+      (is (= "typed-by-nobody" (.-value slug))
+          "the glass moved")
+      (is (= "intents-are-data" (model m :slug))
+          "and the model did not. That gap is the drift, and it is the
+           one kind nothing in this runtime closes on its own: no change
+           event fired, so no handler ran, so the converge that repairs a
+           keystroke's divergence never saw it")
+
       (click! (node m "#discard"))
       (hm/settle! m)
-      (is (= "intents-are-data" (.-value n))
-          "restored. The revision moved, so the wall opened on a value
-           React's own diff had nothing to say about — this is the case
-           rf2-hic-025 named, reached from a NORMALISING field rather than
-           from a draft map, and it is why the counter cannot be dropped
-           as bookkeeping nobody can see a reason for")
+      (is (= "intents-are-data" (.-value slug))
+          "re-baselined, and the counter is the only thing that could have
+           done it. `:draft :slug` never moved, so of this boundary's two
+           reads the discard touched only `::subs/revision`; the bump
+           re-ran the body, the re-run re-committed the element, and the
+           commit re-asserted the model over a draft React's own value
+           diff had nothing to say about. Delete the `(update :revision
+           (fnil inc 0))` from `::events/discard` and THIS row reds, with
+           the field still showing `typed-by-nobody` — measured, and that
+           is why the counter cannot be dropped as bookkeeping nobody can
+           see a reason for")
       (hm/unmount! m))))
 
 (h/defview bad-revision-box


### PR DESCRIPTION
Closes rf2-5h9k.

## The finding, reproduced before anything was changed

`examples/editor`'s `what-the-revision-bump-is-actually-load-bearing-FOR` is the row
the corpus offered as the CORRECT counterpart to the slice's hollow one (rf2-36bd).
It is hollow too, and that was verified here at source rather than taken on report.

`(update :revision (fnil inc 0))` was deleted from `examples/editor/events.cljs`
`::discard` — nothing else touched — and `npm run test:browser` re-run:

```
Ran 1474 tests containing 9154 assertions.
1 failures, 0 errors.
captured EXIT=1
```

Identical test and assertion counts to the control (1474 / 9154), so nothing
crashed out of the lane. The **one** failure is
`a-discard-restores-every-field-and-bumps-the-revision` at
`flow_dom_cljs_test.cljs:189` — `(not (= 1 0))`, the counter's own arithmetic.
`what-the-revision-bump-is-actually-load-bearing-FOR` stayed **GREEN** with no
revision bump anywhere in the application.

## Replaced, not repaired — and the reason is one file away

The row could not see its own subject, so patching the assertion could not have
made it see one. `impl.controlled/converge!` runs at the end of the change
handler, inside the same discrete event, and writes the model's value onto the
glass. That is exactly what `a-normalised-keystroke-echoes-the-COMMITTED-value`
asserts three rows above, **on the same field with the same setup**. So by the
time the old row clicked `#discard`, the slug field had been showing
`"intents-are-data"` since the keystroke, and the closing assertion re-read a
value nothing had disturbed. The stimulus was wrong; the stimulus is what changed.

**The drift the reset law is about is the drift no handler ran for** — a password
manager, an autofill, an extension assigning `.value`. No change event, so no
handler, so no converge; React's end-of-event restore is not on that path either.
The only repair is React's per-commit controlled re-assert, which runs when the
**boundary re-renders**.

That makes it a claim about the read set of **one boundary**, not of the form.
`views/text-field` reads exactly two addresses — its own field and the counter — so
the replacement dirties the form from the **title**, which makes `#discard` live and
gives the discard real work (`:draft :title` moves, `::subs/dirty?` moves) while
neither address is read by the boundary under measurement. `::subs/dirty?` feeds
`views/buttons`, a separate boundary for the separate reason
`the-per-keystroke-body-count-is-one-and-does-not-grow` measures — and that
separation is what makes the row reachable at all.

## The red demonstration

Same plant (bump deleted), new row in place:

```
Ran 1474 tests containing 9155 assertions.
2 failures, 0 errors.
captured EXIT=1
```

```
FAIL in (a-discard-restores-every-field-and-bumps-the-revision) (…:189:11)
  actual: (not (= 1 0))
FAIL in (what-the-revision-bump-is-actually-load-bearing-FOR) (…:269:11)
  actual: (not (= "intents-are-data" "typed-by-nobody"))
```

The field still showing the eventless drift. Counts against the control:
1474 tests both runs (no namespace lost), 9155 vs 9154 assertions — the new row
carries one more `is` than the old one, which is the whole of the difference.
(`:269` is the line number in the planted tree, before the header paragraph was
added; the same assertion is `:278` on this branch.)

**The plant was reverted and the revert verified by hashing bytes**, not by reading
a diff: the `::discard` region of `events.cljs` from `git show HEAD:` and from the
working tree both hash to
`48df43bc118aad6c34ce8166db377e3902f03fdfea785df6db14ba059aee5513`, and `cmp`
reports them identical. The only change to `events.cljs` on this branch is its
namespace docstring.

## Is the revision witnessable at this tier?

**Yes** — so acceptance (1) settles on the first arm rather than the second, and the
load-bearing claim stays in `examples/editor` instead of moving to the testbed's
`revision` / `revision-strict` arms.

One premise of the bead did not hold, and it is the one that predicted otherwise.
rf2-5h9k reasoned that `#discard`'s enabled/disabled state, `::subs/dirty?` and
`:draft` "are read by the same body". They are not: `::subs/dirty?` is
`views/buttons`' read, and `views/text-field` reads only its own field and the
counter. The editor's form body is wide; the field boundary's read set is two
addresses, and two is narrow enough. The bead's secondary diagnosis — that the old
row was hollow because something else re-ran the body — also does not hold: in that
row's own setup `::subs/dirty?` was asserted false and `:draft :slug` never moved,
so nothing re-ran anything. It was hollow because there was no drift left to repair.

## Prose brought into line (acceptance 3)

- `flow_dom_cljs_test.cljs` header — the third claim now reads "a field that some
  OTHER agent drifted without firing an event", and says why *eventless* is the
  load-bearing word rather than a descriptive one.
- `events.cljs` §"The revision counter is the author's to invent" — names the one
  state the bump repairs, records that a keystroke's own divergence is not that
  state, and demotes the `fnil` to the second and smaller claim it is.

## Quality gates

| gate | tree | captured exit | result |
|---|---|---|---|
| `npm run test:browser` | control (`origin/main`) | **0** | 1474 tests / 9154 assertions, 0 failures, 0 errors |
| `npm run test:browser` | plant A — bump deleted, row unchanged | **1** | 1474 / 9154, 1 failure (`:189` only); row under test GREEN |
| `npm run test:browser` | plant B — bump deleted, replacement row | **1** | 1474 / 9155, 2 failures (`:189` + the new row) |
| `npm run test:browser` | this branch | **0** | 1474 / 9155, 0 failures, 0 errors |
| `npm run test:cljs` | this branch | **0** | 13823 tests / 69923 assertions, 0 failures, 0 errors |

`test:cljs` is here because `events.cljs` is a node-lane namespace; its only change
on this branch is the namespace docstring.

Every exit code above is the one captured with `echo $?` on the same command line as
the gate, redirected to its own log — never the harness's report.

Namespace rosters were compared as well as counts: all four browser runs report
1474 tests, and the two red runs (the only ones whose full console is dumped)
enumerate the same 223 namespaces, so the plant took nothing out of the lane.

One local-environment note, in case it is useful to somebody reading the logs
rather than a defect in this branch: an earlier `test:cljs` attempt reported 18
failures, all in `re-frame.test-quiet-shadow-node-cljs-test`, while a second
`test:cljs` was compiling in the same tree. That namespace spawns real
shadow-cljs child runs, so two concurrent invocations contend over
`implementation/out/`. Run serially and it is clean, as the table shows.
