### PR TITLE
fix(story): the harness owns its deliberate failures, so the dev console fallback stays quiet (rf2-8yyd)

### DIFF
--- a/tools/story/spec/003-Render-Shell.md
+++ b/tools/story/spec/003-Render-Shell.md
@@ -186,6 +186,28 @@ node and reseats the workspace. Decorator fingerprinting tracks
 whether the decorator stack used by a mounted variant has changed at
 the registry level; stale variants re-mount.
 
+### Error-stream ownership
+
+Mounting the shell registers an `:errors` listener; unmounting drops it
+again. The listener carries no behaviour — the registration *is* the
+payload, because it is a claim rather than a sink.
+
+The framework's dev console fallback (Spec 009 §Error-emit listener)
+prints a promoted `:rf.error/*` record to `console.error` only while the
+corpus-wide `:errors` registry is empty, on the reasoning that an
+untooled dev build would otherwise surface a captured refusal nowhere at
+all. A mounted shell is the tooled case. Story runs failing variants on
+purpose, captures every promoted refusal off the trace axis, and shows
+the outcome in the assertion strip, the Test pane's per-row verdict and
+the embedded Xray Trace tab — so a console line would only duplicate
+what is already on screen, once per failing run.
+
+Registering any `:errors` listener takes ownership corpus-wide, which is
+what the framework contract offers as the fallback's off-switch. Story's
+claim is scoped to the mounted shell: unmounting hands the fallback back
+to whatever runs on the page next, and a host app's own `:errors`
+listener rides under its own id and survives a Story unmount untouched.
+
 ### One run owner (prepare / resume)
 
 A focused variant's run spans the real React render boundary — the

--- a/tools/story/src/re_frame/story/ui/shell.cljs
+++ b/tools/story/src/re_frame/story/ui/shell.cljs
@@ -1108,6 +1108,59 @@
           [promotion/promotion-dialog]
           [command-palette/command-palette-host]]))}))
 
+;; ---- error ownership while a shell is mounted (rf2-8yyd) -----------------
+;;
+;; `re-frame.error-emit`'s dev console fallback (rf2-fu75) prints a promoted
+;; `:rf.error/*` record to `console.error` when — and ONLY when — the
+;; corpus-wide `:errors` listener registry is EMPTY. Its whole point is the
+;; UNTOOLED dev build, where a captured refusal would otherwise reach no
+;; channel at all. A mounted Story shell is the opposite case: Story runs
+;; deliberately-failing variants ON PURPOSE, captures every promoted refusal
+;; off the trace axis (`play/register-listener!`, `frames`, `runtime`), and
+;; surfaces the result in the assertion strip, the Test pane's per-row
+;; verdict and the embedded Xray Trace tab. The refusal is owned, asserted
+;; on, and already on screen.
+;;
+;; Left unclaimed, the fallback printed one console line per captured
+;; refusal — 227 of them in a single Story feature-load browser run — which
+;; reds `examples/scripts/run-story-feature-load-tests.cjs` (console errors
+;; are fatal there, not just `pageerror`).
+;;
+;; So the shell claims the stream the way the fallback's contract defines:
+;; registering ANY `:errors` listener takes corpus-wide ownership and the
+;; fallback goes quiet, "even if that listener ignores this category". That
+;; IS the documented off-switch — there is deliberately no suppression knob
+;; — and the claim is honest here rather than a workaround.
+;;
+;; The listener body is empty on purpose. Story's capture path is the trace
+;; axis, which carries the per-variant frame scope Story's assertions need;
+;; the always-on `:errors` record is corpus-wide and frame-fanned, so
+;; buffering it here would be a second copy nothing reads. The registration
+;; is the whole payload.
+;;
+;; Scoped to the shell's own lifetime and registered under the shell's own
+;; id: unmounting releases the claim (a later untooled dispatch on the same
+;; page gets its console line back), and a host app that registered its own
+;; `:errors` listener keeps it — ids are independent, and dropping ours
+;; never drops theirs.
+
+(def ^:private error-ownership-listener-id
+  ::error-ownership)
+
+(defn- claim-error-ownership!
+  "Take corpus-wide `:errors` ownership for the mounted shell. See the
+  §Error ownership note above. Returns nil."
+  []
+  (rf/register-listener! :errors error-ownership-listener-id (fn [_record] nil))
+  nil)
+
+(defn- release-error-ownership!
+  "Release the shell's `:errors` claim on unmount, restoring the untooled
+  dev console fallback for whatever runs on the page next. Returns nil."
+  []
+  (rf/unregister-listener! :errors error-ownership-listener-id)
+  nil)
+
 ;; ---- mount / unmount surface ---------------------------------------------
 
 (defonce ^:private shell-singleton
@@ -1129,6 +1182,9 @@
       (try
         (rdc/unmount (:root prev))
         (catch :default _ nil)))
