### PR TITLE
bench+docs(hicasso): S8, the direct-return escape's clock, in a pinned quiet window (rf2-5yn9)

### DIFF
--- a/docs/design/hicasso/product/budgets.md
+++ b/docs/design/hicasso/product/budgets.md
@@ -189,15 +189,34 @@ Two departures from this section's stated method, both deliberate:
   and it is also their limit: **they say what work is skipped, never how long
   that work took.**
 
-**The clock half of the direct-return delta is an OPEN obligation, not a
-figure.** Specification §6 lists it in the bounded experiment set, and the bead
-asks for a pinned interleaved run on both named reference profiles published
-with witness, instrument and confidence. No such run has been taken: the
-instrument would be the P0 lane driver riding `:hicasso-bench`, and the machine
-available to `rf2-hic-033` was carrying three concurrent compiles, which is not
-a window a duration can be attributed in. Nothing in D10–D13 licenses a claim
-about how much faster a direct return is, and a reader wanting the remedy's
-price must wait for that row rather than read one off these. It is tracked as
+**The clock half of the direct-return delta is TAKEN, and it is `S8` in §4**
+(`rf2-5yn9`, 2026-08-13). Nothing in D10–D13 licenses a claim about how much
+faster a direct return is — a count says what work is skipped, never how long
+that work took — so a reader wanting the remedy's price reads `S8` and not
+these rows. The two halves are different instruments on the same pair, and
+neither re-derives the other: D10–D13 count entries during one server render;
+`S8` clocks the same pair mounted in a browser.
+
+**`S8`'s fairness gate is the STRONGER one, and that is worth reading back into
+this section.** The rows above are settled on markup under
+`renderToStaticMarkup`, which this section states as their limit — it says
+nothing about a mounted node's properties or about what a commit does. `S8`
+mounts both arms and compares their canonical DOM, attribute names sorted, and
+the two pages agree exactly, at 601 elements and 23,004 bytes, on every run.
+The equality D10–D13 could only assert in markup therefore holds in the
+document as well.
+
+**Half of §6's obligation is REFUSED, at source, and the refusal is not a
+scheduling problem.** Specification §6 asks for a pinned interleaved run on
+BOTH named reference profiles. The CI-RUNNER-A half cannot be published here
+under this page's own rules: §1 registers that profile class for *correctness
+gates and same-run relative drift only* and states that a hosted runner **may
+never source a distributional product budget**, and §9's gate mechanises it —
+the lane vocabulary a distributional row is allowed to name carries no
+CI-RUNNER-A value at all, by construction. `S8` is therefore a single-profile
+P-DEV-1 figure like every other distributional row on this page, and it
+inherits §1's single-profile limitation whole. Reconciling §6's wording with
+§1's rule is a ruling rather than a measurement, and it stays open on
 `rf2-5yn9`.
 
 **On D14–D16 — the island band's structural half (`rf2-hic-034`).** These read the
@@ -261,6 +280,7 @@ and the allocation row has no publishable claim to re-pin.
 | S5 | Teardown, retained **bytes** | indistinguishable from zero — all ten candidate rungs' bands straddle 0 | as S1 | **package figure** |
 | S6 | Cold mount vs direct UIx-on-subs | `1.1718x` [1.1263–1.2190] n=8; `1.1976x` [1.1504–1.2468] n=6 | final K1 estimator | **bench-tree figure** — registered `1.10x` gate missed; `1.25x` is the *accepted price* for that miss (ratified 2026-08-13), never a line this row is judged on |
 | S7 | Warm allocation | no publishable claim | allocation instrument | **bench-tree** — no fitted series clears the quality floor |
