### PR TITLE
docs(machines): repair four semantic defects in the reshaped guide

### DIFF
--- a/docs/machines/actors.md
+++ b/docs/machines/actors.md
@@ -4,8 +4,8 @@
 <a id="actors-spawning-child-machines"></a>
 
 Every machine so far has been a **singleton**: one `reg-machine` id, one live
-instance. `[:rf/machine :auth.login/flow]` is that instance, or `nil` before
-the first event.
+instance in the frame. `[:rf/machine :auth.login/flow]` is that instance, or
+`nil` before the first event.
 
 A **spawned** actor is another live instance of a machine **type**, created
 at run time. It gets an allocated id (`:auth/request#0`). Use one when you
@@ -32,13 +32,34 @@ The singleton login machine spawns a request actor on `:submitting`:
 (rf/reg-machine :auth/request
   {:initial :running
    :data    {}
+
+   :actions
+   {:issue-request
+    ;; The tutorial's managed request, addressed to this actor's own id.
+    (fn [{data :data}]
+      {:fx [[:rf.http/managed
+             {:request    {:method :post :url "/api/login"
+                           :body (:credentials data)
+                           :request-content-type :json}
+              :decode     :json
+              :on-success [(:rf/self-id data) [:server-ok]]
+              :on-failure [(:rf/self-id data) [:server-err]]}]]})
+
+    :keep-token
+    (fn [{data :data [_ {:keys [value]}] :event}]
+      {:data (assoc data :token (:token value))})
+
+    :report-success
+    (fn [{data :data}]
+      {:fx [[:dispatch [(:rf/parent-id data) [:auth.login/success]]]]})}
+
    :states
    {:running
     {:entry :issue-request
      :on    {:server-ok {:target :done
                          :action :keep-token}
              :server-err :failed}}
-    :done   {:final? true :output-key :token}
+    :done   {:entry :report-success :final? true :output-key :token}
     :failed {:final? true :error? true}}})
 
 :submitting
@@ -49,12 +70,20 @@ The singleton login machine spawns a request actor on `:submitting`:
          :on-done    (fn [{:keys [data result]}]
                        (assoc data :token result))
          :on-error   {:target :error-shown}}
- :on    {:auth.login/cancel :idle}}
+ :on    {:auth.login/success :authed
+         :auth.login/cancel  :idle}}
 ```
 
 `:auth.login/flow` is still the singleton. `:auth/request` is the **type**.
 Each visit to `:submitting` allocates a new spawned id. Leaving
 `:submitting` — success, error, cancel, timeout — destroys that actor.
+
+The two success halves do different jobs. `:on-done` folds the child's token
+into the parent's `:data` and stops there; it is not a transition, so on its
+own the parent would sit in `:submitting` wearing `:auth/busy` with the child
+already gone. The move is an ordinary trigger: the child's final state
+dispatches `[:auth.login/success]` to `:rf/parent-id`, and `:submitting`
+handles it. Failure needs no counterpart — `:on-error` **is** a transition.
 
 A larger shipped case binds one socket actor to a parent that spans several
 children:
@@ -64,6 +93,12 @@ children:
 (rf/reg-machine :ws/connection
   {:initial :disconnected
    :data    {:url nil :auth-token nil}
+
+   :actions
+   {:record-options
+    (fn [{data :data [_ {:keys [url auth-token]}] :event}]
+      {:data (assoc data :url url :auth-token auth-token)})}
+
    :states
    {:disconnected
     {:on {:ws/connect {:target :active
@@ -79,7 +114,10 @@ children:
      :initial :connecting
      :states  {:connecting     {:on {:ws/opened :authenticating}}
                :authenticating {:on {:ws/auth-ok :connected}}
-               :connected      {}}}}})
+               :connected      {}}}
+
+    :reconnecting {:on {:ws/connect :active}}
+    :failed       {:on {:ws/connect :active}}}})
 ```
 
 The socket is spawned on the `:active` *parent*, so one actor spans

