### PR TITLE
ci: freehand-conformance.yml no longer claims a requirement it does not have

### DIFF
--- a/.github/workflows/freehand-conformance.yml
+++ b/.github/workflows/freehand-conformance.yml
@@ -14,8 +14,10 @@ name: freehand-conformance
 #
 # REQUIRED-CHECK SHAPE. The `pull_request` trigger is deliberately UNFILTERED
 # and the single job is NOT surface-gated, so the `Freehand conformance index`
-# status context is present on every PR and can be required by the branch
+# status context is present on every PR and CAN BE required by the branch
 # ruleset without the phantom-pending trap a path-filtered workflow creates.
+# Note the mood: can be. It is not — see NAMING at the end of this header — so
+# the shape buys readiness, not a live gate.
 # There is no aggregator job because there is nothing to aggregate: one job,
 # always present, ~30 seconds including the pip install.
 #
@@ -65,9 +67,16 @@ name: freehand-conformance
 # drifted. An archive that can quietly shrink or be edited is worse than no
 # archive. Stdlib Python, well under a second.
 #
-# The job id and display name stay `index` / `Freehand conformance index` even
-# though the job proves two ledgers: that string is the status context the
-# branch ruleset requires, and renaming it would silently drop the requirement.
+# NAMING. The job id and display name stay `index` / `Freehand conformance
+# index` even though the job proves two ledgers. That string is NOT a required
+# status context. The branch ruleset on `main` requires exactly three — `All
+# required checks passed` (test.yml), `Lint required` (lint.yml) and `Docs
+# required` (docs.yml) — and this job can reach none of them, because `needs:`
+# cannot span workflow files. So this gate is ADVISORY, held by the standing
+# practice that a red PR gets fixed rather than merged. Keep the name stable
+# regardless: it is the handle the PR rollup and TESTING.md use, and the string
+# the ruleset would have to name if the context were ever required. Renaming it
+# would not drop a requirement, because there is none to drop.
 
 on:
   # BOTH triggers are intentionally UNFILTERED. The PR one for the


### PR DESCRIPTION
Closes rf2-m4kh (P2, from the rf2-m08s CI cleanup audit).

## The claim

`.github/workflows/freehand-conformance.yml` lines 68-70, verbatim:

```
# The job id and display name stay `index` / `Freehand conformance index` even
# though the job proves two ledgers: that string is the status context the
# branch ruleset requires, and renaming it would silently drop the requirement.
```

Both halves are false, and this is a claim about the merge gate itself — anyone
reading it concludes the check blocks merges.

## How I established what the ruleset actually requires

Not from a PR rollup — every workflow that runs appears there, required or not.
Three queries, two of them independent readings of the requirement set.

**1. Enumerate the rulesets.** One exists.

```
$ gh api repos/day8/re-frame2/rulesets
[{"id":16120663,"name":"main","target":"branch","source_type":"Repository",
  "source":"day8/re-frame2","enforcement":"active", ...}]
```

**2. Read that ruleset's stored definition.**

```
$ gh api repos/day8/re-frame2/rulesets/16120663
ruleset id= 16120663 name= main enforcement= active target= branch
conditions= {"ref_name": {"exclude": [], "include": ["~DEFAULT_BRANCH"]}}
RULE TYPE: deletion
RULE TYPE: non_fast_forward
RULE TYPE: required_linear_history
RULE TYPE: required_status_checks
    REQUIRED CONTEXT:  'All required checks passed'
    REQUIRED CONTEXT:  'Lint required'
    REQUIRED CONTEXT:  'Docs required'
    strict_required_status_checks_policy= False
```

**3. Read GitHub's *computed effective* rules for the `main` ref** — the endpoint
that aggregates every ruleset applying to a branch, repository- and
organisation-level, rather than the one I happened to name:

```
$ gh api repos/day8/re-frame2/rules/branches/main
total effective rules on main: 4
TYPE: deletion               | source= day8/re-frame2 | ruleset_id= 16120663
TYPE: non_fast_forward       | source= day8/re-frame2 | ruleset_id= 16120663
TYPE: required_linear_history| source= day8/re-frame2 | ruleset_id= 16120663
TYPE: required_status_checks | source= day8/re-frame2 | ruleset_id= 16120663
     CONTEXT: 'All required checks passed'
     CONTEXT: 'Lint required'
     CONTEXT: 'Docs required'

ALL effective required contexts: ['All required checks passed', 'Lint required', 'Docs required']
freehand present? False
```

**Ruling out a second source of required checks.** Classic branch protection is
not in play, so the ruleset is the whole gate:

```
$ gh api repos/day8/re-frame2/branches/main/protection
gh: Branch not protected (HTTP 404)
```

