### PR TITLE
docs: drop Prerequisites blocks from the published guide

### DIFF
--- a/docs/async/continuations-are-data.md
+++ b/docs/async/continuations-are-data.md
@@ -7,8 +7,6 @@ You know `:on-success` on [HTTP](http.md), `:reply-to` on mutations, `:on-done` 
 that sentence — the one move, what `await` costs, what you gain when the continuation
 is a value.
 
-**Prerequisites.** Issue at least one managed request ([tutorial](tutorial.md)).
-
 !!! tip "Just want the `.then` / `.catch` / `.finally` map?"
 
     [Coming from Promises](coming-from-promises.md) is the quick table; this page is

--- a/docs/async/custom-effects.md
+++ b/docs/async/custom-effects.md
@@ -7,8 +7,6 @@ API** (promise SDK, callback, IndexedDB, worker) so its result is a named reply
 Same continuation *style* as HTTP — not the managed extras (retry, abort, stale
 suppression, HTTP failure kinds) unless you build them.
 
-**Prerequisites.** [Effects](../core/effects.md); ideally the [HTTP tutorial](tutorial.md).
-
 !!! note "The one rule"
 
     An [event handler](../core/effects.md) is pure — no `.then`, no `await`. The **`fx`

--- a/docs/async/http-going-further.md
+++ b/docs/async/http-going-further.md
@@ -7,8 +7,6 @@ You know [managed HTTP](http.md). This page is two production jobs:
 
 Neither is required to be productive — open this when the app grows into them.
 
-**Prerequisites.** [Managed HTTP](http.md) and the [tutorial](tutorial.md).
-
 ## Interceptors: stamp every request once
 
 Threading `"Authorization"` into every call site is a cross-cutting concern. re-frame2

--- a/docs/async/index.md
+++ b/docs/async/index.md
@@ -22,8 +22,7 @@ have a name on the same wire as everything else.
 
 <a id="in-this-section"></a>
 
-**Prerequisites.** [Effects](../core/effects.md) — returning an effect map from a
-handler. Managed HTTP plugs into that pipeline; it does not replace events or app-db.
+Managed HTTP plugs into the event pipeline. It does not replace events or app-db.
 
 ## Scope
 

--- a/docs/async/tutorial.md
+++ b/docs/async/tutorial.md
@@ -4,8 +4,7 @@ Load an article from a server one idea at a time: request → failure path → v
 schema → retry → race cure → network-free test. By the end you have every piece of
 `:rf.http/managed` everyday work needs.
 
-**Prerequisites.** [Effects](../core/effects.md) — return an effect map from a handler.
-Full key catalogue after this walk-through: [Managed HTTP](http.md).
+Full key catalogue: [Managed HTTP](http.md).
 
 ## Step 0 — turn managed HTTP on
 

--- a/docs/core/freehand/get-running/build-a-view.md
+++ b/docs/core/freehand/get-running/build-a-view.md
@@ -1,10 +1,8 @@
 # Build a view
 
 A working Freehand screen, one idea at a time: subscription as a value, handler as
-data, controlled field, mount. Not a tour of every option.
-
-**Prerequisites:** basic re-frame2 events, subscriptions, and frames, plus a
-project that [depends on Freehand](install.md).
+data, controlled field, mount. Not a tour of every option. The project
+[depends on Freehand](install.md).
 
 One namespace:
 

--- a/docs/machines/index.md
+++ b/docs/machines/index.md
@@ -34,9 +34,8 @@ there.
 
 The same table shape covers a login flow or a request. Only the names change.
 
-**Prerequisites.** The [Core introduction](../core/introduction.md) — events,
-app-db, subscriptions, effects. Machines plug into those; they do not replace
-them.
+Machines plug into [events](../core/introduction.md), app-db, subscriptions,
+and effects. They do not replace them.
 
 ## Why nest states
 

--- a/docs/machines/tutorial.md
+++ b/docs/machines/tutorial.md
@@ -17,8 +17,6 @@ By the end you will have:
 
 The example is small on purpose. The goal is the shape, not a production auth system.
 
-**Prerequisites.** [Core introduction](../core/introduction.md) (events, app-db, effects).
-
 ## Step 0 — turn machines on
 
 Machines are an optional artefact. Require the namespace once from a boot or feature namespace:

--- a/docs/resources/how-to/invalidate-after-a-mutation.md
+++ b/docs/resources/how-to/invalidate-after-a-mutation.md
@@ -20,10 +20,6 @@ watch → optional arms (populate, patches, optimistic, cross-scope).
     **declare** invalidation on the mutation registration (once), and it matches by
     **tags within a scope** — only owned entries refetch immediately.
 
