### PR TITLE
ci(portability): make the ai/ ratchet cheap without making it toothless, and name the third job for its rule (rf2-uol6, rf2-p3zf)

### DIFF
--- a/.github/workflows/portability.yml
+++ b/.github/workflows/portability.yml
@@ -13,8 +13,8 @@
 # the per-gate shellcheck below, aimed at the rf2-ldkuk class: a script CI
 # runs whose defects surface only on the runner.
 #
-# It also carries the tracked-`ai/` RATCHET (rf2-lsp1i) and the re-frame.ui
-# view-lifetime residue ratchet (rf2-5e8zv) — see those jobs below. The gates
+# It also carries the tracked-`ai/` RATCHET (rf2-lsp1i) and the repo-wide
+# view-lifetime vocabulary ratchet (rf2-5e8zv) — see those jobs below. The gates
 # live together because each is the UPSTREAM lock for a leak class that would
 # otherwise surface downstream: the 2026-07-18 incident was a force-added ai/
 # dossier carrying a personal worktree path, which failed the portability gate
@@ -251,21 +251,34 @@ jobs:
           AI_RATCHET_BASE_REF: ${{ steps.base.outputs.ref }}
         run: sh scripts/check-ai-tracking-ratchet.sh
 
-  # The re-frame.ui view-lifetime residue ratchet (rf2-5e8zv, the excision
-  # epic finale). Like the tracked-ai/ ratchet above this is a whole-tree,
-  # every-PR git invariant with a ZERO baseline — the excision epic removed the
-  # view-lifetime concept in full (the observation surface returns a HANDLE,
-  # Resources pin liveness with an OWNER), and ANY tracked file can reintroduce
-  # its vocabulary, so the only correct surface is the whole tree. The guard
-  # scans `git ls-files` content AND paths for every lexical form (natural
-  # language singular/plural/past/gerund, snake/camel/kebab identifiers, and
-  # file names), excludes ONLY `.beads/**`, and carries no baseline, ceiling, or
-  # allowlist for product files. It constructs its own forbidden token so the
-  # guard is never its own violation, and ordinary words (release, please) plus
-  # the excision's survivors (handle, owner, route, machine, ssr, app-event) are
-  # never flagged.
+  # The REPO-WIDE view-lifetime vocabulary ratchet (rf2-5e8zv, the excision epic
+  # finale; renamed by rf2-p3zf).
+  #
+  # THIS GATE DOES NOT RETIRE WITH `implementation/ui/`, and the name it used to
+  # carry — "No re-frame.ui view-lifetime residue" — argued that it did. The rule
+  # has NO coupling to re-frame.ui, or to any substrate: read
+  # `scripts/check_view_lifetime_residue.py` and the whole mechanism is
+  # `git ls-files -z` over every tracked path with `_EXCLUDE_PREFIXES =
+  # (".beads/",)`. No donor tree is named, scanned for, or scoped to. The rule is
+  # "this word does not appear in this repository", full stop. EP-0038 HD-018
+  # rules that on a win the public re-frame.freehand and re-frame.ui surfaces are
+  # DELETED; a worker executing that deletion must NOT take this job with them.
+  # It is precisely what stops the next substrate reintroducing the vocabulary
+  # the excision removed — the case it is most needed for.
+  #
+  # Like the tracked-ai/ ratchet above this is a whole-tree, every-PR git
+  # invariant with a ZERO baseline — the excision epic removed the view-lifetime
+  # concept in full (the observation surface returns a HANDLE, Resources pin
+  # liveness with an OWNER), and ANY tracked file can reintroduce its vocabulary,
+  # so the only correct surface is the whole tree. The guard scans `git ls-files`
+  # content AND paths for every lexical form (natural language
+  # singular/plural/past/gerund, snake/camel/kebab identifiers, and file names),
+  # excludes ONLY `.beads/**`, and carries no baseline, ceiling, or allowlist for
+  # product files. It constructs its own forbidden token so the guard is never
+  # its own violation, and ordinary words (release, please) plus the excision's
+  # survivors (handle, owner, route, machine, ssr, app-event) are never flagged.
   view-lifetime-residue-ratchet:
-    name: No re-frame.ui view-lifetime residue
+    name: No retired view-lifetime vocabulary, repo-wide
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2

--- a/.github/workflows/portability.yml
+++ b/.github/workflows/portability.yml
@@ -152,25 +152,50 @@ jobs:
     name: No newly tracked files under ai/
     runs-on: ubuntu-latest
     steps:
-      # fetch-depth: 0 is REQUIRED, not incidental (rf2-ow7dz, rf2-7hq4l). The
-      # gate compares the tracked ai/ set against the last ACCEPTED state, and
-      # that base is the event's accepted base — resolved in the step below,
-      # NOT HEAD^:
+      # THE BASE IS ONE NAMED COMMIT, so the checkout fetches TWO and the step
+      # below fetches THAT ONE (rf2-uol6). This job used fetch-depth: 0 and spent
+      # 211 of its 216 seconds cloning history it never walked — measured over
+      # three runs (216 / 216 / 233s) against 14–16s for its two siblings, which
+      # made it the most expensive job on every PR by more than 3x.
+      #
+      # WHAT THE GATE ACTUALLY NEEDS FROM HISTORY, measured rather than inferred
+      # from the flag name: the base COMMIT OBJECT AND ITS TREE, and nothing
+      # else. The script resolves the base and then runs `git ls-tree` on it; it
+      # never walks an ancestor. A `git fetch --depth=1 origin <sha>` of a
+      # 1200-commit-deep sha took 2.8s and made `ls-tree` succeed while that
+      # commit's own PARENT stayed unresolvable — which is the proof that no
+      # ancestry is required.
+      #
+      # THE BASE IS STILL THE EVENT'S ACCEPTED BASE, unchanged (rf2-ow7dz,
+      # rf2-7hq4l) — resolved in the step below, NOT HEAD^:
       #   * push to main: github.event.before, the tip main pointed at before
       #     this push. On a MULTI-COMMIT push HEAD^ is only the second-to-last
       #     commit of this same push, so a path first tracked in an earlier
       #     commit and retained at the tip is present on both sides and escapes
-      #     (the rf2-7hq4l defect). The accepted base can be arbitrarily deep,
-      #     so a full checkout is the only depth that is guaranteed to hold it.
+      #     (the rf2-7hq4l defect). The accepted base can be arbitrarily deep —
+      #     which is why it is FETCHED BY NAME rather than cloned up to.
       #   * pull_request: github.event.pull_request.base.sha, the base-branch
       #     tip — which equals the merge commit's first parent, so HEAD^ was
       #     already sound here; the base sha is passed explicitly so both event
       #     shapes share one contract instead of relying on HEAD^ by accident.
+      #
+      # WHY 2 AND NOT 1. workflow_dispatch carries no accepted base, so the
+      # script falls back to its own HEAD^ default; depth 1 would make that
+      # fallback unresolvable and red the manual run. Depth 2 holds HEAD^ for
+      # one extra commit's worth of delta. This is also the depth
+      # `_ai-tracking-ratchet.test.cjs` has always pinned.
+      #
       # If the base cannot be resolved the script FAILS closed rather than
-      # passing vacuously (its own guard), so a missing base certifies nothing.
+      # passing vacuously, so a fetch that misses the base reds — it does not
+      # pass. That guard was NOT sound before this change: `git rev-parse
+      # --verify --quiet <40-hex>` returns the sha with exit 0 even when the
+      # object is absent, so an unfetched base sailed through and the gate
+      # reported "END STATE reached" over a base it never read. rf2-uol6 measured
+      # that false green and hardened the script; a shallower checkout is safe
+      # only because it is now genuinely fail-closed.
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
-          fetch-depth: 0
+          fetch-depth: 2
 
       # Same precedent as the gate above: lint the gate script itself so a
       # future edit cannot introduce a shell bug that silently weakens it.