--- a/docs/machines/automatic-transitions.md
+++ b/docs/machines/automatic-transitions.md
@@ -6,13 +6,13 @@ The [first machine](tutorial.md) already uses one automatic form: `:after`
 on `:submitting` cancels if the server stalls. This page is the rest of the
 family.
 
-Most transitions wait for a trigger from `dispatch`. Some triggers are
-produced by the machine itself:
+Most transitions wait for a trigger from `dispatch`. Four triggers come from
+the machine itself:
 
-- a guard becomes true;
-- a decision node resolves immediately;
-- a delay expires;
-- a deadline is missed.
+- an eventless step whose guard passes;
+- a decision node resolving on entry;
+- a delay expiring;
+- a deadline being missed.
 
 re-frame2 has four authoring forms for this, built on two engines.
 
@@ -26,6 +26,8 @@ re-frame2 has four authoring forms for this, built on two engines.
 ## Eventless `:always`
 
 `:always` is checked after a state is entered and after transitions that remain in, or land in, that state.
+
+Those points and no others. Nothing watches the guard in between, so a `:data` change that arrives outside a macrostep — a spawned child's [`:on-done` fold](actors.md#when-a-child-finishes), say — does not move the machine on its own. The next event does.
 
 Login can skip the form when a session token is already in `:data`:
 
@@ -97,23 +99,32 @@ This is the safe "loop until done" pattern. The action changes `:data`; once the
 
 An `:always` transition may not target its own declaring state. That shape either loops forever or does nothing useful, so `reg-machine` throws `:rf.error/machine-always-self-loop`.
 
+An `:always` step runs with no event, so its guards and actions receive `:event` as `nil`. Anything that reads a trigger payload belongs on the event-driven transition; put the result in `:data` and let the `:always` guard read that.
+
 ## Choice states
 
 A choice state is a named decision node. The machine enters it and immediately leaves through the first passing candidate.
 
-The first machine's failure candidate list can be written as a choice instead:
+The first machine's failure candidate list can be written as a choice instead. `:record-error` stays on the way in, where it can still read the failure message off the event, so the choice reads the *incremented* `:attempts`:
 
 ```clojure
+:guards
+{:retries-left?
+ (fn [{data :data}]
+   (< (:attempts data) 3))}
+
 :submitting
 {:on {:auth.login/failure {:target :decide-failure
                            :action :record-error}}}
 
 :decide-failure
 {:type   :choice
- :choice [{:guard  :under-retry-limit
+ :choice [{:guard  :retries-left?
            :target :error-shown}
           {:target :locked-out}]}
 ```
+
+The tutorial's `:under-retry-limit` guard is `(< (:attempts data) 2)` because it runs *before* `:record-error`. `:retries-left?` runs after, so it compares against 3. Both lock out on the third failure.
 
 A smaller decision node looks the same:
 
@@ -281,6 +292,8 @@ Readable shorthands such as `"5s"` or `"10ms"` are not accepted, nor are subscri
 | Registration throws `:rf.error/machine-always-self-loop` | `:always` targets its own declaring state | Use a targetless `:always` with an action that flips the guard, or target a different state |
 | Macrostep fails `:rf.error/machine-always-depth-exceeded` | Eventless loop did not settle within 16 steps | Break the cycle; a targetless drain-until-false is the safe loop |
 | Registration throws `:rf.error/machine-bad-choice` | `:choice` is a function, empty, or missing a default | Declarative non-empty vector with an unguarded last candidate |
+| A choice or `:always` candidate read `nil` where the payload should be | An eventless step runs with no event | Read the payload on the event-driven transition and store it in `:data` |
+| A retry limit trips one failure early after the count moved into a choice | The entering action already incremented the count the choice's guard reads | Compare against the post-action number |
 | Timer fired but the snapshot did not move | Guard was false at expiry, or the state had already been left | Expected. A late timer is stale; a false guard discards that firing |
 | Registration throws `:rf.error/machine-bad-timeout-duration` | `"5s"` shorthand, or a non-positive / malformed duration | Integer milliseconds or ISO-8601 (`"PT5S"`) |
 | Registration throws `:rf.error/spawn-timeout-ms-removed` | `:timeout-ms` on a spawn spec | Use `:timeout` + `:on-timeout`, or `:after` on the parent state |

