### PR TITLE
docs(hicasso): the door states its four event-value shapes; settle! stops over-promising (rf2-lu0s, rf2-jljf)

### DIFF
--- a/docs/design/hicasso/product/authoring-report-slice.md
+++ b/docs/design/hicasso/product/authoring-report-slice.md
@@ -111,7 +111,9 @@ The same is true of any **async mutation reply**, and there it is the applicatio
 
 Neither of those is a defect on its own. What is missing is a door: **the L3 facade has `settle!` for React's work and `dispatch-and-settle!` for a dispatch it makes itself, and nothing for "work is enqueued in the router; let it land."** The slice uses `re-frame.test-support/poll-until`, which is the supported condition-poll and composes with `cljs.test/async`, and states the rule in its own namespace docstring.
 
-*Candidate for the freeze, and it belongs to rf2-hic-027 rather than to the facade:* an `hm/drain!` or a `:until` option on `settle!`, so the L3 vocabulary covers the async half of the runtime it is a facade for.
+*Candidate for the freeze, and it belongs to the L3 test facade rather than to the product door:* an `hm/drain!` or a `:until` option on `settle!`, so the L3 vocabulary covers the async half of the runtime it is a facade for.
+
+**Owner: rf2-6m4w.** This line first named `rf2-hic-027`, which had closed on 2026-08-10 — before this report was written — so the checkpoint's most-confirmed finding was assigned to a bead that could not carry it. rf2-jljf corrected `settle!`'s docstring, filed rf2-6m4w as the owner, and recorded there why neither candidate spelling survives as written: the router drain is a macrotask, so no synchronous `drain!` is possible and a `:until` option would make the one synchronous door conditionally asynchronous.
 
 ### 7. The virtual clock and `poll-until` cannot be used together
 

--- a/docs/design/hicasso/product/authoring-report-todo.md
+++ b/docs/design/hicasso/product/authoring-report-todo.md
@@ -76,7 +76,9 @@ The slice found this on a save and a discard against a stand-in server, and its 
 
 So the finding is wider than the slice could show: the missing L3 door is needed by an application that never talks to anything. The mounted suite here uses `re-frame.test-support/poll-until` through one helper, `drained`, for the same reason.
 
-*The candidate remedy stands unchanged and belongs to rf2-hic-027:* an `hm/drain!`, or a `:until` option on `settle!`.
+*The candidate remedy stands unchanged:* an `hm/drain!`, or a `:until` option on `settle!`.
+
+**Owner: rf2-6m4w.** This line first named `rf2-hic-027`, which had closed on 2026-08-10 — before this report was written — so the remedy was assigned to a bead that could not carry it. rf2-jljf corrected `settle!`'s docstring and filed rf2-6m4w as the owner; the reasons neither candidate spelling survives as written are recorded there.
 
 ### 7. The virtual clock and `poll-until` cannot be used together — CONFIRMED by construction
 

--- a/implementation/hicasso/src/re_frame/hicasso.cljc
+++ b/implementation/hicasso/src/re_frame/hicasso.cljc
@@ -104,6 +104,48 @@
   makes the head's identity stable by construction and leaves the codec's
   stable-component-head cache with nothing to do.
 