@@ -183,6 +208,14 @@ jobs:
       # empty, so the script falls back to its own HEAD^ default. Context
       # values arrive via `env:` — never interpolated into the script body — so
       # the step is injection-safe regardless of what the event carries.
+      #
+      # ...and then FETCH that one commit if the depth-2 checkout above does not
+      # already hold it (rf2-uol6). `--depth=1` brings down the commit and its
+      # tree and stops; the ratchet needs no ancestor, and the existing shallow
+      # boundary for HEAD is untouched (measured: HEAD^ still resolves after
+      # this fetch). GitHub serves a reachable SHA to `git fetch` — the accepted
+      # base is always an ancestor of a ref — and a fetch that fails leaves the
+      # base unresolvable, which the script turns into a RED rather than a pass.
       - name: Resolve the accepted base
         id: base
         env:
@@ -198,6 +231,10 @@ jobs:
           esac
           if [ "$base" = '0000000000000000000000000000000000000000' ]; then
             base=''
+          fi
+          if [ -n "$base" ] && ! git rev-parse --verify --quiet "$base^{commit}" >/dev/null; then
+            echo "base $base is deeper than this shallow clone; fetching that one commit."
+            git fetch --no-tags --no-recurse-submodules --depth=1 origin "$base"
           fi
           echo "ref=$base" >> "$GITHUB_OUTPUT"
 

--- a/implementation/scripts/_ai-tracking-ratchet.test.cjs
+++ b/implementation/scripts/_ai-tracking-ratchet.test.cjs
@@ -359,7 +359,9 @@ test('ARM 7: an unresolvable base ref fails closed rather than passing vacuously
 
     // The realistic shape, taking the DEFAULT base: a root commit, which is
     // also what a depth-1 shallow clone looks like to this gate. This is why
-    // portability.yml checks out with fetch-depth: 2.
+    // portability.yml checks out with fetch-depth: 2 — the depth that holds
+    // HEAD^ for the manual-dispatch fallback. (This assertion outlived a spell
+    // when the workflow said 0; rf2-uol6 put the file back in step with it.)
     const rootCommit = h.run();
     assert.equal(rootCommit.status, 1, 'an unresolvable HEAD^ must fail, not pass');
     assert.match(rootCommit.stderr, /cannot resolve base ref HEAD\^/);
@@ -436,6 +438,59 @@ test('ARM 8: a multi-commit push — an ai/ path added before the tip escapes HE
 });
 
 // ---------------------------------------------------------------------------
