### PR TITLE
docs(hicasso): bracket HD-019's superseded rf2-digtt sentences; rule budgets.md Authority column two-mode (rf2-glut, rf2-iay8)

### DIFF
--- a/docs/design/hicasso/decisions.md
+++ b/docs/design/hicasso/decisions.md
@@ -1165,7 +1165,10 @@ baseline, but "composition survives value reassertion" is false for every
 implementation the moment the model disagrees. Whether to suspend convergence
 until `compositionend` is a behavioural choice inside this exception's scope and
 is unruled (`rf2-digtt`); until it is settled, K4's IME half is open rather than
-green. On a PATCH back end the restore obligation transfers to the renderer
+green.
+**[Settled 2026-08-03, carve-out IN (`rf2-digtt`) — see this entry's addendum
+above; the open status this sentence records ended that day.]**
+On a PATCH back end the restore obligation transfers to the renderer
 (architecture.md, hard gate).
 **Rationale.** The harness's trap table is explicit: any design where the input
 value round-trips through an external store must *name* its synchronous door.
@@ -1191,6 +1194,7 @@ goes red — React mirroring controlled text into `defaultValue` is what makes
 the node-held record valid, and it is not a public React guarantee — or if any
 candidate second call site appears. The composition value path reopens on
 `rf2-digtt`'s ruling, whichever way it goes.
+**[This trigger fired 2026-08-03; the addendum above is its record.]**
 
 > **Addendum, 2026-08-07 — the reset law is applied at the element as
 > `::h/revision` (`rf2-zq8kh`).** The trigger sentence above — *resets are by

--- a/docs/design/hicasso/product/budgets.md
+++ b/docs/design/hicasso/product/budgets.md
@@ -819,6 +819,27 @@ that exists and runs in the first lane; a distributional row may never name the
 first lane at all. *Authority* is the bead that owns the row's disposition
 today. *Disposition* is a link that must resolve to a section naming the row.
 
