### PR TITLE
fix(hicasso): an inert macro form is not a fence claim (rf2-t9kd)

### DIFF
--- a/implementation/hicasso/scripts/check_example_fence_coverage.py
+++ b/implementation/hicasso/scripts/check_example_fence_coverage.py
@@ -42,8 +42,11 @@ WHAT IS CHECKED, IN ONE DIRECTION
 ---------------------------------
 Every package directly under `examples/` that holds application code is
 named by at least one `emit-application-namespaces` call somewhere under
-`examples/`.  That macro argument IS the fence's declaration of what it
-fences, which is what makes the PACKAGE -> FENCE mapping n:m rather than
+`examples/` that the reader actually EVALUATES — a disabled, quoted or
+commented-out call is not a claim about anything, and counting one let a
+package look covered by a fence that no longer ran (rf2-t9kd).  That macro
+argument IS the fence's declaration of what it fences, which is what makes
+the PACKAGE -> FENCE mapping n:m rather than
 1:1: `witness_surface_cljs_test.cljs` at the examples root names
 `…examples.editor` AND `…examples.grid`, so the cheap check — *every
 package directory contains a `surface_cljs_test.cljs`* — would false-red
@@ -130,17 +133,111 @@ CLAIM_RE = re.compile(
 STRING_RE = re.compile(r'"(?:[^"\\]|\\.)*"', re.S)
 COMMENT_RE = re.compile(r";.*")
 
+# `(comment …)` and not `(comment-on …)`: the lookahead is the symbol-tail
+# class, so only the bare core form opens a comment.
+COMMENT_FORM_RE = re.compile(r"\(\s*comment(?![\w.*+!?<>=$%&|:'/-])")
+
+OPENERS = "([{"
+CLOSERS = ")]}"
+
+
+def form_end(text, i):
+    """Index just past the ONE form beginning at or after `text[i]`.
+
+    `text` has already been through the string and line-comment passes, so
+    every remaining bracket is structural.  A character literal is the one
+    exception and is skipped whole: `\\(` is a paren that closes nothing,
+    and miscounting it would unbalance the rest of the file.
+    """
+    n = len(text)
+    while i < n and text[i].isspace():
+        i += 1
+    if i >= n:
+        return n
+    if text[i] == "\\":  # character literal: `\(`, `\;`, `\newline`
+        return min(i + 2, n)
+    if text[i] not in OPENERS:  # a bare symbol, keyword or number
+        while i < n and not text[i].isspace() and text[i] not in OPENERS + CLOSERS:
+            i += 1
+        return i
+    depth = 0
+    while i < n:
+        ch = text[i]
+        if ch == "\\":
+            i += 2
+            continue
+        if ch in OPENERS:
+            depth += 1
+        elif ch in CLOSERS:
+            depth -= 1
+            if depth == 0:
+                return i + 1
+        i += 1
+    return n
+
+
+def strip_inert(text):
+    """`text` with the three INERT form shapes blanked out (rf2-t9kd).
+
+    A form the reader discards is not a claim about anything, so a gate that
+    counted one could certify a package whose fence had been switched off:
+
+        #_(rg/emit-application-namespaces …)              reader discard
+        (comment (rg/emit-application-namespaces …))      comment macro
+        '(rg/emit-application-namespaces …)               quoted
+
+    Those three and no more.  DELIBERATELY NOT HANDLED, because none occurs
+    in this tree and a general Clojure reader is a far larger artefact than
+    this gate deserves: reader conditionals (`#?(:clj …)`), dead-by-value
+    branches (`(when false …)`, `(if false …)`), stacked discards (`#_#_`),
+    `#_` applied to a set or prefixed form (`#_#{…}`, `#_'x`), a
+    fully-qualified `(clojure.core/comment …)`, and `comment` shadowed by a
+    local binding.  Each of those still counts as a live claim; the failure
+    mode is a package looking covered, which is the same one this function
+    narrows rather than a new one.
+
+    Blanking preserves length and newlines so the surviving text keeps its
+    offsets, and the walk resumes at the END of each inert form — a live
+    claim sitting beside a disabled one still counts.
+    """
+    chars = list(text)
+    i, n = 0, len(text)
+    while i < n:
+        ch = text[i]
+        if ch == "\\":  # character literal, as in `form_end`
+            i += 2
+            continue
+        if text.startswith("#_", i):
+            start, body = i, i + 2
+        elif ch in "'`" and (i == 0 or text[i - 1].isspace() or text[i - 1] in OPENERS):
+            # `'` is a legal SYMBOL character in Clojure (`next'`), so it
+            # quotes only where a form may start. Without that guard the gate
+            # would blank a LIVE claim and false-red a fenced package.
+            start, body = i, i + 1
+        elif COMMENT_FORM_RE.match(text, i):
+            start, body = i, i  # the `(comment …)` form is inert entire
+        else:
+            i += 1
+            continue
+        end = form_end(text, body)
+        for j in range(start, end):
+            if chars[j] != "\n":
+                chars[j] = " "
+        i = end
+    return "".join(chars)
+
 
 def read_forms(source):
-    """`source` with strings and line comments blanked out.
+    """`source` reduced to the forms the reader would actually EVALUATE.
 
-    Read off FORMS, never off prose — the rule
+    Read off LIVE FORMS, never off prose — the rule
     `check_optional_module_reachability.py` states for the same reason.
     These files carry long docstrings ABOUT the macro; one that quoted a
     call would otherwise register a claim nothing asserts.  Strings go
-    first, so a `;` inside one cannot start a comment.
+    first, so a `;` inside one cannot start a comment; line comments go
+    second, so a `)` inside one cannot unbalance [[strip_inert]]'s walk.
     """
-    return COMMENT_RE.sub("", STRING_RE.sub('""', source))
+    return strip_inert(COMMENT_RE.sub("", STRING_RE.sub('""', source)))
 
 
 def package_of(ns_symbol):
@@ -248,6 +345,21 @@ def scan(tree):
 
 
 def self_test():
+    # THIS SELF-TEST'S OWN CLAIMS MUST NOT BE DISCARDABLE. `python -O` deletes
+    # every `assert` below, and the function would print OK having proved
+    # nothing — a control silenced by a reader that drops its forms, which is
+    # the exact defect rf2-t9kd exists to stop this gate having. It would be
+    # a poor gate that could not catch its own case.
+    try:
+        assert False
+    except AssertionError:
+        pass
+    else:
+        raise SystemExit(
+            "assertions are disabled (python -O / PYTHONOPTIMIZE), so this "
+            "self-test would prove nothing. Re-run without -O."
+        )
+
     # The n:m case, which is the one the cheap check gets wrong: two
     # packages, one fence file naming both, and no `surface_cljs_test.cljs`
     # in either directory.
@@ -316,6 +428,51 @@ def self_test():
     )
     assert len(prose) == 1, prose
     assert prose[0].startswith("examples/ghost/"), prose
+
+    # AN INERT FORM IS NOT A CLAIM (rf2-t9kd). One unfenced package, one
+    # fence file, and the only difference between the rows below is whether
+    # the reader evaluates the call in it.
+    def ghost(fence_body):
+        return scan(
+            {
+                "ghost/views.cljs": "(ns re-frame.hicasso.examples.ghost.views)",
+                "notes_cljs_test.cljs":
+                    "(ns re-frame.hicasso.examples.notes-cljs-test)\n" + fence_body,
+            }
+        )
+
+    # The LIVE claim is green, and it is what keeps the three reds honest: a
+    # checker that had simply stopped counting `emit-application-namespaces`
+    # would satisfy every negative row below and be worth nothing.
+    live = ghost("(rg/emit-application-namespaces re-frame.hicasso.examples.ghost)")
+    assert live == [], live
+
+    # None of these three expands, so none installs a fence, so none may
+    # certify coverage. Each was reproduced GREEN against the landed scanner.
+    for inert in (
+        "#_(rg/emit-application-namespaces re-frame.hicasso.examples.ghost)",
+        "(comment\n  (rg/emit-application-namespaces re-frame.hicasso.examples.ghost))",
+        "(def forms\n  ['(rg/emit-application-namespaces re-frame.hicasso.examples.ghost)])",
+    ):
+        disabled = ghost(inert)
+        assert len(disabled) == 1, (inert, disabled)
+        assert disabled[0].startswith("examples/ghost/"), (inert, disabled)
+
+    # Blanking stops at the END of the inert form rather than running to the
+    # end of the file: a live claim beside a disabled one still covers.
+    beside = ghost(
+        "#_(rg/emit-application-namespaces re-frame.hicasso.examples.gone)\n"
+        "(rg/emit-application-namespaces re-frame.hicasso.examples.ghost)"
+    )
+    assert beside == [], beside
+
+    # And `'` closes over a form only where a form may START, because it is
+    # also a legal symbol character. `next'` must not swallow what follows it.
+    tick = ghost(
+        "(def next' 1)\n"
+        "(rg/emit-application-namespaces re-frame.hicasso.examples.ghost)"
+    )
+    assert tick == [], tick
 
     # The vacuity floor fires rather than reporting a green nothing.
     empty = scan({})


### PR DESCRIPTION
Closes rf2-t9kd. Follow-on from rf2-689l (PR #8106), which added the gate.

## The defect

`check_example_fence_coverage.py`'s `claims()` blanked strings and line comments, then regex-matched `emit-application-namespaces` anywhere in what remained. Three shapes the reader never evaluates therefore counted as live claims, so a package could be certified as covered by a fence that had been switched off. All three were **reproduced GREEN against the landed scanner** on an otherwise-unfenced `ghost` package before any code changed:

| form | landed scanner | this PR |
|---|---|---|
| `#_(rg/emit-application-namespaces …)` | green — counted | **red** |
| `(comment (rg/emit-application-namespaces …))` | green — counted | **red** |
| `'(rg/emit-application-namespaces …)` | green — counted | **red** |
| a live claim (the n:m case) | green | **green** |

None of the three expands, so none installs a fence, so none may certify coverage.

## The fix

`read_forms` gains a third pass, `strip_inert`, which blanks those three shapes and only those three. `form_end` walks bracket depth over text whose strings and line comments are already gone.

**What is deliberately NOT handled**, named in the docstring rather than left for a reader to discover: reader conditionals `#?(:clj …)`, dead-by-value branches `(when false …)`, stacked discards `#_#_`, `#_` applied to a set or prefixed form (`#_#{…}`, `#_'x`), a fully-qualified `(clojure.core/comment …)`, and `comment` shadowed by a local binding. Each still counts as a live claim — the failure mode is unchanged, merely narrowed. A general Clojure reader is a far larger artefact than this gate deserves.

Quote is recognised **only where a form may start**, because `'` is also a legal symbol character in Clojure. Without that guard `(def next' 1)` would blank the claim following it and false-red a properly fenced package.

## The self-test is four assertions, not one

A checker that simply stopped counting `emit-application-namespaces` would satisfy all three negative rows and be worth nothing, so the live claim is asserted green first and the three reds are built against it. Two further guards close the cheap wrong fixes: the walk resumes at the **end** of an inert form (a live claim beside a disabled one still covers), and `next'` is not a quote.

## It now catches its own case

Every assertion in this self-test is deleted by `python -O`, and the function then printed `self-test OK` having proved nothing — the same defect class as the bug being fixed, sitting in the control that proves the fix. `--self-test` now refuses to run when assertions are disabled.

## Quality gates

Run from this worktree, on the final rebased base (`HEAD~1 == origin/main == f82afa4d8b`). Exit codes captured with `cmd > log 2>&1; echo "$?" > exit` in one shell — never through a pipe.

| gate | captured exit |
|---|---|
| `npm run test:hicasso-invariants` (the gate named in the acceptance) | **0** |
| `python scripts/check_fast_pr_gap.py` | **0** |
| `python -O …check_example_fence_coverage.py --self-test` (must refuse) | **1** |

**Sabotage runs**, because `scripts/check_*.py` gates print no `gate root:` banner and a green run proves nothing about which tree was read:

- Planted `#_` on the live `ledger` fence claim in **this worktree**. The gate went red naming `examples/ledger/` — the plant, in my tree. The landed scanner stays green on that same plant. Restore verified byte-identical by `git hash-object` against the committed blob (`6a886507e2…`), not by `git diff`.
- Bypassed `strip_inert` in `read_forms`. The self-test failed at the first inert row, naming the exact form: `AssertionError: ('#_(rg/emit-application-namespaces …ghost)', [])`.

No workflow file was touched — the gate is already chained into `test.yml`'s `cljs` job and `scripts/test-fast-pr.sh`, so no CI arm is needed and no roster moved.

## Same class in the siblings — verified, filed, not fixed here

Asking the generalising question of the family turned up three live instances, all reproduced, all out of this bead's scope:

1. **The `-O` hole is family-wide.** All five sibling `--self-test`s (`check_freeze`, `check_optional_module_reachability`, `check_complaint_catalogue`, `check_budget_ledger`, `check_lint_export`) exit **0** printing "self-test OK" under `python -O`, having proved nothing.
2. **`check_optional_module_reachability.ns_of` takes the FIRST `(ns …)` match.** `#_(ns re-frame.hicasso.motion)` above a file's real `ns` form makes `ns_of` answer `re-frame.hicasso.motion`, and `scan()` *skips* files whose declared ns is the module's own — a false **green**, the same direction as this bug.
3. **`check_freeze.declared_namespace`** has the same first-match behaviour, and `definitions()` counts `#_(def a 1)` as a definition. Both fail red rather than green, so they are cosmetic by comparison.
