### PR TITLE
test-support: :async? true selects the host's usable fixture shape (rf2-e8ea)

### DIFF
--- a/docs/api/re-frame.test-support.md
+++ b/docs/api/re-frame.test-support.md
@@ -71,7 +71,7 @@ The fixture primitives follow one pattern: snapshot the registrar before the tes
   | `:clear-kinds` | Collection of registrar kinds cleared after the snapshot capture and before the body (the snapshot restores them on the way out). |
   | `:clear-app-schemas?` | Boolean; clear the schemas artefact's per-frame side-table for the test's duration. |
   | `:ambient-frame` | Frame id bound as the body's ambient scope when an adapter is installed. Default `:rf/default`; pass `nil` to opt out (for tests that create their own top-level frames). |
-  | `:async?` | Boolean, default `false`. Selects the return shape: `false` returns the synchronous fn-form fixture; `true` returns a `cljs.test` map-form fixture `{:before … :after …}`, **required** for suites with `(async done …)` tests. |
+  | `:async?` | Boolean, default `false`. Declares the suite **async-capable**; the return shape that delivers it is chosen per host. On CLJS you get a `cljs.test` map-form fixture `{:before … :after …}`, **required** for suites with `(async done …)` tests. On the JVM the option is inert and you always get the fn-form — `clojure.test` has no async tests, and no map-fixture support at all (it *invokes* a fixture, and a Clojure map is `IFn`, so a map fixture would silently skip every test body). |
 - **Example**:
   ```clojure
   (use-fixtures :each
@@ -81,6 +81,10 @@ The fixture primitives follow one pattern: snapshot the registrar before the tes
   (use-fixtures :each
     (ts/make-reset-runtime-fixture {:adapter plain-atom/adapter :async? true}))
   ```
+
+  A `.cljc` suite whose CLJS rows are async writes the same plain `:async? true`
+  — no reader conditional at the call site, because the factory already picks
+  the map on CLJS and the fn-form on the JVM.
 
 ## Bundle co-load hygiene
 

--- a/implementation/core/src/re_frame/test_support.cljc
+++ b/implementation/core/src/re_frame/test_support.cljc
@@ -685,15 +685,28 @@
                     per-frame schemas, so they're restored on the way
                     out — they only disappear for the duration of the
                     test.
-    :async?       — boolean (default false). Select the RETURN SHAPE:
-                    false → the synchronous fn-form fixture `(fn [test-fn]
-                    …)` (the default — for sync `cljs.test` / `clojure.test`
-                    suites); true → a `cljs.test` map-form fixture
-                    `{:before … :after …}` for suites with ASYNC tests. See
-                    §Async map-form variant below for why async suites NEED
-                    this and what changes.
+    :async?       — boolean (default false). Declare the suite ASYNC-CAPABLE.
+                    The RETURN SHAPE that delivers that is PLATFORM-DECIDED
+                    (rf2-e8ea), not something the caller picks:
+                      • `:cljs` → the map-form fixture `{:before … :after …}`,
+                        the only shape `cljs.test` will run an `(async done …)`
+                        row under (§Async map-form variant below).
+                      • `:clj`  → INERT; the fn-form is returned regardless.
+                        `clojure.test` has no async tests to be capable OF,
+                        and no map-fixture support at all — it INVOKES a
+                        fixture, and a Clojure map is `IFn`, so a `{:before …}`
+                        fixture composes to a key lookup returning nil and the
+                        test body NEVER RUNS ("Ran 0 tests", silent GREEN).
+                        The fn-form IS the correct async-capable JVM shape.
+                    So a `.cljc` suite with async CLJS rows writes a plain
+                    `:async? true` — no reader conditional at the call site,
+                    and the map-on-JVM silent swallow is unrepresentable.
 
-  ## Async map-form variant (`:async? true`)
+  ## Async map-form variant (`:async? true`, CLJS)
+
+  This whole section is about CLJS. On the JVM `:async? true` selects nothing
+  — see the option's entry above — so everything below describes what
+  `:async? true` does when the host is `:cljs`.
 
   `cljs.test` HARD-ERRORS on a fn-form fixture for an `(async done …)` test
   (\"Async tests require fixtures to be specified as maps\" / \"Fixtures may
@@ -733,8 +746,10 @@
   via the recover-and-emit `:rf.error/frame-destroyed` path. Re-ensuring the
   frame in `:before` is what closes that gap.)
 