+// ARM 9 — AN ABSENT BASE SHA FAILS CLOSED. The tooth for rf2-uol6, and the one
+// that makes a SHALLOW CI checkout safe to run this gate under.
+//
+// `git rev-parse --verify --quiet <40-hex>` echoes the sha back with EXIT 0 even
+// when the object is not in the store: for a full-length hex name git does not
+// consult the object database at all. The gate's fail-closed guard therefore did
+// not fire on the one shape a shallow clone actually produces — an accepted base
+// deeper than the fetch. `git ls-tree` then failed INTO A PIPELINE, whose POSIX
+// status is `sort`'s, so `set -e` did not fire either, and the two leaks composed
+// into "END STATE reached", exit 0, over a base that was never read.
+//
+// The negative control is the pre-fix resolution itself, run against this
+// fixture: `git rev-parse --verify --quiet <sha>` exits 0 here, which is exactly
+// what the old guard consulted. So the fixture DISCRIMINATES — it is not a base
+// that everything would reject.
+
+test('ARM 9: a base sha absent from the object store fails closed, not vacuously green', () => {
+  withFixtureRepo((h) => {
+    h.write('README.md', '# fixture\n');
+    seedAi(h, 2);
+    h.commit('seed');
+    h.write('README.md', '# fixture, edited\n');
+    h.commit('a second commit, so HEAD^ resolves and only the ABSENT base is at issue');
+
+    // Well-formed, syntactically valid, and not an object in this repository —
+    // the shape `github.event.before` takes in an over-shallow clone.
+    const absent = '0123456789abcdef0123456789abcdef01234567';
+
+    // NEGATIVE CONTROL: the resolution the gate used BEFORE this arm existed.
+    // It exits 0 on this very sha, so the old guard let it through.
+    const legacyResolve = spawnSync(
+      'git',
+      ['rev-parse', '--verify', '--quiet', absent],
+      { cwd: h.root, encoding: 'utf8' },
+    );
+    assert.equal(
+      legacyResolve.status,
+      0,
+      'negative control: `rev-parse --verify` PASSES an absent 40-hex sha — the fixture discriminates',
+    );
+
+    const r = h.run(absent);
+    assert.equal(r.status, 1, 'an absent base sha must fail closed');
+    assert.match(r.stderr, new RegExp(`cannot resolve base ref ${absent}`));
+    assert.doesNotMatch(
+      r.stdout,
+      /END STATE reached/,
+      'the gate must not certify an end state it read no base for',
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
 // Non-vacuity of the SUITE itself: the arms above are not all failures. If a
 // future edit made the gate fail unconditionally, arms 1, 3, 6a and the drain
 // would catch it — this asserts that mix is actually present, so the suite
@@ -447,6 +502,7 @@ test('SUITE: the arms include genuine passes, so a fail-everything gate is caugh
   assert.ok(names.some((n) => n.startsWith('ARMS 3+4')), 'the decrease-then-increase sequence must be present');
   assert.ok(names.some((n) => n.startsWith('ARMS 6a+6b')), 'the end-state sequence must be present');
   assert.ok(names.some((n) => n.startsWith('ARM 8')), 'the multi-commit push tooth must be present');
+  assert.ok(names.some((n) => n.startsWith('ARM 9')), 'the absent-base fail-closed tooth must be present');
 });
 
 let failed = 0;

--- a/scripts/check-ai-tracking-ratchet.sh
+++ b/scripts/check-ai-tracking-ratchet.sh
@@ -73,9 +73,22 @@
 # `HEAD^` stays the default for LOCAL and manual runs, where the parent is a
 # sensible base and there is no event to consult. If the base cannot be
 # resolved (root commit, or an over-shallow clone) the gate FAILS rather than
-# passing: a guard that cannot see its base must not certify anything. The
-# workflow therefore checks out with fetch-depth: 0, because the accepted push
-# base can be arbitrarily deep.
+# passing: a guard that cannot see its base must not certify anything.
+#
+# THE BASE IS PEELED TO `^{commit}`, AND THAT IS LOAD-BEARING (rf2-uol6). The
+# first cut resolved it with `git rev-parse --verify --quiet "$base_ref"`, which
+# looks fail-closed and is not: for a FULL 40-hex sha git echoes the string back
+# with exit 0 WITHOUT consulting the object store, so an absent base passed the
+# guard. `git ls-tree` on it then failed — into a pipeline, whose POSIX status is
+# the LAST command's (`sort`, exit 0), so `set -e` never fired either. Both
+# leaks composed into a false green: an empty base list, an empty diff, and
+# "END STATE reached" printed over a base that was never read. Peeling forces
+# the lookup, and the ls-tree below is run UNPIPED with its status checked.
+#
+# That is what makes a SHALLOW CI checkout safe. portability.yml checks out with
+# fetch-depth: 2 (holding HEAD^ for the manual-dispatch fallback) and fetches the
+# accepted base as a single `--depth=1` commit when it is deeper — the gate needs
+# the base's TREE, never its ancestry. A fetch that misses the base now reds.
 #
 # Cross-platform: POSIX sh. No bashisms (`[[`, arrays, `<<<`, process
 # substitution). Runs identically on the ubuntu-latest CI runner, on macOS,
@@ -95,17 +108,23 @@ cd "$repo_root"
 
 base_ref=${AI_RATCHET_BASE_REF:-HEAD^}
 
-# `--verify --quiet` prints nothing and exits non-zero on an unresolvable
-# ref. Guard the assignment so `set -e` does not abort before the message.
-base_sha=$(git rev-parse --verify --quiet "$base_ref" 2>/dev/null) || base_sha=''
+# `--verify --quiet` prints nothing and exits non-zero on an unresolvable ref.
+# The `^{commit}` peel is REQUIRED, not decorative: without it a full 40-hex sha
+# resolves to itself even when the object is missing from a shallow clone (see
+# the header). Guard the assignment so `set -e` does not abort before the
+# message.
+base_sha=$(git rev-parse --verify --quiet "$base_ref^{commit}" 2>/dev/null) || base_sha=''
 
 if [ -z "$base_sha" ]; then
   printf 'ai/ tracking ratchet FAILED: cannot resolve base ref %s.\n' "$base_ref" >&2
   printf '\n' >&2
   printf 'This gate compares the tracked ai/ set against the last accepted\n' >&2
   printf 'state, so without a base it cannot certify anything and will not\n' >&2
-  printf 'pass by default. Usual cause: a depth-1 shallow clone (CI must\n' >&2
-  printf 'check out with fetch-depth: 2) or a root commit with no parent.\n' >&2
+  printf 'pass by default. Usual causes: a depth-1 shallow clone (CI checks\n' >&2
+  printf 'out with fetch-depth: 2, which holds HEAD^); an accepted base that\n' >&2
+  printf 'is deeper than that and was never fetched (CI fetches it as a\n' >&2
+  printf 'single --depth=1 commit — see .github/workflows/portability.yml);\n' >&2
+  printf 'or a root commit with no parent.\n' >&2
   printf 'Set AI_RATCHET_BASE_REF to name the base explicitly.\n' >&2
   exit 1
 fi
@@ -114,6 +133,7 @@ fi
 # bashism. Clean up on every exit path.
 current_list=$(mktemp)
 base_list=$(mktemp)
+base_raw=$(mktemp)
 added_list=$(mktemp)
 removed_list=$(mktemp)
 # `cleanup` IS reachable: `trap cleanup EXIT` below invokes it, and a POSIX
@@ -126,15 +146,29 @@ removed_list=$(mktemp)
 # on the function. Listing both keeps this lint-clean on either version.
 # shellcheck disable=SC2317,SC2329
 cleanup() {
-  rm -f "$current_list" "$base_list" "$added_list" "$removed_list"
+  rm -f "$current_list" "$base_list" "$base_raw" "$added_list" "$removed_list"
 }
 trap cleanup EXIT
 
 # Current state: the INDEX, so a staged force-add is caught before it is
 # even committed. Base state: the tree at BASE. Both sorted under LC_ALL=C
 # so `comm` sees the same collation on every locale.
+#
+# The base read is UNPIPED and its status checked. Piping it into `sort` hides
+# the failure — a POSIX pipeline reports the LAST command's status — and the
+# gate would then compare against an empty base and pass anything.
 git ls-files ai/ | LC_ALL=C sort > "$current_list"
-git ls-tree -r --name-only "$base_sha" -- ai/ | LC_ALL=C sort > "$base_list"
+if ! git ls-tree -r --name-only "$base_sha" -- ai/ > "$base_raw" 2>/dev/null; then
+  printf 'ai/ tracking ratchet FAILED: cannot read the tree at base %s (%s).\n' \
+    "$base_ref" "$base_sha" >&2
+  printf '\n' >&2
+  printf 'The commit resolved but its tree could not be listed, so the base\n' >&2
+  printf 'state is unknown and this gate will not certify anything. Usual\n' >&2
+  printf 'cause: a partial clone missing that tree. Fetch the base commit\n' >&2
+  printf 'in full, or set AI_RATCHET_BASE_REF to a base you hold.\n' >&2
+  exit 1
+fi
+LC_ALL=C sort "$base_raw" > "$base_list"
 
 current_count=$(wc -l < "$current_list" | tr -d ' ')
 base_count=$(wc -l < "$base_list" | tr -d ' ')


### PR DESCRIPTION
Two beads on `.github/workflows/portability.yml`, one commit each, from the rf2-m08s CI cleanup audit.

## rf2-uol6 — the ai/ ratchet spent 211 of 216 seconds cloning history it never walked

The `No newly tracked files under ai/` job was the most expensive job on every PR by more than 3x (216 / 216 / 233s across three runs, against 14–16s for its two siblings), and 211 of those seconds were the `fetch-depth: 0` checkout.

**What the gate needs from history, measured rather than inferred from the flag name:** the base **commit object and its tree**, and nothing else. The script resolves the base and runs `git ls-tree` on it; it never walks an ancestor. Against the real remote, `git fetch --depth=1 origin <sha>` of a 1200-commit-deep sha took **2.8s**, made `ls-tree` succeed, and left **that commit's own parent unresolvable** — which is the proof that no ancestry is required.

So the checkout drops to `fetch-depth: 2` and the base-resolution step fetches the accepted base as a single commit when it is deeper. **Depth 2 and not 1** because `workflow_dispatch` carries no accepted base and falls back to the script's own `HEAD^` default. The accepted-base semantics are untouched: `github.event.before` for a push, `github.event.pull_request.base.sha` for a pull_request.

### The premise that did not hold, and it had to be fixed first

The bead reasoned that a shallower shape was safe to attempt *because* the script fails closed on an unresolvable base. **It did not.**

* `git rev-parse --verify --quiet <40-hex>` echoes the sha back with **exit 0** without consulting the object store, so an unfetched base passed the guard.
* `git ls-tree` then failed **into a pipeline**, whose POSIX status is `sort`'s, so `set -e` did not fire either.

The two leaks composed into `ai/ tracking ratchet OK: nothing under ai/ is tracked. END STATE reached.` and **exit 0**, over a base that was never read. Measured in a depth-2 clone of this repository, same absent base sha:

| script | raw exit | verdict |
|---|---|---|
| `origin/main` | **0** | `END STATE reached` (false green) |
| this branch | **1** | `cannot resolve base ref 27c5d127…` |

The script now peels the base to `^{commit}` (which forces the lookup) and reads the base tree unpiped with its status checked. That is what makes a shallow checkout safe — and it also closes a live hole under `fetch-depth: 0`, because a `github.event.before` that a force-push made unreachable is absent from a full clone too.

### The stale pin

`implementation/scripts/_ai-tracking-ratchet.test.cjs:362` asserted the script's failure message says `fetch-depth: 2` while the workflow said `0`. **The pin recorded the intended depth and the workflow had drifted from it** — rf2-7hq4l moved the base to the accepted base and bumped the checkout to `0` without touching the message or the assertion. After this change the assertion is true again and is kept. A new **ARM 9** covers the absent-base shape, with the pre-fix resolution as its negative control (`git rev-parse --verify --quiet` exits 0 on the very sha the arm feeds in, so the fixture discriminates). Teeth: 8 → 9 passed.

### Proof the cheaper gate still bites

Driven against a real `fetch-depth: 2` clone of this repository with the changed script installed:

| scenario | raw exit | output |
|---|---|---|
| deep accepted base, **not** fetched | **1** | `cannot resolve base ref c0b29391…` (fails closed) |
| targeted `--depth=1` fetch (4s), base's parent still absent | **0** | `END STATE reached` |
| **force-add `ai/findings/uol6-probe.md`** | **1** | `ADDED: ai/findings/uol6-probe.md` |
| **remove it again** | **0** | `END STATE reached` |
| base that tracks an `ai/` file | **0** | `FELL from 1 to 0` / `REMOVED: ai/findings/base-side.md` |
| `workflow_dispatch`: no base, `HEAD^` fallback at depth 2 | **0** | pass |

The depth-2 fetch + checkout took **16s** locally, against 211s for the full-history checkout on the runner.

### Measured on the runner — this PR's own portability run (31671604352)

| job | before | after |
|---|---|---|
| No newly tracked files under ai/ | 216 / 216 / 233s | **11s** |
| No hardcoded personal/home paths | 15 / 16 / 16s | 16s |
| the third job (renamed here) | 14 / 14 / 15s | 14s |

Step level, the job the bead is about:

```
0s  Set up job
7s  Run actions/checkout@de0fac…      <-- was 211s at fetch-depth: 0
1s  Shellcheck the ratchet script
0s  Resolve the accepted base          <-- includes the targeted base fetch
0s  Run the tracked-ai/ ratchet
0s  Post Run actions/checkout
0s  Complete job
```

**216s → 11s**, comfortably inside the bead's "under 30s" close criterion, and the job is now the cheapest of the three rather than the most expensive on the PR. The renamed job ran green under its new display name in the same run.

## rf2-p3zf — retitle the third job so its name matches its rule

`No re-frame.ui view-lifetime residue` was named for a tree EP-0038 HD-018 schedules for deletion, while the rule has no coupling to that tree at all.

**Verified at source, not assumed.** `scripts/check_view_lifetime_residue.py` scans `git ls-files -z` — every tracked path — with `_EXCLUDE_PREFIXES = (".beads/",)` and nothing else. It names no substrate, no directory, no donor; it builds its forbidden stem from fragments at run time and holds the permitted count at zero. So the finding holds and a rename is the right remedy rather than a report.

The job is now **`No retired view-lifetime vocabulary, repo-wide`**, and the comment block leads with the fact that it does **not** retire with `implementation/ui/`.

**A job name is a required-check name, so the ruleset was queried before renaming** — not inferred from a PR rollup, where every workflow that runs appears whether required or not:

```
$ gh api repos/day8/re-frame2/rulesets/16120663 \
    --jq '.rules[]|select(.type=="required_status_checks")|.parameters.required_status_checks[].context'
All required checks passed
Lint required
Docs required

$ gh api repos/day8/re-frame2/branches/main/protection
gh: Branch not protected (HTTP 404)
```

Three required contexts, **none of them a portability.yml job**, and no legacy branch protection. Nothing is un-required by this rename. No consumer names the old display string either (unlike the sibling gate, which `docs/tools/playground/sci/scripts/copy-bundle.mjs` names by its).

`spec/conformance/freehand/donor-inventory.md:484` still pins an undisposed row naming this coupling; that tree is outside this PR's fence and the row is a separate disposition.

## Quality gates

Every exit code below is the **raw** `$?` captured on the same command line as the gate, redirected to a log — never piped through `tail`/`head`/`grep`, and never the harness's.

| gate | raw exit | result |
|---|---|---|
| `python scripts/check_fast_pr_gap.py --list` (before) | 0 | 96 unrun |
| `python scripts/check_fast_pr_gap.py --list` (after) | 0 | **96 unrun — unchanged** |
| gap-map planted-fault discriminator | 0 | 96 → **97** → 96 |
| `python scripts/check_gate_scheduling.py` (before / after) | 0 / 0 | 51 gate commands, 43 scheduled, 8 declared — unchanged |
| `node implementation/scripts/_ai-tracking-ratchet.test.cjs` | 0 | **9 passed** (was 8) |
| `shellcheck scripts/check-ai-tracking-ratchet.sh` (0.11.0) | 0 | clean |
| `sh -n scripts/check-ai-tracking-ratchet.sh` | 0 | clean |
| `python scripts/check_view_lifetime_residue.py --self-test --verbose` | 0 | 21 self-tests passed |
| `python scripts/check_view_lifetime_residue.py --verbose` | 0 | ratchet clean |
| PyYAML load of `portability.yml` | 0 | valid |
| `python scripts/check_ci_reproduce_commands.py` | 0 | 41 checker steps in sync |
| `python scripts/check_jvm_lane_rosters.py` | 0 | 33 rostered artefacts, bijection holds |
| `python scripts/check_donor_inventory.py` | 0 | 224 / 224 rows |
| `python scripts/check_adapter_disposition.py` | 0 | clean |
| `python scripts/check_runtime_subsystem_grading.py` | 0 | clean |
| `node implementation/scripts/_docs-workflow-policy.test.cjs` | 0 | 5 passed |
| `node implementation/scripts/_lint-workflow-policy.test.cjs` | 0 | 4 passed |
| `node implementation/scripts/_release-dag-policy.test.cjs` | 0 | 10 passed |
| `node implementation/scripts/_changed-surfaces.test.cjs` | 0 | 338 passed |
| `node implementation/scripts/_rigorous-local-inventory.test.cjs` | 0 | 6 passed |

### Gap map — before and after

Both runs print the same header line:

```
REQUIRED CHECKS THIS SPINE DOES NOT RUN (96) -- derived by scripts/check_fast_pr_gap.py
```

**It cannot move for this PR, and that is a fact about the checker rather than luck:** `check_fast_pr_gap.py`'s `AGGREGATORS` covers `test.yml`, `lint.yml` and `docs.yml` only, so `portability.yml` is never parsed by it. The brief's trap — "changing a step can flip its job to an unrun gate in the gap map" — does not reach this file. The discriminator proves the map is nonetheless live: neutralising one spine checker invocation moved it **96 → 97**, and restoring the file (verified by SHA-256, not by diff — `scripts/test-fast-pr.sh` byte hash identical before and after) moved it back to 96.

### PyYAML shape comparison

Decoded with an explicit `encoding="utf-8"` on both sides — the em-dashes in this file mojibake under the Windows codepage otherwise, and a sibling reported phantom drift that way. Keys are stringified first because YAML 1.1 resolves the bare `on:` key to the boolean `True`.

Whole-PR delta against `origin/main`, complete — **three changes, nothing else**:

```diff
-            "fetch-depth": 0
+            "fetch-depth": 2

-          "run": "…\nfi\necho \"ref=$base\" >> \"$GITHUB_OUTPUT\"\n"
+          "run": "…\nfi\nif [ -n \"$base\" ] && ! git rev-parse --verify --quiet \"$base^{commit}\" >/dev/null; then\n  echo …\n  git fetch --no-tags --no-recurse-submodules --depth=1 origin \"$base\"\nfi\necho \"ref=$base\" >> \"$GITHUB_OUTPUT\"\n"

-      "name": "No re-frame.ui view-lifetime residue"
+      "name": "No retired view-lifetime vocabulary, repo-wide"
```

Bead 2's own delta, taken separately, is the **job name line and nothing else** — no trigger, concurrency, `runs-on`, step, `uses` pin or `run` body moved with it.

### Negative controls, planted at lines this PR edits

| planted at | gate | raw exit | restored |
|---|---|---|---|
| the `fetch-depth: 2` line (bead 1) | PyYAML load | **1** — `expected ',' or '}'` | exit 0, SHA-256 identical |
| the comment block I rewrote (bead 2) | `check_view_lifetime_residue.py` | **1** — names `portability.yml` | exit 0, SHA-256 identical |
| the job-`name:` line (bead 2) | PyYAML load | **1** — `expected ',' or ']'` | exit 0, SHA-256 identical |

Every restore was verified **by hashing the bytes**, not by a diff: this file is `i/lf w/crlf` in the working tree, so a restore that flattened CRLF to LF would pass a diff and fail a hash. (The first plant attempt missed for exactly that reason — the LF-terminated needle matched zero times.)

`check_gate_scheduling.py` stayed at exit 0 under broken YAML. That is correct for what it is — a line-based `run:` reachability parser, not a YAML validator — and is recorded here as an observation, not a defect for this PR.

## Notes

* `scripts/check-ai-tracking-ratchet.sh` is outside the literal file fence I was given. It is in scope because bead 1's remedy is unsafe without it: the shallow checkout is only sound once the script genuinely fails closed, and the measurement above is what established that it did not.
* CI has not previously run `portability.yml` at this depth; this PR's own portability run is the first end-to-end measurement of the job's new wall-clock.
