### PR TITLE
docs(method): diff against origin/main before pushing, re-run gates after a rebase (rf2-35kj)

### DIFF
--- a/docs/the-mayor-method/dispatch-prompt-template.md
+++ b/docs/the-mayor-method/dispatch-prompt-template.md
@@ -184,7 +184,7 @@ relying on CI"). A silent skip fails review.
 
 ### How a gate is run, not just which one
 
-Five rules about the mechanics. Each is here because it cost real hours, and
+Seven rules about the mechanics. Each is here because it cost real hours, and
 none of them is obvious from the gate command itself.
 
 - **Detaching a long gate is CORRECT; ending the turn afterwards is the defect.**
@@ -347,6 +347,27 @@ none of them is obvious from the gate command itself.
   `git worktree remove` refuses the tree from then on. Nine worktrees
   accumulated exactly that way before anyone worked out why they would not reap.
   Cheapest fix is to not create the residue.
+
+- **Re-run the gates on the final base after every rebase.** A pre-rebase green
+  is evidence about a tree that no longer exists, and under a saturated wave the
+  trunk moves under a worker routinely rather than rarely. Nothing warns you: the
+  rebase reports success, and the old log still says exit 0. PR #8080's worker
+  rebased four times past eleven landings, and re-running the gates on the final
+  base *changed the artefact* rather than merely reconfirming it — fixes for three
+  of its own five findings had merged in the interval, so the governance record it
+  was about to publish carried a membership count **false of `main`**. A false
+  count in a record like that is not caught later; it is cited later.
+
+- **Diff against `origin/main` before you push, and read that diff for what you
+  would REVERT.** Not for conflicts — git reports those itself, and a clean rebase
+  is exactly the case this rule is for. The question the diff answers is whether
+  your push undoes something a sibling landed while you worked, which git will
+  not raise and no gate covers: a revert of a merged change is well-formed, it
+  compiles, and it passes every check the tree has. In a shared document a stale
+  copy of one region reapplies as a silent deletion of everything that landed in
+  it since. One worker's first push would have reverted a concurrent rewrite of a
+  shared ledger; it caught that by reading the diff before reporting, and by
+  nothing else.
 
 ### Briefing a correction — sweep every carrier
 


### PR DESCRIPTION
Adds the two missing rules to the gate-mechanics section of
`docs/the-mayor-method/dispatch-prompt-template.md` — the file pasted verbatim
into every editing dispatch, so the wording propagates on the next tick.

The bead's premise was re-verified at `origin/main` before editing:
`grep -ci rebase docs/the-mayor-method/dispatch-prompt-template.md` → **0**,
`grep -ci rebase .claude/commands/mayor-dispatch.md` → **0**. The only `rebase`
hits anywhere in the eight method + command files are about the *mayor's* own
post-merge pull (`README.md:195` `gh pr merge --rebase`, `bootstrap.md:256`
`git pull --rebase origin main`, and one line in `mayor-merge.md`) — none is the
worker-facing rule. Premise holds.

## What changed

Two new bullets at the end of *How a gate is run, not just which one*, and the
section's count updated **five → seven**. Nothing else in the section moved; no
checklist, no restructure.

1. **Re-run the gates on the final base after every rebase** — a pre-rebase green
   is evidence about a tree that no longer exists. Carries PR #8080's incident:
   four rebases past eleven landings, and the re-run *changed the artefact*
   (three of its five findings had been fixed in the interval, so the record was
   about to publish a membership count false of `main`).
2. **Diff against `origin/main` before you push, and read that diff for what you
   would REVERT** — deliberately *not* "check for conflicts", which git already
   reports and which a clean rebase leaves silent. Carries the ledger incident: a
   worker's first push would have reverted a concurrent rewrite of a shared
   document, caught by reading the diff and by nothing else. No gate covers it —
   a revert of a merged change compiles and passes every check the tree has.

Deliberately **not** added to `.claude/commands/*`: those cite this section
rather than duplicating it (`rf2-w5pj`). Verified they stay clean — the string
`origin/main`/pre-push-diff rule appears in none of the five `mayor-*.md`.

## Quality gates

Every gate below was invoked by absolute path, redirected to a log with `echo $?`
on the same command line in the same shell; the codes quoted are the ones
captured, not the harness's.

| Gate | Exit code | Notes |
|---|---|---|
| `python scripts/check_readme_links.py` | **0** | Ran green, but see negative control — it does not read this file. |
| `python scripts/check_doc_slugs.py` | **0** | Covers this surface (proven below). |
| `python -m mkdocs build --strict` | **0** | `the-mayor-method/` is not in `exclude_docs`; covers this surface (proven below). |

### Negative control — proving a bannerless gate read this worktree

None of these gates prints a `gate root:` banner and their failure paths are
repo-relative, so the discrimination is the planted red itself.

Planted a broken relative link (`./no-such-file-nc-35kj.md`) on line 355 — a line
this PR adds — and re-ran:

| Gate | Exit under plant | Evidence |
|---|---|---|
| `check_doc_slugs.py` | **1** | `BROKEN TARGET: docs\the-mayor-method\dispatch-prompt-template.md:355 -> ./no-such-file-nc-35kj.md` — the exact line planted. |
| `mkdocs build --strict` | **1** | `Doc file 'the-mayor-method/dispatch-prompt-template.md' contains a link './no-such-file-nc-35kj.md' … not found` |
| `check_readme_links.py` | **0** | Stayed green: it is a README-family link gate and does **not** read this file. Reported rather than claimed as coverage. |

The plant genuinely applied (hash moved
`7f54c172…f515e` → `7c08af48…e6e7b3`) and the restore was verified by hashing the
bytes, not by reading `git diff`: post-restore hash is
`7f54c17259e1ea6ba780adc88334b40c1bafab0f4e985dd0de008757107f515e`, identical to
the pre-plant hash. `git status` clean.

### The two rules, applied to this PR

- Diffed against `origin/main` before pushing: `git diff --stat origin/main...HEAD`
  is one file, +22/-1, and `git log --oneline origin/main ^HEAD` is **empty** —
  nothing landed since my base, so this push reverts nothing.
- Rebased once (base `8f2998b9bd` → `850dab381a`) **before** any editing, and all
  three gates above were run on that final base. No post-gate rebase, so no
  re-run was owed.