--- a/docs/machines/glossary.md
+++ b/docs/machines/glossary.md
@@ -65,7 +65,10 @@ One named mode of a machine, such as `:idle`, `:submitting`, or `:authed`.
 
 The thing that can fire a transition. A dispatched trigger is the inner
 vector, such as `[:auth.login/submit credentials]`. A timer expiry (`:after`)
-and a guard that became true (`:always`) are triggers too.
+and an eventless `:always` step are triggers too.
+
+A guard is not a trigger. The runtime samples guards when a trigger runs, and
+never between, so a guard that turns true on its own moves nothing.
 
 Do not call the inner vector an "event." In re-frame2, the **event** is the
 outer vector whose id is the machine id.
@@ -255,8 +258,10 @@ See [Automatic transitions](automatic-transitions.md).
 
 ### **singleton**
 
-A machine registered with `reg-machine`. One id, one live instance. The
-snapshot is `nil` until the first event. Login is a singleton.
+A machine registered with `reg-machine`. One id, one live instance per
+[frame](../core/glossary.md#frame) — the snapshot lives in that frame's
+runtime-db, so a second frame runs its own. The snapshot is `nil` until the
+first event. Login is a singleton.
 
 See [Actors](actors.md).
 

--- a/docs/machines/hierarchical-states.md
+++ b/docs/machines/hierarchical-states.md
@@ -20,6 +20,20 @@ under `:authenticated`:
   {:initial :unauthenticated
    :data    {:attempts 0 :error nil}
 
+   ;; Unchanged from the first machine — nesting is a change to :states only.
+   :guards
+   {:form-valid?
+    (fn [{[_ creds] :event}]
+      (and (seq (:email creds)) (seq (:password creds))))}
+
+   :actions
+   {:clear-error
+    (fn [_] {:data {:error nil}})
+
+    :store-session
+    (fn [{[_ {:keys [value]}] :event}]
+      {:fx [[:auth.session/store {:token (:token value)}]]})}
+
    :states
    {:unauthenticated
     {:initial :idle

--- a/docs/machines/index.md
+++ b/docs/machines/index.md
@@ -103,8 +103,8 @@ that can fire a transition. Here it is another vector: `[:auth.login/submit]`.
 The table matches the first keyword against the current state's `:on` map.
 Anything after that keyword is payload.
 
-Not every trigger comes from `dispatch`. A timer expiry and a guard that
-became true are triggers too — [Automatic transitions](automatic-transitions.md).
+Not every trigger comes from `dispatch`. A timer expiry is a trigger, and so
+is an eventless `:always` step — [Automatic transitions](automatic-transitions.md).
 
 `reg-machine` is sugar over `reg-event`: same registry, same `dispatch`. Read
 the live value with an ordinary `subscribe`. That value — the snapshot — lives
@@ -112,7 +112,9 @@ in [runtime-db](../core/glossary.md#runtime-db), the framework half of the
 frame, so undo, Xray, SSR, and tests see it the way they see any other event's
 result.
 
-`:auth.login/flow` is a **singleton**: one registered id, one live instance.
+`:auth.login/flow` is a **singleton**: one registered id, one live instance
+per frame. The snapshot sits in that frame's runtime-db, so a second frame
+running the same app runs its own login machine, independently.
 The snapshot is `nil` until the first event. A **spawned** actor is a second
 live instance of a type, created at run time with an allocated id. Login is a
 singleton. An in-flight request protocol is often spawned. The spec heading

--- a/docs/machines/index.md
+++ b/docs/machines/index.md
@@ -113,13 +113,12 @@ frame, so undo, Xray, SSR, and tests see it the way they see any other event's
 result.
 
 `:auth.login/flow` is a **singleton**: one registered id, one live instance
-per frame. The snapshot sits in that frame's runtime-db, so a second frame
-running the same app runs its own login machine, independently.
-The snapshot is `nil` until the first event. A **spawned** actor is a second
-live instance of a type, created at run time with an allocated id. Login is a
-singleton. An in-flight request protocol is often spawned. The spec heading
-says "dynamic actors" for the second kind; that is an adjective, not a third
-kind. This guide says **singleton** and **spawned**.
+per frame. The snapshot sits in that frame's runtime-db and is `nil` until the
+first event; a second frame running the same app runs its own login machine. A
+**spawned** actor is a second live instance of a type, created at run time with
+an allocated id. Login is a singleton. An in-flight request protocol is often
+spawned. The spec heading says "dynamic actors" for the second kind; that is an
+adjective, not a third kind. This guide says **singleton** and **spawned**.
 [Actors](actors.md) is the full treatment.
 
 Already using XState? [Coming from XState](coming-from-xstate.md) is the


### PR DESCRIPTION
Reopened by the merged-PR audit of #8091. The reshape itself is sound — the
numbered nav, the anchors, the tables and the login spine are untouched. These
are four bounded semantic repairs inside it, plus one same-class defect found
while verifying the second.

Every claim below was verified against the runtime before it was acted on:
`re-frame.machines/validate-machine!` for registration, and
`machine-transition` for behaviour.

## 1. The choice rewrite taught a behaviour change (`automatic-transitions.md`)

Reproduced. `:record-error` runs on the transition *into* the choice state, so
`:under-retry-limit` saw the incremented count. Against the tutorial's
`(< attempts 2)` guard the published rewrite locked out on failure **two**:

| failure | `tutorial.md` candidate vector | published choice rewrite |
| --- | --- | --- |
| 1 | `:error-shown`, attempts 1 | `:error-shown`, attempts 1 |
| 2 | `:error-shown`, attempts 2 | **`:locked-out`, attempts 2** |
| 3 | `:locked-out`, attempts 3 | `:locked-out`, attempts 3 |

That contradicted `tutorial.md`'s pre-action contract and its "Third failure
does not lock out" troubleshooting row.

Repaired by **preserving the behaviour**, not weakening the claim: the choice
guard is now `:retries-left?`, `(< (:attempts data) 3)`, and the page says why
the number differs from the tutorial's. The three-failure behaviour now matches
the tutorial exactly — state, count **and** error message, on all three
failures.

The other candidate repair — moving `:record-error` onto the choice candidates,
which keeps the guard arithmetic identical — was rejected at source: a choice
candidate is an `:always` microstep, and the engine applies it with a `nil`
event (`apply-transition-once m snap nil … :always` in `transition.cljc`), so
`:record-error` would silently lose the failure message and fall back to
`"Login failed."` on every failure. That fact is now taught under
`## :always rules`, which is also why `:record-error` stays where it is.

## 2. The whole-machine forms did not register (`hierarchical-states.md`, `actors.md`)

Reproduced, and one more found:

| form | thrown at registration |
| --- | --- |
| `hierarchical-states.md` `session` | `:rf.error/machine-unresolved-guard` — `:form-valid?` |
| `actors.md` `:auth/request` | `:rf.error/machine-unresolved-action` — `:keep-token` |
| `actors.md` `:ws/connection` | `:rf.error/machine-unresolved-target` — `:reconnecting` / `:failed` never declared, and `:record-options` undefined |

`:ws/connection` is **not** new in #8091 (only its lead-in sentence is), so it
is outside the audit's finding as written — but it is the same defect, on the
same page, under the same `AUTHORING.md` rule, and four lines from correct.
Repaired rather than left.

All three now carry their `:guards` / `:actions` and declare every state they
target. Every handler named in every example on the changed pages resolves.

**The successful spawn path now settles.** `:on-done` is a data-fold — verified
in `lifecycle_fx/finalize.cljc`, which writes the parent's `:data` straight to
runtime-db with no parent macrostep, so it moves nothing and re-checks no
`:always`. As published, a successful login left the parent in `:submitting`
wearing `:auth/busy` with the child already destroyed. The child's `:final?`
leaf now dispatches `[:auth.login/success]` to `:rf/parent-id` — the mechanism
the page already teaches under "Child runtime stamps", and the one its own
`:spawn-all` example uses — and `:submitting` handles it. Spec 005 confirms a
final state's `:entry` runs as part of the entering cascade, before auto-destroy.

## 3. A guard becoming true is not a trigger (`index.md`, `automatic-transitions.md`, `glossary.md`)

Confirmed against Spec 005 §Tags ("not an autonomous transition-driver… a
transition still needs an event or an eventless `:always` step to fire") and the
microstep loop, which checks `:always` only within a macrostep. All three pages
now name `:always` as the eventless trigger. The glossary says plainly that
guards are sampled when a trigger runs and never between.

**Premise correction:** the audit says "Spec 005 says the opposite". Partly. Spec
005 §Eventless itself opens with the same loose shorthand — "fires automatically
when its guard becomes true" — and only then qualifies it with "Checked after
entry (or after any transition that lands in this state)". The load-bearing
statements are §Tags 2215 and that qualifier, not the §Eventless headline. The
guide is now precise where the spec is loose; no spec edit (hot zone).

## 4. Singleton is per frame, not per process (`glossary.md`, `index.md`, `actors.md`)

Confirmed — Spec 005:4443: "Per-frame isolation falls out of each frame having
its own runtime-db and thus its own `[:rf.runtime/machines :snapshots]` map."

Qualified at the central definition (`glossary.md`) and where the term is
introduced (`index.md`), with a two-word qualifier on `actors.md`'s recap.
`tutorial.md` is deliberately left alone: `AUTHORING.md` forbids re-parenthesising
a definition throughout the guide, and page 1 should not introduce frame
machinery before the reader needs it. Nothing now implies process-global state.

## Not done, and why

No guide-truth pin was added for the repaired claims. The bead's acceptance
rules it out — "No runtime/API change, new doctest framework, or generalized
documentation gate." Worth knowing for review: the machines JVM guide-truth
suites read only `docs/machines/parallel-states.md` and `concepts.md`, neither
of which this PR touches, so **no test in the repo covers these five files**
(measured — see the negative control below). The correctness evidence here is
the validator and engine runs, not the suite.

Nothing was restructured. No nav, heading, anchor or table-column change.

## Quality gates

| Gate | Raw captured exit |
| --- | --- |
| `cd implementation/machines && clojure -M:test` | **0** — Ran 1202 tests containing 4189 assertions. 0 failures, 0 errors. |
| `python scripts/check_doc_slugs.py` | **0** |
| `python -m mkdocs build --strict` | **0** |

All three re-run after the rebase onto `origin/main`; the table is the post-rebase run.

**Negative controls**, each planted at a line this PR edits, then restored and
the restore verified by `sha256sum` (all 13 files in `docs/machines/`
byte-identical to their pre-control state):

- `check_doc_slugs.py` — broke the `#frame` anchor added in `glossary.md` → exit **1**, `BROKEN ANCHOR: docs\machines\glossary.md:262`.
- `mkdocs build --strict` — broke the `actors.md` link added in `automatic-transitions.md` → exit **1**, `Aborted with 1 warnings in strict mode!`.
- `implementation/machines` suite — reverted the repaired guard/trigger claim in `glossary.md` → still exit **0**. The gate has no teeth on the files this PR changes; it runs because a `docs/machines/` change arms `implementation_jvm`. Its teeth on this corpus are real but aimed elsewhere (`guard-has-teeth` in `transition_geometry_terminology_jvm_test`, green).

**Rebase note.** `origin/main` moved mid-flight and landed "drop Prerequisites
blocks from the published guide", which rewrites `index.md` a few lines above one
of these edits. The diff was read for reverts, not just conflicts: nothing here
reverts it, and the paragraph was reflowed to sit correctly against the new text.

rf2-npgc
