### PR TITLE
fix(hicasso): inert ancestry and disabled fieldsets are not focus stops (rf2-hic-052)

### DIFF
--- a/implementation/hicasso/src/re_frame/hicasso/impl/overlay.cljs
+++ b/implementation/hicasso/src/re_frame/hicasso/impl/overlay.cljs
@@ -281,11 +281,34 @@
     (pos? (.-length (.getClientRects el)))))
 
 (defn- tab-stop?
-  "Would Tab stop here? Disabled elements take no focus, a negative
-  `tabIndex` is reachable only programmatically, and an element the
-  engine does not render is reachable by nothing — see [[rendered?]]."
+  "Would Tab stop here? Four ways the answer is no, and each is asked of
+  the engine in the form the engine itself uses.
+
+  **`:disabled` the pseudo-class, and not the `.disabled` property.** The
+  IDL property reflects the element's OWN attribute, so a control inside
+  a `<fieldset disabled>` reports `disabled: false` while the engine
+  refuses it focus — measured. The pseudo-class is the EFFECTIVE state,
+  which makes it a strictly wider reading of the same question rather
+  than a second rule beside it: it still matches a plainly `disabled`
+  control, and it gets the fieldset's own carve-out right for free.
+  Controls in a disabled fieldset's FIRST `<legend>` stay enabled, and
+  they are real stops; walking up to `fieldset[disabled]` by hand would
+  have dropped them, and a candidate set too SMALL aims the wrap at the
+  wrong control, which [[rendered?]] explains is the worse failure.
+
+  **`inert` is read as the attribute, because there is no pseudo-class
+  for it** — `matches(':inert')` throws `SyntaxError` in this repo's
+  Chromium, measured rather than assumed. `closest` is what makes the
+  reading INHERITED, which is the shape inertness actually has: the
+  attribute goes on the region, and every control under it stops being a
+  stop.
+
+  The other two doors are unchanged: a negative `tabIndex` is reachable
+  only programmatically, and an element the engine does not render is
+  reachable by nothing — see [[rendered?]]."
   [^js el]
-  (and (not (.-disabled el))
+  (and (not (.matches el ":disabled"))
+       (nil? (.closest el "[inert]"))
        (not (neg? (.-tabIndex el)))
        (rendered? el)))
 
@@ -342,49 +365,57 @@
     with document order inside each bucket.
 
   **It is not the platform's focus algorithm and does not try to be.**
-  Two things the engine skips are still counted here, and they are named
-  rather than half-modelled: an element inside an `inert` subtree, and a
-  control inside a `disabled` `<fieldset>`. Shadow roots,
-  `delegatesFocus` and scrollable-overflow focusability are outside the
-  set entirely.
+  Shadow roots, `delegatesFocus` and scrollable-overflow focusability
+  are outside the set entirely, and a control the engine skips for any
+  reason not listed on [[tab-stop?]] is still counted here.
 
-  Two more used to be on that list and are now filtered, by
-  [[rendered?]] asking `checkVisibility` instead of reading client
-  rects: `visibility:hidden`, and the contents of a closed `<details>`
-  (whose UA `content-visibility:hidden` the bare call already answers).
-  A `content-visibility:hidden` subtree goes with them, which was not on
-  the list at all. All measured.
+  ## The four effective non-stops, and why counting them was a defect
 
-  ## Why one of those four was a defect after all, and why the two left are not
+  Four ways an element can be a candidate this scan finds and a stop the
+  engine never visits were named on this function across two beads:
+  `visibility:hidden`, the contents of a closed `<details>`, an `inert`
+  subtree, and a `disabled` `<fieldset>`. All four are now excluded —
+  the first two by [[rendered?]] asking `checkVisibility` instead of
+  reading client rects, the last two by [[tab-stop?]] asking `:disabled`
+  and `[inert]` — and the argument that kept them is worth keeping too,
+  because it was half right and the half that failed is instructive.
 
   A surplus candidate costs a WRAP THAT DOES NOT FIRE when it cannot
   take focus, and a WRAP THAT LANDS WRONG when it can — and
   [[wrap-tab!]] only takes the default action away once the landing is
-  confirmed, so the first of those degrades to exactly the engine's own
-  conduct. Measured with `.focus()` on each: inert, disabled-fieldset,
-  `visibility:hidden` and closed-`<details>` contents ALL refuse focus,
-  while an unchecked radio in a checked group ACCEPTS it. That is the
-  whole reason the radio group was a wrong landing rather than a missed
-  wrap.
+  confirmed, so the first of those looked like it degraded to exactly
+  the engine's own conduct. Measured with `.focus()` on each: all four
+  refuse focus, while an unchecked radio in a checked group ACCEPTS it.
+  That is the whole reason the radio group was a wrong landing rather
+  than a missed wrap.
 
-  **But a missed wrap is not free at the LAST candidate**, and rf2-5lzq
-  measured the difference the `.focus()` reading could not show. A
-  trailing `visibility:hidden` control — a conditionally-hidden final
-  button, ordinary markup — becomes `peek`, so Tab off the real last
-  control matches no edge, the handler declines, and the engine's own
-  end-of-scope step puts `document.activeElement` on `<body>`: the leak
-  this whole handler exists to close, by a fourth route. `refuses focus`
-  and `costs nothing` are different claims and only the first was ever
-  measured. [[a-real-tab-wraps-past-a-trailing-hidden-control]] holds
-  the second.
+  **But a missed wrap is not free at the LAST candidate.** There the
+  surplus is what `peek` returns, so Tab off the real last control
+  matches no edge, the handler declines, and the engine's own
+  end-of-scope step puts `document.activeElement` on `<body>` — the leak
+  this whole handler exists to close, reached by a fourth route.
+  Shift+Tab off the first stop fails the same way from the other end:
+  the wrap AIMS at the surplus, `.focus()` declines, `preventDefault` is
+  correctly withheld, and withholding it is what lets focus out.
+  `refuses focus` and `costs nothing` are different claims and only the
+  first was ever measured.
 
-  The two still counted keep the old argument, now stated as the
-  narrower thing it is: they cost a missed wrap, and they are left
-  because no measured markup puts either of them LAST in a modal.
-  Whichever does earns the fix rather than a rule written ahead of it —
-  and for the `<fieldset>` the remedy is already measured, `:disabled`
-  as a pseudo-class matching the effective state that the `.disabled`
-  property above does not.
+  rf2-5lzq measured that for `visibility:hidden` and then argued the
+  remaining two were safe because *no measured markup puts either of
+  them LAST in a modal*. **That claim was false, and it was contradicted
+  by evidence the same bead already held.** Both had been appended after
+  a modal's real final control in a raw `<dialog>`, both stayed in the
+  computed vector, and trusted Tab off the real last control reached
+  `<body>`. It is also ordinary markup rather than exotic: a wizard step
+  the user has not arrived at is an `inert` region, and a form section a
+  prior answer has not unlocked is a `disabled` `<fieldset>`, and either
+  is naturally written after the buttons that lead to it. The claim was
+  never a measurement — it was an absence of one — and it is recorded
+  here because the mistake was reasoning about a population from a
+  survey nobody had run.
+  [[a-real-tab-wraps-past-a-trailing-inert-region]] and
+  [[a-real-tab-wraps-past-a-trailing-disabled-fieldset]] are that survey,
+  and they red on the predicate that shipped without it.
 
   A group whose checked member sits OUTSIDE `panel` needs no rule: this
   handler is the modal's alone, so everything outside the panel is
@@ -412,16 +443,22 @@
 
   **The engine confirms the landing before the default action is taken
   away.** `HTMLElement.focus()` on an element that cannot be focused —
-  inert because a nested modal is open above it, or inside a `disabled`
-  `<fieldset>` — is a no-op that leaves `activeElement` where it was, so
-  the move is attempted first and `preventDefault` follows only if it
-  took. A wrap that could not land therefore degrades to exactly the
-  engine's own conduct rather than to a Tab that does nothing.
+  inert because a nested modal is open above it, which carries no
+  attribute for [[tab-stop?]] to read — is a no-op that leaves
+  `activeElement` where it was, so the move is attempted first and
+  `preventDefault` follows only if it took. A wrap that could not land
+  therefore degrades to exactly the engine's own conduct rather than to
+  a Tab that does nothing.
 
-  That confirmation is a floor and not a licence to feed this a loose
-  candidate set: it saves a wrap that lands nowhere, and cannot save one
-  aimed at the wrong CONTROL. [[sequential-tab-stops]] states which
-  candidates are still surplus and why each is affordable.
+  **That confirmation is a floor, and reading it as a licence to feed
+  this a loose candidate set is the mistake this handler made twice.**
+  It saves a wrap aimed at nothing. It cannot save one aimed at the
+  wrong CONTROL — and it cannot save the case where a surplus candidate
+  is never aimed at at all, because the surplus DISPLACED THE EDGE and
+  the press off the real edge matches nothing. The second is the subtler
+  one and cost two beads: the failure happens one step before the
+  landing this confirmation guards, so no amount of care here reaches
+  it. [[sequential-tab-stops]] carries that account.
 
   A press a control inside the panel has already claimed is left alone:
   the native event's `defaultPrevented` is read rather than the synthetic

--- a/implementation/hicasso/test/re_frame/hicasso/overlay_focus_dom_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/overlay_focus_dom_cljs_test.cljs
@@ -237,6 +237,70 @@
     [:button#ghost {:type "button" :style {:visibility "hidden"}} "Ghost"]]
    [:button#after {:type "button"} "After"]])
 
+;; THE TWO THE PAGE ABOVE DOES NOT COVER, and they are separate pages for
+;; the reason the two above it are: each puts its ghost LAST, and a panel
+;; can only have one last element. They differ from the hidden one in the
+;; only way that matters here — the platform still calls them VISIBLE, so
+;; `checkVisibility` cannot reach them and the exclusion has to be asked
+;; for another way.
+
+(h/defview a-page-with-a-modal-whose-last-control-is-inert [_]
+  ;; A TRAILING `inert` REGION, which is ordinary modal markup: the step
+  ;; of a wizard the user has not arrived at yet, painted but switched
+  ;; off. Document order is [reason ok cancel ghost]; sequential order is
+  ;; [reason ok cancel], because an inert subtree takes no focus.
+  ;;
+  ;; `ghost` is LAST for the reason the hidden page gives, and its
+  ;; wrapper carries the attribute rather than the button itself so the
+  ;; row measures INHERITED inertness — the shape a wizard actually has,
+  ;; and the one a predicate reading only the element in hand misses.
+  [:div
+   [:button#before {:type "button"} "Before"]
+   [:button#trigger {:type "button" :on-click [::opened]} "Open"]
+   [overlay/modal {:open?      (h/sub [::open?])
+                   :on-dismiss [::dismissed]
+                   :label      "Confirm"}
+    [:input#reason {:type "text" :aria-label "Reason"}]
+    [:button#ok {:type "button"} "OK"]
+    [:button#cancel {:type "button"} "Cancel"]
+    [:div#later {:inert true}
+     [:button#ghost {:type "button"} "Ghost"]]]
+   [:button#after {:type "button"} "After"]])
+
+(h/defview a-page-with-a-modal-whose-last-control-is-in-a-disabled-fieldset [_]
+  ;; A TRAILING `disabled` `<fieldset>`, equally ordinary: a form section
+  ;; switched off until an earlier choice enables it. Document order is
+  ;; [reason ok cancel ghost]; sequential order is [reason ok cancel].
+  ;;
+  ;; The fieldset also carries the case that says WHICH reading is
+  ;; correct. `ghost.disabled` is FALSE — the IDL property reflects the
+  ;; element's own attribute and the element has none — so the property
+  ;; the predicate used to read cannot see this at all, while the
+  ;; `:disabled` PSEUDO-CLASS matches the effective state. The row below
+  ;; asserts both halves of that, because the gap between them is the
+  ;; whole defect.
+  [:div
+   [:button#before {:type "button"} "Before"]
+   [:button#trigger {:type "button" :on-click [::opened]} "Open"]
+   [overlay/modal {:open?      (h/sub [::open?])
+                   :on-dismiss [::dismissed]
+                   :label      "Confirm"}
+    [:input#reason {:type "text" :aria-label "Reason"}]
+    [:button#ok {:type "button"} "OK"]
+    [:button#cancel {:type "button"} "Cancel"]
+    [:fieldset#later {:disabled true}
+     ;; The FIRST `<legend>` of a disabled fieldset is NOT disabled, and
+     ;; `legend-button` is here to hold that boundary: it is the one
+     ;; control in this subtree the engine still focuses, so a fix that
+     ;; excluded the whole fieldset by walking ancestors would drop a
+     ;; REAL stop and move the panel's last edge onto `cancel`'s
+     ;; predecessor. It is written before `ghost` and is therefore not
+     ;; the edge; the forward cycle names it, which is how the row
+     ;; notices if it ever stops being a stop.
+     [:legend [:button#legend-button {:type "button"} "Legend"]]
+     [:button#ghost {:type "button"} "Ghost"]]]
+   [:button#after {:type "button"} "After"]])
+
 ;; `:async? true` — the MAP shape — because the trusted-input row below
 ;; is `(async done …)`. `make-reset-runtime-fixture` returns the
 ;; POSITIONAL fn by default, and cljs.test throws a bare string that
@@ -744,6 +808,160 @@
                   (finally (finish)))))
             (catch :default e
               (is false (str "the hidden-trailing-control row threw: "
+                             (.-message e)))
+              (finish))))))))
+
+;; ---------------------------------------------------------------------------
+;; The two the platform still calls VISIBLE
+;; ---------------------------------------------------------------------------
+;;
+;; SAME DEFECT, AND THE REASON THE ROW ABOVE COULD NOT REACH THEM. That
+;; row is answered by `checkVisibility`, because `visibility:hidden` and a
+;; closed `<details>` are exactly what the platform means by not visible.
+;; An `inert` region and a `disabled` `<fieldset>` are PAINTED — the user
+;; can read them, they are simply switched off — so `checkVisibility`
+;; answers true for both, measured, and no amount of visibility reasoning
+;; will exclude them.
+;;
+;; They were left counted with the argument that a surplus candidate only
+;; ever costs a wrap that does not fire. rf2-5lzq had already priced that
+;; wrong at the last position — a surplus at the END is what `peek`
+;; returns — and the reason given for leaving these two anyway was that no
+;; measured markup puts either of them last. These two pages are that
+;; markup, and both are the ordinary kind: the wizard step not yet reached,
+;; and the form section a prior answer has not unlocked. Both were measured
+;; taking `document.activeElement` to `<body>` on BOTH edges.
+
+(deftest a-real-tab-wraps-past-a-trailing-inert-region
+  (if-not (browser?)
+    (skip! ":node-test has no modality, and no engine to press a key at")
+    (if-not (trusted/bridge?)
+      (trusted/unwitnessed! "the trap over a panel ending in an inert region")
+      (async done
+        (let [m      (hm/mount! [a-page-with-a-modal-whose-last-control-is-inert {}])
+              finish (fn [] (hm/unmount! m) (done))]
+          (try
+            (open! m)
+            (is (.contains ($ m "dialog") (active))
+                "premise: opening put focus inside the panel")
+
+            ;; THE PREMISES, and they are the row. If the attribute never
+            ;; reached the DOM the panel would be three ordinary controls
+            ;; and every cycle below would pass without measuring
+            ;; anything — so the condition is asserted rather than assumed.
+            (is (some? (.closest ($ m "#ghost") "[inert]"))
+                "premise: the ghost really does sit under an `inert`
+                 ancestor — INHERITED, not carried on the button itself")
+            (is (true? (.checkVisibility ($ m "#ghost")
+                                         #js {"visibilityProperty" true}))
+                "premise: and the platform calls it VISIBLE, which is why
+                 the `checkVisibility` repair that answered the hidden
+                 control cannot answer this one")
+            (is (false? (focusable? ($ m "#ghost")))
+                "premise: the engine refuses focus on it all the same, so
+                 it is an element of the panel and not a stop of it")
+
+            (both-edges!
+              m "#reason" 5
+              (fn [forward backward]
+                (try
+                  (is (= ["ok" "cancel" "reason" "ok" "cancel"] forward)
+                      (str "THE CYCLE, FORWARD. `cancel` is the last stop, "
+                           "so Tab off it lands on `reason`. Against the "
+                           "predicate that counted an inert element, the "
+                           "computed edge was `ghost`, the press off "
+                           "`cancel` matched nothing, and the third landing "
+                           "was `body` — measured. Pressed: " (pr-str forward)))
+                  (is (= ["cancel" "ok" "reason" "cancel" "ok"] backward)
+                      (str "THE CYCLE, BACKWARD. Shift+Tab off `reason` "
+                           "lands on `cancel`. Against that predicate the "
+                           "wrap AIMED at `ghost`, `.focus()` declined, "
+                           "`preventDefault` was correctly withheld, and "
+                           "withholding it is what put the FIRST landing on "
+                           "`body` — measured. Pressed: " (pr-str backward)))
+                  (is (empty? (filter #{"before" "trigger" "after" "body" "ghost"}
+                                      (concat forward backward)))
+                      (str "and not one landing in either lap was a control "
+                           "of the page behind, the nowhere between them, or "
+                           "the switched-off button itself. Pressed: "
+                           (pr-str (concat forward backward))))
+                  (finally (finish)))))
+            (catch :default e
+              (is false (str "the inert-trailing-region row threw: "
+                             (.-message e)))
+              (finish))))))))
+
+(deftest a-real-tab-wraps-past-a-trailing-disabled-fieldset
+  (if-not (browser?)
+    (skip! ":node-test has no modality, and no engine to press a key at")
+    (if-not (trusted/bridge?)
+      (trusted/unwitnessed! "the trap over a panel ending in a disabled fieldset")
+      (async done
+        (let [m      (hm/mount!
+                       [a-page-with-a-modal-whose-last-control-is-in-a-disabled-fieldset {}])
+              finish (fn [] (hm/unmount! m) (done))]
+          (try
+            (open! m)
+            (is (.contains ($ m "dialog") (active))
+                "premise: opening put focus inside the panel")
+
+            ;; THE PREMISE THAT NAMES THE READING. The property and the
+            ;; pseudo-class disagree here, and that disagreement is the
+            ;; entire defect: one reflects the element's own attribute,
+            ;; the other the state the engine actually enforces.
+            (is (false? (.-disabled ($ m "#ghost")))
+                "premise: `ghost.disabled` is FALSE — the IDL property
+                 reflects the button's own attribute and it has none, so
+                 the property reading cannot see this case at all")
+            (is (true? (.matches ($ m "#ghost") ":disabled"))
+                "premise: while `:disabled` matches, because the
+                 pseudo-class is the EFFECTIVE state the fieldset imposes")
+            (is (true? (.checkVisibility ($ m "#ghost")
+                                         #js {"visibilityProperty" true}))
+                "premise: and it is VISIBLE — painted and greyed, not
+                 hidden — so #8093's repair does not reach it either")
+            (is (false? (focusable? ($ m "#ghost")))
+                "premise: the engine refuses focus on it")
+
+            ;; THE OTHER DIRECTION, and it is why this fix asks the
+            ;; pseudo-class rather than walking up to a `fieldset[disabled]`.
+            (is (true? (focusable? ($ m "#legend-button")))
+                "premise: the FIRST `<legend>`'s contents are NOT disabled
+                 by the fieldset, so `legend-button` is a REAL stop inside
+                 the switched-off section — an exclusion that dropped the
+                 whole subtree would lose it, and losing a stop makes the
+                 wrap fire at the wrong control rather than merely miss")
+
+            (both-edges!
+              m "#reason" 5
+              (fn [forward backward]
+                (try
+                  (is (= ["ok" "cancel" "legend-button" "reason" "ok"] forward)
+                      (str "THE CYCLE, FORWARD, and the last stop is "
+                           "`legend-button` — not `cancel`, and not "
+                           "`ghost`. Against the predicate that read the "
+                           "`.disabled` PROPERTY, the computed edge was "
+                           "`ghost`, and the fourth landing was `body` — "
+                           "measured. A fix that excluded the fieldset "
+                           "wholesale reds here the other way, landing the "
+                           "wrap on `cancel`. Pressed: " (pr-str forward)))
+                  (is (= ["legend-button" "cancel" "ok" "reason" "legend-button"]
+                         backward)
+                      (str "THE CYCLE, BACKWARD. `reason` is the first "
+                           "stop, so Shift+Tab off it lands directly on "
+                           "`legend-button`. Against that predicate the "
+                           "wrap aimed at `ghost`, could not land, and the "
+                           "FIRST landing was `body` — measured. Pressed: "
+                           (pr-str backward)))
+                  (is (empty? (filter #{"before" "trigger" "after" "body" "ghost"}
+                                      (concat forward backward)))
+                      (str "and not one landing in either lap was a control "
+                           "of the page behind, the nowhere between them, or "
+                           "the disabled button itself. Pressed: "
+                           (pr-str (concat forward backward))))
+                  (finally (finish)))))
+            (catch :default e
+              (is false (str "the disabled-fieldset row threw: "
                              (.-message e)))
               (finish))))))))
 


### PR DESCRIPTION
The residual two cases of rf2-hic-052, after PR #8093 (`47a3f84a61`) landed
the `checkVisibility` half.

## The defect

`tab-stop?` read the `.disabled` IDL **property** and nothing about `inert`.
The property reflects an element's OWN attribute, so a control inside a
`<fieldset disabled>` reports `disabled: false`; and there was no `inert`
reading at all. Both stayed in the computed stop vector.

`checkVisibility` cannot reach either — both are **painted**, and the call
returns `true` for both, measured. That is why #8093's repair, sound as it
is, could not close them.

At the LAST position that is the leak `wrap-tab!` exists to close, and it
fails by **both** routes:

- **Forward** — the surplus is what `peek` returns, so the press off the
  real edge matches nothing, the handler declines, and the engine's own
  end-of-scope step lands on `<body>`.
- **Backward** — the wrap AIMS at the surplus, `.focus()` refuses, and
  `preventDefault` is correctly withheld; withholding it is what lets focus
  out.

Measured with trusted input against the predicate as it stood at
`47a3f84a61`:

| panel | forward (5 Tabs from `#reason`) | backward (5 Shift+Tabs from `#reason`) |
|---|---|---|
| trailing `inert` region | `["ok" "cancel" **"body"** "reason" "ok"]` | `[**"body"** "cancel" "ok" "reason" **"body"**]` |
| trailing `disabled` `<fieldset>` | `["ok" "cancel" "legend-button" **"body"** "reason"]` | `[**"body"** "legend-button" "cancel" "ok" "reason"]` |

## The fix

```clojure
(and (not (.matches el ":disabled"))
     (nil? (.closest el "[inert]"))
     (not (neg? (.-tabIndex el)))
     (rendered? el))
```

**`:disabled` the pseudo-class REPLACES the property rather than joining
it.** The pseudo-class is the effective state, so it is a strictly wider
reading of the same question — it still matches a plainly `disabled`
control — and it gets the fieldset's own carve-out right for free.

That carve-out is load-bearing and is why the pseudo-class beats the
obvious alternative. Controls in a disabled fieldset's **first `<legend>`**
stay enabled and remain real stops, measured; walking up to
`fieldset[disabled]` by hand would have dropped them, and a candidate set
too SMALL aims the wrap at the wrong control, which is the worse failure.
The fieldset fixture carries `#legend-button` for exactly this: a fix that
excluded the subtree wholesale reds the row the other way.

**`inert` is read as the attribute**, because there is no pseudo-class for
it: `matches(':inert')` throws `SyntaxError` in this repo's Chromium,
measured rather than assumed. `closest` is what makes the reading
inherited, which is the shape inertness has — the attribute goes on the
region, and everything under it stops being a stop.

## The docstring's false claim, corrected

The merged source claimed *"no measured markup puts either of them LAST in
a modal"*. **Re-verified at source: the claim is false**, and it was
contradicted by evidence this bead already held (the #8089 audit had
appended both after a modal's real final control and measured `<body>`).
#8093's own table independently confirms `checkVisibility` returns true
while `.focus()` refuses both — the two agree on the mechanism and
disagreed only on whether it can occur.

It is also ordinary markup rather than exotic: a wizard step the user has
not arrived at is an `inert` region, and a form section a prior answer has
not unlocked is a `disabled` `<fieldset>`, and either is naturally written
after the buttons that lead to it.

The claim is corrected rather than trimmed. It was never a measurement —
it was the absence of one — and `sequential-tab-stops` now records that,
because the mistake was reasoning about a population from a survey nobody
had run.

## Preserved from #8093, untouched

Native Escape, the stateless bubbling handler, zero idle listeners,
radio-group and positive-`tabindex` ordering, and the landed
`checkVisibility({visibilityProperty: true})` boundary — including its
deliberate exclusions of `contentVisibilityAuto` and `opacityProperty`,
re-measured here as still focusable and still kept.

## The controls

Both new rows were made to FAIL before anything was fixed, and every
*premise* assertion in both passed in that red run — which is what says the
pages hold the condition rather than passing vacuously. The premises
asserted are `closest('[inert]')` non-nil, `checkVisibility` true,
`.disabled` false while `:disabled` true, `.focus()` refused, and
`#legend-button` still focusable.

## Quality gates

| gate | when | captured exit | result |
|---|---|---|---|
| `npm run test:browser` (real-DOM lane) | **before the fix**, new rows only | **1** | 1487 tests / 9278 assertions, **6 failures** — all 6 in the two new rows, both edges reaching `body` |
| `npm run test:browser` | after the fix | **0** | 1487 tests / 9278 assertions, 0 failures, 0 errors |
| `npm run test:browser` | **on the final rebased base** | **0** | 1487 tests / 9278 assertions, 0 failures, 0 errors |
| `scripts/test-fast-pr.sh` | **on the final rebased base** | **0** | green; `gate root` verified as this worktree |

Identical test and assertion counts across the red and green runs — the
same population ran, only the verdict changed.

The real-DOM lane is the decisive one here and is not in the fast-PR spine
(`cljs-browser` is listed among the spine's known gaps), so it was run
directly. No `spec/**`, no `.github/workflows/*`, no `.beads/*`.

Closes rf2-hic-052.