-  Returns a fixture fn (`:async?` false) or a `{:before :after}` map
-  (`:async?` true), each suitable for `(use-fixtures :each …)`.
+  Returns a `{:before :after}` map when `:async? true` AND the host is CLJS;
+  a fixture fn otherwise — which is the default on both hosts, and the ONLY
+  shape ever returned on the JVM. Either is suitable for
+  `(use-fixtures :each …)` on its own host.
 
   Example (CLJS):
 
@@ -772,7 +787,14 @@
               (rf/dispatch-sync [:counter/inc])
               (is (= 1 (:n (rf/app-db-value :rf/default))))
               (done))
-            0)))"
+            0)))
+
+  Example (`.cljc`, a cross-host suite whose CLJS rows are async) — the SAME
+  plain `:async? true`, because the shape is platform-decided for you:
+
+      (use-fixtures :each
+        (test-support/make-reset-runtime-fixture
+          {:adapter plain-atom/adapter :async? true}))"
   ([] (make-reset-runtime-fixture {}))
   ([{:keys [adapter init-fn] :as opts}]
    ;; `:ambient-frame` (EP-0002, rf2-9o48ih): the frame the fixture establishes
@@ -814,8 +836,34 @@
          ;; `:rf.error/no-frame-context`. For the fn-form that scope is the
          ;; enclosing `binding`; for the async map-form it is the persistent
          ;; `set!` already in effect when this runs.
-         run-init!             (fn [] (when init-fn (init-fn)))]
-     (if (:async? opts)
+         run-init!             (fn [] (when init-fn (init-fn)))
+         ;; rf2-e8ea — `:async?` declares the suite ASYNC-CAPABLE; the SHAPE
+         ;; that delivers that is decided HERE, per host, because the two
+         ;; runners disagree about what a fixture even is:
+         ;;
+         ;;   • `cljs.test` — `execution-strategy` classifies an ns's fixtures
+         ;;     (`{:map :async :fn :sync}`); a `:sync` ns whose body returns an
+         ;;     async object throws `::async-disabled`, which `test-var-block*`
+         ;;     catches and RE-THROWS as "Async tests require fixtures to be
+         ;;     specified as maps.  Testing aborted." — outside per-test
+         ;;     accounting, so it unwinds the whole bundle. On CLJS an async-
+         ;;     capable fixture MUST therefore be the map.
+         ;;   • `clojure.test` — has no map-fixture support at all. Its
+         ;;     `compose-fixtures` INVOKES each fixture (`(f1 (fn [] (f2 g)))`)
+         ;;     and a Clojure map is `IFn`, so a `{:before …}` fixture composes
+         ;;     to a key lookup returning nil and the test body NEVER RUNS: the
+         ;;     namespace reports "Ran 0 tests" and reads GREEN. (Hit in-tree
+         ;;     while implementation/ssr/test/re_frame/ssr/streaming_component_
+         ;;     cljs_test.cljc was being written — see its comment.) And
+         ;;     `clojure.test` has no async tests to be capable OF, so the
+         ;;     fn-form IS the correct async-capable JVM shape.
+         ;;
+         ;; Guarding here rather than at the call site makes the map-on-JVM
+         ;; silent swallow UNREPRESENTABLE: a `.cljc` suite with async CLJS
+         ;; rows writes a plain `:async? true` and gets the right shape on each
+         ;; host by construction, with no reader conditional to get wrong.
+         map-shape?            #?(:clj false :cljs (boolean (:async? opts)))]
+     (if map-shape?
        ;; ---- async map-form (cljs.test only) — see §Async map-form variant.
        ;; cljs.test runs tests sequentially (each async test's `done` gates the
        ;; next), so the :before/:after pair never overlaps and a single atom

--- a/implementation/core/src/re_frame/test_support.cljc
+++ b/implementation/core/src/re_frame/test_support.cljc
@@ -696,7 +696,7 @@
                         and no map-fixture support at all — it INVOKES a
                         fixture, and a Clojure map is `IFn`, so a `{:before …}`
                         fixture composes to a key lookup returning nil and the
-                        test body NEVER RUNS ("Ran 0 tests", silent GREEN).
+                        test body NEVER RUNS (\"Ran 0 tests\", silent GREEN).
                         The fn-form IS the correct async-capable JVM shape.
                     So a `.cljc` suite with async CLJS rows writes a plain
                     `:async? true` — no reader conditional at the call site,

--- a/implementation/core/test/re_frame/async_fixture_platform_shape_cljs_test.cljc
+++ b/implementation/core/test/re_frame/async_fixture_platform_shape_cljs_test.cljc
@@ -1,0 +1,102 @@
+(ns re-frame.async-fixture-platform-shape-cljs-test
+  "Platform-shape contract for `make-reset-runtime-fixture`'s `:async?` option
+  (rf2-e8ea), per Spec 008 §Test-support.
+
+  `:async?` declares the suite ASYNC-CAPABLE. Which SHAPE delivers that is
+  decided by the factory, per host, because the two runners disagree about
+  what a fixture is:
+
+    • `cljs.test` classifies an ns's fixtures (`{:map :async :fn :sync}`) and
+      a `:sync` ns whose body returns an async object throws \"Async tests
+      require fixtures to be specified as maps.  Testing aborted.\" from
+      OUTSIDE per-test accounting — it unwinds the whole bundle, so every
+      namespace after it silently never runs. Async on CLJS needs the map.
+    • `clojure.test` has NO map-fixture support. `compose-fixtures` INVOKES
+      each fixture — `(fn [g] (f1 (fn [] (f2 g))))` — and a Clojure map is
+      `IFn`, so a `{:before …}` fixture composes to a key lookup returning
+      nil and the test body NEVER RUNS. The namespace reports \"Ran 0 tests\"
+      and reads GREEN. And `clojure.test` has no async tests to be capable
+      OF, so the fn-form IS the correct async-capable JVM shape.
+
+  WHY THIS NAMESPACE DOES NOT REGISTER THE `:async?` FIXTURE ITSELF. The JVM
+  failure it guards is a SILENT SKIP, so a suite that registered the shape
+  under test would, on regression, skip these very assertions and report
+  green with a smaller count. Its own `:each` fixture is therefore the plain
+  default fn-form, and every shape claim below is made by DRIVING a
+  separately-built fixture through `clojure.test`'s own composition path.
+  Regressing the guard reds this file loudly rather than emptying it.
+
+  The end-to-end CLJS proof — a real `(async done …)` row draining a bare
+  `dispatch-sync` under the map shape — lives in
+  `re-frame.async-reset-fixture-cljs-test` and is unaffected by this file.
+
+  Named `*-cljs-test` so the shadow-cljs `:node-test` build (ns-regexp
+  `cljs-test$`) discovers it; the `-test` suffix also satisfies the JVM
+  cognitect test-runner, so this one `.cljc` file runs on both runtimes —
+  which is the point, since the contract IS the difference between them."
+  (:require #?(:clj  [clojure.test :refer [deftest is testing use-fixtures join-fixtures]]
+               :cljs [cljs.test :refer-macros [deftest is testing use-fixtures]])
+            [re-frame.core                 :as rf]
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.test-support         :as test-support]))
+
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
+
+(defn- async-capable-fixture []
+  (test-support/make-reset-runtime-fixture {:adapter plain-atom/adapter
+                                            :async?  true}))
+
+;; ---- 1. `:async? true` returns the shape THIS host can actually run -------
+
+(deftest async-opt-in-returns-the-hosts-usable-shape
+  (testing ":async? true selects the shape the running host's test runner can use"
+    (let [fx (async-capable-fixture)]
+      #?(:clj
+         (is (fn? fx)
+             "on the JVM :async? true returns the fn-form — clojure.test has no async tests and no map-fixture support, so the map would be an IFn key lookup that silently skips every test")
+         :cljs
+         (do
+           (is (map? fx)
+               "on CLJS :async? true returns the {:before :after} map — the only shape cljs.test will run an (async done …) row under")
+           (is (fn? (:before fx)) "…with a zero-arg :before")
+           (is (fn? (:after fx))  "…and a zero-arg :after"))))))
+
+;; ---- 2. the JVM anti-silent-swallow control ------------------------------
+;;
+;; Composed through `clojure.test/join-fixtures` — the exact call
+;; `clojure.test/test-vars` makes — so this asserts against the runner's own
+;; behaviour rather than a restatement of it. Under a map-on-JVM regression
+;; `join-fixtures` composes to a key lookup, the body never runs, `ran?`
+;; stays false, and this test fails LOUDLY.
+
+#?(:clj
+   (deftest jvm-async-capable-fixture-actually-runs-the-test-body
+     (testing "clojure.test's own join-fixtures runs the body under an :async? true fixture"
+       (let [ran?   (atom false)
+             landed (atom nil)]
+         ((join-fixtures [(async-capable-fixture)])
+          (fn []
+            (reset! ran? true)
+            (rf/reg-event :afps/inc (fn [{:keys [db]} _] {:db (update db :n (fnil inc 0))}))
+            (rf/dispatch-sync [:afps/inc])
+            (reset! landed (:n (rf/app-db-value :rf/default)))))
+         (is (true? @ran?)
+             "the test body RAN — a map fixture here would compose to a nil-returning key lookup and skip it, leaving the namespace at \"Ran 0 tests\" and GREEN")
+         (is (= 1 @landed)
+             "and it ran with the fixture's ambient scope established: a bare dispatch-sync drained into :rf/default")))))
+
+;; ---- 3. the rf2-pn3d ruling is not disturbed ------------------------------
+;;
+;; rf2-pn3d ruled that the DEFAULT stays the fn-form on both hosts (~479 CLJS
+;; suites compose it alongside sibling fn fixtures, and three call sites
+;; invoke it as a function). rf2-e8ea changes only what `:async? true` means.
+
+(deftest default-shape-is-still-the-fn-form-on-both-hosts
+  (testing "omitting :async? still yields a callable fn-form fixture on every host (rf2-pn3d)"
+    (let [fx (test-support/make-reset-runtime-fixture {:adapter plain-atom/adapter})]
+      (is (fn? fx)
+          "the default shape did not flip — sibling fn-fixture composition and fixture-as-a-function call sites still hold")
+      (let [ran? (atom false)]
+        (fx (fn [] (reset! ran? true)))
+        (is (true? @ran?) "and invoking it as a function runs the body")))))

