### PR TITLE
fix(hicasso): a hidden trailing control is not the modal's edge (rf2-5lzq)

### DIFF
--- a/implementation/hicasso/src/re_frame/hicasso/impl/overlay.cljs
+++ b/implementation/hicasso/src/re_frame/hicasso/impl/overlay.cljs
@@ -247,14 +247,47 @@
        "iframe,object,embed,audio[controls],video[controls],"
        "[contenteditable],[tabindex]"))
 
+(defn- rendered?
+  "Is `el` rendered — painted somewhere a user could reach it?
+
+  `checkVisibility` is the platform's own answer and is asked for it,
+  because the obvious substitute is wrong in the direction that costs a
+  WRONG landing. `getClientRects()` reports a box for
+  `visibility:hidden` and for the contents of a closed `<details>`
+  (measured `rects: 1` for both, in this repo's Chromium), and both of
+  those refuse focus — so reading rects counts a trailing control that
+  is not a stop, and rf2-5lzq measured what that costs: Tab off a
+  modal's real last control found the surplus candidate at the edge
+  instead, declined to wrap, and let focus reach `<body>`.
+
+  **`visibilityProperty` and NOT `contentVisibilityAuto`, measured
+  rather than copied from the option list.** A control inside a
+  `content-visibility:auto` subtree that is currently skipped STILL
+  TAKES FOCUS — the engine renders it on the way in — while
+  `checkVisibility({contentVisibilityAuto: true})` answers false for it.
+  Passing that option would drop a real stop, and a set too SMALL puts
+  the wrap at the wrong control rather than merely failing to fire it.
+  `opacityProperty` is left off for the same reason: `opacity:0` is
+  focusable, measured.
+
+  The rect test stays as the fallback for an engine without the method.
+  It is the weaker answer — it is exactly the reading whose two gaps are
+  named above — but it is the reading this module shipped with, so an
+  engine that lacks `checkVisibility` is left no worse than before
+  rather than left with no test at all."
+  [^js el]
+  (if (fn? (.-checkVisibility el))
+    (.checkVisibility el #js {"visibilityProperty" true})
+    (pos? (.-length (.getClientRects el)))))
+
 (defn- tab-stop?
   "Would Tab stop here? Disabled elements take no focus, a negative
-  `tabIndex` is reachable only programmatically, and an element with no
-  client rect is not rendered at all — `display:none` or `hidden`."
+  `tabIndex` is reachable only programmatically, and an element the
+  engine does not render is reachable by nothing — see [[rendered?]]."
   [^js el]
   (and (not (.-disabled el))
        (not (neg? (.-tabIndex el)))
-       (pos? (.-length (.getClientRects el)))))
+       (rendered? el)))
 
 (defn- radio-group-of
   "The radio group `el` belongs to, or nil when it belongs to none.
@@ -309,16 +342,20 @@
     with document order inside each bucket.
 
   **It is not the platform's focus algorithm and does not try to be.**
-  Four things the engine skips are still counted here, and they are
-  named rather than half-modelled: an element inside an `inert`
-  subtree, a control inside a `disabled` `<fieldset>`, a control under
-  `visibility:hidden`, and the contents of a closed `<details>`. (That
-  last one also retires a claim this file used to make: content inside a
-  closed `<details>` DOES report client rects in Chromium, so
-  [[tab-stop?]] never filtered it.) Shadow roots, `delegatesFocus` and
-  scrollable-overflow focusability are outside the set entirely.
+  Two things the engine skips are still counted here, and they are named
+  rather than half-modelled: an element inside an `inert` subtree, and a
+  control inside a `disabled` `<fieldset>`. Shadow roots,
+  `delegatesFocus` and scrollable-overflow focusability are outside the
+  set entirely.
 
-  ## Why that boundary is safe where the radio group was not
+  Two more used to be on that list and are now filtered, by
+  [[rendered?]] asking `checkVisibility` instead of reading client
+  rects: `visibility:hidden`, and the contents of a closed `<details>`
+  (whose UA `content-visibility:hidden` the bare call already answers).
+  A `content-visibility:hidden` subtree goes with them, which was not on
+  the list at all. All measured.
+
+  ## Why one of those four was a defect after all, and why the two left are not
 
   A surplus candidate costs a WRAP THAT DOES NOT FIRE when it cannot
   take focus, and a WRAP THAT LANDS WRONG when it can — and
@@ -328,8 +365,26 @@
   `visibility:hidden` and closed-`<details>` contents ALL refuse focus,
   while an unchecked radio in a checked group ACCEPTS it. That is the
   whole reason the radio group was a wrong landing rather than a missed
-  wrap, and the reason the four above are not this bead's defect one
-  level further in.
+  wrap.
+
+  **But a missed wrap is not free at the LAST candidate**, and rf2-5lzq
+  measured the difference the `.focus()` reading could not show. A
+  trailing `visibility:hidden` control — a conditionally-hidden final
+  button, ordinary markup — becomes `peek`, so Tab off the real last
+  control matches no edge, the handler declines, and the engine's own
+  end-of-scope step puts `document.activeElement` on `<body>`: the leak
+  this whole handler exists to close, by a fourth route. `refuses focus`
+  and `costs nothing` are different claims and only the first was ever
+  measured. [[a-real-tab-wraps-past-a-trailing-hidden-control]] holds
+  the second.
+
+  The two still counted keep the old argument, now stated as the
+  narrower thing it is: they cost a missed wrap, and they are left
+  because no measured markup puts either of them LAST in a modal.
+  Whichever does earns the fix rather than a rule written ahead of it —
+  and for the `<fieldset>` the remedy is already measured, `:disabled`
+  as a pseudo-class matching the effective state that the `.disabled`
+  property above does not.
 
   A group whose checked member sits OUTSIDE `panel` needs no rule: this
   handler is the modal's alone, so everything outside the panel is
@@ -357,11 +412,16 @@
 
   **The engine confirms the landing before the default action is taken
   away.** `HTMLElement.focus()` on an element that cannot be focused —
-  `visibility:hidden`, inert because a nested modal is open above it — is
-  a no-op that leaves `activeElement` where it was, so the move is
-  attempted first and `preventDefault` follows only if it took. A wrap
-  that could not land therefore degrades to exactly the engine's own
-  conduct rather than to a Tab that does nothing.
+  inert because a nested modal is open above it, or inside a `disabled`
+  `<fieldset>` — is a no-op that leaves `activeElement` where it was, so
+  the move is attempted first and `preventDefault` follows only if it
+  took. A wrap that could not land therefore degrades to exactly the
+  engine's own conduct rather than to a Tab that does nothing.
+
+  That confirmation is a floor and not a licence to feed this a loose
+  candidate set: it saves a wrap that lands nowhere, and cannot save one
+  aimed at the wrong CONTROL. [[sequential-tab-stops]] states which
+  candidates are still surplus and why each is affordable.
 
   A press a control inside the panel has already claimed is left alone:
   the native event's `defaultPrevented` is read rather than the synthetic

--- a/implementation/hicasso/test/re_frame/hicasso/overlay_focus_dom_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/overlay_focus_dom_cljs_test.cljs
@@ -27,6 +27,7 @@
   | a REAL Tab and a REAL Shift+Tab cycle inside the trap, and a REAL Escape lets the page back out | [[a-real-tab-cycles-within-the-modal-and-a-real-escape-gives-the-page-back]] |
   | the wrap fires at the SEQUENTIAL edge, over a panel whose sequential order is shorter than its markup | [[a-real-tab-wraps-at-the-radio-groups-edge-and-not-at-the-dom-s]] |
   | …and over one whose sequential order is a permutation of it | [[a-real-tab-wraps-at-the-tabindex-ordered-edge]] |
+  | …and over one whose LAST element is not a stop at all | [[a-real-tab-wraps-past-a-trailing-hidden-control]] |
 
   The middle claim is an emptiness claim about everything outside a
   dialog, and an emptiness claim is exactly the shape that passes
@@ -96,6 +97,17 @@
   population, one panel per way the two lists can differ. What
   `impl.overlay/sequential-tab-stops` does and does not model is stated
   on that function; these rows measure the part it claims.
+
+  [[a-real-tab-wraps-past-a-trailing-hidden-control]] is the third way,
+  and it is about the boundary itself rather than the model inside it.
+  Those two rows differ from the DOM in ORDER; this panel differs in
+  LENGTH, and only at the end — a `visibility:hidden` final button,
+  which reports a client rect and refuses focus. #8071's audit had
+  argued a candidate like that costs only a wrap that does not fire.
+  That is true and, at the LAST position, not free: the surplus becomes
+  the edge, so the handler declines and `<body>` gets the focus. The row
+  exists because *refuses focus* was measured and *costs nothing* was
+  inferred.
 
   `overlay-dom-cljs-test` holds the synthetic-versus-trusted comparison
   for Escape itself; this file does not re-litigate it.
@@ -200,6 +212,29 @@
     [:button#second {:type "button" :tab-index 2} "Second"]
     [:button#first {:type "button" :tab-index 1} "First"]
     [:button#third {:type "button"} "Third"]]
+   [:button#after {:type "button"} "After"]])
+
+(h/defview a-page-with-a-modal-whose-last-control-is-hidden [_]
+  ;; A TRAILING `visibility:hidden` CONTROL, which is ordinary modal
+  ;; markup — a final button hidden by a condition rather than removed.
+  ;; Document order is [reason ok cancel ghost]; sequential order is
+  ;; [reason ok cancel], because `ghost` takes no focus.
+  ;;
+  ;; `ghost` is LAST on purpose, and that position is the whole row.
+  ;; A surplus candidate anywhere else is free — the handler never looks
+  ;; at it. At the END it is what `peek` returns, so it becomes both the
+  ;; edge the forward wrap tries to MATCH and the control the backward
+  ;; wrap tries to LAND on, and it can be neither.
+  [:div
+   [:button#before {:type "button"} "Before"]
+   [:button#trigger {:type "button" :on-click [::opened]} "Open"]
+   [overlay/modal {:open?      (h/sub [::open?])
+                   :on-dismiss [::dismissed]
+                   :label      "Confirm"}
+    [:input#reason {:type "text" :aria-label "Reason"}]
+    [:button#ok {:type "button"} "OK"]
+    [:button#cancel {:type "button"} "Cancel"]
+    [:button#ghost {:type "button" :style {:visibility "hidden"}} "Ghost"]]
    [:button#after {:type "button"} "After"]])
 
 ;; `:async? true` — the MAP shape — because the trusted-input row below
@@ -622,6 +657,94 @@
                   (finally (finish)))))
             (catch :default e
               (is false (str "the tabindex trap row threw: " (.-message e)))
+              (finish))))))))
+
+;; ---------------------------------------------------------------------------
+;; The trap over a panel whose LAST element is not a stop
+;; ---------------------------------------------------------------------------
+;;
+;; THE THIRD WAY THE TWO LISTS DIFFER, and the one that took a second
+;; bead to see. The two rows above are about a candidate set in the
+;; wrong ORDER. This one is about a candidate set of the wrong LENGTH at
+;; the one end where length is load-bearing.
+;;
+;; `sequential-tab-stops` still counts candidates the engine skips, and
+;; #8071's audit reasoned that was affordable: they refuse `.focus()`,
+;; and `wrap-tab!` confirms the landing before taking the default action
+;; away, so a surplus candidate costs a wrap that DOES NOT FIRE rather
+;; than one that fires at the wrong place. That argument is sound and
+;; still holds — but *refuses focus* and *costs nothing* are different
+;; claims, and only the first of them was measured.
+;;
+;; A missed wrap is not free at the LAST candidate. There the surplus is
+;; what `peek` returns, so Tab off the real final control matches no
+;; edge at all, the handler declines, and the engine's own end-of-scope
+;; step puts `document.activeElement` on `<body>` — the exact leak this
+;; handler was written to close, reached by a fourth route. rf2-5lzq
+;; measured it on the one of those four cases that is ordinary markup: a
+;; conditionally-hidden final button.
+;;
+;; The row names `body` explicitly for the reason the two above do.
+
+(deftest a-real-tab-wraps-past-a-trailing-hidden-control
+  (if-not (browser?)
+    (skip! ":node-test has no modality, and no engine to press a key at")
+    (if-not (trusted/bridge?)
+      (trusted/unwitnessed! "the trap over a panel whose last element is hidden")
+      (async done
+        (let [m      (hm/mount! [a-page-with-a-modal-whose-last-control-is-hidden {}])
+              finish (fn [] (hm/unmount! m) (done))]
+          (try
+            (open! m)
+            (is (.contains ($ m "dialog") (active))
+                "premise: opening put focus inside the panel")
+
+            ;; THE TWO PREMISES THAT MAKE THIS PANEL THE CASE IT IS, and
+            ;; they pull in opposite directions — which is precisely why
+            ;; a rects-based reading counted `ghost` and a keyboard
+            ;; never reaches it.
+            (is (pos? (.-length (.getClientRects ($ m "#ghost"))))
+                "premise: `visibility:hidden` still occupies layout, so
+                 the hidden button DOES report a client rect — this is
+                 not `display:none`, and a predicate reading rects has
+                 no way to tell it from a real control")
+            (is (false? (focusable? ($ m "#ghost")))
+                "premise: and the engine refuses focus on it anyway, so
+                 it is an element of the panel and not a stop of it")
+
+            (both-edges!
+              m "#reason" 5
+              (fn [forward backward]
+                (try
+                  (is (= ["ok" "cancel" "reason" "ok" "cancel"] forward)
+                      (str "THE CYCLE, FORWARD, OVER A PANEL WHOSE LAST "
+                           "ELEMENT IS NOT ITS LAST STOP. `cancel` is the "
+                           "final stop, so Tab off it must land on "
+                           "`reason`. Against a predicate that counted "
+                           "`ghost`, the panel's edge was an element the "
+                           "press could never arrive at: the handler "
+                           "matched nothing, let the default action stand, "
+                           "and the third landing was `body`. Pressed: "
+                           (pr-str forward)))
+                  (is (= ["cancel" "ok" "reason" "cancel" "ok"] backward)
+                      (str "THE CYCLE, BACKWARD, and it fails the other "
+                           "way for the same reason. Shift+Tab off "
+                           "`reason` must land on `cancel`; with `ghost` "
+                           "counted, the wrap AIMED at `ghost`, `.focus()` "
+                           "declined, `preventDefault` was correctly "
+                           "withheld — and withholding it is what let the "
+                           "engine put focus on `body`. Pressed: "
+                           (pr-str backward)))
+                  (is (empty? (filter #{"before" "trigger" "after" "body" "ghost"}
+                                      (concat forward backward)))
+                      (str "and not one landing in either lap was a control "
+                           "of the page behind, the nowhere between them, or "
+                           "the hidden button itself. Pressed: "
+                           (pr-str (concat forward backward))))
+                  (finally (finish)))))
+            (catch :default e
+              (is false (str "the hidden-trailing-control row threw: "
+                             (.-message e)))
               (finish))))))))
 
 ;; ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes rf2-5lzq. Follow-on to #8089 (rf2-hic-052), which named this case at source rather than half-modelling it.

## What was wrong

`tab-stop?` read `getClientRects()` to decide whether an element is rendered. That is not the same question. **`visibility:hidden` still occupies layout and reports a rect** — measured `rects: 1` in this repo's Chromium, as do the contents of a closed `<details>` — while both refuse focus. So both were counted as tab-stop candidates.

#8089's audit had already noticed those, and argued they were affordable: a candidate that cannot take focus costs a wrap that **does not fire** rather than one that **lands wrong**, because `wrap-tab!` confirms the landing before taking the default action away. That argument is sound and still holds.

**What it did not measure is that a missed wrap is not free at the *last* candidate.** There the surplus is what `peek` returns, so Tab off the real final control matches no edge, the handler declines, and the engine's own end-of-scope step puts `document.activeElement` on `<body>` — the leak this handler exists to close, reached by a fourth route. A conditionally-hidden final button in a modal is ordinary markup.

## It reproduces — measured on `activeElement`, not on `.focus()`'s return

Trusted Tab over a modal holding `[reason, ok, cancel, ghost]` where `ghost` is `visibility:hidden`, with the pre-fix predicate in place:

```
forward  (from #reason):  ["ok" "cancel" "body" "reason" "ok"]
backward (from #reason):  ["body" "cancel" "ok" "reason" "body"]
```

`body` at both edges. The forward edge leaks because `ghost` is mistaken for the last stop; the backward edge leaks because the wrap *aims* at `ghost`, `.focus()` declines, `preventDefault` is correctly withheld — and withholding it is what hands focus to the engine.

## The fix, and one option deliberately not passed

`rendered?` now asks the platform: `checkVisibility({visibilityProperty: true})`, falling back to the old rect reading on an engine without the method (the support-matrix branch that kept this outside #8089's bounded repair).

**`contentVisibilityAuto` is NOT passed, and that is a correction to the remedy as filed.** Measured: a control inside a skipped `content-visibility:auto` subtree **still takes focus**, while `checkVisibility({contentVisibilityAuto: true})` answers `false` for it. Passing it would drop a *real* stop, and a candidate set that is too **small** puts the wrap at the wrong control — strictly worse than one that fails to fire. `opacityProperty` is off for the same reason: `opacity:0` is focusable, measured.

## How many of the four it closes: two, not three

The bead (from #8089's worker) estimated three. Measured against `.focus()` in this repo's Chromium:

| case | `rects` | takes focus | `checkVisibility({visibilityProperty})` | closed? |
|---|---|---|---|---|
| `visibility:hidden` | 1 | no | `false` | **yes** |
| closed `<details>` contents | 1 | no | `false` (bare call — UA `content-visibility:hidden`) | **yes** |
| `inert` subtree | 1 | no | `true` | no — still named |
| `disabled <fieldset>` | 1 | no | `true` | no — still named |

A `content-visibility:hidden` subtree is closed too, which was not on the list at all. The two that remain are **named on `sequential-tab-stops`** rather than half-modelled, with the reason they are affordable stated as the narrower thing it now is: they cost a missed wrap, and no measured markup puts either of them *last* in a modal. For the `<fieldset>` the remedy is recorded where the next worker will find it — `:disabled` as a pseudo-class matches the effective state that the `.disabled` property does not.

## The control

`a-real-tab-wraps-past-a-trailing-hidden-control` is the deliverable. Plant = the pre-fix rect predicate restored (an assertion failure scoped to the module, never a crash); restore verified by hashing the file bytes (`sha256sum -c` → OK, identical before and after).

| run | raw exit | tests / assertions | failures |
|---|---|---|---|
| PLANTED (pre-fix predicate) | **1** | 1477 / 9199 | **3, 0 errors** — all three in this row |
| restored (fix in place) | **0** | 1477 / 9199 | 0, 0 errors |

**Identical test and assertion counts across both runs**, so the plant reddened this row and did not stop any namespace after it — the run continued through `portal-dom-cljs-test` and `presence-intent-dom-cljs-test` in the planted log.

## Quality gates

Run from `implementation/`. Raw captured exit codes (`echo $?` on the same command line), not the harness's.

| gate | raw exit | result |
|---|---|---|
| `npm run test:browser` (planted control, base `41f7f90c94`) | `1` | 1477 tests / 9199 assertions, 3 failures, 0 errors — the control bites |
| `npm run test:browser` (fix restored, base `41f7f90c94`) | `0` | 1477 tests / 9199 assertions, 0 failures, 0 errors |
| `npm run test:cljs` | `0` | 13826 tests / 69940 assertions, 0 failures, 0 errors |
| `npm run test:browser` (re-run after rebase onto `78e3868efd`) | `0` | 1478 tests / 9204 assertions, 0 failures, 0 errors |

The fourth row is the deciding one: #8089 merged mid-task, so this branch was rebased off its worker branch onto `main` and the gate re-run there. The two files' bytes are unchanged across the rebase (hash verified). Compiler warnings: 8 before and 8 after, none naming `checkVisibility` — the `^js` hint infers the extern.

## Fence

Touches only `implementation/hicasso/src/re_frame/hicasso/impl/overlay.cljs` and its witness. No spec, no workflows, no `deps.edn`, no `shadow-cljs.edn`. The trusted-input bridge is untouched. Nothing on `rf2-umjv`'s ground (the overlay anchor refusal and the guide's focus one-shot recipe) was reached.
