### PR TITLE
docs(mayor-method): give the backlog-reread loop the body its table promised (rf2-juht)

### DIFF
--- a/docs/the-mayor-method/bootstrap.md
+++ b/docs/the-mayor-method/bootstrap.md
@@ -76,7 +76,7 @@ and paste that block verbatim into every dispatch preamble. Skip the interview i
 the operator's opening message already names the stance; restate it as a one-line
 confirmation instead.
 
-SET UP THE LOOPS. The five bodies are in `loops.md`. Codify each as a command file
+SET UP THE LOOPS. The five loops are in `loops.md`. Codify each as a command file
 in this repository so each is one invocation and one source of truth, rather than
 re-pasted prose. When a method rule changes, re-read the matching command file — a
 link checker catches renamed files, not semantic drift.

--- a/docs/the-mayor-method/loops.md
+++ b/docs/the-mayor-method/loops.md
@@ -26,6 +26,10 @@ including yours after a refactor.
 Some people prefer merge and dispatch as separate loops. One loop is simpler and
 has a real advantage: a merge frees a worker slot, and the same tick refills it.
 
+**Five loops, six bodies.** Merge and dispatch share one tick, but each is long
+enough to want a heading of its own, so they are written separately below. The
+numbering follows the bodies; the cadence follows the table.
+
 **Loops fire on time, not on state.** Several ticks legitimately have nothing to
 do. *"Nothing to merge, fleet saturated, here is why"* is a complete report. A
 loop that manufactures work to look busy is worse than a quiet one.
@@ -378,7 +382,56 @@ needs the operator, and do not manufacture work.
 
 ---
 
-## 3. Posture, and the stranded sweep
+## 3. Backlog reread
+
+**Dispatch reads the ready list; this loop reads everything else.** A ready list is a
+projection. It answers *what could go out right now*, and by construction it omits held
+items, blocked items and items a live worker already holds. Those are the ones that fail
+quietly: a dispatchable item that goes wrong is caught on the next tick, because the tick
+is looking straight at it, while a held item that should have been released is caught by
+nobody, because nothing in the short loop reads it again.
+
+So on a medium cadence, read **all** open items from the raw list — not a saved filter, not
+the ready view, not what you remember filing. Read each one bottom-up, newest note first;
+*Dispatch* above explains why.
+
+Four things surface here and nowhere else.
+
+**A fence that has cleared.** The dispatch tick records the fence on the item and moves on,
+and nothing removes it when the condition is met. An item sequenced behind another's merge
+becomes dispatchable the moment that change lands, and the tracker does not notice: the
+short tick keeps skipping it because it is still not *ready*, and the note is the only
+record that anything is being waited on at all. Re-testing those conditions is this loop's
+most productive minute — **recording a fence is worth nothing without the loop that reads
+it back.**
+
+**A dependency that has outlived what it was enforcing.** The item is still blocked, the
+thing it was waiting for shipped, and only a full read notices. The remedy, and why it
+needs its reasoning written onto the item, is under *Tracker mechanics* below.
+
+**A closure that reverted.** Verifying at the moment you close is not enough, so re-check
+what this session closed. **But read the item's notes before re-closing anything.** On a
+project that audits its merged changes, most reappearances are the audit working rather
+than a lost write, and re-closing one destroys a real finding while looking like tidiness.
+
+**A hold that is costing more than it is holding.** Separate *needs a decision* from *needs
+work under a decision already made* — the second is dispatchable now, and it tends to sit in
+the first pile. For the ones that genuinely need the operator, record what the hold is
+costing: which items are behind it, and what stops if it stays. A hold with no cost written
+on it reads as free, and the cheapest-looking item in a list is the one that stays there
+longest.
+
+In-progress items are read here too, but their liveness question belongs to the stranded
+sweep in the next loop. Read them for scope and for fences; leave *is this worker still
+alive?* to the loop that owns it.
+
+**Most passes find nothing, and a pass that finds nothing is complete.** What is not
+complete is a pass that reports nothing without having read the raw list. Inferring the
+backlog from the ready view is the exact failure this loop exists to go behind.
+
+---
+
+## 4. Posture, and the stranded sweep
 
 ### Posture
 
@@ -435,7 +488,7 @@ it forms a coherent change.
 
 ---
 
-## 4. Hygiene
+## 5. Hygiene
 
 ### Reaping
 
@@ -565,7 +618,7 @@ inventing another proxy.** A stale directory is cheap. A destroyed run is not.
 
 ---
 
-## 5. Method reread
+## 6. Method reread
 
 **This loop earns its place, but not by re-reading.** Re-reading unchanged files spends context for
 nothing.


### PR DESCRIPTION
Closes rf2-juht.

`loops.md` advertised five scheduled loops in its cadence table, one of them a
medium-cadence **Backlog reread** of *all* open items. The five bodies below it were
Merge, Dispatch, Posture, Hygiene and Method reread. Sections 1 and 2 together
implement the combined merge+dispatch tick, so neither supplied the separately
advertised reread — and Dispatch reads only the *ready* list, which omits held,
blocked and in-progress work and therefore could not satisfy the promise even in
principle.

