### PR TITLE
fix(xray): classify the subs operation before its identity (rf2-hic-037)

### DIFF
--- a/tools/xray/spec/028-Hicasso-Advisor.md
+++ b/tools/xray/spec/028-Hicasso-Advisor.md
@@ -187,6 +187,40 @@ none of it ran.* **`:runs` stays 0**: the skip is classified as observed activit
 without being promoted to a run, because making the arithmetic work by
 reclassifying the event would be the same lie one layer down.
 
+#### The operation is classified BEFORE the identity
+
+Sharing a predicate is not enough if a consumer can answer before consulting
+it. The advisor's timing fold tested `(nil? sid)` **first**, so identity loss
+short-circuited the operation question entirely and every untagged `:subs`
+event became a real unnamed RUN — while link 2, which filters on operation
+first, read the same events correctly. The two views therefore still disagreed,
+on exactly the path where identity is absent (audit #8063, reproduced on the
+merge):
+
+| Untagged event | The advisor said | Link 2 said |
+|---|---|---|
+| `:rf.sub/skip` | `:unnamed-runs 1`, `:by-read {}` | `:holds []`, `:skipped {:count 1 :sub-ids []}` |
+| `:rf.sub/dispose` | `:unnamed-runs 1` | no recompute and no skip |
+
+**What an event IS does not depend on whether it carried a tag**, so the tag
+cannot be the outer question. The fold classifies the operation first and
+handles identity loss INSIDE each arm, where it means a different thing in
+each:
+
+| Operation | With an `:rf.sub/id` | Without one |
+|---|---|---|
+| `:rf.sub/run` / `:rf.sub/create` | priced on `[frame-id sub-id]` | `:unnamed-runs` — uncorrelated WORK |
+| `:rf.sub/skip` | `:memo-hits` on that read edge | `:unnamed-skips` — an uncorrelated OBSERVATION |
+| `:rf.sub/dispose` | dropped: an eviction is not work | dropped, for the same reason |
+
+`:unnamed-skips` is a second window-level field rather than a second number
+inside `:unnamed-runs`, and it carries its own `:unnamed-skip-loss`
+`:uncorrelated` account. A reader deciding what to do next needs to know
+whether the untagged half of a window was work or the ABSENCE of work, which is
+exactly the distinction the old ordering collapsed — and it is link 2's
+`:skipped {:count …}` over an empty `:sub-ids`, stated on the advisor's side of
+the same window.
+
 Three thresholds, each with its reason attached rather than a taste:
 
 | Constant | Value | Why |
@@ -361,7 +395,7 @@ bead: no new sentinel, no new evidence machinery, and no code under
 |---|---|---|
 | `…panels.hicasso-advisor-cljs-test` | node + JVM | the timing fold (untimed ≠ zero; a memo hit is not work; an unnamed run is `:uncorrelated`, never dropped; the per-frame scope); the top-3 against a HAND profile whose frequency order deliberately inverts its time order; the fallback axis says `NOT by time`; the five classifications, each driven from a real window; `:cap` and `:host-opaque` are two remedies in two sentences; **the native refusal as a property over the classifier's whole output**, with the ladder's non-vacuity control beside it; the refusal names a non-Xray authority per candidate |
 | `…panels.hicasso-causal-cljs-test` | node (reactive substrate) | the seven links on a REAL interaction through the real commit seam and the real router; links 1–4 evidenced and 5–7 host-opaque with three distinct authorities; the 2→3 join `:uncorrelated` while the 1→2 join is `:evidenced`; **four mutation rows, each with its positive control**; the loss chips reach the page under distinct testids and change between two genuinely different window states; the advisor answers on the running app and still refuses the ladder; advice and slice come from ONE turn |
