### PR TITLE
docs: retire two keys that no longer resolve (rf2-cnij, rf2-a8e1); rf2-4u7x refused as fenced

### DIFF
--- a/docs/core/how-to/keep-secrets-out-of-traces.md
+++ b/docs/core/how-to/keep-secrets-out-of-traces.md
@@ -186,7 +186,7 @@ Some data lives *inside* a runtime subsystem — a [machine](../../machines/glos
    :schemas   {:data [:map [:payment [:map [:token :string] [:receipt-pdf :bytes]]]]}
    :initial :collecting
    :states  {:collecting {:on {:submit :charging}}
-             :charging   {:spawn {:src :checkout/charge :on-done :done}}
+             :charging   {:spawn {:machine-id :checkout/charge :on-done :done}}
              :done       {}}})
 ```
 

--- a/implementation/machines/src/re_frame/machines.cljc
+++ b/implementation/machines/src/re_frame/machines.cljc
@@ -269,7 +269,7 @@
 ;; elision bundle.
 
 (fx/reg-fx :rf.machine/spawn
-  {:doc "Spawn a machine instance. Per Spec 005 §Declarative :spawn (sugar over spawn). Args carry `:machine-id`, optional `:system-id`, and optional `:initial-data`."}
+  {:doc "Spawn a machine instance. Per Spec 005 §Declarative :spawn (sugar over spawn). Args carry `:machine-id`, optional `:system-id`, and optional `:data`."}
   spawn-fx)
 
 (fx/reg-fx :rf.machine/destroy
@@ -330,7 +330,7 @@
 ;; off `:rf/machine` — so a view that only cares about whether a specific
 ;; tag is present re-renders only when the containment-bit flips.
 (subs/reg-runtime-sub :rf.machine/has-tag?
-  {:doc "Subscribe to a machine's `:fsm/tags` containment-bit for `tag`. Returns `true` iff the named machine's snapshot's `:tags` set contains `tag`, `false` otherwise (including unknown / not-yet-initialised machines). Per Spec 005 §State tags."}
+  {:doc "Subscribe to a machine's `:tags` containment-bit for `tag`. Returns `true` iff the named machine's snapshot's `:tags` set contains `tag`, `false` otherwise (including unknown / not-yet-initialised machines). Per Spec 005 §State tags."}
   (fn [runtime-db [_ machine-id tag]]
     (contains? (get-in runtime-db (paths/snapshot-path machine-id :tags)) tag)))
 


### PR DESCRIPTION
Three beads of one shape: **a document or docstring teaches a symbol or key that does not exist**, a reader copies it, and it fails. Two carried a real defect and are fixed here. The third is a verified refusal — its remaining half is fenced, and the fence does not clear the way the bead assumes.

The whole diff is six lines across two files. The reason it is small is in the third section.

## rf2-cnij — two machines facade docstrings named keys with no referent

`:rf.machine/spawn`'s `:doc` advertised an optional `:initial-data` arg. No such key exists. `spawn-fx` initialises the actor snapshot from the spec's `:initial` / `:data` "overridden by the spawn args' `:data`" (`spawn.cljc:761-766`), and `:initial-data` appears nowhere else in the tracked tree. Following the docstring got you a spawn whose initial data was silently dropped.

`:rf.machine/has-tag?`'s `:doc` called the subscribed thing the machine's `:fsm/tags` containment-bit. `:fsm/tags` is the **capability-matrix keyword** (`spec/005` §Capability matrix, `spec/conformance/README.md`) — not a snapshot slot. The slot is `:tags`, which the same docstring's very next sentence already spelled correctly, and which the sub itself reads via `(paths/snapshot-path machine-id :tags)`. So the docstring contradicted itself in two consecutive sentences.

Docstring text only, no behaviour change. Nothing pins these bytes: `docs/api/re-frame.machines.md` is hand-written prose rather than generated, and `machine_doc_opts_prod_elision_test.clj` asserts `:doc` *presence / absence* under the production gate, never its content. Both were checked before editing.

## rf2-a8e1 — a how-to page taught a spawn key that fails registration

`docs/core/how-to/keep-secrets-out-of-traces.md` spawned with `{:src :checkout/charge …}`. `:src` is the xstate v4 spelling. It is not in re-frame2's spawn-spec vocabulary, and a **bare** key outside that closed set is a hard registration error, not a silent no-op.

Per the bead's load-bearing step, this was verified by running the page's machine — verbatim — through the real validator rather than by reasoning from the key list:

| probe | result |
|---|---|
| as-published (`:src`) | **THROW** `:rf.error/machine-unknown-spawn-key` |
| corrected (`:machine-id`) | PASS |
| spawn removed entirely | PASS |

> `:spawn on state :charging declares unknown bare key(s) [:src] — a bare key outside the reserved spawn-spec vocabulary reads as a typo (e.g. :machine for :machine-id) and would leave the spawn silently under-specified. Valid keys: [:data :definition :fixed-actor-id :id :id-prefix :machine-id :on-done :on-error :on-spawn :on-timeout :source-code :source-coords :start :system-id :timeout]`

The third probe is what makes the diff one key wide: it isolates the defect to `:src` and clears everything else on the page's machine (`:sensitive`, `:large`, `:schemas`, the `:on` map form, `:on-done`).

**Neighbour sweep**, as the bead required. `:spawn` across `docs/core/**` has exactly one occurrence — this line. `docs/machines/**` carries eleven and every one already spells `:machine-id` (PR #8100 landed). Repo-wide, no other `:src` spawn survives anywhere in `docs/`.

## rf2-4u7x — refused: nothing actionable is in reach, and the fence does not clear it

**No file was edited for this bead.** The bead stays open. The reasoning is recorded on the bead itself; the short form:

**The census drifted**, so it is restated here, measured at `origin/main` `213f54ca71` — 7 files / 17 hits against the bead's 8 files / 14 hits:

| file | hits | vs bead |
|---|---|---|
| `draft-guide/00-installation.md` | 6 | unchanged |
| `draft-guide/18-ssr-and-hydration.md` | 3 | unchanged |
| `draft-guide/glossary.md` | 2 | unchanged |
| `draft-guide/REWRITE-NOTES.md` | 1 | unchanged |
| `product/naming-ledger.md` | 2 | unchanged |
| `product/invariants.md` | 2 | **was 1** — PR #8035 added the ledger-13 row |
| `product/lanes/ergonomics-api.md` | 1 | unchanged |
| `product/dispositions.md` | 0 | **was 1** — no longer carries the spelling |

Both deltas are the product half moving under its own landed work.

**The core fact still holds**, re-verified at source rather than taken from the bead: the facade roster is `root!` / `render!` / `unmount!` at `hicasso.cljc` `:629` / `:642` / `:649` — the bead's `:566`/`:579`/`:586` have drifted. A word-boundary grep for a standalone `mount!` in that file is **empty**; every `mount!` byte in it belongs to `unmount!`.

**The product half's refusal is independently upheld.** All five hits were re-read against the discriminator — *does this line claim something about code that runs, or record the open naming question?* All five record the open question: `invariants.md:51` sits under a heading that says **PROVISIONAL facade**; `invariants.md:85` is the section-5 row PR #8035 itself added, which states "ratified provisional until the naming sitting … **Half landed**"; `ergonomics-api.md:16` is under "**Proposed** core surface"; `naming-ledger.md:26` and `:31` are ledger rows still marked `open`. None is a defect.

**The finding that matters.** The bead fences the remaining draft-guide half behind rf2-hic-092 on the premise that the rewrite clears it. Measured against both staged branches, **it does not** — the incoming corpus carries every hit forward, and one branch grows the count:

| branch | hits |
|---|---|
| `docs/hicasso-draft-guide-from-findings` | `installation.md` 6 · `glossary.md` 2 · `17-ssr-and-hydration.md` 3 · `REWRITE-NOTES.md` 1 |
| `docs/hicasso-guide-authoring-apply` | `installation.md` **7** · `glossary.md` 2 |

Note the rename: `00-installation.md` becomes `installation.md`, `18-ssr-and-hydration.md` becomes `17-ssr-and-hydration.md`. A fix written against today's filenames would not merely conflict — it would land on files that cease to exist. That is the concrete reason not to pre-empt the rewrite, and it is why the sweep belongs *inside* rf2-hic-092. Cross-referenced onto that bead.

The draft-guide hits are the genuine defects under the discriminator (a guide chapter teaching `(h/mount! (js/document.getElementById "app") …)` is a claim about code that runs), which is exactly why they need the owner who is rewriting those files, not a racing edit from here.

## Quality gates

Every code below is the one **captured** on the running shell's own line (`; echo "$?" > …`), never the harness's report.

| gate | captured exit | notes |
|---|---|---|
| `implementation/machines` JVM suite (`clojure -M:test`) | **0** | 1202 tests, 4189 assertions, 0 failures / 0 errors. One `Ran …` summary line in the log — no orphan-writer overlap. rf2-cnij's own artefact. |
| `python scripts/check_doc_slugs.py` (baseline, post-fix) | **0** | |
| `python scripts/check_doc_slugs.py` (**negative control**) | **1** | See below. |
| `python scripts/check_doc_slugs.py` (post-restore) | **0** | |
| `python -m mkdocs build --strict` | **0** | `docs/core/` **is** in the site corpus. |
| `sh scripts/test-fast-pr.sh` (full spine) | **0** | Spine's own verdict line: `PASS fast PR spine`. 82 lanes. See the integrity note below. |

The spine log was checked for the two known ways a green can be counterfeit before the colour was believed:

- `gate root: /c/Users/miket/code/re-frame2-worktrees/docsymbols-4u7x` — names **this** worktree, and appears exactly **once** (a second would mean an orphaned run from a previous attempt was writing into the same log).
- **0** actual NUL bytes, and three `0 failures, 0 errors` summaries.
- The log does contain ten lines matching `FAILED`. Every one is prefixed `ok` — they are the pom-validator's own negative-control fixtures asserting that bad input *is* rejected (`ok   empty <dependencies/> → FAILED`). Filtering for `FAILED` lines **not** prefixed `ok` returns nothing.

Note the spine's own closing disclaimer applies as always: it names 96 required CI checks it does not run, so green here is not green in CI.

**Negative control**, proving the doc gate actually reads the file I edited. The edited line is inside a fenced code block, and no structural gate reads fenced *content* — so the control was planted on the nearest prose line of the same file (line 180, which carries real links) to prove file coverage:

- planted a broken anchor → `check_doc_slugs.py` captured exit **1**, naming `docs\core\how-to\keep-secrets-out-of-traces.md:180`
- restored → file **byte-identical**, `sha256 80f62c62ed162d3a4330346896e3601c2d45aa7fc101ac933f540d53417e5ce1` before and after (hashed rather than diffed, so a CRLF→LF flattening could not pass)
- re-ran → captured exit **0**

Because no structural gate can read fenced code content, the *correctness* of the corrected form is proved by the validator run in the rf2-a8e1 section above, not by these gates. That is the real check on this change.

**Skipped, and why.** `mkdocs build --strict` was **not** nominated as the gate for anything under `docs/design/hicasso/**` — `mkdocs.yml`'s `exclude_docs` block lists `design/hicasso/`, so a build over that tree exits green having verified nothing. It is irrelevant here in any case, since rf2-4u7x changed no file. `samples_coverage_jvm_test.clj`'s digest pin covers `docs/core/freehand/` only (`guide-dir` is `"docs/core/freehand"`); the page edited here is `docs/core/how-to/`, so this is a genuine one-file change rather than the usual two-file guide edit — checked before assuming it.
