### PR TITLE
docs(mayor-method): a skipped check is not evidence about the trunk (rf2-52rh)

### DIFF
--- a/docs/the-mayor-method/loops.md
+++ b/docs/the-mayor-method/loops.md
@@ -90,6 +90,16 @@ across four workflows away from mergeable, not one.
 Count only the conclusions that mean the work ran and was fine. Read every other
 value, cancellation included, as a check that has not passed.
 
+**Skipped is accepted, and it says nothing about the trunk.** A surface-armed job is
+skipped on every change that touches none of its surfaces — including, on the trunk, the
+push that broke it. One gate here was skipped on the breaking commit and on every push
+after, while the trunk's rollup read green throughout; it surfaced only when a change
+happened to touch a surface that armed it. So when a change reds a gate the trunk is
+green on, **check whether that job actually ran on the trunk** before concluding the
+change caused it. If it did not, the defect is the trunk's and the fix belongs on a new
+branch off it — the reflex prescribes a fix worker onto the red change's branch, which
+puts a workaround on an innocent one.
+
 ### Clause 3 — require the terminal state, do not enumerate the bad ones
 
 Do not test this by listing the states that block. The vocabulary is longer than it
@@ -259,8 +269,9 @@ routed item is exactly the kind a worker may reasonably decline.
 ### When a change is not green
 
 A real, repeated failure on the touched surface is not a flake and is never an override
-candidate. Dispatch a fix worker onto the **existing** branch that runs the **actual**
-failing gate, not a proxy that already passed.
+candidate. Once you have established the failure is the change's own and not the trunk's,
+dispatch a fix worker onto the **existing** branch that runs the **actual** failing gate,
+not a proxy that already passed.
 
 ---
 


### PR DESCRIPTION
Closes rf2-52rh.

## What and why

Clause 2 of the merge criterion reads *"Every check in a passing or skipped state"*, and
its prose then unpacks only the **cancelled** half. The **skipped** half was never
explained, and that silence is what cost.

Accepting a skipped check is correct and stays correct — a surface-armed job that
legitimately does not apply to a change must not block it. But accepting it is a statement
about **one change**, and it was being read as a statement about **the trunk**. A
surface-armed job is skipped on every push that touches none of its surfaces, including the
trunk push that broke it, so the trunk's rollup can read green while a real regression sits
there.

The expensive half is that it **inverts the diagnosis**. When a change reds a gate the
trunk is green on, the reflex is *"this change broke it"*, and that reflex prescribes a fix
worker onto that change's branch. When the defect is actually on the trunk, that puts a
workaround on an innocent branch.

## The change

One paragraph added at the end of **Clause 2**, saying three things: a skipped check is not
evidence about the trunk; check whether the job actually ran on the trunk before concluding
the change caused a red; and if it did not, the fix goes on a new branch off the trunk.

Clause 2 was chosen over *After each merge* because it is the clause that accepts skipped
and currently never mentions it — the caveat lands on the exact sentence that creates the
misreading, and it fills a genuine hole rather than appending to an unrelated section.

**One neighbouring tightening.** *When a change is not green* prescribed the fix-worker
dispatch unconditionally; it is now conditioned on having established the failure is the
change's own and not the trunk's. That is where a reader facing a red change actually
looks, and it was the sentence carrying the wrong reflex. Kept to one clause deliberately,
so the rule lives in one place rather than two copies that can drift.

## What was deliberately not done

- The criterion is **not** restructured, clauses are **not** renumbered, and skipped states
  do **not** fail. Making skipped fail would ground every surface-armed job.
- No headings changed, so no anchors moved.
- `README.md` untouched — it stays the human-facing piece.
- The policy question (arm the gates on the trunk, schedule them, or accept the silence) is
  out of scope and held separately. This records how to read a signal, not which remedy to
  pick.

## Generic-register check

`docs/the-mayor-method/` is written for a different repository, OS and toolchain. Every
sentence was checked by hand against that: no repository or product names, no tracker ids,
no PR or run numbers, no job names, no absolute paths, no OS mechanics, no named CI
provider. The shape and direction of the failure are kept, the specifics dropped. "One gate
here…" matches the file's existing idiom for measured incidents ("One change here was
reported as…").

## Quality gates

Both gates print nothing on success, so each was **proven live by sabotage** before being
trusted. Exit codes below are the ones I captured to a file, not the harness's.

| Gate | Captured exit |
|---|---|
| `python scripts/check_doc_slugs.py` (baseline) | **0** |
| `python scripts/check_readme_links.py` (baseline) | **0** |
| `check_doc_slugs.py` — **sabotage** | **1** |
| `check_readme_links.py` — **sabotage** | **1** |
| `python scripts/check_doc_slugs.py` (final) | **0** |
| `python scripts/check_readme_links.py` (final) | **0** |

**Sabotage detail.** A single-line broken anchor was planted in `loops.md`; the slug gate
went red naming it precisely — `BROKEN ANCHOR: docs\the-mayor-method\loops.md:634 ->
loops.md#no-such-heading-clause2-52rh`. A broken doc reference was planted in a mayor-loop
command file; the readme-links gate went red naming
`docs/the-mayor-method/clause2-52rh-no-such-doc.md`. Both plants carried a slug unique to
this branch, so neither red could have come from a sibling worktree.

Both restores were verified with `git hash-object` against the committed blob (not
`sha256sum`, which reports a correct restore as failed under line-ending translation, and
not `git diff`, which cannot distinguish "unchanged" from "never applied"). Both matched
exactly and the tree is clean.

**`mkdocs build --strict` was NOT nominated and must not be.** `docs/the-mayor-method/` is
not in `mkdocs.yml`'s nav, so the site build exits green having inspected none of these
pages.

**Nothing gates prose quality.** Register, wrapping, em-dash style and the generic
constraint were verified by hand against the surrounding sections.