### PR TITLE
ci: hold each browser DOM lane to an executor, and say that freehand-bench.yml is load-bearing (rf2-j8os, rf2-vyqq)

### DIFF
--- a/.github/workflows/freehand-bench.yml
+++ b/.github/workflows/freehand-bench.yml
@@ -26,6 +26,60 @@ name: freehand bench
 #     distributions are published evidence with no automatic numeric
 #     pass/fail.
 #
+# AND YET THIS FILE IS LOAD-BEARING FOR THE MERGE GATE (rf2-vyqq). Nothing in
+# it gates a merge; DELETING it reds something that does, and the file said so
+# nowhere. `scripts/check_gate_scheduling.py` requires every `test:` / `bench:`
+# / `build:` script in `implementation/package.json` to be reachable from an
+# executable `run:` in some workflow, or to carry a checked `DISPOSITIONS`
+# entry. FOUR are reachable from here and from nowhere else:
+#
+#   bench:freehand-browser   the browser lane's run step
+#   bench:freehand-node      the ClojureScript lane's run step
+#   build:freehand-matched   B5's matched-pair build
+#   test:freehand            B5's capture step
+#
+# `test.yml` NAMES the last two in prose, which is precisely what that checker
+# stopped counting under rf2-6ckzl — a `run:` deleted while its paragraph stays
+# put is how a gate loses its home in the first place. A fifth script,
+# `clean:freehand-matched`, is sole-homed here too and goes unremarked only
+# because its prefix is outside the scanned families.
+#
+# That checker runs as a step of `test.yml`'s `verify-skill-mcp-drift` job,
+# which is a `needs:` of `all-required-passed` — and `All required checks
+# passed` is one of the three status contexts the branch ruleset on `main`
+# requires. Read off the ruleset rather than off a PR rollup, where every
+# workflow that ran appears whether required or not: `gh api
+# repos/day8/re-frame2/rules/branches/main` returns that context, `Lint
+# required` and `Docs required`, and `gh api
+# repos/day8/re-frame2/branches/main/protection` returns 404, so no classic
+# branch protection adds a fourth. This workflow's own job names are NOT among
+# them and cannot be — `needs:` does not span workflow files, as the bullet
+# above says. The coupling is the file's EXISTENCE, not its results.
+#
+# So a PR deleting this file and nothing else reds a required check the moment
+# it lands on main, and blocks every open PR until it is fixed. Loud, not
+# silent — but discovered on CI rather than here, which is the only reason this
+# paragraph exists.
+#
+# A RETIREMENT PR THEREFORE REMOVES THIS FILE AND THOSE SCRIPTS TOGETHER, in
+# one commit, and two more things travel with them: the `bench:hicasso`
+# disposition in that same checker gives its reason as "its sibling
+# `bench:freehand-browser` DOES yield a verdict, which is why that one is
+# scheduled (freehand-bench.yml)" — a bare `not-a-gate` declaration, so it rots
+# rather than reddens — and `implementation/scripts/
+# _rigorous-local-inventory.test.cjs` pins three claims about this file being
+# those commands' sole scheduled home.
+#
+# AND THE BUILD ID GOES TOO, or the removal trades one red for another.
+# `implementation/scripts/_browser-dom-lane-partition.test.cjs` holds
+# `:browser-test-freehand-bench` to having an executor (rf2-j8os), and
+# `bench:freehand-browser` IS that executor. That red is deliberate: the seven
+# `re-frame.freehand.bench.*` DOM suites run in a browser HERE and nowhere else
+# in CI, because `:browser-test` excludes them by negative lookahead
+# (rf2-mf4uy), so retiring their runner without deciding what becomes of them
+# is the one outcome nothing else would have announced. The staged order lives
+# in rf2-8z9q; this comment does not authorise any part of it.
+#
 # THE PIN. `runs-on` names an explicit runner image rather than
 # `ubuntu-latest`, and `RF2_HARDWARE_CLASS` names the class the numbers may
 # be compared within. Successive results are only comparable because both

