### PR TITLE
fix(hicasso): two checker controls that fail green (rf2-uyhh, rf2-df9b)

### DIFF
--- a/implementation/hicasso/scripts/check_budget_ledger.py
+++ b/implementation/hicasso/scripts/check_budget_ledger.py
@@ -601,6 +601,23 @@ def tally(rows):
 # ---------------------------------------------------------------------------
 
 def self_test():
+    # THIS SELF-TEST'S OWN CLAIMS MUST NOT BE DELETABLE (rf2-uyhh). `python -O`
+    # — and `PYTHONOPTIMIZE` in the environment, which needs no flag at the
+    # call site — strips every `assert` below, leaving a function that runs to
+    # its success line having verified nothing. That is a control failing
+    # GREEN, the one direction that never announces itself. The check is
+    # empirical rather than a reading of `__debug__`, so it also catches a
+    # `.pyc` compiled under `-O` and run without it.
+    try:
+        assert False
+    except AssertionError:
+        pass
+    else:
+        raise SystemExit(
+            "assertions are disabled (python -O / PYTHONOPTIMIZE), so this "
+            "self-test would prove nothing. Re-run without -O."
+        )
+
     assert slugify("5.2 The read-free boundary shell — the disposition") == \
         "52-the-read-free-boundary-shell--the-disposition", slugify(
             "5.2 The read-free boundary shell — the disposition")

--- a/implementation/hicasso/scripts/check_complaint_catalogue.py
+++ b/implementation/hicasso/scripts/check_complaint_catalogue.py
@@ -393,6 +393,23 @@ def read_all():
 # ---------------------------------------------------------------------------
 
 def self_test():
+    # THIS SELF-TEST'S OWN CLAIMS MUST NOT BE DELETABLE (rf2-uyhh). `python -O`
+    # — and `PYTHONOPTIMIZE` in the environment, which needs no flag at the
+    # call site — strips every `assert` below, leaving a function that runs to
+    # its success line having verified nothing. That is a control failing
+    # GREEN, the one direction that never announces itself. The check is
+    # empirical rather than a reading of `__debug__`, so it also catches a
+    # `.pyc` compiled under `-O` and run without it.
+    try:
+        assert False
+    except AssertionError:
+        pass
+    else:
+        raise SystemExit(
+            "assertions are disabled (python -O / PYTHONOPTIMIZE), so this "
+            "self-test would prove nothing. Re-run without -O."
+        )
+
     assert mask('(fail! :rf.error/a "text :rf.error/in-a-string")') \
         .count(":rf.error/") == 1, "a string literal must not emit an id"
     assert ":rf.error/" not in mask("; :rf.error/in-a-comment\n"), \

--- a/implementation/hicasso/scripts/check_freeze.py
+++ b/implementation/hicasso/scripts/check_freeze.py
@@ -598,6 +598,23 @@ def _write(path, text):
 
 def self_test():
     """Every assertion here is a case the live run must be able to fail on."""
+    # AND EVERY ONE OF THEM MUST BE UNDELETABLE (rf2-uyhh). `python -O` — and
+    # `PYTHONOPTIMIZE` in the environment, which needs no flag at the call
+    # site — strips every `assert` below, leaving a function that runs to its
+    # success line having verified nothing. That is a control failing GREEN,
+    # the one direction that never announces itself. The check is empirical
+    # rather than a reading of `__debug__`, so it also catches a `.pyc`
+    # compiled under `-O` and run without it.
+    try:
+        assert False
+    except AssertionError:
+        pass
+    else:
+        raise SystemExit(
+            "assertions are disabled (python -O / PYTHONOPTIMIZE), so this "
+            "self-test would prove nothing. Re-run without -O."
+        )
+
     assert read_edn('{:a "x" :b [1 2] :c true}') == {":a": "x", ":b": [1, 2], ":c": True}
     assert read_edn(";; lead comment\n{:a 1}") == {":a": 1}
     assert read_edn('{:s re-frame.hicasso.impl.codec}')[":s"] == "re-frame.hicasso.impl.codec"