-| `…panels.hicasso-skip-semantics-cljs-test` | node + JVM | **both public results, off ONE window** — a skip-only window is `:memo-hits-only` / `:host-opaque` with `:runs` 0, routed to measure-first and never to the retention knob, while the same window's slice holds `[]` recomputes and one `:skipped`; a bundle carrying all four `:rf.sub` operations gives the advisor's recompute COUNT and the slice's recompute ROSTER the same reading; the three unattributed states are pairwise distinct and exactly one names `:rf.trace/events-retained`; an untagged RUN beside a tagged skip still degrades to `:unknown` with a `:dropped` of 1 |
+| `…panels.hicasso-skip-semantics-cljs-test` | node + JVM | **both public results, off ONE window** — a skip-only window is `:memo-hits-only` / `:host-opaque` with `:runs` 0, routed to measure-first and never to the retention knob, while the same window's slice holds `[]` recomputes and one `:skipped`; a bundle carrying all four `:rf.sub` operations gives the advisor's recompute COUNT and the slice's recompute ROSTER the same reading; the three unattributed states are pairwise distinct and exactly one names `:rf.trace/events-retained`; an untagged RUN beside a tagged skip still degrades to `:unknown` with a `:dropped` of 1; **and the four-operation matrix** — every `:rf.sub` operation with an `:rf.sub/id` and without one, each cell asserted against what the operation IS *and* against link 2's reading of the same event |
 
 The pair-in-one-row shape of the third suite is the point: an advisor-only row
 would go green against a causal slice that had drifted back, and a causal-only
@@ -369,6 +403,21 @@ row against an advisor that had. Its red demonstration is the pre-repair
 predicate planted in both places — 17 failures across six of its rows, naming
 `:cap` where the window held evidence and a five-element roster where two
 recomputes ran.
+
+The matrix is the second control, and it exists because the first one **covered
+the adjacent case rather than the failing one**: an untagged RUN beside a tagged
+skip, which the pre-repair ordering happened to get right, while untagged
+non-work was what it got wrong. A table over four operations by tagged/untagged
+cannot leave a cell to nobody's row. Both assertions per cell are load-bearing —
+the absolute expectation alone is escapable by two views drifting together, and
+the cross-view agreement alone by both drifting the same way — and the untagged
+run and create rows are the controls that stop the table being satisfied by
+*everything untagged is zero*. Its red demonstration is the `(nil? sid)` branch
+restored to the head of the `cond`: **11 failures at exit 1**, four of them the
+matrix's two untagged non-work cells, over the same 1320 tests and 6246
+assertions the green run reports — so the plant stopped no namespace. Every
+pre-existing row in the suite stayed GREEN under that plant, which is the
+finding restated as a measurement.
 
 All three suites run in the existing `:node-test` build (`tools/xray/test` is
 already on its source paths) and the two `.cljc` ones additionally under

--- a/tools/xray/src/day8/re_frame2_xray/panels/hicasso_advisor.cljc
+++ b/tools/xray/src/day8/re_frame2_xray/panels/hicasso_advisor.cljc
@@ -256,7 +256,7 @@
                           {}
                           frames)
         unnamed   (get folded ::unnamed-runs 0)
-        unskipped (get folded ::unnamed-skips 0)
+        unnamed-sk (get folded ::unnamed-skips 0)
         by-read   (dissoc folded ::unnamed-runs ::unnamed-skips)
         retained  (reduce + 0 (map (comp count val) windows))]
     {:schema        timing-schema
@@ -281,10 +281,10 @@
      ;; know whether the untagged half of this window was work or was the
      ;; absence of work — which is the very distinction the fold above
      ;; collapsed (audit #8063). `hicasso-causal`'s link 2 states the same
-     ;; pair as `:skipped {:count …}` over `:sub-ids [] `.
-     :unnamed-skips unskipped
-     :unnamed-skip-loss (when (pos? unskipped)
-                          {:reason :uncorrelated :dropped unskipped})}))
+     ;; pair as a `:skipped :count` its `:sub-ids` cannot account for.
+     :unnamed-skips unnamed-sk
+     :unnamed-skip-loss (when (pos? unnamed-sk)
+                          {:reason :uncorrelated :dropped unnamed-sk})}))
 
 ;; ---------------------------------------------------------------------------
 ;; The join — a boundary's read edges, priced