+| S8 | Direct-return escape (Rung 3): mount time against the same page written as hiccup | `0.770x` [0.646–0.842] over 10 rounds in 2 runs — **23.0% of mount time recovered** [15.8–35.4%] | P0 lane direct-return clock arm | **package figure** — the band excludes 1.0 in both runs, and it CROSSES C8's 20% line |
 
 The run's evidence, its controls and its full provenance are
 [on the ladder's studio page](../studio/reads-per-boundary-heap-ladder.md#the-package-itself-priced-on-this-rung-at-last-rf2-fe0l);
@@ -294,6 +314,45 @@ operator ruling rather than by the sitting it was held for
 does not clear it. The registered `1.10x` line is still the only adjudicated
 one, S6 stays `BREACH` against it, and **no evidence row may use the accepted
 ceiling to mark K1 green.**
+
+**S8 prices the Rung 3 escape, and the answer is that it is real and that it
+does not by itself clear C8.** The witness is `direct_return_cljs_test`'s pair —
+one page written twice, same props, same two ambient reads, same data — at 200
+boundaries, mounted inside one `flushSync` window. The escape recovers
+`23.0%` of the mount, band `[15.8–35.4%]`, and the band excludes 1.0 in both
+runs, so it is a real effect rather than a null. Read against
+[C8](#the-comparative-and-regression-rules) it decides nothing on its own:
+
+- **`≥ 20% recovered`** — the point estimate clears the line and **the band
+  crosses it**. Under the rule the operator adopted with §5's freeze, a
+  confidence band that crosses a line is UNRESOLVED and not a pass. So is this
+  one, and §9's gate is what holds it there.
+- **`≥ 2 ms p95`** — MISSED, and not narrowly. The saving is `0.45 ms` on a
+  200-boundary mount, about `2.2 µs` per boundary, so a single commit would
+  have to construct on the order of **900 boundaries** before the escape saved
+  2 ms. Whole pages of that size exist; a hot re-render is rarely one.
+- **converting a failed user-visible budget** — NOT ASSESSABLE. U1–U4 are
+  `UNPINNED` on the package, so there is no failed budget available to convert.
+
+**What that means for an author, which is the only form of this figure worth
+acting on.** C8 is a rule about *an escape at a site* — an island missing its
+threshold is simplified or removed — so one witness at one size cannot pass or
+fail it corpus-wide, and S8 does not try to. What S8 gives is the price an
+author measures their own site against: past roughly 900 boundaries in one
+commit the escape is worth 2 ms; below that it is worth about a quarter of the
+mount, and the author has to decide whether a quarter of *their* mount is a
+number their users can feel. **The escape's other prices are not on the clock
+at all** and both are already recorded: it leaves the L2 assertion tier, and it
+gives up controlled-input repair and intent lowering inside the returned
+element (§3's D10–D13 note, and the pair's own source).
+
+**S8 is one witness, and its band is what a second run bought.** Two runs were
+taken back to back on the same binary with nothing changed between them, and
+they read `0.742x` `[0.646–0.841]` and `0.798x` `[0.691–0.842]`. The published
+row pools all ten rounds rather than quoting the better run. On both runs the
+arm-order guard returned `reportable`, the positive control saw the `2.00x` its
+own arithmetic predicts, and every one of the 225 measured mounts was read back
+out of the document at its own far end.
 
 ### The §6 user-visible budgets
 
@@ -634,7 +693,7 @@ and no figure may be scaled from one onto the other.
 | Family | Enforcement home |
 |---|---|
 | Deterministic rows D1–D16 | ordinary blocking PR gates; framework in `rf2-hic-089`, full gates in `rf2-hic-071` |
-| Distributional rows S1–S7, U1–U4 | pinned interleaved evidence runs on P-DEV-1; never converted into flaky PR thresholds |
+| Distributional rows S1–S8, U1–U4 | pinned interleaved evidence runs on P-DEV-1; never converted into flaky PR thresholds |
 | Shell breach disposition | `rf2-0xx2` |
 | K3 per-read record | `rf2-hic-070` — [`k3-disposition.md`](k3-disposition.md), whose §8 makes the 10% same-witness per-read rule executable for `rf2-hic-071` |
 
@@ -787,6 +846,7 @@ today. *Disposition* is a link that must resolve to a section naming the row.
 | S5 | teardown retained indistinguishable from 0 | indistinguishable from 0; all ten rungs' bands straddle it | package | `MET` | P0 heap ladder, package candidate arm (P-DEV-1 evidence run) | `rf2-hic-089` | — |
 | S6 | 1.10x cold mount against direct UIx-on-subs | 1.1718x [1.1263–1.2190] n=8; 1.1976x [1.1504–1.2468] n=6 | bench-tree | `BREACH` | final K1 estimator (P-DEV-1 evidence run) | `rf2-hic-085` | [§9.2](budgets.md#92-what-each-not-green-row-is-waiting-on) |
 | S7 | warm allocation, a fitted series clearing the quality floor | no publishable claim | bench-tree | `UNPINNED` | — (none) | `rf2-hic-071` | [§9.2](budgets.md#92-what-each-not-green-row-is-waiting-on) |
+| S8 | C8's first disjunct: an escape recovers ≥ 20% | `0.770x` [0.646–0.842] — 23.0% recovered [15.8–35.4%]; 0.45 ms on a 200-boundary mount | package | `UNRESOLVED` | P0 lane direct-return clock arm (P-DEV-1 evidence run) | `rf2-5yn9` | [§9.2](budgets.md#92-what-each-not-green-row-is-waiting-on) |
 | U1 | echo within one 60 Hz frame at p95 | — | — | `UNPINNED` | — (none) | `rf2-hic-071` | [§9.2](budgets.md#92-what-each-not-green-row-is-waiting-on) |
 | U2 | ≤ 50 ms p95 and ≤ 100 ms p99 to next paint | — | — | `UNPINNED` | — (none) | `rf2-hic-071` | [§9.2](budgets.md#92-what-each-not-green-row-is-waiting-on) |
 | U3 | ≤ 100 ms p95 for broad operations | — | — | `UNPINNED` | — (none) | `rf2-hic-071` | [§9.2](budgets.md#92-what-each-not-green-row-is-waiting-on) |
@@ -805,7 +865,7 @@ today. *Disposition* is a link that must resolve to a section naming the row.
 
 <!-- rf2-hic-089: end-ledger -->
 
-Thirty-eight rows: the sixteen deterministic figures of §3, the seven distributional
+Thirty-nine rows: the sixteen deterministic figures of §3, the eight distributional
 rows and six user-visible budgets of §4, the eight comparative rules §4 now
 gives ids to, and one row registered off this page — **I9**, the two-hook
 ceiling frozen by
@@ -874,6 +934,22 @@ pinned bands' upper edges, `1,107 B` and `1,101 B`.
   and the consequence is written down rather than worked around: `rf2-hic-085`
   stays open while this record stands, and closing it would leave both rows
   pointing at nobody.
+- **`S8`'s band crosses C8's own line, which is what `UNRESOLVED` is for.** The
+  reading is not thin and the rig is not the problem: two runs on one binary,
+  the arm-order guard `reportable` on both, the positive control seeing its
+  predicted `2.00x` on both, 225 of 225 measured mounts read back at their far
+  end, and a mounted-DOM fairness gate that agreed and was driven to disagree on
+  purpose. What the band does is straddle `20%` — `23.0%` recovered, `[15.8–35.4%]`
+  — so the first of C8's three disjuncts is neither met nor missed, exactly the
+  case §5's freeze ruling created this status for. **Narrowing it is a
+  measurement and widening the line is forbidden**: more rounds on the same
+  instrument would settle it, and that is `rf2-5yn9`'s to schedule as its own
+  window rather than something to fold into this one. Two further things are
+  needed before C8 itself can move off `UNPINNED`, and neither is a reading: a
+  ruling on what population C8 is stated over — it governs *an escape at a
+  site*, so a single witness cannot pass it corpus-wide — and the reconciliation
+  of §6's *both reference profiles* against §1's prohibition on a hosted runner
+  sourcing a distributional figure, recorded in §3.
 - **`S7` has no publishable claim to pin.** No fitted allocation series clears
   the quality floor. This is a property of the readings rather than of the
   rig, so it is `UNPINNED` rather than `UNRESOLVED`: nothing crossed a line,

--- a/implementation/freehand/test/re_frame/bench/hicasso/direct_return_clock_app.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/direct_return_clock_app.cljs
@@ -1,0 +1,412 @@
+(ns re-frame.bench.hicasso.direct-return-clock-app
+  "THE CLOCK HALF OF THE DIRECT-RETURN DELTA (rf2-5yn9).
+
+  `rf2-hic-033` took the DETERMINISTIC half — budgets.md D10–D13, entries
+  into `codec/vec->element`, `codec/convert-props`, `intent/lower-prop`
+  and `controlled/install!`, each read against the crossing's own floor.
+  It did not take the clock: the machine available to it was carrying
+  three concurrent compiles, and a duration measured beside three
+  compiles is a number nobody can attribute. This entry is the clock, on
+  the P0 lane, in a pinned quiet window.
+
+  D10–D13 are CITED, never re-derived here. A second source for one
+  number is a second thing to drift, and the counts are the half that
+  needs no window.
+
+  ## The pair, and why it is transcribed rather than required
+
+  [[hiccup-body]] and [[direct-body]] are `direct_return_cljs_test`'s
+  pair, verbatim: the same props in the same order, the same two ambient
+  reads, the same data, the same spelled-out class shorthand. The
+  original lives in
+  `implementation/hicasso/test/re_frame/hicasso/direct_return_cljs_test.cljs`,
+  which is a `*-cljs-test` namespace on the node lane. Requiring it from
+  an `:advanced` `:browser` bundle would pull `cljs.test` and the whole
+  suite into the measured page, so the pair is COPIED.
+
+  **A copy is a thing that can drift, and the fairness gate is what
+  stops it drifting silently.** [[parity!]] mounts both arms and compares
+  their canonical DOM before a clock is read; a transcription that had
+  lost a prop, a read or a class would part the two pages and the run
+  refuses before it measures anything. The gate is also driven to FAIL
+  on purpose ([[parity-can-fail?]]), because an equality that cannot
+  answer false is not a gate.
+
+  It is MOUNTED-DOM equality here, through `lane/canonical`, and that is
+  a STRONGER claim than the deterministic half made. That file states its
+  own limit explicitly: it settles markup under `renderToStaticMarkup`
+  and says nothing about a mounted node's properties or what a commit
+  does — the axes a controlled field and a native input genuinely differ
+  on. Taking the equality in the browser is this arm's own obligation and
+  it is taken before the first sample.
+
+  ## What is measured
+
+  One page written twice, at [[boundaries]] boundaries, mounted into a
+  fresh container inside ONE `react-dom/flushSync` window
+  (`lane/mount-batch!`). The window therefore holds the substrate's
+  element construction AND React's render, commit and DOM mutation —
+  which is the point: the escape removes CLJS lowering from a cost React
+  otherwise dominates, and a figure that excluded React's share would
+  overstate what an author gets.
+
+    :floor    the crossing carrying nothing — [[floor-body]] answers nil,
+              so the page is the wrapper and no more. Every ratio is
+              against the floor measured in THAT round, because this box
+              drifts across rounds by more than the effect being measured.
+    :hiccup   the Rung 1 spelling
+    :direct   the Rung 3 spelling
+    :ctl-2x   THE POSITIVE CONTROL — the hiccup arm's own page, mounted
+              TWICE inside one window. Not a doubled page: literally the
+              same operation performed twice, so the per-sample additive
+              constants double with it and the prediction is a clean
+              2.00x rather than a modelled one. `rf2-jcm3p` records the
+              other shape UNDERSHOOTING (1.8173x over seven runs) for
+              exactly the constant this one doubles.
+
+  `:floor` and `:ctl-2x` are `:parity-exempt?`: one builds an empty page
+  and one builds two pages, both on purpose, and folding either into the
+  equality would make the fairness gate a permanent failure.
+
+  ## The published figure
+
+  `lane/ratio-between :direct :hiccup` over the per-round floor-normalised
+  ratios — direct-return mount time as a fraction of the hiccup spelling's,
+  with its range and its `:straddles-1?` flag. A range that includes 1.0
+  means INDISTINGUISHABLE and the row must say so rather than quote the
+  mean as a win. That is the reading budgets.md §4 takes, and C8's benefit
+  threshold (>= 20% recovered, or >= 2 ms p95, or a failed user-visible
+  budget converted) is adjudicated against it.
+
+  Owner: rf2-5yn9. Instrument: `lane.cljs`, ridden through `run.cjs` on the
+  existing `:hicasso-bench` build id via `HICASSO_INIT_FN` — no
+  `shadow-cljs.edn` edit, which is what the driver's `--config-merge`
+  exists for."
+  (:require [re-frame.adapter.uix :as uix-adapter]
+            [re-frame.bench.hicasso.lane :as lane]
+            [re-frame.core :as rf]
+            [re-frame.hicasso :as h]
+            [re-frame.hicasso.native :as n]))
+
+(def frame-id ::direct-return-clock)
+
+(def ^:private boundaries
+  "Boundaries per page. Large enough that the per-mount constants
+  (`createRoot`, the container, the root crossing) are a small share of
+  the window and that the window clears Chrome's 100 us
+  `performance.now()` clamp by orders of magnitude; small enough that a
+  round is seconds rather than minutes."
+  200)
+
+;; ---------------------------------------------------------------------------
+;; Subscriptions and data — `direct_return_cljs_test`'s, scaled to N ids
+;; ---------------------------------------------------------------------------
+;;
+;; The pair reads `[:dr/label id]` and `[:dr/tags id]`. Both survive
+;; verbatim; only the SEED grows, because a page of one boundary cannot
+;; be timed. Labels are per-row so the far-end read-back distinguishes a
+;; page that rendered from a page that rendered its prefix.
+
+(rf/reg-sub :dr/label (fn [db [_ id]] (get-in db [:labels id])))
+(rf/reg-sub :dr/tags  (fn [db [_ id]] (get-in db [:tags id])))
+
+(rf/reg-event :dr/seed (fn [_ [_ db]] {:db db}))
+
+(defn- seed-db
+  [n label-of]
+  {:labels (into {} (map (fn [i] [i (label-of i)])) (range n))
+   :tags   (into {} (map (fn [i] [i ["clj" "react"]])) (range n))})
+
+(defn- default-label [i] (str "quarterly-" i))
+(defn- mutated-label [i] (str "annual-" i))
+
+;; ---------------------------------------------------------------------------
+;; The pair — `direct_return_cljs_test`'s, verbatim
+;; ---------------------------------------------------------------------------
+;;
+;; The prop keys are written in the SAME ORDER on both sides and the class
+;; shorthand is spelled out rather than folded, because both sides
+;; normalise through the one `impl.slot/prop-name` rule. Same rule plus
+;; same order is what makes the equality a property of the source rather
+;; than something to discover.
+
+(defn hiccup-body
+  "The ordinary Rung 1 spelling. Two ambient reads, an intent vector at a
+  callback slot, and a controlled field."
+  [{:keys [id]}]
+  (let [label (h/sub [:dr/label id])
+        n     (count (h/sub [:dr/tags id]))]
+    [:div {:class "row" :on-click [:dr/picked id]}
+     [:span {:class "label"} (str label " " n)]
+     [:input {:class "field" :value label :on-input [:dr/edited id ::h/value]}]]))
+
+(defn direct-body
+  "The Rung 3 spelling of the same page. The reads are the boundary's,
+  unchanged. Past `n/$` there is no intent lowering, so the callback slot
+  holds an ordinary function; and no controlled repair, so the field's
+  echo is the author's to write."
+  [{:keys [id]}]
+  (let [label (h/sub [:dr/label id])
+        n     (count (h/sub [:dr/tags id]))]
+    (n/$ :div {:class "row" :on-click (fn [_] nil)}
+         (n/$ :span {:class "label"} (str label " " n))
+         (n/$ :input {:class "field" :value label :on-change (fn [_] nil)}))))
+
+(defn floor-body
+  "The crossing carrying nothing. A boundary is reached through a hiccup
+  vector whatever its body answers, so the floor is the crossing and not
+  zero."
+  [_]
+  nil)
+
+(h/defview hiccup-arm [props] (hiccup-body props))
+(h/defview direct-arm [props] (direct-body props))
+(h/defview floor-arm  [props] (floor-body props))
+
+;; ---------------------------------------------------------------------------
+;; The page — identical for every arm but the body
+;; ---------------------------------------------------------------------------
+;;
+;; Children are spliced into a VECTOR rather than lowered as a seq, so no
+;; arm meets the key diagnostic and the two arms cannot differ on it. The
+;; wrapper `div` is common to all three and is the floor's whole page.
+
+(defn- page [view]
+  (into [:div {:class "page"}]
+        (map (fn [i] [view {:id i}]))
+        (range boundaries)))
+
+(def ^:private page-elements
+  "Elements per mounted page. The wrapper, plus `div`/`span`/`input` per
+  boundary — the arithmetic written down before the run, so a mount that
+  rendered a prefix cannot be banked as a sample."
+  (+ 1 (* 3 boundaries)))
+
+(def ^:private floor-elements 1)
+
+;; ---------------------------------------------------------------------------
+;; Arms
+;; ---------------------------------------------------------------------------
+
+(defn- mount-page
+  [view]
+  (fn [container _props _n] (h/root! container frame-id (page view))))
+
+(defn- unmount-page [handle] (h/unmount! handle))
+
+(def ^:private arms
+  [{:id :floor  :k 1 :elements floor-elements :parity-exempt? true
+    :mount (mount-page floor-arm)  :unmount unmount-page}
+   {:id :hiccup :k 1 :elements page-elements
+    :mount (mount-page hiccup-arm) :unmount unmount-page}
+   {:id :direct :k 1 :elements page-elements
+    :mount (mount-page direct-arm) :unmount unmount-page}
+   {:id :ctl-2x :k 2 :elements page-elements :parity-exempt? true
+    :mount (mount-page hiccup-arm) :unmount unmount-page}])
+
+(def ^:private sampling {:warmup 3 :samples 6})
+(def ^:private rounds 5)
+(def ^:private control-slack 0.25)
+
+;; ---------------------------------------------------------------------------
+;; Read-back — every measured mount, at its own far end
+;; ---------------------------------------------------------------------------
+
+(defn- far-end
+  "The LAST `.label` span's text, or nil. Reading the far end and not the
+  first is the difference between proving the page rendered and proving
+  it started: a mount that rendered its prefix passes an element count
+  taken at index 0 and fails here."
+  [container]
+  (let [ns' (.querySelectorAll container "span.label")
+        c   (.-length ns')]
+    (when (pos? c) (.-textContent (.item ns' (dec c))))))
+
+(defn- expected-far-end []
+  (str (default-label (dec boundaries)) " 2"))
+
+(defn- verified?
+  "This arm's own arithmetic, on this mount. The floor has no `.label` to
+  read, so its far-end probe is its element count and nothing else — a
+  probe that cannot pass manufactures a defect and hides real ones behind
+  it."
+  [arm container]
+  (and (= (:elements arm) (lane/element-count container))
+       (or (= :floor (:id arm))
+           (= (expected-far-end) (far-end container)))))
+
+;; ---------------------------------------------------------------------------
+;; The fairness gate
+;; ---------------------------------------------------------------------------
+
+(defn parity!
+  "Mount every arm at once and compare the judged arms' canonical DOM.
+  Answers `lane/parity`'s verdict with the mounts already released."
+  []
+  (let [{:keys [mounts] :as p} (lane/parity arms nil)]
+    (doseq [m mounts] (lane/release! m))
+    p))
+
+(defn parity-can-fail?
+  "THE MUTATION. Move the data under one arm and the gate must part the
+  two pages; an equality that cannot answer false is not a gate. Reseeds
+  to the run's own labels afterwards, so nothing downstream is measured
+  on the mutated page."
+  []
+  (let [before (let [m (lane/mount-arm! (nth arms 1) nil)
+                     s (lane/canonical (:container m))]
+                 (lane/release! m)
+                 s)]
+    (rf/with-frame frame-id
+      (rf/dispatch-sync [:dr/seed (seed-db boundaries mutated-label)]))
+    (let [after (let [m (lane/mount-arm! (nth arms 2) nil)
+                      s (lane/canonical (:container m))]
+                  (lane/release! m)
+                  s)]
+      (rf/with-frame frame-id
+        (rf/dispatch-sync [:dr/seed (seed-db boundaries default-label)]))
+      (not= before after))))
+
+;; ---------------------------------------------------------------------------
+;; The measured window
+;; ---------------------------------------------------------------------------
+
+(defn- measure-one!
+  [tally arm]
+  (let [{:keys [ms mounts]} (lane/mount-batch! arm nil (:k arm))]
+    (doseq [m mounts]
+      (let [ok? (verified? arm (:container m))]
+        (swap! tally (fn [{:keys [of bad]}]
+                       {:of (inc of) :bad (if ok? bad (inc bad))}))))
+    (doseq [m mounts] (lane/release! m))
+    ms))
+
+(defn- fmt [x n] (.toFixed (double x) n))
+
+(defn- measurement-method []
+  (str "a SAMPLE is " boundaries " boundaries mounted into a fresh container "
+       "inside ONE react-dom/flushSync window, containers created and attached "
+       "BEFORE the clock starts; the :ctl-2x arm's sample is the SAME operation "
+       "performed TWICE inside one window, so its per-sample constants double "
+       "with its work and its prediction is 2.00x by construction rather than by "
+       "model. Arms interleaved at the SAMPLE level under the lane's rotating AND "
+       "REFLECTING schedule, so no arm always follows the same neighbour; "
+       rounds " rounds of " (:warmup sampling) " warm-up + " (:samples sampling)
+       " samples per arm per round; every measured mount read back out of the DOM "
+       "against THAT ARM'S OWN element count and at its own FAR END; every ratio "
+       "against the floor measured in THAT round. Nothing runs inside an `act` "
+       "environment."))
+
+;; ---------------------------------------------------------------------------
+;; Boot
+;; ---------------------------------------------------------------------------
+
+(defn ^:export -main []
+  (rf/init! uix-adapter/adapter)
+  (lane/leave-act-environment!)
+  (lane/self-test!)
+  (-> (js/Promise.resolve nil)
+      (.then
+        (fn [_]
+          (rf/make-frame {:id frame-id
+                          :initial-events [[:dr/seed (seed-db boundaries default-label)]]})
+          (rf/with-frame frame-id
+            (rf/dispatch-sync [:dr/seed (seed-db boundaries default-label)]))
+          ;; THE FAIRNESS GATE, before a clock is read. Both halves, and
+          ;; both fatal: the arms must agree, and the comparison must be
+          ;; known able to disagree.
+          (let [p         (parity!)
+                can-fail? (parity-can-fail?)]
+            (lane/record! :direct-return-clock-parity
+                          {:agree?    (:agree? p)
+                           :disagree  (:disagree p)
+                           :counts    (:counts p)
+                           :can-fail? can-fail?
+                           :bytes     (lane/utf8-bytes (or (:reference p) ""))})
+            (when-not (:agree? p)
+              (throw (ex-info (str "FAIRNESS GATE: the two arms do not build the same "
+                                   "mounted page, so no ratio between them is about the "
+                                   "lowering. Disagreeing arms: " (pr-str (:disagree p)))
+                              {:counts (:counts p)})))
+            (when-not can-fail?
+              (throw (ex-info (str "FAIRNESS GATE: the canonical-DOM comparison did NOT "
+                                   "part two pages built from different data. An equality "
+                                   "that cannot answer false is not a gate, and the "
+                                   "agreement above is worth nothing.")
+                              {}))))
+          (lane/assert-teardown-clean! "the fairness gate")
+          (.then (lane/settle!) (fn [_] nil))))
+      (.then
+        (fn [_]
+          (let [baseline (lane/residue frame-id)
+                tally    (lane/tally)
+                {:keys [readings samples]}
+                (lane/rounds! arms sampling rounds (partial measure-one! tally))
+                norm     (mapv #(lane/normalise % :floor) readings)
+                ratios   (mapv :ratio norm)
+                summ     (lane/across-rounds ratios)
+                p50s     (mapv :p50 norm)
+                abs      (into {}
+                               (map (fn [{:keys [id]}]
+                                      [id (lane/summarise (mapv #(get % id) p50s))]))
+                               arms)
+                escape   (lane/ratio-between ratios :direct :hiccup)
+                gv       (lane/guard! samples "direct-return clock arms (in-page ms)")
+                ctl      (lane/control-verdict
+                           (* 2.0 (:p50 (get abs :hiccup)))
+                           (let [s (get abs :ctl-2x)]
+                             {:min (:min s) :max (:max s) :mean (:p50 s)})
+                           control-slack)
+                tv       (lane/tally-value tally)]
+            (lane/assert-teardown-clean! "the measured rounds")
+            (lane/record! :direct-return-clock
+                          {:benchmark   :hicasso.P0/direct-return-clock
+                           :bead        "rf2-5yn9"
+                           :cites       "budgets.md D10-D13 (rf2-hic-033) — the deterministic half, NOT re-derived here"
+                           :grade       :distributional
+                           :runtime     (lane/runtime-label)
+                           :boundaries  boundaries
+                           :elements    {:floor floor-elements :page page-elements}
+                           :design      {:rounds rounds :sampling sampling}
+                           :method      (measurement-method)
+                           :absolute-ms abs
+                           :ratio-to-floor summ
+                           :escape      escape
+                           :control     ctl
+                           :writes      tv})
+            (js/console.log ";; ==== DIRECT-RETURN CLOCK (rf2-5yn9) ====")
+            (js/console.log (str ";;   " boundaries " boundaries/page, " page-elements
+                                 " elements; " rounds " rounds x ("
+                                 (:warmup sampling) "+" (:samples sampling) ")"))
+            (doseq [{:keys [id]} arms]
+              (let [a (get abs id)
+                    r (get summ id)]
+                (js/console.log
+                  (str ";;   " (name id) ": " (fmt (:p50 a) 4) " ms/mount ["
+                       (fmt (:min a) 4) " - " (fmt (:max a) 4) "]  ratio-to-floor "
+                       (fmt (:mean r) 4) " [" (fmt (:min r) 4) " - " (fmt (:max r) 4) "]"))))
+            (js/console.log
+              (str ";;   ESCAPE direct/hiccup: " (fmt (:mean escape) 4)
+                   "x [" (fmt (:min escape) 4) " - " (fmt (:max escape) 4) "]"
+                   (if (:straddles-1? escape)
+                     "  <- STRADDLES 1.0: INDISTINGUISHABLE"
+                     "  <- range excludes 1.0")))
+            (js/console.log (str ";;   per-round: " (pr-str (:per-round escape))))
+            (js/console.log (str ";;   control: " (:why ctl)))
+            (js/console.log (str ";;   writes: " (:unverified tv) " unverified of "
+                                 (:writes tv)))
+            (when (pos? (:unverified tv))
+              (throw (ex-info (str "READ-BACK: " (:unverified tv) " of " (:writes tv)
+                                   " measured mounts did not match their own arithmetic")
+                              tv)))
+            (when (:refuse? gv)
+              (set! (.-HICASSO_GUARD_REFUSED js/window) true))
+            (when-not (:ok? ctl)
+              (set! (.-HICASSO_CONTROL_FAILED js/window) true))
+            (.then (lane/settle!)
+                   (fn [_]
+                     (lane/assert-residue! baseline frame-id "the measured rounds")
+                     (lane/done!))))))
+      (.catch (fn [e]
+                (lane/fail! (or (some-> e .-message) (str e)))
+                (lane/done!)))))

--- a/implementation/hicasso/scripts/check_budget_ledger.py
+++ b/implementation/hicasso/scripts/check_budget_ledger.py
@@ -183,11 +183,15 @@ EXTRA_ROWS = {
 # same terms: `rf2-hic-033` and `rf2-hic-034` took them on
 # `implementation/hicasso` and §3's heading is what they landed under.  An
 # unpinned row is the hole this constant exists to close, so a new row is
-# pinned as it lands rather than later.
+# pinned as it lands rather than later.  `S8` — the direct-return escape's
+# clock, `rf2-5yn9` — is pinned `package` on that rule: the instrument that
+# read it lives in the bench tree, as the P0 heap ladder behind S1–S5 does,
+# but the SUBJECT is `implementation/hicasso`, and this column names the
+# subject rather than the instrument's address.
 POPULATION_PIN = dict(
     [("D%d" % n, "package") for n in range(1, 17)]
     + [("S%d" % n, "package") for n in range(1, 6)]
-    + [("S6", "bench-tree"), ("S7", "bench-tree")]
+    + [("S6", "bench-tree"), ("S7", "bench-tree"), ("S8", "package")]
     + [("U%d" % n, "—") for n in range(1, 5)]
     + [("U5", "package"), ("U6", "package")]
     + [("C1", "—"), ("C2", "bench-tree"), ("C3", "—"), ("C4", "—"),


### PR DESCRIPTION
## The clock half of the direct-return delta, taken (rf2-5yn9)

`rf2-hic-033` delivered the deterministic half — budgets.md `D10`–`D13`, entries
into `codec/vec->element`, `codec/convert-props`, `intent/lower-prop` and
`controlled/install!`, each read against the crossing's own floor. It stopped
short of the clock because the machine it had was carrying three concurrent
compiles. This is the clock, taken in a pinned quiet window with the fleet at
zero.

**`D10`–`D13` are cited and not re-derived.** A second source for one number is
a second thing to drift.

### The figure

**`S8` — the Rung 3 escape reads `0.770x` `[0.646–0.842]`, i.e. `23.0%` of mount
time recovered `[15.8–35.4%]`**, over ten rounds in two runs.

The band **excludes 1.0** on both runs, so the effect is real rather than a
null. It also **crosses C8's `20%` line**, so the ledger row is `UNRESOLVED`
rather than a pass — the status the operator's own band rule (adopted with §5's
`1,024 B` freeze) exists to hold. C8's second disjunct, `≥ 2 ms p95`, is missed
by about a factor of four: the saving is `0.45 ms` on a 200-boundary mount,
roughly `2.2 µs` per boundary, so a commit would need on the order of **900
boundaries** before the escape were worth 2 ms. The third disjunct is not
assessable — `U1`–`U4` are `UNPINNED`, so there is no failed budget to convert.

### What was refused, and why it is not a scheduling problem

**The CI-RUNNER-A half of spec §6's obligation is REFUSED at source**, on two
independent grounds, neither of which more machine time would move:

1. budgets.md **§1** registers CI-RUNNER-A for *correctness gates and same-run
   relative drift only* and states that a hosted runner **may never source a
   distributional product budget**. A §4 row is exactly that.
2. §9's own gate mechanises it. The lane vocabulary a distributional row is
   permitted to name is `PR gate` / `P-DEV-1 evidence run` / `none` — there is
   no CI-RUNNER-A value to write, by construction.

Taking it would also have required a `.github/workflows/*` edit, which this
work was fenced out of. Reconciling §6's *both reference profiles* with §1's
prohibition is a **ruling, not a measurement**, and it stays open on `rf2-5yn9`.

### The instrument

`re-frame.bench.hicasso.direct-return-clock-app`, riding the existing
`:hicasso-bench` build id through `run.cjs`'s `HICASSO_INIT_FN` —
**no `implementation/shadow-cljs.edn` edit**, which is what the driver's
`--config-merge` exists for.

The subject is `direct_return_cljs_test`'s pair, transcribed verbatim (the
original is a `*-cljs-test` namespace; requiring it would pull `cljs.test` into
an `:advanced` browser bundle). The transcription is not taken on trust — the
fairness gate is what proves it is still the same pair, and it runs before any
clock is read.

Four arms, per-round floor normalisation, the lane's rotating **and reflecting**
schedule:

| arm | what it is |
|---|---|
| `:floor` | the crossing carrying nothing — 200 boundaries whose bodies answer nil |
| `:hiccup` | the Rung 1 spelling, 200 boundaries |
| `:direct` | the Rung 3 spelling, same page |
| `:ctl-2x` | the positive control — the **same operation performed twice** in one window, so the per-sample constants double with the work and `2.00x` is structural rather than modelled |

`rf2-jcm3p` records the other doubling shape *undershooting* (`1.8173x` over
seven runs) because an additive per-sample constant survives the tare. This
control doubles that constant along with everything else, which is why its
prediction is clean.

### The mounted-DOM equality is a stronger claim than §3 could make

`direct_return_cljs_test` states its own limit in terms: it settles **markup**
under `renderToStaticMarkup` and says nothing about a mounted node's properties
or about what a commit does. This arm takes the equality through
`lane/canonical` in a real browser, attribute names sorted. The two arms build
**identical pages — 601 elements, 23,004 bytes, on every run** — and the
comparison is driven to answer *false* on purpose, because an equality that
cannot fail is not a gate.

### Controls — every one of them, passing or not

| control | run 1 | run 2 |
|---|---|---|
| canonical-DOM parity, `:hiccup` vs `:direct` | agree, 601/601, 23,004 B | agree, 601/601, 23,004 B |
| the parity gate driven to fail | `can-fail? true` | `can-fail? true` |
| arm-order guard (predecessor **and** phase) | `VERDICT: reportable` | `VERDICT: reportable` |
| positive control, predicted vs measured | predicted `4.500`, measured `4.300` `[3.950–4.950]` — **ok** | predicted `4.000`, measured `4.200` `[3.800–5.150]` — **ok** |
| read-back, every measured mount at its far end | **0 unverified of 225** | **0 unverified of 225** |
| teardown + residue | clean | clean |

### Raw readings

| arm | run 1 ms/mount | run 2 ms/mount |
|---|---|---|
| `:floor` | `0.20` `[0.20–0.40]` | `0.30` `[0.15–0.30]` |
| `:hiccup` | `2.25` `[2.00–2.55]` | `2.00` `[1.85–2.75]` |
| `:direct` | `1.70` `[1.55–1.85]` | `1.65` `[1.50–1.90]` |
| `:ctl-2x` | `4.30` `[3.95–4.95]` | `4.20` `[3.80–5.15]` |

Escape ratio per round —
run 1 `[0.6667 0.7556 0.8409 0.8000 0.6458]` (mean `0.7418`),
run 2 `[0.6909 0.8222 0.8250 0.8108 0.8421]` (mean `0.7982`).
**The published row pools all ten rounds rather than quoting the better run.**

Runtime: HeadlessChrome `147.0.7727.15` (Playwright), `:advanced`,
`goog.DEBUG false`, `hardwareConcurrency 24`, `deviceMemory 32`.

### The quiet window, measured rather than asserted

`Win32_Processor.LoadPercentage` is not used — it has read 93% against a true
11%. **Processor queue length is the decisive number**, sampled throughout
rather than once:

| when | queue | CPU |
|---|---|---|
| before dispatch, 5 samples | `0 0 0 0 0` | 8.2–17.4% |
| run 1, build + measure, 6 samples | `0 0 0 0 0 0` | 10.0–30.0% |
| run 2, **build** phase, 8 samples | `0 0 0 0 0 0 0 13` | 21.2–50.0% |
| run 2, **measured** phase, 14 samples | `0` ×14 | 1.8–12.1% |
| fast-PR spine, 10 samples | `0 0 0 0 0 1 0 1 0 0` | 9.8–27.9% |

The one queue reading above zero during a run belongs to **this run's own
`:advanced` compile**, which saturates 24 threads and is finished before the
browser launches. The measured phase is a single headless Chromium page, and it
read `0` on every sample.

### Scope beyond the literal fence, stated rather than buried

The bead grants §4's row and §3's obligation paragraph. Three further edits are
**mechanically forced** by the repository's own budget-ledger gate and are not
discretionary:

- **§9's ledger gains an `S8` row** — L4 requires exactly one ledger row per id
  registered outside the ledger.
- **§9.2 gains an `S8` entry** — L3 requires every not-`MET` row to name a
  disposition whose section names the row.
- **§9's row-count sentence** moves 38 → 39 and *seven* → *eight* distributional
  rows, and §7's routing row moves `S1–S7` → `S1–S8`, so the page does not
  contradict its own ledger.

**None of `S1`, `S2`, `S3`, `S6`, `C2`, `C5` or `C6` is touched.** `C8` stays
`UNPINNED`: it governs *an escape at a site*, so one witness cannot pin it
corpus-wide, and moving it would need a population ruling. That is written into
§9.2 rather than taken here.

`check_budget_ledger.py` gains one line — `S8` in `POPULATION_PIN`. That is the
discipline the script's own comment states (*"a new row is pinned as it lands
rather than later"*) and it **tightens** the gate against a later cell rewrite
of my own row. No threshold is widened anywhere in this change.

## Quality gates

Every number below is the exit code **captured on the runner's own command
line**, never one reported about the run.

Every gate below was re-run **on the final base after the rebase**, and the
table reports the post-rebase run.

| gate | exit | evidence it read THIS worktree |
|---|---|---|
| `run.cjs` clock arm, attempt 1 | `0` | the entry namespace exists only in this tree, so a build elsewhere could not have compiled it |
| `run.cjs` clock arm, attempt 2 | `0` | as above |
| `check_budget_ledger.py --self-test` | `0` | — |
| `check_budget_ledger.py` (live) | `0` | reports **39 rows, 3 UNRESOLVED** — was 38 / 2, so it read `S8` |
| `check_doc_slugs.py` | `0` | see the planted fault below |
| `check_doc_slugs.py` **with a planted fault** | `1` | `BROKEN ANCHOR: docs\design\hicasso\product\budgets.md:324 -> #SABOTAGE-clockhalf-5yn9-no-such-anchor` — names exactly what was planted, in this tree's file |
| `check_provenance_pins.py --changed-since origin/main` (the CI form) | `0` | `1 files, 5 cited pins (5 landed, 0 stranded)` |
| `scripts/test-fast-pr.sh` | `0` | green pre-rebase and re-run green on the final base |

**The two clock runs were not re-taken after the rebase, and that is a checked
claim rather than a convenience.** `git diff --name-only <old-base> origin/main`
over `implementation/hicasso/`, the bench lane, `deps.edn`, `package.json` and
`shadow-cljs.edn` returns exactly two files — `check_example_fence_coverage.py`
and `check_optional_module_reachability.py`, both gate checkers. No runtime
source, no lane file, no build configuration. The compiled bundle the readings
were taken on is byte-identical on the final base.

The planted fault was reverted and the revert **verified by hashing the bytes**,
not by reading a diff: `git hash-object` returns `a87177bb120094def68c07ca4745fbe47884ba9a`
before the plant and after the restore.

`check_provenance_pins.py` with no flag exits `1` on this tree and on `main`
alike — the corpus carries stranded pins the census catalogued and left
standing. It names no file in this change. CI scopes it to changed pages, which
is the form run above.

**Examples are test-free and none is touched.** No `*.spec.cjs` is added.