--- a/implementation/hicasso/scripts/check_lint_export.py
+++ b/implementation/hicasso/scripts/check_lint_export.py
@@ -287,6 +287,23 @@ def self_test():
     each pinned by the mutation that would bring it back. No count is stated
     here on purpose — the list grows, and a number in prose does not.
     """
+    # AND A GATE NOBODY HAS TESTED IS ALSO WHAT THIS BECOMES UNDER `python -O`
+    # (rf2-uyhh) — or `PYTHONOPTIMIZE` in the environment, which needs no flag
+    # at the call site. Either strips every `assert` below, leaving a function
+    # that runs to its success line having verified nothing: a control failing
+    # GREEN, the one direction that never announces itself. The check is
+    # empirical rather than a reading of `__debug__`, so it also catches a
+    # `.pyc` compiled under `-O` and run without it.
+    try:
+        assert False
+    except AssertionError:
+        pass
+    else:
+        raise SystemExit(
+            "assertions are disabled (python -O / PYTHONOPTIMIZE), so this "
+            "self-test would prove nothing. Re-run without -O."
+        )
+
     with open(HOOK_FILE, encoding="utf-8") as fh:
         original = fh.read()
 

--- a/implementation/hicasso/scripts/check_optional_module_reachability.py
+++ b/implementation/hicasso/scripts/check_optional_module_reachability.py
@@ -175,13 +175,105 @@ NS_FORM = re.compile(r"\(ns\s+([A-Za-z0-9_.*+!?<>=$%&/-]+)")
 def ns_of(text):
     """The namespace a source file declares, or None. Read from code rather
     than prose for the same reason the requires are — a docstring here opens
-    with `(ns my.app …)` as its usage example."""
+    with `(ns my.app …)` as its usage example.
+
+    The FIRST `(ns …)` in the live text, which is only the file's own because
+    [[code_only]] has already dropped the forms the reader discards.  Before
+    it did, a `#_(ns re-frame.hicasso.motion)` sitting above the real form won
+    the search and [[scan]] then exempted the file as the module's own engine
+    — the whole reachability check switched off for it, silently and green
+    (rf2-df9b).
+    """
     m = NS_FORM.search(code_only(text))
     return m.group(1) if m else None
 
 
+OPENERS = "([{"
+CLOSERS = ")]}"
+
+
+def form_end(text, i):
+    """Index just past the ONE form beginning at or after `text[i]`.
+
+    `text` has already been through [[code_only]]'s string, comment and
+    character-literal passes, so every remaining bracket is structural.
+    """
+    n = len(text)
+    while i < n and text[i].isspace():
+        i += 1
+    if i >= n:
+        return n
+    if text[i] not in OPENERS:  # a bare symbol, keyword or number
+        while i < n and not text[i].isspace() and text[i] not in OPENERS + CLOSERS:
+            i += 1
+        return i
+    depth = 0
+    while i < n:
+        ch = text[i]
+        if ch in OPENERS:
+            depth += 1
+        elif ch in CLOSERS:
+            depth -= 1
+            if depth == 0:
+                return i + 1
+        i += 1
+    return n
+
+
+# `(comment …)` and not `(comment-on …)`: the lookahead is the symbol-tail
+# class, so only the bare core form opens a comment.
+COMMENT_FORM_RE = re.compile(r"\(\s*comment(?![\w.*+!?<>=$%&|:'/-])")
+
+
+def strip_inert(text):
+    """`text` with the three INERT form shapes blanked out (rf2-df9b).
+
+    A form the reader discards is not a claim about anything, and this gate
+    decides two questions from claims — which namespace a file DECLARES, and
+    which it REQUIRES:
+
+        #_(ns re-frame.hicasso.motion)        reader discard
+        (comment (ns re-frame.hicasso.motion))  comment macro
+        '(ns re-frame.hicasso.motion)         quoted
+
+    Those three and no more.  DELIBERATELY NOT HANDLED, because none occurs
+    in this tree and a general Clojure reader is a far larger artefact than
+    this gate deserves: reader conditionals (`#?(:clj …)`), dead-by-value
+    branches (`(when false …)`), stacked discards (`#_#_`), `#_` applied to
+    a set or prefixed form (`#_#{…}`, `#_'x`), a fully-qualified
+    `(clojure.core/comment …)`, and `comment` shadowed by a local binding.
+
+    Blanking preserves length and newlines so the surviving text keeps its
+    offsets, and the walk resumes at the END of each inert form — a live
+    form sitting beside a discarded one still counts, which is what stops
+    this narrowing from becoming a false RED of its own.
+    """
+    chars = list(text)
+    i, n = 0, len(text)
+    while i < n:
+        ch = text[i]
+        if text.startswith("#_", i):
+            start, body = i, i + 2
+        elif ch in "'`" and (i == 0 or text[i - 1].isspace() or text[i - 1] in OPENERS):
+            # `'` is a legal SYMBOL character in Clojure (`next'`), so it
+            # quotes only where a form may start. Without that guard the gate
+            # would blank a LIVE require and report an unreachable module.
+            start, body = i, i + 1
+        elif COMMENT_FORM_RE.match(text, i):
+            start, body = i, i  # the `(comment …)` form is inert entire
+        else:
+            i += 1
+            continue
+        end = form_end(text, body)
+        for j in range(start, end):
+            if chars[j] != "\n":
+                chars[j] = " "
+        i = end
+    return "".join(chars)
+
+
 def code_only(text):
