### PR TITLE
fix(xray): land the Static Machines hydrate on the frame-mount seam (rf2-qw0o)

### DIFF
--- a/tools/xray/spec/003-Machine-Inspector.md
+++ b/tools/xray/spec/003-Machine-Inspector.md
@@ -1325,7 +1325,9 @@ The user's Static-Machines state survives reloads via **two** localStorage slots
 | `xray.static.machines.selected-id` | bare string (machine-id keyword name; namespaced ids store as `ns/name`) | currently selected machine-id; mirrors the `xray.mode` pattern — bare string keeps it cheap to inspect from devtools |
 | `xray.static.machines.sub-mode-by-id` | EDN map `{machine-id sub-mode}` | per-machine sub-mode choice. EDN because the map will grow new keys as new sub-modes land; modes are an enum but the per-machine keying needs structured serialisation |
 
-`hydrate!` is called on Static-Machines `install!` so the first render after a reload restores the prior selection + per-machine sub-mode choices. Test fixtures call `clear!` in their `:each` setup.
+Both slots are lifted into `:rf/xray`'s app-db by `mount.cljs`'s `::hydrate-static-machines` first-mount hook, so the first render after a reload restores the prior selection + per-machine sub-mode choices. Test fixtures call `clear!` in their `:each` setup.
+
+**The hook is the landing site, not `install!` (rf2-qw0o).** Static-Machines `install!` also calls `hydrate!`, but `install!` runs from `registry/register-xray-handlers!` — orchestrator time, *before* `mount/ensure-xray-frame!` has registered `:rf/xray`. A dispatch naming a frame that does not exist is not queued for replay: it is refused with a promoted `:rf.error/frame-destroyed` and dropped. Pre-fix this section promised a restore that never happened — the selection was silently discarded on every reload, and the refusal surfaced one console error per Xray-preloaded dev page load. `hydrate!` therefore guards on the frame being registered (the same guard its two siblings `views.resizable-table/hydrate!` and `frame-switcher/hydrate!` already carry), which makes the `install!` call an honest no-op on the production path and a live hydrate wherever the frame already exists — a shadow-cljs `:after-load`, or a test installing handlers against a live frame. Durable-preference hooks are ordered after the transient-filter reset; see [`018-Event-Spine.md`](018-Event-Spine.md) §2.5 for the durable-vs-transient split.
 
 ### Frame isolation
 

--- a/tools/xray/src/day8/re_frame2_xray/mount.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/mount.cljs
@@ -54,6 +54,8 @@
             [day8.re-frame2-xray.shell :as shell]
             [day8.re-frame2-xray.spine :as spine]
             [day8.re-frame2-xray.spine-filters :as spine-filters]
+            [day8.re-frame2-xray.static.machines.persistence
+             :as static-machines-persistence]
             [day8.re-frame2-xray.static.persistence :as static-persistence]
             [day8.re-frame2-xray.self-noise :as self-noise]
             [day8.re-frame2-xray.theme.global-styles :as global-styles]
@@ -748,6 +750,31 @@
   (fn [frame-id]
     (rf/with-frame frame-id
       (rf/dispatch-sync [:rf.xray/set-mode (static-persistence/load)]))))