--- a/tools/xray/src/day8/re_frame2_xray/panels/hicasso_advisor.cljc
+++ b/tools/xray/src/day8/re_frame2_xray/panels/hicasso_advisor.cljc
@@ -164,7 +164,23 @@
   a fold that treated a missing tag as zero would report a subscription
   it never timed as instantaneous — the loudest possible version of the
   `unknown is never zero` mistake, because the reader would then rank
-  it last."
+  it last.
+
+  **The OPERATION is classified before the identity, and that ordering is
+  the whole correctness of this fold** (rf2-hic-037, merged-PR audit
+  #8063). It was inverted: `(nil? sid)` was the first branch, so it ran
+  ahead of `hh/sub-recompute?` and every untagged `:subs` event became an
+  unnamed RUN — an untagged `:rf.sub/skip` and an untagged
+  `:rf.sub/dispose` alike were reported as work that happened, while
+  `hicasso-causal`'s link 2 (which filters on operation first) reported
+  no recompute for the same window. One event, two public answers, and
+  the shared predicate was bypassed on exactly the path where identity is
+  absent. What an event IS does not depend on whether it carried a tag,
+  so the tag cannot be the outer question. Identity loss is handled
+  INSIDE each operation arm, where it means something different in each:
+  a run that joins to nothing is uncorrelated WORK, a skip that joins to
+  nothing is an uncorrelated OBSERVATION, and an eviction is neither
+  either way."
   [acc frame-id bundle]
   (let [did (:dispatch-id bundle)]
     (reduce
@@ -172,26 +188,37 @@
         (let [sid (get-in ev [:tags :rf.sub/id])
               k   [frame-id sid]]
           (cond
-            ;; A sub event with no registration id is a real run that
-            ;; joins to no subscription. It is counted at the window level
-            ;; (below) rather than dropped, because dropping it would let
-            ;; an untagged stream read as an idle one.
-            (nil? sid)      (update m ::unnamed-runs (fnil inc 0))
-
+            ;; RUN / CREATE — the body ran.
             (hh/sub-recompute? ev)
-            (let [ms (get-in ev [:tags :rf.sub/elapsed-ms])]
-              (-> m
-                  (update-in [k :runs] (fnil inc 0))
-                  (update-in [k :dispatch-ids] (fnil conj #{}) did)
-                  (cond->
-                    (number? ms) (-> (update-in [k :elapsed-ms] (fnil + 0.0) ms)
-                                     (update-in [k :timed-runs] (fnil inc 0))
-                                     (update-in [k :max-ms] (fnil max 0.0) ms))
-                    (not (number? ms)) (update-in [k :untimed-runs] (fnil inc 0)))))
+            (if (nil? sid)
+              ;; Work with no registration id joins to no subscription. It
+              ;; is counted at the window level (below) rather than
+              ;; dropped, because dropping it would let an untagged stream
+              ;; read as an idle one. ONLY this arm may increment it.
+              (update m ::unnamed-runs (fnil inc 0))
+              (let [ms (get-in ev [:tags :rf.sub/elapsed-ms])]
+                (-> m
+                    (update-in [k :runs] (fnil inc 0))
+                    (update-in [k :dispatch-ids] (fnil conj #{}) did)
+                    (cond->
+                      (number? ms) (-> (update-in [k :elapsed-ms] (fnil + 0.0) ms)
+                                       (update-in [k :timed-runs] (fnil inc 0))
+                                       (update-in [k :max-ms] (fnil max 0.0) ms))
+                      (not (number? ms)) (update-in [k :untimed-runs] (fnil inc 0))))))
 
+            ;; SKIP — a memo hit, whether or not it named the cell it hit.
+            ;; An untagged one is still a skip: the cell was considered and
+            ;; the memo held, and the only thing missing is which cell.
             (hh/sub-skip? ev)
-            (update-in m [k :memo-hits] (fnil inc 0))
+            (if (nil? sid)
+              (update m ::unnamed-skips (fnil inc 0))
+              (update-in m [k :memo-hits] (fnil inc 0)))
 
+            ;; `:rf.sub/dispose`, and any operation the vocabulary grows
+            ;; later: an eviction is neither work nor a memo hit, tagged or
+            ;; untagged, and a producer that adds a fifth operation must be
+            ;; a decision in `hh/sub-recompute-operations` rather than a
+            ;; silent reclassification here.
             :else m)))
       acc
       (:subs bundle))))
@@ -206,7 +233,8 @@
       ;;     :loss {:reason :cap :dropped :unknown}
       ;;     :by-read {[:app/main :todo] {:runs 4 :timed-runs 4 :untimed-runs 0
       ;;                                  :elapsed-ms 6.4 :max-ms 2.1
-      ;;                                  :memo-hits 9 :dispatch-ids #{41 42 43 44}}}}
+      ;;                                  :memo-hits 9 :dispatch-ids #{41 42 43 44}}}
+      ;;     :unnamed-runs 0 :unnamed-skips 0}
 
   `windows` is `{frame-id [event-bundle …]}` exactly as
   `re-frame.trace.tooling/trace-buffer` answers it, one entry per frame.
@@ -228,7 +256,8 @@
                           {}
                           frames)
         unnamed   (get folded ::unnamed-runs 0)
-        by-read   (dissoc folded ::unnamed-runs)
+        unskipped (get folded ::unnamed-skips 0)
+        by-read   (dissoc folded ::unnamed-runs ::unnamed-skips)
         retained  (reduce + 0 (map (comp count val) windows))]
     {:schema        timing-schema
      :producer      timing-producer
@@ -243,7 +272,19 @@
      ;; than folded away so an untagged stream cannot read as an idle one.
      :unnamed-runs  unnamed
      :unnamed-loss  (when (pos? unnamed)
-                      {:reason :uncorrelated :dropped unnamed})}))
+                      {:reason :uncorrelated :dropped unnamed})
+     ;; And its counterpart, which used to be counted as a run. A skip
+     ;; whose tag is absent is uncorrelated in the SAME way and a
+     ;; different fact: the memo held and the cell it held for is what
+     ;; joins to nothing. It is a second field rather than a second number
+     ;; in the first, because a reader deciding what to do next needs to
+     ;; know whether the untagged half of this window was work or was the
+     ;; absence of work — which is the very distinction the fold above
+     ;; collapsed (audit #8063). `hicasso-causal`'s link 2 states the same
+     ;; pair as `:skipped {:count …}` over `:sub-ids [] `.
+     :unnamed-skips unskipped
+     :unnamed-skip-loss (when (pos? unskipped)
+                          {:reason :uncorrelated :dropped unskipped})}))
 
 ;; ---------------------------------------------------------------------------
 ;; The join — a boundary's read edges, priced