-**Prerequisites.** `re-frame.resources` + `re-frame.http.managed` on the require
-list; reads registered with `reg-resource`. If that is unfamiliar, start at
-[the model](../concepts.md).
-
 ## 1. Tag the reads
 
 A [cache tag](../glossary.md#cache-tag) names a *fact*, not a resource. `[:article "welcome"]` and `[:article-list]` are facts — a specific article, and the list as a whole. When two resources carry the same tag, that tag becomes the join key a write uses to reach both of them at once.

--- a/docs/resources/index.md
+++ b/docs/resources/index.md
@@ -40,8 +40,8 @@ leak boundary. Views *read* — they never fetch.
 ;; => {:status :loading …}  then  {:status :loaded :data …}
 ```
 
-**Prerequisites.** The [Core introduction](../core/introduction.md). Resources plug into
-events, app-db, and effects; they do not replace them. The transport underneath is
+Resources plug into [events](../core/introduction.md), app-db, and effects.
+They do not replace them. The transport underneath is
 [managed HTTP](../async/index.md) (`:rf.http/managed`).
 
 ## Three lanes

--- a/docs/routing/how-to/guard-unsaved-changes.md
+++ b/docs/routing/how-to/guard-unsaved-changes.md
@@ -5,9 +5,8 @@ unsaved changes"** before leaving an editor.
 
 Shape: `:can-leave` boolean sub (`true` = leave is fine) → `false` parks the attempt
 in `[:rf/pending-navigation]` → dialog dispatches `:rf.route/continue` or
-`:rf.route/cancel`. Data all the way; tests with zero DOM.
-
-**Prerequisites.** [The model → Blocking](../concepts.md#blocking-a-navigation).
+`:rf.route/cancel`. Data all the way; tests with zero DOM. The
+[blocking contract](../concepts.md#blocking-a-navigation) is the model.
 
 ## 1. Write the "is it safe to leave?" sub
 

--- a/docs/routing/index.md
+++ b/docs/routing/index.md
@@ -23,8 +23,8 @@ with [SSR](../ssr/index.md), no separate server router.
 
 <a id="in-this-section"></a>
 
-**Prerequisites.** [Core introduction](../core/introduction.md) — events, app-db,
-subscriptions, views. Routing plugs into those; it does not replace them.
+Routing plugs into [events](../core/introduction.md), app-db, subscriptions,
+and views. It does not replace them.
 
 ## When *not* to use routing
 

--- a/docs/routing/tutorial.md
+++ b/docs/routing/tutorial.md
@@ -4,7 +4,6 @@ Build a three-page app — **home**, **articles list**, **article detail** — t
 per-page activation work, a 404, the Back button, and a shared layout. One idea the whole way: the
 URL is application state (read via a sub, change via dispatch).
 
-**Prerequisites.** [Core introduction](../core/introduction.md) (events, app-db, views).
 Vocabulary after this walk-through: [The model](concepts.md). From React Router:
 [the mapping](coming-from-react-router.md).
 

--- a/docs/ssr/head.md
+++ b/docs/ssr/head.md
@@ -2,10 +2,8 @@
 
 You know [server render + hydrate](concepts.md). This page is one job: put
 **`<title>`, `<meta>`, OpenGraph, and JSON-LD** on the first byte as pure data from
-app-db — not an imperative DOM API. Crawlers don't run JS.
-
-**Prerequisites.** [The model](concepts.md) and a [route](../routing/concepts.md) that
-can name a head id.
+app-db — not an imperative DOM API. Crawlers don't run JS. A
+[route](../routing/concepts.md) names the head.
 
 ## Register a head, name it on the route
 

--- a/docs/ssr/index.md
+++ b/docs/ssr/index.md
@@ -18,8 +18,8 @@ in the browser; only genuinely one-sided code is fenced with `:platforms`.
 (ssr/hydrate! {:frame :app :render-tree-fn (fn [] ((rf/view :app/root)))})
 ```
 
-**Prerequisites.** [Core introduction](../core/introduction.md) — events, app-db, views,
-frames. SSR plugs into those; it does not replace them.
+SSR plugs into [events](../core/introduction.md), app-db, views, and frames.
+It does not replace them.
 
 ## When *not* to use SSR
 

--- a/docs/ssr/response.md
+++ b/docs/ssr/response.md
@@ -7,8 +7,6 @@ Server-only [effects](../core/glossary.md#effect) write a per-request accumulato
 Ring adapter materialises it. Response logic stays pure and testable like any
 [effect map](../core/glossary.md#effect-map).
 
-**Prerequisites.** [The model](concepts.md) or the [tutorial](tutorial.md) through Step 7.
-
 ## The effects
 
 | fx-id | args | does |

--- a/docs/ssr/streaming.md
+++ b/docs/ssr/streaming.md
@@ -6,9 +6,7 @@ is one job: **ship a shell on the first byte, then stream slow regions in**.
 React 18 / Next.js `loading.js` use `<Suspense>`; re-frame2 uses one component.
 Runnable tree:
 [`examples/capabilities/ssr/ssr_streaming/`](../../examples/capabilities/ssr/ssr_streaming).
-
-**Prerequisites.** [The model](concepts.md) and the
-[Ring adapter](tutorial.md#step-7--swap-in-the-ring-adapter).
+The Ring adapter is in the [tutorial](tutorial.md#step-7--swap-in-the-ring-adapter).
 
 !!! note "Don't reach for streaming by default"
 


### PR DESCRIPTION
## What

Follow-up to #8096. Remove every `**Prerequisites.**` / `**Prerequisites:**`
block from the published guide.

Where the block was the only home of a useful fact ("plugs into events,
does not replace them"; the HTTP transport under resources; a blocking
or Ring-adapter link), that fact is now an inline sentence.

`docs/design/hicasso/draft-guide/README.md` still has a Prerequisites
heading. That tree is not the published guide.

## Pages

async, machines, routing, resources, ssr, and the Freehand get-running
view page.

## Gates

Worktree: `C:\Users\miket\code\re-frame2-worktrees\machines-nav-restructure`

```
py -3 scripts/check_doc_slugs.py   # exit 0
```

Anchors kept (`in-this-section` on the async and routing landings).
Tables on those pages were not reflowed.