-    """`text` with every string literal and line comment blanked out.
+    """`text` reduced to the forms the reader would actually EVALUATE.
 
     Everything downstream reads CODE, and this is the one place that
     distinction is made.  It has teeth: this package's namespaces document
@@ -195,6 +287,13 @@ def code_only(text):
     `\\"` is a character literal in Clojure, not a string, so a backslash
     outside a string consumes the character after it; inside a string it is
     the escape it looks like.
+
+    Prose is only half of what is not code, though, and the other half read
+    green for longer: a form the reader DISCARDS is not a claim either, so
+    [[strip_inert]] runs last over what survives.  It runs last because the
+    passes above are what make its walk safe — a `)` inside a string or a
+    line comment would otherwise unbalance it — and because by then every
+    character literal is gone, so every remaining bracket is structural.
     """
     out = []
     i, n = 0, len(text)
@@ -224,7 +323,7 @@ def code_only(text):
             continue
         out.append(ch)
         i += 1
-    return "".join(out)
+    return strip_inert("".join(out))
 
 
 def required_namespaces(text):
@@ -384,6 +483,74 @@ def self_test():
     clean = scan(
         {
             "src/m.cljs": "(ns {}\n  (:require [{} :as p]))".format(door, engine)
+        }
+    )
+    assert clean == [], clean
+
+    # AN INERT FORM IS NOT A DECLARATION (rf2-df9b), and the exemption above
+    # is what gave that teeth: `scan` skips any file whose declared ns the
+    # module owns, so a file that could pass itself off as the engine escaped
+    # the reachability check entirely. `ns_of` took the FIRST `(ns …)` in the
+    # file, and a discarded one sits happily above the real one.
+    #
+    # The rows below share one body and differ only in what precedes it, so
+    # what they compare is the DISGUISE and nothing else.
+    body = "(ns re-frame.hicasso.core\n  (:require [{} :as mo]))".format(door)
+
+    # The honest file is flagged. This row is what keeps the three reds below
+    # honest: a checker that had simply stopped exempting owned modules would
+    # satisfy them all and be worth nothing.
+    flagged = scan({"src/honest.cljs": body})
+    assert len(flagged) == 1, flagged
+    assert door in flagged[0], flagged
+
+    # None of these three declares anything, so none may claim the exemption.
+    # Each was reproduced GREEN — the whole file exempted — against the
+    # landed scanner.
+    for disguise in (
+        "#_(ns {})\n".format(door),
+        "(comment (ns {}))\n".format(door),
+        "(def forms ['(ns {})])\n".format(door),
+    ):
+        evader = scan({"src/evader.cljs": disguise + body})
+        assert len(evader) == 1, (disguise, evader)
+        assert door in evader[0], (disguise, evader)
+
+    # And the exemption still WORKS, which is the half a checker reading
+    # every file would fail: the door declared for real, discard above it.
+    clean = scan(
+        {
+            "src/m.cljs": "#_(ns re-frame.hicasso.core)\n"
+            "(ns {}\n  (:require [{} :as p]))".format(door, engine)
+        }
+    )
+    assert clean == [], clean
+
+    # Blanking stops at the END of the inert form rather than running to the
+    # end of the file — otherwise every file with a `#_` at the top would
+    # lose its ns and be scanned as an anonymous one.
+    assert ns_of("#_(ns {})\n(ns re-frame.hicasso.core)".format(door)) == \
+        "re-frame.hicasso.core"
+
+    # `'` closes over a form only where a form may START, because it is also
+    # a legal symbol character. `next'` must not swallow the require after it
+    # — that direction is a false GREEN, this gate's own subject.
+    flagged = scan(
+        {
+            "src/t.cljs": "(ns re-frame.hicasso.core\n"
+            "  (:require [{} :as mo]))\n(def next' 1)".format(door)
+        }
+    )
+    assert len(flagged) == 1, flagged
+
+    # A require the reader discards is not a require: the module stays absent
+    # from the bundle, so flagging it would be a false RED.
+    clean = scan(
+        {
+            "src/d.cljs": "(ns re-frame.hicasso.core\n"
+            "  (:require #_[{} :as mo] [re-frame.hicasso.impl.codec :as c]))".format(
+                door
+            )
         }
     )
     assert clean == [], clean

--- a/implementation/hicasso/scripts/check_optional_module_reachability.py
+++ b/implementation/hicasso/scripts/check_optional_module_reachability.py
@@ -300,6 +300,24 @@ def read_src():
 
 
 def self_test():
+    # THIS SELF-TEST'S OWN CLAIMS MUST NOT BE DELETABLE (rf2-uyhh). `python -O`
+    # — and `PYTHONOPTIMIZE` in the environment, which needs no flag at the
+    # call site — strips every `assert` below, leaving a function that runs to
+    # its success line having verified nothing. That is a control failing
+    # GREEN, which is this gate's own subject: rf2-df9b below is the same
+    # shape one level down, a form the reader drops still counted as a claim.
+    # The check is empirical rather than a reading of `__debug__`, so it also
+    # catches a `.pyc` compiled under `-O` and run without it.
+    try:
+        assert False
+    except AssertionError:
+        pass
+    else:
+        raise SystemExit(
+            "assertions are disabled (python -O / PYTHONOPTIMIZE), so this "
+            "self-test would prove nothing. Re-run without -O."
+        )
+
     door = "re-frame.hicasso.motion"
     engine = "re-frame.hicasso.impl.presence-react"
 


### PR DESCRIPTION
Two controls in `implementation/hicasso/scripts/` that failed **GREEN** — the
direction that never announces itself, because the gate reports success while
proving nothing. Both were filed by `worker/fencecheck-t9kd` while fixing
rf2-t9kd, from asking of each control whether it is built so as to avoid the
case it exists to catch.

Both premises were re-verified at source before anything was changed, and both
held.

## rf2-uyhh — a self-test `python -O` has emptied

`python -O`, and `PYTHONOPTIMIZE=1` in the environment which needs no flag at
the call site, strips every `assert` statement. A `--self-test` built from bare
asserts therefore runs **zero** checks under it, falls through to its success
line and exits 0. Measured on the landed scripts, all five siblings did exactly
that:

```
check_budget_ledger                 plain=0  -O=0   "OK: ... self-test passed"
check_complaint_catalogue           plain=0  -O=0   "OK: ... self-test passed"
check_freeze                        plain=0  -O=0   "OK: ... self-test passed"
check_lint_export                   plain=0  -O=0   "check_lint_export self-test: PASS"
check_optional_module_reachability  plain=0  -O=0   "... self-test OK"
```

The guard is the one PR #8114 landed in `check_example_fence_coverage.py`,
**copied rather than reinvented**: assert something false and require the
`AssertionError`. Note it is empirical rather than a reading of `__debug__` —
which the bead's remedy also allows — because that additionally catches a
`.pyc` compiled under `-O` and run without it, where `__debug__` is `True` but
the asserts are already gone.

After, for all five, and by both routes:

```
plain --self-test = 0    -O = 1    PYTHONOPTIMIZE=1 = 1
```

with `-O` printing `assertions are disabled (python -O / PYTHONOPTIMIZE), so
this self-test would prove nothing. Re-run without -O.`

**Scope stops at the five hicasso siblings, deliberately.** The idiom is shared
by 45 `--self-test` scripts repo-wide, 38 of them `scripts/check_*.py` at the
root. Copying five lines into forty files is not a trade worth making for a
hole no invocation in this repo opens — every npm script and workflow calls
plain `python` — and rf2-uyhh explicitly licenses saying so. The hicasso five
are a bounded, coherent set that is the measured surface of an active lane.
`check_example_fence_coverage.py` is the sixth sibling and is **left to
PR #8114**, which fixes it; touching it here would have conflicted.

## rf2-df9b — an inert `(ns ...)` form read as a declaration

`ns_of` took the **first** `(ns ...)` in the file, and `code_only` blanked
strings and line comments but not the forms the reader **discards**. Reproduced
against the landed script before fixing:

```python
src = '#_(ns re-frame.hicasso.motion)\n(ns re-frame.hicasso.core (:require [re-frame.hicasso.motion :as mo]))'
ns_of(src)                 -> 're-frame.hicasso.motion'   # the real ns is ...core
scan({'src/x.cljs': src})  -> []                          # FALSE GREEN
```

…while the identical file without the discard yields one problem. The teeth are
out of proportion to the size: `scan` skips any file whose declared ns the
module owns — *the module may of course reach its own engine* — so the file
above was exempted from the reachability check **entirely**, and the invariant
it guards is that an optional module is absent from an application that never
requires it.

Same class as rf2-t9kd one level up: an inert form counted as a live claim. The
remedy is that PR's `strip_inert`/`form_end` pair — reader discard,
`(comment ...)`, quote, **and no more**; not a general Clojure reader, with the
unhandled shapes named in the docstring — composed into `code_only`, the one
place that separates code from prose, so it now also separates live forms from
discarded ones. Both readers downstream get it, so a discarded `:require` no
longer reads as a require either (a harmless but real false red).

**On reuse:** PR #8114 is unmerged, so the pair is not importable and is
**copied**. Lifting it into a shared module would have meant editing that PR's
file and conflicting with it. The family's idiom today is self-contained
scripts, and the bead leaves the choice to the implementor. The two copies
differ in one respect: this one drops #8114's character-literal branches,
because `code_only` turns a character literal into a space before `strip_inert`
ever runs, so they would be dead here. If the two are ever lifted into a shared
module, that is the difference to reconcile.

## `check_freeze` — confirmed NOT a defect, and left alone

The reporting bead notes `declared_namespace` and `definitions` share the shape
but fail RED. Confirmed by driving them:

- `declared_namespace` on a discarded ns above the real one returns the
  discarded one, but the result is compared against the row's pinned `:ns`, so
  the mismatch is a `MOVED` failure.
- `definitions` on a discarded `#_(def ghost 1)` returns `['ghost', 'real']`,
  but the roster is the **donor's**, so a phantom name the package lacks is a
  `MOVED` failure.

Both fail closed. Not fixed, per the bead.

One observation offered as a note rather than actioned: a third function,
`definition_form`, reads the **package** side and would return a discarded
`#_(def a 1)` as a definition, which is the false-green direction. It is
unreachable today — that path is only taken for `:whole-file? false` rows, and
`frozen-sources.edn` records *"Seven rows remain, all `front/*`, all
whole-file."* Minutiae against a dead path; reporting it rather than expanding
scope.

## Acceptance shape

Every new control is **four assertions, not one** — the fault reds *and* the
legitimate case stays green — because a checker that reds on everything would
satisfy half of it and be worthless. For rf2-df9b the pinned greens are: the
honest file still flagged; the genuine door-reaching-its-own-engine exemption
still granted (with a discard above it); blanking stopping at the end of the
inert form so a live `(ns ...)` beside a discarded one still declares; a
trailing-quote symbol not swallowing the require after it; and a discarded
`:require` not read as a require.

Proven to have teeth by reverting the fix in place: the self-test goes RED at
`assert len(evader) == 1` with `('#_(ns re-frame.hicasso.motion)\n', [])` — the
reproduction itself. Restored and verified by `git hash-object` against the
committed blob (not `sha256sum`, which reports a correct restore as failed
under line-ending translation).

## Quality gates

Run from the worktree on the final rebased base (`14f27ce1ad`), redirected with
the exit code captured on the same command line — never piped through `tail`.

| gate | captured exit |
| --- | --- |
| `npm run test:hicasso-invariants` | **0** |
| `npm run test:hicasso-lint` | **0** |
| `python scripts/check_fast_pr_gap.py` | **0** — no required-check roster movement |
| `--self-test`, plain, each of 5 scripts | **0** |
| `--self-test` under `python -O`, each of 5 | **1** (was 0) |
| `--self-test` under `PYTHONOPTIMIZE=1`, each of 5 | **1** (was 0) |
| live `check_optional_module_reachability.py` over real `src/` | **0** |

`check_fast_pr_gap.py` reports the roster unmoved: *85 required jobs across 3
workflows; 29 fully covered by the spine, 5 partly, 51 not at all.*

**No workflow arm was added, and none is needed** — confirmed rather than
assumed. `test:hicasso-invariants` is already chained at
`.github/workflows/test.yml:2973` and in the fast-PR spine at
`scripts/test-fast-pr.sh:1486`; `test:hicasso-lint` at
`.github/workflows/lint.yml:414` and `scripts/test-fast-pr.sh:1505`. Both
already run every touched script.

The full fast-PR spine was not run. Its coverage of this surface is exactly the
two gates above plus `test:hicasso-compile`, a shadow-cljs bench compile that a
Python checker cannot affect; the remainder reads docs, skills and CLJS, none of
which this diff touches. No module imports any of these scripts, so there is no
other consumer to break. CI owns the rest.