+
+(register-first-mount-hook!
+  ::hydrate-static-machines
+  ;; Hydrate the Static Machines selection + per-machine sub-mode slots
+  ;; from localStorage (rf2-qw0o). Durable preferences, exactly like the
+  ;; column widths and the Dynamic ↔ Static mode above — the operator's
+  ;; last-inspected machine is a reading position, not a transient
+  ;; exploration filter, so it carries across sessions.
+  ;;
+  ;; This hook is the FIX for the bead. `static/machines/panel.cljs`'s
+  ;; `install!` already called `persistence/hydrate!`, but `install!`
+  ;; runs from `registry/register-xray-handlers!` — orchestrator time,
+  ;; before this fn has registered the frame. The hydrate dispatch
+  ;; therefore named a frame that did not exist yet and was refused with
+  ;; a promoted `:rf.error/frame-destroyed`: the selection was silently
+  ;; dropped and never restored, and every Xray-preloaded dev page load
+  ;; emitted that refusal to the console. `hydrate!` now carries the same
+  ;; frame guard its two siblings carry, so the orchestrator-time call
+  ;; short-circuits cleanly and THIS hook is the landing site.
+  ;;
+  ;; Ordered after `::hydrate-static-mode` for reading order (both are
+  ;; Static-surface durable prefs); the two slots are independent, so
+  ;; the sequencing is not load-bearing.
+  (fn [frame-id]
+    (static-machines-persistence/hydrate! frame-id)))
 
 (register-first-mount-hook!
   ::auto-open-watcher

--- a/tools/xray/src/day8/re_frame2_xray/static/machines/panel.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/static/machines/panel.cljs
@@ -239,7 +239,15 @@
   ;; event + sub family the Sim rail consumes.
   (sim/install!)
   ;; Hydrate from localStorage. The persistence ns guards storage
-  ;; availability internally so the JVM test path is a no-op.
+  ;; availability internally so the JVM test path is a no-op, and guards
+  ;; on the shell frame being registered so this orchestrator-time call
+  ;; short-circuits cleanly when it isn't (rf2-qw0o). On the production
+  ;; path it isn't: `register-xray-handlers!` runs well before
+  ;; `mount/ensure-xray-frame!`, whose `::hydrate-static-machines`
+  ;; first-mount hook is the call that actually lands the restore. This
+  ;; call stays for the paths where the frame ALREADY exists when the
+  ;; handlers (re-)register — a shadow-cljs `:after-load`, or a test
+  ;; installing handlers against a live frame.
   (persistence/hydrate!)
   ;; Register the Static Machines tab with the internal L4 tab registry.
   (panel-registry/reg-l4-tab!

--- a/tools/xray/src/day8/re_frame2_xray/static/machines/persistence.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/static/machines/persistence.cljs
@@ -37,6 +37,7 @@
   their `:each` fixture."
   (:require [cljs.reader :as reader]
             [re-frame.core :as rf]
+            [re-frame.frame :as frame]
             [day8.re-frame2-xray.defaults :as defaults]
             [day8.re-frame2-xray.local-storage :as ls]
             [day8.re-frame2-xray.static.machines.helpers :as h]))
@@ -130,19 +131,58 @@
   nil)
 
 (defn hydrate!
-  "Dispatch a hydrate event carrying the persisted selection + sub-mode
-  map. Runs once at install! time. Safe to call before frame
-  `:rf/xray` is mounted — `dispatch` queues the event; it lands after
-  the frame is registered. Per `mount.cljs/ensure-xray-frame!` the
-  registry handlers install before the frame mounts, so the dispatch
-  goes through the standard queue and is replayed against the new
-  frame on the first dispatch-cycle."
-  []
-  ;; Init-time hydration targets the production Xray shell frame via the
-  ;; named `defaults/default-frame-id` Var (production-singleton seam),
-  ;; not a `{:frame :rf/xray}` literal.
-  (rf/dispatch [:rf.xray.static.machines/hydrate
-                {:selected-id    (load-selected-id)
-                 :sub-mode-by-id (load-sub-mode-by-id)}]
-               {:frame defaults/default-frame-id})
-  nil)
+  "Lift the persisted selection + per-machine sub-mode map into the
+  shell frame's app-db, so a reload restores the operator's last
+  choices.
+
+  Mirrors `views.resizable-table/hydrate!` and `frame-switcher/
+  hydrate!`: re-entrant; safe to call from `install!` (orchestrator
+  time, before the frame is registered) AND from `mount.cljs/
+  ensure-xray-frame!`'s `::hydrate-static-machines` first-mount hook
+  (first open, frame registered). Both invocations converge on the
+  same slots because:
+
+    - both loads are pure reads;
+    - the hydrate event assocs each slot wholesale, so re-running
+      against the same source produces the same app-db;
+    - the frame guard short-circuits the pre-mount call without
+      losing state — localStorage is still readable at the second
+      call.
+
+  ## Why the frame guard is load-bearing (rf2-qw0o)
+
+  This fn used to dispatch UNGUARDED, on the documented premise that
+  `dispatch` queues an event aimed at a not-yet-registered frame and
+  replays it once that frame exists. It does not. `install!` runs from
+  `registry/register-xray-handlers!`, which is orchestrator-time —
+  well before `ensure-xray-frame!` registers `:rf/xray` — so the
+  dispatch named a frame that did not exist, was refused with a
+  promoted `:rf.error/frame-destroyed`, and was DROPPED. The persisted
+  selection therefore never restored (silent state loss on every
+  reload), and the refusal surfaced one promoted console error on every
+  Xray-preloaded dev page load. Guarding here makes the early call an
+  honest no-op; the first-mount hook is what lands the restore.
+
+  `frame-id` (rf2-lnluk) defaults to the production singleton
+  `defaults/default-frame-id` (`:rf/xray`). A second shell instance
+  passes its own frame-id (threaded by `ensure-xray-frame!`'s
+  first-mount hook) so the durable slots land on that instance's app-db.
+
+  `dispatch-sync` because this runs at boot — the first subscribe must
+  see the hydrated value rather than the registry default.
+
+  Returns nil. No-op when neither slot holds anything to restore."
+  ([] (hydrate! defaults/default-frame-id))
+  ([frame-id]
+   (let [selected-id    (load-selected-id)
+         sub-mode-by-id (load-sub-mode-by-id)]
+     ;; Nothing persisted → no dispatch at all. The hydrate event would
+     ;; be a pure no-op on empty slots, and Xray's own trace ring is the
+     ;; surface it inspects; a boot-time write of nothing is noise.
+     (when (and (or (some? selected-id) (seq sub-mode-by-id))
+                (some? (frame/frame frame-id)))
+       (rf/with-frame frame-id
+         (rf/dispatch-sync [:rf.xray.static.machines/hydrate
+                            {:selected-id    selected-id
+                             :sub-mode-by-id sub-mode-by-id}]))))
+   nil))

