### PR TITLE
fix(hicasso): wrap Tab at the modal's sequential edge, not its DOM edge

### DIFF
--- a/implementation/hicasso/src/re_frame/hicasso/impl/overlay.cljs
+++ b/implementation/hicasso/src/re_frame/hicasso/impl/overlay.cljs
@@ -228,19 +228,21 @@
 ;; is bought for "focus cannot Tab outside it", which the guide promises
 ;; and rf2-hic-052 owns, so the two edges are closed here.
 ;;
-;; This is a WRAP AT TWO EDGES and not a focus manager. It computes no
-;; order, tracks no state, and does not run for any key but Tab: between
-;; the edges the engine moves focus exactly as it always did.
+;; This is a WRAP AT TWO EDGES and not a focus manager. It tracks no
+;; state, holds no listener while idle, and does not run for any key but
+;; Tab: between the edges the engine moves focus exactly as it always
+;; did. It does have to know which control IS each edge, and that much
+;; order it derives on the press — see [[sequential-tab-stops]], which
+;; states its own boundary because a half-model that did not is what
+;; the audit of #8071 found here.
 
 (def ^:private tab-stop-selector
   "Everything the engine could make a tab stop of, as a selector.
 
-  A superset on purpose. It is filtered down by [[tab-stop?]] asking the
-  properties the engine itself decides tabbability by, and the two are
-  used only to recognise the panel's FIRST and LAST stop. A candidate
-  this misses therefore costs a wrap that does not fire — the engine's
-  own conduct, unchanged — and never a wrap that fires at the wrong
-  place, because the set can only be too large."
+  A superset on purpose, narrowed by [[tab-stop?]] and then ORDERED by
+  [[sequential-tab-stops]]. On its own it answers *which elements are
+  candidates*, which is not the same question as *where Tab goes*, and
+  the gap between the two is what the audit of #8071 measured."
   (str "a[href],area[href],button,input,select,textarea,summary,"
        "iframe,object,embed,audio[controls],video[controls],"
        "[contenteditable],[tabindex]"))
@@ -248,17 +250,106 @@
 (defn- tab-stop?
   "Would Tab stop here? Disabled elements take no focus, a negative
   `tabIndex` is reachable only programmatically, and an element with no
-  client rect is not rendered at all — `display:none`, `hidden`, or
-  inside a closed `<details>`."
+  client rect is not rendered at all — `display:none` or `hidden`."
   [^js el]
   (and (not (.-disabled el))
        (not (neg? (.-tabIndex el)))
        (pos? (.-length (.getClientRects el)))))
 
