### PR TITLE
docs(hicasso): combobox witness, migration census + hm/shadow!, and a refused h/mount! sweep (rf2-56v4, rf2-me76, rf2-4u7x)

### DIFF
--- a/docs/design/hicasso/draft-guide/13-overlays-and-focus.md
+++ b/docs/design/hicasso/draft-guide/13-overlays-and-focus.md
@@ -221,6 +221,7 @@ does not require another overlay primitive.
         active     (h/sub [:combo/active id])
         values     (mapv :value items)
         trigger-id (str "combo-" id "-trigger")
+        listbox-id (str "combo-" id "-listbox")
         option-id  (fn [v] (str "combo-" id "-opt-" v))
         label      (or (some #(when (= value (:value %))
                                (:label %))
@@ -229,8 +230,10 @@ does not require another overlay primitive.
     [:div.combo
      [:button
       {:id trigger-id
+       :role "combobox"
        :aria-haspopup "listbox"
        :aria-expanded open?
+       :aria-controls (when open? listbox-id)
        :aria-activedescendant
        (when (and open? active)
          (option-id active))
@@ -246,20 +249,43 @@ does not require another overlay primitive.
        :on-dismiss [:combo/dismissed id]
        :anchor     trigger-id
        :placement  :bottom-start}
-      [:ul {:role "listbox"}
-       (for [{:keys [value label]} items]
+      [:ul {:id listbox-id
+            :role "listbox"}
+       (for [{v :value l :label} items]
          [:li
-          {:key value
-           :id (option-id value)
+          {:key v
+           :id (option-id v)
            :role "option"
-           :aria-selected (= value active)
-           :on-click [:combo/selected id on-commit value]}
-          label])]]]))
+           :aria-selected (= v value)
+           :on-click [:combo/selected id on-commit v]}
+          l])]]]))
 ```
 
 Escape is not listed in the key map because the native popover owns Escape and
 dispatches `:on-dismiss`. Focus stays on the trigger. There is no document
 listener or portal.
+
+Four details make the active-descendant model announceable, and each one is
+load-bearing:
+
+- `:role "combobox"` on the trigger. `:aria-activedescendant` is defined
+  against a fixed set of roles, and a plain button is not among them.
+- `:aria-controls` naming the listbox. That is the ownership edge the platform
+  resolves the pointer through; without it the id names an element the trigger
+  has no stated relationship to.
+- Both are emitted only while the list is open, because a closed overlay has no
+  DOM node. An unconditional `:aria-controls` would spend most of its life
+  pointing at nothing.
+- `:aria-selected` follows the committed `value`, while
+  `:aria-activedescendant` follows the transient `active`. Selection does not
+  follow focus here, so those are two different options for as long as the user
+  is arrowing around, and collapsing them announces a choice nobody has made.
+
+None of the four is visible on screen or reachable by a click-driven test. The
+witness that decides them —
+[`combobox_keyboard_dom_cljs_test.cljs`](../../../../implementation/hicasso/test/re_frame/hicasso/combobox_keyboard_dom_cljs_test.cljs)
+— audits this markup against the same view with the repair removed, so each
+claim is shown failing as well as passing.
 
 The same event-and-address model works for a toggletip, command menu, or other
 popover-shaped control.

--- a/docs/design/hicasso/draft-guide/15-testing.md
+++ b/docs/design/hicasso/draft-guide/15-testing.md
@@ -353,7 +353,7 @@ budgets belong to [Performance](19-performance.md).
 
 ## Migration shadow tests
 
-`ht/shadow!` is a development-only migration harness. It drives a Hicasso view
+`hm/shadow!` is a development-only migration harness. It drives a Hicasso view
 and its Reagent original with one script, then compares canonical DOM and
 intent streams at each checkpoint. Its full use belongs to
 [Migrating from Reagent](20-migration-from-reagent.md).

--- a/docs/design/hicasso/draft-guide/20-migration-from-reagent.md
+++ b/docs/design/hicasso/draft-guide/20-migration-from-reagent.md
@@ -8,8 +8,9 @@ it still uses re-frame v1 shapes, complete that migration first.
 
 Use three migration tools in this order:
 
-1. **Reporter** — classify every foreign React crossing and identify mechanical
-   rewrites, human decisions, and runtime blockers.
+1. **Reporter** — classify every foreign React crossing, and census every
+   Reagent API call site, as mechanical rewrites, human decisions, and runtime
+   blockers.
 2. **Shadow comparison** — run the Reagent original and Hicasso port side by
    side and compare canonical DOM and intent streams.
 3. **Codemod** — apply only source transformations whose behaviour is
@@ -62,6 +63,44 @@ example, declaring a render prop as `:event` can replace its return value with
 a dispatch path and blank the UI without a useful runtime error. Confirm every
 contract against the component library's documentation.
 
+### The report's second half: the census
+
+Everything above describes the **fixer**, and its population — the `[:>]`
+family — is not what a Reagent codebase is mostly made of. Run over this
+repository's own 81-file example corpus the fixer reports **zero entries**,
+because the corpus crosses into React nowhere. A migrator reading only that
+sees 81 files the report never mentions.
+
+So the same run also emits a **census**, under `:census`, whose population is
+the Reagent API **call site**: `r/atom`, `r/with-let`, `r/create-class`,
+`r/as-element`, `r/cursor`, `r/reactify-component`, root mounting, and the rest
+of the roster. On that same corpus it reports **62 sites across 28 files**.
+
+| Half | Population | Addressed at | Verdicts |
+| --- | --- | --- | --- |
+| fixer (`:entries`) | `[:>]`-family crossing sites | the site | rewrote, or refused in the classes above |
+| census (`:census`) | Reagent API call sites | the call | `:mechanical`, `:human-decision`, `:runtime-blocker` |
+
+The two halves measure different things and neither is a denominator for the
+other. Every census class is a shape §2's translation table already teaches:
+
+| Verdict | Named classes | Meaning |
+| --- | --- | --- |
+| Human decision | `:with-let`, `:outward-bridge`, `:adapt-react-class`, `:react-create-element`, `:props-helper`, `:reagent-partial`, `:render-control`, `:root-mount` | A Hicasso translation exists, but which one depends on intent the source does not carry |
+| Runtime blocker | `:local-reactive-cell`, `:derived-cell`, `:lifecycle-class`, `:as-element`, `:component-introspection` | Hicasso has no equivalent tier, so the site raises or silently misrenders until someone chooses the shape |
+| Mechanical | none | The bucket is always emitted, at `:mechanical 0`. Every mechanical rewrite this tool family knows is a W-rule and every W-rule sits at a crossing, so the zero is a measurement rather than an omission |
+
+Two further classes report a resolution failure rather than a translation, both
+as runtime blockers. A namespace that spells a Reagent name without being
+Reagent's — a vendored inlined copy, for instance — is
+`:unresolved-reagent-require` at the `ns` form, and every roster-named call in
+that file is `:unresolved-alias`. The tool does not guess that such a copy is
+`reagent.core`, because a wrong binding rewrites working code.
+
+What it cannot name it does not count, and says so. A Form-2 component is a
+`defn` returning a `fn` with nothing else marking it, so the census counts the
+`r/atom` that component closes over and reports nothing about the shape itself.
+
 ## 2. Port one screen by hand
 
 Migrate a complete screen rather than changing all component declarations,
@@ -97,17 +136,17 @@ Two common mistakes fail loudly:
 
 ## 3. Prove the port with shadow comparison
 
-`ht/shadow!` mounts the original and candidate against isolated copies of the
+`hm/shadow!` mounts the original and candidate against isolated copies of the
 same seeded frame. One interaction script drives both implementations. At
 each checkpoint it compares canonical DOM and the intent stream.
 
 ```clojure
 (ns app.migration.article-row-shadow
-  (:require [re-frame.hicasso.test :as ht]
+  (:require [re-frame.hicasso.test.mounted :as hm]
             [app.views.article-row-reagent :as old]
             [app.views.article-row :as new]))
 
-(ht/shadow!
+(hm/shadow!
  {:reference      [old/article-row {:article-id 7}]
   :candidate      [new/article-row {:article-id 7}]
   :initial-events [[:demo/install-fixture]]

--- a/docs/design/hicasso/draft-guide/22-accessibility.md
+++ b/docs/design/hicasso/draft-guide/22-accessibility.md
@@ -84,7 +84,9 @@ invalid state. Read the fact once and use it for both behaviour and ARIA:
 
 The same pattern appears elsewhere in the guide:
 
-- `:aria-expanded` and `:aria-activedescendant` on the dropdown;
+- `:aria-expanded`, `:aria-activedescendant`, and `:aria-selected` on the
+  dropdown — the last two read different facts, the keyboard's transient
+  position and the committed value;
 - `:aria-current "page"` on the active route link;
 - `:aria-busy` on a resource-backed suggestion list;
 - `:inert` and `:aria-hidden` on an exiting presence node.
@@ -126,7 +128,7 @@ Focus movement has specific owners:
 | --- | --- | --- |
 | Route change | Focus a keyed `main` region with `:tab-index -1` and `preventScroll` | [Routing and navigation](07-routing-and-navigation.md) |
 | Overlay open and close | Apply `:auto-focus`, use the platform trap, restore the opener | [Overlays and focus](13-overlays-and-focus.md) |
-| Menu or listbox navigation | Keep DOM focus on the trigger and move `:aria-activedescendant` | [Overlays and focus](13-overlays-and-focus.md) |
+| Menu or listbox navigation | Keep DOM focus on the trigger and move `:aria-activedescendant` from a `combobox` that `:aria-controls` the list, leaving `:aria-selected` on the committed value | [Overlays and focus](13-overlays-and-focus.md) |
 | Exit animation | Add `:inert` and `:aria-hidden` during unmounting | [Motion and presence](12-motion-and-presence.md) |
 | Virtualised collection | Decide how keyboard users reach items that do not exist in the DOM and verify it in a browser | [Lists and collections](06-lists-and-collections.md) |
 

--- a/docs/design/hicasso/draft-guide/REWRITE-NOTES.md
+++ b/docs/design/hicasso/draft-guide/REWRITE-NOTES.md
@@ -127,7 +127,7 @@ implementation confirmation:
 - `re-frame.hicasso.server` and the `server/render` option map
 - `ht/tree`, its `{:subs ...}` fixture shape, and tree helper names
 - mounted-facade helper names and exact handle shape
-- `ht/shadow!` and its config/result maps
+- `hm/shadow!` and its config/result maps
 - `defhost :slots`
 - `h/portal {:target ...}`
 - `h/as-component`


### PR DESCRIPTION
Three beads on `docs/design/hicasso/draft-guide/**`, all unfenced by rf2-hic-092's closure. Two landed as edits; one is a source-located refusal.

## rf2-56v4 — the select-only dropdown, trued up to the combobox witness

Merged-PR audit #7914 found the guide's dropdown is not an accessible combobox. The trigger carried `aria-activedescendant` for a sibling listbox with neither `role="combobox"` nor `aria-controls`, so the active-descendant model was invalid and the keyboard position was never announced; and `aria-selected` followed the transient `:active` although the committed value moves only on Enter or click.

rf2-hic-049 discharged the witness half. This is the doc half, taking the four changes from `select-dropdown`'s docstring in `implementation/hicasso/test/re_frame/hicasso/combobox_keyboard_dom_cljs_test.cljs`:

1. `role="combobox"` on the trigger;
2. `aria-controls` naming the listbox (which gains an `:id`);
3. both emitted only while open, because a closed overlay has no DOM node and an unconditional `aria-controls` would point at nothing;
4. `aria-selected` following the committed value, leaving `aria-activedescendant` to follow the keyboard.

The witness is linked, not restated. One change the bead did not name but the repair requires: the `for` binding becomes `{v :value l :label}`, because the old `{:keys [value label]}` shadowed the outer `value` prop — without that rename `aria-selected` cannot read the committed value at all.

ch22 moves with it: its "Menu or listbox navigation" row named only half the contract, and its ARIA-state bullet listed only two of the three attributes the example now derives.

## rf2-me76 — the reporter's census half, and the shadow door's real name

**Point 1.** §1 described only the fixer. Its table lists the `[:>]`-family crossing classes, but the same run also emits a `:census` section whose population is the Reagent API call site. On this repository's own example corpus the fixer reports **0 entries over 81 files** while the census reports **62 sites across 28 files** — a migrator reading only the first sees 81 files the report never mentions. New subsection carries both halves, the thirteen census classes grouped by their shipped verdicts, the two resolution-failure classes (`:unresolved-reagent-require`, `:unresolved-alias`, both runtime blockers), and the stated silence about Form-2 shapes.

Every class, verdict and number verified at source in `migration/reagent-to-hicasso/codemod/src/re_frame/migration/hicasso/census.clj` (the roster at :98-130 and the two unresolved entries at :283/:306) and that tree's README, not restated from the bead.

**Point 2.** `ht/shadow!` does not exist and never has. The door ships as `hm/shadow!` in `re-frame.hicasso.test.mounted` (`test/mounted.cljs:1874`); `re-frame.hicasso.test` itself points at it by full name at :514. Corrected at all three carriers: ch20's prose and its worked example (whose `:require` moves with it), ch15's one-line pointer, and REWRITE-NOTES' governance list. ch15 already aliased that namespace `hm` at :14 and spells every other door `hm/`, so :356 was its one outlier.

The REWRITE-NOTES hit is a record of an open name, so only its **prefix** moves. Naming-ledger row 24 settles `re-frame.hicasso.test.mounted` as the door's home, and row 25 already performed the identical propagation on itself, in terms — "row 24's settled HOME propagating into a row that quotes it, not a spelling this row settles." What row 25 leaves open, the config and result maps, stays recorded unchanged as that entry's subject.

Everything else on both pages shipped as written: option keys, step spellings, the return map, scriptless mode, the per-side frame copy, the sabotage-control paragraph.

## rf2-4u7x — REFUSED, no files changed

Census re-run at today's main matches the bead's own last count exactly: 12 hits / 4 files (`00-installation.md` 6, `18-ssr-and-hydration.md` 3, `glossary.md` 2, `REWRITE-NOTES.md` 1). Applying the #8023 discriminator with the charter in view, all four come out the same way.

1. **The charter is in the corpus and is reader-facing.** `draft-guide/README.md` ends with a Status block: "This guide describes the intended completed Hicasso programme. Public names may still change during the remaining naming review. Treat the spellings here as the current recommended defaults until that review freezes them." All 12 sit under it.
2. **`REWRITE-NOTES.md:124` is a record, confirmed by its section heading** — "Current guide spellings that still need naming governance", entry "root lifecycle configuration around `h/mount!`, `h/hydrate!`, `h/render!`, and `h/unmount!`". That is the discriminator's protected case, and it is this tree's counterpart to the ledger-13 disposition row PR #8035 added to `invariants.md` §5. It already exists here.
3. **The verb is not separable from the shape.** Shipped `root!` is `(container frame-kw hiccup)` plus an optional `opts` carrying one key, `:identifier-prefix` (`impl/mount.cljs:196`, re-exported `hicasso.cljc:629`). All 12 carriers teach `(h/mount! node {:frame … :initial-events …} view)`, the config-map shape naming-ledger row 20 keeps "as taught" and **open**. A verb-only sweep would name a real door and hand it arguments it refuses — a call that still does not run, now wrong in a second way and contradicting an open ledger row.
4. **Consistent-standard test**, the one that refused `lanes/ergonomics-api.md:16`. Measured on today's guide: `h/fn` at 51 sites across 13 files while the macro ships as `hfn` (`hicasso.cljc:238`, docstring: "spelled `hfn` here because `h/fn` is qualified in the product"), ledger row 1 open; `h/hydrate!` at 9 sites, shipping only as `impl.mount/hydrate-root!` and deliberately not re-exported (`hicasso.cljc:588-628`, rf2-k1mp); `h/mount!` at 12. Sweeping the smallest member of the three-name family the mayor's own correction records as diverging **by design** would apply one standard to one third of it.

**Surfaced for the naming sitting** (rf2-84w6 is closed and routed to the ledger, so this is recorded on the bead rather than dispatched): `00-installation.md:82` is the sharpest case and deserves the sitting's attention *as a case, not as a sweep*. It is a `defonce` a reader types on day one, inside a boot block whose other three lines — `h/render!`, `h/unmount!`, the returned handle — do run today. Settling it needs rows 13 **and** 20 together, verb and argument shape, which is exactly why no sweep can reach it.

## What was re-located, and where it moved

The brief warned that the 2026-08-11 rewrite had moved chapters. It had moved fewer than expected, and one warning did not hold:

| Carrier | Bead said | Found at today's tip |
| --- | --- | --- |
| migration chapter | renumbered 20 → 19 | **still `20-migration-from-reagent.md`** — the renumber died with the superseded branch |
| the dropdown | `13-overlays-and-focus.md:234` | `13-overlays-and-focus.md`, code block under *Build a dropdown from a popover*, trigger props from :230 |
| ch22 dependent row | "Menu or listbox navigation" row | `22-accessibility.md:129`, plus its ARIA-state bullet at :87 which the bead did not name |
| `ht/shadow!` | 20:100, 20:110, 15:356, REWRITE-NOTES:130 | all four confirmed at those exact lines |
| `h/mount!` | 12 hits / 4 files | all 12 confirmed |

**Premise that did not hold:** the brief's "rf2-me76's own note records the migration chapter renumbering from 20 to 19" is a stale mayor comment (2026-08-12 21:01), superseded by that bead's own 2026-08-13 comment which states the renumber died and the file keeps its number. Verified directly against the tip rather than either comment.

**One stale claim found in passing, outside this PR's fence and not touched:** naming-ledger row 1 asserts "The 22-chapter guide is now committed to `h/event` corpus-wide — grep-verified zero `h/handler`, `h/fn`, `hfn`". At today's main the landed guide teaches `h/fn` at 51 sites, and `h/event` appears exactly once — at `REWRITE-NOTES.md:187`, listed as a spelling the rewrite *removed*. Row 1's parenthetical describes the superseded branch, not the corpus that landed. Recorded on rf2-4u7x for a mayor eye.

## Quality gates

`mkdocs build --strict` is **not** the gate for this tree, and it was verified rather than assumed: `mkdocs.yml`'s `exclude_docs` block names five entries, `design/hicasso/` among them. The test is `exclude_docs`, not the site nav.

| Gate | Result |
| --- | --- |
| `scripts/check_doc_slugs.py` | **exit 0** |
| `scripts/check_provenance_pins.py --changed-since origin/main --verbose` | **exit 0** — "5 files, 0 cited pins" |
| `implementation/hicasso/scripts/check_complaint_catalogue.py` | **exit 0** — "74 live, 6 reserved, 1 pending retirement, 1 retired; every anchor resolves" |
| `scripts/test-fast-pr.sh` | **exit 0** — classified `docs=true jvm=false node=false` |

Every exit code above was captured from the runner itself, redirected to a log with the code echoed on the same line in the same shell — never piped through a filter, and never read off a harness report.

**Which tree the gates read.** `test-fast-pr.sh` prints `gate root: /c/Users/miket/code/re-frame2-worktrees/guidefix-cluster` as its first line, and `check_provenance_pins.py` reports exactly the 5 files this branch changed. `check_doc_slugs.py` passes silently, so it was discriminated by a **planted fault**: a bogus anchor `22-accessibility.md#planted-guidefix-cluster-sabotage` was added inside the chapter 13 paragraph this PR writes; the gate went red with `BROKEN ANCHOR: docs\design\hicasso\draft-guide\13-overlays-and-focus.md:284 -> 22-accessibility.md#planted-guidefix-cluster-sabotage`, naming the plant in this worktree's file. The plant was then removed and the restore verified by hashing the bytes — `git hash-object` returned `528943e0583ce8a86895e61f59c0fb7b2c4bdbdf` before the plant and the same after, not by reading a diff.

**Code fences.** `samples_coverage_jvm_test.clj` lives under `implementation/freehand/` and digest-pins `docs/core/freehand/`, not this tree — verified by locating the file and its corpus. No digest-pinned block was touched, so the two-file change that trap implies does not arise here.

**Verified by hand, because nothing validates them.** Table column counts on every table this PR touched: the new fixer/census table is 4 columns across header, separator and both body rows; the new verdict table is 3 across header, separator and all three body rows; chapter 22's focus-ownership table stays 3 across all seven of its lines. Anchors and rendering were read by eye — the new cross-tree link `../../../../implementation/hicasso/test/re_frame/hicasso/combobox_keyboard_dom_cljs_test.cljs` follows the established four-dot idiom already used from `product/budgets.md:135` and the `studio/` pages, and sits in prose rather than inside a fence, which `FENCED_DOC_LINK_TREES` covers for this tree.

**Merge-base diff read for reverts.** `git diff origin/main...HEAD` (three-dot) is 5 files, +83/−16, and every deleted line is one this PR intentionally replaces. Nothing outside `docs/design/hicasso/draft-guide/**` is touched: `TESTING.md`, `.github/workflows/*`, `implementation/routing/**`, `docs/design/hicasso/decisions.md` and `docs/design/hicasso/product/budgets.md` are all untouched, as fenced.

No `implementation/node_modules` junction was created in this worktree, so none needed removing.
