### PR TITLE
docs(async): a reply is not always delivered, and :status is not the three the table lists (rf2-axp0)

### DIFF
--- a/docs/async/http.md
+++ b/docs/async/http.md
@@ -102,15 +102,16 @@ Three conveniences worth knowing:
 
 ## Handling the reply
 
-Every reply is the one **canonical reply envelope** — a plain map with a closed `:status`:
+Every reply is the one **canonical reply envelope** — a plain map with a closed `:status`. The framework-wide set has [five members](continuations-are-data.md#one-envelope-under-every-async-surface); managed HTTP produces four of them (`:partial` belongs to protocols that return data *and* problems in one response — plain HTTP never emits it):
 
 | `:status` | Shape | Notes |
 |---|---|---|
 | `:ok` | `{:status :ok :value value …}` | `value` is the decoded 2xx body. If you supplied `:accept`, this is the value inside `{:ok value}`. |
 | `:error` | `{:status :error :error failure-map …}` | `failure-map` is one of the [category maps below](#failures-are-a-closed-set). Branch on `(-> reply :error :kind)`. |
 | `:cancelled` | `{:status :cancelled :error {:kind :rf.http/aborted …} …}` | An aborted request — the `:rf.http/aborted` map rides under `:error`, with `:cancel/reason` alongside. |
+| `:stale` | `{:status :stale :stale? true :rf.reply/stale-reason reason …}` | The request's correlation went obsolete before delivery — a [superseded `:request-id`](#cancellation-supersession-and-abort), an epoch restore, or an actor destroy whose reply addressed the destroyed actor. **Never dispatched to your handler**; it is trace-only. Carries no `:value`. |
 
-So the *reply's* `:status` tells you which path (`:ok` / `:error` / `:cancelled`), and a failure's inner `:error` map carries its **own** `:kind` — the category. This is the one reply contract every async surface shares — the full envelope (`:work/id`, `:completed-at`, …) lives in [Why no await](continuations-are-data.md#one-envelope-under-every-async-surface); everyday requests read only `:status` / `:value` / `:error`.
+So the *reply's* `:status` tells you which path (`:ok` / `:error` / `:cancelled` — `:stale` never arrives), and a failure's inner `:error` map carries its **own** `:kind` — the category. This is the one reply contract every async surface shares — the full envelope (`:work/id`, `:completed-at`, …) lives in [Why no await](continuations-are-data.md#one-envelope-under-every-async-surface); everyday requests read only `:status` / `:value` / `:error`.
 
 Every request **addresses its reply** — there is no implicit default. There are two **equal** ways to do it — pick by fit, not correctness.
 
@@ -175,7 +176,7 @@ The first time it runs there is no `reply`, so the handler issues the request. W
 
 - **Reply targets must be event vectors.** When you supply `:reply-to`, `:on-success`, or `:on-failure`, each must be an event vector. `nil` means "silence this side"; a keyword, map, string, or any other non-vector value is rejected when that side's reply is dispatched, with `:rf.error/http-bad-reply-target`, so a misshaped continuation cannot be silently rerouted.
 - **The reply lands in the same [frame](../core/frames.md) the request went out from.** The fx carries the frame from the original dispatch through to the reply, so a frame leak — a dispatch firing after the frame has unwound — cannot happen here. ([Frame identity is carried, not found](../core/glossary.md#frame-identity-is-carried-not-found).)
-- **A stale reply is never delivered.** A reply from a superseded request ([below](#cancellation-supersession-and-abort)) does not reach your app at all; it is trace-only.
+- **A stale reply is never delivered.** A reply whose correlation went obsolete before delivery ([below](#cancellation-supersession-and-abort)) — a superseded `:request-id`, or an actor destroy whose reply addressed the destroyed actor — does not reach your app at all; it is trace-only.
 
 ### Timestamps come from a coeffect
 
@@ -316,7 +317,11 @@ Three related surfaces, one per situation.
 
 !!! note "Requests that die with their machine"
 
-    There's a third `:reason`, `:actor-destroyed`. A `:rf.http/managed` request issued from *inside* a spawned [state-machine](../machines/concepts.md) actor is aborted automatically when that actor is destroyed — its outstanding work dies with it, no manual abort needed. Requests dispatched from ordinary event handlers have no such lifecycle peg and are not auto-cancelled; that's deliberate, and `:request-id` remains your app-level cancel handle for them.
+    There's a third `:reason`, `:actor-destroyed`. A `:rf.http/managed` request issued from *inside* a spawned [state-machine](../machines/concepts.md) actor is aborted automatically when that actor is destroyed — its outstanding work dies with it, no manual abort needed.
+
+    The request is always aborted, but a reply is not always delivered. A reply addressed to an ordinary event dispatches as `:status :cancelled` with `{:kind :rf.http/aborted :reason :actor-destroyed}` under `:error`. A reply addressed **back to the actor being destroyed** — the `[(:rf/self-id data) …]` shape — is never dispatched: the runtime classifies it `:status :stale` and records a `:rf.http/stale-suppressed` trace row. Expect no reply on that shape; clean up in the child's `:exit`, or address the reply to an event outside the actor. [Actors — Cancellation](../machines/actors.md#cancellation) has the actor-side detail.
+
+    Requests dispatched from ordinary event handlers have no such lifecycle peg and are not auto-cancelled; that's deliberate, and `:request-id` remains your app-level cancel handle for them.
 
 The [managed-http counter example](../../examples/core/managed_http_counter) demonstrates the manual-abort path end-to-end — plus the 404-is-not-a-decode-failure rule — in one small file.
 


### PR DESCRIPTION
Closes rf2-axp0. Docs-only; `docs/async/http.md` is the whole diff.

## What was wrong

`docs/async/http.md` said

> Every reply is the one **canonical reply envelope** — a plain map with a closed `:status`:

and then tabled exactly three members: `:ok`, `:error`, `:cancelled`. That is not an omission — it is a **closure claim over a set it does not contain**. A reader branching exhaustively on that table writes code with no arm for `:stale`, and the word *closed* is precisely what tells them they need not check.

Verified at source rather than taken on the bead's word:

- `implementation/core/src/re_frame/reply.cljc` — `statuses` is `#{:ok :partial :error :cancelled :stale}`. **Five**, not three. `validate-reply` rejects anything outside it.
- `implementation/http/src/re_frame/http/transport.cljc` — `dispatch-aborted!` routes every abort. For `:actor-destroyed` it derives the reply event's head and tests it with `actor-destroy-target-obsolete?` (`http/reply.cljc`, literally `(= reply-target-id actor-id)`): head = the destroyed actor-id goes to `emit-actor-destroy-stale-trace!` with **no app dispatch at all**; head = an ordinary event goes to `dispatch-failure!` with `:status :cancelled`.
- `spec/Managed-Effects.md` — "Plain managed HTTP does not emit `:partial`", and "A stale envelope is **never** delivered to a reply target."

So `:stale` is a genuine member of the closed set *and* a genuine HTTP outcome; `:partial` is a genuine member that HTTP genuinely never emits.

## How the closure claim is resolved

The word *closed* stays, because the vocabulary really is closed — it was the **arity** that was wrong. The sentence now scopes it: five members framework-wide, four produced by managed HTTP, with `:partial` named and excused in-line. The table gains its fourth row.

Because a `:stale` envelope is never delivered, the row says so in bold and the follow-on sentence now ends "— `:stale` never arrives". A reader must not add a dead fourth `case` arm; `docs/async/coming-from-promises.md`'s three-arm `case` example stays correct, and is now explained rather than merely unexplained.

## Wording, before and after

**Site 1 — the envelope table (`## Handling the reply`)**

- Before: "… a plain map with a closed `:status`:" followed by 3 rows.
- After: "… a plain map with a closed `:status`. The framework-wide set has [five members](…); managed HTTP produces four of them (`:partial` belongs to protocols that return data *and* problems in one response — plain HTTP never emits it):" followed by 4 rows, the new one being `:stale`.
- Also: "tells you which path (`:ok` / `:error` / `:cancelled`)" became "… (`:ok` / `:error` / `:cancelled` — `:stale` never arrives)".

**Site 2 — the `!!! note "Requests that die with their machine"` admonition**

- Before: one paragraph ending "its outstanding work dies with it, no manual abort needed" — no mention of suppression.
- After: the same opening, then the landed `docs/machines/actors.md` sentence verbatim — **"The request is always aborted, but a reply is not always delivered."** — followed by the two-case split (ordinary target dispatches `:status :cancelled` with `{:kind :rf.http/aborted :reason :actor-destroyed}` under `:error`; a target addressed back to the actor being destroyed is never dispatched, is classified `:status :stale`, and records a `:rf.http/stale-suppressed` trace row), and a link to `../machines/actors.md#cancellation`.

**Site 3 — Delivery rules bullet (found in the sweep, same fact)**

- Before: "A reply from a superseded request … does not reach your app at all" — narrower than the truth.
- After: "A reply whose correlation went obsolete before delivery — a superseded `:request-id`, or an actor destroy whose reply addressed the destroyed actor — …".

Terminology is taken from the merged #8116 (`docs/machines/actors.md`) and from `docs/async/continuations-are-data.md`; nothing new is coined, and the `actors.md` Troubleshooting row ("Expect no reply — it is suppressed as `:status :stale`") is echoed, not contradicted.

## The self-addressed-example trap: http.md does NOT have it

The reason `docs/machines/actors.md` was worse than its prose is that it *taught* the `[(:rf/self-id data) …]` shape in its own example and then promised it a reply it never gets. **`docs/async/http.md` carries no such trap.** `grep -rn "self-id" docs/async/` is empty, and every example on the page (`[:article/loaded]`, `[:article/load-error]`, `[:counter/+1]`, `[:items/loaded]`, `[:comment/created]`) addresses an ordinary event. Nothing a reader copies from this page lands in the suppressed case — which is why this is a prose-completeness fix and not a broken-example fix.

## Sweep of `docs/async/`

Discriminator applied: does the sentence describe the behaviour now, or record what was true then?

- `continuations-are-data.md` — already carries the full five-member table with `:stale` and the `:partial` caveat. **Correct, untouched.**
- `coming-from-promises.md` — already names `:stale` as "never delivered, by design". **Correct, untouched.**
- `tutorial.md`, `http-going-further.md`, `index.md`, `examples.md`, `custom-effects.md` — their "closed set" claims are about the **failure `:kind`** taxonomy (eight categories), a different and accurate set. **Untouched.**

`http.md` was the only carrier.

## Refused

- **No Troubleshooting section.** `docs/AUTHORING.md` says "Use a table when **several** failures belong together". This page has one such failure, `docs/machines/actors.md` already carries its row, and the self-addressed shape is an actors-page shape that `http.md` never teaches. A one-row section here would be scaffolding, so the fact went into the `:actor-destroyed` note where the reader already is.
- **No runtime change.** The behaviour is the intended contract — documented at source and locked by `implementation/http/test/re_frame/http_actor_destroy_stale_test.clj`. The docs were wrong, not the code.
- **No `spec/` edit.** Cited as authority only.
- **No `docs/machines/` edit** (`worker/machnav-npgc` owns it) — read as the wording authority, nothing written.

## Quality gates

Run from the worktree, exit codes **captured on the same command line** (`> log 2>&1; echo "$?" > .exit`), never piped. **Both re-run after the rebase onto `origin/main` @ `5680b7ff4f`.**

| Gate | Captured exit |
|---|---|
| `python -m mkdocs build --strict --config-file <worktree>/mkdocs.yml` | **0** |
| `python scripts/check_doc_slugs.py` | **0** |

**Gate read this tree, proven.** mkdocs logged `Building documentation to directory: C:\Users\miket\code\re-frame2-worktrees\httpstale-axp0\site` and `Documentation built in 58.20 seconds`, with zero warnings under `--strict`.

**Sabotage run** (`check_doc_slugs.py` prints nothing on success, so a green run proves nothing on its own). A single-line plant changed `../machines/actors.md#cancellation` to `#sabotage-axp0-no-such-anchor`. The gate went **RED, exit 1**, naming the plant:

```
1 broken anchor link(s) found:
  BROKEN ANCHOR: docs\async\http.md:322 -> ../machines/actors.md#sabotage-axp0-no-such-anchor
```

Restored and verified with `git hash-object` against the committed blob — not `sha256sum` (line-ending translation reports a correct restore as failed) and not `git diff` ("unchanged" and "never applied" are the same diff): working `6b210fe112…` equals `HEAD:docs/async/http.md` `6b210fe112…`.

**Table structure, verified by hand** (nothing in CI validates it). Every table in `http.md` counted with an `awk -F'|'` pass over the file:

| Table | Header cols | Separator cols | Body rows | Cols on every row |
|---|---|---|---|---|
| Top-level keys | 3 | 3 | 12 | 3 |
| `:request` keys | 3 | 3 | 13 | 3 |
| **Reply envelope — edited** | **3** | **3** | **4** | **3** |
| Failure `:kind` | 3 | 3 | 8 | 3 |
| When not to reach for it | 2 | 2 | 3 | 2 |

The edited table's new `:stale` row is 3 columns, matching its header, separator and three sibling rows.
