### PR TITLE
docs(machines): correctness, completeness and tutorial-quality review (rf2-ys42)

### DIFF
--- a/docs/machines/actors.md
+++ b/docs/machines/actors.md
@@ -330,7 +330,8 @@ A spawned actor is destroyed when:
 
 Destroy releases exactly three framework-managed kinds:
 
-- in-flight `:rf.http/managed` requests this actor issued (the reply is
+- in-flight `:rf.http/managed` requests this actor issued (the reply arrives
+  with `:status :cancelled` and an `:error` of
   `{:kind :rf.http/aborted :reason :actor-destroyed}`);
 - this actor's armed `:after` timers;
 - `:rf.resource/*` owners this actor holds.
@@ -423,6 +424,8 @@ Rules:
 
 - **Each child needs a unique `:id`** (the join key) on top of the usual
   spawn keys. Duplicates are `:rf.error/machine-spawn-all-duplicate-id`.
+- **`:on-child-done` and `:on-child-error` are required** event keywords —
+  missing either is `:rf.error/machine-spawn-all-bad-shape`.
 - **`:join` is only `:all` or `:any`.** There is no `{:n n}` and no
   predicate. Quorum ("N of M") is `:after` / `:always` plus a
   `:done-guard` that reads the join's done count — not a `:join` mode.

--- a/docs/machines/automatic-transitions.md
+++ b/docs/machines/automatic-transitions.md
@@ -72,7 +72,7 @@ Inside that one macrostep, the runtime:
 5. repeats until no `:always` is enabled and no raised event remains;
 6. commits the final snapshot once.
 
-The loop is bounded. The default depth limit is 16. A runaway `:always` or `:raise` cycle raises `:rf.error/machine-always-depth-exceeded` and aborts the macrostep atomically; the previous snapshot remains visible.
+The loop is bounded. The default depth limit is 16. A runaway cycle raises `:rf.error/machine-always-depth-exceeded` (eventless) or `:rf.error/machine-raise-depth-exceeded` (`:raise`) and aborts the macrostep atomically; the previous snapshot remains visible.
 
 ## `:always` rules
 
@@ -291,7 +291,8 @@ Readable shorthands such as `"5s"` or `"10ms"` are not accepted, nor are subscri
 | --- | --- | --- |
 | Registration throws `:rf.error/machine-always-self-loop` | `:always` targets its own declaring state | Use a targetless `:always` with an action that flips the guard, or target a different state |
 | Macrostep fails `:rf.error/machine-always-depth-exceeded` | Eventless loop did not settle within 16 steps | Break the cycle; a targetless drain-until-false is the safe loop |
-| Registration throws `:rf.error/machine-bad-choice` | `:choice` is a function, empty, or missing a default | Declarative non-empty vector with an unguarded last candidate |
+| Registration throws `:rf.error/machine-bad-choice` | `:choice` is a function, empty, or otherwise not a candidate vector | Declarative non-empty vector of candidate maps |
+| Registration throws `:rf.error/machine-choice-no-default` | Every `:choice` candidate is guarded | End the vector with an unguarded candidate |
 | A choice or `:always` candidate read `nil` where the payload should be | An eventless step runs with no event | Read the payload on the event-driven transition and store it in `:data` |
 | A retry limit trips one failure early after the count moved into a choice | The entering action already incremented the count the choice's guard reads | Compare against the post-action number |
 | Timer fired but the snapshot did not move | Guard was false at expiry, or the state had already been left | Expected. A late timer is stale; a false guard discards that firing |

--- a/docs/machines/concepts.md
+++ b/docs/machines/concepts.md
@@ -31,6 +31,7 @@ A table has five everyday parts:
 Resting leaves such as `:authed` keep the snapshot around so a view can still
 render them. They are **not** `:final?` — that flag destroys the machine
 ([Final states](#final-states)).
+
 ## Register and drive
 
 <a id="register-and-drive"></a>
@@ -150,7 +151,11 @@ self-transition. Click into the cell and press **`Ctrl-Enter`**
 | `:tags` | Runtime-projected union of active states' tags |
 
 `[:rf/machine id]` is `nil` until the first event. A view that renders earlier
-should fall back to the definition's `:initial` and `:data`.
+should fall back to the definition's `:initial` and `:data`. To boot a
+singleton eagerly instead, dispatch the reserved start marker at startup:
+`(rf/dispatch [:auth.login/flow [:rf.machine/start]])`. It runs the initial
+entry — `:entry` actions fire, `:after` timers arm — and stops; it never
+matches an `:on` transition.
 
 Do not build views that switch on detailed `:state` shapes unless the exact
 state is the product decision. For "busy", "read-only", "connected", use

--- a/docs/machines/parallel-states.md
+++ b/docs/machines/parallel-states.md
@@ -194,6 +194,23 @@ Root targets are region-qualified:
 A bare keyword target at the root of a parallel machine is rejected at
 registration with `:rf.error/machine-parallel-root-on-bad-target`.
 
+A parallel root may also declare its own `:after` — the timer-driven analog
+of the root `:on`. It arms at machine birth and belongs to the root, so no
+region's own transitions cancel or restart it.
+
+## When every region finishes
+
+When every region reaches a `:final?` leaf, the root's `:on-done` fires. A
+parallel root's `:on-done` runs its `:action` and emits its `:fx` only; a
+`:target` is rejected at registration
+(`:rf.error/machine-parallel-on-done-target`) because the root has no
+sibling state to land on. The machine stays in the all-final configuration.
+
+Without a root `:on-done`, all-regions-final ends the machine the way a
+root-level `:final?` leaf does: a singleton is destroyed, and a spawned
+child reports to its parent
+([Actors](actors.md#when-a-child-finishes)).
+
 ## Coordinating regions: tags as `stateIn`
 
 A region guard or action gets two extra context keys. They appear only inside a

--- a/docs/machines/tags.md
+++ b/docs/machines/tags.md
@@ -90,7 +90,7 @@ The query is this subscription:
 
 ```clojure
 (rf/reg-view sign-in-button []
-  (let [busy? @(rf/subscribe [:rf.machine/has-tag? :auth.login/flow :auth/busy])]
+  (let [busy? @(subscribe [:rf.machine/has-tag? :auth.login/flow :auth/busy])]
     [:button {:disabled busy?} "Sign in"]))
 ```
 
@@ -157,7 +157,7 @@ The root view branches once:
 
 ```clojure
 (rf/reg-view root-view []
-  (case @(rf/subscribe [:ui/render])
+  (case @(subscribe [:ui/render])
     :done      [view-done]
     :correct   [view-correct]
     :incorrect [view-incorrect]
@@ -174,7 +174,7 @@ the data bucket — living in one table. Adding a render case is one row plus on
 
 ```clojure
 (rf/reg-view new-todo-form []
-  (let [read-only? @(rf/subscribe [:rf.machine/has-tag? :ui/nine-states :mode/read-only])]
+  (let [read-only? @(subscribe [:rf.machine/has-tag? :ui/nine-states :mode/read-only])]
     [:button {:disabled read-only?} "Add"]))
 ```
 

--- a/docs/machines/tutorial.md
+++ b/docs/machines/tutorial.md
@@ -289,7 +289,7 @@ Project the snapshot. Ask **tags** for shared intent. The credential draft is or
   (let [state @(subscribe [:auth.login/state])
         error @(subscribe [:auth.login/error])
         draft @(subscribe [:auth.login/draft])
-        busy? @(rf/subscribe [:rf.machine/has-tag? :auth.login/flow :auth/busy])]
+        busy? @(subscribe [:rf.machine/has-tag? :auth.login/flow :auth/busy])]
     (case state
       nil          [:button {:on-click #(dispatch [:login/submit draft])}
                     "Sign in"]          ;; singleton snapshot is nil until first dispatch


### PR DESCRIPTION
## Scope and method

Full review of the 13 pages of `docs/machines/` (~3,687 lines) for correctness, completeness and tutorial quality, judged against `docs/AUTHORING.md`, in three phases:

1. **Correctness** — every code sample and API claim verified against the shipped code, not memory: all cited `:rf.error/*` / `:rf.warning/*` / `:rf.machine*` ids git-grepped to their exact keyword in `implementation/machines/` + `implementation/core/` (28 ids, all present with the exact namespaces the docs cite); arities checked at the definition (`reg-machine` 2/3-arity macro, `machine-transition [machine snapshot event]`, `result/ok?`-`snap`-`fx`-`fail?`-`info`); semantic claims checked against `spec/005-StateMachines.md` and, where behaviour-critical, the engine source (`choice.cljc`, `timeout.cljc`, `grammar.cljc`, `transition.cljc`, `parallel.cljc`, `join.cljc`, `data_validation.cljc`, `spawn.cljc`, `teardown.cljc`, the HTTP `reply.cljc`/`encoding.cljc`/`registry.cljc`, and the `re-frame.machines` facade).
2. **Completeness** — the implementation's public surface compared against the page set; all cross-page links and all four `examples/` targets confirmed to exist; escape hatches (`:rf.machine/update-snapshot`, `reg-machine*`, query fns) confirmed covered by `docs/api/re-frame.machines.md`, so the guide rightly omits them. No missing page found.
3. **Tutorial quality** — the tutorial arc (register → guard → actions/candidates → entry/`:after`/HTTP → view → pure test → complete listing) checked step by step: each snippet's claimed result traced through the transition semantics; examples confirmed idiomatic (form draft in app-db, tags for busy, projection subs); no prerequisites blocks, no nav-restating sections.

## What changed

**concepts.md**
- Rendering fix: `## Register and drive` had no blank line before it, so Python-Markdown absorbed the heading into the preceding paragraph (it rendered as literal `## Register and drive` text). Verified fixed: the built page now carries `<h2 id="register-and-drive">`. A scan of all 13 pages found no other instance.
- Snapshot section now mentions the eager-start marker (`(rf/dispatch [id [:rf.machine/start]])`) as the alternative to nil-snapshot fallback — a shipped, spec'd capability (spec/005 §Synthetic creation marker) the guide never surfaced.

**automatic-transitions.md**
- Run-to-completion: a runaway `:raise` cycle raises `:rf.error/machine-raise-depth-exceeded`, not `machine-always-depth-exceeded`; both are now named (matching concepts.md, which already had this right).
- Troubleshooting: a `:choice` vector missing its unguarded default is rejected with `:rf.error/machine-choice-no-default` (`choice.cljc:304`), not `machine-bad-choice` — the row conflated the two; split into two correct rows.

**actors.md**
- The actor-destroy HTTP abort reply was described as `{:kind :rf.http/aborted :reason :actor-destroyed}`; the reply envelope actually arrives with `:status :cancelled` and that map under `:error` (`reply.cljc` `failure-reply`; the old `{:kind …}` reply dialect was deleted pre-alpha). Corrected.
- `:spawn-all` rules now state `:on-child-done` / `:on-child-error` are required event keywords (`validation.cljc:311-319` rejects their absence with `machine-spawn-all-bad-shape`); the example carried them but the rules list omitted the requirement.

**parallel-states.md**
- New short section "When every region finishes": the parallel root's `:on-done` (action + fx only; `:target` rejected with `:rf.error/machine-parallel-on-done-target`; machine stays in the all-final configuration), and what all-regions-final means without it. This shipped capability (spec/005 §Parallel `:on-done`) was previously undocumented anywhere in the guide.
- One sentence noting a parallel root may declare its own `:after` (root-owned, armed at birth, not cancelled by region transitions).

**tags.md, tutorial.md**
- View bodies now use the bare `subscribe` noun that `reg-view` injects, instead of a mixed bare/`rf/`-qualified spelling within the same block — the corpus convention (`docs/core/*` and this corpus's own live cell).

Everything else checked out: the whole error-id taxonomy, transition grammar (including the bare-vector absolute-path target hierarchical-states.md uses — `grammar.cljc` `transition-value-form` `:vec-target`), history key/value shapes incl. region qualification, timer semantics (delay forms, staleness, sub-vector restart-from-now), parallel select-then-apply and root-fallback suppression, spawn stamps and `:rf/spawned`, join grammar, reply-envelope append onto the inner trigger (`route-inner-event`), cofx grammar, schema dev-gating, trace record shapes, and the XState v6 mapping (behavioural parity, divergences flagged, consistent with spec/005 §Lessons from xstate).

## Findings reported, not fixed

Both are implementation-side docstring drift — outside this PR's fence (`docs/machines/` only); no spec drift and no code bug found.

1. `implementation/machines/src/re_frame/machines.cljc:272` — the `:rf.machine/spawn` reg-fx `:doc` says args carry "optional `:initial-data`", but the handler and Spec 005 use `:data` (spawn.cljc: "overridden by the spawn args' `:data`"; the guide and API reference also say `:data`).
2. `implementation/machines/src/re_frame/machines.cljc:333` — the `:rf.machine/has-tag?` sub `:doc` says "Subscribe to a machine's `:fsm/tags` containment-bit"; the snapshot slot is `:tags` (`:fsm/*` is capability-matrix vocabulary, not a snapshot key).

## Quality gates

- `python scripts/check_doc_slugs.py` — exit **0**
- `python -m mkdocs build --strict` — exit **0**

Coverage proof for the silent slug gate: a deliberately broken anchor was planted in `docs/machines/concepts.md` (`#final-states` → `#final-states-broken-anchor-coverage-proof`); the gate then exited **1** with `BROKEN ANCHOR: docs\machines\concepts.md:33 -> #final-states-broken-anchor-coverage-proof`; the plant was reverted with the Edit tool and the restore verified **byte-identical by sha256** (`6f6c47e9fc38a408f8e35b57349f30acb32acaff8020256c6ac5ef78f2cf6fae` before and after); both gates were then re-run clean with the exit codes above.

CLJS/JVM lanes are untouched by this docs-only diff and are deferred to CI.

Anchors and table column counts were hand-verified: every in-page anchor target and cross-page link resolved (slug gate + manual check of `examples/` directory targets, which sit outside the built site), and a code-span-aware scan of every table in the 13 pages found zero inconsistent column counts.


## Rebase

Main moved under this branch: 7f36c0301e ("repair four semantic defects in the reshaped guide") and 9bec89f4a4 ("reflow the singleton paragraph") landed on `docs/machines/` after the branch was cut. Both incoming commits were read in full before rebasing, and their claims spot-verified at source (eventless steps do pass `nil` as the event — `transition.cljc:3981`; the choice-entry action does run before the choice's candidates evaluate, so the post-action count comparison is right). Their four repairs and this PR's four fixes address disjoint defects.

Overlap resolution:

- **actors.md, glossary.md, hierarchical-states.md, index.md** — disjoint hunks; git auto-merged. Their registering forms, `:report-success` success path, trigger-vocabulary and per-frame-singleton wording all survive alongside this PR's abort-reply and spawn-all fixes.
- **automatic-transitions.md troubleshooting table** — the one real conflict. Main's side still carried the pre-fix `machine-bad-choice` row ("function, empty, or missing a default") plus their two new behavioural rows; this PR's side carried the corrected split (`machine-bad-choice` for malformed shapes, `:rf.error/machine-choice-no-default` for a missing default — verified at `choice.cljc:304`). Resolved by merging intents: the corrected two rows AND their two new rows, no blind side-pick. The verified-at-source error-id split wins over the stale row text.

Post-rebase, all of this PR's corrections were re-verified present (`machine-raise-depth-exceeded`, `machine-choice-no-default`, the `:status :cancelled` abort-reply shape, `[:rf.machine/start]`, the parallel "When every region finishes" section, the required `:on-child-done` / `:on-child-error` rule), and both gates were re-run from the rebased tree:

- `python scripts/check_doc_slugs.py` — exit **0**
- `python -m mkdocs build --strict` — exit **0**