--- a/implementation/ui/test/re_frame/ui/reactive_epoch_cljs_test.cljc
+++ b/implementation/ui/test/re_frame/ui/reactive_epoch_cljs_test.cljc
@@ -55,9 +55,12 @@
             [re-frame.ui.test               :as uit]))
 
 (use-fixtures :each
+  ;; `:async?` declares async-CAPABILITY; `make-reset-runtime-fixture` picks
+  ;; the shape per host (rf2-e8ea) — the map on CLJS, the fn-form on the JVM,
+  ;; where `clojure.test` would silently swallow a map fixture. So this is a
+  ;; plain option, not the reader-conditional `cond->` dance it used to be.
   (test-support/make-reset-runtime-fixture
-   (cond-> {:adapter plain-atom/adapter}
-     #?(:clj false :cljs true) (assoc :async? true)))
+   {:adapter plain-atom/adapter :async? true})
   #?(:clj
      (fn [f]
        (reactive/reset-scheduler!)

--- a/implementation/ui/test/re_frame/ui/render_batch_host_checkpoint_cljs_test.cljc
+++ b/implementation/ui/test/re_frame/ui/render_batch_host_checkpoint_cljs_test.cljc
@@ -62,9 +62,12 @@
             [re-frame.ui.reactive  :as reactive]))
 
 (use-fixtures :each
+  ;; `:async?` declares async-CAPABILITY; `make-reset-runtime-fixture` picks
+  ;; the shape per host (rf2-e8ea) — the map on CLJS, the fn-form on the JVM,
+  ;; where `clojure.test` would silently swallow a map fixture. So this is a
+  ;; plain option, not the reader-conditional `cond->` dance it used to be.
   (test-support/make-reset-runtime-fixture
-   (cond-> {:adapter ui/adapter :ambient-frame nil}
-     #?(:clj false :cljs true) (assoc :async? true)))
+   {:adapter ui/adapter :ambient-frame nil :async? true})
   #?(:clj
      (fn [f]
        (reactive/reset-scheduler!)


### PR DESCRIPTION
Closes rf2-e8ea.

`make-reset-runtime-fixture` returned the `{:before :after}` map for `:async? true` on **both** hosts. `:async?` now declares async-**capability** and the factory picks the shape the running host can actually use: the map on `:cljs`, the fn-form on `:clj`.

## The platform split, verified from the two runners' own source

Not taken from the bead's text — read out of the jars on this machine.

**`cljs.test` (clojurescript 1.12.145, `cljs/test.cljs`)** — `execution-strategy` classifies a namespace's fixtures with `({:map :async :fn :sync} type :async)`. A `:sync` namespace wraps each body in `disable-async`, which throws `::async-disabled` when the body returns an async object; `test-var-block*` catches that and **re-throws** `"Async tests require fixtures to be specified as maps.  Testing aborted."` from inside the catch — outside per-test accounting, so it unwinds the whole block runner and every namespace after it silently never runs. `(every? map? coll)` / `(every? fn? coll)` is also why mixing shapes in one `use-fixtures` asserts `"Fixtures may not be of mixed types"`. **On CLJS an async-capable fixture must be the map.**

**`clojure.test` (clojure 1.12.0, `clojure/test.clj`)** — there is no map-fixture support anywhere in the file. `join-fixtures` is `(reduce compose-fixtures default-fixture fixtures)` and `compose-fixtures` is `(fn [g] (f1 (fn [] (f2 g))))` — every fixture is **invoked**. A Clojure map is `IFn`, so `({:before … :after …} g)` is a key lookup returning `nil` and `g` never runs. The namespace reports `Ran 0 tests` and reads **GREEN**. `clojure.test` also has no async tests to be capable *of*. **On the JVM the fn-form is the correct async-capable shape, and the map is not a shape at all.**

So the split is real and forced by the runners; neither shape is correct on both.

## Is a guard the right answer, or does it hide a distinction?

It is the right answer, and it hides nothing an author needs. The distinction a platform guard normally conceals is a *choice*, and here there is none to make: `(async done …)` is a `cljs.test` macro, so a `.cljc` suite's JVM side is always synchronous, and on that side `:async? true` can only mean the fn-form. The author's real intent — "this suite has async rows" — is stated once; the shape follows mechanically.

The alternative — keep `:async?` meaning "map shape" and *throw* on the JVM — was considered and rejected: it preserves an unusable option purely so it can complain about it, and it keeps the `cond->` ritual at every `.cljc` call site. Deliberately **no** diagnostic was added for `:async? true` on a `.clj`-only suite: the legitimate `.cljc` case is indistinguishable from it at runtime, so any such assert would fire on correct code. Inert is exactly right.

## What changed

- `implementation/core/src/re_frame/test_support.cljc` — one `let` binding, `map-shape? #?(:clj false :cljs (boolean (:async? opts)))`, plus the `:async?` docstring entry, the §Async map-form heading, the Returns line and a `.cljc` example.
- The two `.cljc` consumers drop the reader-conditional dance for a plain `:async? true` — identical resulting shapes on both hosts, by construction:
  - `implementation/ui/test/re_frame/ui/reactive_epoch_cljs_test.cljc`
  - `implementation/ui/test/re_frame/ui/render_batch_host_checkpoint_cljs_test.cljc`
- `implementation/core/test/re_frame/async_fixture_platform_shape_cljs_test.cljc` — **new**, the control (below).
- `docs/api/re-frame.test-support.md` — the `:async?` table row said "Selects the return shape", which is now false. Prose only; no public symbol changed.

**The default shape did not change on any host.** rf2-pn3d ruled (delegated, 2026-08-13) that the fn-form default stays, and this PR does not touch it — the new suite pins that explicitly (`default-shape-is-still-the-fn-form-on-both-hosts`). The 44/41 fn-form browser-lane namespaces are untouched.

## The control, and proof that it bites

`re-frame.async-fixture-platform-shape-cljs-test` deliberately does **not** register the `:async?` fixture as its own — the JVM failure it guards is a *silent skip*, so a suite that registered the shape under test would, on regression, skip its own assertions and report green with a smaller count. It drives a separately-built fixture through `clojure.test/join-fixtures` — the exact call `test-vars` makes — so it asserts against the runner's behaviour rather than a restatement of it.

**Plant**: `map-shape?` reverted to `(boolean (:async? opts))`, i.e. the map on both hosts. **Restore** verified by hashing the bytes (`git diff HEAD` empty; LF-normalised sha256 of the new file back to `7b3865be…`, the CRLF being git's checkout filter).

| Run | tests | assertions | failures | raw exit |
|---|---|---|---|---|
| core JVM — baseline (`origin/main` content) | 2240 | 11675 | 1 † | 1 † |
| core JVM — **this PR** | 2243 | 11680 | 0 | **0** |
| core JVM — **planted** | 2243 | 11680 | **3** | **1** |
| ui JVM — baseline | 702 | 17614 | 0 | 0 |
| ui JVM — **this PR** | 702 | 17614 | 0 | **0** |
| ui JVM — **planted** | **678** | **17400** | **0** | **0** ‡ |

† The baseline's single failure is an artefact of the control procedure, not of the baseline code: producing it meant deleting a file that is tracked in `HEAD`, and `observation_render_law_drift_test.clj`'s `drift-census-is-not-vacuous` correctly fails when a `git ls-files` path is missing from the working tree. It names exactly the deleted file and nothing else.

‡ **This row is the whole point.** With the guard removed, the ui JVM lane loses 24 tests and 214 assertions — the two `.cljc` suites' JVM rows, swallowed by the map's key lookup — and still exits **0 with 0 failures**. Silent green. That is the trap the guard makes unrepresentable.

The core JVM plant is a pure **assertion failure**, by design: identical test and assertion counts to the control (2243 / 11680), three `FAIL`s, no errors, no aborted namespace. The scoping requirement was that the plant must not crash a namespace, and it does not.

```
FAIL in (async-opt-in-returns-the-hosts-usable-shape)
expected: (fn? fx)
  actual: (not (fn? {:before #object[…before_reset_runtime…], :after #object[…after_reset_runtime…]}))

FAIL in (jvm-async-capable-fixture-actually-runs-the-test-body)
expected: (true? (clojure.core/deref ran?))
  actual: (not (true? false))          ; ← the body never ran

FAIL in (jvm-async-capable-fixture-actually-runs-the-test-body)
expected: (= 1 (clojure.core/deref landed))
  actual: (not (= 1 nil))
```

The end-to-end CLJS proof — a real `(async done …)` row draining a bare `dispatch-sync` under the map shape — is the pre-existing `re-frame.async-reset-fixture-cljs-test`, plus `reactive-epoch-cljs-test`'s two async rows, all green on the node lane below.

## Quality gates

Raw captured exit codes (`echo $?` on the same command line as the gate), never the harness's.

| Gate | tests / assertions | control run (baseline) | raw exit |
|---|---|---|---|
| `implementation/core` `clojure -M:test` | 2243 / 11680 | 2240 / 11675 → **+3 / +5**, exactly the new namespace's JVM rows | **0** |
| `implementation/ui` `clojure -M:test` | 702 / 17614 | 702 / 17614 → **identical** | **0** |
| `npm run test:cljs` (node) | 13826 / 69935 | 13824 / 69930 → **+2 / +5**, exactly the new namespace's CLJS rows | **0** |
| `npm run test:browser` | 1475 / 9158 | 1475 / 9158 → **identical** | **0** |

Every delta is accounted for by the new namespace alone; nothing pre-existing moved in any lane, which is the bead's count-invariance acceptance. The browser lane cannot see the new file (it is `*_cljs_test.cljc`, and `:browser-test`'s `ns-regexp` selects `-dom-cljs-test$`) — and the run confirms it.

Rebased onto `origin/main` at push time; none of the five files overlap anything the trunk moved this session.
