### PR TITLE
test(hicasso): derive each witness's import-fence population from its package directory (rf2-ccuw)

### DIFF
--- a/implementation/hicasso/test/re_frame/hicasso/examples/forms/surface_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/examples/forms/surface_cljs_test.cljs
@@ -38,21 +38,18 @@
   (:require-macros [re-frame.hicasso.examples.require-graph :as rg]))
 
 (def ^:private app-namespaces
-  "Every namespace the recipes' APPLICATION is made of. Its suites are
-  deliberately absent: a test may reach past a door the application may
-  not — the mounted suite reaches the test kit — which is the whole
-  reason the two are held to different rules."
-  ["re-frame.hicasso.examples.forms.db"
-   "re-frame.hicasso.examples.forms.events"
-   "re-frame.hicasso.examples.forms.subs"
-   "re-frame.hicasso.examples.forms.views"])
+  "Every namespace the recipes' APPLICATION is made of, read off the
+  package directory at macro-expansion time rather than typed (rf2-ccuw).
+  Its suites are deliberately absent: a test may reach past a door the
+  application may not — the mounted suite reaches the test kit — which is
+  the whole reason the two are held to different rules, and the exclusion
+  is the build's own `cljs-test$`."
+  (rg/emit-application-namespaces re-frame.hicasso.examples.forms))
 
 (def ^:private graph
-  (rg/emit-dependency-graph
-    '[re-frame.hicasso.examples.forms.db
-      re-frame.hicasso.examples.forms.events
-      re-frame.hicasso.examples.forms.subs
-      re-frame.hicasso.examples.forms.views]))
+  "Same population, other instrument: a namespace the analyzer never saw
+  is absent here and present in [[app-namespaces]]."
+  (rg/emit-dependency-graph re-frame.hicasso.examples.forms))
 
 (def ^:private own? (set app-namespaces))
 
