### PR TITLE
docs(machines): grow one login machine across a numbered guide

### DIFF
--- a/docs/api/re-frame.machines.md
+++ b/docs/api/re-frame.machines.md
@@ -227,7 +227,7 @@ The framework-registered subscription vectors and reserved effect tuples that ad
   ```clojure
   [:rf/machine machine-id]
   ```
-- **Description**: The canonical machine read. Returns a reaction whose value is the snapshot `{:state :data}` (plus framework-managed `:tags`), or `nil` if the machine is not yet initialised. The [machines model](../machines/concepts.md#register-and-drive) walks through subscribing to a snapshot and chaining named projections off it.
+- **Description**: The canonical machine read. Returns a reaction whose value is the snapshot `{:state :data}` (plus framework-managed `:tags`), or `nil` if the machine is not yet initialised. [The table](../machines/concepts.md#register-and-drive) walks through subscribing to a snapshot and chaining named projections off it.
 - **Example**:
   ```clojure
   (let [{:keys [state data]} @(rf/subscribe [:rf/machine :auth.login/flow])]
@@ -306,7 +306,7 @@ The framework-registered subscription vectors and reserved effect tuples that ad
 | `:output-key` | Requires `:final?`. Designates the child's `:data` slot reported back via the parent's `:on-done`. |
 | `:on-done` (spawn-spec key) | `(fn [{:keys [data result]}] new-data)` on the parent's `:spawn` map. Fires synchronously when the spawned child enters a `:final?` state. `result` is the child's `:data` slot named by the final state's `:output-key` (or `nil`). |
 
-See [Final states](../machines/concepts.md#final-states) in the machines model guide.
+See [Final states](../machines/concepts.md#final-states) in [The table](../machines/concepts.md).
 
 ### `[:rf.machine/dispatch-to-system [system-id event]]`
 
@@ -570,6 +570,6 @@ The registration-time and `:data`-schema-boundary validators. The three `:data` 
 
 - [re-frame.core.md](re-frame.core.md) — `reg-machine` / `defmachine` / `machine-has-tag?` are reached on the `re-frame.core` facade; `dispatch` / `subscribe` / `reg-event` drive and read a machine.
 - [re-frame.schemas.md](re-frame.schemas.md) — machines declare schemas for their `:data` slot the same way ordinary handlers do; the `validate-*-data!` validators gate them.
-- [Machines concept guide](../machines/concepts.md) — the narrative walkthrough: the transition table, guards, actions, tags, `:after`, final states, and when to reach for a machine. The v1 transition-table grammar covers a specific subset of Statechart capabilities: sequencing, `:after` timers, internal-vs-external transitions, guards, action lists, hierarchical states, parallel regions, and final-state semantics. The guide covers the exact subset and its rationale.
-- [Machines glossary](../machines/glossary.md) — the surface vocabulary in one place.
+- [The table](../machines/concepts.md) — the flat-table contract: guards, actions, encapsulation, finals, schemas. The numbered Machines pages grow one login machine through tags, automatic transitions, hierarchy, parallel regions, history, and actors.
+- [Glossary](../machines/glossary.md) — the surface vocabulary in one place.
 - [Coming from XState](../machines/coming-from-xstate.md) — the v6 parity delta for XState users.

--- a/docs/machines/actors.md
+++ b/docs/machines/actors.md
@@ -1,19 +1,63 @@
-# Actors: spawning child machines
+# 8. Actors
 
-A machine can start another machine and bind that child's lifetime to a state.
+<a id="actors"></a>
+<a id="actors-spawning-child-machines"></a>
 
-The child is a live machine instance with its own snapshot. re-frame2 calls that
-instance an **actor**. Use one when work should start on state entry and be
-cleaned up on every exit path: a request protocol, a websocket, a worker, a
-cancellable job, a sub-flow that reports a result.
+Every machine so far has been a **singleton**: one `reg-machine` id, one live
+instance. `[:rf/machine :auth.login/flow]` is that instance, or `nil` before
+the first event.
 
-Assumes the [flat model](concepts.md). Child completion often uses
+A **spawned** actor is another live instance of a machine **type**, created
+at run time. It gets an allocated id (`:auth/request#0`). Use one when you
+need many concurrent instances, or a child whose lifetime is bound to a
+parent state.
+
+The spec heading says "dynamic actors." That is an adjective for spawned
+instances, not a third kind. This guide says **singleton** and **spawned**.
+
+Login stays the singleton. The HTTP request becomes a spawned child: it
+starts when `:submitting` is entered and is destroyed on every exit.
+
+Assumes the [flat table](concepts.md). Child completion often uses
 [final states](concepts.md#final-states).
 
 ## State-bound spawn
 
 Put `:spawn` on a state node. Entering the state creates the child. Leaving the
 state — by any transition — destroys it.
+
+The singleton login machine spawns a request actor on `:submitting`:
+
+```clojure
+(rf/reg-machine :auth/request
+  {:initial :running
+   :data    {}
+   :states
+   {:running
+    {:entry :issue-request
+     :on    {:server-ok {:target :done
+                         :action :keep-token}
+             :server-err :failed}}
+    :done   {:final? true :output-key :token}
+    :failed {:final? true :error? true}}})
+
+:submitting
+{:tags  #{:auth/busy}
+ :spawn {:machine-id :auth/request
+         :data       (fn [{:keys [event]}]
+                       {:credentials (second event)})
+         :on-done    (fn [{:keys [data result]}]
+                       (assoc data :token result))
+         :on-error   {:target :error-shown}}
+ :on    {:auth.login/cancel :idle}}
+```
+
+`:auth.login/flow` is still the singleton. `:auth/request` is the **type**.
+Each visit to `:submitting` allocates a new spawned id. Leaving
+`:submitting` — success, error, cancel, timeout — destroys that actor.
+
+A larger shipped case binds one socket actor to a parent that spans several
+children:
 
 ```clojure
 ;; cf. examples/patterns/websocket

--- a/docs/machines/automatic-transitions.md
+++ b/docs/machines/automatic-transitions.md
@@ -1,6 +1,13 @@
-# Automatic transitions
+# 4. Automatic transitions
 
-Most transitions wait for an event. Some transitions are driven by the machine itself:
+<a id="automatic-transitions"></a>
+
+The [first machine](tutorial.md) already uses one automatic form: `:after`
+on `:submitting` cancels if the server stalls. This page is the rest of the
+family.
+
+Most transitions wait for a trigger from `dispatch`. Some triggers are
+produced by the machine itself:
 
 - a guard becomes true;
 - a decision node resolves immediately;
@@ -20,33 +27,35 @@ re-frame2 has four authoring forms for this, built on two engines.
 
 `:always` is checked after a state is entered and after transitions that remain in, or land in, that state.
 
+Login can skip the form when a session token is already in `:data`:
+
 ```clojure
-(rf/reg-machine :quiz
-  {:initial :asking
-   :data    {:correct 0}
+:guards
+{:has-session?
+ (fn [{data :data}]
+   (some? (:token data)))}
 
-   :guards
-   {:enough? (fn [{data :data}]
-               (>= (:correct data) 10))}
-
-   :actions
-   {:count-correct (fn [{data :data}]
-                     {:data {:correct (inc (:correct data))}})}
-
-   :states
-   {:asking
-    {:always [{:guard :enough?
-               :target :winner}]
-     :on     {:answer-correct {:action :count-correct}
-              :answer-wrong   :loser}}
-
-    :winner {}
-    :loser  {}}})
+:idle
+{:always [{:guard  :has-session?
+           :target :authed}]
+ :on     {:auth.login/submit {:target :submitting
+                              :guard  :form-valid?
+                              :action :clear-error}}}
 ```
 
-The `:answer-correct` transition has no `:target`, so it updates `:data` while staying in `:asking`. Then `:always` is checked. If the count has reached ten, the machine moves to `:winner` in the same macrostep.
+Birth lands on `:idle`. If `:data` already has a token (hydration, a restore
+event), `:always` moves to `:authed` in the same macrostep. External
+observers see the settled result, not the hop through `:idle`.
 
-External observers see the settled result, not each internal microstep.
+The same form works as a counter that trips a threshold. A targetless
+`:on` updates `:data`; then `:always` is checked:
+
+```clojure
+:asking
+{:always [{:guard :enough? :target :winner}]
+ :on     {:answer-correct {:action :count-correct}
+          :answer-wrong   :loser}}
+```
 
 ## Run to completion
 
@@ -92,6 +101,22 @@ An `:always` transition may not target its own declaring state. That shape eithe
 
 A choice state is a named decision node. The machine enters it and immediately leaves through the first passing candidate.
 
+The first machine's failure candidate list can be written as a choice instead:
+
+```clojure
+:submitting
+{:on {:auth.login/failure {:target :decide-failure
+                           :action :record-error}}}
+
+:decide-failure
+{:type   :choice
+ :choice [{:guard  :under-retry-limit
+           :target :error-shown}
+          {:target :locked-out}]}
+```
+
+A smaller decision node looks the same:
+
 ```clojure
 :checking
 {:type   :choice
@@ -113,7 +138,7 @@ Choice rules:
 
 `:after` maps a delay to a transition. Entering the state arms the timer. Leaving the state cancels it.
 
-The [login tutorial](tutorial.md#step-4--talk-to-a-real-server) uses an 8-second `:after` as a server deadline. The same key works for any wall-clock wait:
+The [first machine](tutorial.md#step-4--talk-to-a-real-server) uses an 8-second `:after` as a server deadline. The same key works for any wall-clock wait:
 
 ```clojure
 (rf/reg-machine :boot
@@ -248,3 +273,14 @@ Positive integer milliseconds.
 An ISO-8601 duration string.
 
 Readable shorthands such as `"5s"` or `"10ms"` are not accepted, nor are subscription vectors or delay functions. A bad duration fails at registration with `:rf.error/machine-bad-timeout-duration`. Use integer milliseconds or ISO-8601.
+
+## Troubleshooting
+
+| Symptom | Cause | Fix |
+| --- | --- | --- |
+| Registration throws `:rf.error/machine-always-self-loop` | `:always` targets its own declaring state | Use a targetless `:always` with an action that flips the guard, or target a different state |
+| Macrostep fails `:rf.error/machine-always-depth-exceeded` | Eventless loop did not settle within 16 steps | Break the cycle; a targetless drain-until-false is the safe loop |
+| Registration throws `:rf.error/machine-bad-choice` | `:choice` is a function, empty, or missing a default | Declarative non-empty vector with an unguarded last candidate |
+| Timer fired but the snapshot did not move | Guard was false at expiry, or the state had already been left | Expected. A late timer is stale; a false guard discards that firing |
+| Registration throws `:rf.error/machine-bad-timeout-duration` | `"5s"` shorthand, or a non-positive / malformed duration | Integer milliseconds or ISO-8601 (`"PT5S"`) |
+| Registration throws `:rf.error/spawn-timeout-ms-removed` | `:timeout-ms` on a spawn spec | Use `:timeout` + `:on-timeout`, or `:after` on the parent state |

--- a/docs/machines/coming-from-xstate.md
+++ b/docs/machines/coming-from-xstate.md
@@ -168,19 +168,24 @@ XState event objects commonly look like:
 { type: "SUBMIT", credentials }
 ```
 
-re-frame2 machine events are vectors:
+XState's `{ type: "SUBMIT", credentials }` is one event object. re-frame2
+writes that same object as a **trigger** vector:
 
 ```clojure
 [:auth.login/submit credentials]
 ```
 
-Dispatch wraps the machine event in the outer re-frame2 event:
+You do not `send` that vector to an actor. You `dispatch` it *inside* a
+normal re-frame2 **event** whose id is the machine id:
 
 ```clojure
 (rf/dispatch [:auth.login/flow [:auth.login/submit credentials]])
 ```
 
-The outer id chooses the machine. The inner event is what the machine sees.
+`:auth.login/flow` is the handler id — the same id you passed to
+`reg-machine`. That id is a **singleton**. `[:auth.login/submit credentials]`
+is the trigger the table matches against `:on`. The first keyword is the
+`:on` key; the rest is payload.
 
 ## Reading the snapshot
 
@@ -262,7 +267,9 @@ The child is destroyed automatically when the parent leaves `:authenticating`.
 transition.
 
 `spawn` is the same lifecycle idea as `invoke`, renamed because a child actor
-exists while the state is active.
+exists while the state is active. The parent registered with `reg-machine` is
+the **singleton**. Each `:spawn` creates a **spawned** instance of a type.
+The spec heading says "dynamic actors"; this guide uses those two words.
 
 ## Completion is event-shaped
 

--- a/docs/machines/concepts.md
+++ b/docs/machines/concepts.md
@@ -1,14 +1,13 @@
-# The model
+# 2. The table
 
+<a id="concepts"></a>
+<a id="the-model"></a>
 <a id="state-machines"></a>
 
-This page is the **flat machine model** — a single-level transition table, how
-you register and drive it, and the contracts guards and actions live under.
-Nested states, parallel regions, history, and actors grow the same grammar;
-each has its own page.
-
-To *build* a login machine step by step (guard → action → HTTP → view → test),
-use the [tutorial](tutorial.md).
+The [first machine](tutorial.md) filled the slots. This page is the rest of
+the **flat table** contract — registration, the snapshot, transition forms,
+encapsulation, self-transitions, finals, schemas, and `:raise`. It does not
+rebuild the login walk-through.
 
 !!! note "Where should this value live?"
 
@@ -19,64 +18,9 @@ use the [tutorial](tutorial.md).
 
 <a id="a-machine-at-a-glance"></a>
 <a id="the-same-flow-as-a-transition-table"></a>
-
-You already write state machines: a `:status` keyword in app-db plus informal
-rules in handlers about what may follow what. A machine writes those rules down
-as **one value** — a transition table — so you can read, test, and change the
-flow in one place.
+<a id="the-idea"></a>
 
 A table has five everyday parts:
-
-```clojure
-;; cf. examples/capabilities/machines/state_machine_walkthrough/
-(rf/defmachine login-flow
-  {:initial :idle
-   :data    {:attempts 0 :error nil}
-
-   :guards
-   {:form-valid?
-    (fn [{[_ creds] :event}]
-      (and (seq (:email creds)) (seq (:password creds))))
-    :under-retry-limit
-    (fn [{data :data}]
-      (< (:attempts data) 2))}          ;; three attempts; see Guards
-
-   :actions
-   {:clear-error
-    (fn [_] {:data {:error nil}})
-    :record-error
-    (fn [{data :data [_ {:keys [error]}] :event}]
-      {:data (-> data
-                 (update :attempts inc)
-                 (assoc  :error (or (:message error) "Login failed.")))})
-    :store-session
-    (fn [{[_ {:keys [value]}] :event}]
-      {:fx [[:dispatch [:auth.session/store {:token (:token value)}]]]})}
-
-   :states
-   {:idle
-    {:on {:auth.login/submit {:target :submitting
-                              :guard  :form-valid?
-                              :action :clear-error}}}
-
-    :submitting
-    {:tags #{:auth/busy}
-     :on   {:auth.login/success {:target :authed :action :store-session}
-            :auth.login/failure [{:target :error-shown
-                                  :guard  :under-retry-limit
-                                  :action :record-error}
-                                 {:target :locked-out
-                                  :action :record-error}]}}
-
-    :error-shown
-    {:on {:auth.login/dismiss {:target :idle}
-          :auth.login/submit  {:target :submitting
-                               :guard  :form-valid?
-                               :action :clear-error}}}
-
-    :authed     {:meta {:terminal? true}}
-    :locked-out {:meta {:terminal? true}}}})
-```
 
 - `:initial` — where the machine starts.
 - `:data` — private working memory.
@@ -84,10 +28,9 @@ A table has five everyday parts:
 - `:actions` — return `{:data … :fx …}`; they never perform side effects.
 - `:states` — the nodes and their outgoing transitions.
 
-`:authed` and `:locked-out` are resting leaves. They keep the snapshot around
-so a view can still render them. They are **not** `:final?` — that flag
-destroys the machine ([Final states](#final-states)).
-
+Resting leaves such as `:authed` keep the snapshot around so a view can still
+render them. They are **not** `:final?` — that flag destroys the machine
+([Final states](#final-states)).
 ## Register and drive
 
 <a id="register-and-drive"></a>
@@ -115,33 +58,44 @@ Avoid `(def m {…})` then `(reg-machine :id m)`. The macro never sees the
 literal, so source stamps are empty and dev warns
 `:rf.warning/machine-source-unstamped`.
 
-**Dispatch** addresses the machine id; the *inner* vector is the machine event:
+You drive the machine with `dispatch`, not `send`. The outer vector is a
+re-frame2 **event** whose id is the machine id. The second element is the
+**trigger** the table matches:
 
 ```clojure
 (rf/dispatch [:auth.login/flow [:auth.login/submit credentials]])
 ```
+
+`:auth.login/submit` is the `:on` key. `credentials` is payload, read from
+`:event` in a guard or action. The [landing page](index.md#first-class-support)
+introduces this split; the [first machine](tutorial.md) drives it.
 
 **Subscribe** with the framework sub — there is no function sugar:
 
 ```clojure
 @(rf/subscribe [:rf/machine :auth.login/flow])
 ;; => {:state :submitting :data {:attempts 0 :error nil} :tags #{:auth/busy}}
-;;    nil before the first event
+;;    nil before the first event — this is a singleton
 ```
 
 The snapshot lives in [runtime-db](../core/glossary.md#runtime-db), so undo,
 time-travel, and SSR hydration work without extra wiring.
 
+A singleton is the registered id. A spawned actor is a second live instance
+of a type, with an allocated id — [Actors](actors.md).
+
 !!! note "Async composes"
 
     Point managed HTTP replies at the machine:
-    `:on-success [:auth.login/flow [:auth.login/success]]` (outer id, inner
-    event). The reply is *appended* into the inner event. Full walk-through in
-    the [tutorial](tutorial.md#step-4--talk-to-a-real-server).
+    `:on-success [:auth.login/flow [:auth.login/success]]` (outer event id,
+    inner trigger). The reply is *appended* onto the trigger. Full
+    walk-through in the [first machine](tutorial.md#step-4--talk-to-a-real-server).
 
 ## See one run
 
-Click into the cell and press **`Ctrl-Enter`** (**`Cmd-Enter`** on macOS):
+A tiny clickable machine, not the login flow. Use it to feel a
+self-transition. Click into the cell and press **`Ctrl-Enter`**
+(**`Cmd-Enter`** on macOS):
 
 ```cljs-rf2
 (require '[re-frame.core :as rf])
@@ -296,15 +250,8 @@ Return **descriptions**, the same idea as `reg-event`:
 ```
 
 Require `[re-frame.http.managed]` wherever `:rf.http/managed` appears, or the
-effect is `:rf.error/no-such-fx`. `:on-success` / `:on-failure` are one
-element short on purpose — managed HTTP **appends** the reply envelope:
-
-```clojure
-[:auth.login/success {:status :ok    :value {:token "…"} …}]
-[:auth.login/failure {:status :error :error {:message "…"} …}]
-```
-
-`:record-error` reads `:error`. `:store-session` reads `:value`.
+effect is `:rf.error/no-such-fx`. The reply envelope and the one-element-short
+target shape are in the [first machine](tutorial.md#step-4--talk-to-a-real-server).
 
 ### The effect map `{:data :fx}`
 
@@ -483,37 +430,11 @@ reaches runtime-db (`:where :machine-data`).
 
 <a id="testing-transitions-are-pure-function-calls"></a>
 
-The table is a value. Drive it with no frame, no browser, no network:
-
-```clojure
-(ns app.login-test
-  (:require [clojure.test :refer [deftest is]]
-            [re-frame.machines :as machines]
-            [re-frame.machines.result :as result]
-            [app.login :refer [login-flow]]))
-
-(deftest login-flow-test
-  (let [r (machines/machine-transition
-            login-flow
-            {:state :idle :data {:attempts 0 :error nil}}
-            [:auth.login/submit {:email "a@b.com" :password "secret"}])]
-    (is (result/ok? r))
-    (is (= :submitting (:state (result/snap r)))))
-
-  ;; Two failures already recorded; the third is terminal.
-  (let [r (machines/machine-transition
-            login-flow
-            {:state :submitting :data {:attempts 2 :error nil}}
-            [:auth.login/failure {:error {:message "bad creds"}}])]
-    (is (result/ok? r))
-    (is (= :locked-out (:state (result/snap r))))
-    (is (= 3 (get-in (result/snap r) [:data :attempts])))
-    (is (= "bad creds" (get-in (result/snap r) [:data :error])))))
-```
-
-Discriminate with `result/ok?` / `result/fail?`; read the next snapshot and
-the emitted effects with `result/snap` / `result/fx`. More, including Xray:
-[Inspecting and testing](inspecting-machines.md).
+The table is a value. `(machines/machine-transition definition snapshot trigger)`
+returns the next snapshot and the effects the action described. The
+[first machine](tutorial.md#step-6--test-it-a-transition-is-a-pure-function)
+has the login cases. [Inspecting and testing](inspecting-machines.md) is the
+full surface.
 
 ## Troubleshooting
 
@@ -525,23 +446,14 @@ the emitted effects with `result/snap` / `result/fx`. More, including Xray:
 | Action fails `:rf.error/machine-action-wrote-db` | Returned `:db` | Update the snapshot via `:data`; write app-db through a named event in `:fx` |
 | Dispatch does nothing | Current state has no matching `:on` | Expected no-op (`:rf.machine.event/unhandled-no-op`). Bad names fail at registration |
 | `:rf.error/no-such-fx` on `:rf.http/managed` | HTTP artefact not loaded | Require `[re-frame.http.managed]` |
+| External dispatch of a private event is refused | Id is in `:internal-events` | Raise it from an action, or drop it from the set |
+| Macrostep fails `:rf.error/machine-always-depth-exceeded` or `-raise-depth-exceeded` | Eventless / `:raise` loop did not settle | Break the cycle; default bound is 16 |
 
-## When the table grows
+## Raise and internal events
 
+<a id="when-the-table-grows"></a>
 <a id="when-the-machine-grows"></a>
 <a id="tags-and-timers"></a>
-
-Same model, more keys — each page assumes this one:
-
-| Need | Page |
-| --- | --- |
-| Label intent so views don't enumerate states | [Tags](tags.md) — `@(rf/subscribe [:rf.machine/has-tag? id :auth/busy])` |
-| Moves the table takes without a user event | [Automatic transitions](automatic-transitions.md) (`:after` / `:always` / choice / timeout) |
-| Nested sub-flows | [Hierarchical states](hierarchical-states.md) |
-| Independent axes at once | [Parallel regions](parallel-states.md) |
-| Resume mid-compound | [History](history.md) |
-| Per-request / worker children | [Actors](actors.md) |
-| Prove the table / watch live | [Inspecting and testing](inspecting-machines.md) |
 
 **`:raise`** in an action's `:fx` re-enters *this* machine atomically before
 commit. **`:internal-events`** is the set of event ids that external
@@ -556,17 +468,10 @@ no-op.
 
 <a id="when-to-reach-for-a-machine--and-when-not"></a>
 
-**Yes:** named mutually exclusive stages; legal and illegal events;
-timers, cancellation, retries, or cleanup; the flow is easier to draw than
-to describe; tests should assert `(state, event) → next state + effects`.
+Use a machine when named mutually exclusive stages are the load-bearing
+concept: legal and illegal triggers, timers, cancellation, retries, or
+cleanup; the flow is easier to draw than to describe; tests should assert
+`(state, trigger) → next state + effects`.
 
-**No:**
-
-| Situation | Prefer |
-| --- | --- |
-| A counter, list, or form field | app-db + events |
-| A two-state flag | a keyword or boolean |
-| Server cache lifecycle | [resources](../resources/concepts.md) |
-| A fixed sequence of operations | chained events |
-
-Named states are the concept — not named operations.
+The [landing page](index.md#when-not-to-use-a-machine) has the when-not
+table.

--- a/docs/machines/examples.md
+++ b/docs/machines/examples.md
@@ -7,8 +7,8 @@ name the same machinery.
 
 | Example | What it shows | Pair with |
 |---|---|---|
-| [state_machine_walkthrough](../../examples/capabilities/machines/state_machine_walkthrough) | A small transition table; guards and actions kept with the spec; pure `machine-transition` tests; the same machine value in the browser and on the JVM | [Tutorial](tutorial.md), [The model](concepts.md) |
-| [nine_states](../../examples/patterns/nine_states) | Parallel regions for orthogonal UI axes; tags as render semantics; a `render-priority` table; one view branch instead of a cross-product | [Parallel regions](parallel-states.md), [State tags](tags.md) |
+| [state_machine_walkthrough](../../examples/capabilities/machines/state_machine_walkthrough) | A small transition table; guards and actions kept with the spec; pure `machine-transition` tests; the same machine value in the browser and on the JVM | [First machine](tutorial.md), [The table](concepts.md) |
+| [nine_states](../../examples/patterns/nine_states) | Parallel regions for orthogonal UI axes; tags as render semantics; a `render-priority` table; one view branch instead of a cross-product | [Parallel regions](parallel-states.md), [Tags](tags.md) |
 | [long_running_work](../../examples/patterns/long_running_work) | A parent `:spawn-all` of N workers; `:join :all`; progress as an internal self-transition; cooperative cancel and teardown on every exit | [Actors](actors.md), [Automatic transitions](automatic-transitions.md) |
 | [websocket](../../examples/patterns/websocket) | Hierarchical connection states; a `:spawn`ed socket actor; `:after` exponential backoff; `:always` queue flush; tags for status; `:current-socket?` drops events from a replaced socket | [Hierarchical states](hierarchical-states.md), [Actors](actors.md), [Automatic transitions](automatic-transitions.md) |
 

--- a/docs/machines/glossary.md
+++ b/docs/machines/glossary.md
@@ -1,4 +1,6 @@
-# Machines glossary
+# Glossary
+
+<a id="machines-glossary"></a>
 
 One term, short definition, tiny code when the spelling matters. *See* points
 at the teaching page.
@@ -15,7 +17,7 @@ named states and transitions.
 (rf/reg-machine :auth.login/flow login-flow)
 ```
 
-See [The model](concepts.md).
+See [The table](concepts.md).
 
 ### **transition table**
 
@@ -41,8 +43,9 @@ It lives in [runtime-db](../core/glossary.md#runtime-db). Read it with
 @(rf/subscribe [:rf/machine :auth.login/flow])
 ```
 
-`nil` until the first event. `:state` is a keyword, a path vector, or a
-region map.
+`nil` until the first event on a **singleton**. A spawned actor has a
+snapshot from the moment it is spawned. `:state` is a keyword, a path
+vector, or a region map.
 
 See [The snapshot](concepts.md#the-snapshot).
 
@@ -58,9 +61,20 @@ See [The idea](concepts.md#the-idea).
 
 One named mode of a machine, such as `:idle`, `:submitting`, or `:authed`.
 
+### **trigger**
+
+The thing that can fire a transition. A dispatched trigger is the inner
+vector, such as `[:auth.login/submit credentials]`. A timer expiry (`:after`)
+and a guard that became true (`:always`) are triggers too.
+
+Do not call the inner vector an "event." In re-frame2, the **event** is the
+outer vector whose id is the machine id.
+
+See [Native to re-frame2](index.md#first-class-support).
+
 ### **transition**
 
-A move from one state to another, usually in response to an event under a
+A move from one state to another, usually in response to a trigger under a
 state's `:on` map.
 
 ### **guard**
@@ -102,7 +116,7 @@ See [The effect map](concepts.md#the-effect-map-data-fx).
 ### **compound state**
 
 A state with nested `:states` and its own `:initial`. The snapshot's `:state`
-becomes a vector path, such as `[:authenticated :cart :paying]`.
+becomes a vector path, such as `[:authenticated :settings]`.
 
 See [Hierarchical states](hierarchical-states.md).
 
@@ -239,10 +253,25 @@ See [Automatic transitions](automatic-transitions.md).
 
 ## Actors and composition
 
+### **singleton**
+
+A machine registered with `reg-machine`. One id, one live instance. The
+snapshot is `nil` until the first event. Login is a singleton.
+
+See [Actors](actors.md).
+
+### **spawned actor**
+
+A live instance created at run time with `:spawn` or `[:rf.machine/spawn …]`.
+It has an allocated id such as `:auth/request#0`. The spec heading says
+"dynamic actors"; that is an adjective, not a third kind.
+
+See [Actors](actors.md).
+
 ### **actor**
 
-A live machine instance. A singleton machine and a spawned child are both
-actors. Liveness is the presence of a snapshot in runtime-db.
+A live machine instance. A singleton and a spawned child are both actors.
+Liveness is the presence of a snapshot in runtime-db.
 
 See [Actors](actors.md).
 
@@ -292,14 +321,14 @@ the macrostep commits.
 {:fx [[:raise [:check-complete]]]}
 ```
 
-See [When the table grows](concepts.md#when-the-table-grows).
+See [Raise and internal events](concepts.md#when-the-table-grows).
 
 ### **:internal-events**
 
 A top-level set of event ids that may be raised internally but are refused
 when dispatched from outside the machine.
 
-See [When the table grows](concepts.md#when-the-table-grows).
+See [Raise and internal events](concepts.md#when-the-table-grows).
 
 ## Runtime terms
 

--- a/docs/machines/hierarchical-states.md
+++ b/docs/machines/hierarchical-states.md
@@ -1,61 +1,70 @@
-# Hierarchical states
+# 5. Hierarchical states
 
-A flat machine has one active state at a time. A hierarchical machine lets a
-state contain its own child states.
+<a id="hierarchical-states"></a>
 
-Use hierarchy when several states form a sub-flow or share a lifecycle — every
-authenticated screen handles `:logout` the same way, or checkout is a nested
-flow inside shopping.
+The [first machine](tutorial.md) is flat. Login sits next to "which screen
+after login?" Those share a session. Nest them.
+
+A hierarchical machine lets a state contain its own child states. The parent
+holds what the children share. The children hold what differs.
 
 ## A compound state
 
 A state with `:states` is a compound state. It must declare `:initial`.
 
+Wrap the login leaves in `:unauthenticated`, and put the signed-in screens
+under `:authenticated`:
+
 ```clojure
-(rf/defmachine shop
+(rf/defmachine session
   {:initial :unauthenticated
+   :data    {:attempts 0 :error nil}
 
    :states
    {:unauthenticated
-    {:on {:login [:authenticated]}}
+    {:initial :idle
+     :states
+     {:idle
+      {:on {:auth.login/submit {:target :submitting
+                                :guard  :form-valid?
+                                :action :clear-error}}}
+      :submitting
+      {:tags  #{:auth/busy}
+       :on    {:auth.login/success {:target [:authenticated]
+                                    :action :store-session}
+               :auth.login/failure :error-shown}}
+      :error-shown
+      {:on {:auth.login/dismiss :idle}}
+      :locked-out
+      {:tags #{:auth/locked}
+       :meta {:terminal? true}}}}
 
     :authenticated
     {:initial :dashboard
-     :tags    #{:auth/logged-in}
-     :on      {:logout [:unauthenticated]}  ;; inherited by descendants
-
+     :tags    #{:auth/authed}
+     :on      {:auth.logout [:unauthenticated]}  ;; inherited by descendants
      :states
-     {:dashboard
-      {:on {:open-settings :settings
-            :open-cart     :cart}}
+     {:dashboard {:on {:open-settings :settings}}
+      :settings  {:on {:close :dashboard}}}}}}})
 
-      :settings
-      {:on {:close :dashboard}}
-
-      :cart
-      {:initial :browsing
-       :on      {:close :dashboard}
-       :states
-       {:browsing  {:on {:checkout :paying}}
-        :paying    {:on {:success :confirmed
-                         :failure :browsing}}
-        :confirmed {}}}}}}})
-
-(rf/reg-machine :shop shop)
+(rf/reg-machine :auth.login/flow session)
 ```
 
 Entering `:authenticated` does not stop at the parent. The machine follows the
-`:initial` chain to `[:authenticated :dashboard]`.
+`:initial` chain to `[:authenticated :dashboard]`. Success uses a vector
+target so it leaves `:unauthenticated` entirely.
+
+This is still a **singleton**. The id did not change. Only the table grew.
 
 ## The snapshot state becomes a path
 
 A hierarchical snapshot uses a vector path from the root to the active leaf:
 
 ```clojure
-@(rf/subscribe [:rf/machine :shop])
-;; => {:state [:authenticated :cart :paying]
+@(rf/subscribe [:rf/machine :auth.login/flow])
+;; => {:state [:authenticated :settings]
 ;;     :data  {...}
-;;     :tags  #{:auth/logged-in}}
+;;     :tags  #{:auth/authed}}
 ```
 
 A flat root state is treated as a one-element path internally, but flat machines
@@ -66,7 +75,7 @@ Avoid matching long paths in views. Put `:tags` on states and ask semantic
 questions:
 
 ```clojure
-(when @(rf/subscribe [:rf.machine/has-tag? :shop :auth/logged-in])
+(when @(rf/subscribe [:rf.machine/has-tag? :auth.login/flow :auth/authed])
   [account-menu])
 ```
 
@@ -112,9 +121,10 @@ A target can be a keyword or a vector.
 | `:settings` | sibling of the state that declares the transition |
 | `[:authenticated :settings]` | absolute path from the root |
 
-Use vector targets for cross-level jumps. They are unambiguous. In the shop
-machine, `:open-settings :settings` is a sibling of `:dashboard`;
-`:login [:authenticated]` is an absolute path from the root.
+Use vector targets for cross-level jumps. They are unambiguous. In the
+session machine, `:open-settings :settings` is a sibling of `:dashboard`;
+`:auth.login/success {:target [:authenticated]}` is an absolute path from
+the root.
 
 A keyword target is resolved relative to the declaring state's parent, not the
 currently active leaf. That is a static rule. A target that names a compound
@@ -131,11 +141,11 @@ That gives two useful patterns:
 
 ```clojure
 :authenticated
-{:on {:logout :unauthenticated}     ;; factored to parent
+{:on {:auth.logout [:unauthenticated]}  ;; factored to parent
  :states
  {:dashboard {}
   :settings  {}
-  :modal     {:on {:logout {}}}}}    ;; child consumes and blocks logout
+  :modal     {:on {:auth.logout {}}}}}  ;; child consumes and blocks logout
 ```
 
 - A parent can factor common transitions.
@@ -169,15 +179,18 @@ as handled.
 Moving from one path to another fires exits and entries along the least common
 compound ancestor.
 
-From `[:authenticated :cart :paying]` to `[:authenticated :dashboard]`, the
-least common active ancestor is `:authenticated`.
+From `[:authenticated :settings]` to `[:unauthenticated :idle]`, the least
+common active ancestor is the root.
 
 The cascade is:
 
-1. exit `:paying`;
-2. exit `:cart`;
+1. exit `:settings`;
+2. exit `:authenticated`;
 3. run the transition action;
-4. enter `:dashboard`.
+4. enter `:unauthenticated`, then `:idle`.
+
+A move from `[:authenticated :settings]` to `[:authenticated :dashboard]`
+does not exit `:authenticated`.
 
 The ancestor that remains active is not exited or re-entered.
 
@@ -241,6 +254,6 @@ child's root-level `:final?` is how it reports back — see
 | `reg-machine` throws `:rf.error/machine-compound-state-missing-initial` | A `:states` map with no `:initial` | Name the child to enter when the compound is targeted |
 | `reg-machine` throws `:rf.error/machine-unresolved-target` | A keyword target that is not a sibling of the declaring state | Use a vector path for a cross-level jump |
 | Landed in the wrong leaf | The target named a compound, so `:initial` cascaded | Target the leaf with a vector path |
-| `:logout` does nothing in one child | That child declares `:logout {}` or `:logout nil` | Remove the key to inherit; keep it only to block |
+| `:auth.logout` does nothing in one child | That child declares `:auth.logout {}` or `:auth.logout nil` | Remove the key to inherit; keep it only to block |
 | View broke after reshaping the tree | The view matched a long `:state` path | Ask a tag: `@(rf/subscribe [:rf.machine/has-tag? id tag])` |
 | Machine vanished after the "last screen" | A root-level `:final?` auto-destroys | Omit `:final?` on a resting leaf |

--- a/docs/machines/history.md
+++ b/docs/machines/history.md
@@ -1,14 +1,14 @@
-# History states
+# 7. History
 
-A history state lets a [compound](hierarchical-states.md) remember where it was
-when you left it.
+<a id="history"></a>
+<a id="history-states"></a>
 
-Use it to resume where you left off:
+The [session machine](hierarchical-states.md) forgets which signed-in screen
+you were on. Logout lands on `:unauthenticated`. The next success always
+opens `:dashboard`, even if you left from `:settings`.
 
-- a media player resumes mid-track
-- a wizard returns to the last step
-- a settings panel reopens on the same tab
-- a nested editor returns to the last active mode
+A history state lets a [compound](hierarchical-states.md) remember where it
+was when you left it.
 
 History is only for compound states. If the remembered thing is a flat value,
 store it in [`:data`](glossary.md#data).
@@ -21,59 +21,64 @@ The machine never occupies it. A transition targets it, and the runtime resolves
 that target to a real child. The [snapshot](glossary.md#snapshot)'s `:state`
 records the resolved leaf — never the pseudo-state.
 
-## Example: media player
+## Example: last signed-in screen
 
 ```clojure
-(rf/reg-machine :media/player
-  {:initial :tray
+(rf/reg-machine :auth.login/flow
+  {:initial :unauthenticated
 
    :states
-   {:tray
-    {:on {:insert [:player :hist]}}
+   {:unauthenticated
+    {:initial :idle
+     :states
+     {:idle
+      {:on {:auth.login/submit :submitting}}
+      :submitting
+      {:on {:auth.login/success [:authenticated :hist]
+            :auth.login/failure :error-shown}}
+      :error-shown
+      {:on {:auth.login/dismiss :idle}}}}
 
-    :player
-    {:initial :stopped
-     :on      {:eject :tray}
+    :authenticated
+    {:initial :dashboard
+     :on      {:auth.logout [:unauthenticated]}
 
      :states
      {:hist
       {:type :history
        :deep? true
-       :default-target :stopped}
+       :default-target :dashboard}
 
-      :stopped
-      {:on {:play [:player :playing]}}
+      :dashboard
+      {:on {:open-settings :settings}}
 
-      :playing
-      {:initial :at-start
-       :on      {:pause [:player :paused]
-                 :stop  [:player :stopped]}
-       :states
-       {:at-start  {:on {:seek :mid-track}}
-        :mid-track {}}}
-
-      :paused
-      {:on {:resume [:player :playing]}}}}}})
+      :settings
+      {:on {:close :dashboard}}}}}})
 ```
 
-Drive it with `dispatch-sync` so each line has settled before the next. Read it
-with the ordinary machine subscription:
+Drive it with `dispatch-sync` so each line has settled before the next:
 
 ```clojure
-(rf/dispatch-sync [:media/player [:insert]]) ;; [:player :stopped]
-(rf/dispatch-sync [:media/player [:play]])   ;; [:player :playing :at-start]
-(rf/dispatch-sync [:media/player [:seek]])   ;; [:player :playing :mid-track]
-(rf/dispatch-sync [:media/player [:eject]])  ;; :tray, recording :player
-(rf/dispatch-sync [:media/player [:insert]]) ;; restores [:player :playing :mid-track]
+(rf/dispatch-sync [:auth.login/flow [:auth.login/submit]])
+(rf/dispatch-sync [:auth.login/flow [:auth.login/success]])
+;; => [:authenticated :dashboard]
+(rf/dispatch-sync [:auth.login/flow [:open-settings]])
+;; => [:authenticated :settings]
+(rf/dispatch-sync [:auth.login/flow [:auth.logout]])
+;; => [:unauthenticated :idle], recording :authenticated
+(rf/dispatch-sync [:auth.login/flow [:auth.login/submit]])
+(rf/dispatch-sync [:auth.login/flow [:auth.login/success]])
+;; => restores [:authenticated :settings]
 
-@(rf/subscribe [:rf/machine :media/player])
-;; => {:state      [:player :playing :mid-track]
+@(rf/subscribe [:rf/machine :auth.login/flow])
+;; => {:state      [:authenticated :settings]
 ;;     :data       {}
-;;     :rf/history {[:player] [:player :playing :mid-track]}}
+;;     :rf/history {[:authenticated] [:authenticated :settings]}}
 ```
 
-The target `[:player :hist]` means "enter `:player` through its history
-pseudo-state."
+The target `[:authenticated :hist]` means "enter `:authenticated` through
+its history pseudo-state." First login has no recording, so
+`:default-target` opens `:dashboard`.
 
 ## The keys
 
@@ -81,7 +86,7 @@ pseudo-state."
 :hist
 {:type :history
  :deep? true
- :default-target :stopped}
+ :default-target :dashboard}
 ```
 
 | Key | Meaning |
@@ -100,28 +105,25 @@ vector for an absolute path.
 
 ## Shallow vs deep
 
-Suppose the player leaves from:
-
-```clojure
-[:player :playing :mid-track]
-```
+Suppose you leave `:authenticated` from `:settings`.
 
 Deep history records the full leaf path:
 
 ```clojure
-:rf/history {[:player] [:player :playing :mid-track]}
+:rf/history {[:authenticated] [:authenticated :settings]}
 ```
 
-Restoring returns to `[:player :playing :mid-track]`.
+Restoring returns to `[:authenticated :settings]`.
 
 Shallow history records only the direct child of the owning compound:
 
 ```clojure
-:rf/history {[:player] :playing}
+:rf/history {[:authenticated] :settings}
 ```
 
-Restoring enters `:playing` and then follows `:playing`'s `:initial`, landing at
-`[:player :playing :at-start]`.
+If `:settings` were itself a compound, restoring would enter `:settings`
+and then follow its `:initial`. For a leaf, deep and shallow land in the
+same place.
 
 Use deep when the precise nested position matters. Use shallow when only the
 top-level branch matters.
@@ -130,11 +132,12 @@ top-level branch matters.
 
 History records when the owning compound is actually exited.
 
-In the example, `:eject` leaves `:player` for `:tray`, so the runtime records
-`:player`'s last configuration.
+In the example, `:auth.logout` leaves `:authenticated` for
+`:unauthenticated`, so the runtime records `:authenticated`'s last
+configuration.
 
-A transition between children of `:player` does not record history, because
-`:player` was never exited. It remained the
+A transition between `:dashboard` and `:settings` does not record history,
+because `:authenticated` was never exited. It remained the
 [least common ancestor](hierarchical-states.md#entryexit-cascading-along-the-lca).
 
 If history is not sticking, check that the transition leaves the compound that
@@ -160,9 +163,9 @@ not a separate transition mechanism.
 History recordings live in a runtime-owned snapshot slot:
 
 ```clojure
-{:state      [:player :stopped]
+{:state      [:authenticated :dashboard]
  :data       {...}
- :rf/history {[:player] [:player :playing :mid-track]}}
+ :rf/history {[:authenticated] [:authenticated :settings]}}
 ```
 
 The key is the compound's declaration path. The value is either a full path for
@@ -189,7 +192,7 @@ history in one region leaves the others alone.
 
 | Symptom | Cause | Fix |
 |---|---|---|
-| History never restores; always hits default | Owning compound never left (sibling moves keep it as LCA) | Give the compound an off-state outside it (the `:tray` pattern) |
+| History never restores; always hits default | Owning compound never left (sibling moves keep it as LCA) | Give the compound an off-state outside it (`:unauthenticated` next to `:authenticated`) |
 | View `case`s on `:hist` | Pseudo-state is never in `:state` | Transition to `:hist` resolves to a real leaf — case on that |
 | Registration error at root / bare parallel | History needs an enclosing compound | Nest under a compound with `:states` + `:initial`. Error: `:rf.error/machine-history-misplaced` |
 | Two history children under one compound | At most one history node per compound | Use one node; deep vs shallow is `:deep?`. Error: `:rf.error/machine-history-duplicate` |

--- a/docs/machines/index.md
+++ b/docs/machines/index.md
@@ -2,20 +2,77 @@
 
 <a id="theyre-everywhere"></a>
 
-Some state is not a number in app-db — it is **which named stage you are in**,
-and what may legally move it. Login is idle, then submitting, then authed or
-error or locked-out. A websocket is connecting, open, reconnecting, closed.
-Those flows usually hide as enums and booleans scattered across handlers.
+A single-page app is full of finite state machines. Most of them are never
+written down.
 
-<a id="first-class-support"></a>
+The session is anonymous, submitting, authed, or locked out. An HTTP request
+is idle, in flight, succeeded, or failed. A dropdown is closed, open, or
+disabled. Same shape at every scale: a handful of named stages, and a smaller
+set of events that may leave each one.
 
-A **machine** makes that shape explicit: one data table of states and
-transitions, driven by ordinary `dispatch`, read by ordinary `subscribe`,
-living in the same [frame](../core/frames.md) as the rest of re-frame2.
+What you usually write instead is a pile of booleans and a `cond` in every
+handler — `:loading?`, `:error?`, `:open?`, `:disabled?`. The machine is still
+there. It is just poorly specified. Each handler re-decides what is legal. A
+new stage means another `if`. Two flags combine into a state nobody named
+(`:loading?` true and `:error?` true). An event that should be impossible
+gets through.
+
+A **machine** is that process written as one table: the stages, and which
+triggers may leave them.
+
+```clojure
+{:initial :closed
+ :states  {:closed   {:on {:open :open}}
+           :open     {:on {:close :closed
+                           :pick  :closed}}
+           :disabled {}}}
+```
+
+From `:closed`, only `:open` moves you. From `:disabled`, nothing does. You
+cannot open a disabled dropdown by forgetting a branch — the branch is not
+there.
+
+The same table shape covers a login flow or a request. Only the names change.
 
 **Prerequisites.** The [Core introduction](../core/introduction.md) — events,
 app-db, subscriptions, effects. Machines plug into those; they do not replace
-them. This page says when a machine fits and shows the smallest working form.
+them.
+
+## Why nest states
+
+A flat list is enough for one process. Some stages are really a *cluster*.
+`:connecting`, `:authenticating`, and `:connected` all share one live socket.
+Every authenticated screen should honour `:logout` the same way. Checkout is
+a sub-flow with its own start and end, inside a larger shopping flow.
+
+A **hierarchical** machine lets a state contain child states. The parent holds
+what the children share. The children hold what differs. Common transitions
+live once, on the parent; a child can override or block them.
+
+```clojure
+:authenticated
+{:initial :dashboard
+ :on      {:logout :unauthenticated}   ;; every child inherits this
+ :states  {:dashboard {}
+           :settings  {}
+           :cart      {:initial :browsing
+                       :states  {:browsing {}
+                                 :paying   {}}}}}
+```
+
+Entering `:authenticated` lands on `:dashboard`. `:logout` works from any
+child. Moving from `:browsing` to `:paying` does not leave `:authenticated`.
+[Hierarchical states](hierarchical-states.md) is the grammar.
+
+## Native to re-frame2
+
+<a id="first-class-support"></a>
+<a id="deeply-integrated"></a>
+
+re-frame2 does not add a second runtime. Other chart libraries give you an
+actor: you start it and `send` it messages. re-frame2 already has that job —
+events go on one queue via `dispatch`. So a machine is not a new object. It is
+an event handler. The id you register is the event id you dispatch to.
 
 ```clojure
 (:require [re-frame.core :as rf]
@@ -36,20 +93,43 @@ them. This page says when a machine fits and shows the smallest working form.
 ;; => {:state :submitting :data {}}
 ```
 
-The outer id routes to the machine. The inner vector is the event the table
-handles.
+Look at the `dispatch` line. You `dispatch`. You do not `send`.
 
-<a id="deeply-integrated"></a>
+The outer vector is a re-frame2 **event**. `:auth.login/flow` is a normal
+event id — the same slot as `:todo/add`. You registered that id with
+`reg-machine`, so the handler that runs is the table.
 
-`reg-machine` is sugar over `reg-event`. There is one event system — you
-`dispatch`, you do not `send` — and one state model: the snapshot rides
-[runtime-db](../core/glossary.md#runtime-db), so undo, Xray, SSR, and tests
-share the same pipeline as the rest of the app.
+The second element is a **trigger**. In a statechart, a trigger is the thing
+that can fire a transition. Here it is another vector: `[:auth.login/submit]`.
+The table matches the first keyword against the current state's `:on` map.
+Anything after that keyword is payload.
 
-A keyword in app-db is enough for two stages. Use a machine when the table is
-the source of truth — which events are legal where, and what happens next.
+Not every trigger comes from `dispatch`. A timer expiry and a guard that
+became true are triggers too — [Automatic transitions](automatic-transitions.md).
+
+`reg-machine` is sugar over `reg-event`: same registry, same `dispatch`. Read
+the live value with an ordinary `subscribe`. That value — the snapshot — lives
+in [runtime-db](../core/glossary.md#runtime-db), the framework half of the
+frame, so undo, Xray, SSR, and tests see it the way they see any other event's
+result.
+
+`:auth.login/flow` is a **singleton**: one registered id, one live instance.
+The snapshot is `nil` until the first event. A **spawned** actor is a second
+live instance of a type, created at run time with an allocated id. Login is a
+singleton. An in-flight request protocol is often spawned. The spec heading
+says "dynamic actors" for the second kind; that is an adjective, not a third
+kind. This guide says **singleton** and **spawned**.
+[Actors](actors.md) is the full treatment.
+
+Already using XState? [Coming from XState](coming-from-xstate.md) is the
+translation.
 
 ## When *not* to use a machine
+
+<a id="when-not-to-use-a-machine"></a>
+
+A two-state flag is already a tiny machine. Leave it as a boolean. Write a
+table when the stages multiply, or when illegal combinations start appearing.
 
 | Situation | Prefer |
 |---|---|
@@ -62,6 +142,3 @@ Reach for a machine when **named stages and legal transitions** are the thing
 you are modelling — not when the thing is a value or a network cache.
 [Where should this value live?](../core/where-state-lives.md) has the full
 decision table.
-
-Already using XState? [Coming from XState](coming-from-xstate.md) is the
-translation.

--- a/docs/machines/inspecting-machines.md
+++ b/docs/machines/inspecting-machines.md
@@ -1,4 +1,7 @@
-# Inspecting and testing machines
+# 9. Inspecting and testing
+
+<a id="inspecting-and-testing"></a>
+<a id="inspecting-and-testing-machines"></a>
 
 Machines are ordinary re-frame2 state and ordinary re-frame2 events.
 
@@ -22,7 +25,7 @@ The primary read is the framework subscription. There is no named-read-sugar fun
 ;;     :tags  #{:auth/busy}}
 ```
 
-The [snapshot](glossary.md#snapshot) is `nil` before the first event addressed to a singleton machine.
+The [snapshot](glossary.md#snapshot) is `nil` before the first event addressed to a **singleton**. A spawned actor's snapshot exists from the moment it is spawned.
 
 For views, prefer projection subscriptions:
 
@@ -117,10 +120,10 @@ In development this can include captured source, file, line, and handler functio
 A transition table is a value. A transition is a pure function of:
 
 ```clojure
-(definition, snapshot, event)
+(definition, snapshot, trigger)
 ```
 
-Import `login-flow` from the tutorial's [`defmachine`](tutorial.md#the-complete-machine) value and call it directly:
+Import `login-flow` from the [first machine](tutorial.md#the-complete-machine) and call it directly:
 
 ```clojure
 (ns app.login-test
@@ -170,7 +173,7 @@ If a machine is already registered and you want its registered definition, use m
 (machines/machine-transition
   (machines/machine-meta :auth.login/flow)
   snapshot
-  event)
+  trigger)
 ```
 
 Most tests should import the transition table value directly. Use registered metadata when the registration itself is part of what you are testing.
@@ -190,3 +193,12 @@ Keep most tests at the first level. It is fast, deterministic, and does not requ
 A throwing guard or action becomes a failure result at the pure testing surface. It does not escape as an exception from the test call: `(result/fail? r)` is true and `(result/info r)` carries the diagnostic.
 
 At runtime, the same failure aborts the macrostep atomically. The previous snapshot remains visible. The error is reported as `:rf.error/machine-action-exception` (a thrown guard does not fall through to the next candidate).
+
+## Troubleshooting
+
+| Symptom | Cause | Fix |
+| --- | --- | --- |
+| `[:rf/machine id]` is `nil` | No event has addressed that singleton yet | Dispatch first, or fall back to the definition's `:initial` |
+| `machine-transition` is unresolved | Required from `re-frame.machines`, not `rf/` | `(:require [re-frame.machines :as machines])` |
+| Guard threw and a later candidate did not run | Thrown guards abort the macrostep | Fix the guard; do not rely on fall-through after a throw |
+| Test expected `:rf.http/managed` and got none | `:entry` did not run, or the table under test is not the `defmachine` value | Import `login-flow`; start from `:idle` so `:submitting` entry fires |

--- a/docs/machines/parallel-states.md
+++ b/docs/machines/parallel-states.md
@@ -1,15 +1,20 @@
-# Parallel regions
+# 6. Parallel regions
 
-Sometimes one feature has several independent state axes active at the same time.
+<a id="parallel-regions"></a>
+<a id="parallel-states"></a>
 
-A todos page might be:
+The session machine so far has one active leaf. A login **page** often has
+two independent axes at once:
 
-- in a data state: `:nothing | :loading | :empty | :some | :error`;
-- in a form state: `:neutral | :valid | :invalid`;
-- in a mode state: `:active | :archived`.
+- the form: editing, valid, or invalid;
+- the submit flow: idle, submitting, authed, or error.
 
-Those axes are orthogonal. A flat machine would have to name the cross-product.
-Parallel regions keep the axes separate.
+Those axes are orthogonal. A flat machine would have to name the
+cross-product (`:idle-and-invalid`, `:submitting-and-valid`, …). Parallel
+regions keep the axes separate.
+
+The [Nine States example](../../examples/patterns/nine_states) is the same
+idea with three axes. This page teaches it on the login page first.
 
 ## When to use parallel regions
 
@@ -30,53 +35,48 @@ There is no per-region `:data`. A parallel machine has one shared `:data` map.
 A parallel machine has `:type :parallel` and `:regions` at the root.
 
 ```clojure
-;; cf. examples/patterns/nine_states
-(rf/defmachine nine-states
+(rf/defmachine login-page
   {:type :parallel
-   :data {:items [] :error nil}
+   :data {:attempts 0 :error nil}
 
    :guards
-   {:empty? (fn [{data :data}]
-              (zero? (count (:items data))))}
-
-   :actions
-   {:set-items (fn [{data :data [_ {:keys [items]}] :event}]
-                 {:data (assoc data :items (vec items))})}
+   {:form-valid?
+    (fn [{:keys [tags]}]
+      (contains? tags :form/valid))}
 
    :regions
-   {:data
-    {:initial :nothing
+   {:form
+    {:initial :editing
      :states
-     {:nothing   {:tags #{:data/nothing}
-                  :on   {:fetch-started :loading}}
-      :loading   {:tags #{:data/loading}
-                  :on   {:fetch-succeeded {:target :resolving
-                                           :action :set-items}
-                         :fetch-failed    :error}}
-      :resolving {:always [{:guard :empty? :target :empty}
-                           {:target :some}]}
-      :empty     {:tags #{:data/empty}}
-      :some      {:tags #{:data/some}}
-      :error     {:tags #{:data/error}}}}
+     {:editing {:tags #{:form/editing}
+                :on   {:form/valid   :valid
+                       :form/invalid :invalid}}
+      :valid   {:tags #{:form/valid}
+                :on   {:form/invalid :invalid}}
+      :invalid {:tags #{:form/invalid}
+                :on   {:form/valid :valid}}}}
 
-    :form
-    {:initial :neutral
+    :auth
+    {:initial :idle
      :states
-     {:neutral {:tags #{:form/neutral}
-                :on   {:submit-valid   :valid
-                       :submit-invalid :invalid}}
-      :valid   {:tags #{:form/valid}}
-      :invalid {:tags #{:form/invalid}}}}
+     {:idle
+      {:on {:auth.login/submit {:target :submitting
+                                :guard  :form-valid?}}}
+      :submitting
+      {:tags #{:auth/busy}
+       :on   {:auth.login/success :authed
+              :auth.login/failure :error-shown}}
+      :authed      {:tags #{:auth/authed}}
+      :error-shown {:on {:auth.login/dismiss :idle}}}}}}})
 
-    :mode
-    {:initial :active
-     :states
-     {:active   {:tags #{:mode/active}
-                 :on   {:archive :archived}}
-      :archived {:tags #{:mode/archived :mode/read-only}}}}}})
-
-(rf/reg-machine :ui/nine-states nine-states)
+(rf/reg-machine :auth.login/flow login-page)
 ```
+
+Still one **singleton**. The form region does not know the auth region's
+state names. Submit reads `:form/valid` off the tag union.
+
+The [Nine States example](../../examples/patterns/nine_states) is the same
+shape with a third `:mode` region.
 
 Each region body looks like a small machine: it has `:initial` and `:states`.
 
@@ -87,12 +87,11 @@ the root has both, or if a region is missing its own `:initial`.
 ## The snapshot state is a region map
 
 ```clojure
-@(rf/subscribe [:rf/machine :ui/nine-states])
-;; => {:state {:data :loading
-;;             :form :neutral
-;;             :mode :active}
-;;     :data  {:items [] :error nil}
-;;     :tags  #{:data/loading :form/neutral :mode/active}}
+@(rf/subscribe [:rf/machine :auth.login/flow])
+;; => {:state {:form :valid
+;;             :auth :submitting}
+;;     :data  {:attempts 0 :error nil}
+;;     :tags  #{:form/valid :auth/busy}}
 ```
 
 A compound region contributes a path as its region value:
@@ -123,9 +122,9 @@ For each region:
 - otherwise that region stays where it is.
 
 ```clojure
-(rf/dispatch-sync [:ui/nine-states [:fetch-started]])
-;; only the :data region handles it
-;; {:data :loading, :form :neutral, :mode :active}
+(rf/dispatch-sync [:auth.login/flow [:form/valid]])
+;; only the :form region handles it
+;; {:form :valid, :auth :idle}
 ```
 
 If several regions handle the same event, their actions run in region
@@ -264,11 +263,11 @@ The snapshot's `:tags` is the union of every active state in every region.
 That lets a view ask one question without knowing which region owns the tag:
 
 ```clojure
-@(rf/subscribe [:rf.machine/has-tag? :ui/nine-states :mode/read-only])
+@(rf/subscribe [:rf.machine/has-tag? :auth.login/flow :auth/busy])
 ```
 
 It also lets you build a single render-priority table across all axes. See
-[State tags](tags.md#collapsing-many-states-into-one-render-decision).
+[Tags](tags.md#collapsing-many-states-into-one-render-decision).
 
 ## Limitations
 
@@ -278,3 +277,13 @@ may not itself declare `:type :parallel`. Registration throws
 
 If you find yourself wanting nested parallel, flatten the axes into one
 parallel root or split the feature into several machines.
+
+## Troubleshooting
+
+| Symptom | Cause | Fix |
+| --- | --- | --- |
+| Registration throws `:rf.error/machine-parallel-bad-shape` | Root also has `:initial` / `:states`, or a region lacks `:initial` | `:type :parallel` uses `:regions` only; every region declares `:initial` |
+| Registration throws `:rf.error/machine-parallel-root-on-bad-target` | Root `:on` used a bare keyword target | Region-qualify: `[:left :two]` or `[[:left :two] [:right :two]]` |
+| Registration throws `:rf.error/machine-parallel-nested-not-supported` | A region itself declares `:type :parallel` | Flatten the axes, or split into separate machines |
+| Shared `:data` incremented twice on one event | Two regions handled the same event and both wrote | Put the write in one region, or on a root `:on` |
+| Guard cannot see a sibling's same-event move | Selection is frozen for the round | Use `:raise`, or a later `:always` round |

--- a/docs/machines/tags.md
+++ b/docs/machines/tags.md
@@ -1,45 +1,33 @@
-# State tags
+# 3. Tags
+
+<a id="tags"></a>
+<a id="state-tags"></a>
+
+The [first machine](tutorial.md) already put `#{:auth/busy}` on `:submitting`
+so the view could ask "busy?" without naming that state. This page is that
+idea as a contract.
 
 A view often does not care which exact state a machine is in. It cares about a
-semantic question:
+semantic question: is this flow busy? read-only? terminal?
 
-- is this flow busy?
-- is this screen read-only?
-- is this state terminal?
-- should the root view render loading, empty, error, or content?
-
-A **[state tag](glossary.md#state-tag)** is a label on a state that answers those
-questions without forcing the view to enumerate state names.
+A **[state tag](glossary.md#state-tag)** is a label on a state that answers
+those questions without forcing the view to enumerate state names.
 
 ## Declare tags on states
 
+Start from the login table. Tag the states the view actually asks about:
+
 ```clojure
-(rf/reg-machine :todos/loader
-  {:initial :idle
-   :states
-   {:idle
-    {:on {:fetch :loading}}
-
-    :loading
-    {:tags #{:data/in-flight}
-     :on   {:ok :ready
-            :fail :retrying}}
-
-    :retrying
-    {:tags #{:data/in-flight}
-     :on   {:ok :ready
-            :give-up :error}}
-
-    :ready
-    {:tags #{:data/ready}}
-
-    :error
-    {:tags #{:data/error}}}})
+:submitting  {:tags #{:auth/busy}   …}
+:authed      {:tags #{:auth/authed}
+              :meta {:terminal? true}}
+:locked-out  {:tags #{:auth/locked :auth/terminal}
+              :meta {:terminal? true}}
 ```
 
-Both `:loading` and `:retrying` advertise `:data/in-flight`. A third in-flight
-state later is one more `:tags` entry; the view that asks for that tag does not
-change.
+If login later grows a second in-flight state (refreshing a token, restoring
+a session), put `#{:auth/busy}` on that state too. The view that asks for the
+tag does not change.
 
 `:tags` is a **set of keywords** on a state node. A vector or a lone keyword is
 rejected at registration with `:rf.error/machine-bad-tags`.
@@ -71,10 +59,10 @@ The runtime unions the tags on every active state and writes the result onto the
 [snapshot](glossary.md#snapshot):
 
 ```clojure
-@(rf/subscribe [:rf/machine :todos/loader])
-;; => {:state :retrying
+@(rf/subscribe [:rf/machine :auth.login/flow])
+;; => {:state :submitting
 ;;     :data  {...}
-;;     :tags  #{:data/in-flight}}
+;;     :tags  #{:auth/busy}}
 ```
 
 How the union is computed depends on the machine's shape:
@@ -96,15 +84,14 @@ projection of `:state`. When no active state declares tags, the runtime
 The query is this subscription:
 
 ```clojure
-@(rf/subscribe [:rf.machine/has-tag? :todos/loader :data/in-flight])
+@(rf/subscribe [:rf.machine/has-tag? :auth.login/flow :auth/busy])
 ;; => true or false
 ```
 
 ```clojure
-(rf/reg-view spinner-or-list []
-  (if @(rf/subscribe [:rf.machine/has-tag? :todos/loader :data/in-flight])
-    [spinner]
-    [todo-list]))
+(rf/reg-view sign-in-button []
+  (let [busy? @(rf/subscribe [:rf.machine/has-tag? :auth.login/flow :auth/busy])]
+    [:button {:disabled busy?} "Sign in"]))
 ```
 
 It returns `false` for an unknown or not-yet-initialised machine. The sub is
@@ -117,13 +104,15 @@ vector. The membership question is `[:rf.machine/has-tag? machine-id tag]`.
 Need the whole set? Read the snapshot:
 
 ```clojure
-(:tags @(rf/subscribe [:rf/machine :todos/loader]))
-;; => #{:data/in-flight}
+(:tags @(rf/subscribe [:rf/machine :auth.login/flow]))
+;; => #{:auth/busy}
 ```
 
 Use that form for selectors and render-priority tables.
 
-## Collapsing many states into one render decision
+<a id="collapsing-many-states-into-one-render-decision"></a>
+
+## Advanced: collapsing many states into one render decision
 
 Several tags can be live at once in a [parallel](parallel-states.md) machine, but
 a page can render only one main view.

--- a/docs/machines/tutorial.md
+++ b/docs/machines/tutorial.md
@@ -1,6 +1,10 @@
-# Tutorial: build a login machine
+# 1. First machine
 
-This tutorial builds one login flow, adding one idea at a time.
+<a id="tutorial"></a>
+<a id="tutorial-build-a-login-machine"></a>
+
+This page builds one **singleton** login machine — one registered id, one live
+instance. Later pages grow that same flow.
 
 By the end you will have:
 
@@ -13,7 +17,7 @@ By the end you will have:
 
 The example is small on purpose. The goal is the shape, not a production auth system.
 
-**Prerequisites.** [Core introduction](../core/introduction.md) (events, app-db, effects). Vocabulary for later pages: [The model](concepts.md).
+**Prerequisites.** [Core introduction](../core/introduction.md) (events, app-db, effects).
 
 ## Step 0 — turn machines on
 
@@ -59,18 +63,27 @@ A machine is a map. It names an initial state, some private `:data`, and the sta
 
 Targets here are bare keywords. The next two steps turn those into maps, then into candidate vectors.
 
-`reg-machine` is machine-shaped `reg-event`. The machine id is the event id you dispatch to; the **inner** vector is the machine event:
+You do not `send` to the machine. You `dispatch`, as you would to any handler.
 
 ```clojure
 (rf/dispatch [:auth.login/flow [:auth.login/submit {:email "a@b.com" :password "x"}]])
 ```
+
+The outer vector is a re-frame2 **event**. `:auth.login/flow` is the event id.
+It is also the machine id you registered, so the handler that runs is the table.
+This id is a **singleton**: one live instance. The snapshot is `nil` until
+this first dispatch.
+
+`[:auth.login/submit {…}]` is the **trigger** — the thing the table matches.
+`:auth.login/submit` is the `:on` key. The map is payload; a guard or action
+reads it from `:event`.
 
 Read the live [snapshot](glossary.md#snapshot):
 
 ```clojure
 @(rf/subscribe [:rf/machine :auth.login/flow])
 ;; => {:state :submitting :data {:attempts 0 :error nil}}
-;;    nil before the first event — the machine boots on first dispatch
+;;    nil before the first event — a singleton boots on first dispatch
 ```
 
 ## Step 2 — add a guard
@@ -193,7 +206,7 @@ Add actions for clearing an old error, recording a failed attempt, and storing a
 !!! note "`:data` merges"
 
     `{:data {:error nil}}` changes only `:error`. It does not replace the whole map.
-    Details: [The model → effect map](concepts.md#the-effect-map-data-fx).
+    Details: [The table → effect map](concepts.md#the-effect-map-data-fx).
 
 ```clojure
 (rf/dispatch-sync [:auth.login/flow [:auth.login/failure {:error {:message "nope"}}]])
@@ -245,7 +258,7 @@ Managed HTTP is its own artefact. Require `[re-frame.http.managed]` at boot (it 
 
 The timeout uses the **same guarded candidate list** as failure (an `:after` value takes the same shape as an `:on` clause), so the third stall — or the third failure — records its error and locks out.
 
-`:on-success [:auth.login/flow [:auth.login/success]]` is written one element short on purpose. The outer vector routes to the machine; the inner event is what the machine handles. Managed HTTP **appends** the reply envelope onto that inner event:
+`:on-success [:auth.login/flow [:auth.login/success]]` is written one element short on purpose. The outer vector is the event that addresses the singleton. The inner vector is the trigger the table handles. Managed HTTP **appends** the reply envelope onto that inner vector:
 
 ```clojure
 [:auth.login/success {:status :ok    :value {:token "…"} …}]
@@ -281,7 +294,7 @@ Project the snapshot. Ask **tags** for shared intent. The credential draft is or
         busy? @(rf/subscribe [:rf.machine/has-tag? :auth.login/flow :auth/busy])]
     (case state
       nil          [:button {:on-click #(dispatch [:login/submit draft])}
-                    "Sign in"]          ;; before the first machine event
+                    "Sign in"]          ;; singleton snapshot is nil until first dispatch
       :idle        [:button {:disabled busy?
                              :on-click #(dispatch [:login/submit draft])}
                     "Sign in"]
@@ -334,6 +347,16 @@ A transition is a pure function of *(definition, snapshot, event)*. No browser, 
 ```
 
 Discriminate with `result/ok?`. Read the next snapshot and the effects vector with `result/snap` and `result/fx`. More on Result accessors and Xray: [Inspecting and testing](inspecting-machines.md).
+
+## Troubleshooting
+
+| Symptom | Cause | Fix |
+| --- | --- | --- |
+| First `reg-machine` throws `:rf.error/machines-artefact-missing` | `[re-frame.machines]` not required | Require it once at boot |
+| `:rf.error/no-such-fx` on `:rf.http/managed` | HTTP artefact not loaded | Require `[re-frame.http.managed]` |
+| Submit stays on `:idle` | `:form-valid?` saw empty credentials | Put email and password on the event |
+| Snapshot is `nil` | No event has addressed the machine yet | Dispatch first, or fall back to `:initial` in the view |
+| Third failure does not lock out | Guard compared the post-action count, or lockout skipped `:record-error` | Guard sees pre-action `:attempts`; use `(< n 2)` and record on the default candidate |
 
 ## The complete machine
 
@@ -426,4 +449,4 @@ Everything above in one registration — the form you copy into a real app:
     {:fx [[:dispatch [:auth.login/flow [:auth.login/submit credentials]]]]}))
 ```
 
-When a flat table is no longer enough — nested checkout under auth, parallel form axes, spawned workers — open [The model](concepts.md) for vocabulary, then the matching growth page.
+This is the complete singleton. Later pages grow the same flow.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -288,25 +288,22 @@ nav:
     - "re-frame.ui.test (donor)": api/re-frame.ui.test.md
 
   - Machines:
-    # Landing routes; tutorial first (build), then the flat model, then
-    # growth features in order of dependency, then operate / migrate.
+    # Section label IS the landing page (navigation.indexes). Flat list —
+    # titles match each page H1. Numbered pages grow one login machine.
+    # Examples / migrate / glossary stay unnumbered.
     - machines/index.md
-    - "Tutorial: login machine": machines/tutorial.md
-    - "The model": machines/concepts.md
-    - "Growing the table":
-      # Tags and automatic transitions work on flat machines (tutorial uses both).
-      # Hierarchy / parallel / history / actors build on the flat model next.
-      - "Tags": machines/tags.md
-      - "Automatic transitions": machines/automatic-transitions.md
-      - "Hierarchical states": machines/hierarchical-states.md
-      - "Parallel regions": machines/parallel-states.md
-      - "History": machines/history.md
-      - "Actors": machines/actors.md
-    - "Operating":
-      - "Inspecting and testing": machines/inspecting-machines.md
-      - "Examples": machines/examples.md
-    - "Coming from XState": machines/coming-from-xstate.md
-    - "Glossary": machines/glossary.md
+    - "1. First machine": machines/tutorial.md
+    - "2. The table": machines/concepts.md
+    - "3. Tags": machines/tags.md
+    - "4. Automatic transitions": machines/automatic-transitions.md
+    - "5. Hierarchical states": machines/hierarchical-states.md
+    - "6. Parallel regions": machines/parallel-states.md
+    - "7. History": machines/history.md
+    - "8. Actors": machines/actors.md
+    - "9. Inspecting and testing": machines/inspecting-machines.md
+    - Examples: machines/examples.md
+    - Coming from XState: machines/coming-from-xstate.md
+    - Glossary: machines/glossary.md
 
   - Resources:
     # Landing → tutorial (build) → model → recipes / test → examples → migrate.


### PR DESCRIPTION
## What

Reshape the Machines guide so the left nav is a tutorial path that covers
every shipped feature, growing one login machine instead of restarting the
domain on each page.

## Structure

Flat nav. Numbered teaching spine. Filenames unchanged (inbound links).

1. First machine — working singleton login
2. The table — leftover flat-table contract (no second walk-through)
3. Tags
4. Automatic transitions (`:always`, `:choice`, `:after`, `:timeout`)
5. Hierarchical states
6. Parallel regions
7. History
8. Actors (singleton vs spawned)
9. Inspecting and testing

Examples, Coming from XState, and the glossary stay unnumbered.

Landing still argues FSM in SPA terms, then hierarchy, then native
`dispatch`. No in-page reading-order lists.

## Terminology

- The outer vector is a re-frame2 **event**. Its id is the machine id. You
  `dispatch`. You do not `send`.
- The inner vector is a **trigger** — the statechart name for the thing that
  can fire a transition. `:always` and `:after` are other trigger kinds.
- A `reg-machine` id is a **singleton**. A `:spawn` instance is a **spawned
  actor**. The spec heading "dynamic actors" is an adjective, not a third
  kind. This guide does not say "dynamic machine."

## Dedup

The table page no longer rebuilds the login walk-through. Feature pages
start from the first machine and show the delta. Shipped examples
(nine_states, websocket, long_running_work) stay as larger cases.

## Gates

Worktree: `C:\Users\miket\code\re-frame2-worktrees\machines-nav-restructure`

```
sh scripts/check_doc_slugs.py   # exit 0
py -3 -m mkdocs build --strict  # exit 0
```

`mkdocs build --strict` does not cover `docs/design/**`. This PR does not
touch that tree.

Anchors: old H1 slugs kept as `<a id>` (tutorial, the-model, state-tags,
history-states, collapsing-many-states-into-one-render-decision, …).
Tables: column counts checked by hand on every troubleshooting and mapping
table this PR edited.

rf2-npgc