+    ;; Before the first render: a variant prepared on mount can already
+    ;; produce a captured refusal. See §Error ownership above.
+    (claim-error-ownership!)
     (let [root (rdc/create-root dom-node)]
       (rdc/render root [shell])
       (let [handle {:root root :node dom-node}]
@@ -1154,6 +1210,7 @@
        (catch :default _ nil))
      (state/reset-shell-state!)
      (teardown-all-listeners!)
+     (release-error-ownership!)
      (stop-hot-reload-poll!)
      (reset! shell-singleton nil)
      nil)))

--- a/tools/story/test/re_frame/story/ui/shell_error_ownership_cljs_test.cljs
+++ b/tools/story/test/re_frame/story/ui/shell_error_ownership_cljs_test.cljs
@@ -1,0 +1,73 @@
+(ns re-frame.story.ui.shell-error-ownership-cljs-test
+  "rf2-8yyd — the mounted Story shell OWNS the `:errors` stream, so
+  `re-frame.error-emit`'s untooled-dev console fallback stays quiet while
+  Story runs its deliberately-failing variants.
+
+  The fallback (rf2-fu75) prints a promoted `:rf.error/*` record to
+  `console.error` when — and only when — the corpus-wide `:errors`
+  listener registry is EMPTY. Story's testbeds run failing scenarios on
+  purpose (`failing-event-throws`, `failing-play`, `failing-fx-stub-miss`,
+  `deliberately-failing`), so every one of those printed a console line;
+  227 of them redded the Story feature-load browser gate, which treats a
+  console error as fatal.
+
+  The assertions below pin the EXACT registry the fallback keys on
+  (`re-frame.error-emit/listeners`) rather than a proxy, so narrowing the
+  claim to a different stream, a different id, or a `goog.DEBUG` branch
+  the fallback does not consult would fail here rather than in a
+  twelve-minute browser gate.
+
+  What this namespace does NOT do is assert that a console error stops
+  appearing — that is the browser gate's job
+  (`npm run test:story-feature-load`), which counts console errors for
+  real."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [re-frame.error-emit :as error-emit]
+            [re-frame.story.ui.shell :as shell]))
+
+(def ^:private claim!   @#'shell/claim-error-ownership!)
+(def ^:private release! @#'shell/release-error-ownership!)
+
+;; The registry the fallback's `(empty? @listeners)` guard reads. Private
+;; in `error-emit` because it is not an app-facing surface; read here
+;; because it is the precise thing this fix has to move.
+(def ^:private listeners @#'error-emit/listeners)
+
+(use-fixtures :each
+  {:before #(error-emit/clear-error-listeners!)
+   :after  #(error-emit/clear-error-listeners!)})
+
+(deftest claim-makes-the-fallback-registry-non-empty
+  (testing "with no shell mounted the registry is empty — the fallback fires"
+    (is (empty? @listeners)))
+  (testing "claiming ownership leaves the registry non-empty, which is the
+            whole off-switch: the fallback goes quiet for EVERY category"
+    (claim!)
+    (is (seq @listeners))))
+
+(deftest release-restores-the-fallback
+  (testing "releasing on unmount hands the untooled-dev console fallback
+            back to whatever runs on the page next"
+    (claim!)
+    (is (seq @listeners))
+    (release!)
+    (is (empty? @listeners))))
+
+(deftest claim-is-idempotent
+  (testing "re-mounting a shell replaces the same id rather than stacking
+            claims, so ONE release still frees the registry"
+    (claim!)
+    (claim!)
+    (is (= 1 (count @listeners)))
+    (release!)
+    (is (empty? @listeners))))
+
+(deftest release-never-drops-a-host-app-listener
+  (testing "a consuming app's own `:errors` listener is registered under its
+            own id — the shell's release drops only the shell's claim, and
+            the app keeps ownership (and its records) across a Story unmount"
+    (error-emit/register-error-listener! ::host-app (fn [_record] nil))
+    (claim!)
+    (is (= 2 (count @listeners)))
+    (release!)
+    (is (= [::host-app] (vec (keys @listeners))))))


### PR DESCRIPTION
Part of rf2-8yyd. **Read the gate table before merging: this fixes the cause
rf2-8yyd names, and the gate is still red on a SECOND cause that is not
Story's and that this PR is fenced out of** (rf2-qw0o, filed with full
evidence). rf2-8yyd is deliberately left OPEN.

## What was red

`Story/Xray browser gates (PR-smoke)` has failed for every PR that arms it
since `fcf866ea1d` (rf2-fu75, #8108) landed the unowned-error dev console
fallback. Reproduced here on `origin/main`, byte for byte with #8118's CI
failure:

```
FAIL Story feature exercise + 20-event load gate: Browser emitted 227 console error(s) and 0 page error(s)
FAIL Story browser scenarios (rf2-dczqg): Browser emitted 20 console error(s) and 0 page error(s)
Ran 2 Story feature-load specs. 2 failures.
```

Nothing throws — 0 page errors. `report-unowned-error!` prints a promoted
`:rf.error/*` record to `console.error` while the corpus-wide `:errors`
listener registry is empty, and the Story harness runs deliberately-failing
variants on purpose. The failing scenarios are the gate working and the
fallback is the fallback working; what was false is the runner's "zero console
errors" assumption.

## Route A, and why

The Story shell claims the `:errors` stream on mount and releases it on
unmount. `implementation/core/src/re_frame/error_emit.cljc` is **unchanged** —
read, not edited. No gate assertion is weakened and no workflow file is
touched, so route B was neither needed nor taken.

That claim is the off-switch the fallback's own contract defines: registering
any `:errors` listener takes corpus-wide ownership and the fallback goes quiet,
"even if that listener ignores this category". It is honest rather than a
workaround, because a mounted Story shell is exactly the case the fallback's
empty-registry test is asking about. Story captures every promoted refusal off
the trace axis and shows the outcome in the assertion strip, the Test pane's
per-row verdict and the embedded Xray Trace tab. The build is tooled; a console
line only duplicates what is already on screen, once per failing run.

The listener body is deliberately empty. Story's capture path is the trace
axis, which carries the per-variant frame scope Story's assertions need, so
buffering the corpus-wide record here would be a second copy nothing reads. The
registration is the payload. Scoping it to the shell keeps the fallback intact
everywhere else: unmounting hands it back, and a host app's own `:errors`
listener rides under its own id and survives a Story unmount untouched.

## The second cause — rf2-qw0o, not fixed here

After this fix the gate falls from 227 + 20 console errors to 94 + 12, and
**all 106 remaining lines are one single refusal repeated once per page
navigation**:

```
{:error        :rf.error/frame-destroyed
 :event-id     :rf.xray.static.machines/hydrate
 :frame        :rf/xray
 :source-coord {:ns day8.re-frame2-xray.static.machines.panel …:line 200}}
```

Xray dispatches its Static-Machines hydrate into the `:rf/xray` frame before
that frame exists. Measured, not inferred: the record was read out of the
browser through the CLJS value's own `toString`, and the same single error
fires on `/counter-with-stories/#/` with **no Story shell mounted at all**, so
it is not Story's. A 5ms-interval sample of the registry from before the first
app script shows the refusal at `t=1251.9ms` and the shell's claim landing at
`t=1610.5ms` — no shell-scoped claim can reach it, and claiming earlier would
be a lie, because the shell owns nothing before it mounts.

The hydrate is also DROPPED, so the persisted Static-Machines selection never
restores after a reload. That is a real defect the fallback surfaced exactly as
designed. It lives under `tools/xray/`, which this worker was fenced out of, so
it is filed as **rf2-qw0o (P1)** with the full diagnosis and linked as a
blocker of rf2-8yyd.

## Quality gates

Every number is the exit code captured on the command's own line, in
`re-frame2-worktrees/storyconsole-8yyd` (each log's shadow-cljs config line
names that worktree).

**The actual failing gate** — `npm run test:story-feature-load`, the CI job's
`Run the FULL Story feature-load gate` step. Not `test:browser`, which is the
proxy that stayed green through this because it only counts `pageerror`.

| run | tree | captured | console errors | verdict |
|---|---|---|---|---|
| 1 | `origin/main` | `EXIT=1` | 227 + 20 | RED — reproduces CI exactly |
| 2 | with this fix | `EXIT=1` | 94 + 12 | RED — every line is rf2-qw0o |
| 3 | fix + planted console error, spec 2 only | `EXIT=1` | 23 (was 12) | RED — the plant counted and named |

Run 3 is the hollow-gate control. A fix that stopped the runner counting
console errors would be worthless, so a bare
`(js/console.error "rf2-8yyd PLANTED UNEXPECTED CONSOLE ERROR")` was planted in
`tools/story/testbeds/counter_with_stories/core.cljs`'s `run`, and the same
spec re-run alone (`STORY_FEATURE_LOAD_SPEC=story_browser_scenarios`) went from
12 console errors to 23 — the 11 extra are one plant per page navigation, and
the runner named each one verbatim in its failure evidence:

```
console errors:
[browser:error] [re-frame2] {meta: null, cnt: 8, arr: Array(16), …}
[browser:error] rf2-8yyd PLANTED UNEXPECTED CONSOLE ERROR
```

The plant was in the compiled module graph, not merely in the source: that
run's log opens with `[:examples/counter-with-stories] Build completed. (706
files, 1 compiled …)`. It was then reverted and the restore verified with
`git hash-object` against the committed blob —
`a883f70c9bc201a717ac28e33114282d546c2c0a` on both sides, working tree clean.
The runner file itself has a zero-line diff in this PR.

**The deliberate failures still fail as declared.** `npm run
test:story-play-scripts` (the job's other step, which drives the same live
shell) — `EXIT=0`, 33 rows all `OK`, including:

```
OK   story.counter-diagnostics/failing-event-throws  expected=fail actual=fail  steps=1
OK   story.counter-diagnostics/failing-play  expected=fail actual=fail  steps=1
OK   story.counter-matrix/failing-fx-stub-miss  expected=fail actual=fail  steps=1
OK   story.counter-play-script/multi[deliberately-failing]  expected=fail actual=fail  steps=2
OK   story.counter-play-script/dom-expected-fail[type-click-and-assert-dom-wrong]  expected=fail actual=fail  steps=6
OK   story.counter-play-script/failing[initialise-one-but-expect-nine]  expected=fail actual=fail  steps=2
```

**`npm run test:cljs`** — `EXIT=0`, 13847 tests / 69980 assertions, 0 failures,
0 errors, and the `:node-test` build compiled with 0 warnings. That run
includes the new `re-frame.story.ui.shell-error-ownership-cljs-test`, which
pins the exact registry the fallback keys on
(`re-frame.error-emit/listeners`) rather than a proxy: empty before,
non-empty after the claim, empty again after release, idempotent across a
re-mount, and a host app's own listener surviving the release.

## Scope

- `tools/story/src/re_frame/story/ui/shell.cljs` — the claim / release.
- `tools/story/test/re_frame/story/ui/shell_error_ownership_cljs_test.cljs` — new.
- `tools/story/spec/003-Render-Shell.md` — §Error-stream ownership under
  §Shell lifecycle, so the shell's lifecycle spec names the claim.

Untouched: `implementation/core/src/re_frame/error_emit.cljc` (read only),
`.github/workflows/*`, `TESTING.md`, root `spec/**`, and everything under
`tools/xray/`.

## Also filed

- **rf2-qw0o** (P1) — the Xray hydrate defect above. Blocks rf2-8yyd.
- **rf2-9eta** (P2) — the wider hole rf2-8yyd asked about. This regression
  reached main because `Story/Xray browser gates (PR-smoke)` is surface-armed
  and was **skipped** on the pushes that landed it, including `fcf866ea1d`
  itself, so it surfaced days later on an innocent PR. Filed as a decision,
  not a task; deliberately not fixed here.