@@ -70,10 +67,14 @@
 
 (deftest the-graph-is-populated
   (testing "the analyzer answered for every application namespace"
+    ;; The DIRECTORY on the left, the ANALYZER on the right. A namespace
+    ;; the analyzer never saw is absent on the right and fenced by
+    ;; nothing — every check below would pass over it vacuously.
     (is (= (set app-namespaces) (set (keys graph)))
-        "a namespace the analyzer has not analysed answers an EMPTY edge
-         set, and an empty edge set passes every check below vacuously —
-         so the roster and the graph's key set are compared first"))
+        "a source file under `examples/forms/` is not on this namespace's
+         `:require` list, so the analyzer has no record of it and its
+         imports are fenced by nothing. Add it to the `ns` form above, or
+         take the file out of the package"))
   (testing "the reads that matter are present"
     (is (some #{"re-frame.hicasso"} (get graph "re-frame.hicasso.examples.forms.views"))
         "views depends on the public door")

--- a/implementation/hicasso/test/re_frame/hicasso/examples/ledger/surface_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/examples/ledger/surface_cljs_test.cljs
@@ -44,26 +44,30 @@
   any other."
   "re-frame.hicasso.examples.ledger.vendor")
 
+(def ^:private package-namespaces
+  "Every ClojureScript namespace under `examples/ledger/`, read off the
+  package directory at macro-expansion time rather than typed (rf2-ccuw).
+  Test suites are deliberately absent — a test may reach past a door the
+  application may not, which is the whole reason the two are held to
+  different rules, and the exclusion is the build's own `cljs-test$`."
+  (rg/emit-application-namespaces re-frame.hicasso.examples.ledger))
+
 (def ^:private app-namespaces
-  "Every namespace the APPLICATION is made of. Its test suites are
-  deliberately absent — a test may reach past a door the application may
-  not, which is the whole reason the two are held to different rules."
-  ["re-frame.hicasso.examples.ledger.app"
-   "re-frame.hicasso.examples.ledger.events"
-   "re-frame.hicasso.examples.ledger.subs"
-   "re-frame.hicasso.examples.ledger.views"])
+  "The package MINUS the vendor: the namespaces the application itself is
+  made of. The one subtraction is spelled out above, and it is the only
+  name this file still holds by hand — everything else arrives from the
+  directory, so a namespace added to the ledger tomorrow is fenced the
+  day it lands."
+  (vec (remove #{vendor-ns} package-namespaces)))
 
 (def ^:private graph
   "`{namespace [dependency …]}`, read off the analyzer at
   macro-expansion time. The vendor is included so that its OWN edges can
   be asserted; it is excluded from `app-namespaces` so that the
-  application's edge onto it is counted as foreign."
-  (rg/emit-dependency-graph
-    '[re-frame.hicasso.examples.ledger.app
-      re-frame.hicasso.examples.ledger.events
-      re-frame.hicasso.examples.ledger.subs
-      re-frame.hicasso.examples.ledger.vendor
-      re-frame.hicasso.examples.ledger.views]))
+  application's edge onto it is counted as foreign. Same population as
+  [[package-namespaces]], other instrument: a namespace the analyzer
+  never saw is absent here and present there."
+  (rg/emit-dependency-graph re-frame.hicasso.examples.ledger))
 
 (def ^:private own? (set app-namespaces))
 
@@ -84,10 +88,19 @@
 
 (deftest the-graph-is-populated
   (testing "the analyzer answered for every namespace asked about"
-    (is (= (conj (set app-namespaces) vendor-ns) (set (keys graph)))
-        "a namespace the analyzer has not analysed answers an empty edge
-         set, and an empty edge set passes every check below VACUOUSLY —
-         so the roster and the graph's key set are compared first"))
+    ;; The DIRECTORY on the left, the ANALYZER on the right. A namespace
+    ;; the analyzer never saw is absent on the right and fenced by
+    ;; nothing — every check below would pass over it VACUOUSLY.
+    (is (= (set package-namespaces) (set (keys graph)))
+        "a source file under `examples/ledger/` is not on this namespace's
+         `:require` list, so the analyzer has no record of it and its
+         imports are fenced by nothing. Add it to the `ns` form above, or
+         take the file out of the package")
+
+    (is (some #{vendor-ns} package-namespaces)
+        "the vendor is the one name this file subtracts by hand, and a
+         subtraction of a name that is no longer there would quietly stop
+         subtracting anything"))
 
   (testing "the reads that matter are present"
     ;; Positive controls, because a fence over an empty graph is green

--- a/implementation/hicasso/test/re_frame/hicasso/examples/require_graph.clj
+++ b/implementation/hicasso/test/re_frame/hicasso/examples/require_graph.clj
@@ -65,14 +65,35 @@
   application is on that chain by construction — that is what wiring it
   in means — and the commit that wires it recompiles the consumer.
 
+  ## And the WARM-CACHE boundary, which is worth stating exactly
+
+  [[re-frame.hicasso.examples.typeahead.census]] gives the structural
+  argument these expansions rest on: the calling test `:require`s every
+  namespace it reads about, so editing one recompiles the test and
+  re-expands the macro against the new bytes. That argument covers an
+  EDIT to a namespace already on the chain. It does not cover a file
+  APPEARING in or DISAPPEARING from the directory while nothing on the
+  chain changes, because shadow-cljs keys its cache on source hashes and
+  a directory listing is not one — observed while rf2-ccuw was written:
+  a plant deleted from disk was still named by a warm expansion.
+
+  The boundary is narrow and it falls on the safe side. CI compiles
+  cold, so the gate is always read from the directory as it is. Locally,
+  a file that is genuinely joining an application is joining it by being
+  `:require`d — an edit on the chain — which re-expands this macro in
+  the same compile. The residue is a file that no namespace references
+  at all, and until something references it, it is not what the fence is
+  a claim about.
+
   ## Why it sits at the `examples/` root (rf2-urgk)
 
   It was written twice. rf2-hic-025 wrote it for the slice, rf2-hic-086
   wrote it again for the Todo witness, and neither branch could
   `:require` the other's namespace because the two beads ran in parallel
   off one base. Both copies were the same file bar the docstring. This
-  is the one copy, at the root both applications sit under, consumed by
-  all three `surface-cljs-test` namespaces.
+  is the one copy, at the root every witness sits under, consumed by all
+  six `surface-cljs-test` namespaces — the slice, the Todo, the forms
+  recipes, the ledger, the typeahead, and the editor/grid pair.
 
   ## Scope
 

--- a/implementation/hicasso/test/re_frame/hicasso/examples/require_graph.clj
+++ b/implementation/hicasso/test/re_frame/hicasso/examples/require_graph.clj
@@ -167,7 +167,7 @@
 
   Throws rather than answers empty. An empty population passes every
   fence VACUOUSLY, and a macro that returns `[]` because a source root
-  moved would turn three suites green while proving nothing."
+  moved would turn all six suites green while proving nothing."
   [package-sym]
   (let [package  (name package-sym)
         rel-path (-> package (str/replace "." "/") (str/replace "-" "_"))

--- a/implementation/hicasso/test/re_frame/hicasso/examples/require_graph.clj
+++ b/implementation/hicasso/test/re_frame/hicasso/examples/require_graph.clj
@@ -32,6 +32,39 @@
   recompiled, and the test namespace that depends on it is recompiled
   too — with this macro re-expanded against the new graph.
 
+  ## Asking the compiler about WHICH namespaces (rf2-ccuw)
+
+  A predicate over the wrong population proves nothing about the
+  application, and for three releases the population was a hand-written
+  vector — written twice per consumer, once as the roster and once as
+  the argument to the macro below. So a namespace added to an
+  application tomorrow was compiled, was loaded, was part of the
+  application, and was invisible to every assertion in the file. Nothing
+  went red. The claim each consumer makes silently narrowed from *the
+  application* to *these seven files*, and rf2-hic-074 had already
+  extended one of them after its report was written.
+
+  So the population is asked for too. [[application-namespaces]] reads
+  the package's own directory off the JVM classpath at expansion time
+  and answers every ClojureScript source under it — the same walk
+  shadow-cljs does to find them, so a file that the build can compile is
+  a file this macro can see. The test-suite exclusion is the BUILD's own
+  rule rather than a second one to keep in step: `:node-test` selects
+  `cljs-test$`, so a namespace ending that way is a suite and not
+  application code.
+
+  ## The one thing the derived population cannot do
+
+  It can only report a namespace the ANALYZER also knows about, and the
+  analyzer knows a namespace because something on the calling test's
+  `:require` chain reached it. That is not a hole, because it is
+  reported: [[emit-dependency-graph]] omits a namespace the analyzer has
+  no record of, so the graph's key set is narrower than the directory's
+  and each consumer's `the-graph-is-populated` compares the two and
+  names the file to add. A namespace that is genuinely part of an
+  application is on that chain by construction — that is what wiring it
+  in means — and the commit that wires it recompiles the consumer.
+
   ## Why it sits at the `examples/` root (rf2-urgk)
 
   It was written twice. rf2-hic-025 wrote it for the slice, rf2-hic-086
@@ -39,16 +72,20 @@
   `:require` the other's namespace because the two beads ran in parallel
   off one base. Both copies were the same file bar the docstring. This
   is the one copy, at the root both applications sit under, consumed by
-  both `surface-cljs-test` namespaces.
+  all three `surface-cljs-test` namespaces.
 
   ## Scope
 
   Macro-expansion only, and JVM-only by construction (a `.clj`). It
   matches no test `ns-regexp` — `:node-test` selects `cljs-test$`,
   `:browser-test` selects `-dom-cljs-test$` — so it is compiled as a
-  dependency of its two consumers and run nowhere."
+  dependency of its consumers and run nowhere."
   (:require [cljs.analyzer.api :as ana-api]
-            [cljs.env :as env]))
+            [cljs.env :as env]
+            [clojure.java.io :as io]
+            [clojure.string :as str])
+  (:import (java.io File)
+           (java.net URL)))
 
 (defn dependency-edges
   "The set of namespace symbols `ns-sym` depends on, read off the
@@ -80,17 +117,89 @@
                   (vals (:uses info))
                   (vals (:use-macros info))))))
 
+(defn- package-directories
+  "Every directory on the JVM classpath that holds `rel-path`.
+
+  Plural, and deliberately: `io/resource` answers the FIRST root a
+  relative path resolves under, and this repository has more than one
+  test root by design — `hicasso/test_kit/test` exists precisely so a
+  witness can be written while `hicasso/test` is held by another branch.
+  A single-root lookup would narrow the population silently, which is
+  the bug this whole namespace exists to stop having."
+  [rel-path]
+  (->> (.getResources (.getContextClassLoader (Thread/currentThread)) rel-path)
+       enumeration-seq
+       (filter #(= "file" (.getProtocol ^URL %)))
+       (map io/file)
+       (filter #(.isDirectory ^File %))))
+
+(defn application-namespaces
+  "Every APPLICATION namespace under the package `package-sym`, read off
+  the classpath rather than typed.
+
+  ClojureScript sources only (`.cljs`, `.cljc`), walked recursively so a
+  subdirectory cannot escape, and test suites excluded by the build's own
+  rule: `:node-test`'s `ns-regexp` is `cljs-test$`, so a namespace ending
+  that way is a suite. Test suites are held to different rules than the
+  application on purpose — a test may reach past a door the application
+  may not.
+
+  Throws rather than answers empty. An empty population passes every
+  fence VACUOUSLY, and a macro that returns `[]` because a source root
+  moved would turn three suites green while proving nothing."
+  [package-sym]
+  (let [package  (name package-sym)
+        rel-path (-> package (str/replace "." "/") (str/replace "-" "_"))
+        dirs     (package-directories rel-path)
+        nss      (into (sorted-set)
+                       (for [^File dir  dirs
+                             ^File file (file-seq dir)
+                             :when      (.isFile file)
+                             :let       [rel (-> (.toPath dir)
+                                                 (.relativize (.toPath file))
+                                                 str
+                                                 (str/replace "\\" "/"))
+                                         [_ stem ext] (re-matches #"(.+)\.([^./]+)" rel)]
+                             :when      (and stem (#{"cljs" "cljc"} ext))
+                             :let       [ns-name (str package "."
+                                                      (-> stem
+                                                          (str/replace "/" ".")
+                                                          (str/replace "_" "-")))]
+                             :when      (not (str/ends-with? ns-name "cljs-test"))]
+                         (symbol ns-name)))]
+    (when (empty? nss)
+      (throw (ex-info (str "no application namespace found for package " package
+                           " — the fence would pass vacuously")
+                      {:package package :classpath-path rel-path :directories (mapv str dirs)})))
+    (vec nss)))
+
+(defmacro emit-application-namespaces
+  "Expand to a literal sorted vector of `\"<namespace>\"` strings: every
+  application namespace under package `package-sym`, as the package
+  DIRECTORY has them.
+
+  This is the population, and it is the half [[emit-dependency-graph]]
+  is checked against — a name here with no entry there is a file the
+  analyzer never saw."
+  [package-sym]
+  (mapv str (application-namespaces package-sym)))
+
 (defmacro emit-dependency-graph
   "Expand to a literal `{\"<namespace>\" [\"<dependency>\" …]}` map for
-  each namespace in `ns-syms` (a quoted vector of symbols), read from the
+  every application namespace under package `package-sym`, read from the
   ClojureScript analyzer's compilation environment.
+
+  A namespace the analyzer has no record of is OMITTED rather than
+  emitted with an empty edge set: an empty edge set is indistinguishable
+  from a clean namespace and passes every fence vacuously, whereas an
+  absent key is a difference the consumer's `the-graph-is-populated`
+  prints against [[emit-application-namespaces]].
 
   Strings rather than symbols so the emitted value is plain data a
   failing assertion prints legibly, and sorted so a report is stable."
-  [ns-syms]
-  (let [syms (if (and (seq? ns-syms) (= 'quote (first ns-syms)))
-               (second ns-syms)
-               ns-syms)]
-    (into (sorted-map)
-          (map (fn [s] [(str s) (mapv str (dependency-edges env/*compiler* s))]))
-          syms)))
+  [package-sym]
+  (into (sorted-map)
+        (keep (fn [s]
+                (when (ana-api/find-ns env/*compiler* s)
+                  [(str s) (mapv str (dependency-edges env/*compiler* s))])))
+        (application-namespaces package-sym)))

--- a/implementation/hicasso/test/re_frame/hicasso/examples/slice/surface_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/examples/slice/surface_cljs_test.cljs
@@ -24,7 +24,22 @@
   pinned list, and it is the one that goes red when the slice quietly
   grows a dependency: a fence cannot see a new PUBLIC door being reached
   for, and the facade freeze at rf2-hic-026 wants to know about that
-  more than about anything else in this file."
+  more than about anything else in this file.
+
+  ## And the population is asked for too (rf2-ccuw)
+
+  Both claims are only worth the set of namespaces they are made over,
+  and that set used to be typed here — twice, as a roster literal and as
+  the macro's argument. A predicate over a hand-written population
+  covers a namespace added tomorrow only if somebody remembers to type
+  it, which is the reviewer problem this file opens by rejecting. It was
+  not hypothetical: a `slice/http.cljs` reaching `re-frame.hicasso.impl`
+  compiled, loaded, ran, and left every row below green.
+
+  So [[app-namespaces]] is read off the package DIRECTORY and
+  [[graph]] off the ANALYZER, and [[the-graph-is-populated]] compares
+  them. A file in the package the analyzer never saw is the difference,
+  and it names itself."
   (:require [cljs.test :refer-macros [deftest is testing]]
             [clojure.string :as str]
             ;; Required so the analyzer has analysed them when the macro
@@ -40,29 +55,20 @@
   (:require-macros [re-frame.hicasso.examples.require-graph :as rg]))
 
 (def ^:private app-namespaces
-  "Every namespace the slice's APPLICATION is made of. The test suites
-  are deliberately absent: a test may reach past a door the application
-  may not, which is the whole reason the two are held to different
-  rules."
-  ["re-frame.hicasso.examples.slice.app"
-   "re-frame.hicasso.examples.slice.db"
-   "re-frame.hicasso.examples.slice.events"
-   "re-frame.hicasso.examples.slice.i18n"
-   "re-frame.hicasso.examples.slice.routes"
-   "re-frame.hicasso.examples.slice.subs"
-   "re-frame.hicasso.examples.slice.views"])
+  "Every namespace the slice's APPLICATION is made of, read off the
+  package directory at macro-expansion time rather than typed. The test
+  suites are deliberately absent: a test may reach past a door the
+  application may not, which is the whole reason the two are held to
+  different rules — and the exclusion is the build's own `cljs-test$`,
+  not a second rule kept in step by hand."
+  (rg/emit-application-namespaces re-frame.hicasso.examples.slice))
 
 (def ^:private graph
   "`{namespace [dependency …]}` for the slice's application namespaces,
-  read off the analyzer at macro-expansion time."
-  (rg/emit-dependency-graph
-    '[re-frame.hicasso.examples.slice.app
-      re-frame.hicasso.examples.slice.db
-      re-frame.hicasso.examples.slice.events
-      re-frame.hicasso.examples.slice.i18n
-      re-frame.hicasso.examples.slice.routes
-      re-frame.hicasso.examples.slice.subs
-      re-frame.hicasso.examples.slice.views]))
+  read off the analyzer at macro-expansion time. Same population, other
+  instrument: a namespace the analyzer never saw is absent here and
+  present in [[app-namespaces]]."
+  (rg/emit-dependency-graph re-frame.hicasso.examples.slice))
 
 (def ^:private own?
   "Is this dependency one of the slice's own namespaces?"
@@ -82,10 +88,16 @@
 
 (deftest the-graph-is-populated
   (testing "the analyzer answered for every application namespace"
+    ;; Two instruments over one population: the DIRECTORY on the left,
+    ;; the ANALYZER on the right. A namespace the analyzer never saw is
+    ;; absent on the right and fenced by nothing — every check below
+    ;; would pass over it VACUOUSLY — so the two are compared first, and
+    ;; `=` prints the file to open.
     (is (= (set app-namespaces) (set (keys graph)))
-        "a namespace the analyzer has not analysed answers an empty edge
-         set, and an empty edge set passes every check below VACUOUSLY —
-         so the roster and the graph's key set are compared first"))
+        "a source file under `examples/slice/` is not on this namespace's
+         `:require` list, so the analyzer has no record of it and its
+         imports are fenced by nothing. Add it to the `ns` form above, or
+         take the file out of the package"))
 
   (testing "the reads that matter are present"
     ;; Positive controls, because a fence over an empty graph is green

--- a/implementation/hicasso/test/re_frame/hicasso/examples/todo/surface_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/examples/todo/surface_cljs_test.cljs
@@ -24,7 +24,20 @@
   it is the one that goes red when the application quietly grows a
   dependency: a fence cannot see a new PUBLIC door being reached for,
   and the facade freeze at rf2-hic-026 wants to know about that more
-  than about anything else in this file."
+  than about anything else in this file.
+
+  ## And the population is asked for too (rf2-ccuw)
+
+  Both claims are only worth the set of namespaces they are made over,
+  and that set used to be typed here — twice, as a roster literal and as
+  the macro's argument. A predicate over a hand-written population
+  covers a namespace minted tomorrow only if somebody remembers to type
+  it, which is the reviewer problem this file opens by rejecting.
+
+  So [[app-namespaces]] is read off the package DIRECTORY and [[graph]]
+  off the ANALYZER, and [[the-graph-is-populated]] compares them. A file
+  in the package the analyzer never saw is the difference, and it names
+  itself."
   (:require [cljs.test :refer-macros [deftest is testing]]
             [clojure.string :as str]
             ;; Required so the analyzer has analysed them when the macro
@@ -39,26 +52,20 @@
   (:require-macros [re-frame.hicasso.examples.require-graph :as rg]))
 
 (def ^:private app-namespaces
-  "Every namespace this APPLICATION is made of. The test suites are
-  deliberately absent: a test may reach past a door the application may
-  not, which is the whole reason the two are held to different rules."
-  ["re-frame.hicasso.examples.todo.app"
-   "re-frame.hicasso.examples.todo.db"
-   "re-frame.hicasso.examples.todo.events"
-   "re-frame.hicasso.examples.todo.routes"
-   "re-frame.hicasso.examples.todo.subs"
-   "re-frame.hicasso.examples.todo.views"])
+  "Every namespace this APPLICATION is made of, read off the package
+  directory at macro-expansion time rather than typed. The test suites
+  are deliberately absent: a test may reach past a door the application
+  may not, which is the whole reason the two are held to different rules
+  — and the exclusion is the build's own `cljs-test$`, not a second rule
+  kept in step by hand."
+  (rg/emit-application-namespaces re-frame.hicasso.examples.todo))
 
 (def ^:private graph
   "`{namespace [dependency …]}` for the application's namespaces, read
-  off the analyzer at macro-expansion time."
-  (rg/emit-dependency-graph
-    '[re-frame.hicasso.examples.todo.app
-      re-frame.hicasso.examples.todo.db
-      re-frame.hicasso.examples.todo.events
-      re-frame.hicasso.examples.todo.routes
-      re-frame.hicasso.examples.todo.subs
-      re-frame.hicasso.examples.todo.views]))
+  off the analyzer at macro-expansion time. Same population, other
+  instrument: a namespace the analyzer never saw is absent here and
+  present in [[app-namespaces]]."
+  (rg/emit-dependency-graph re-frame.hicasso.examples.todo))
 
 (def ^:private own?
   "Is this dependency one of the application's own namespaces?"
@@ -78,10 +85,16 @@
 
 (deftest the-graph-is-populated
   (testing "the analyzer answered for every application namespace"
+    ;; Two instruments over one population: the DIRECTORY on the left,
+    ;; the ANALYZER on the right. A namespace the analyzer never saw is
+    ;; absent on the right and fenced by nothing — every check below
+    ;; would pass over it VACUOUSLY — so the two are compared first, and
+    ;; `=` prints the file to open.
     (is (= (set app-namespaces) (set (keys graph)))
-        "a namespace the analyzer has not analysed answers an empty edge
-         set, and an empty edge set passes every check below VACUOUSLY —
-         so the roster and the graph's key set are compared first"))
+        "a source file under `examples/todo/` is not on this namespace's
+         `:require` list, so the analyzer has no record of it and its
+         imports are fenced by nothing. Add it to the `ns` form above, or
+         take the file out of the package"))
 
   (testing "the reads that matter are present"
     ;; Positive controls, because a fence over an empty graph is green

--- a/implementation/hicasso/test/re_frame/hicasso/examples/typeahead/surface_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/examples/typeahead/surface_cljs_test.cljs
@@ -54,26 +54,20 @@
   (:require-macros [re-frame.hicasso.examples.require-graph :as rg]))
 
 (def ^:private app-namespaces
-  "Every namespace this APPLICATION is made of. The test suites are
-  deliberately absent: a test may reach past a door the application may
-  not — `demand-dom-cljs-test` mounts through the test kit and wraps the
-  screen in `React.StrictMode` — which is the whole reason the two are
-  held to different rules."
-  ["re-frame.hicasso.examples.typeahead.app"
-   "re-frame.hicasso.examples.typeahead.db"
-   "re-frame.hicasso.examples.typeahead.events"
-   "re-frame.hicasso.examples.typeahead.service"
-   "re-frame.hicasso.examples.typeahead.subs"
-   "re-frame.hicasso.examples.typeahead.views"])
+  "Every namespace this APPLICATION is made of, read off the package
+  directory at macro-expansion time rather than typed (rf2-ccuw). The
+  test suites are deliberately absent: a test may reach past a door the
+  application may not — `demand-dom-cljs-test` mounts through the test
+  kit and wraps the screen in `React.StrictMode` — which is the whole
+  reason the two are held to different rules, and the exclusion is the
+  build's own `cljs-test$`. `census.clj` is a JVM macro namespace and no
+  part of the compiled application, so no ClojureScript walk sees it."
+  (rg/emit-application-namespaces re-frame.hicasso.examples.typeahead))
 
 (def ^:private graph
-  (rg/emit-dependency-graph
-    '[re-frame.hicasso.examples.typeahead.app
-      re-frame.hicasso.examples.typeahead.db
-      re-frame.hicasso.examples.typeahead.events
-      re-frame.hicasso.examples.typeahead.service
-      re-frame.hicasso.examples.typeahead.subs
-      re-frame.hicasso.examples.typeahead.views]))
+  "Same population, other instrument: a namespace the analyzer never saw
+  is absent here and present in [[app-namespaces]]."
+  (rg/emit-dependency-graph re-frame.hicasso.examples.typeahead))
 
 (def ^:private own? (set app-namespaces))
 
@@ -91,10 +85,14 @@
 
 (deftest the-graph-is-populated
   (testing "the analyzer answered for every application namespace"
+    ;; The DIRECTORY on the left, the ANALYZER on the right. A namespace
+    ;; the analyzer never saw is absent on the right and fenced by
+    ;; nothing — every check below would pass over it VACUOUSLY.
     (is (= (set app-namespaces) (set (keys graph)))
-        "a namespace the analyzer has not analysed answers an empty edge
-         set, and an empty edge set passes every check below VACUOUSLY —
-         so the roster and the graph's key set are compared first"))
+        "a source file under `examples/typeahead/` is not on this
+         namespace's `:require` list, so the analyzer has no record of it
+         and its imports are fenced by nothing. Add it to the `ns` form
+         above, or take the file out of the package"))
 
   (testing "the reads that matter are present"
     (is (some #{"re-frame.hicasso"} (get graph "re-frame.hicasso.examples.typeahead.views"))

--- a/implementation/hicasso/test/re_frame/hicasso/examples/witness_surface_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/examples/witness_surface_cljs_test.cljs
@@ -25,6 +25,15 @@
   application. It is the one that reds when a witness quietly grows a
   dependency, which a fence cannot see.
 
+  Both are only worth the set of namespaces they are made over, and that
+  set used to be typed here — twice, as the [[witnesses]] literal and as
+  the macro's argument (rf2-ccuw). A predicate over a hand-written
+  population fences a namespace minted tomorrow only if somebody
+  remembers to type it. So [[witnesses]] is read off each package's
+  DIRECTORY and [[graph]] off the ANALYZER, and [[the-graph-is-populated]]
+  compares them; a file in either package the analyzer never saw is the
+  difference, and it names itself.
+
   [[neither-witness-registers-a-route]] is the third, and it is here
   rather than in a routing suite because it is the same kind of fact: an
   absent edge. rf2-hic-025's finding 8 — route PATHS are plain strings
@@ -50,35 +59,25 @@
   (:require-macros [re-frame.hicasso.examples.require-graph :as rg]))
 
 (def ^:private witnesses
-  "Each witness application and the namespaces it is made of. Its test
-  suites are deliberately absent: a test may reach past a door the
+  "Each witness application and the namespaces it is made of, read off
+  each package's directory at macro-expansion time rather than typed.
+  Test suites are deliberately absent: a test may reach past a door the
   application may not — `scaling-dom-cljs-test` reads the runtime's own
   body-run counter — which is the whole reason the two are held to
-  different rules."
+  different rules, and the exclusion is the build's own `cljs-test$`."
   {"the four-field editor"
-   ["re-frame.hicasso.examples.editor.app"
-    "re-frame.hicasso.examples.editor.events"
-    "re-frame.hicasso.examples.editor.subs"
-    "re-frame.hicasso.examples.editor.views"]
+   (rg/emit-application-namespaces re-frame.hicasso.examples.editor)
 
    "the 100-cell grid"
-   ["re-frame.hicasso.examples.grid.app"
-    "re-frame.hicasso.examples.grid.events"
-    "re-frame.hicasso.examples.grid.subs"
-    "re-frame.hicasso.examples.grid.views"]})
+   (rg/emit-application-namespaces re-frame.hicasso.examples.grid)})
 
 (def ^:private graph
   "`{namespace [dependency …]}` for both applications, read off the
-  analyzer at macro-expansion time."
-  (rg/emit-dependency-graph
-    '[re-frame.hicasso.examples.editor.app
-      re-frame.hicasso.examples.editor.events
-      re-frame.hicasso.examples.editor.subs
-      re-frame.hicasso.examples.editor.views
-      re-frame.hicasso.examples.grid.app
-      re-frame.hicasso.examples.grid.events
-      re-frame.hicasso.examples.grid.subs
-      re-frame.hicasso.examples.grid.views]))
+  analyzer at macro-expansion time. Same population, other instrument: a
+  namespace the analyzer never saw is absent here and present in
+  [[witnesses]]."
+  (merge (rg/emit-dependency-graph re-frame.hicasso.examples.editor)
+         (rg/emit-dependency-graph re-frame.hicasso.examples.grid)))
 
 (def ^:private app-namespaces
   (into #{} cat (vals witnesses)))
@@ -98,10 +97,16 @@
 
 (deftest the-graph-is-populated
   (testing "the analyzer answered for every application namespace"
+    ;; Two instruments over one population: the DIRECTORIES on the left,
+    ;; the ANALYZER on the right. A namespace the analyzer never saw is
+    ;; absent on the right and fenced by nothing — every check below
+    ;; would pass over it vacuously — so the two are compared first, and
+    ;; `=` prints the file to open.
     (is (= app-namespaces (set (keys graph)))
-        "a namespace the analyzer has not analysed answers an EMPTY edge
-         set, and an empty edge set passes every check below vacuously —
-         so the roster and the graph's key set are compared first"))
+        "a source file under `examples/editor/` or `examples/grid/` is not
+         on this namespace's `:require` list, so the analyzer has no record
+         of it and its imports are fenced by nothing. Add it to the `ns`
+         form above, or take the file out of the package"))
 
   (testing "the reads that matter are present"
     ;; Positive controls. A fence over an empty graph is green having


### PR DESCRIPTION
Closes rf2-ccuw.

Every witness application's import fence enforced its predicates over a **hand-written population**. The namespace roster was typed *twice* per consumer — once as the `app-namespaces` literal, once as the quoted vector handed to `emit-dependency-graph`. Each file's docstring claimed "a namespace added tomorrow is covered the day it lands"; the *predicate* was, the *population* was not.

## The escape, demonstrated on `origin/main` before anything was changed

A new application namespace `slice/http.cljs` reaching past the public door:

```clojure
(ns re-frame.hicasso.examples.slice.http
  (:require [re-frame.hicasso.impl.collector]))
```

| plant, on unmodified `origin/main` | captured exit | result |
|---|---|---|
| control, no plant | `RAW_EXIT=0` | 1128 tests / 4612 assertions, 0 failures |
| `http.cljs` present, not yet wired | `RAW_EXIT=0` | 1128 / 4612 — **byte-identical to the control.** Zero signal. |
| `http.cljs` wired in from `app.cljs` | `RAW_EXIT=1` | 1 failure — **and it is the wrong one** |

The third row is the important one. `the-slice-names-no-private-namespace` — **the fence** — stayed **GREEN**. The only red was the *roster*, and what it reported was:

```
actual: (not (= #{"re-frame.adapter.uix" "re-frame.core" "re-frame.hicasso" "re-frame.routing"}
                #{… "re-frame.hicasso.examples.slice.http" …}))
```

It named the slice's *own* namespace as a new foreign door. The forbidden `re-frame.hicasso.impl.collector` import is never mentioned, by any row, anywhere.

## The repair

`require-graph/application-namespaces` reads the package's own directory off the JVM classpath at macro-expansion time: ClojureScript sources only, walked recursively so a subdirectory cannot escape, test suites excluded by **the build's own rule** (`:node-test` selects `cljs-test$`) rather than by a second rule kept in step by hand. It throws rather than answering empty, because an empty population passes every fence vacuously.

The population is then read by **two instruments and the two are compared**:

- `emit-application-namespaces` answers the **directory**.
- `emit-dependency-graph` answers the **analyzer**, and *omits* a namespace the analyzer has no record of.

So each consumer's existing `the-graph-is-populated` row — until now a comparison of two hand-written literals, and therefore near-tautological — becomes a real assertion that names the file to add to the `ns` form.

## The same plant, after

| plant, on this branch | captured exit | result |
|---|---|---|
| `http.cljs` wired in | `RAW_EXIT=1` | **fence RED**: `[["…slice.http" "re-frame.hicasso.impl.collector"]]` |
| `http.cljs` present, not wired | `RAW_EXIT=1` | `the-graph-is-populated` RED, naming `…slice.http` |
| plant removed | `RAW_EXIT=0` | 1128 / 4613, 0 failures |

The fence now names both the file to open and the import it may not have.

## Scope: six consumers, not two

The bead named two witnesses. The macro's argument changed from a quoted vector to a package symbol, and a dual-arity shim is not something this codebase carries, so all six consumers moved: **slice, todo, forms, ledger, typeahead**, and the **editor/grid** pair in `witness_surface_cljs_test`. Each was carrying the identical hand-written roster.

The **ledger** keeps its one deliberate subtraction — `vendor` stands in for an npm package and must count as *foreign* — and gains a row asserting the subtracted name is still in the package, so the subtraction cannot quietly stop subtracting.

## What did not change

**No fence predicate was touched.** The `forbidden` block is byte-identical in all six files:

```
$ git diff origin/main -- <the six suites> | grep -E "match\?|starts-with|:label|forbidden"
(no output)
```

`every-fence-predicate-fires` — the sabotage control — is untouched in all six. `(is …)` forms across the six suites go **88 → 89**: exactly the one new ledger row, matching the observed assertion delta 4612 → 4613. Nothing was removed or hollowed out.

## Honest limitation, stated in the docstring

shadow-cljs keys its cache on source hashes, and a directory listing is not one. A file **appearing in or disappearing from** a package while nothing on the consumer's `:require` chain changes does not re-expand the macro — **observed directly while this was written**, when a plant deleted from disk was still named by a warm expansion. CI compiles cold, and a file genuinely joining an application joins it by being `:require`d, which *is* an edit on the chain. The residue is a file nothing references, which is not yet what the fence is a claim about. This is the same boundary `typeahead/census.clj` already documents and ships.

## Finding filed, not fixed

**rf2-hcgo** (P2) — `examples/navigation/` has **no import fence at all**. Six of the seven witness packages carry one; navigation carries none, and it is not inert (per rf2-p5og it registers routes into the process-global registry at load). Same class one level up: the roster of *fenced packages* is itself hand-written, spread across six `ns` forms.

No existing predicate violator was found — discovery turned up exactly the namespaces each roster already listed. The rosters were complete **today**, by nobody having added a file yet rather than by construction.

## Quality gates

All at merge base `8fdb2558` (rebased onto trunk after 18 commits landed under this branch, including the two sibling workers on the slice and editor sources).

| gate | captured exit | result |
|---|---|---|
| `node-test-hicasso` — **control**, my 7 files reverted to `origin/main`, cold | `RAW_EXIT=0` | 1131 tests / **4613** assertions, 0 failures 0 errors |
| `node-test-hicasso` — this branch, cold | `RAW_EXIT=0` | 1131 tests / **4614** assertions, 0 failures 0 errors |
| `npm run test:cljs` — this branch | `RAW_EXIT=0` | 13823 tests / 69938 assertions, 0 failures 0 errors |

Control and branch run the **same 1131 tests** — no namespace was dropped — and differ by **exactly one assertion**, the new ledger row. That matches the static count: `(is …)` forms across the six suites go 88 → 89.

The control was produced by checking the seven files out of `origin/main` in place, then restoring them; the restore was verified by **hashing the bytes** of each against its recorded HEAD blob (all seven OK), not by reading a diff.

Exit codes are the raw `$?` captured on the same command line as the gate, redirected to a log — not the harness's.

`node-test-hicasso` is the lane that carries all six changed suites (`^re-frame\.hicasso\..+-cljs-test$`), which is why the controlled before/after pair is on it. No browser gate: every changed suite is `-cljs-test`, so the `:browser-test` build never expands these macros. `npm run test:hicasso-hmr` was not run (binds `:dev-http` 8061).

Test-only change: no production code, no facade export, no hot-zone file, no docs or spec surface.
