### PR TITLE
fix(core): surface unowned framework refusals to the dev browser console (rf2-fu75)

### DIFF
--- a/implementation/core/src/re_frame/error_emit.cljc
+++ b/implementation/core/src/re_frame/error_emit.cljc
@@ -54,6 +54,7 @@
   redaction surface on this path."
   (:require [re-frame.elision        :as elision]
             [re-frame.emit-substrate :as emit]
+            [re-frame.interop        :as interop]
             [re-frame.late-bind      :as late-bind]
             [re-frame.source-coords  :as source-coords]
             [re-frame.trace          :as trace]))
@@ -85,6 +86,96 @@
   "Drop every registered listener. Test-isolation only; production
   code should never call this. Returns nil."
   (:clear registry))
+
+;; ---- unowned-error dev console fallback (rf2-fu75) ------------------------
+;;
+;; RULED (rf2-fu75, 2026-08-13): an UNTOOLED dev build DOES surface a
+;; framework refusal. Before this, a captured refusal reached NO channel at
+;; all unless the app had attached an `:errors` listener — measured, not
+;; inferred: `dispatch` / `dispatch-sync` return normally (the interceptor
+;; chain captures into `:rf/interceptor-error`; `router/emit-pipeline-
+;; exception!` states the reason — "the drain must not abort"), nothing is
+;; thrown, and nothing was printed. A typo'd event id produced literally
+;; nothing. That trap cost rf2-06lp four browser runs and rf2-e4y9 a full
+;; escalate-investigate-exonerate cycle.
+;;
+;; The fallback is deliberately the narrowest thing that removes it:
+;;
+;;   * `console.error`, NOT `js/reportError`. `reportError` reports "in the
+;;     same fashion as an unhandled exception" (HTML Standard) — it
+;;     dispatches a genuine window `error` event, and
+;;     `implementation/scripts/run-browser-tests.cjs` treats console output
+;;     as diagnostic-only but FAILS an otherwise-green run on ANY
+;;     `pageerror` ("only pageerror is fatal", rf2-mwx08). Several suites
+;;     exercise promoted refusals on purpose, so `reportError` would convert
+;;     expected framework outcomes into runner failures. It is also
+;;     semantically false here: a refusal is CAUGHT and normalised, and
+;;     categories such as `:rf.error/no-such-handler` carry no exception at
+;;     all, so it would synthesise an `Error` whose stack points at the
+;;     reporting site rather than at the cause. (The two in-repo
+;;     `reportError` sites — `freehand/root.cljs`, `substrate/spine.cljs` —
+;;     preserve React's OWN default for uncaught / recoverable React
+;;     callback errors. Different situation; untouched by this.)
+;;
+;;   * ONLY while the listener registry is EMPTY. Registering ANY `:errors`
+;;     listener (`rf/register-listener! :errors …` →
+;;     [[register-error-listener!]]) takes corpus-wide OWNERSHIP and the
+;;     fallback goes quiet — even if that listener ignores this category or
+;;     itself throws. That self-suppression is what keeps this from being a
+;;     nag-diagnostic, and it is why there is NO suppression knob and no new
+;;     API: the off-switch is the listener an owning app already has.
+;;     Dropping the last listener resumes the fallback. Xray does NOT
+;;     populate this registry (it rides the dev-only TRACE axis — `router`
+;;     forwards to `trace/emit-error!`), so a console line may coexist with
+;;     an Xray row; the tutorial already frames console + Xray as
+;;     complementary and the duplication is accepted.
+;;
+;;   * DEV + BROWSER-HOSTED only. `interop/debug-enabled?` (`@define`
+;;     `goog/DEBUG`) is the outer gate, so `:advanced` + `goog.DEBUG=false`
+;;     constant-folds the entire body away — neither the prefix literal nor
+;;     the call path survives into a production artefact. A bare
+;;     `#?(:cljs …)` would be too broad: Node-targeted CLJS and CLJS SSR
+;;     have a console too and stay listener-only, for exactly the reason the
+;;     JVM lane does — those are REPL / test / server lanes where the caller
+;;     observes the dispatch directly and a listener is one line, and
+;;     neither measured incident happened there. `js/document` presence is
+;;     this repo's DOM-host discriminator (see
+;;     `resources/revalidate_listeners.cljc`).
+;;
+;; The record goes to the console AS A VALUE, with the original
+;; `:exception` object as its own separate argument when the category
+;; carries one — never a flattened string, so the host's inspector renders
+;; the structure and the real stack survives. Consequence, accepted rather
+;; than engineered around: the record's raw `:exception` (the deliberate
+;; advanced-listener contract) now also reaches a local dev console.
+;; Per-category ownership, sink discovery, a formatter, deduplication and a
+;; suppression setting all stay REJECTED as premature.
+;;
+;; Everything is try/catch wrapped: observability must never abort the drain.
+
+(defn- report-unowned-error!
+  "Print `record` to the browser console when NOTHING owns it. Dev builds
+  only, browser hosts only, and only while the corpus-wide `:errors`
+  listener registry is EMPTY — see §Unowned-error dev console fallback
+  above for why each of those three conditions is load-bearing.
+
+  A no-op on the JVM, on Node-targeted CLJS (and CLJS SSR), and in any
+  `goog.DEBUG=false` build, where the whole body constant-folds away.
+  Never throws. Returns nil."
+  [record]
+  #?(:clj nil
+     :cljs
+     (when interop/debug-enabled?
+       (try
+         (when (and (empty? @listeners)
+                    (exists? js/document)
+                    (exists? js/console)
+                    (fn? (.-error js/console)))
+           (if-some [ex (:exception record)]
+             (.error js/console "[re-frame2]" record ex)
+             (.error js/console "[re-frame2]" record)))
+         (catch :default _ nil))
+       nil)))
 
 ;; ---- kind-aware source-coord lookup --------------------------------------
 ;;
