### PR TITLE
docs(machines): actor-destroy cancellation does not reply on a self-target (rf2-j44x)

### DIFF
--- a/docs/machines/actors.md
+++ b/docs/machines/actors.md
@@ -330,11 +330,17 @@ A spawned actor is destroyed when:
 
 Destroy releases exactly three framework-managed kinds:
 
-- in-flight `:rf.http/managed` requests this actor issued (the reply arrives
-  with `:status :cancelled` and an `:error` of
-  `{:kind :rf.http/aborted :reason :actor-destroyed}`);
+- in-flight `:rf.http/managed` requests this actor issued;
 - this actor's armed `:after` timers;
 - `:rf.resource/*` owners this actor holds.
+
+The request is always aborted, but a reply is not always delivered. A reply
+addressed to an ordinary event dispatches with `:status :cancelled` and an
+`:error` of `{:kind :rf.http/aborted :reason :actor-destroyed}`. A reply
+addressed back to the actor being destroyed — the `[(:rf/self-id data) …]`
+shape `:auth/request` uses above — is never dispatched. The runtime classifies
+it `:status :stale` and records a `:rf.http/stale-suppressed` trace row
+carrying `:rf.reply/stale-reason :rf.http/actor-destroyed-target-obsolete`.
 
 Anything else — a raw `js/WebSocket`, a `setInterval`, a Worker — you close
 yourself in the child's `:exit`. That action runs on every destroy path:
@@ -452,4 +458,5 @@ N separate `:spawn`s, not a non-cancelling join.
 | `:join :all` rejected | missing `:on-all-complete` | Give `:on-all-complete` an event vector |
 | `:join :any` rejected | missing `:on-some-complete` | Give `:on-some-complete` an event vector |
 | Socket / interval / Worker still open after destroy | not a framework-managed resource | Close it in the child's `:exit` |
+| A self-addressed `:on-failure` never fires when the actor is destroyed | the reply target names the actor being torn down, so it is obsolete | Expect no reply — it is suppressed as `:status :stale`. Clean up in the child's `:exit`, or address the reply to an event outside the actor |
 | Children torn down (or respawned) on a progress event | the parent's `:on` had a `:target` | Omit `:target` so the transition is internal |


### PR DESCRIPTION
Closes rf2-j44x.

`docs/machines/actors.md` promised that destroying an actor delivers a
`:status :cancelled` reply for every in-flight `:rf.http/managed` request the
actor issued. The runtime only does that when the reply target is an ordinary
event. A reply addressed back to the actor being destroyed is never dispatched
— and that self-addressed shape is the one the page's own `:auth/request`
example uses, so the wrong half was the common actor path. A reader following
the page writes a state that waits for a reply that never comes.

## Behaviour, read from the source

`dispatch-aborted!` in `implementation/http/src/re_frame/http/transport.cljc`
is the single choke every abort routes through. For `reason` `:actor-destroyed`
it derives the reply event's head with `reply-target-id` (the explicit
`:on-failure` vector's head, else the originating event-id) and asks
`re-frame.http.reply/actor-destroy-target-obsolete?` whether that head equals
the destroyed `:actor-id`:

- **equal (self-addressed)** → `emit-actor-destroy-stale-trace!`. No app
  dispatch at all. The reply is classified `:status :stale` /
  `:rf.reply/work-status :suppressed`, and a `:rf.http/stale-suppressed` trace
  row carries `:rf.reply/stale-reason
  :rf.http/actor-destroyed-target-obsolete`.
- **different (ordinary event)** → `dispatch-failure!`, the live
  `:status :cancelled` delivery with `{:kind :rf.http/aborted :reason
  :actor-destroyed}` under `:error`.

Either way the request itself is aborted and `:rf.http/aborted` is emitted.
`implementation/http/src/re_frame/http/machine_wrapper.cljc` supplies
`:on-failure [self-id [:rf.http/failed]]` as the machine-shape default, which
is the obsolete case by construction.
`implementation/http/test/re_frame/http_actor_destroy_stale_test.clj` locks
both branches.

## Wording

Before:

> Destroy releases exactly three framework-managed kinds:
>
> - in-flight `:rf.http/managed` requests this actor issued (the reply arrives
>   with `:status :cancelled` and an `:error` of
>   `{:kind :rf.http/aborted :reason :actor-destroyed}`);

After — the three-kinds list stays concise, and the reply contract moves to a
short paragraph under it:

> Destroy releases exactly three framework-managed kinds:
>
> - in-flight `:rf.http/managed` requests this actor issued;
> - this actor's armed `:after` timers;
> - `:rf.resource/*` owners this actor holds.
>
> The request is always aborted, but a reply is not always delivered. A reply
> addressed to an ordinary event dispatches with `:status :cancelled` and an
> `:error` of `{:kind :rf.http/aborted :reason :actor-destroyed}`. A reply
> addressed back to the actor being destroyed — the `[(:rf/self-id data) …]`
> shape `:auth/request` uses above — is never dispatched. The runtime
> classifies it `:status :stale` and records a `:rf.http/stale-suppressed`
> trace row carrying `:rf.reply/stale-reason
> :rf.http/actor-destroyed-target-obsolete`.

Plus one Troubleshooting row, since this is a failure a reader hits rather
than reads about:

| Symptom | Cause | Fix |
|---|---|---|
| A self-addressed `:on-failure` never fires when the actor is destroyed | the reply target names the actor being torn down, so it is obsolete | Expect no reply — it is suppressed as `:status :stale`. Clean up in the child's `:exit`, or address the reply to an event outside the actor |

Docs-only. One file, `docs/machines/actors.md`. No `implementation/` or
`spec/` change: the runtime behaviour is the intended contract, not a defect.

## Quality gates

Run from the worktree `C:/Users/miket/code/re-frame2-worktrees/machdoc-j44x`,
rebased onto `origin/main` at `dd77a64923`. Exit codes captured to file, not
read from the harness.

| Gate | Captured exit |
|---|---|
| `python -m mkdocs build --strict --config-file <worktree>/mkdocs.yml` | **0** |
| `python <worktree>/scripts/check_doc_slugs.py` | **0** |

`mkdocs` is not on this machine's Bash `PATH` (`mkdocs build --strict` returns
127 there), so it was invoked as `python -m mkdocs` with an absolute
`--config-file`. The build log names the worktree it read:
`Building documentation to directory:
C:\Users\miket\code\re-frame2-worktrees\machdoc-j44x\site`.

`check_doc_slugs.py` prints nothing on success, so it was proved live before
being trusted: a single broken anchor was planted in `docs/machines/actors.md`
and the checker went **red, exit 1**, naming the plant —

```
BROKEN ANCHOR: docs\machines\actors.md:464 -> concepts.md#no-such-anchor-machdoc-j44x
```

The plant was then removed and the restore verified by blob hash rather than
by `git diff`: `git hash-object docs/machines/actors.md` equals
`git rev-parse HEAD:docs/machines/actors.md`
(`f70f4bcf6acf00803e6f62c398e30f0a9e141c6c`). The clean re-run after restore is
the exit 0 tabled above.

Table column counts and rendering checked by hand: the new Troubleshooting row
has three cells, matching the existing five-row table, and the added paragraph
introduces no heading, so no anchor changed.

No fenced code block under `docs/core/freehand/` was touched, so the JVM
sample-coverage hash test is not implicated.