+  ## What a value at an `on-*` prop may be — FOUR shapes
+
+  A body writes its handlers as DATA, and the SHAPE of the value at an
+  `on-*` position selects the behaviour — so there is no roster of
+  blessed prop names, and `:on-click` and `:onClick` read the same:
+
+      [:li    {:on-click [:todo/toggle id]}]               ;; a vector
+      [:input {:on-key-down {\"Enter\"  [:todo/commit id]    ;; a map
+                             \"Escape\" [:todo.ui/cancel id]}}]
+      [:input {:on-change (h/hfn [e] …)}]                  ;; the one callback
+      [:div   {:on-focus  a-plain-fn}]                     ;; a plain fn
+
+  - **A vector is an intent**, dispatched into this boundary's frame.
+    `::h/value` and `::h/checked` substitute the event target's current
+    value at dispatch time, and `::h/prevent` is the reserved head that
+    calls `.preventDefault` before dispatching the intent it wraps —
+    `[::h/prevent [:filter/show-done]]`, the opt-in an anchor acting as
+    a button needs, since `:on-submit` is the only position that
+    prevents by default.
+  - **A map is a KEY MAP** — the key exactly as the browser spells it
+    (`\"Enter\"`, `\"Escape\"`) → an intent vector or a function. It is
+    lowered ONCE per render into a plain string→handler map, so an event
+    costs one lookup and no allocation, and it is **composition-gated
+    centrally**: a keystroke arriving mid-IME-composition commits
+    nothing. That gate is the half a hand-written `.key` test does not
+    have, which is why the key map is the spelling to reach for — the
+    hand-written version yields an application that works and is wrong
+    for every user who composes.
+  - **[[hfn]] (`h/fn`) is the one callback form**, for when the event
+    itself is wanted. At an `on-*` position a returned vector is
+    dispatched and any other return is ignored.
+  - **A plain function is passed through untouched**, reaching React by
+    identity so `React.memo` and every handler-identity bail-out keep
+    working.
+
+  The vector and the key map are EVENT-FIRST: both read the DOM event
+  from argument one, and a position whose invoker passes something else
+  — a value-first foreign callback — refuses loudly at the position
+  rather than doing nothing. Which contract a position imposes on a
+  callback, and what a [[defhost]] declaration changes about it, is
+  [[re-frame.hicasso.impl.intent]]'s position table.
+
   ## The fn this expands to is ANONYMOUS, and that is the contract
   (rf2-jan2)
 

--- a/implementation/hicasso/test_kit/src/re_frame/hicasso/test/mounted.cljs
+++ b/implementation/hicasso/test_kit/src/re_frame/hicasso/test/mounted.cljs
@@ -97,7 +97,10 @@
 
   After anything that stimulates the page from OUTSIDE a facade door — a
   user-event sequence, a raw `.click`, a timer you fired yourself — call
-  [[settle!]] before you assert.
+  [[settle!]] before you assert. It commits what already reached React
+  and no more: work the router has merely ENQUEUED — a route-link click,
+  any async reply — lands on a later task, and [[settle!]] names what to
+  wait on instead.
 
   ## Settled, not `act`
 
@@ -976,9 +979,42 @@
   handle. The empty `flushSync` — no work of its own.
 
   Call it after anything that stimulated the page from outside a facade
-  door: a `user-event` sequence, a raw `.click`, a resolved promise, a
-  timer you fired yourself. After it returns the DOM is the one a user
-  would be looking at.
+  door and whose handlers have ALREADY RUN: a `user-event` sequence, a
+  raw `.click` on an element carrying a Hicasso intent, a timer you
+  fired yourself. An intent lowered in a body dispatches through the
+  arm's frame-locked SYNCHRONOUS door, so by the time the click returns
+  the handlers have run and app-db has moved; this commits the echo, and
+  the next line reads the DOM a user would be looking at.
+
+  ## It cannot reach work that is merely ENQUEUED
+
+  That promise is about React, and it is only as good as what reached
+  React before the flush. **Two ordinary clicks on one page settle
+  differently, and nothing at either call site says which is which.**
+
+  - A **route-link** click ends in `re-frame.routing/activate-link!`,
+    which ends in `router/dispatch!` — the ASYNC door. The navigation is
+    enqueued and the router drains it on `interop/next-tick`, a
+    next-turn TASK, so at this line nothing is scheduled in React and
+    the flush has nothing to flush.
+  - Every **async reply** arrives the same way, and there it is the
+    application being ordinary rather than routing being special: an fx
+    that replies with `rf/dispatch` after the drain that started it has
+    finished — an HTTP response, a `.then`, a `setTimeout` — enqueues
+    rather than runs.
+
+  Awaiting a promise does not close the gap either, because the drain is
+  a MACROTASK and a `.then` runs at the microtask checkpoint ahead of
+  it. Nor does `{:clock true}`: firing a timer only enqueues the reply,
+  and [[advance-clock!]] deliberately does not drive the task the drain
+  rides on.
+
+  So wait on the CONDITION rather than on this door.
+  `re-frame.test-support/poll-until` is the supported condition-poll —
+  a published core door, not an internal — and it returns a promise that
+  composes with `cljs.test/async`. This facade has no verb of its own
+  for *work is enqueued in the router; let it land*, and whether it
+  should is **rf2-6m4w**, which owns that question.
 
   The flush is React's and is therefore page-wide; the handle is taken so
   that every door in this facade reads the same way."


### PR DESCRIPTION
Two facade-documentation defects filed by CHECKPOINT 2. One commit per bead. **Nothing about the runtime changes** — no facade export is added, moved or removed, and no behaviour is touched.

---

## rf2-lu0s — the public door never stated the four event-value shapes

**Verified at source before writing.** `implementation/hicasso/src/re_frame/hicasso.cljc` was 607 lines with **zero** occurrences of `on-key`, `key-map` or `keymap`, and every event example on it was an intent vector. The four shapes are written out in exactly one place a reader can reach: `impl/intent.cljs`'s namespace docstring table — inside `re-frame.hicasso.impl.*`, which the door's *first paragraph* tells authors is below the line they write against. `::h/prevent` was named in the door's marker list (`:40-42`) and explained nowhere on it.

The four shapes, confirmed independently at `impl.intent/lower-prop`:

```clojure
(if (event-prop? k)
  (cond
    (vector? v)   (intent-handler k v)     ;; 1. an intent, dispatched into this frame
    (map? v)      (key-map-handler k v)    ;; 2. a key map, composition-gated
    (callback? v) (event-callback k v)     ;; 3. h/hfn — a returned vector dispatches
    :else         v)                       ;; 4. a plain fn, untouched → React by identity
  …)
```

`defview`'s docstring now carries one section stating all four, with the Enter/Escape key-map example, the composition gate named as the half an author cannot re-derive, and `::h/prevent` given the one line the door owed it. The position/contract taxonomy stays in `impl.intent` behind a pointer — the door owes the *ordinary* shapes, not the taxonomy.

The runtime's argument law runs **first** in `key-map-handler` (`event-arg!` before `composing?` before the lookup), so a key map at a non-keyboard prop raises `:rf.error/hicasso-intent-needs-the-event` naming the position rather than doing nothing. The new text is consistent with that and does not warn about a failure the runtime already reports well.

## rf2-jljf — `settle!` promised a DOM it cannot reach, and the remedy was assigned to a closed bead

### The docstring half (delivered)

`impl.mount/settle!` is `(react-dom/flushSync (fn [] nil))`. The docstring listed *"a raw `.click`"* and *"a resolved promise"* among what it settles, then promised *"After it returns the DOM is the one a user would be looking at."* For half the clicks on an ordinary page that is false:

- An **intent** lowered in a body dispatches through the arm's frame-locked **synchronous** door (`collector/mint-frame-dispatch` closes over `:dispatch-sync`), so handlers have run and app-db has moved before the click returns. `settle!` commits the echo — promise holds.
- A **route-link** click ends in `re-frame.routing/link/activate-link!`, which ends in `router/dispatch!` — the async door. `interop/next-tick` is `goog.async.nextTick`, a **macrotask**. Nothing is scheduled in React at that line, so the flush has nothing to flush.
- Awaiting a promise does not close it either: a `.then` runs at the microtask checkpoint *ahead* of the macrotask drain.

The docstring now says what it commits, what it cannot reach, names the router drain, and points at `re-frame.test-support/poll-until`. The namespace docstring's one-line version of the same claim is corrected with it.

### The missing door (reported, not answered)

An L3 verb is an API addition and a naming question, so it is not mine to settle. Three findings narrow it, all at source:

1. **The gap is real.** `mounted.cljs` defines no `drain!` and `settle!` takes no options — its signature is `[handle]`.
2. **But an author is not without a spelling, and the spelling is first-class.** `re-frame.test-support/poll-until` lives on `core`'s published `:paths` with its own Spec 008 audience-split section — a sibling public door, not an internal reached past a facade. **Fourteen files under `implementation/hicasso/` already reference it, not two.** That makes the second-caller argument *stronger* than the reports state and the "authors have nowhere to go" argument *weaker*: what is missing is facade vocabulary, not a capability.
3. **Neither proposed spelling survives contact.** The drain is a macrotask, so a synchronous `hm/drain!` is impossible — it must return a promise, which puts it outside the facade's handle-first threading contract. A `:until` option would make the one synchronous door conditionally asynchronous. And a drain has no fixed tick count (an fx reply may schedule another), so an honest door needs a condition *and* a deadline — which is `poll-until`'s contract. The live candidate is a thin promise-returning condition door over it, not a drain primitive.

### The ownership half

Both reports assigned the remedy to **`rf2-hic-027`, closed 2026-08-10 (VERIFIED-DUPLICATE)** — before either report was written. Nothing open owned it.

**I filed a new bead, `rf2-6m4w` (`[OPERATOR-DECISION]`, P2), rather than naming `rf2-jljf` itself** — matching rf2-zk87's reasoning: a bead that closes cannot own an obligation that outlives it, and naming a closing bead reproduces the exact defect being fixed. Both report lines and `settle!`'s docstring now name `rf2-6m4w`.

The docstring's `poll-until` pointer is deliberately framed as *the spelling that works today* rather than as a decline, so it forecloses nothing rf2-6m4w may rule.

---

## Quality gates

Run from `implementation/` (npm) or repo root (python), foreground, redirected to a log with `$?` echoed on the same command line. Exit codes below are the ones **I captured**, not the harness's.

| Gate | Exit |
|---|---|
| `npm run test:cljs` | **0** — `Ran 13823 tests containing 69923 assertions. 0 failures, 0 errors.` |
| `npm run test:cljs` — negative control (unescaped `"` planted in `settle!`'s new docstring) | **1** |
| `npm run test:hicasso-invariants` | **0** |
| `python scripts/check_doc_slugs.py` | **0** |
| `python scripts/check_doc_slugs.py` — negative control (broken anchor planted in the todo report's new line) | **1** |
| `python scripts/check_provenance_pins.py --changed-since origin/main --verbose` | **0** (`2 files, 0 cited pins`) |
| `python scripts/check_provenance_pins.py` — negative control (unlanded head planted in the slice report's new line) | **1** |

Every planted control was restored and the restore **verified by hashing the bytes** back to the pre-plant `sha256`.

**Trunk moved twice under this branch** and it was rebased both times. The four edited files came through **byte-identical each time**, verified by `sha256sum` against the pre-rebase hashes. The slugs, provenance-pins and hicasso-invariants gates were re-run on the final base (all 0). The `test:cljs` **0** was captured one base earlier, on `9a981a12d7`; nothing in either trunk move touches this branch's surface — the second brought in `docs/design/hicasso/product/async-routing-recipes.md`, which is application-level routing/resource recipes and mentions neither `settle!`, the router drain nor `poll-until`.

**Gate-selection notes, stated rather than assumed:**

- The `test:cljs` control is the discriminating one for both `.cljs` edits. It reds at `mounted.cljs:1036` — which is the useful fact, because it proves `hicasso/test_kit/src` is genuinely on the `:node-test` compile path rather than only on the browser lane.
- **The freeze manifest does not read either file I touched.** `implementation/hicasso/frozen-sources.edn` is down to one row (`front/slot.cljc`, a bench donor). Its SEALED scan *is* package-wide and does read both files — but only for forbidden `:require` prefixes, which a docstring cannot affect. `test:hicasso-invariants` was run anyway (exit 0) and is honestly reported as **non-discriminating for a prose-only edit**.
- `mkdocs build --strict` is **not** nominated: `mkdocs.yml`'s `exclude_docs` keeps `docs/design/` out of the site.
- `npm run test:hicasso-hmr` was **not** run (binds `:dev-http` 8061).

**Anchors and tables verified by hand** (nothing under `docs/design/**` validates rendering):

- Neither report edit adds or renames a heading, so **no anchor changed**; `check_doc_slugs.py` re-confirms every link target and heading anchor across the tree (exit 0).
- Neither edit adds, removes or touches a table row. Column counts, counted by hand and unchanged:
  - `authoring-report-slice.md` — 2 tables. *Reached / Used for*: **2 columns**, 8 body rows. *Suite / Namespace suffix / Lane*: **3 columns**, 2 body rows.
  - `authoring-report-todo.md` — 2 tables. *Reached / Used for*: **2 columns**, 8 body rows. *Suite / Namespace suffix / Lane*: **3 columns**, 2 body rows.
- Both added paragraphs are plain prose with inline code only — no links, no pipes, no fenced blocks.

## Fence

Touched: `implementation/hicasso/src/re_frame/hicasso.cljc`, `implementation/hicasso/test_kit/src/re_frame/hicasso/test/mounted.cljs`, and the two authoring reports **only** at the lines assigning the remedy to the closed bead. No hot-zone file, no `spec/*`, no workflow, no build id, no `:dev-http` port. `docs/design/hicasso/product/correction-ledger.md`, `docs/machines/**`, `implementation/machines/test/**`, `.github/**` and the slice witnesses under `examples/slice/` are untouched.
