### PR TITLE
docs(mayor-method): the pre-push diff is three-dot, and the reap cost is stated where hygiene reads it (rf2-0ko8, rf2-0bmf)

### DIFF
--- a/docs/the-mayor-method/dispatch-prompt-template.md
+++ b/docs/the-mayor-method/dispatch-prompt-template.md
@@ -500,13 +500,21 @@ gates on the final base *changed the artefact* rather than merely reconfirming i
 findings had merged in the interval, so the governance record it was about to publish carried a membership count
 **false of the trunk**. A false count in a record like that is not caught later; it is cited later.
 
-**Diff against the trunk before you push, and read that diff for what you would REVERT.** Not for conflicts —
-version control reports those itself, and a clean rebase is exactly the case this rule is for. The question the diff
-answers is whether your push undoes something a sibling landed while you worked, which nothing will raise and no gate
-covers: a revert of a merged change is well-formed, it compiles, and it passes every check the tree has. In a shared
-document, a stale copy of one region reapplies as a silent deletion of everything that landed in it since. One
-worker's first push would have reverted a concurrent rewrite of a shared ledger; it caught that by reading the diff
-before reporting, and by nothing else.
+**Diff your branch against its MERGE BASE before you push, and read that diff for what you would REVERT.** Not for
+conflicts — version control reports those itself, and a clean rebase is exactly the case this rule is for. The
+question the diff answers is whether your push undoes something a sibling landed while you worked, which nothing will
+raise and no gate covers: a revert of a merged change is well-formed, it compiles, and it passes every check the tree
+has. In a shared document, a stale copy of one region reapplies as a silent deletion of everything that landed in it
+since. One worker's first push would have reverted a concurrent rewrite of a shared ledger; it caught that by reading
+the diff before reporting, and by nothing else.
+
+**The base is half that instruction, and the wrong base defeats it.** Compare against the point your branch left the
+trunk, never against the trunk's current tip. A tip comparison also carries everything the *trunk* gained while you
+worked, which is not what this step asks: it buries the one hunk that matters under siblings' unrelated work, and it
+degrades worst exactly when the trunk has moved most — which is when this read is most needed. One worker, following
+a tip-shaped wording, read several hundred kilobytes of content none of which was its own. In the dominant toolchain
+the merge-base comparison is the three-dot form, `<TRUNK>...HEAD`; plain `<TRUNK>` is the two-dot one that produced
+that noise.
 
 ---
 


### PR DESCRIPTION
Two items on `docs/the-mayor-method/`, ridden by one agent because two workers on that tree merge-conflict.

## rf2-0ko8 — the pre-push step named the wrong base (fixed)

**The bead's quoted text was already stale, and the defect survived the rewrite.** The bead quotes *"Diff against origin/main before you push"* and asks for `git diff origin/main...HEAD`. PR #8112 had already genericised that line hours earlier to **"Diff against the trunk before you push"** — so there is now **no literal command anywhere in the tracked tree** to change: `git grep "git diff origin/main"` over tracked files (excluding `.beads`) returns **nothing**.

The defect survived genericisation, and arguably got worse. *"Diff against the trunk"* is the two-dot comparison **stated in words**: it names the trunk's current tip as the base, so a reader implementing it faithfully gets the noisy form — and now has no command to copy that would have got it right.

The fix is therefore at the level the tree actually operates: **name the merge base in the instruction**, and give the reason so it is not "simplified" back.

Measured live on this branch, which reproduces the bead's premise:

| form | files shown |
|---|---|
| `git diff --stat origin/main...HEAD` (three-dot) | **1** — mine |
| `git diff --stat origin/main` (two-dot) | **5** — four of them the trunk's, shown as *my deletions* |

That second row is the whole argument. The trunk's advance appears in a two-dot diff **as reversed hunks** — precisely the false *"you are reverting this"* signal the step exists to detect. The noise is not merely bulk; it is the same shape as the thing being hunted.

### Carriers — swept, and what was left standing

`git grep` over tracked files for `git diff origin/main`, `diff against origin/main`, `what you would REVERT`, `merge-base origin/main`, `origin/main...`.

**Changed (1)** — the only carrier that names a base:

- `docs/the-mayor-method/dispatch-prompt-template.md:503`

**Left standing deliberately**, under the bead's discriminator (*only a carrier giving the command, or that a worker would copy, needs changing; a carrier stating the rule in prose is correct and stays*):

- `docs/the-mayor-method/loops.md:173` — "the diff matches its tracker item": the mayor's merge review, a different rule.
- `docs/the-mayor-method/loops.md:256` — "verify it landed in the diff": routing verification, a different rule.
- `docs/the-mayor-method/loops.md:318` and `dispatch-prompt-template.md:156` — "can silently revert each other": prose about two workers sharing a surface.
- `docs/the-mayor-method/loops.md:603,610` — tracker-write reverts, an unrelated surface.
- `scripts/test-fast-pr.sh:270,286`, `scripts/git-hooks/test-pre-commit.sh:716`, `scripts/_test_fixtures/test_fast_pr_docs_gate/run-self-test.sh:91` — **already merge-base-correct** (`origin/main...HEAD`, `git merge-base origin/main HEAD`). Nothing to fix; these are the good form.
- `.claude/commands/mayor-*.md` — **checked; carries no pre-push diff instruction in any wording.** Nothing to change.

**Correction to the bead:** it names `docs/the-mayor-method/loops.md` as a known carrier. It is not one. `loops.md` carries no pre-push diff rule at all — the pre-push read is a *worker* instruction and lives only in the dispatch template.