--- a/tools/xray/test/day8/re_frame2_xray/panels/hicasso_skip_semantics_cljs_test.cljc
+++ b/tools/xray/test/day8/re_frame2_xray/panels/hicasso_skip_semantics_cljs_test.cljc
@@ -33,6 +33,24 @@
   the same fixture. A row that only checked the advisor would go green
   against a causal slice that had drifted back, and vice versa.
 
+  ## And the path that still bypassed the predicate
+
+  Sharing a predicate is not enough if one consumer can decide the answer
+  before consulting it. The advisor's fold tested `(nil? sid)` FIRST, so
+  identity loss short-circuited the operation question entirely and every
+  untagged `:subs` event was counted as a real unnamed RUN — an untagged
+  `:rf.sub/skip` gave the advisor `:unnamed-runs 1` and `:by-read {}`
+  while link 2 gave `:holds []` and `:skipped {:count 1 :sub-ids []}`, and
+  an untagged `:rf.sub/dispose` gave the advisor `:unnamed-runs 1` while
+  link 2 reported no recompute and no skip at all (merged-PR audit #8063).
+  The two views still disagreed, on exactly the path where identity is
+  absent.
+
+  The first regression here covered an untagged RUN beside a tagged skip
+  — the adjacent case, not the failing one — which is why
+  [[operation-matrix]] is a TABLE: four operations by tagged/untagged, so
+  the untagged non-work cells cannot be the ones nobody wrote a row for.
+
   Pure data → data, so this runs under the JVM target beside the CLJS
   one. The live-runtime claims stay in `hicasso_causal_cljs_test`.
 
@@ -80,6 +98,14 @@
     :operation op
     :tags      (cond-> {:rf.sub/id sub-id}
                  (number? ms) (assoc :rf.sub/elapsed-ms ms))}))