Verified at source before acting: the table and the body headings were exactly as the
bead described.

## Acceptance route taken: (a), add the body

The bead offered either adding the body or reconciling the table if the loop were
intentionally omitted. I took (a). The promise in the table is the correct one — the
loop it names is a real loop that does real work, and the material for it already
existed scattered across the page rather than being absent. Route (b) would have
deleted a true row to match an incomplete document.

## What landed

**New `## 3. Backlog reread`.** It states what the loop reads that the ready list
cannot project, then the four things it catches and nothing else does: a fence that
has cleared, a dependency that outlived what it was enforcing, a closure that
reverted, and a hold costing more than it is holding. It closes with the boundary
against the stranded sweep and with when reporting nothing is complete.

**Renumbering.** Posture 3→4, Hygiene 4→5, Method reread 5→6.

**One clarifying sentence under the cadence table** — five loops, six bodies, because
merge and dispatch share one tick but each wants a heading. That is the root cause of
the original mismatch: a reader counting headings against table rows had no way to
reconcile them.

## Folded vs left standing

Folded by **cross-reference, not by copying** — the page's own rule is that two copies
of one rule disagree within days:

- the bottom-up reading rule stays in Dispatch; the new body points at it.
- *A dependency can outlive what it was enforcing* and *a tracker write can silently
  revert* stay in **Tracker mechanics**, which is explicitly cross-loop. The new body
  owns the *when* (this is the loop that performs them) and points there for the *how*.
- §2's *record the fence on the item* stays in Dispatch. The new body supplies the
  missing other half — the loop that reads fences back — and says so.

Left standing because already correct:

- `README.md` — "the five standing loops" is still true; there are five loops. No edit.
- `bootstrap.md` line 27, "`loops.md` (the loop bodies and the merge criterion)" — no
  count, still accurate.

Changed because it went false: `bootstrap.md`'s handoff said "The five **bodies** are
in `loops.md`", which is now six. It reads "The five **loops**" — the count a reader
needs is the number of schedules to register.

No repository name, tracker id, PR number, path, tool name, OS mechanic or command
appears in the new text.

## Declined

`.claude/commands/mayor-*.md` untouched — the bead fenced them, and editing this
repository's private loop files from a generic-docs bead conflates the two layers the
bead exists to keep apart. Filed **rf2-k13d** instead (owner rf2-juht): this repo has
five command files and the method now names five loops, but no backlog-reread and no
method-reread command file exists; `mayor-cluster` is the nearest neighbour to the
former and may or may not discharge it. Recorded as a claim to check, with "the
mapping is deliberately not one-to-one" named as an acceptable outcome.

## Quality gates

Docs-only change. The spine classified it and ran the documentation tier; JVM, node
and clj-kondo lanes were skipped as unreachable from a markdown edit.

| Gate | Result | Captured exit |
|---|---|---|
| `scripts/test-fast-pr.sh` (docs tier, pre-rebase) | PASS | 0 |
| `scripts/test-fast-pr.sh` (docs tier, **on final rebased base**) | PASS | 0 |
| `python -m mkdocs build --strict` | PASS, built in 32–42s | 0 |
| `python scripts/check_doc_slugs.py` | PASS, 0 broken targets | 0 |
| `check_doc_slugs.py` **planted-fault control** | correctly RED | 1 |

Every exit code above is the one captured by `echo $?` into a per-worktree,
per-attempt `.exit` file on the same command line as the redirect. None is a
harness-reported number, and no gate was piped through a filter.

**Coverage was verified, not assumed.** `mkdocs.yml`'s `exclude_docs` block excludes
`design/freehand/` and `design/hicasso/` but **not** `the-mayor-method/`, so the docs
build does cover this surface — confirmed positively by the built artefact:
`site/the-mayor-method/loops/index.html` contains `id="1-merge"` through
`id="6-method-reread"`, including the new `id="3-backlog-reread"`. The renumbered
anchors render as intended.

**Which tree the gates read was proved, both ways available.** The spine and mkdocs
each print a root, and both named this worktree. `check_doc_slugs.py` prints nothing on
success, so it got the planted-fault treatment: a deliberate broken link was appended
to `loops.md`, the checker went red naming `docs\the-mayor-method\loops.md:687` — a
line that exists only in this worktree — and the fault was then removed and the restore
verified by `git hash-object` against the committed object rather than by reading a
diff. Both hashes `2a766e10`.

The spine log contains exactly one `PASS fast PR spine` line, so no orphaned run
contaminated it.

**Anchors:** no inbound `loops.md#…` anchor link exists anywhere in the repository, so
the renumbering breaks no cross-reference. The new body refers to sibling sections in
prose rather than by anchor, matching how the rest of the page already does it.

**Not run and why:** browser, bundle, adapter, Xray, MCP and tool-JVM gates are in no
local tier and run in CI. None is reachable from a markdown edit under
`docs/the-mayor-method/`.