+**[Amended 2026-08-13.]** *Authority* is read in **two modes**, and which one
+applies follows the state of the **disposition**, not the state of the bead.
+While a live transition remains to be made — the `UNPINNED` rows waiting on
+`rf2-hic-071`'s instruments; `S6` and `C2`, whose K1 price record is amendable
+only through `rf2-hic-085`; `S3` and `C6`, handed onward because real work
+remained — the cell names the **live** bead that can actually move the row, and
+a closed id there is a defect. Once the row's *Disposition* cell records a
+**taken, complete** ruling carrying its own reopen conditions and revert
+trigger, the cell names the bead that **took** it, and a closed id is then
+correct: the decision outlives the decider. That is why `S1`, `S2` and `C5`
+keep `rf2-0xx2` after its close ([§9.2](#92-what-each-not-green-row-is-waiting-on)),
+and it is not a loosening — the discriminator is never bead liveness, it is
+whether a live transition remains. The column has never been a uniformly
+live-owner field in practice: many `MET` rows in the table below name closed
+beads, and this amendment describes what the ledger already does rather than
+permitting something new. Should a taken disposition ever need amending with no
+route to it, the fix is to give **that record** a named standing amendment-route
+bead on the K1 pattern — `rf2-hic-085` is the worked example — never to read a
+settled row back into live-route mode. The gate is indifferent to all of this:
+it reads the cell for **shape, not for life**, and says so in its own output.
+
 <!-- rf2-hic-089: ledger -->
 
 | # | Registered line | Current value | Population | Status | Instrument (lane) | Authority | Disposition |
@@ -896,6 +917,25 @@ that one: the scoped acceptance ruled on `rf2-0xx2` and recorded in
 It moves neither reading and neither status — both rows stay `BREACH` against
 the unmoved `1,024 B` line, and the acceptance reaches no further than the
 pinned bands' upper edges, `1,107 B` and `1,101 B`.
+
+**[Amended 2026-08-13.]** `S1`, `S2` and `C5` keep `rf2-0xx2` as their
+authority although that bead has closed, and keeping it is a decision rather
+than an omission — these are the settled-mode rows of
+[§9.1](#91-how-to-read-a-row), not live-route ones. What the three were waiting
+on was a disposition, and the disposition has been **taken**: the scoped
+acceptance ruled on `rf2-0xx2` and recorded in
+[§5](budgets.md#5-the-read-free-boundary-shell-the-byte-exact-line-now-frozen-at-1024-b)
+on the five fields `specification.md` §6 requires, reopen conditions and revert
+trigger among them. A ruling that carries its own amendment machinery needs no
+live bead to hold it, and the cell naming who took it is the audit trail —
+`rf2-0xx2`'s close reason is where the scoping is recorded. The remaining path
+is not owed an owner either: a shell arm landing under `1,024 B` on the
+package, on which day the acceptance is **deleted rather than kept as a floor**,
+[stays live and deliberately unowned](correction-ledger.md#deferred-items-and-the-release-decision)
+by the programme's own choice, so there is no live bead to name and naming one
+would fabricate ownership the programme withheld. Contrast `S6` and `C2` below,
+where a route to change the record does exist and the cell names it: same rule,
+other mode.
 
 - **No package-resident clock instrument exists.** `U1`, `U2`, `U3` and `U4`
   are latency budgets, and §4 says in terms that they cannot be pinned until

--- a/implementation/hicasso/scripts/check_budget_ledger.py
+++ b/implementation/hicasso/scripts/check_budget_ledger.py
@@ -36,8 +36,8 @@ THE TWO THINGS IT EXISTS TO PREVENT, stated plainly:
   has ruled against; a gate that greened it would be the normalisation
   budgets.md §5 forbids. So a `BREACH` row does not redden this gate —
   an UNRECORDED breach does. L3 is the whole of that: every not-green
-  row names an owner and a disposition record, and that record has to
-  exist and name the row.
+  row names a bead reference and a disposition record, and that record
+  has to exist and name the row.
 
 THE RULES
 ---------
@@ -434,7 +434,7 @@ def check(rows, registered, sections, existing_files):
         if not _AUTHORITY_RE.match(row["authority"]):
             failures.append(
                 "L3 %s names authority %r, which is not a bead id. Every row "
-                "has an owner" % (rid, row["authority"]))
+                "names a bead reference" % (rid, row["authority"]))
         if row["status"] != PASSING_STATUS:
             link = _LINK_RE.search(row["disposition"])
             if not link:
@@ -772,8 +772,9 @@ def main(argv=None):
     print("An Authority cell is read for SHAPE, not for life. This gate reads "
           "two markdown files and has no tracker access, so it cannot see "
           "that a named bead has closed:")
-    print("a row can name an owner and have none. Whether the named beads are "
-          "open is a question for a reader, and it is not certified here.")
+    print("a row can name a bead reference and have no live owner. Whether "
+          "the named beads are open is a question for a reader, and it is not "
+          "certified here.")
     print("This is a verdict about the RECORD. It is not a statement that any "
           "budget is met -- %d rows are not MET."
           % (len(rows) - counts["MET"]))


### PR DESCRIPTION
Two hicasso governance records, both ruled by the operator on 2026-08-13, on different files. One commit each.

## rf2-glut — HD-019's two superseded `rf2-digtt` sentences (Option B)

**Directed:** add two short dated in-place brackets at the superseded sentences in `docs/design/hicasso/decisions.md`, each pointing up to HD-019's existing 2026-08-03 addendum. Option A (close with no edit) rejected — leaves the grep-trap armed. Option C (execute as filed) rejected — its investigation half duplicates the addendum. Items 1 and 4 of the description verified MOOT.

**Done:** exactly that, and no re-investigation. `rf2-digtt` was genuinely ruled — carve-out IN, 2026-08-03, shipped in PR #7441 — and the outcome is already the ~70-line dated addendum at HD-019's head (commit `0342d3787d`), 115 lines above the stale sites, which is precisely why a reader arriving by grep or line citation never met it.

Both original sentences are preserved **byte-for-byte**; the brackets sit beside them and adjudicate nothing themselves:

- at the `…is unruled (rf2-digtt); until it is settled, K4's IME half is open rather than green` sentence — *[Settled 2026-08-03, carve-out IN (`rf2-digtt`) — see this entry's addendum above; the open status this sentence records ended that day.]*
- at the Reopens clause `The composition value path reopens on rf2-digtt's ruling, whichever way it goes` — *[This trigger fired 2026-08-03; the addendum above is its record.]*

Per the tree's un-struck convention (`native-ime-scripted-witness.md:240-244` and `:390` — superseded text quoted in place and bracketed, never rewritten), rendered in this tree's `**[Amended YYYY-MM-DD.]**` beside-amendment house style.

The brackets deliberately **do not** cite `rf2-hic-016`. Two different rulings: `rf2-digtt` (2026-08-03) settled the composition **value path**; the native-IME **per-engine cells** went green by the separate `rf2-hic-016` operator ruling of 2026-08-13. Conflating them was called out in the brief and is avoided.

Fence honoured: `decisions.md` only. K4/K6 criterion text in `validation.md` untouched; the native-IME per-engine table in `product/dispositions.md` untouched.

## rf2-iay8 — the budgets ledger Authority column, ruled two-mode (Option 2)

**Directed:** wording diff only. (1) a dated beside-amendment at the Authority definition stating the two-mode rule; (2) a short §9.2 paragraph for `S1`/`S2`/`C5` mirroring the existing `S6`/`C2` one; (3) optional, same PR: explanatory `owner` → `bead reference` in `check_budget_ledger.py`, no logic. `S1`/`S2`/`C5` **keep `rf2-0xx2`** — those cells were already correct.

**Done:** all three. **No Authority cell was repointed**, and no figure, band, threshold, ceiling, line cell or status moved — `S1`, `S2` and `C5` stay `BREACH`.

The rule as recorded: Authority is read in two modes, and which applies follows the state of the **disposition**, not the state of the bead. While a live transition remains, the cell names the live bead that can move the row and a closed id there is a defect. Once the Disposition cell records a taken, complete ruling carrying its own reopen conditions and revert trigger, the cell names the bead that **took** it, and a closed id is then correct — the decision outlives the decider. The discriminator is never bead liveness.

This describes what the ledger already does rather than permitting something new: many `MET` rows name closed beads today. The recurrence engine dissolves by definition — a disposition closure stops being a defect.

The §9.2 paragraph records why `S1`/`S2`/`C5` are settled-mode: `rf2-0xx2` took the scoped acceptance on the five fields `specification.md` §6 requires, and the remaining path — a shell arm landing under `1,024 B` — [stays live and deliberately unowned](docs/design/hicasso/product/correction-ledger.md) by the programme's own choice, so no live Authority is owed and naming one would fabricate ownership the programme withheld. `S6`/`C2` keep `rf2-hic-085` as the live-mode half of the same rule, explicitly untouched.

`check_budget_ledger.py`: three explanatory wording changes only (module docstring, the L3 failure message, the closing caveat line). **No** logic, regex (`_AUTHORITY_RE`), or tally change; no tracker access, liveness gate, cell annotation or second column added.

## Quality gates

Every number below is the exit code captured on the runner's own command line, redirected to a per-worktree, per-attempt log — never a filtered pipeline and never a harness-reported status.

| Gate | Exit | Result |
|---|---|---|
| `implementation/hicasso/scripts/check_budget_ledger.py` | **0** | `OK: 39 ledger rows -- 21 MET, 5 BREACH, 3 UNRESOLVED, 10 UNPINNED.` |
| `implementation/hicasso/scripts/check_budget_ledger.py --self-test` | **0** | `OK: check_budget_ledger self-test passed (39 rows: 21 MET, 5 BREACH, 3 UNRESOLVED, 10 UNPINNED)` |
| `scripts/check_doc_slugs.py` | **0** | silent pass |
| `scripts/check_provenance_pins.py --changed-since origin/main --verbose` | **0** | `2 files, 6 cited pins (6 landed, 0 stranded, 0 unresolvable, 0 foreign)` |
| `scripts/test-fast-pr.sh` | **0** | `PASS fast PR spine` |

**The harness and the captured exit code disagreed on this run, and the captured one governs.** On the attempt that failed, the harness reported the background command as *"completed (exit code 0)"* while the `.exit` file written by the runner itself read **1**. The `.exit` file is what is quoted here — every gate above was redirected to a per-worktree, per-attempt log with the runner's own `$?` echoed on the same command line, never piped through a filter (a pipeline's status is its last command's, so a red runner reads green).

Log integrity was checked before any verdict was believed: the passing spine log has **0 NUL bytes, exactly one `PASS fast PR spine`, and zero `FAIL`** lines — no orphaned shell from an earlier attempt spliced into it.

**The ledger tally is unchanged by this PR.** It was captured *before* any edit and again after, and both reads are identical: 39 rows / 21 MET / 5 BREACH / 3 UNRESOLVED / 10 UNPINNED, 18 rows not MET.

**`mkdocs build --strict` is not nominated, because it would verify nothing here.** `mkdocs.yml`'s `exclude_docs` block names five entries — `tools/playground/`, `migration/from-re-frame-v1/codemod/`, `migration/reagent-to-hicasso/codemod/`, `design/freehand/`, `design/hicasso/` — and both files edited by this PR are under the last. The test is `exclude_docs`, not the site nav. (`test-fast-pr.sh` runs mkdocs in its docs tier regardless; that run is not evidence about these two files.)

### Each gate was proved to have read *this* worktree

Both silent-or-rootless gates were discriminated on the **final tree** by planting a fault, running red, and confirming the failure names what was planted — the red itself is the discrimination, and a green sabotage run would have been a reason to stop.

- **Ledger gate** — planted `PLANTED FAULT govdocs-cluster attempt4` into `S1`'s Authority cell (line 863), anchored to that single line. Ran **exit 1**: `L3 S1 names authority 'PLANTED FAULT govdocs-cluster attempt4', which is not a bead id. Every row names a bead reference`. That red doubles as proof the reworded L3 message is the live one.
- **Slug gate** — `check_doc_slugs.py` passes silently, so the red *is* the only available proof. Planted a broken anchor at line 832 (the link in the new §9.1 amendment). Ran **exit 1**: `BROKEN ANCHOR: docs\design\hicasso\product\budgets.md:832 -> #planted-fault-govdocs-cluster-attempt4` — naming this worktree's path.

Restores verified by hash, both equal to the committed blob: `budgets.md` → `87884573625dc6069f46f4ad931dfd206b572776`, `decisions.md` → `adc3cf459e72b9d23e6faaa2bdf5746569f2a32d`.

Both restores were verified **by hashing the bytes**, not by reading a diff — "unchanged" and "not attempted" produce the same diff — using `git hash-object` against the committed blob.

`check_provenance_pins.py` prints its own scope and named **2 files** — exactly this branch's two changed docs — so it needed no planted fault.

### Hand-verification of tables and anchors — nothing validates this tree's tables

**No table row was touched by either bead.** This is verified against `origin/main` rather than asserted:

- `budgets.md` — all **146** table lines byte-identical to `origin/main`.
- `decisions.md` — all **17** table lines byte-identical to `origin/main`; all **30** headings identical, so no anchor moved.

Column counts, counted by hand across the §9 ledger and the whole file:

- The §9 ledger block (between the `rf2-hic-089: ledger` / `end-ledger` markers) is **41 lines = 1 header + 1 separator + 39 data rows**, and **every one of the 41 is exactly 8 columns** (`# | Registered line | Current value | Population | Status | Instrument (lane) | Authority | Disposition`).
- Every other table in `budgets.md` is internally consistent: 39 lines at 5 columns, 31 at 3, 22 at 2, 13 at 4.

Anchors added by this PR were checked to resolve: `#92-what-each-not-green-row-is-waiting-on`, `#91-how-to-read-a-row`, `#5-the-read-free-boundary-shell-the-byte-exact-line-now-frozen-at-1024-b`, and `correction-ledger.md#deferred-items-and-the-release-decision` (heading present at `correction-ledger.md:91`, and already used from `validation.md:805`). The slug gate confirms all of them.

### Read for what it would REVERT

`budgets.md` is a shared ledger with several changes landed in it today, so the three-dot diff was read for deletions, not just additions: `git diff origin/main...HEAD` shows `budgets.md` **+40 / −0** — purely additive, reverting nothing. `check_budget_ledger.py` is +6/−5, all five deletions being the three intended wording lines. `decisions.md` is +5/−1, the single deletion being a soft-wrap split of `green. On a PATCH back end…` into two lines; no prose was removed.

## Premises that did not hold

1. **`rf2-iay8`'s stated tally is stale.** Acceptance criterion (4) fixes it at *"38 rows: 21 MET / 5 BREACH / 2 UNRESOLVED / 10 UNPINNED"*. On `main` today it is **39 rows / 21 / 5 / 3 / 10** — row `S8` (C8's first disjunct, `UNRESOLVED`, authority `rf2-5yn9`) landed after the bead was written. Criterion (3)'s *"all 17 non-MET rows = 3 completed dispositions + 14 live routes"* is correspondingly **18 = 3 completed (`S1`, `S2`, `C5`) + 15 live routes**. I held the invariant that actually matters — the tally is *unchanged by this edit*, identical before and after, exit 0 — rather than forcing the ledger to the bead's stale number, which would have meant moving a row.
2. **Line numbers had drifted in `rf2-iay8`.** The Authority definition is cited at `budgets.md:760` in the Design field and `:695` in the description; it is at **`:819`** on `main`. The `S6`/`C2` §9.2 paragraph cited at `:863-876` is at **`:923-936`**. `correction-ledger.md:102` was accurate. `rf2-glut`'s cited sites (`~1165-1168`, `~1192-1193`) were accurate.
3. **A fresh worker worktree cannot run the spine's node tier.** The first completed spine run failed with a captured **exit 1** at `FAIL CLJS node integration` — `compile-node-test: could not resolve shadow-cljs: Cannot find module 'shadow-cljs/cli/runner.js'`. Nothing in this PR can reach shadow-cljs resolution (two markdown docs and three prose strings in a Python file). The cause is that a new worktree has no `implementation/node_modules`; this project junctions it at the mayor checkout's real one. Creating the junction turned the same spine green with no source change. The junction was then removed with `cmd /c rmdir` — the **link**, never its target — and the mayor's tree re-checked: `implementation/node_modules 103/2933/2`, matching the documented canary exactly, with `shadow-cljs` intact.
4. Nothing else. Both rulings' factual premises checked out at source, including `rf2-glut`'s moot-items finding, which I did not re-litigate.

## Not done, deliberately

Per the fences: no dossier files under `ai/decisions/` (both were deleted after recording, by protocol); no class remedy from `rf2-6ng7`; `rf2-hic-085`'s standing-custody arrangement untouched; no `docs/design/hicasso/draft-guide/**`, `TESTING.md`, `.github/workflows/*`, `implementation/routing/**`, or `implementation/ui/**`.
