### PR TITLE
docs(hicasso): synchronize three stale freeze-record carriers with the landed door (rf2-lu0s)

### DIFF
--- a/docs/design/hicasso/product/authoring-report-todo.md
+++ b/docs/design/hicasso/product/authoring-report-todo.md
@@ -114,6 +114,8 @@ An author who reads only the door and needs Enter-and-Escape reaches for the one
 
 *Candidate remedy:* one paragraph on the door — most naturally in `defview`'s docstring beside the intent-vector example — stating the four shapes a value at an `on-*` prop may take. Nothing about the runtime changes.
 
+*Since closed (2026-08-13).* The freeze filed this as `rf2-lu0s` and PR #8088 took the candidate remedy as written: `defview`'s docstring now carries a *FOUR shapes* section with the Enter/Escape key-map example and the central composition gate named. **The finding above stands unedited** — it records what the door was when this application was authored, which is the only thing a witness report is for.
+
 ### N2. A `reg-state` concern belongs to neither `subs` nor `events`, and the door does not say where to put it
 
 `h/reg-state` mints a subscription **and** an event under one keyword, so the keyword has no home in the two-namespace split every ordinary re-frame2 application uses. Declare it in `subs` and every write reads `[::subs/draft id text]`; declare it in `events` and every read reads `(h/sub [::events/draft id])`. Half the call sites are wrong either way, and the slice's `tags-open?` shows the first form.

--- a/docs/design/hicasso/product/facade-freeze.md
+++ b/docs/design/hicasso/product/facade-freeze.md
@@ -16,6 +16,18 @@ spellings remain in use everywhere, including in this page.
 The evidence this freeze reads is reported, not restated, in
 [`checkpoint-2-slice.md`](checkpoint-2-slice.md). Read it before quoting anything here.
 