-(defn- tab-stops
-  "`panel`'s own tab stops, in document order."
+(defn- radio-group-of
+  "The radio group `el` belongs to, or nil when it belongs to none.
+
+  HTML groups radio buttons by FORM OWNER **and** NAME together, and a
+  radio with an empty name is in no group at all. Both halves measured
+  rather than read: two same-named groups inside two `<form>`s keep one
+  stop each, and two unnamed radios side by side are two stops."
+  [^js el]
+  (when (and (.matches el "input[type='radio']")
+             (not= "" (.-name el)))
+    [(.-form el) (.-name el)]))
+
+(defn- one-stop-per-radio-group
+  "`stops` with every named radio group collapsed to the single element
+  the engine actually sequences to.
+
+  **A radio group is one tab stop, not one per button** — the checked
+  member, or the first focusable member when none is checked. Measured in
+  this repo's Chromium over a modal holding
+  `[unchecked r1, checked r2, ok]`: Tab visits `r2` and `ok` and never
+  `r1`.
+
+  The choice is made over elements [[tab-stop?]] has ALREADY kept, which
+  is what makes the two degenerate cases fall out rather than need
+  rules: a checked-but-disabled member is gone before the vote, so the
+  first surviving member takes the slot, and a group whose members are
+  all disabled contributes no stop at all. Both measured."
+  [stops]
+  (let [chosen (into {}
+                     (for [[group members] (group-by radio-group-of stops)
+                           :when (some? group)]
+                       [group (or (first (filter #(.-checked ^js %) members))
+                                  (first members))]))]
+    (filterv (fn [el]
+               (if-some [group (radio-group-of el)]
+                 (identical? el (get chosen group))
+                 true))
+             stops)))
+
+(defn- sequential-tab-stops
+  "`panel`'s tab stops IN THE ORDER TAB VISITS THEM.
+
+  ## What this models, and what it does not
+
+  It models the two places sequential order departs from document order
+  inside an ordinary panel, both of which the audit of #8071 measured
+  choosing the wrong edge:
+
+  - a named radio group is ONE stop ([[one-stop-per-radio-group]]);
+  - a positive `tabindex` sorts ahead of every `tabindex=0`, ascending,
+    with document order inside each bucket.
+
+  **It is not the platform's focus algorithm and does not try to be.**
+  Four things the engine skips are still counted here, and they are
+  named rather than half-modelled: an element inside an `inert`
+  subtree, a control inside a `disabled` `<fieldset>`, a control under
+  `visibility:hidden`, and the contents of a closed `<details>`. (That
+  last one also retires a claim this file used to make: content inside a
+  closed `<details>` DOES report client rects in Chromium, so
+  [[tab-stop?]] never filtered it.) Shadow roots, `delegatesFocus` and
+  scrollable-overflow focusability are outside the set entirely.
+
+  ## Why that boundary is safe where the radio group was not
+
+  A surplus candidate costs a WRAP THAT DOES NOT FIRE when it cannot
+  take focus, and a WRAP THAT LANDS WRONG when it can — and
+  [[wrap-tab!]] only takes the default action away once the landing is
+  confirmed, so the first of those degrades to exactly the engine's own
+  conduct. Measured with `.focus()` on each: inert, disabled-fieldset,
+  `visibility:hidden` and closed-`<details>` contents ALL refuse focus,
+  while an unchecked radio in a checked group ACCEPTS it. That is the
+  whole reason the radio group was a wrong landing rather than a missed
+  wrap, and the reason the four above are not this bead's defect one
+  level further in.
+
+  A group whose checked member sits OUTSIDE `panel` needs no rule: this
+  handler is the modal's alone, so everything outside the panel is
+  inert, cannot be the group's stop, and the engine falls to the first
+  focusable member inside — which is what scanning only `panel` already
+  computes. Measured."
   [^js panel]
-  (filterv tab-stop? (array-seq (.querySelectorAll panel tab-stop-selector))))
+  (->> (array-seq (.querySelectorAll panel tab-stop-selector))
+       (filterv tab-stop?)
+       (one-stop-per-radio-group)
+       ;; Document order is the tie-break INSIDE a tabindex bucket, so it
+       ;; is carried explicitly rather than left to `sort-by` being
+       ;; stable: the rule is the point, and a sort that quietly stopped
+       ;; being stable would surface as a flaky wrap rather than as a
+       ;; failure anyone could read.
+       (map-indexed (fn [i ^js el]
+                      (let [t (.-tabIndex el)]
+                        [(if (pos? t) t js/Infinity) i el])))
+       (sort-by (fn [[bucket i _]] [bucket i]))
+       (mapv peek)))
 
 (defn- wrap-tab!
   "Tab off the panel's last stop lands on its first; Shift+Tab off its
@@ -275,12 +366,18 @@
   A press a control inside the panel has already claimed is left alone:
   the native event's `defaultPrevented` is read rather than the synthetic
   event's copy, which React takes at construction and which a child's
-  `preventDefault` during the same dispatch would not update."
+  `preventDefault` during the same dispatch would not update.
+
+  **First and last are read off SEQUENTIAL order, not document order.**
+  They are different lists — a radio group is three elements and one
+  stop — and taking the second for the first is how this handler came to
+  send Tab from a modal's last control onto an unchecked radio, and
+  Shift+Tab from its checked one onto `<body>`."
   [^js e]
   (when (and (= "Tab" (.-key e))
              (not (.. e -nativeEvent -defaultPrevented)))
     (let [^js panel (.-currentTarget e)
-          stops     (tab-stops panel)]
+          stops     (sequential-tab-stops panel)]
       (when (seq stops)
         (let [back? (.-shiftKey e)
               edge  (if back? (first stops) (peek stops))

--- a/implementation/hicasso/test/re_frame/hicasso/overlay_focus_dom_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/overlay_focus_dom_cljs_test.cljs
@@ -25,6 +25,8 @@
   | the module's modal is the trapping kind: the reachable set becomes EXACTLY the panel's controls | [[an-open-modal-is-the-whole-of-what-a-keyboard-can-reach]] |
   | the module's popover is NOT a trap, and must not be read as one | [[an-open-popover-leaves-the-page-behind-it-reachable]] |
   | a REAL Tab and a REAL Shift+Tab cycle inside the trap, and a REAL Escape lets the page back out | [[a-real-tab-cycles-within-the-modal-and-a-real-escape-gives-the-page-back]] |
+  | the wrap fires at the SEQUENTIAL edge, over a panel whose sequential order is shorter than its markup | [[a-real-tab-wraps-at-the-radio-groups-edge-and-not-at-the-dom-s]] |
+  | …and over one whose sequential order is a permutation of it | [[a-real-tab-wraps-at-the-tabindex-ordered-edge]] |
 
   The middle claim is an emptiness claim about everything outside a
   dialog, and an emptiness claim is exactly the shape that passes
@@ -77,6 +79,23 @@
   edges. The row asserts the three-stop cycle, so it reddens the day that
   handler stops working — and the version of it that recorded `<body>` as
   a waypoint is what the audit of #8058 correctly refused to accept.
+
+  ## What that row still could not fail on, and the two below that can
+
+  Its panel is three plain controls, and over three plain controls the
+  ELEMENTS a selector finds and the STOPS Tab visits are the same list in
+  the same order. A handler computing the first from document order was
+  therefore indistinguishable, here, from one computing it correctly —
+  and the audit of #8071 measured the difference on a panel this fixture
+  could not hold: a radio group, which is three elements and ONE stop,
+  where Shift+Tab off the checked member went to `<body>` because the
+  handler had taken the unchecked one for the panel's first stop.
+
+  [[a-real-tab-wraps-at-the-radio-groups-edge-and-not-at-the-dom-s]] and
+  [[a-real-tab-wraps-at-the-tabindex-ordered-edge]] are that missing
+  population, one panel per way the two lists can differ. What
+  `impl.overlay/sequential-tab-stops` does and does not model is stated
+  on that function; these rows measure the part it claims.
 
   `overlay-dom-cljs-test` holds the synthetic-versus-trusted comparison
   for Escape itself; this file does not re-litigate it.
@@ -137,6 +156,50 @@
     [:button#confirm {:type "button"} "Delete"]
     [:input#reason {:type "text" :aria-label "Reason"}]
     [:button#cancel {:type "button" :on-click [::closed]} "Cancel"]]
+   [:button#after {:type "button"} "After"]])
+
+;; THE TWO SHAPES THE THREE-PLAIN-CONTROL PANEL ABOVE CANNOT CONTAIN, and
+;; the reason they are separate pages rather than extra controls on that
+;; one. Both are panels whose SEQUENTIAL focus order differs from their
+;; DOCUMENT order, which is the difference the audit of #8071 measured
+;; `impl.overlay` getting wrong; the rows above are about inertness and
+;; the popover contrast, and folding a radio group into their fixture
+;; would change what every one of them reads without making any of them
+;; measure a wrap.
+
+(h/defview a-page-with-a-modal-holding-a-radio-group [_]
+  ;; A RADIO GROUP IS THREE ELEMENTS AND ONE TAB STOP. Document order in
+  ;; this panel is [small large ok reason]; sequential order is
+  ;; [large ok reason], because `small` is an unchecked member of a group
+  ;; whose checked member is `large`. The group is FIRST on purpose — that
+  ;; puts the discrepancy on the backward edge, where a handler reading
+  ;; document order finds `small` and never `large`.
+  [:div
+   [:button#before {:type "button"} "Before"]
+   [:button#trigger {:type "button" :on-click [::opened]} "Open"]
+   [overlay/modal {:open?      (h/sub [::open?])
+                   :on-dismiss [::dismissed]
+                   :label      "Pick a size"}
+    [:input#small {:type "radio" :name "size" :aria-label "Small"}]
+    [:input#large {:type "radio" :name "size" :default-checked true
+                   :aria-label "Large"}]
+    [:button#ok {:type "button"} "OK"]
+    [:input#reason {:type "text" :aria-label "Reason"}]]
+   [:button#after {:type "button"} "After"]])
+
+(h/defview a-page-with-a-modal-ordered-by-tabindex [_]
+  ;; A POSITIVE `tabindex` SORTS AHEAD OF EVERY ZERO. Document order is
+  ;; [second first third]; sequential order is [first second third],
+  ;; because 1 precedes 2 and both precede the implicit 0.
+  [:div
+   [:button#before {:type "button"} "Before"]
+   [:button#trigger {:type "button" :on-click [::opened]} "Open"]
+   [overlay/modal {:open?      (h/sub [::open?])
+                   :on-dismiss [::dismissed]
+                   :label      "Ordered by tabindex"}
+    [:button#second {:type "button" :tab-index 2} "Second"]
+    [:button#first {:type "button" :tab-index 1} "First"]
+    [:button#third {:type "button"} "Third"]]
    [:button#after {:type "button"} "After"]])
 
 ;; `:async? true` — the MAP shape — because the trusted-input row below
@@ -431,6 +494,134 @@
                     (finish)))))
             (catch :default e
               (is false (str "the trap row threw: " (.-message e)))
+              (finish))))))))
+
+;; ---------------------------------------------------------------------------
+;; The trap over a panel whose sequential order is not its document order
+;; ---------------------------------------------------------------------------
+;;
+;; WHY THE ROW ABOVE COULD NOT HAVE CAUGHT THIS. Its panel is three plain
+;; controls, and over three plain controls *the elements a selector finds*
+;; and *the stops Tab visits* are the same list in the same order. So a
+;; handler that read the first and taught itself it had the second passed
+;; that row perfectly, and went on choosing the wrong edge on any panel
+;; where the two lists differ — which the audit of #8071 then measured.
+;;
+;; The two rows below are that population, added rather than argued: one
+;; panel whose sequential order is SHORTER than its document order (a
+;; radio group), one whose sequential order is a PERMUTATION of it (a
+;; positive `tabindex`). Both drive both edges with trusted input, and
+;; both name `body` explicitly, because `<body>` is where a wrap that did
+;; not fire puts focus and reading it as merely "some other control" is
+;; how #8058 shipped.
+
+(defn- both-edges!
+  "Focus `start`, walk `n` trusted Tabs, re-focus `start`, walk `n` trusted
+  Shift+Tabs, and hand the two laps to `k`.
+
+  Re-focusing between the laps rather than continuing from wherever the
+  forward one finished, so the backward lap is measured FROM the edge
+  Shift+Tab has to wrap at."
+  [m start n k]
+  (.focus ($ m start))
+  (trusted/walk!
+    "Tab" n
+    (fn [] (some-> (active) label-of))
+    (fn [forward]
+      (.focus ($ m start))
+      (trusted/walk!
+        "Shift+Tab" n
+        (fn [] (some-> (active) label-of))
+        (fn [backward] (k forward backward))))))
+
+(deftest a-real-tab-wraps-at-the-radio-groups-edge-and-not-at-the-dom-s
+  (if-not (browser?)
+    (skip! ":node-test has no modality, and no engine to press a key at")
+    (if-not (trusted/bridge?)
+      (trusted/unwitnessed! "the trap over a panel holding a radio group")
+      (async done
+        (let [m      (hm/mount! [a-page-with-a-modal-holding-a-radio-group {}])
+              finish (fn [] (hm/unmount! m) (done))]
+          (try
+            (open! m)
+            (is (.contains ($ m "dialog") (active))
+                "premise: opening put focus inside the panel")
+            (is (true? (.-checked ($ m "#large")))
+                "premise: `large` is the group's checked member, so it — and
+                 not `small` — is the one stop the group contributes")
+
+            ;; FIVE presses over a three-stop cycle, for the reason the
+            ;; three-control row gives: three is a wrap, five closes it.
+            (both-edges!
+              m "#large" 5
+              (fn [forward backward]
+                (try
+                  (is (= ["ok" "reason" "large" "ok" "reason"] forward)
+                      (str "THE CYCLE, FORWARD, OVER A PANEL WHOSE FIRST "
+                           "STOP IS NOT ITS FIRST ELEMENT. The wrap off "
+                           "`reason` lands on `large` — the group's CHECKED "
+                           "member, which is where the engine's own "
+                           "sequential order starts — and never on `small`, "
+                           "which is an element of the panel but not a stop "
+                           "of it. Against the algorithm this row was "
+                           "written for, the third landing was `small`. "
+                           "Pressed: " (pr-str forward)))
+                  (is (= ["reason" "ok" "large" "reason" "ok"] backward)
+                      (str "THE CYCLE, BACKWARD, and this is the edge that "
+                           "was measured broken. `large` IS the panel's "
+                           "first stop, so Shift+Tab off it must land "
+                           "directly on `reason`; a handler that took the "
+                           "panel's first ELEMENT for its first STOP found "
+                           "`small`, matched nothing, let the default action "
+                           "stand and put focus on `<body>`. Pressed: "
+                           (pr-str backward)))
+                  (is (empty? (filter #{"before" "trigger" "after" "body" "small"}
+                                      (concat forward backward)))
+                      (str "and not one landing in either lap was a control "
+                           "of the page behind, the nowhere between them, or "
+                           "the group member the engine does not sequence to. "
+                           "Pressed: " (pr-str (concat forward backward))))
+                  (finally (finish)))))
+            (catch :default e
+              (is false (str "the radio-group trap row threw: " (.-message e)))
+              (finish))))))))
+
+(deftest a-real-tab-wraps-at-the-tabindex-ordered-edge
+  (if-not (browser?)
+    (skip! ":node-test has no modality, and no engine to press a key at")
+    (if-not (trusted/bridge?)
+      (trusted/unwitnessed! "the trap over a panel ordered by positive tabindex")
+      (async done
+        (let [m      (hm/mount! [a-page-with-a-modal-ordered-by-tabindex {}])
+              finish (fn [] (hm/unmount! m) (done))]
+          (try
+            (open! m)
+            (is (.contains ($ m "dialog") (active))
+                "premise: opening put focus inside the panel")
+
+            (both-edges!
+              m "#first" 5
+              (fn [forward backward]
+                (try
+                  (is (= ["second" "third" "first" "second" "third"] forward)
+                      (str "THE CYCLE, FORWARD, OVER A PANEL WHOSE ORDER IS "
+                           "A PERMUTATION OF ITS MARKUP. `first` carries "
+                           "`tabindex=1` and is written SECOND; the wrap off "
+                           "`third` must land on it rather than on the "
+                           "panel's first element. Pressed: " (pr-str forward)))
+                  (is (= ["third" "second" "first" "third" "second"] backward)
+                      (str "THE CYCLE, BACKWARD. `first` is the panel's "
+                           "first stop, so Shift+Tab off it lands directly "
+                           "on `third` — the last, because a `tabindex=0` "
+                           "sorts AFTER every positive one. Pressed: "
+                           (pr-str backward)))
+                  (is (empty? (filter #{"before" "trigger" "after" "body"}
+                                      (concat forward backward)))
+                      (str "and neither lap left the panel or rested nowhere. "
+                           "Pressed: " (pr-str (concat forward backward))))
+                  (finally (finish)))))
+            (catch :default e
+              (is false (str "the tabindex trap row threw: " (.-message e)))
               (finish))))))))
 
 ;; ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes rf2-hic-052, reopened by the merged-PR audit of #8071.

## The audit's measurement, reproduced first

Before changing anything, the claim was reproduced independently in headless Chromium: the merged `tab-stops` + `wrap-tab!` algorithm transcribed to JS, planted on a raw `<dialog>` with children `[unchecked radio r1, checked radio r2, button ok]`, driven with real `page.keyboard.press`.

```
tab-stops (merged)  = ["r1","r2","ok"]
per-candidate       = r1 {tabIndex:0, checked:false}  r2 {tabIndex:0, checked:true}  ok {tabIndex:0}
BACKWARD: from r2 --Shift+Tab--> body
FORWARD:  from ok --Tab-->        r1
```

Both halves of the audit hold. `tabIndex` is `0` on **both** radios, so `tab-stop?` had nothing to tell them apart, and the handler took the unchecked `r1` for the panel's first stop: Shift+Tab off the checked member matched no edge, the default action stood, and focus landed on `<body>`; Tab off the last control wrapped onto `r1`, which the engine never sequences to.

## Why this is #8071's defect one level in

#8071's witness is three plain controls, and over three plain controls *the elements a selector finds* and *the stops Tab visits are the same list in the same order*. A handler computing the first and calling it the second was indistinguishable there. A radio group is the smallest shape where the two lists differ — three elements, one stop — and the witness had none.

## What `tab-stops` computed before, and what `sequential-tab-stops` computes now

| | before | after |
|---|---|---|
| name | `tab-stops` | `sequential-tab-stops` |
| answers | which elements are *candidates*, in document order | where **Tab goes**, in order |
| radio group | one entry per button | one entry per group — the checked member, else the first focusable one |
| positive `tabindex` | ignored; document order | sorted ahead of the zeros, ascending, document order inside each bucket |

Both rules were validated against the engine's own trusted-input walk over **ten panel shapes** before a line of CLJS was written — checked-second, none-checked, first-checked, unnamed radios, checked-but-disabled, first-radio-`display:none`, positive tabindex, two groups, same name in two `<form>`s, and #8071's own three plain controls. 10/10 match the engine's cycle.

Two degenerate cases fall out of *choosing over elements `tab-stop?` has already kept* rather than needing rules of their own: a checked-but-disabled member is gone before the vote so the first survivor takes the slot, and a group whose members are all disabled contributes no stop at all. Both measured.

## The boundary, stated in the code

`sequential-tab-stops`' docstring says plainly that it is **not** the platform's focus algorithm. Four things the engine skips are still counted, named rather than half-modelled:

- an element inside an `inert` subtree
- a control inside a `disabled` `<fieldset>` (the `disabled` IDL reflects only the content attribute, so it reads `false`)
- a control under `visibility:hidden` (it has client rects)
- the contents of a closed `<details>` — which also **retires a false claim the file used to make**: that docstring said `getClientRects` filtered them, and it does not. Measured: `rects: 1`.

Shadow roots, `delegatesFocus` and scrollable-overflow focusability are outside the candidate set entirely.

**Why that boundary is safe where the radio group was not**, and this is measured rather than argued. A surplus candidate costs a *wrap that does not fire* when it cannot take focus, and a *wrap that lands wrong* when it can — and `wrap-tab!` only takes the default action away once the landing is confirmed, so the first degrades to exactly the engine's own conduct. Calling `.focus()` on each:

```
inert-b: false   fs-b: false   vh: false   det-b: false   r-unchecked: TRUE
```

The unchecked radio is the only one that accepts focus. That is precisely why the radio group was a wrong landing rather than a missed wrap, and why the four above are not this bead's defect one level further in.

A group whose checked member sits **outside** the panel needs no rule: this handler is the modal's alone, so everything outside is inert and cannot be the group's stop; the engine falls to the first focusable member inside, which is what scanning only the panel already computes. Measured.

## The witnesses, and the shape they now contain

Two new modal fixtures, one per way sequential order can differ from document order — one **shorter** than its markup (a radio group), one a **permutation** of it (a positive `tabindex`) — each driving **both** edges with trusted input and each naming `body` explicitly, because `<body>` is where a wrap that did not fire puts focus and reading it as merely "some other control" is how #8058 shipped.

The radio group is written **first** in its panel on purpose: that puts the discrepancy on the backward edge, which is the edge the audit measured broken.

## The red demonstration, against the merged algorithm

`sequential-tab-stops`' body was replaced with the merged `#8071` expression — `(filterv tab-stop? (array-seq (.querySelectorAll panel tab-stop-selector)))`. A pure-function swap, so it can only produce **assertion failures, never a crash**: a crashing plant would stop every namespace after it while the log still looked plausible.

| run | raw exit | tests | assertions | failures | errors |
|---|---|---|---|---|---|
| control (this diff) | `0` | 1476 | 9183 | 0 | 0 |
| **planted (merged algorithm)** | **`1`** | **1476** | **9183** | **6** | **0** |
| restored + rebased | `0` | 1476 | 9183 | 0 | 0 |

**Identical test and assertion counts across control and plant** — same reach, only outcomes changed — and all 6 failures land in the two new rows and nowhere else:

```
FAIL a-real-tab-wraps-at-the-radio-groups-edge-and-not-at-the-dom-s   (x3)
FAIL a-real-tab-wraps-at-the-tabindex-ordered-edge                    (x3)
```

What the plant actually pressed:

```
radio group, forward from `large` : ["ok" "reason" "small" "large" "ok"]   ← wrap landed on the UNCHECKED radio
radio group, backward from `large`: ["body" "reason" "ok" "large" "body"]  ← BODY, the audit's exact reading
tabindex,   forward from `first`  : ["second" "third" "second" "third" "second"]  ← `first` never reached at all
tabindex,   backward from `first` : ["body" "third" "second" "third" "second"]
```

The plant was restored with `git checkout HEAD --` and the restore **verified by hashing the bytes**:

```
db142a76567782f581b3b68204f557068a3447bf53ed43246866e75d10f1ea01  (before plant)
db142a76567782f581b3b68204f557068a3447bf53ed43246866e75d10f1ea01  (after restore)
```

`git status` clean, and a residue grep for `PLANT`/`sequential-tab-stops-real` returns nothing.

## Kept, deliberately

The stateless two-edge handler and the zero-idle-listener posture are untouched: `keydown` still bubbles to the root React already owns, `:open?` false still renders no element, and the handler still runs for no key but Tab. No general focus manager was built. The trusted-input bridge (`implementation/scripts/`, `trusted_input_support.cljs`) was not edited — #8071 established it is correct.

## Quality gates

| gate | raw exit | result |
|---|---|---|
| `npm run test:browser` (control) | `0` | Ran 1476 tests containing 9183 assertions. 0 failures, 0 errors. |
| `npm run test:browser` (planted, expected red) | `1` | Ran 1476 tests containing 9183 assertions. 6 failures, 0 errors. |
| `npm run test:browser` (restored + rebased) | `0` | Ran 1476 tests containing 9183 assertions. 0 failures, 0 errors. |
| `npm run test:cljs` | `0` | Ran 13825 tests containing 69925 assertions. 0 failures, 0 errors. |

Exit codes are the raw `$?` captured on the same command line as the run, not the harness's verdict.

Spec unchanged: nothing under `tools/xray/` is touched.