## rf2-0bmf — already covered; no change (verified)

The bead asks whether the hygiene loop should hold a worktree while its PR is open, and says explicitly that *"a verified 'this is correct as it stands' is a complete deliverable"*.

**It is already answered, in three places, and the answer is "keep the rule".** No edit was made.

1. `docs/the-mayor-method/loops.md:477-482` (*Hygiene → Reaping*) states the cost, the recovery and the ruling:

   > **Reaping on the report is correct and still costs something.** A worker can need its tree *after* it reports, because its change hits a conflict and needs a rebase. Pushed commits make that survivable — the worker recreates the tree on the existing branch and continues. Whether to hold a worktree while its change is open is a real trade, and "leave the rule alone and accept the rebuild" is a defensible answer. **Do not add a second condition to a rule whose strength is that it has one.**

2. `docs/the-mayor-method/bootstrap.md:311-318`, under the heading *"Two tensions the method does not resolve"*, carries the bead's second explicit ask (*"a worker resumed after its worktree is reaped must rebuild before rebasing, and pushed commits are what make that safe"*) almost verbatim:

   > There is a second cost too: a worker can need its tree *after* it reports, because its change hits a conflict and needs a rebase. Nothing is lost when that happens, because the commits were pushed, but the worker has to rebuild its tree first.
   >
   > Keep the rule. Let the residue accumulate, and clear it on explicit operator authority rather than inventing another proxy.

3. `docs/the-mayor-method/dispatch-prompt-template.md:124-128` records the same incident from the dispatch side, as the scheduling error that caused it — "Two costs from one scheduling error."

This repository's own instantiation, `.claude/commands/mayor-hygiene.md:6`, already points the hygiene loop at that exact section and says **"do not add a seventh"**.

**Refused:** anything further. A seventh reap-proxy is out of scope by the bead's own words; a second condition on the reap rule is forbidden by the text quoted above; and restating the recovery a fourth time is duplication, not coverage. The bead's own preferred outcome — *"if the answer is 'leave it', close the bead with that reasoning recorded rather than actioning it"* — is what happened.

## Genericity

The changed paragraph carries no repository or product name, no tracker id, no PR number, no absolute path, no operator name and no OS-specific mechanic. It keeps the count that argues for how hard to look ("several hundred kilobytes") and drops the specifics, matching the register PR #8112 established. The concrete spelling uses a `<TRUNK>` placeholder, consistent with the file's existing `<MAYOR_CHECKOUT>` / `<ASSIGNED_WORKTREE>` convention, and is introduced as "in the dominant toolchain" so a reader on another version-control system keeps the concept. `README.md` was not touched.

## Quality gates

`mkdocs build --strict` was **not** nominated and must not be: `docs/the-mayor-method/` is absent from `mkdocs.yml`'s nav, so it would exit green having inspected none of these pages.

| gate | captured exit | notes |
|---|---|---|
| `python scripts/check_doc_slugs.py` | **0** | green on the final tree |
| `python scripts/check_readme_links.py` | **0** | green on the final tree; run because this PR touches the target side of the `.claude/commands/` → `docs/the-mayor-method/` link |

Exit codes were captured to `.exit` files on the same command line as each run — never through a pipe, whose status would be the last stage's — and are quoted from those files rather than from the harness.

### Sabotage: both gates proven to read this worktree

Both gates print nothing on success and no root banner, so a bare green proves nothing.

| gate | plant | captured exit | output |
|---|---|---|---|
| `check_doc_slugs.py` | one-line broken link at `dispatch-prompt-template.md` | **1** | `BROKEN TARGET: docs\the-mayor-method\dispatch-prompt-template.md:511 -> no-such-file-hygrule-0bmf.md` |
| `check_readme_links.py` | one-line ref rewrite at `.claude/commands/mayor-posture.md:4` | **1** | `BROKEN COMMAND-FILE REFERENCE: .claude/commands/mayor-posture.md:4 -> docs/the-mayor-method/no-such-page-hygrule-0bmf.md` |

Each plant was anchored to a **single line** with an asserted match count of exactly 1, and each restore was verified with `git hash-object` against the pre-plant hash — not `sha256sum`, which mis-reports a correct restore under line-ending translation, and not `git diff`, for which "restored" and "never applied" read alike:

- `dispatch-prompt-template.md` — pre-plant `68fbee2863b00e1c87da9a5f50d422df4ecd4f07`, post-restore `68fbee2863b00e1c87da9a5f50d422df4ecd4f07`
- `mayor-posture.md` — pre-plant `4a10cf6b853ea74065ab7d316e564f8dfc32d4a7`, post-restore `4a10cf6b853ea74065ab7d316e564f8dfc32d4a7`

`git status` after both restores showed only the one intended file modified. `.claude/commands/mayor-posture.md` is **not** in this diff.

### Verified by hand (nothing gates these)

Prose quality, wrapping and markup are ungated, so they were checked by hand: line widths 112–118, inside the file's existing 120 maximum; bold and backtick delimiters balanced in the new paragraph; no table added or altered; and every sentence of the original paragraph survives the rewrap, with only the bolded lead clause changed.

### Pre-push revert read

Done with the three-dot form this PR lands — `git diff origin/main...HEAD` — showing one file, 15 insertions, 7 deletions, all mine. Nothing reverted.

---

Items: rf2-0ko8 (fixed), rf2-0bmf (verified already covered, no change).
