### PR TITLE
docs(machines): one job per page, and let MkDocs do the navigation (rf2-npgc)

### DIFF
--- a/docs/machines/actors.md
+++ b/docs/machines/actors.md
@@ -18,9 +18,6 @@ instances, not a third kind. This guide says **singleton** and **spawned**.
 Login stays the singleton. The HTTP request becomes a spawned child: it
 starts when `:submitting` is entered and is destroyed on every exit.
 
-Assumes the [flat table](concepts.md). Child completion often uses
-[final states](concepts.md#final-states).
-
 ## State-bound spawn
 
 Put `:spawn` on a state node. Entering the state creates the child. Leaving the
@@ -259,9 +256,9 @@ is also at `[:rf.runtime/machines :spawned <parent-id> <invoke-id>]` for reads
 
 ## When a child finishes
 
-A one-shot child reports success by entering a **root-level** `:final?` leaf
-and naming the `:data` slot to hand up with `:output-key`. The parent folds
-that value in `:on-done`:
+A one-shot child reports success by entering a **root-level**
+[`:final?`](concepts.md#final-states) leaf and naming the `:data` slot to hand
+up with `:output-key`. The parent folds that value in `:on-done`:
 
 ```clojure
 (rf/reg-machine :auth/request

--- a/docs/machines/tutorial.md
+++ b/docs/machines/tutorial.md
@@ -3,8 +3,8 @@
 <a id="tutorial"></a>
 <a id="tutorial-build-a-login-machine"></a>
 
-This page builds one **singleton** login machine — one registered id, one live
-instance. Later pages grow that same flow.
+This page builds one [**singleton**](glossary.md#singleton) login machine.
+Later pages grow that same flow.
 
 By the end you will have:
 
@@ -69,8 +69,9 @@ You do not `send` to the machine. You `dispatch`, as you would to any handler.
 
 The outer vector is a re-frame2 **event**. `:auth.login/flow` is the event id.
 It is also the machine id you registered, so the handler that runs is the table.
-This id is a **singleton**: one live instance. The snapshot is `nil` until
-this first dispatch.
+This id is a **singleton**: one registered id, one live instance per
+[frame](../core/glossary.md#frame). The snapshot lives in that frame's
+runtime-db and is `nil` until this first dispatch.
 
 `[:auth.login/submit {…}]` is the **trigger** — the thing the table matches.
 `:auth.login/submit` is the `:on` key. The map is payload; a guard or action


### PR DESCRIPTION
Closes rf2-npgc.

## What this is, and what it is not

The dispatch asked for a nav restructure of `docs/machines/`. **The restructure
has already shipped and the premise no longer holds.** The bead, read
bottom-up, agrees: its newest note (the merged-PR audit of #8100) scopes the
remaining work to a *bounded repair* and says in terms "No broader
machines-guide sweep." This PR delivers that repair, plus the one residual
`AUTHORING.md` navigation violation left in the corpus, and refuses the rest
with evidence.

### Evidence that the restructure is done

* The flat, numbered nav landed in `5c790f052d` (PR #8091). `mkdocs.yml` now
  reads `machines/index.md`, then `1. First machine` … `9. Inspecting and
  testing`, then the three unnumbered pages (Examples, Coming from XState,
  Glossary). Every nav title matches its page H1 exactly — checked all 13.
* The bead's own audit of #8091 records the same finding: "The reshape is
  structurally sound: numbered flat nav matches the pages, every changed H1
  keeps its old anchor, changed tables have consistent columns."
* `Prerequisites` blocks were deleted corpus-wide in `f9fe9a2933`; `Start here`
  mini-TOCs in `7a2edf7d6d`. A grep of `docs/machines/` for
  `prerequisit|start here|next, read|what's next|before you start|## Next`
  returns **zero** hits.
* Every page opens with a content hook, not a reading-order header — e.g.
  Tags opens on what the first machine already tagged, then teaches tags.
  Those are inline links used where the fact is used, which is what
  `AUTHORING.md` asks for.

So: no page renamed, no page split, no nav entry moved. **`mkdocs.yml` is not
touched by this PR at all** — the machines nav block already satisfies the
brief, so there was nothing to change and no inbound links to sweep.

## The four changes

**`docs/machines/tutorial.md` — the bead's bounded repair.** The page defined
*singleton* twice, both times without the frame boundary, so page one taught
process-global machine cardinality. `index.md`, `actors.md` and `glossary.md`
were already qualified by PR #8100; tutorial was the carrier left behind.

* The opening now links the qualified glossary definition instead of restating
  a wrong one, which keeps page-one prose light (`AUTHORING.md`: define a term
  clearly once, link to the glossary when needed).
* Step 1 carries the qualified definition where the mechanism is actually being
  explained: one registered id, one live instance **per frame**, with the
  snapshot in that frame's runtime-db.

**`docs/machines/actors.md` — the last prerequisite line.** The page opened its
body with `Assumes the [flat table](concepts.md). Child completion often uses
[final states](concepts.md#final-states).` That is a reading-order header,
which `AUTHORING.md` names explicitly under "Navigation and MkDocs". Deleted.
The final-states fact is not lost — it now links from the point of use, on
`## When a child finishes`, where the root-level `:final?` leaf is introduced.

## Interaction with open PR #8116

#8116 (`rf2-j44x`) is **still open** and edits this same file. Per the
dispatch, I did not move or rewrite the actor-destroy material. #8116's hunks
sit at `actors.md` ~330 (the destroy-releases list and the new
self-addressed-reply paragraph) and ~458 (the new Troubleshooting row). My two
hunks are at line 18 and line 256 — no overlap, no shared context lines, and
nothing in the destroy/cancellation region is touched. Whichever merges first,
the other rebases cleanly.

## What I deliberately did not do

* **No page renames or splits.** No page in this corpus is simultaneously a
  tutorial and a reference catalogue. `concepts.md` is the longest at 482
  lines but has one job — the flat-table contract — and says so in its opener.
* **No new page categories.** `AUTHORING.md` forbids Basics / Going further /
  Expert mode; `tags.md` already uses the one sanctioned form,
  `## Advanced: collapsing many states into one render decision`.
* **No renaming of concepts.** `singleton` / `spawned` / `trigger` / `snapshot`
  are used consistently across all 13 pages.
* **No `spec/` and no `implementation/` edits.**
* `concepts.md`'s `## When to reach for a machine` and `index.md`'s
  `## When *not* to use a machine` look like duplicates but are not: the first
  is the positive case and links the second's table rather than repeating it.
  Left alone.

## Quality gates

Run from the worktree `re-frame2-worktrees/machnav-npgc`, each redirected to a
file with the exit code captured on the same command line — no pipelines.

| Gate | Captured exit |
| --- | --- |
| `python -m mkdocs build --strict --config-file <worktree>/mkdocs.yml` | **0** |
| `python scripts/check_doc_slugs.py` | **0** |

The mkdocs log confirms it read this tree, not another:
`INFO - Building documentation to directory:
C:\Users\miket\code\re-frame2-worktrees\machnav-npgc\site`, built in 31.46s.

**Sabotage proof for `check_doc_slugs.py`.** That script prints no banner and
nothing on success, so a green run proves nothing on its own. I rewrote the new
`glossary.md#singleton` link in `tutorial.md:6` to `glossary.md#sabotage-npgc-1`
and re-ran it. It failed with captured exit **1**, naming the plant:

```
1 broken anchor link(s) found:
  BROKEN ANCHOR: docs\machines\tutorial.md:6 -> glossary.md#sabotage-npgc-1
      (target: docs\machines\glossary.md)
```

Restore verified with `git hash-object` against the committed blob (not
`sha256sum`, which mis-reports on CRLF): working file and
`HEAD:docs/machines/tutorial.md` both `80ab041c75ad37621cba37975b01e80633ecade1`.

`git diff origin/main...HEAD` (three dots) reviewed before pushing: it contains
exactly the four hunks described above and reverts nothing from #8091, #8100 or
#8104.