--- a/tools/xray/test/day8/re_frame2_xray/static/machines/hydrate_restore_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/static/machines/hydrate_restore_cljs_test.cljs
@@ -178,8 +178,13 @@
             loss the bead is about: pre-fix the hydrate was refused and
             dropped, so this slot came up nil on every reload."
     (seed-prior-session!)
-    (is (nil? (frame-sub [:rf.xray.static.machines/selected-id]))
-        "precondition: no frame / no app-db slot before boot")
+    ;; Precondition asserted against localStorage, NOT a pre-boot
+    ;; subscribe: subscribing before `:rf/xray` exists is itself a
+    ;; recover-but-emit `:rf.error/frame-destroyed`, which would put a
+    ;; refusal of our own making on the channel the tests below observe.
+    (is (= prior-selection (persistence/load-selected-id))
+        "precondition: the prior session's choice is in storage, and no
+         frame exists yet to have hydrated it")
     (boot!)
     (is (= prior-selection
            (frame-sub [:rf.xray.static.machines/selected-id]))

--- a/tools/xray/test/day8/re_frame2_xray/static/machines/hydrate_restore_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/static/machines/hydrate_restore_cljs_test.cljs
@@ -1,0 +1,278 @@
+(ns day8.re-frame2-xray.static.machines.hydrate-restore-cljs-test
+  "The Static Machines selection + per-machine sub-mode RESTORE across a
+  reload, driven through the real production boot path (rf2-qw0o).
+
+  ## The defect these tests pin
+
+  `static/machines/panel.cljs`'s `install!` called
+  `persistence/hydrate!`, which dispatched
+  `:rf.xray.static.machines/hydrate` at `{:frame :rf/xray}`. But
+  `install!` runs from `registry/register-xray-handlers!` —
+  ORCHESTRATOR time, well before `mount/ensure-xray-frame!` registers
+  the `:rf/xray` frame. `hydrate!`'s docstring asserted that `dispatch`
+  QUEUES an event aimed at a not-yet-registered frame and replays it
+  once the frame appears. It does not: the dispatch was refused with a
+  promoted `:rf.error/frame-destroyed` and DROPPED.
+
+  Two things followed, and both are asserted below:
+
+    1. The persisted selection never reached app-db, so the operator's
+       last-inspected machine silently failed to restore on every
+       reload — a real state loss, not just log noise.
+    2. Every Xray-preloaded dev page load emitted exactly one promoted
+       refusal to the console. It was the whole of the residual console
+       error count in the Story feature-load gate.
+
+  The fix gives `hydrate!` the frame guard its two siblings
+  (`views.resizable-table/hydrate!`, `frame-switcher/hydrate!`) already
+  carry, and registers a `::hydrate-static-machines` first-mount hook in
+  `mount.cljs` — the seam that knows the frame exists.
+
+  ## Why these tests drive `ensure-xray-frame!`
+
+  The pre-fix `persistence_cljs_test.cljs` suite is comprehensive on the
+  localStorage round-trip and stayed green throughout, because it never
+  called `hydrate!` — it tested `save!`/`load` directly. The defect lived
+  entirely in the seam BETWEEN a correct round-trip and the boot
+  sequence, so a test that calls `hydrate!` by hand would route around
+  it exactly as the old suite did. These tests therefore go through
+  `registry/register-xray-handlers!` + `mount/ensure-xray-frame!` — the
+  same walk a real page load performs — and never call `hydrate!`
+  themselves.
+
+  ## The error listener is a TEST observer, not an Xray listener
+
+  `error-emit/register-error-listener!` below is registered BY THE TEST
+  to observe the always-on error channel, the same way the framework's
+  own `*_conformance` suites use it. It is emphatically NOT Xray
+  registering an `:errors` listener: rf2-fu75 ruled that Xray does not
+  populate that registry (it rides the dev-only trace axis), and nothing
+  here changes Xray's production posture. The observer exists so the
+  console-error regression has a cheap node-test lever instead of only
+  the expensive browser gate.
+
+  Node-test has no jsdom, so this ns installs the same minimal in-memory
+  `js/window.localStorage` stub `init_filter_reset_cljs_test` uses. The
+  stub is what lets a test SEED a prior session's choices pre-boot and
+  then assert they survive into app-db."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.error-emit :as error-emit]
+            [day8.re-frame2-xray.config :as config]
+            [day8.re-frame2-xray.mount :as mount]
+            [day8.re-frame2-xray.registry :as registry]
+            [day8.re-frame2-xray.static.machines.persistence :as persistence]
+            [day8.re-frame2-xray.static.persistence :as static-persistence]
+            [day8.re-frame2-xray.test-support :as xray-test-support]))
+
+;; -------------------------------------------------------------------------
+;; in-memory localStorage stub (node-test has no jsdom)
+;; -------------------------------------------------------------------------
+
+(defn- make-local-storage []
+  (let [store (atom {})]
+    #js {:getItem    (fn [k] (get @store k nil))
+         :setItem    (fn [k v] (swap! store assoc k (str v)) js/undefined)
+         :removeItem (fn [k] (swap! store dissoc k) js/undefined)
+         :clear      (fn [] (reset! store {}) js/undefined)}))
+
+(defn- install-local-storage! []
+  (when-not (exists? js/globalThis.window)
+    (set! (.-window js/globalThis) #js {}))
+  (set! (.-localStorage js/globalThis.window) (make-local-storage)))
+
+(defn- uninstall-local-storage! []
+  ;; Drop the whole window stub we installed so we don't leak a
+  ;; localStorage into sibling test namespaces.
+  (js-delete js/globalThis "window"))
+
+(def ^:private runtime-fixture
+  (xray-test-support/make-xray-runtime-fixture
+    {:post-reset (fn []
+                   (persistence/clear!)
+                   (static-persistence/clear!)
+                   (config/set-filter-seed! nil))}))
+
+(defn- with-local-storage-stub [test-fn]
+  (install-local-storage!)
+  (try
+    (runtime-fixture test-fn)
+    (finally
+      (uninstall-local-storage!)
+      (error-emit/clear-error-listeners!))))
+
+(use-fixtures :each with-local-storage-stub)
+
+;; -------------------------------------------------------------------------
+;; boot harness
+;; -------------------------------------------------------------------------
+
+(defn- register-handlers!
+  "Orchestrator time ONLY — the phase in which `panel/install!` (and so
+  the pre-fix eager `hydrate!`) runs. Deliberately stops short of
+  `ensure-xray-frame!` so the tests can observe this phase on its own."
+  []
+  (registry/register-xray-handlers!))
+
+(defn- boot!
+  "The full production boot: register the handlers, then run
+  `ensure-xray-frame!`, which registers `:rf/xray` and walks the
+  first-mount hook table. Never calls `hydrate!` directly — landing the
+  restore is precisely what is under test."
+  []
+  (register-handlers!)
+  (mount/ensure-xray-frame!))
+
+(defn- frame-sub [q]
+  (rf/with-frame :rf/xray
+    @(rf/subscribe q)))
+
+(defn- capture-errors!
+  "Attach a test observer to the always-on error channel and return an
+  atom collecting every record emitted from here on."
+  []
+  (let [seen (atom [])]
+    (error-emit/register-error-listener!
+      ::hydrate-restore-observer
+      (fn [record] (swap! seen conj record)))
+    seen))
+
+(defn- hydrate-refusals
+  "The `:rf.error/frame-destroyed` records attributable to the Static
+  Machines hydrate — the exact console line rf2-qw0o is about."
+  [records]
+  (filterv (fn [{:keys [error event-id]}]
+             (and (= :rf.error/frame-destroyed error)
+                  (= :rf.xray.static.machines/hydrate event-id)))
+           records))
+
+;; A prior session's choices, as localStorage would hold them.
+(def ^:private prior-selection :checkout.flow/payment)
+(def ^:private prior-sub-modes {:checkout.flow/payment :sim
+                                :auth/login            :instances})
+
+(defn- seed-prior-session! []
+  (persistence/save-selected-id! prior-selection)
+  (persistence/save-sub-mode-by-id! prior-sub-modes))
+
+;; -------------------------------------------------------------------------
+;; (0) preconditions — the stub is real
+;; -------------------------------------------------------------------------
+
+(deftest local-storage-stub-round-trips
+  (testing "the in-memory stub backs save!/load, so the seeding below is
+            a real persisted prior session rather than a no-op"
+    (seed-prior-session!)
+    (is (= prior-selection (persistence/load-selected-id))
+        "selection slot round-trips through the stub")
+    (is (= prior-sub-modes (persistence/load-sub-mode-by-id))
+        "sub-mode slot round-trips through the stub")))
+
+;; -------------------------------------------------------------------------
+;; (1) THE ACCEPTANCE — the persisted selection restores after a reload
+;; -------------------------------------------------------------------------
+
+(deftest persisted-selection-restores-after-reload
+  (testing "rf2-qw0o — a machine selected in a prior session is the
+            selected machine after the next boot. This is the user-visible
+            loss the bead is about: pre-fix the hydrate was refused and
+            dropped, so this slot came up nil on every reload."
+    (seed-prior-session!)
+    (is (nil? (frame-sub [:rf.xray.static.machines/selected-id]))
+        "precondition: no frame / no app-db slot before boot")
+    (boot!)
+    (is (= prior-selection
+           (frame-sub [:rf.xray.static.machines/selected-id]))
+        "the prior session's selection IS restored on the real production
+         boot path — WITHOUT the test calling hydrate! itself")))
+
+(deftest persisted-sub-mode-map-restores-after-reload
+  (testing "rf2-qw0o — the per-machine sub-mode map restores with the
+            selection; both slots ride the one hydrate event"
+    (seed-prior-session!)
+    (boot!)
+    (is (= prior-sub-modes
+           (frame-sub [:rf.xray.static.machines/sub-mode-by-id]))
+        "the whole {machine-id sub-mode} map is restored")
+    (is (= :sim
+           (frame-sub [:rf.xray.static.machines/sub-mode
+                       :checkout.flow/payment]))
+        "the effective sub-mode for the restored machine resolves to the
+         persisted :sim, not the :topology default")))
+
+(deftest restore-survives-a-second-boot
+  (testing "rf2-qw0o — the hook is re-entrant: a second
+            `ensure-xray-frame!` for the same frame-id (the popout! path)
+            leaves the restored slots intact"
+    (seed-prior-session!)
+    (boot!)
+    (mount/ensure-xray-frame!)
+    (is (= prior-selection
+           (frame-sub [:rf.xray.static.machines/selected-id]))
+        "selection unchanged by the second call")
+    (is (= prior-sub-modes
+           (frame-sub [:rf.xray.static.machines/sub-mode-by-id]))
+        "sub-mode map unchanged by the second call")))
+
+;; -------------------------------------------------------------------------
+;; (2) THE CONSOLE ERROR — boot emits no frame-destroyed refusal
+;; -------------------------------------------------------------------------
+
+(deftest orchestrator-time-install-emits-no-refusal
+  (testing "rf2-qw0o — registering the Xray handlers BEFORE any frame
+            exists must not emit a promoted `:rf.error/frame-destroyed`.
+            This is the exact pre-fix line: one per Xray-preloaded dev page
+            load, and the whole of the Story feature-load gate's residual
+            console-error count."
+    (seed-prior-session!)
+    (let [seen (capture-errors!)]
+      (register-handlers!)
+      (is (empty? (hydrate-refusals @seen))
+          "no frame-destroyed refusal attributable to the Static Machines
+           hydrate — the frame guard makes the pre-mount call a clean
+           no-op instead of a dropped dispatch"))))
+
+(deftest full-boot-emits-no-refusal
+  (testing "rf2-qw0o — and the same holds across the whole boot, so the
+            fix does not merely move the refusal to the first-mount hook"
+    (seed-prior-session!)
+    (let [seen (capture-errors!)]
+      (boot!)
+      (is (empty? (hydrate-refusals @seen))
+          "no frame-destroyed refusal anywhere in the boot sequence")
+      (is (= prior-selection
+             (frame-sub [:rf.xray.static.machines/selected-id]))
+          "and the restore still landed — silence here is not the dispatch
+           having been deleted"))))
+
+;; -------------------------------------------------------------------------
+;; (3) the empty-storage case stays quiet
+;; -------------------------------------------------------------------------
+
+(deftest nothing-persisted-boots-clean-and-quiet
+  (testing "rf2-qw0o — a first-ever load (both slots empty) leaves the
+            slots at their registry defaults and dispatches nothing. Xray
+            inspects the trace ring it would otherwise be writing a
+            no-op boot event into."
+    (is (nil? (persistence/load-selected-id))
+        "precondition: the fixture cleared the selection slot")
+    (let [seen (capture-errors!)]
+      (boot!)
+      (is (nil? (frame-sub [:rf.xray.static.machines/selected-id]))
+          "no selection — registry default")
+      (is (= {} (frame-sub [:rf.xray.static.machines/sub-mode-by-id]))
+          "no sub-modes — registry default empty map")
+      (is (empty? (hydrate-refusals @seen))
+          "and nothing was refused"))))
+
+(deftest sub-mode-only-slot-still-restores
+  (testing "rf2-qw0o — the two slots are independent: a persisted
+            sub-mode map with NO selection still hydrates (the guard is
+            `either slot has content`, not `selection is present`)"
+    (persistence/save-sub-mode-by-id! prior-sub-modes)
+    (boot!)
+    (is (nil? (frame-sub [:rf.xray.static.machines/selected-id]))
+        "no selection was persisted, so none is restored")
+    (is (= prior-sub-modes
+           (frame-sub [:rf.xray.static.machines/sub-mode-by-id]))
+        "the sub-mode map restores on its own")))


### PR DESCRIPTION
Fixes rf2-qw0o. This is the Xray-side half of the defect whose Story-side half landed as #8126; it unblocks rf2-8yyd's acceptance.

## The defect

`static/machines/panel.cljs`'s `install!` hydrated the persisted Static-Machines selection by dispatching `:rf.xray.static.machines/hydrate` at `{:frame :rf/xray}`. But `install!` runs from `registry/register-xray-handlers!` — orchestrator time, well before `mount/ensure-xray-frame!` registers that frame.

`hydrate!`'s own docstring asserted the premise that made this look safe:

> Safe to call before frame `:rf/xray` is mounted — `dispatch` queues the event; it lands after the frame is registered.

It does not. A dispatch naming an unregistered frame is refused with a promoted `:rf.error/frame-destroyed` and **dropped**. Two consequences, both fixed here:

1. **The persisted selection never restored.** Silent state loss on every reload — the user-visible half, and the one a "the error is gone" test would not catch.
2. **One promoted console error per Xray-preloaded dev page load.** All 106 residual console errors in the Story feature-load gate were this single refusal, repeated once per page navigation.

`spec/003-Machine-Inspector.md` carried the same false claim ("`hydrate!` is called on Static-Machines `install!` so the first render after a reload restores the prior selection") — a spec promising a restore that never happened. Corrected here.

## The fix

The repo already had the pattern, twice over. `views.resizable-table/hydrate!` and `frame-switcher/hydrate!` both guard on the frame being registered and land their restore from a `mount.cljs` first-mount hook; `resizable-table`'s docstring even claims to "mirror `static-machines/hydrate!`" — parity that did not exist. This change makes it exist:

- `static/machines/persistence.cljs` — `hydrate!` gains the frame guard and the `frame-id` arity its two siblings carry, and `dispatch-sync`s so the first subscribe sees the hydrated value. No dispatch at all when neither slot holds anything to restore.
- `mount.cljs` — new `::hydrate-static-machines` first-mount hook. This is the seam that knows the frame exists, and it is what now lands the restore.
- `static/machines/panel.cljs` — the `install!`-time call **stays**. It is now an honest no-op on the production path, and a live hydrate on the paths where the frame already exists (a shadow-cljs `:after-load`, or a test installing handlers against a live frame).

I did not delete the dispatch, and I did not register an `:errors` listener from Xray — rf2-fu75's ruling that Xray rides the dev-only trace axis is untouched.

## Proving the restore, not just the silence

The pre-existing `persistence_cljs_test.cljs` suite is thorough on the localStorage round-trip and stayed green throughout the defect's life, because it tested `save!`/`load` directly and never called `hydrate!`. The bug lived entirely in the seam between a correct round-trip and the boot sequence, so a test calling `hydrate!` by hand routes around it exactly as the old suite did.

The new `hydrate_restore_cljs_test.cljs` therefore drives the real `registry/register-xray-handlers!` + `mount/ensure-xray-frame!` boot (the harness `init_filter_reset_cljs_test` uses) and never calls `hydrate!` itself. 8 tests / 17 assertions covering: the selection restores; the sub-mode map restores; a second `ensure-xray-frame!` leaves them intact; orchestrator-time install emits no refusal; the full boot emits no refusal *and still restores*; empty storage boots clean and quiet; a sub-mode-only slot restores on its own.

The error observer in that ns is a **test** observer on the always-on channel (the same seam the framework's own conformance suites use). It is not Xray registering an `:errors` listener.

## Quality gates

Run from `C:/Users/miket/code/re-frame2-worktrees/xrayhydrate-qw0o`, on the **rebased** base (main already carries #8126). Each exit code below is the one captured by the runner itself into a `.exit` file, not one reported about the run.

| Gate | Result | Captured exit |
|---|---|---|
| `npm run test:story-feature-load` | Ran 2 Story feature-load specs. **0 failures, 0 console errors** | **0** |
| `npm run test:cljs` | Ran 13861 tests, 70051 assertions. **0 failures, 0 errors** | **0** |
| `scripts/test-fast-pr.sh` | `PASS fast PR spine` (docs + mkdocs --strict + node/CLJS + clj-kondo; JVM tier skipped as unclassified for this diff) | **0** |

(An earlier pre-rebase run of the same two gates was also green — 13851 tests / 69989 assertions, exit 0 — but the numbers above are the ones from the final base, which is what counts.)
| `scripts/check_doc_slugs.py` | passed (validates the spec/003 edit's links + anchors) | **0** |

### Gate provenance — planted faults, both directions

Neither acceptance claim rests on a green run alone.

**The restore is proved by a red, not asserted.** Planting `:rf2-qw0o/PLANTED-SABOTAGE` as the expected selection produced:

```
actual: (not (= :rf2-qw0o/PLANTED-SABOTAGE :checkout.flow/payment))
Ran 8 tests containing 17 assertions.
1 failures, 0 errors.
```

The runtime app-db slot held `:checkout.flow/payment` — the persisted prior-session selection. That is the restore working, read off the live frame. It also proves all 8 tests execute and that the gate reads this worktree.

**The console-error count is proved causally.** The Story gate prints no root, so its provenance is the red from a planted fault. Removing *only* the frame guard — restoring the original defect — on the same tree:

| tree | console errors | exit |
|---|---|---|
| guard removed (defect restored) | 94 + 12 = **106** | 1 |
| guard in place (this PR) | **0** | 0 |

106 reproduces the bead's independently-measured residual (`94 + 12`) exactly, and 92 of those log lines name `:rf.xray.static.machines/hydrate`. Both plants were reverted and verified byte-identical to their committed objects via `git hash-object`.

### What this local run does not cover

`test:story-feature-load` is a **nightly** gate (`expensive-tests.yml`), not a required PR check — it will not run on this PR automatically. `scripts/test-fast-pr.sh --plan` reports for this diff: `docs=true jvm=false node=true`, and its own note is that "no browser, bundle, adapter, Xray, MCP or tool-JVM gate is in any tier". So the Xray browser gates and the JVM artefact suites run in CI, not here.

## Spec

`tools/xray/spec/003-Machine-Inspector.md` §localStorage persistence — names `::hydrate-static-machines` as the landing site and records why the `install!`-time call remains. I deliberately did **not** touch `017-Test-Coverage-Matrix.md`: its Static Machines row is feature-level and gated on the e2e test, and this PR adds unit coverage for an existing feature rather than a new one.

## Fence

Confined to `tools/xray/src/day8/re_frame2_xray/{mount.cljs, static/machines/**}`, `tools/xray/test/**`, and `tools/xray/spec/003-Machine-Inspector.md`. No `implementation/story/**`, no `implementation/core/**`, no `.github/workflows/*`, and nothing in `hicasso_advisor.cljc` / `spec/028` (held by `worker/advisorid-hic037`, whose work arrived in main during this branch's life and rebased cleanly).