@@ -428,6 +519,11 @@
            ;; Elision is callback-bearing. Corpus sibling fanout is one
            ;; already-linearized publication; frame routing is a later one.
            (when (trace/continuation-live?)
+             ;; rf2-fu75 — decided immediately before publication, under the
+             ;; SAME continuation/ownership conditions, exactly once per
+             ;; fully built record. Fires only when the registry is empty, so
+             ;; the fan-out below is a no-op whenever this printed.
+             (report-unowned-error! record)
              ((:fan-out registry) record trace/continuation-live?)
              ;; EP-0015 §9: frame-owned observability sink route. Pass the RAW
              ;; event so the sink projects under its own egress profile rather
@@ -669,6 +765,11 @@
   but the bare frame id can no longer name A's sink policy and must not resolve
   to a same-id successor B."
   [record route-frame?]
+  ;; rf2-fu75 — the union-record fan-out site's half of the unowned-error dev
+  ;; console fallback. Same rule as `dispatch-on-error!`: immediately before
+  ;; publication, under the same (here unconditional) conditions, exactly once
+  ;; per record, and only while the registry is empty.
+  (report-unowned-error! record)
   ((:fan-out registry) record trace/continuation-live?)
   (when (and route-frame? (trace/continuation-live?))
     (when-let [route-error-record! (late-bind/get-fn-cached

--- a/implementation/core/test/re_frame/error_emit_dev_console_dom_cljs_test.cljs
+++ b/implementation/core/test/re_frame/error_emit_dev_console_dom_cljs_test.cljs
@@ -1,0 +1,273 @@
+(ns re-frame.error-emit-dev-console-dom-cljs-test
+  "rf2-fu75 — the unowned-error dev console fallback in
+  `re-frame.error-emit`.
+
+  RULED (2026-08-13): an untooled dev build DOES surface a framework
+  refusal, via a dev-build console.error fallback that fires ONLY when the
+  corpus-wide `:errors` listener registry is EMPTY. Not `reportError`; no
+  new API knob; browser-hosted dev builds only.
+
+  This suite is the two-way control the ruling asks for, and BOTH halves are
+  the contract:
+
+    - with an EMPTY registry a promoted refusal reaches the console exactly
+      once, as `[\"[re-frame2]\" <record> <exception>]` — the structured
+      record and the ORIGINAL exception as separate console ARGUMENTS, never
+      a rendered string (console presentation is implementation-defined);
+    - with ANY `:errors` listener attached the fallback is SILENT — that is
+      what stops it being the nag-diagnostic the ruling avoided. Ownership
+      is corpus-wide and implicit: a listener that ignores the category, or
+      one that itself throws, still owns the stream. Dropping the last
+      listener resumes the fallback.
+
+  And, in every case, ZERO `reportError` calls. `reportError` reports \"in
+  the same fashion as an unhandled exception\" (HTML Standard), which
+  Chromium turns into a `pageerror` — and
+  `implementation/scripts/run-browser-tests.cjs` fails an otherwise-green
+  run on any `pageerror` while treating console output as diagnostic-only
+  (\"only pageerror is fatal\", rf2-mwx08). Suites elsewhere in this bundle
+  exercise promoted refusals deliberately, so the no-`reportError`
+  assertion is what keeps this addition off the runner's fatal channel.
+
+  ## Why the ns is `-dom-cljs-test`
+
+  The `-dom-cljs-test$` suffix puts this namespace on the `:browser-test`
+  build (the only lane with a real browser host, where the fallback is
+  live), and the broader `cljs-test$` regexp ALSO puts it on the always-on
+  `:node-test` build — where it runs the other half of the host boundary:
+  Node-targeted CLJS has a `console` too and must stay listener-only, so
+  the Node lane asserts SILENCE for the same refusal. One file, both sides
+  of the boundary, neither able to drift from the other.
+
+  The JVM / SSR lane is listener-only by the same rule and needs no
+  counterpart here: `#?(:clj …)` in `report-unowned-error!` is `nil`."
+  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.error-emit :as error-emit]
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.test-support :as test-support]))
+
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture
+    {:adapter plain-atom/adapter
+     :init-fn (fn []
+                ;; The listener registry is a `defonce` atom that survives
+                ;; test re-runs, and EMPTINESS is the whole condition under
+                ;; test here — a listener leaked from a sibling test would
+                ;; silently invert every assertion below.
+                (error-emit/clear-error-listeners!))}))
+
+(defn- browser?
+  "True only on a real DOM host. `js/document` presence is the same
+  discriminator the fallback itself uses."
+  []
+  (and (exists? js/document)
+       (some? (.-createElement js/document))))
+
+(defn- capture-console
+  "Run `thunk` with `console.error` swapped for a recorder and
+  `globalThis.reportError` swapped for a counter. Returns
+
+      {:console      [[arg …] …]   ;; one entry per call, ARGUMENTS not text
+       :report-error <int>}
+
+  Restores both, including when `thunk` throws. Arguments are kept
+  unflattened on purpose: the contract is what the framework PASSES, not
+  how a console chooses to render it."
+  [thunk]
+  (let [calls       (atom [])
+        reports     (atom 0)
+        orig-error  (.-error js/console)
+        orig-report (.-reportError js/globalThis)]
+    (set! (.-error js/console)
+          (fn [& args] (swap! calls conj (vec args)) nil))
+    (set! (.-reportError js/globalThis)
+          (fn [& _] (swap! reports inc) nil))
+    (try
+      (thunk)
+      (finally
+        (set! (.-error js/console) orig-error)
+        (set! (.-reportError js/globalThis) orig-report)))
+    {:console @calls :report-error @reports}))
+
+(defn- register-refusal-handlers! []
+  (rf/reg-event :fu75.console/throws
+                (fn [_ _] (throw (ex-info "kaboom" {:cause :test}))))
+  (rf/reg-event :fu75.console/foreign-fx
+                (fn [_ _] {:db {} :fu75.console/not-an-fx-key 1})))
+
+;; ===========================================================================
+;; EMPTY REGISTRY — the fallback fires, exactly once, with the right arguments
+;; ===========================================================================
+
+(deftest unowned-refusal-reaches-the-dev-console
+  (when (browser?)
+    (register-refusal-handlers!)
+    (testing "a throwing handler — one structured diagnostic, no reportError"
+      (let [{:keys [console report-error]}
+            (capture-console #(rf/dispatch-sync [:fu75.console/throws]))]
+        (is (= 1 (count console))
+            (str "exactly one console.error for one refusal; got "
+                 (pr-str (mapv first console))))
+        (let [[prefix record ex] (first console)]
+          (is (= "[re-frame2]" prefix) "the stable prefix leads")
+          (is (map? record) "the structured record rides as its OWN argument")
+          (is (= :rf.error/handler-exception (:error record)))
+          (is (= :fu75.console/throws (:event-id record)))
+          (is (= [:fu75.console/throws] (:event record)))
+          (is (= :rf/default (:frame record)))
+          (is (identical? ex (:exception record))
+              "the ORIGINAL exception object rides as its own argument")
+          (is (= "kaboom" (ex-message ex))
+              "and it is the handler's exception, not a synthesised one"))
+        (is (zero? report-error)
+            "no reportError — so no window `error` event and no pageerror")))
+
+    (testing "the effect-map envelope refusal — same shape"
+      (let [{:keys [console report-error]}
+            (capture-console #(rf/dispatch-sync [:fu75.console/foreign-fx]))]
+        (is (= 1 (count console)))
+        (is (= "[re-frame2]" (ffirst console)))
+        (is (= :rf.error/effect-map-shape (:error (second (first console)))))
+        (is (zero? report-error))))
+
+    (testing "an unregistered event id — the typo case, and it carries NO
+              exception, so the diagnostic is two arguments not three"
+      (let [{:keys [console report-error]}
+            (capture-console #(rf/dispatch-sync [:fu75.console/nothing-here]))]
+        (is (= 1 (count console)))
+        (let [args (first console)]
+          (is (= 2 (count args))
+              (str "prefix + record only — nothing synthesised to stand in for "
+                   "the absent exception; got " (count args) " arguments"))
+          (is (= "[re-frame2]" (first args)))
+          (is (= :rf.error/no-such-handler (:error (second args))))
+          (is (nil? (:exception (second args)))))
+        (is (zero? report-error))))))
+
+(deftest unowned-diagnostic-does-not-change-control-flow
+  (when (browser?)
+    (register-refusal-handlers!)
+    (let [outcome (atom nil)]
+      (capture-console
+        (fn []
+          (reset! outcome
+                  (try (rf/dispatch-sync [:fu75.console/throws]) ::returned
+                       (catch :default e e)))))
+      (is (= ::returned @outcome)
+          "the refusal was still CAPTURED — printing it re-raises nothing"))))
+
+;; ===========================================================================
+;; NON-EVENT UNION RECORD — the second fan-out site follows the same rule
+;; ===========================================================================
+
+(deftest unowned-union-record-reaches-the-dev-console
+  (when (browser?)
+    (testing "`dispatch-error-record*`'s site — reached here through the
+              genuine frame-teardown report caller, a non-event union record
+              that carries no top-level `:exception`"
+      (let [{:keys [console report-error]}
+            (capture-console
+              (fn []
+                (error-emit/dispatch-frame-teardown-report!
+                  :rf/default
+                  [{:hook :fu75/step :exception (ex-info "teardown" {})
+                    :where :safe-call-hook!}]
+                  1234)))]
+        (is (= 1 (count console)))
+        (let [args (first console)]
+          (is (= 2 (count args)))
+          (is (= "[re-frame2]" (first args)))
+          (is (= :rf.error/frame-teardown-failed (:error (second args))))
+          (is (= 1 (count (:hook-failures (second args))))))
+        (is (zero? report-error))))))
+
+;; ===========================================================================
+;; OWNED — a listener suppresses the fallback, on BOTH fan-out sites
+;; ===========================================================================
+
+(deftest an-attached-listener-suppresses-the-fallback
+  (when (browser?)
+    (register-refusal-handlers!)
+    (let [seen (atom [])]
+      (rf/register-listener! :errors :fu75/owner
+                            (fn [record] (swap! seen conj record)))
+      (testing "the listener receives the record exactly once and the console
+                stays silent"
+        (let [{:keys [console report-error]}
+              (capture-console #(rf/dispatch-sync [:fu75.console/throws]))]
+          (is (= [:rf.error/handler-exception] (mapv :error @seen))
+              "the owner got its record")
+          (is (empty? console)
+              (str "and the fallback stayed quiet; got " (pr-str console)))
+          (is (zero? report-error))))
+
+      (testing "the union-record site is suppressed by the same ownership"
+        (reset! seen [])
+        (let [{:keys [console]}
+              (capture-console
+                (fn []
+                  (error-emit/dispatch-frame-teardown-report!
+                    :rf/default
+                    [{:hook :fu75/step :where :safe-call-hook!}]
+                    1234)))]
+          (is (= [:rf.error/frame-teardown-failed] (mapv :error @seen)))
+          (is (empty? console)))))))
+
+(deftest ownership-is-implicit-and-corpus-wide
+  (when (browser?)
+    (register-refusal-handlers!)
+    (testing "a listener that IGNORES the category still owns the stream —
+              ownership is the registration, not the handling"
+      (rf/register-listener! :errors :fu75/indifferent (fn [_record] nil))
+      (let [{:keys [console]}
+            (capture-console #(rf/dispatch-sync [:fu75.console/throws]))]
+        (is (empty? console))))
+
+    (testing "and so does one that THROWS — the substrate swallows the
+              listener throw, and the fallback must not read that as
+              nobody-owns-it"
+      (error-emit/clear-error-listeners!)
+      (rf/register-listener! :errors :fu75/broken
+                            (fn [_record] (throw (ex-info "listener boom" {}))))
+      (let [{:keys [console]}
+            (capture-console #(rf/dispatch-sync [:fu75.console/throws]))]
+        (is (empty? console))))))
+
+(deftest dropping-the-last-listener-resumes-the-fallback
+  (when (browser?)
+    (register-refusal-handlers!)
+    (rf/register-listener! :errors :fu75/owner (fn [_record] nil))
+    (let [owned (capture-console #(rf/dispatch-sync [:fu75.console/throws]))]
+      (is (empty? (:console owned)) "quiet while owned"))
+    (rf/unregister-listener! :errors :fu75/owner)
+    (let [unowned (capture-console #(rf/dispatch-sync [:fu75.console/throws]))]
+      (is (= 1 (count (:console unowned)))
+          "the registry is empty again, so the fallback resumes")
+      (is (= "[re-frame2]" (ffirst (:console unowned))))
+      (is (zero? (:report-error unowned))))))
+
+;; ===========================================================================
+;; HOST BOUNDARY — Node-targeted CLJS stays listener-only
+;; ===========================================================================
+
+(deftest node-targeted-cljs-stays-quiet
+  (when-not (browser?)
+    (register-refusal-handlers!)
+    (testing "same refusal, same empty registry, no DOM host: the fallback is
+              a browser-DEVELOPMENT diagnostic, not a generic CLJS print. A
+              Node lane's caller observes the dispatch directly and attaches
+              a listener in one line, exactly as the JVM lane does."
+      (let [{:keys [console report-error]}
+            (capture-console #(rf/dispatch-sync [:fu75.console/throws]))]
+        (is (empty? console)
+            (str "no console output off a DOM host; got " (pr-str console)))
+        (is (zero? report-error))))
+
+    (testing "and the record still reaches an attached listener — the
+              always-on axis is unchanged off-browser"
+      (let [seen (atom [])]
+        (rf/register-listener! :errors :fu75/owner
+                              (fn [record] (swap! seen conj record)))
+        (rf/dispatch-sync [:fu75.console/throws])
+        (is (= [:rf.error/handler-exception] (mapv :error @seen)))))))


### PR DESCRIPTION
Closes rf2-fu75.

An untooled dev build now surfaces a captured framework refusal. Until this, a
refusal reached **no channel at all** unless the app had attached an `:errors`
listener: `dispatch` / `dispatch-sync` return normally (the interceptor chain
captures into `:rf/interceptor-error`; `router/emit-pipeline-exception!` states
why — "the drain must not abort"), nothing is thrown, nothing was printed. A
typo'd event id produced literally nothing. That trap cost rf2-06lp four browser
runs and rf2-e4y9 a full escalate-investigate-exonerate cycle.

Executes the delegated ruling on the bead (cycle 1, 2026-08-13, ratified and
narrowed by cycle 2): a dev-build `console.error` fallback in `error_emit.cljc`
that fires **only when the error-listener registry is empty**; browser-hosted
dev only; **not** `reportError`; no new API knob; no JVM/SSR change.

## The fallback

One private helper, `report-unowned-error!`, invoked at **both** fan-out sites —
`dispatch-on-error!` (event-centric path) and `dispatch-error-record*`
(union-record path) — immediately before publication, under the same
continuation/ownership conditions, exactly once per fully built record. It is
**not** in `emit_substrate.cljc` (that substrate serves non-error events too) and
**not** installed as a registry member (that would change empty-registry
semantics and listener ordering).

```clojure
(defn- report-unowned-error! [record]
  #?(:clj nil
     :cljs
     (when interop/debug-enabled?
       (try
         (when (and (empty? @listeners)
                    (exists? js/document)
                    (exists? js/console)
                    (fn? (.-error js/console)))
           (if-some [ex (:exception record)]
             (.error js/console "[re-frame2]" record ex)
             (.error js/console "[re-frame2]" record)))
         (catch :default _ nil))
       nil)))
```

Three conditions, each load-bearing:

- **`interop/debug-enabled?`** — the `@define` `goog/DEBUG` gate, so `:advanced` +
  `goog.DEBUG=false` constant-folds the whole body away. Verified on a real
  artefact, not asserted from the mechanism (below).
- **A browser host.** `js/document` presence is this repo's DOM-host
  discriminator (`resources/revalidate_listeners.cljc`). A bare `#?(:cljs …)`
  would be too broad — Node-targeted CLJS and CLJS SSR have a console too and
  stay listener-only, for exactly the reason the JVM lane does. This is cycle
  2's binding narrowing.
- **An EMPTY registry.** Registering any `:errors` listener takes corpus-wide
  ownership and the fallback goes quiet — even if that listener ignores the
  category or itself throws. Dropping the last listener resumes it. That
  self-suppression *is* the off-switch, which is why there is no suppression
  knob and no new API surface.

The record goes to the console as a **value**, with the original `:exception`
object as its own separate argument when the category carries one — never a
flattened string, so the host's inspector renders the structure and the real
stack survives. Everything is try/catch wrapped: observability must never abort
the drain.

### Why not `reportError`

The dossier's original recommendation, overridden by the ruling on two grounds
this PR keeps:

1. `reportError` reports "in the same fashion as an unhandled exception" (HTML
   Standard) — it dispatches a genuine window `error` event, which Chromium
   turns into a `pageerror`, and `implementation/scripts/run-browser-tests.cjs`
   fails an otherwise-green run on **any** `pageerror` while treating console
   output as diagnostic-only ("only pageerror is fatal", rf2-mwx08). Suites in
   this bundle exercise promoted refusals on purpose, so that route converts
   expected framework outcomes into runner failures.
2. It is semantically false here: a refusal is caught and normalised, and
   `:rf.error/no-such-handler` carries no exception at all, so it would
   synthesise an `Error` whose stack points at the reporting site rather than at
   the cause.

The two in-repo `reportError` sites (`freehand/root.cljs`,
`substrate/spine.cljs`) preserve React's *own* default for uncaught/recoverable
React callback errors — a different situation, untouched here.

**Measured, not argued:** across six full browser-lane runs — including a plant
where the fallback fired on *every* promoted error in all 1485 tests — the log
contains **zero** occurrences of `pageerror`.

## The two-way control

`re-frame.error-emit-dev-console-dom-cljs-test` (new). The `-dom-cljs-test$`
suffix puts it on `:browser-test` (the only lane with a real browser host) and
the broader `cljs-test$` regexp *also* puts it on `:node-test` — so one file
carries both sides of the host boundary and neither can drift from the other.

- **Fires** on an empty registry: three refusal classes (throwing handler,
  `:rf.error/effect-map-shape`, `:rf.error/no-such-handler`), one diagnostic
  each, asserted on the console **call arguments** (prefix, record identity,
  original exception identity) — never on rendered text, which is
  implementation-defined. `:rf.error/no-such-handler` is asserted to arrive as
  *two* arguments, proving nothing is synthesised to stand in for the absent
  exception. Zero `reportError` calls in every case.
- **Silent** with a listener attached, on both fan-out sites; silent for a
  listener that ignores the category and for one that throws (ownership is the
  registration, not the handling); **resumes** after the last listener is
  unregistered.
- **Union record**: reached through the genuine `dispatch-frame-teardown-report!`
  caller, proving `dispatch-error-record*` follows the same rule.
- **Node lane**: same refusal, same empty registry, no DOM host → no console
  output, and the record still reaches an attached listener.
- Dispatch still returns normally — printing re-raises nothing.

The #8012 witness (`captured-refusal-escapes-no-caller-and-reaches-no-host-channel`)
**passes unedited**: it attaches a listener before dispatching, so the fallback
is suppressed throughout, and it deliberately asserts nothing about printing.

## Production erasure

`shadow-cljs release examples/counter` (`:advanced`, `goog.DEBUG=false` pinned
for release in that build's config) — the stable prefix literal `[re-frame2]`
occurs **0** times in `out/examples/counter/main.js`, while `error-emit`'s own
catalogue keywords (`rf.error/handler-exception`, `rf.error/no-such-handler`) are
present in the same artefact. So the absence is DCE, not "the namespace wasn't
compiled in". String literals survive `:advanced`, which is what makes this a
proof rather than a symbol-renaming artefact.

## spec/009 — STOPPED, not edited

Channel #5's closing sentence at `spec/009-Instrumentation.md:1285` is now
**stale**:

> **With no `:errors` listener attached — and, in a dev build, no trace consumer
> such as Xray — a framework-captured failure is invisible: nothing throws,
> nothing prints.**

`nothing prints` is false for a browser dev build as of this PR. `spec/*` is hot
zone and sequential, so the correction is a separately sequenced dispatch, not
part of this one. The #8012 corrections at `:1327` and `:1394` are **unaffected**
— both are about `window.onerror` / a native SDK, which still see nothing a
cascade captured.

Checked and needing no edit: `docs/resources/tutorial/index.md:252` promises
every failure arrives "in the console **and** as a row in Xray". The tutorial app
registers no `:errors` listener, so that promise now **holds as written** —
previously the console half was unimplemented.

## Quality gates

Exit codes are the ones captured by `echo "EXIT=$?"` in the same shell as the
gate, redirected to a log — never a harness-reported status.

| Gate | Tree | Exit | Result |
|---|---|---|---|
| `npm run test:cljs` | pre-rebase | **0** | Ran 13836 tests / 69942 assertions. 0 failures, 0 errors. |
| `npm run test:browser` | pre-rebase, control | **0** | Ran 1485 tests / 9242 assertions. 0 failures, 0 errors. 0 `pageerror`. |
| `npm run test:browser` | **PLANT A** — empty-registry condition removed | **1** | 1485 / 9242 (unchanged). 5 failures — exactly the five suppression assertions. 0 `pageerror`. |
| `npm run test:browser` | **PLANT B** — `dispatch-error-record*` call removed | **1** | 1485 / 9242 (unchanged). 5 failures — only the union-record test; the event-path tests stayed green. |
| `npm run test:browser` | **PLANT C** — `dispatch-on-error!` call removed | **1** | 1485 / 9242 (unchanged). 17 failures — only the event-path tests and the "resumes" half; the union-record test stayed green. |
| `npx shadow-cljs release examples/counter` | restored | **0** | Advanced artefact carries 0 occurrences of the prefix literal. |
| `npm run test:browser` | **post-rebase, final** | **0** | Ran 1485 tests / 9242 assertions. 0 failures, 0 errors. 0 `pageerror`. |
| `npm run test:cljs` | **post-rebase, final** | **0** | Ran 13836 tests / 69942 assertions. 0 failures, 0 errors. |
| `clojure -M:test -n re-frame.on-error-cljs-test` (JVM, focused) | post-rebase | **0** | Ran 47 tests / 189 assertions. 0 failures, 0 errors — the exact count the ruling names, and silent. |
| `npm run test:script-policy` | post-rebase | **0** | The new `*_dom_cljs_test` namespace partitions correctly across the two browser DOM lanes (`_browser-dom-lane-partition.test.cjs`). |

**The browser lane stayed green and no `pageerror` is produced** — that was the
whole defect of the rejected alternative, so it is the assertion this PR is
built around.

Each plant was scoped to the module and made an *assertion* failure, never a
crash: the namespace and assertion totals are identical (1485 / 9242) across the
control and all three plants, so no namespace was silently skipped. Plants B and
C are complementary — each reds only its own fan-out site's tests — which proves
both call sites are independently load-bearing and both halves of the test are
honest. Restores were verified by hashing bytes
(`sha256 0c646670a09d3dc1ca38b40b62a41404677aaa9b75baace0ec7e6f95b3c9f3c8`,
identical before and after every plant) with a clean `git status`.

Diff vs `origin/main`: 2 files, **+374 / −0** — nothing reverted.
`npm run test:hicasso-hmr` was not run (machine-exclusive lane, port 8061).