+> **Amended 2026-08-13.** Three sentences on this page said, in the present tense, that the four
+> event-value shapes were missing from the public door — in
+> [§1](#1-the-membership-and-how-it-was-decided), in [§2](#2-the-frozen-laws) row 7, and in
+> [§6](#6-what-this-record-is-not). Each was true when this page was written and had stopped being true
+> before it merged: `rf2-lu0s` was fixed and closed by PR #8088, which put a *FOUR shapes* section in
+> `defview`'s docstring carrying the Enter/Escape key-map example and naming the central composition
+> gate. The three now read in the past tense and keep the finding, because a record that AGED is not a
+> record that was WRONG. Nothing else moves —
+> [§4](#4-the-one-law-that-could-not-be-applied) already reads the landed fix and what it reports that
+> fix published is unchanged, and [`correction-ledger.md`](correction-ledger.md) carries the closure
+> evidence clause by clause.
+
 ## Where each fact lives
 
 | Fact | Owner |
@@ -67,7 +79,8 @@ the claim that an ordinary application meets it.
 Beyond the nine and the three, the Todo class added exactly one thing to the union and **it is not a
 name**: the key-map shape at an `:on-*` prop, `{"Enter" […] "Escape" […]}`. It is why that
 application's `views.cljs` contains no callback at all. It is frozen as part of the event grammar in
-[§2](#2-the-frozen-laws) and it is missing from the door, which is `rf2-lu0s`.
+[§2](#2-the-frozen-laws), and it was missing from the door when this page was written, which is
+`rf2-lu0s` — since fixed and closed.
 
 **One member is frozen conditionally.** `reg-state` is on this list because two independent ordinary
 applications reached it, which is the evidence this freeze weighs. But
@@ -90,7 +103,7 @@ disagree the owner governs and this row is the defect.
 | 4 | Reads in branches and loops are legal, and a branch not taken contributes no edge. `use-subs` is the control: it declares its edge set, so an untaken branch still costs its edge. | §3.3; the facade's own two docstrings | slice `editor` (ambient, branching) vs `article-row` (grouped) |
 | 5 | React owns keys, refs, hooks, effects, errors, concurrency, hydration and component identity. | authoring law 4; §3.2 | Todo N4 (`:ref` identity); §4 hooks-not-in-a-body |
 | 6 | Event vectors are data. One explicit callback form. Ordinary `fn` values keep ordinary JavaScript callback semantics, and **position selects the contract**. | authoring law 5; §3.5; §4.1 | `impl.intent`'s position table; neither app needed the callback form once |
-| 7 | A value at an `on-*` prop takes one of four shapes: an intent vector, a key map, the one callback form, or a plain function passed through. | §4.1; ergonomics-api §Surface boundaries | Todo N1 — **and the door does not say so (`rf2-lu0s`)** |
+| 7 | A value at an `on-*` prop takes one of four shapes: an intent vector, a key map, the one callback form, or a plain function passed through. | §4.1; ergonomics-api §Surface boundaries | Todo N1 — **and the door did not say so when this page was written (`rf2-lu0s`, since fixed and closed)** |
 | 8 | Key maps are composition-gated centrally, so an IME's Enter commits nothing. | §4.1 *must make IME composition behavior explicit* | `impl.intent` `composing?`; `test:hicasso-controlled`, three engines |
 | 9 | Controlled fields are a framework law, not an application pattern: same-turn convergence, committed echo, rejection/normalization, caret and selection preservation, composition safety, and identity-preserving reset through an explicit revision. | §4.2; authoring law 6 | `test:hicasso-controlled` — 97 checks × 13 sections × 3 engines. **The revision half is witnessed there and by NEITHER ordinary application (`rf2-36bd`, closed); [§5](#5-what-is-not-in-the-ordinary-surface) states its real population.** |
 | 10 | Owned control attributes beat forwarded attributes by presence, not truthiness. | authoring law 7 | testbed `empty` arm (`""` is falsy and still wins) |
@@ -184,4 +197,5 @@ page would then have to be amended to admit, with its witness. It is not evidenc
 hot-path facades, which Phase 3 freezes from their own witnesses. And it is not a statement that
 every frozen law is witnessed by the Phase 2 applications: row 9's revision half is not — `rf2-36bd`
 measured that, the slice's inert bookkeeping came out, and the law keeps its own three-engine witness —
-and row 7 is witnessed in the applications and absent from the door, which is `rf2-lu0s`.
+and row 7 is witnessed in the applications and was absent from the door when this page was written,
+which is `rf2-lu0s`, since fixed and closed.

--- a/implementation/hicasso/test/re_frame/hicasso/examples/todo/views.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/examples/todo/views.cljs
@@ -33,9 +33,8 @@
      door tells authors they never need to open. That was rf2-lu0s, and
      it is fixed: `defview`'s docstring now carries a *FOUR shapes*
      section with this Enter/Escape example and the central composition
-     gate named. (The draft guide and
-     `docs/design/hicasso/authoring.md` teach it too; neither is what an
-     editor shows on `h/`.)
+     gate named. (The draft guide and `docs/design/hicasso/authoring.md`
+     teach it too; neither is what an editor shows on `h/`.)
 
   3. **A `:ref` must be a STABLE function**, so [[focus-on-mount]] is a
      top-level `def`. React detaches and re-attaches a ref whose identity

--- a/implementation/hicasso/test/re_frame/hicasso/examples/todo/views.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/examples/todo/views.cljs
@@ -22,15 +22,20 @@
      id] \"Escape\" [::h/clear db/draft id]}` is a first-class lowered
      shape — one `.key` lookup per event, composition-gated centrally so
      an IME's Enter commits nothing — and it is why this file contains no
-     callback at all. It is also **absent from the door**:
-     `re-frame.hicasso`'s own docstrings never mention it, and the only
-     statement of the four event-value shapes a runtime reader can reach
-     is `re-frame.hicasso.impl.intent`'s, in the namespace the door tells
-     authors they never need to open. (The draft guide and
-     `docs/design/hicasso/authoring.md` teach it; neither is what an
-     editor shows on `h/`.) Without it, the Todo class's Enter/Escape
-     pair reaches for the one callback form and a hand-written `.-key`
-     test — losing the composition gate with it.
+     callback at all. Without it, the Todo class's Enter/Escape pair
+     reaches for the one callback form and a hand-written `.-key` test —
+     losing the composition gate with it.
+
+     It was **absent from the door** when this application was written:
+     `re-frame.hicasso`'s own docstrings never mentioned it, and the only
+     statement of the four event-value shapes a runtime reader could
+     reach was `re-frame.hicasso.impl.intent`'s, in the namespace the
+     door tells authors they never need to open. That was rf2-lu0s, and
+     it is fixed: `defview`'s docstring now carries a *FOUR shapes*
+     section with this Enter/Escape example and the central composition
+     gate named. (The draft guide and
+     `docs/design/hicasso/authoring.md` teach it too; neither is what an
+     editor shows on `h/`.)
 
   3. **A `:ref` must be a STABLE function**, so [[focus-on-mount]] is a
      top-level `def`. React detaches and re-attaches a ref whose identity


### PR DESCRIPTION
Closes `rf2-lu0s` (reopened by the merged-PR audit of #8080).

`facade-freeze.md` merged carrying three sentences that say, in the **present tense**, that the four
event-value shapes are missing or absent from the public door. PR #8088 (`f96aaf8d73`) landed the
*What a value at an `on-*` prop may be — FOUR shapes* section in `defview`'s docstring **before**
`facade-freeze.md` merged, so all three were already false on arrival. Verified at my tip: the door
carries the section at `implementation/hicasso/src/re_frame/hicasso.cljc:107`, with the Enter/Escape
key-map example and the central composition gate named.

**The discriminator.** *Does this sentence describe the state NOW, or record what was true THEN?* A
present-tense claim that the door lacks the shapes is stale. A past-tense record of the finding, or a
record of its closure, is correct and is the audit trail. Records merged twelve seconds apart can
legitimately describe different worlds, so a record that **aged** must not be mistaken for one that
was **wrong** — nothing is erased here, and the three carriers keep their finding in the past tense
under one dated amendment note rather than being deleted.

## What changed

| Carrier | Was | Now |
|---|---|---|
| `facade-freeze.md` §1 (was `:70`) | "…and it **is** missing from the door, which is `rf2-lu0s`." | "…and it **was** missing from the door **when this page was written** … — since fixed and closed." |
| `facade-freeze.md` §2 row 7 (was `:93`) | *Witnessed by* cell: "Todo N1 — **and the door does not say so (`rf2-lu0s`)**" | "Todo N1 — **and the door did not say so when this page was written (`rf2-lu0s`, since fixed and closed)**" |
| `facade-freeze.md` §6 (was `:187`) | "…and row 7 is witnessed in the applications and **absent** from the door, which is `rf2-lu0s`." | "…and **was** absent from the door **when this page was written**, which is `rf2-lu0s`, since fixed and closed." |
| `facade-freeze.md` — new | — | One dated **Amended 2026-08-13** note after the intro, naming all three sites, the fixing PR, and why the finding is kept rather than erased. One note instead of three inline repetitions. |

**Verdict on the old line 93.** It **was** stale, and the stale half is the *Witnessed by* column only.
The row's Law column ("A value at an `on-*` prop takes one of four shapes…") and its Source column are
correct and untouched; the parenthetical "and the door does not say so" was the present-tense claim.

**Two further carriers of the same claim, found by `git grep` across tracked files, settled here:**

- `implementation/hicasso/test/re_frame/hicasso/examples/todo/views.cljs` — the Todo witness's ns
  docstring said "It **is** also **absent from the door**: `re-frame.hicasso`'s own docstrings never
  mention it…". Past-tensed with the closure recorded. Docstring prose only; no code, no runtime, no
  test assertion touched.
- `docs/design/hicasso/product/authoring-report-todo.md` N1 — the finding text is left **unedited**
  (it is a dated witness report and the finding was true when written); one *Since closed (2026-08-13)*
  line is appended, matching the same file's existing "has since" style used when finding 5 was
  withdrawn.

## What was deliberately left standing

- `facade-freeze.md` §4 — "`rf2-lu0s`'s fix put the exemption on the **door** too" — records the fix as
  landed. Correct.
- `checkpoint-2-slice.md:266`, `:288`, `:318` — past tense plus "**Fixed and `closed`** — PR #8088".
  Correct; this is the closure evidence.
- `correction-ledger.md:73` — the closed row with its clause-by-clause re-grep evidence. Correct.
- `checkpoint-2-slice.md:306` — "What *is* filed is that the door does not say which shapes it accepts
  at all (`rf2-lu0s`)". Borderline: framed as the content of a filing, and the same file records the
  closure twice. **Not touched, and the deciding reason is ownership** — `checkpoint-2-slice.md` is in
  flight right now under `rf2-5h9k` (`worker/editorgate-5h9k` has uncommitted edits to it, to
  `authoring-report-slice.md` and to `correction-ledger.md`). Editing it here would race that worker.
  Flagged for the mayor rather than taken.
- `spec/api-manifest-metadata.edn:191`, `spec/conformance/freehand/fixtures/fh-react-005.edn:27` —
  "absent from the door's JVM surface" is a different claim about `ns-publics`, not about these
  docstrings. Also `spec/**`, which is fenced.
- `docs/core/freehand/authoring/events-and-handlers.md:148` — "`:on-before-input` is not on the door"
  is Freehand and a different subject.

## Quality gates

`mkdocs build --strict` is **not** the gate for this change and was not run: `mkdocs.yml`'s
`exclude_docs` block keeps `design/hicasso/` out of the site, so a run over this tree exits green
having verified nothing. The gates that actually cover it, all foreground, invoked by absolute path,
redirected to a file with `$?` captured on the same command line — **captured** exit codes quoted:

| Gate | Captured exit |
|---|---|
| `python scripts/check_doc_slugs.py` (baseline, pre-rebase) | **0** |
| `python scripts/check_doc_slugs.py` (**sabotage plant**) | **1** |
| `python scripts/check_doc_slugs.py` (after restore) | **0** |
| `python scripts/check_doc_slugs.py` (**re-run on the final rebased base**) | **0** |
| `python scripts/check_provenance_pins.py --changed-since origin/main --verbose` (pre-rebase) | **0** |
| `python scripts/check_provenance_pins.py --changed-since origin/main --verbose` (**final base**) | **0** |
| ns-form reader check on the edited `.cljs` (docstring is a valid string, escapes intact) | **0** |

**Sabotage.** The `check_*.py` gates print no root banner, so the tree they read was proven by planting
a fault. `#6-what-this-record-is-not` became `#6-what-this-record-is-nott` on a single line in the new
amendment note; `git diff --numstat` confirmed `1 1`, so the plant was not a silent no-op. The gate went
**RED, captured exit 1**, naming the planted line:

    BROKEN ANCHOR: docs\design\hicasso\product\facade-freeze.md:22 -> #6-what-this-record-is-nott

The fault existed only in this worktree, so the red is the discrimination. Restore verified by hashing
bytes with `git hash-object` against the committed blob (not `sha256sum`, which this checkout's
line-ending translation can defeat): working `6a103bf71e3dc059424aa757ab41af24f4b8a2c6` equals committed
`6a103bf71e3dc059424aa757ab41af24f4b8a2c6`. The provenance gate reported `2 files, 0 cited pins`,
confirming it read this branch's changed set.

**Hand-verification, because nothing validates this tree's tables, rendering or nav.**

- **Table column counts.** The `## 2. The frozen laws` table is the only table touched (row 7). Pipe
  counts across the header, the separator and all fourteen rows: **5 pipes / 4 columns on every line**,
  row 7 included, unchanged from its neighbours. The edit is confined to the fourth cell's text and
  introduces no `|`.
- **Anchors.** The four links in the new amendment note were checked by hand and by the gate:
  `#1-the-membership-and-how-it-was-decided`, `#2-the-frozen-laws` and
  `#4-the-one-law-that-could-not-be-applied` are already used elsewhere on the page;
  `#6-what-this-record-is-not` is new and resolves to `## 6. What this record is not` under
  `pymdownx.slugs.slugify(case=lower)`, which is exactly what the sabotage run proved the gate checks.
  The relative link to `correction-ledger.md` resolves; the file is a sibling in the same directory.
- No heading was added, renamed or removed, so no existing inbound anchor moved.

**Revert check.** `git diff origin/main` was read for what it would silently revert, not just for
conflicts — `facade-freeze.md` is a shared design record. Every hunk is additive or a targeted tense
change on the exact stale clause; no region is replaced wholesale, and none of the three files another
live worker holds is touched.

## Scope

Prose only. No runtime change, no API change, no new documentation mechanism.
`implementation/hicasso/src/re_frame/hicasso.cljc` — the door — is **not touched**; it is already
correct and is what makes the three carriers stale. Nothing under `spec/**`. No `.beads/*` file.
