### PR TITLE
docs: :rf.sub/dispose in the :subs comments, the listener/fallback distinction, and a recorded refusal (rf2-08gw, rf2-t9t0, rf2-bkvo)

### DIFF
--- a/implementation/core/src/re_frame/trace/projection.cljc
+++ b/implementation/core/src/re_frame/trace/projection.cljc
@@ -37,8 +37,9 @@
                      `:rf.fx/handled`, `:rf.fx/override-applied`,
                      `:rf.fx/skipped-on-platform`)
     5. `:sub`      — `:op-type :rf.sub` (`:operation :rf.sub/run` recompute,
-                     `:rf.sub/skip` memo-hit, or `:rf.sub/create` first-time
-                     signal-graph build)
+                     `:rf.sub/skip` memo-hit, `:rf.sub/create` first-time
+                     signal-graph build, or `:rf.sub/dispose` cache-slot
+                     eviction)
     6. `:render`   — `:op-type :rf.view` + `:operation :rf.view/render`
 
   Events whose op-type/operation pair doesn't fit any bucket flow
@@ -69,8 +70,9 @@
 
 (def ^:private sub-op-types
   "Op-types that classify as the fifth domino — subscription work.
-  `:rf.sub/run` is the recompute path; `:rf.sub/create` is the first-time
-  signal-graph build."
+  `:rf.sub/run` is the recompute path; `:rf.sub/skip` is the memo-hit;
+  `:rf.sub/create` is the first-time signal-graph build; `:rf.sub/dispose`
+  is a cache-slot eviction. All four land in the `:subs` slot."
   #{:rf.sub})
 
 (defn domino-bucket
@@ -311,6 +313,7 @@
        :effects     [<trace-event> ...]       ;; :op-type :rf.fx
        :subs        [<trace-event> ...]       ;; :rf.sub/run + :rf.sub/skip
                                               ;;   + :rf.sub/create
+                                              ;;   + :rf.sub/dispose
        :renders     [<trace-event> ...]       ;; :rf.view/render
        :other       [<trace-event> ...]}      ;; everything else
                                               ;;   (errors, warnings,

--- a/implementation/hicasso/scripts/check_example_fence_coverage.py
+++ b/implementation/hicasso/scripts/check_example_fence_coverage.py
@@ -199,6 +199,16 @@ def strip_inert(text):
     Blanking preserves length and newlines so the surviving text keeps its
     offsets, and the walk resumes at the END of each inert form — a live
     claim sitting beside a disabled one still counts.
+
+    This function and [[form_end]] are DELIBERATELY duplicated in
+    check_optional_module_reachability.py rather than shared (rf2-t9t0).
+    The copies are NOT identical and must not be naively merged: that
+    script runs its pair after a `code_only` pass has already blanked
+    every character literal, so its copies drop the `\\` branches these
+    two need.  Sharing would mean a flag argument on a twenty-line pure
+    function, and these six checkers are deliberately self-contained
+    single files with no cross-imports — `self_test` and `main` are
+    duplicated six times over for the same reason.
     """
     chars = list(text)
     i, n = 0, len(text)

--- a/implementation/hicasso/scripts/check_optional_module_reachability.py
+++ b/implementation/hicasso/scripts/check_optional_module_reachability.py
@@ -247,6 +247,16 @@ def strip_inert(text):
     offsets, and the walk resumes at the END of each inert form — a live
     form sitting beside a discarded one still counts, which is what stops
     this narrowing from becoming a false RED of its own.
+
+    This function and [[form_end]] are DELIBERATELY duplicated from
+    check_example_fence_coverage.py rather than shared (rf2-t9t0).  The
+    copies are NOT identical and must not be naively merged: [[code_only]]
+    has already blanked every character literal before these run, so both
+    copies here drop the `\\` branches that script's pair needs.  Sharing
+    would mean a flag argument on a twenty-line pure function, and these
+    six checkers are deliberately self-contained single files with no
+    cross-imports — `self_test` and `main` are duplicated six times over
+    for the same reason.
     """
     chars = list(text)
     i, n = 0, len(text)

--- a/implementation/resources/test/re_frame/resources_mutation_cljs_test.cljc
+++ b/implementation/resources/test/re_frame/resources_mutation_cljs_test.cljc
@@ -172,10 +172,14 @@
   every always-on error record fanned during it (capture order).
 
   The `:errors` stream — not stdout, not the dev trace — is where a framework
-  REFUSAL is legible: per Spec 009 §Observability channels the runtime ships no
-  default console sink, so a category that fans a record here is loud in dev
+  REFUSAL is legible: per Spec 009 §Observability channels a listener is the
+  only ALWAYS-ON channel, so a category that fans a record here is loud in dev
   AND in a production build, while a category that fans nothing is invisible
-  everywhere. Sibling of `record-mutation-traces!` above (rf2-06lp)."
+  everywhere. (Since PR #8108 there is ALSO a browser-console fallback, but it
+  is not the always-on contract and cannot fire here: it needs a dev build, a
+  browser host — this suite is the Node lane, no `js/document` — and an EMPTY
+  `:errors` registry, which the listener below fills.) Sibling of
+  `record-mutation-traces!` above (rf2-06lp)."
   [body-fn]
   (let [seen (atom [])
         k    ::error-record-recorder]
@@ -298,8 +302,10 @@
         (is (nil? (mutation-record :i1)) "no work-ledger row was written"))
       (testing "and the refusal is READABLE — the runtime did not stay silent"
         ;; Read off the always-on `:errors` axis, not stderr: per Spec 009
-        ;; §Observability channels the framework ships NO default console sink,
-        ;; so this listener is where a refusal is legible in dev AND prod.
+        ;; §Observability channels a listener is the only ALWAYS-ON channel, so
+        ;; this listener is where a refusal is legible in dev AND prod. The
+        ;; browser-dev console fallback (#8108) is not a second reading here —
+        ;; it needs an EMPTY registry, and this listener fills it.
         (is (some? rec)
             ":rf.mutation/execute fanned an always-on error record")
         (is (= :rf.mutation/execute (:event-id rec)))

--- a/implementation/resources/test/re_frame/resources_optimistic_validation_cljs_test.cljc
+++ b/implementation/resources/test/re_frame/resources_optimistic_validation_cljs_test.cljc
@@ -775,10 +775,16 @@
 ;; carries its reason (`:rf.error/mutation-invalid-target`, catalogued at
 ;; spec/009 with `:recovery :fix-mutation-target` and the `:arm` / `:target`
 ;; facets); it is simply not legible on stdout, because per Spec 009
-;; §Observability channels re-frame2 ships NO default console sink and the
+;; §Observability channels a listener is the only ALWAYS-ON channel and the
 ;; router CAPTURES a handler throw rather than re-throwing it to
-;; `dispatch-sync`'s caller. That residual — framework-wide, not specific to
-;; this arm — is rf2-fu75's, not this path's.
+;; `dispatch-sync`'s caller. That residual was framework-wide rather than
+;; specific to this arm, and rf2-fu75 has since SETTLED it (PR #8108): an
+;; unowned promoted record now ALSO reaches the browser console. It is a
+;; fallback, not a channel, and none of its three conditions holds here — it
+;; needs a dev build, a browser host (this is the Node lane, no `js/document`)
+;; and an EMPTY `:errors` registry, which the listener this suite installs
+;; fills. So the reading below is unchanged, and the always-on axis is still
+;; the one that holds in dev AND in prod.
 ;;
 ;; So this test asserts the readable half on the always-on `:errors` axis,
 ;; which is where a refusal is legible in dev AND in a production build. The
@@ -800,11 +806,14 @@
   always-on error record fanned during it (capture order).
 
   The `:errors` stream — not stdout, not the dev trace — is where a framework
-  REFUSAL is legible: per Spec 009 §Observability channels the runtime ships no
-  default console sink, so a category that fans a record here is loud in dev AND
-  in a production build, while a category that fans nothing is invisible
-  everywhere. Sibling of the same-named helper in `resources-mutation-cljs-test`
-  (rf2-06lp)."
+  REFUSAL is legible: per Spec 009 §Observability channels a listener is the
+  only ALWAYS-ON channel, so a category that fans a record here is loud in dev
+  AND in a production build, while a category that fans nothing is invisible
+  everywhere. (Since PR #8108 there is ALSO a browser-console fallback, but it
+  is not the always-on contract and cannot fire here: it needs a dev build, a
+  browser host — this suite is the Node lane, no `js/document` — and an EMPTY
+  `:errors` registry, which the listener below fills.) Sibling of the same-named
+  helper in `resources-mutation-cljs-test` (rf2-06lp)."
   [body-fn]
   (let [seen (atom [])
         k    ::error-record-recorder]

--- a/implementation/resources/test/re_frame/resources_runtime_cljs_test.cljc
+++ b/implementation/resources/test/re_frame/resources_runtime_cljs_test.cljc
@@ -116,10 +116,14 @@
   every always-on error record fanned during it (capture order).
 
   The `:errors` stream — not stdout, not the dev trace — is where a framework
-  REFUSAL is legible: per Spec 009 §Observability channels the runtime ships no
-  default console sink, so a category that fans a record here is loud in dev
+  REFUSAL is legible: per Spec 009 §Observability channels a listener is the
+  only ALWAYS-ON channel, so a category that fans a record here is loud in dev
   AND in a production build, while a category that fans nothing is invisible
-  everywhere. A refusal that reaches NO channel is indistinguishable from a
+  everywhere. (Since PR #8108 there is ALSO a browser-console fallback, but it
+  is not the always-on contract and cannot fire here: it needs a dev build, a
+  browser host — this suite is the Node lane, no `js/document` — and an EMPTY
+  `:errors` registry, which the listener below fills.)
+  A refusal that reaches NO channel is indistinguishable from a
   silent no-op at the call site, which is exactly the gap rf2-06lp closed on
   the mutation path; this is the copy that lets the read path assert the same
   way (rf2-w67y, sibling of `record-error-records!` in
@@ -540,8 +544,10 @@
         (is (nil? @last-managed-args) "no request reached the transport"))
       (testing "and the refusal is READABLE — the runtime did not stay silent"
         ;; Read off the always-on `:errors` axis, not stderr: per Spec 009
-        ;; §Observability channels the framework ships NO default console sink,
-        ;; so this listener is where a refusal is legible in dev AND in prod.
+        ;; §Observability channels a listener is the only ALWAYS-ON channel, so
+        ;; this listener is where a refusal is legible in dev AND in prod. The
+        ;; browser-dev console fallback (#8108) is not a second reading here —
+        ;; it needs an EMPTY registry, and this listener fills it.
         ;; Without this half the two rows above are satisfied by a silent
         ;; no-op and the test cannot fail.
         (is (some? rec)

--- a/spec/009-Instrumentation.md
+++ b/spec/009-Instrumentation.md
@@ -786,6 +786,7 @@ The raw trace stream is event-at-a-time; pair-shaped UIs (the Story trace panel,
 ;;                                              ;;   skipped-on-platform
 ;;      :subs               [<trace-event> ...]  ;; :rf.sub/run + :rf.sub/skip
 ;;                                              ;;   + :rf.sub/create
+;;                                              ;;   + :rf.sub/dispose
 ;;      :renders            [<trace-event> ...]  ;; :op-type :rf.view /
 ;;                                              ;;   :operation :rf.view/render
 ;;      :other              [<trace-event> ...]} ;; errors, warnings, machines,


### PR DESCRIPTION
Three small beads, comments and prose only. **No runtime change, no assertion change, no renumbering, in any of the three.**

| Bead | P | Outcome |
|---|---|---|
| rf2-08gw | P4 | Repaired — `:rf.sub/dispose` named in the `:subs` slot comments |
| rf2-t9t0 | P4 | **REFUSED** — the duplication is correct; recorded as deliberate so it is not re-filed |
| rf2-bkvo | P2 | Repaired — six comments now distinguish the always-on listener from the dev console fallback |

---

## rf2-08gw — `:rf.sub/dispose` was missing from two shape comments

The projection routes on `:op-type` (`:sub (update acc :subs conj ev)`), so **all four** `:rf.sub` operations land in the event bundle's `:subs` slot. Two shape comments enumerated three.

Verified at source before writing: `:rf.sub/dispose` is the correct fourth spelling, catalogued at `spec/009-Instrumentation.md:202`. The operation vocabulary itself is correct and complete there, which is why no consumer contract is wrong — this is a documentation understatement, not a contract defect. **No renumbering, no restructuring, no new spec row**; both prior repairs on rf2-hic-037 concluded no root spec row was owed and that conclusion is untouched.

Fixed the two carriers the bead names, plus **two same-class carriers in the same file** that enumerate the same operation set and would have re-seeded the identical misreading:

| Location | What it is |
|---|---|
| `spec/009-Instrumentation.md:787` | `:subs` slot shape comment — **the bead's carrier** |
| `trace/projection.cljc:312` | same shape comment, `group-by-event` docstring — **the bead's carrier** |
| `trace/projection.cljc:39` | ns docstring, bucket-5 enumeration — swept |
| `trace/projection.cljc:70` | `sub-op-types` docstring — swept; also omitted `:rf.sub/skip` |

The spec edit is confined to that one comment block; nothing else under `spec/` is touched.

## rf2-t9t0 — refusal: the two copies stay

The bead asked whether the `strip_inert` / `form_end` pair duplicated by #8114 and #8120 should be shared. **It should not.** Four reasons, each verified at source rather than argued:

1. **The copies are not the same function.** `check_example_fence_coverage.py`'s pair carries three character-literal branches its sibling drops. #8120's worker said this was because `code_only` already removes character literals — and that holds: `check_optional_module_reachability.py:311-314` emits a space for a `\` and skips two, so no backslash survives to reach `strip_inert`. A naive merge would reintroduce dead branches or remove live ones.
2. **Sharing costs more than it saves.** Reconciling that difference needs a flag argument on a twenty-line pure function — worse than the duplication it removes.
3. **Duplication is this directory's architecture, not drift.** All six checkers are self-contained single files with no cross-imports and no package. `self_test()` and `main()` are each duplicated **six times over**.
4. **The docstrings are the larger half** and are per-gate specific — different worked examples, different failure modes, different bead attributions. A shared helper would genericise them into uselessness.

Per the stance: do not build a shared-utility module for two callers unless a third appears. What is added instead is **a cross-reference in each copy's docstring**, so the next reader diffing the two finds a documented decision rather than an apparent accident, and does not re-file this. That is the whole change — no behaviour touched.

The four contract assertions still hold for both scripts (measured, below).

## rf2-bkvo — the always-on listener vs. the browser-dev fallback

Six test comments claimed, in the present tense, that re-frame2 ships **no** default console sink. PR #8108 (rf2-fu75) made that false for an unowned promoted error in a browser dev build.

Read the implementation before writing any correction — `error_emit.cljc:156` `report-unowned-error!` and its rationale block at `:90`. The fallback is gated on **three** conditions, all load-bearing: a dev build (`interop/debug-enabled?`, so `goog.DEBUG=false` constant-folds the body away), a browser host (`js/document`; Node-targeted CLJS, CLJS SSR and the JVM stay listener-only), and an **empty** `:errors` registry (registering any listener takes corpus-wide ownership and silences it).

Two facts make every one of these comments still correct in its **operative reasoning**, which is why this is a narrowing and not a reversal: these suites are on the `:node-test` classpath (`implementation/shadow-cljs.edn:121` — the browser lane is selected by a `-dom-cljs-test` suffix these files do not carry), so `js/document` is absent; and each helper installs an `:errors` listener, which fills the registry. **The fallback could not fire in either case.**

### The discriminator used

*Does this sentence make a present-tense claim about how the code behaves now, or record what was true then?* A past-tense record is not stale and was not rewritten.

### Changed — three named by the bead, three found by the sweep

| Location | What it is | Source |
|---|---|---|
| `resources_mutation_cljs_test.cljc:176` | `record-error-records!` docstring | swept |
| `resources_mutation_cljs_test.cljc:301` | inline site comment | bead |
| `resources_optimistic_validation_cljs_test.cljc:778` | inline; **also assigned the residual to rf2-fu75 as unresolved** — now recorded settled | bead |
| `resources_optimistic_validation_cljs_test.cljc:804` | `record-error-records!` docstring | swept |
| `resources_runtime_cljs_test.cljc:120` | `record-error-records!` docstring | swept |
| `resources_runtime_cljs_test.cljc:543` | inline site comment | bead |

### Left standing — each read and classified, none rewritten

| Location | Why it stands |
|---|---|
| `docs/design/hicasso/product/async-routing-recipes.md:70` | **Past tense** — "when this page was written it did not print either". A record of what was true then is not stale. Also outside this worker's fence. |
| `spec/009-Instrumentation.md:1286` | Already corrected by #8117; present tense and accurate. Its correctness is also what **confirms #8108 is on main** — the bead asked for that check explicitly. |
| `implementation/core/test/re_frame/on_error_cljs_test.cljc:125` | The core `on_error` comment, classified in this bead's own close reason as contract-channel wording and explicitly out of scope for this residue. **Not touched.** See the observation below. |
| `docs/resources/tutorial/index.md:252` | Promises "in the console AND as a row in Xray" and now **holds as written**. Left standing per the bead. |
| `implementation/scripts/run-browser-tests.cjs:13` | False positive — "a lane whose `:ns-regexp` selected nothing prints". |

After the change, `git grep -i "ships no default console sink"` over tracked files (excluding the `.beads` export) returns **nothing**.

---

## Quality gates

Every exit code below is the runner's own, captured with `echo $?` on the same command line as the redirect. Nothing is piped through a filter. All gates re-run on the **final base** after rebasing onto `2331fca932`.

| Gate | Result | Exit |
|---|---|---|
| `scripts/test-fast-pr.sh` (post-rebase, final base) | PASS | **0** |
| — JVM `implementation/core` | 2243 tests / 11680 assertions, 0 failures, 0 errors | — |
| — JVM `implementation/resources` | 818 tests / 7284 assertions, 0 failures, 0 errors | — |
| — node/CLJS suite | 13853 tests / 70034 assertions, 0 failures, 0 errors | — |
| — clj-kondo (pinned 2026.04.15) | errors 0, warnings 4561 (informational) | — |
| `scripts/test-jvm-implementation.sh` | PASS, 23 artefacts, every one 0 failures / 0 errors | **0** |
| `npm run test:hicasso-invariants` (post-rebase) | PASS | **0** |
| `npm run test:hicasso-lint` (post-rebase) | PASS — 6 checks fire on fixtures, correct code silent | **0** |
| `check_example_fence_coverage.py --self-test` | PASS (8 packages, all fence-claimed) | **0** |
| `check_example_fence_coverage.py --self-test` under `python -O` | correctly REFUSES | **1** |
| `check_optional_module_reachability.py --self-test` | PASS (motion, overlay, native, forms unreachable from the door) | **0** |
| `check_optional_module_reachability.py --self-test` under `python -O` | correctly REFUSES | **1** |

The last four rows are rf2-t9t0's four-assertions-per-script contract: **passes plain, refuses under `-O`**, for both scripts.

### Gate provenance — which tree was actually read

`test-fast-pr.sh` prints `gate root: /c/Users/miket/code/re-frame2-worktrees/smallmisc-cluster` on line 1 of both runs — this worktree, not a sibling and not the mayor checkout.

The Python gates print no root, so the discrimination is **a planted fault**. `#_` was changed to `#~PLANTED` in `check_optional_module_reachability.py:255`; the gate went red at exit **1** with `AssertionError: ('#_(ns re-frame.hicasso.motion)\n', [])`, and the traceback named `...\re-frame2-worktrees\smallmisc-cluster\...`. The fault existed only in this tree, so a run that had wandered into a sibling's would have come back green. The plant was then reverted and the restore verified **by hashing the bytes**, not by reading a diff — `git hash-object` returned `27ea5e6c12221e163db50af0e7569971b291a3ca`, identical to the pre-plant hash. The gate was re-run green afterwards.

### Rebase and revert check

Rebased onto `2331fca932` after the trunk moved ~30 commits. **No file overlap** with my seven, but the hicasso tree changed and that is the *input* to both Python gates, so both were re-run on the new base (green above), as was the full spine.

`git diff origin/main...HEAD` (three-dot) is 7 files, +67 / −22. Every one of the 22 deleted lines is my own replaced comment text — **nothing a sibling landed is reverted**.

### What this local run does NOT cover

Local-green is not CI. Per `bash .github/scripts/report-changed-surfaces.sh`, this diff classifies `cljs_browser=true`, `examples_compile=true`, `cljs_prod=true` and `bundle_isolation=true` — **none of which is in any local tier** (the spine's own plan says so: "No browser, bundle, adapter, Xray, MCP or tool-JVM gate is in any tier"). `implementation_jvm=true` and `cljs_node_test=true` are covered above. The required set moves; the classifier is the authority, not this list.

---

## Fence

Touched only: `spec/009-Instrumentation.md` (the one comment block), `trace/projection.cljc`, the two named Python checkers, and the three `resources_*_cljs_test.cljc` files. **Not touched:** `.github/workflows/*`, `TESTING.md`, `tools/xray/**`, `implementation/hicasso/**` beyond the two named scripts, `docs/design/hicasso/product/**`, `docs/the-mayor-method/**`, `implementation/story/**`, or anything else under `spec/`.

## One observation, not actioned

`implementation/core/test/re_frame/on_error_cljs_test.cljc:125` says a dev-build console sink "is the **open half** of rf2-fu75, and a test pinning the absence of one would pre-decide a question left to the operator." That question is no longer open — #8108 decided it. I did **not** touch the line: rf2-bkvo's close reason classified this comment as contract-channel wording and told this residue not to relitigate it, and the fence is the fence. Flagging it for the mayor as a possible one-line follow-up rather than acting on it.