`Freehand conformance index` is not a required status context. Nor can the job
reach one: the three contexts are owned by `test.yml:6197`, `lint.yml:660` and
`docs.yml:633`, and `needs:` cannot span workflow files — `test.yml:6188`
("`needs:` must list EVERY gating job in this workflow — GitHub `needs:` only
spans the same workflow file") and `freehand-bench.yml:17-20` both state that
constraint independently. **The job is advisory.** `TESTING.md:146` agrees.

## The fix

Comment text only, in the one file in the fence.

The header block at lines 15-20 was already *accurate* — it says the shape means
the context "can be required by the branch ruleset", which is true. The closing
note then restated it unhedged and wrong. So the correction lands in two places:
the closing note now states the fact and its evidence, and the earlier block
gets one sentence pointing at it so the file cannot read as though the
unfiltered trigger is serving a live requirement.

The new closing note:

```
# NAMING. The job id and display name stay `index` / `Freehand conformance
# index` even though the job proves two ledgers. That string is NOT a required
# status context. The branch ruleset on `main` requires exactly three — `All
# required checks passed` (test.yml), `Lint required` (lint.yml) and `Docs
# required` (docs.yml) — and this job can reach none of them, because `needs:`
# cannot span workflow files. So this gate is ADVISORY, held by the standing
# practice that a red PR gets fixed rather than merged. Keep the name stable
# regardless: it is the handle the PR rollup and TESTING.md use, and the string
# the ruleset would have to name if the context were ever required. Renaming it
# would not drop a requirement, because there is none to drop.
```

**Deliberately not done here.** The context is not added to the ruleset —
changing what gates merges is an operator decision, and it is in tension with
the retirement staging already tracked in **rf2-8z9q**. Re-deriving whether the
unfiltered trigger still earns its cost is the same call and belongs with that
bead; it would change a trigger, which this fence excludes.

## No job, `needs:`, `if:`, trigger or check name moved

A PyYAML shape dump — every non-comment field, including each job's `name` (the
status-context string) — decoded and re-encoded as **explicit UTF-8 on both
sides**, so the Windows ANSI codepage cannot mojibake an em-dash into phantom
drift:

```
before sha256: 310b6ff4ac755584d4ebe65eb53dbc6c8182b12faef0c0a20d8b636de361f2f2
after  sha256: 310b6ff4ac755584d4ebe65eb53dbc6c8182b12faef0c0a20d8b636de361f2f2
IDENTICAL: True

job ids  : True ['index']
job names: True ['Freehand conformance index']
needs    : True [None]
job if   : True
step ifs : True
triggers : True {"pull_request": {"branches": ["main"]}, "push": {"branches": ["main"]}, "workflow_dispatch": null}
runs     : True
```

## Quality gates

| Gate | Before | After | Raw exit |
|---|---|---|---|
| `python scripts/check_fast_pr_gap.py --list` | 96 | 96 (output byte-identical) | `0` |
| `python scripts/check_gate_scheduling.py` | 51 cmds, 43 scheduled, 8 declared | 51 cmds, 43 scheduled, 8 declared | `0` |
| PyYAML parse + shape dump | sha `310b6ff4…` | sha `310b6ff4…` | `0` |
| Post-rebase re-run of all three | — | unchanged | `0` / `0` / `0` |

Exit codes are the `$?` captured on the same command line as the redirect, in
one shell — not the harness's.

### Gate discrimination

**A premise in the brief did not hold, and the correction is itself the
evidence.** The brief expected the gap map to move 96 → 97 on a planted bogus
step. It cannot, for this file: `check_fast_pr_gap.py:94-98` defines its read
universe as exactly three workflows.

```
check_fast_pr_gap REPO_ROOT -> C:\Users\miket\code\re-frame2-worktrees\reqctx-m4kh
read universe (AGGREGATORS keys):
    .github/workflows/test.yml
    .github/workflows/lint.yml
    .github/workflows/docs.yml
freehand-conformance.yml in universe? False
```

`REPO_ROOT` is `Path(__file__).resolve().parent.parent`, so it provably read
*this worktree* — and provably never opens the edited file. A flat 96 is the
correct reading, not an inert one. Confirmed the hard way: under control 1 below
the file was **syntactically invalid YAML** and the gap map still returned 96 and
exit 0.

So the worktree-read proof has to come from the gate that *does* read this file.
`check_gate_scheduling.py` concatenates **every** `.yml` under `.github/workflows`
(`load()`, lines 476-481):

- **Control 1 — YAML validity, planted at line 68, a line this PR edits.**
  Replaced the comment marker with `BOGUS_CONTROL: [unclosed, sequence`. PyYAML:
  `yaml.parser.ParserError: while parsing a flow sequence ... line 68, column 16`.
  **Raw exit 1.** Restored; **sha256 `c1057a9b…` matched the pristine bytes**, 139
  CRLF / 0 bare LF — a byte compare, not a diff, because a CRLF→LF flattening
  passes a diff and fails a hash.
- **Control 2 — worktree read, in-fence.** Planted a `run:` naming
  `npm run test:security` (a currently `covered-by`-declared gate) into this file.
  `43 scheduled, 8 declared` → **`44 scheduled, 7 declared`**. The gate reads this
  worktree's copy of this file. Restored; sha256 `c1057a9b…`, byte-identical again.

No other workflow was touched, at any point, including transiently.

### Other claims in this file, checked while here

The brief asked whether this workflow carries further unexamined claims about
its own necessity, of the kind rf2-vyqq and rf2-j8os found in freehand-bench.yml.
The two load-bearing ones **hold at source**, so nothing further is filed:

- lines 30-37, that `report-changed-surfaces.sh` arms the three lanes for
  `conformance-index.md` as well as the fixtures root — real, at
  `.github/scripts/report-changed-surfaces.sh:1448`, with the rf2-49upn rationale
  at :1482.
- lines 44-46, that the census prints `_binding_note` under both `--verbose` and
  `--report` — real, at `scripts/check_freehand_conformance_index.py:1221`,
  written at :2035 and :2061.

### Provenance

Diffed against `origin/main` before pushing and read for reverts, not conflicts:
`origin/main` had advanced past the branch point, so the branch was rebased onto
it. Post-rebase the diff is this one file, `13 insertions(+), 4 deletions(-)`,
and all three gates were re-run — unchanged, file bytes unchanged (`b044c2da…`,
148 CRLF / 0 bare LF).