+
+(defn- untagged-ev
+  "The same event with its `:rf.sub/id` gone — the shape a stripped or
+  never-tagged emission actually has. `:tags {}` rather than a missing
+  `:tags`, because that is what the seam produces and it is the shape the
+  mutation row in `hicasso_causal_cljs_test` builds too."
+  [op]
+  {:op-type :rf.sub :operation op :tags {}})
 
 (defn- bundle
   [dispatch-id event-id subs]
@@ -200,6 +226,119 @@
                "two definitions of `did work happen` is what produced the "
                "disagreement this row exists to prevent")))))
 
+;; ---------------------------------------------------------------------------
+;; The four operations, tagged and untagged — the whole surface, in one table
+;; ---------------------------------------------------------------------------
+
+(defn- advisor-counts
+  "The advisor fold's window-level reading, in the four quantities link 2
+  also states."
+  [timing]
+  {:named-runs    (reduce + 0 (map #(get (val %) :runs 0) (:by-read timing)))
+   :unnamed-runs  (get timing :unnamed-runs 0)
+   :named-skips   (reduce + 0 (map #(get (val %) :memo-hits 0) (:by-read timing)))
+   :unnamed-skips (get timing :unnamed-skips 0)})
+
+(defn- link2-counts
+  "Link 2's reading of the SAME window, in the same four quantities.
+
+  Read off the link's public fields rather than recomputed: `:holds` is
+  the named recompute roster (or `:unknown` when work joined to nothing),
+  the `:uncorrelated` loss carries the unnamed run count, and `:skipped`
+  states the memo hits as a total beside the ids it could name — so the
+  untagged skips are exactly the total the ids do not account for."
+  [link2]
+  (let [holds (:holds link2)
+        loss  (:loss link2)
+        named-skips (count (get-in link2 [:skipped :sub-ids]))]
+    {:named-runs    (if (hh/unknown? holds) 0 (count holds))
+     :unnamed-runs  (if (= :uncorrelated (:reason loss)) (:dropped loss) 0)
+     :named-skips   named-skips
+     :unnamed-skips (- (get-in link2 [:skipped :count]) named-skips)}))
+
+(def ^:private operation-matrix
+  "Every `:op-type :rf.sub` operation Spec 009 routes through the
+  projection's `:subs` slot, WITH its `:rf.sub/id` and without it, and what
+  each one is.
+
+  The untagged half is the half that was wrong (rf2-hic-037, merged-PR
+  audit #8063): the advisor's fold tested `(nil? sid)` BEFORE
+  `hh/sub-recompute?`, so identity loss decided the classification and
+  every untagged event became a run. The two untagged non-work rows are
+  therefore the rows this table exists for — an untagged `:rf.sub/skip`
+  read as one unnamed run against link 2's one memo hit, and an untagged
+  `:rf.sub/dispose` read as one unnamed run against link 2's nothing at
+  all.
+
+  The absolute expectation is written out per row rather than only
+  comparing the two views, because two views wrong the same way agree
+  perfectly. The untagged run and create rows are the controls that keep
+  the table from being satisfied by *everything untagged is zero* — they
+  MUST still count an unnamed run, which is the rule the repair had to
+  leave standing."
+  [[:rf.sub/run     true  {:named-runs 1 :unnamed-runs 0 :named-skips 0 :unnamed-skips 0}]
+   [:rf.sub/run     false {:named-runs 0 :unnamed-runs 1 :named-skips 0 :unnamed-skips 0}]
+   [:rf.sub/create  true  {:named-runs 1 :unnamed-runs 0 :named-skips 0 :unnamed-skips 0}]
+   [:rf.sub/create  false {:named-runs 0 :unnamed-runs 1 :named-skips 0 :unnamed-skips 0}]
+   [:rf.sub/skip    true  {:named-runs 0 :unnamed-runs 0 :named-skips 1 :unnamed-skips 0}]
+   [:rf.sub/skip    false {:named-runs 0 :unnamed-runs 0 :named-skips 0 :unnamed-skips 1}]
+   [:rf.sub/dispose true  {:named-runs 0 :unnamed-runs 0 :named-skips 0 :unnamed-skips 0}]
+   [:rf.sub/dispose false {:named-runs 0 :unnamed-runs 0 :named-skips 0 :unnamed-skips 0}]])
+
+(deftest every-operation-reads-the-same-in-both-views-with-or-without-an-id
+  ;; THE MATRIX. One event per cell, both public results off it, and each
+  ;; cell asserted twice: against what the operation IS, and against the
+  ;; other view. Either assertion alone is escapable — the first by two
+  ;; views drifting together, the second by both drifting the same way.
+  (doseq [[op tagged? expected] operation-matrix]
+    (testing (str op (if tagged? " with an `:rf.sub/id`" " with NO `:rf.sub/id`"))
+      (let [ev      (if tagged? (sub-ev :a nil op) (untagged-ev op))
+            windows {:app/main [(bundle 1 :e/tick [ev])]}
+            {:keys [advice link2]} (both [[:app/main :a]] windows)
+            adv     (advisor-counts (:timing advice))
+            l2      (link2-counts link2)]
+        (is (= expected adv)
+            (str "the advisor's fold must classify the OPERATION first — "
+                 "an untagged event is still whatever operation it is"))
+        (is (= expected l2)
+            "and link 2's roster must read the same event the same way")
+        (is (= adv l2)
+            (str "one window, two public results, ONE answer to `did work "
+                 "happen` — the disagreement is the defect, and identity "
+                 "loss is where it survived"))))))
+
+(deftest an-untagged-NON-WORK-event-is-uncorrelated-observation-never-work
+  ;; The audit's two reproductions, pinned with their own numbers. The
+  ;; matrix above proves the counts agree; this proves the advisor states
+  ;; the right KIND of absence about them — a skip that joins to nothing
+  ;; is an uncorrelated observation, and an eviction is not an absence at
+  ;; all.
+  (testing "an untagged `:rf.sub/skip` — was `:unnamed-runs 1`, `:by-read {}`"
+    (let [t (advisor/sub-timing
+              {:app/main [(bundle 1 :e/tick [(untagged-ev :rf.sub/skip)])]})]
+      (is (zero? (:unnamed-runs t))
+          "no run happened; the memo answered")
+      (is (nil? (:unnamed-loss t))
+          "and no work is missing an id, so there is no unnamed-RUN account")
+      (is (= 1 (:unnamed-skips t)))
+      (is (= :uncorrelated (:reason (:unnamed-skip-loss t)))
+          (str "the skip is real and the CELL it held for joins to nothing — "
+               "the same uncorrelated state an unnamed run is in, about a "
+               "different fact"))
+      (is (= 1 (:dropped (:unnamed-skip-loss t))))))
+
+  (testing "an untagged `:rf.sub/dispose` — was `:unnamed-runs 1` against link 2's nothing"
+    (let [t (advisor/sub-timing
+              {:app/main [(bundle 1 :e/tick [(untagged-ev :rf.sub/dispose)])]})]
+      (is (zero? (:unnamed-runs t)))
+      (is (zero? (:unnamed-skips t))
+          "an eviction is neither work nor a memo hit, tagged or not")
+      (is (nil? (:unnamed-loss t)))
+      (is (nil? (:unnamed-skip-loss t))
+          (str "and it is not an absence either — nothing was dropped, so "
+               "there is nothing to account for"))
+      (is (= {} (:by-read t))))))
+
 (deftest the-shared-predicate-is-the-one-in-the-shared-algebra
   ;; The predicate is a public var in `hicasso-helpers` precisely so both
   ;; derivations can consult it and a reader can see that they do.
@@ -258,7 +397,7 @@
   ;; untagged run beside a tagged skip is the case where a careless filter
   ;; would count the skip's absence of a tag as the run's.
   (let [windows {:app/main [(bundle 1 :e/tick
-                                    [{:op-type :rf.sub :operation :rf.sub/run :tags {}}
+                                    [(untagged-ev :rf.sub/run)
                                      (sub-ev :a nil :rf.sub/skip)])]}
         {:keys [link2]} (both [[:app/main :a]] windows)]
     (is (hh/unknown? (:holds link2))


### PR DESCRIPTION
Closes the residual the merged-PR audit of #8063 reopened on rf2-hic-037.

## The defect

The tagged skip-only repair shared one recompute predicate between the advisor
and the causal slice, but one path still bypassed it. `hicasso-advisor`'s
`fold-bundle` tested `(nil? sid)` **before** `hh/sub-recompute?` and
`hh/sub-skip?`, so identity loss short-circuited the operation question and
every untagged `:subs` event was counted as a real unnamed RUN.

Both audit claims reproduced on the JVM at the merge base, before changing
anything:

| Untagged event | The advisor said | Link 2 said |
|---|---|---|
| `:rf.sub/skip` | `:unnamed-runs 1`, `:by-read {}`, `:unnamed-loss {:reason :uncorrelated :dropped 1}` | `:holds []`, `:skipped {:count 1 :sub-ids []}` |
| `:rf.sub/dispose` | `:unnamed-runs 1`, `:by-read {}`, `:unnamed-loss {:reason :uncorrelated :dropped 1}` | `:holds []`, `:skipped {:count 0 :sub-ids []}` |

Two public results off one window, disagreeing about whether work happened —
on exactly the path where identity is absent. The controls in the same run
(untagged `:rf.sub/run` and `:rf.sub/create`) already agreed: advisor
`:unnamed-runs 1` against link 2's `:holds :unknown` with
`{:reason :uncorrelated :dropped 1}`. Those had to keep agreeing.

## The repair

**Classify the operation first; handle identity loss inside each arm.** What an
event *is* does not depend on whether it carried a tag, so the tag cannot be
the outer question.

| Operation | With an `:rf.sub/id` | Without one |
|---|---|---|
| `:rf.sub/run` / `:rf.sub/create` | priced on `[frame-id sub-id]` | `:unnamed-runs` — uncorrelated WORK |
| `:rf.sub/skip` | `:memo-hits` on that read edge | `:unnamed-skips` — an uncorrelated OBSERVATION |
| `:rf.sub/dispose` | dropped: an eviction is not work | dropped, for the same reason |

`:unnamed-skips` carries its own `:unnamed-skip-loss` `:uncorrelated` account
rather than being folded into `:unnamed-runs`: a reader deciding what to do next
needs to know whether the untagged half of a window was work or the *absence* of
work, which is precisely the distinction the old ordering collapsed. It is link
2's `:skipped :count` over an empty `:sub-ids`, stated on the advisor's side.

No validator, no store, no trace-normalisation layer — the repair is the `cond`
ordering plus one counterpart field.

After the repair all eight cells agree, and the two control rows are unchanged.

## The control

`every-operation-reads-the-same-in-both-views-with-or-without-an-id` — four
operations × tagged/untagged, both public results off one window per cell.

The regression that shipped with the previous repair covered an untagged **run**
beside a tagged skip: the adjacent case, which the pre-repair ordering happened
to get right. Untagged **non-work** was what it got wrong, and no row drove it.
A table cannot leave a cell to nobody's row.

Each cell is asserted **twice** — against what the operation IS, and against the
other view — because either alone is escapable: the absolute expectation by two
views drifting together, the cross-view agreement by both drifting the same way.
The untagged run and create rows are the controls that stop the table being
satisfied by *everything untagged is zero*.

## Quality gates

Captured exit codes, from the log-and-`.exit` pair on one command line — not the
harness's.

| Gate | Exit | Result |
|---|---|---|
| `tools/xray` `clojure -M:test` | **0** | 1320 tests / 6246 assertions, 0 failures |
| `npm run test:cljs` | **0** | 13845 tests / 70006 assertions, 0 failures |
| `npm run test:xray-feature-gate` (full nightly sweep) | **0** | 17 scenarios, 0 failures, 14 matrix rows |
| `scripts/check_doc_slugs.py` | **0** | no broken links |

Re-run on the final rebased base (`b85e6062ac`): the xray JVM suite (**0**,
1320/6246) and `check_doc_slugs.py` (**0**). The trunk's advance since my base
is docs `.md`, `.beads` and `implementation/hicasso/scripts/*.py` only — no CLJS
source and nothing under `tools/xray` — so the `:node-test` build and the
feature gate compile identical inputs.

### RED before, GREEN after

**The matrix, proved red first.** Planting the pre-repair ordering — the
`(nil? sid)` branch restored to the head of the `cond` — gives **exit 1, 11
failures**, over the *same* 1320 tests and 6246 assertions the green run reports,
so the plant stopped no namespace and skipped no assertion.

- 4 in `every-operation-reads-the-same-in-both-views-with-or-without-an-id` —
  2 absolute-expectation and 2 cross-view, and they are exactly the untagged
  skip and untagged dispose cells. The other six cells stayed green.
- 7 in `an-untagged-NON-WORK-event-is-uncorrelated-observation-never-work`.

**Every pre-existing row in the suite stayed GREEN under that plant** — which is
the finding restated as a measurement: the previous control could not catch this
case.

Restore verified with `git hash-object` against the committed blob
(`ce7cdeb6aff0e6b0de39f09ef9b0bc7c5477923e` both sides), not `sha256sum` and not
`git diff`.

**`check_doc_slugs.py` prints no banner, so it was proved live** on this file
rather than trusted: a planted broken anchor in
`tools/xray/spec/028-Hicasso-Advisor.md` gave **exit 1** with
`BROKEN ANCHOR: tools\xray\spec\028-Hicasso-Advisor.md:427`, and removing it
returned **exit 0**. The plant was removed byte-exactly and the diff carries no
residue.

Every shell gate printed a config/root line naming this worktree
(`…/re-frame2-worktrees/advisorid-hic037`) before any colour was believed.

## Spec

`tools/xray/spec/028-Hicasso-Advisor.md` updated in the same PR, per the standing
rule for `tools/xray/` dispatches: the operation-before-identity ordering with
both audit reproductions, the per-operation tagged/untagged table, the coverage
row for the matrix, and why the first control covered the adjacent case.

**The "no root `spec/*` row owed" conclusion still holds.** Spec 009 already
defines all four `:rf.sub` operations and distinguishes them correctly
(`spec/009-Instrumentation.md:199-202`, elaborated at 242-272); nothing in this
repair asks the instrumentation contract for anything new. The defect was one
consumer answering before consulting the shared predicate — one layer above the
vocabulary, exactly as the previous repair found. `spec/**` is untouched.

While verifying that, I did find a pre-existing understatement in a hot-zone file
and **filed it rather than editing it** (rf2-08gw, P4): the projection routes on
`:op-type` (`trace/projection.cljc:234`), so all four `:rf.sub` operations land in
the `:subs` slot, but both `spec/009-Instrumentation.md:787` and
`trace/projection.cljc:312` list only three, omitting `:rf.sub/dispose`. The
operation vocabulary itself is correct, so no consumer contract is wrong — but
that comment has now misled a premise twice on this surface.