--- a/implementation/scripts/_browser-dom-lane-partition.test.cjs
+++ b/implementation/scripts/_browser-dom-lane-partition.test.cjs
@@ -43,6 +43,8 @@ const path = require('path');
 const IMPL_DIR = path.resolve(__dirname, '..');
 const REPO_ROOT = path.resolve(IMPL_DIR, '..');
 const SHADOW_CLJS = path.join(IMPL_DIR, 'shadow-cljs.edn');
+const PACKAGE_JSON = path.join(IMPL_DIR, 'package.json');
+const GATE_SCHEDULING = path.join(REPO_ROOT, 'scripts', 'check_gate_scheduling.py');
 
 // The two lanes and the builds that own them.
 const CORRECTNESS_BUILD = ':browser-test';
@@ -128,6 +130,85 @@ function domTestNamespaces() {
     .sort((a, b) => a.ns.localeCompare(b.ns));
 }
 
+// ---- deriving the executors ------------------------------------------------
+//
+// rf2-j8os. A partition of SELECTORS is not a proof that both halves EXECUTE,
+// and the second half was held by nothing. `:browser-test-freehand-bench` is
+// the sole browser home of seven `re-frame.freehand.bench.*` DOM suites, and
+// the chain that ends in them running is three links long:
+//
+//   the build id  ->  the npm script that compiles it  ->  a workflow `run:`
+//
+// The first two assertions below hold the FIRST link. The third delegates the
+// second link to `scripts/check_gate_scheduling.py`, which already enforces
+// that every `test:` / `bench:` / `build:` script in `package.json` is either
+// reachable from an executable `run:` or carries a checked `DISPOSITIONS`
+// entry — and which runs in `verify-skill-mcp-drift`, a `needs:` of the
+// required `All required checks passed` aggregator.
+//
+// WHY DELEGATE RATHER THAN RE-DERIVE. Reading workflow `run:` values here
+// would put a second authority on "what counts as executable text" beside the
+// Python one, and that checker's own history is the argument against it: its
+// first cut matched raw YAML, so a `run:` line deleted while its explanatory
+// paragraph stayed put left the gate reading as scheduled (rf2-6ckzl). Two
+// implementations of that rule can disagree, and the one that disagrees
+// downward is a false green. So the link is delegated, not copied — and the
+// delegation is HELD rather than asserted in prose, because a claim about the
+// world in a comment is exactly what this file exists to stop trusting: the
+// executor must carry a prefix that checker asks about, and must not carry a
+// `DISPOSITIONS` entry excusing it from the question. Both are read out of the
+// Python source rather than restated here, for the rf2-k41ph reason a copy is
+// a second authority with nothing holding it in step.
+//
+// WHAT THIS DOES NOT CLOSE. Someone may still add a `DISPOSITIONS` entry for a
+// lane's executor — and this arm will red and make them argue it, which is the
+// whole difference between a decision and an accident. What it does close is
+// the silent path: delete `freehand-bench.yml` and the four `package.json`
+// scripts it is the sole home of (rf2-vyqq), and before this arm every gate in
+// the repo stayed green while seven mounted DOM suites ran nowhere.
+
+// `shadow-cljs <verb> <build-id> ...` is the only way a build id is executed.
+// Whole tokens, never a substring test: `browser-test` is a prefix of
+// `browser-test-freehand-bench`, so `includes()` would report the correctness
+// lane's script as the bench lane's executor too — the same prefix trap
+// `check_gate_scheduling.py`'s `_PROBE_TAIL` was added for.
+function buildIdsInvokedBy(body) {
+  const ids = new Set();
+  for (const m of body.matchAll(/shadow-cljs\s+(?:compile|release|watch)\s+([^&|;<>]*)/g)) {
+    for (const token of m[1].trim().split(/\s+/)) {
+      if (token && !token.startsWith('-')) ids.add(token);
+    }
+  }
+  return ids;
+}
+
+function executorsOf(scripts, buildId) {
+  return Object.keys(scripts)
+    .filter((name) => buildIdsInvokedBy(scripts[name]).has(buildId))
+    .sort();
+}
+
+// The families `check_gate_scheduling.py` asks the scheduling question about.
+function gatePrefixes() {
+  const src = fs.readFileSync(GATE_SCHEDULING, 'utf8');
+  const decl = src.match(/^GATE_PREFIXES\s*=\s*\(([^)]*)\)/m);
+  assert.ok(decl, 'scripts/check_gate_scheduling.py declares no GATE_PREFIXES tuple');
+  const prefixes = [...decl[1].matchAll(/"([^"]+)"/g)].map((m) => m[1]);
+  assert.ok(prefixes.length > 0, 'GATE_PREFIXES parsed as empty — the derivation is broken');
+  return prefixes;
+}
+
+// The scripts that checker excuses from needing a workflow home.
+function dispositionKeys() {
+  const src = fs.readFileSync(GATE_SCHEDULING, 'utf8');
+  const at = src.indexOf('DISPOSITIONS: dict[str, dict] = {');
+  assert.ok(at > -1, 'scripts/check_gate_scheduling.py declares no DISPOSITIONS dict');
+  const rest = src.slice(at);
+  const ends = rest.indexOf('\n}\n');
+  const body = ends > -1 ? rest.slice(0, ends) : rest;
+  return new Set([...body.matchAll(/^ {4}"([^"]+)":\s*\{/gm)].map((m) => m[1]));
+}
+
 // ---- the gate --------------------------------------------------------------
 
 test('the two browser DOM lanes partition every *_dom_cljs_test namespace (rf2-mf4uy)', () => {
@@ -189,6 +270,45 @@ test('the bench lane is exactly the Freehand bench DOM suites (rf2-mf4uy)', () =
     `the evidence lane picked up namespaces outside re-frame.freehand.bench.*, ` +
       `which means ordinary correctness suites left the PR gate:\n  ${stray.join('\n  ')}`,
   );
+});
+
+test('every browser DOM lane has an executor CI is held to running (rf2-j8os)', () => {
+  const text = fs.readFileSync(SHADOW_CLJS, 'utf8');
+  const scripts = JSON.parse(fs.readFileSync(PACKAGE_JSON, 'utf8')).scripts || {};
+  const prefixes = gatePrefixes();
+  const declared = dispositionKeys();
+  const namespaces = domTestNamespaces();
+
+  for (const buildKey of [CORRECTNESS_BUILD, BENCH_BUILD]) {
+    const buildId = buildKey.slice(1);            // `:browser-test` -> `browser-test`
+    const selector = selectorFor(text, buildKey);
+    const selected = namespaces.filter(({ ns }) => selector.test(ns)).map(({ ns }) => ns);
+    const carried = `it selects ${selected.length} DOM suite(s):\n  ${selected.join('\n  ')}`;
+
+    const executors = executorsOf(scripts, buildId);
+    assert.ok(
+      executors.length > 0,
+      `no script in implementation/package.json runs \`shadow-cljs compile|release|watch ` +
+        `${buildId}\`, so the ${buildKey} lane has nothing that executes it — and ${carried}`,
+    );
+
+    const asked = executors.filter((n) => prefixes.some((p) => n.startsWith(p)));
+    assert.ok(
+      asked.length > 0,
+      `the ${buildKey} lane is executed only by ${executors.join(', ')}, and no such name ` +
+        `starts with one of ${prefixes.join(' / ')} — so check_gate_scheduling.py never asks ` +
+        `whether a workflow runs it, and this lane can lose its CI home in silence. ` +
+        `Rename the script into a scanned family, or widen GATE_PREFIXES. Meanwhile ${carried}`,
+    );
+
+    const held = asked.filter((n) => !declared.has(n));
+    assert.ok(
+      held.length > 0,
+      `every executor of the ${buildKey} lane (${asked.join(', ')}) carries a DISPOSITIONS ` +
+        `entry in scripts/check_gate_scheduling.py, which excuses it from needing a workflow ` +
+        `home — so nothing now requires this lane to run anywhere in CI, and ${carried}`,
+    );
+  }
 });
 
 let failed = 0;


### PR DESCRIPTION
Closes **rf2-j8os** (P2) and **rf2-vyqq** (P2), both from the rf2-m08s CI cleanup audit.

Neither bead deletes `freehand-bench.yml`. Both make the hidden coupling visible so
the deletion is safe when it comes. The staged retirement order stays in **rf2-8z9q**;
nothing here retires anything.

---

## Bead 1 — rf2-j8os: the partition test proved selectors, not execution

`implementation/scripts/_browser-dom-lane-partition.test.cjs` derived both
`:ns-regexp`s from `shadow-cljs.edn` and proved they PARTITION the repo's
`*_dom_cljs_test` namespaces. A partition of selectors is not a proof that both
halves execute, and nothing held the second half.

### The hollow gate, measured

Delete `bench:freehand-browser` from `implementation/package.json` — the executor of
`:browser-test-freehand-bench` — and run the **pre-change** file:

```
DEFECT 1 (executor script deleted) -- PRE-CHANGE test: exit 0
browser-dom-lane-partition tests: 2 passed.
```

Green. The selectors still partition. `check_gate_scheduling.py` says nothing either,
because it only asks about scripts that exist. Seven mounted DOM suites run nowhere in
CI and every gate in the repo is green.

### The shape chosen, and the argument for it

The chain that ends in those seven suites running is three links long:

```
the build id  ->  the npm script that compiles it  ->  a workflow `run:`
```

**The new arm holds the first link and delegates the second.** It derives, for each of
the two lane build ids, which `package.json` script invokes
`shadow-cljs compile|release|watch <id>`, and asserts (1) one exists, (2) it carries a
prefix `check_gate_scheduling.py` scans, and (3) it carries no `DISPOSITIONS` entry
excusing it from the scheduling question. Given all three, that checker — which runs as
a step of `test.yml`'s `verify-skill-mcp-drift`, a `needs:` of the required
`All required checks passed` — is obliged to find the script in an executable `run:` or
hard-fail.

**Why not re-derive workflow reachability here.** Reading `run:` values in JS would put a
second authority on "what counts as executable text" beside the Python one, and that
checker's own history is the argument against two: its first cut matched raw YAML, so a
`run:` line deleted while its explanatory paragraph stayed put left the gate reading as
scheduled (rf2-6ckzl). Two implementations of that rule can disagree, and the one that
disagrees downward is a false green — the exact failure class both files exist to close.

**Why the delegation is held rather than written down.** A comment saying "the other
checker covers this" is a claim about the world, and claims rot; `check_gate_scheduling
.py`'s own header says so. So assertions (2) and (3) hold the two conditions under which
the delegation is true, and both `GATE_PREFIXES` and the `DISPOSITIONS` keys are read out
of the Python source rather than restated — the rf2-k41ph posture this file already takes
toward `shadow-cljs.edn`.

**Build ids are matched as whole tokens.** `browser-test` is a prefix of
`browser-test-freehand-bench`, so `includes()` would report the correctness lane's script
as the bench lane's executor too — the same trap `_PROBE_TAIL` was added for one file over.

**Scope.** Three assertions and two six-line derivations, in the file that already owns
this relationship. No new file, no framework, no change to `shadow-cljs.edn` (hot zone,
untouched).

### Red, against all three defects it exists to catch

Each planted byte-exactly, run, restored from a byte backup, restore verified by
**sha256** — a diff would pass a CRLF→LF flattening.

| Planted defect | Raw exit | What it said |
|---|---|---|
| **1.** executor script deleted (the rf2-vyqq retirement recipe) | `1` | `no script in implementation/package.json runs `shadow-cljs compile\|release\|watch browser-test-freehand-bench`, so the :browser-test-freehand-bench lane has nothing that executes it — and it selects 7 DOM suite(s): …` |
| **2.** executor renamed out of `GATE_PREFIXES` | `1` | `…and no such name starts with one of test: / bench: / build: — so check_gate_scheduling.py never asks whether a workflow runs it, and this lane can lose its CI home in silence` |
| **3.** executor given a `DISPOSITIONS` excuse | `1` | `…which excuses it from needing a workflow home — so nothing now requires this lane to run anywhere in CI` |

Each message names the seven namespaces it is about, so the red says what was lost rather
than which string stopped matching.

```
package.json:              9668997dfaa42c9446fc58776c61a528420bc8ca8c879019b5e6da58791497d0  match=True  CRLF/bareLF (86, 0)
check_gate_scheduling.py:  0b4e52f0bd67570d19bca3c1bd6c9186007db46103f809a3bdcf7d04fbc0c64f  match=True  CRLF/bareLF (728, 0)
```

### What this deliberately does not close

Defect 3 is a *deliberate, written* declaration, and the arm makes someone argue it rather
than forbidding it. What it closes is the silent path — and that path is precisely the one
bead 2 prescribes for retirement.

---

## Bead 2 — rf2-vyqq: the file is load-bearing for the merge gate and said so nowhere

Comment only, in `.github/workflows/freehand-bench.yml`.

### Re-count: FOUR, not three

The bead's title said three; its body named four. **It is four.** Measured by re-running
`check_gate_scheduling.py`'s own closure over the workflow corpus with the file removed:

```
gate commands: 51; scheduled with freehand-bench.yml: 43; without: 39

SOLE-HOMED IN freehand-bench.yml (gate-prefixed): 4
  bench:freehand-browser
  bench:freehand-node
  build:freehand-matched
  test:freehand

non-gate scripts also sole-homed there: 1
  clean:freehand-matched

audit() violations if freehand-bench.yml deleted alone: 4
  - bench:freehand-browser: defined in implementation/package.json, invoked by no workflow, …
  - bench:freehand-node: …
  - build:freehand-matched: …
  - test:freehand: …
```

`test.yml` names `test:freehand` and `build:freehand-matched` in **prose only**, which is
exactly what rf2-6ckzl stopped counting. `clean:freehand-matched` is sole-homed too and
goes unremarked only because its prefix is outside the scanned families — recorded in the
comment so a deleter is not surprised by the asymmetry.

### The ruleset, queried — not inferred from a PR rollup

```
$ gh api repos/day8/re-frame2/rulesets
[{"id":16120663,"name":"main","target":"branch","source_type":"Repository",
  "source":"day8/re-frame2","enforcement":"active", …}]

$ gh api repos/day8/re-frame2/rules/branches/main
[{"type":"deletion", …},{"type":"non_fast_forward", …},{"type":"required_linear_history", …},
 {"type":"required_status_checks","parameters":{"strict_required_status_checks_policy":false,
   "do_not_enforce_on_create":false,
   "required_status_checks":[{"context":"All required checks passed"},
                             {"context":"Lint required"},
                             {"context":"Docs required"}]}, …}]

$ gh api repos/day8/re-frame2/branches/main/protection
{"message":"Branch not protected", …, "status":"404"}
gh: Branch not protected (HTTP 404)
```

PR #8101's finding still holds: exactly three required contexts, classic branch protection
absent. The chain to the gate, each link verified in this worktree:

`check_gate_scheduling.py` → a step of `test.yml`'s **`verify-skill-mcp-drift`** job
(`test.yml:666-673`, inside the job opened at `test.yml:162`) → listed in
**`all-required-passed`**'s `needs:` (`test.yml:6196`) → **`All required checks passed`**.

**Not repeating #8101's error in reverse.** The new block claims no requirement it has not
verified: it states plainly that this workflow's own job names are NOT required and cannot
be — `needs:` does not span workflow files, which the header's existing bullet already
says — and that the coupling is the file's **existence**, not its results.

### Confirmation that nothing moved

Comment-only, and PyYAML says so. Decoded and re-encoded as **explicit UTF-8 on both
sides**, so the Windows ANSI codepage cannot mojibake an em-dash into phantom drift:

```
before sha256: 0939c51c15df3a82e4afbb99bb0534f430260d3c295e29983a35b830f1fc922d
after  sha256: 0939c51c15df3a82e4afbb99bb0534f430260d3c295e29983a35b830f1fc922d
IDENTICAL: True

job ids   : True  ["evidence", "react-evidence", "browser-evidence"]
job names : True  ["Freehand B-spine evidence (pinned worker)", "… ClojureScript lane …", "… browser lane …"]
needs     : True  [null, null, null]
job if    : True
all ifs   : True   (recursive walk, every `if:` at any depth)
triggers  : True  {"schedule": [{"cron": "41 5 * * *"}], "workflow_dispatch": null}
runs-on   : True
step names: True
run:      : True
```

No job, `needs:`, `if:`, trigger, `runs-on`, step name, `run:` value or check name moved.

---

## Quality gates

Every exit code below is the `$?` captured on the same command line as the redirect, in
one shell — **not** the harness's.

| Gate | Before | After | Raw exit |
|---|---|---|---|
| `python scripts/check_gate_scheduling.py --verbose` | 51 cmds, 43 scheduled, 8 declared | 51 cmds, 43 scheduled, 8 declared | `0` |
| `python scripts/check_gate_scheduling.py --self-test` | all checks passed | all checks passed | `0` |
| `python scripts/check_fast_pr_gap.py --list` | 96 | 96 | `0` |
| `python scripts/check_ci_reproduce_commands.py` | — | 41 checker steps in sync | `0` |
| `python scripts/check_test_lane_bijection.py` | — | 1940 files, 49 lanes, all selected | `0` |
| `npm run test:script-policy` (the lane that runs the edited test) | — | `browser-dom-lane-partition tests: 3 passed.` | `0` |
| PyYAML parse + shape dump of `freehand-bench.yml` | sha `0939c51c…` | sha `0939c51c…` | `0` |
| **Post-rebase re-run of all of the above** | — | unchanged | `0` each |

### Gate discrimination — negative controls, each planted at a line this PR adds

**`check_fast_pr_gap.py` is flat at 96, and that is correct, not inert.** Per #8101 its
read universe is exactly `test.yml`, `lint.yml`, `docs.yml`; neither edited file is in it.
No 96 → 97 discriminator was chased there. The worktree-read proof comes from the gates
that do read these files.

| Control | Planted at | Raw exit / reading | Restore |
|---|---|---|---|
| **A** — JS validity, bead 1 | line 175, the `buildIdsInvokedBy` signature this PR adds | `1` — `…\benchdep-cluster\implementation\scripts\_browser-dom-lane-partition.test.cjs:176  SyntaxError: Unexpected token 'const'`, and the path names **this** worktree | sha256 `0184c402…` matched, 328 CRLF / 0 bare LF |
| **B** — YAML validity, bead 2 | line 29, the first line of the block this PR adds | `1` — `yaml.parser.ParserError` | sha256 `c966e759…` matched, 551 CRLF / 0 bare LF |
| **C** — worktree read by the implicated gate | same line 29, replaced with `run: npm run test:security` (a currently `covered-by`-declared gate) | `43 scheduled, 8 declared` → **`44 scheduled, 7 declared`** | same sha256 `c966e759…` matched |

Restores are verified by **hashing the bytes**, never by diff.

---

## Premises that did not hold

1. **"three package.json gates"** (rf2-vyqq's title) — it is **four**. The bead's own body
   named four; the title undercounted. Re-measured above.
2. **"deleting the bench workflow loses seven mounted DOM suites silently"** (rf2-j8os) —
   deleting *the workflow alone* is **loud**: it reds `check_gate_scheduling.py`, hence a
   required check, which is rf2-vyqq's finding. The genuinely silent path is the one
   rf2-vyqq prescribes as the retirement recipe: **workflow and its four sole-homed scripts
   removed together**, leaving the build id selecting seven suites nothing runs. That is
   the path bead 1's arm closes, and it is narrower and sharper than the bead stated. The
   two beads' findings compose into one hazard, which is why they land in one PR.
3. **The brief's `check_fast_pr_gap.py` expectation** — the brief already flagged this from
   #8101, and it held: flat 96 is correct for a change confined to these two files.

## Fence

`implementation/shadow-cljs.edn` — **not touched**. The negative-lookahead selector stays
exactly as rf2-mf4uy left it; option (b) from the bead (dropping the lookahead) would
re-incur the 71% wall-clock cost and is a hot-zone change besides.
`.github/workflows/portability.yml` — not touched. `spec/*`, `implementation/deps.edn` —
not touched. `npm run test:hicasso-hmr` — not run.

Diff is **174 insertions, 0 deletions** across two files. Nothing is reverted.
