### PR TITLE
fix(adapter): resolve the ambient frame under react-dom/server (rf2-5rqn)

### DIFF
--- a/implementation/adapters/uix/test/re_frame/adapter/uix_use_subscribe_dom_cljs_test.cljs
+++ b/implementation/adapters/uix/test/re_frame/adapter/uix_use_subscribe_dom_cljs_test.cljs
@@ -78,13 +78,20 @@
     ($ :div (str "k=" v))))
 
 ;; ---- rf2-5rqn: which context slot does the SERVER renderer populate? -------
-;; Reads all three observation points off the SHARED frame-context during a
-;; render, so the suite can pin the MECHANISM of the SSR refusal rather than
-;; only its symptom: the private `_currentValue` slot (what the
-;; `:adapter/current-frame` reader consults), the private `_currentValue2`
-;; slot (React's secondary-renderer slot), and the PUBLIC `useContext` return
-;; (renderer-agnostic). Deliberately calls no re-frame hook — it must render
-;; under `react-dom/server` without tripping the very refusal being measured.
+;; Reads five observation points off the SHARED frame-context during a render,
+;; so the suite can pin the MECHANISM of the SSR behaviour rather than only its
+;; symptom: the private `_currentValue` slot (the PRIMARY, client-renderer
+;; slot), the private `_currentValue2` slot (React's SECONDARY slot, which
+;; `react-dom/server` writes), the PUBLIC `useContext` return
+;; (renderer-agnostic), the SHARED READER
+;; `function-component-current-frame` — the `:adapter/current-frame` hook every
+;; ambient consumer funnels through, so an assertion on it proves the repair is
+;; central rather than hook-local — and `frame/resolve-current-frame`, which
+;; layers the ambient-REFUSAL tier in front of that reader.
+;;
+;; Deliberately calls no re-frame HOOK: it must render under
+;; `react-dom/server` whatever the reader answers, so it can measure a refusal
+;; as readily as a resolution.
 
 (def ^:private ssr-slot-observed (atom nil))
 
@@ -93,7 +100,9 @@
     (reset! ssr-slot-observed
             {:current-value  (.-_currentValue ^js ctx)
              :current-value2 (.-_currentValue2 ^js ctx)
-             :use-context    (React/useContext ctx)})
+             :use-context    (React/useContext ctx)
+             :reader         (adapter-context/function-component-current-frame)
+             :resolve        (frame/resolve-current-frame)})
     ($ :div "slots")))
 
 ;; ---- use-frame probe (rf2-y6dz8t) ------------------------------------------
@@ -342,6 +351,9 @@
    ;; frame: the row is a COLD server render and must not read a sub-cache
    ;; some earlier browser-lane row warmed.
    :ssr-ambient-frame             :rf.uix-5rqn/ssr-ambient-frame
+   ;; The tier-1 contender for the dynamic-precedence control: a SECOND frame,
+   ;; so "the dynamic var won" is distinguishable from "the provider won".
+   :ssr-dynamic-frame             :rf.uix-5rqn/ssr-dynamic-frame
    :probe-ssr-slots-element       (fn [] (uix/$ ProbeSsrSlots))
    :ssr-slot-observed             ssr-slot-observed
    ;; rf2-y6dz8t — use-frame (capture-frame in hook position)

--- a/implementation/core/src/re_frame/adapter/context.cljs
+++ b/implementation/core/src/re_frame/adapter/context.cljs
@@ -249,11 +249,43 @@
 ;;
 ;; UIx renders function components — they have no class-
 ;; component-specific `(.-context cmp)` slot. The substrate-portable
-;; way to observe the active Provider's value is to read
-;; `_currentValue` directly off the shared context object. React
-;; mutates this field as Provider boundaries are entered and exited
-;; during render, so reads from inside a render see the closest
-;; enclosing Provider's value.
+;; way to observe the active Provider's value is to read the context
+;; object's value slot directly. React mutates that field as Provider
+;; boundaries are entered and exited during render, so reads from
+;; inside a render see the closest enclosing Provider's value.
+;;
+;; WHICH SLOT, THOUGH (rf2-5rqn). `createContext` initialises TWO value
+;; slots to the default — `_currentValue` and `_currentValue2` — and a
+;; renderer claims one of them (React 19.2:
+;; packages/react/src/ReactContext.js). The DOM client renderer pushes
+;; and pops `_currentValue`; the Fizz server renderer
+;; (`react-dom/server`) pushes and pops `_currentValue2`
+;; (packages/react-server/src/ReactFizzNewContext.js). A reader that
+;; consults only the primary therefore observes the no-provider sentinel
+;; through an entire server render, and every ambient consumer funnelling
+;; through it refuses with `:rf.error/no-frame-context` beneath a
+;; provider that DID establish a scope. So the reader below falls back to
+;; the secondary slot — and only when the primary is EXACTLY the untouched
+;; sentinel, so a corrupted primary is never masked. Under the client
+;; renderer the secondary is never written and still holds the sentinel,
+;; which classifies to nil, so the fallback changes nothing there.
+;; This is pinned evidence for the React version this repo pins, not a
+;; claim about future React: if an upgrade removes or repurposes the
+;; private slots, thread the public `useContext` return through the hook
+;; surfaces instead (the documented escape hatch, rf2-5rqn's ruling).
+;;
+;; WHERE THE FALLBACK STOPS (measured, rf2-5rqn). Fizz pops the secondary
+;; slot when a render EXITS normally, and does not when a render THROWS —
+;; but the next render pops the abandoned snapshot before running any
+;; component, so no render ever observes another render's frame. The
+;; window is therefore between an aborted render and the next one, and
+;; only a read taken OUTSIDE any render falls in it. That is not what the
+;; ambient tier promises on either renderer: ambient resolution is a
+;; render-time notion, and code running outside a render carries a frame
+;; explicitly or binds one with `with-frame` — tier 1, which outranks both
+;; slots. A stale-slot guard here was ruled out by name as
+;; over-engineering. The behaviour is pinned by part 5 of
+;; `assert-use-subscribe-ambient-under-ssr`.
 ;;
 ;; Per Spec 006 §Frame-provider via React context, this fn is the
 ;; canonical impl that the UIx adapter publishes through the
@@ -315,10 +347,11 @@
     2. The closest enclosing frame boundary via React context — either a
        `frame-provider` (SCOPE) or a `frame-root` (ENSURE); both install
        the same shared context, so a read resolves identically beneath
-       either. Reads `_currentValue` off the shared context object
+       either. Reads the ACTIVE value slot off the shared context object
        directly (the substrate-portable path; UIx's `use-context` is
-       sugar over this read) and classifies
-       it through the shared [[context-value->current-frame]] rules.
+       sugar over this read — which slot is active depends on the renderer,
+       see the NOTE below) and classifies the value it selected, ONCE,
+       through the shared [[context-value->current-frame]] rules.
 
   Returns nil when neither tier names a frame — a component rendered
   beneath neither frame boundary observes the no-provider sentinel, which
@@ -327,13 +360,20 @@
   `frame/require-current-frame!`; low-level readers / tooling model 'no
   context' with the nil directly.
 
-  NOTE (rf2-2rzx0): the direct `_currentValue` slot read is CLIENT-renderer
-  only — React 19.2's `react-dom/server` populates the secondary slot
-  `_currentValue2`, not `_currentValue`. Callers that CAN observe the
-  renderer-agnostic value (a component reading `useContext` inside render,
-  e.g. the compiled ViewCell) pass that value to
-  [[context-value->current-frame]] directly rather than routing through this
-  slot-reading reader."
+  NOTE (rf2-2rzx0, repaired rf2-5rqn): React carries TWO value slots per
+  context — `_currentValue` (primary; the client renderer) and
+  `_currentValue2` (secondary; React 19.2's `react-dom/server` writes and
+  reads THIS one). So tier 2 reads the primary slot and falls back to the
+  secondary ONLY when the primary holds the untouched no-provider sentinel.
+  Under the client renderer the secondary slot is never written, so it still
+  holds `createContext`'s default — the same sentinel — and the fallback is
+  inert. Callers that can observe the renderer-agnostic value (a component
+  reading `useContext` inside render, e.g. the compiled ViewCell) may pass
+  that value to [[context-value->current-frame]] directly instead."
   []
   (or frame/*current-frame*
-      (context-value->current-frame (.-_currentValue ^js frame-context))))
+      (let [primary (.-_currentValue ^js frame-context)]
+        (context-value->current-frame
+          (if (= primary no-provider-sentinel)
+            (.-_currentValue2 ^js frame-context)
+            primary)))))

--- a/implementation/core/src/re_frame/substrate/spine.cljs
+++ b/implementation/core/src/re_frame/substrate/spine.cljs
@@ -3083,7 +3083,9 @@
           ;; `frame/require-current-frame!`, which delegates to
           ;; `resolve-current-frame` → the live `:adapter/current-frame`
           ;; late-bind hook (`function-component-current-frame`: dynamic-var →
-          ;; `_currentValue` with sentinel→nil and corrupted-value detection)
+          ;; the renderer's active context slot — `_currentValue`, falling back
+          ;; to `_currentValue2` under `react-dom/server` (rf2-5rqn) — with
+          ;; sentinel→nil and corrupted-value detection)
           ;; and emits + throws `:rf.error/no-frame-context` on nil. This
           ;; single-sources resolution with `subs/subscribe`'s 1-arity — the
           ;; hook and the imperative read can never diverge — and then hands

--- a/implementation/core/test/re_frame/adapter/react_shared_suite.cljs
+++ b/implementation/core/test/re_frame/adapter/react_shared_suite.cljs
@@ -3608,54 +3608,79 @@
 ;; only node-lane SSR row (`assert-use-subscribe-ssr-render-without-commit-
 ;; nets-zero-at-the-horizon`) drives the EXPLICIT 2-arg probe. So the ambient
 ;; form's server behaviour had never been executed anywhere, and an
-;; application server-rendering a UIx tree meets it on its first page.
+;; application server-rendering a UIx tree met the refusal on its first page.
 ;;
-;; THIS ROW PINS A KNOWN DEFECT, NOT A DESIRED BEHAVIOUR. rf2-5rqn is open and
-;; names three candidate dispositions (repair / document / refuse) without
-;; picking one; picking one changes the SSR contract and is an operator
-;; ruling, so this row records what the runtime DOES today and the mechanism
-;; behind it. Whoever lands the repair should expect part 1 to go red BY
-;; DESIGN and should rewrite it to assert resolution — part 2 is the evidence
-;; that the repair is available and cheap.
+;; WHAT THIS ROW WAS, AND WHAT IT IS NOW. It first landed pinning a DEFECT: the
+;; ambient form refused a server render beneath a provider that had established
+;; a scope, and part 2 measured why. rf2-5rqn ruled disposition (1) REPAIR at
+;; the READER site — `function-component-current-frame` falls back to
+;; `_currentValue2` when `_currentValue` is exactly the no-provider sentinel —
+;; so part 1 is now written the way the header of the defect row said it should
+;; be rewritten: it asserts RESOLUTION. Part 2 is the evidence and survives
+;; unchanged in substance, with the shared reader added to it, because the
+;; measurement is what makes the repair legible. Parts 4 and 5 are the frame
+;; laws the fallback must not have loosened.
+;;
+;; A NOTE ON WHAT WOULD MAKE THIS ROW LIE. The defect is renderer-specific, so
+;; a client-lane approximation of it proves nothing: every part below drives
+;; `react-dom/server`'s `renderToString` directly, and part 2 reads the two
+;; private slots so a green run names WHICH slot answered.
 
 (defn assert-use-subscribe-ambient-under-ssr
-  "rf2-5rqn: the AMBIENT (1-arg) `use-subscribe` cannot resolve a frame under
-  `react-dom/server`, even beneath the adapter's own `frame-provider`.
+  "rf2-5rqn: the AMBIENT (1-arg) `use-subscribe` resolves its frame under
+  `react-dom/server` beneath the adapter's own `frame-provider` — and the
+  frame laws that guard the ambient tier survive the repair that made it so.
 
-  Three parts, measured on the node lane under React 19.2:
+  Five parts, measured on the node lane under React 19.2:
 
-    1. THE SYMPTOM — an ambient `use-subscribe` inside a `frame-provider`
-       REFUSES a server render with `:rf.error/no-frame-context`, an error
-       whose own recovery ladder tells the author to establish a scope with a
-       `frame-provider` they have already established.
+    1. THE REPAIR — an ambient `use-subscribe` inside a `frame-provider`
+       server-renders the subscribed value. It used to throw
+       `:rf.error/no-frame-context`, an error whose own recovery ladder told
+       the author to establish a scope they had already established.
 
     2. THE MECHANISM — during that same server render the shared
-       frame-context's PRIVATE `_currentValue` slot holds the no-provider
+       frame-context's PRIMARY `_currentValue` slot holds the no-provider
        SENTINEL while the SECONDARY `_currentValue2` slot holds the real
        frame, and the PUBLIC `useContext` return answers with the real frame.
        `function-component-current-frame` (the `:adapter/current-frame`
-       reader the whole ambient chain funnels through) reads `_currentValue`,
-       classifies the sentinel as 'no scope', and the refusal follows. This is
-       the same renderer split rf2-2rzx0 already repaired for the compiled
-       ViewCell by sourcing the frame from the `useContext` RETURN — and the
-       spine's 1-arg arm ALREADY calls that hook (for the repaint
-       subscription) and discards its value.
+       reader the WHOLE ambient chain funnels through — 1-arg use-subscribe,
+       `use-frame`, ambient subscribe/dispatch inside render,
+       `rf/current-frame-id`) now reads the primary, sees the untouched
+       sentinel, and falls back to the secondary. Asserting on that reader
+       DIRECTLY, and not only through a hook, is what proves the repair is
+       central rather than one hook's private shortcut.
 
-    3. THE SUPPORTED ROUTE — the EXPLICIT 2-arg form renders the subscribed
-       value under the same server renderer, so the refusal is specific to the
-       ambient tier rather than to SSR, and Spec 002's ladder item (3) 'pass
-       an explicit {:frame <id>}' is a real way out.
+    3. THE OTHER ROUTE — the EXPLICIT 2-arg form renders the subscribed value
+       under the same server renderer. It always did; Spec 002's ladder item
+       (3) 'pass an explicit {:frame <id>}' remains a real way out, and this
+       part pins that the repair did not disturb it.
+
+    4. THE NEGATIVE CONTROLS — the fallback is narrow by construction and
+       these say so: no provider still refuses with
+       `:rf.error/no-frame-context`; the DYNAMIC tier still outranks both
+       slots; a CORRUPTED primary is still reported as
+       `:rf.error/frame-context-corrupted` and is NOT masked by a populated
+       secondary; and a refusing extent still raises
+       `:rf.error/ambient-frame-refused`, because `resolve-current-frame`
+       withdraws the reader entirely rather than gating inside it.
+
+    5. THE ABORTED-RENDER CHECK — the one hazard a private-slot read carries
+       that is cheap to falsify. After a server render that THROWS beneath a
+       provider, the secondary slot must be back at its default and a
+       provider-less render in the same runtime must still refuse. A stale
+       `_currentValue2` would leak one request's frame into the next.
 
   Node-safe: no DOM, no `act()`, no root — `renderToString` only.
 
   cfg keys: `:frame-provider-mount-element`, `:probe-frame-provider-element`,
   `:probe-frame-provider-observed`, `:frame-provider-query`,
   `:probe-ssr-slots-element`, `:ssr-slot-observed`, `:probe-element`,
-  `:refcount-target`, `:us-query`, and `:ssr-ambient-frame` (its own frame)."
+  `:refcount-target`, `:us-query`, `:substrate-kw`, `:ssr-ambient-frame` (its
+  own frame) and `:ssr-dynamic-frame` (the tier-1 contender for part 4b)."
   [{:keys [name frame-provider-mount-element probe-frame-provider-element
            probe-frame-provider-observed ssr-ambient-frame frame-provider-query
-           probe-element refcount-target us-query
-           probe-ssr-slots-element ssr-slot-observed]}]
+           probe-element refcount-target us-query substrate-kw
+           ssr-dynamic-frame probe-ssr-slots-element ssr-slot-observed]}]
   (testing (str name " — ambient use-subscribe under react-dom/server (rf2-5rqn)")
     ;; Clear the fixture's ambient `:rf/default` dynamic scope: the 1-arg form
     ;; resolves tier 1 (dynamic var) FIRST, so a bound `*current-frame*` would
@@ -3670,42 +3695,202 @@
       (rf/dispatch-sync [::ssr-ambient-seed] {:frame ssr-ambient-frame})
       (rf/reg-sub frame-provider-query (fn [db _] (:k db)))
       (rf/reg-sub us-query (fn [db _] (:n db)))
-      (testing "1. the ambient form REFUSES a server render (the defect)"
-        (let [thrown (try (.renderToString react-dom-server
-                            (frame-provider-mount-element
-                              ssr-ambient-frame (probe-frame-provider-element)))
-                          nil
-                          (catch :default e e))]
-          (is (some? thrown)
-              "the server render of an ambient use-subscribe threw")
-          (is (= :rf.error/no-frame-context (:rf.error/id (ex-data thrown)))
-              "and threw the ABSENCE category — under a frame-provider that
-               did establish a scope (rf2-5rqn)")
-          (is (empty? @probe-frame-provider-observed)
-              "the hook never returned a value, so no markup could be produced")))
+      (testing "1. the ambient form RESOLVES under a server render (the repair)"
+        (let [html (.renderToString react-dom-server
+                     (frame-provider-mount-element
+                       ssr-ambient-frame (probe-frame-provider-element)))]
+          (is (str/includes? html "k=:wrapped")
+              "the ambient use-subscribe server-rendered the value it read from
+               the frame the enclosing frame-provider established — this render
+               threw :rf.error/no-frame-context before rf2-5rqn")
+          (is (some #{:wrapped} @probe-frame-provider-observed)
+              "and the hook itself returned that value, so the markup is the
+               hook's output and not an empty render")))
       (testing "2. the MECHANISM — the server renderer populates the SECONDARY slot"
+        (reset! ssr-slot-observed nil)
         (.renderToString react-dom-server
           (frame-provider-mount-element
             ssr-ambient-frame (probe-ssr-slots-element)))
-        (let [{:keys [current-value current-value2 use-context]} @ssr-slot-observed]
+        (let [{:keys [current-value current-value2 use-context reader]} @ssr-slot-observed]
           (is (= adapter-context/no-provider-sentinel current-value)
-              "`_currentValue` — the slot the :adapter/current-frame reader
-               consults — holds the NO-PROVIDER SENTINEL on the server, which
-               classifies to nil ('no scope') and produces the refusal above")
+              "`_currentValue` — the PRIMARY slot, which the client renderer
+               owns — holds the untouched NO-PROVIDER SENTINEL on the server;
+               a reader consulting only it classifies that as 'no scope'")
           (is (= ssr-ambient-frame current-value2)
               "while React's SECONDARY slot `_currentValue2` holds the frame
                the provider established — the value was never absent, only
-               unreachable from the slot the reader reads")
+               unreachable from the slot the reader used to read")
           (is (= ssr-ambient-frame use-context)
-              "and the PUBLIC useContext return — renderer-agnostic, and the
-               hook the spine's 1-arg arm ALREADY calls and discards —
-               resolves the frame correctly under react-dom/server")))
-      (testing "3. the EXPLICIT 2-arg form is the supported route under SSR"
+              "and the PUBLIC useContext return — renderer-agnostic — agrees,
+               which is what makes the secondary slot the right fallback and
+               not a guess")
+          (is (= ssr-ambient-frame reader)
+              "THE SHARED READER — function-component-current-frame, the
+               :adapter/current-frame hook EVERY ambient consumer funnels
+               through — answers with the frame under react-dom/server. This
+               assertion, not part 1, is what proves the repair is central: it
+               calls the reader directly, with no hook in the way")))
+      (testing "3. the EXPLICIT 2-arg form still server-renders (unchanged)"
         (reset! refcount-target ssr-ambient-frame)
         (let [html (.renderToString react-dom-server (probe-element))]
-          (is (re-find #"n=7" html)
+          (is (str/includes? html "n=7")
               "an explicitly-framed use-subscribe server-renders its value —
-               the refusal is specific to the AMBIENT tier, not to SSR"))))))
+               the explicit route the repair had to leave alone")))
+      (testing "4a. NEGATIVE CONTROL — no provider still refuses on the server"
+        (reset! probe-frame-provider-observed [])
+        (let [thrown (try (.renderToString react-dom-server
+                            (probe-frame-provider-element))
+                          nil
+                          (catch :default e e))]
+          (is (= :rf.error/no-frame-context (:rf.error/id (ex-data thrown)))
+              "with NO frame boundary above it the ambient form still fails
+               closed — the fallback reads the secondary slot, it does not
+               synthesise a frame out of one")
+          (is (empty? @probe-frame-provider-observed)
+              "and the hook returned nothing, so nothing rendered")))
+      (testing "4b. NEGATIVE CONTROL — the dynamic tier still outranks both slots"
+        (rf/make-frame {:id ssr-dynamic-frame :doc "rf2-5rqn SSR dynamic-precedence frame"})
+        (reset! ssr-slot-observed nil)
+        (binding [frame/*current-frame* ssr-dynamic-frame]
+          (.renderToString react-dom-server
+            (frame-provider-mount-element
+              ssr-ambient-frame (probe-ssr-slots-element))))
+        (let [{:keys [current-value2 reader]} @ssr-slot-observed]
+          (is (= ssr-ambient-frame current-value2)
+              "the provider did populate the secondary slot, so this is a
+               genuine contest and not a vacuous one")
+          (is (= ssr-dynamic-frame reader)
+              "yet the reader answers with the DYNAMIC frame — tier 1 is
+               consulted before any slot, on the server as on the client")))
+      (testing "4c. NEGATIVE CONTROL — a corrupted primary is not masked by the secondary"
+        ;; The exact-sentinel gate is the whole of what keeps this true: the
+        ;; fallback fires ONLY when the primary holds the untouched default, so
+        ;; a disturbed boundary (rf2-8q66) still reports itself even when a
+        ;; secondary slot is sitting there with a perfectly good frame in it.
+        ;; Asserted against the reader directly, with the SSR slot shape staged
+        ;; by hand, because no renderer produces 'corrupt primary + populated
+        ;; secondary' on its own.
+        (let [ctx       adapter-context/frame-context
+              original  (.-_currentValue  ^js ctx)
+              original2 (.-_currentValue2 ^js ctx)
+              lk        (keyword "re-frame.adapter.react-shared-suite"
+                                 (str "ssr-5rqn-" (clojure.core/name substrate-kw)))
+              traces    (atom [])]
+          (trace-tooling/register-listener! lk (fn [ev] (swap! traces conj ev)))
+          (try
+            (set! (.-_currentValue  ^js ctx) 42)
+            (set! (.-_currentValue2 ^js ctx) ssr-ambient-frame)
+            (is (nil? (adapter-context/function-component-current-frame))
+                "a corrupted PRIMARY resolves to nil even though the secondary
+                 names a real frame — the fallback did not swallow the
+                 corruption")
+            (let [errs (corruption-traces traces)]
+              (is (= 1 (count errs))
+                  "and the distinct :rf.error/frame-context-corrupted category
+                   still fires — the disturbed boundary is reported, not folded
+                   into ordinary 'no scope'")
+              (is (= :number (-> errs first :tags :type))
+                  ":tags :type still names the corrupted shape"))
+            (finally
+              (trace-tooling/unregister-listener! lk)
+              (set! (.-_currentValue  ^js ctx) original)
+              (set! (.-_currentValue2 ^js ctx) original2)))))
+      (testing "4d. NEGATIVE CONTROL — a refusing extent still refuses on the server"
+        ;; `resolve-current-frame` WITHDRAWS the adapter reader for the extent
+        ;; of a refusal (rf2-2rtt6.122) rather than gating inside it, so the
+        ;; secondary-slot fallback cannot route around a substrate that has
+        ;; declared its own read discipline. That is why the repair needed no
+        ;; refusal-awareness of its own — and this part is the proof.
+        (reset! ssr-slot-observed nil)
+        (let [thrown (try (frame/call-with-ambient-frame-refused nil
+                            (fn []
+                              (.renderToString react-dom-server
+                                (frame-provider-mount-element
+                                  ssr-ambient-frame (probe-frame-provider-element)))))
+                          nil
+                          (catch :default e e))]
+          (is (= :rf.error/ambient-frame-refused (:rf.error/id (ex-data thrown)))
+              "inside a refusing extent the ambient form raises REFUSED, not
+               the absence category and not a silent success"))
+        (frame/call-with-ambient-frame-refused nil
+          (fn []
+            (.renderToString react-dom-server
+              (frame-provider-mount-element
+                ssr-ambient-frame (probe-ssr-slots-element)))))
+        (let [{:keys [current-value2 reader] resolved :resolve} @ssr-slot-observed]
+          (is (= ssr-ambient-frame current-value2)
+              "the provider populated the secondary slot inside the refusing
+               extent too, so the withdrawal is what answers below")
+          (is (= ssr-ambient-frame reader)
+              "the raw reader would have answered — the refusal is layered
+               ABOVE it")
+          (is (nil? resolved)
+              "and resolve-current-frame answers nil, having never called the
+               reader at all")))
+      (testing "5. the ABORTED-RENDER check — an aborted render leaks no frame into the next"
+        ;; THE ONE HAZARD A PRIVATE-SLOT READ CARRIES, and the reason rf2-5rqn's
+        ;; ruling made this part a gate rather than a nicety. React pushes the
+        ;; provider's value onto `_currentValue2` on the way into a subtree and
+        ;; pops it on the way out. A render that THROWS mid-tree unwinds by a
+        ;; different path — so ask whether the pop still happens, and, whatever
+        ;; the answer, whether anything can OBSERVE a stale slot. On a server
+        ;; the two questions come apart, and only the second one is a bug.
+        ;;
+        ;; MEASURED (React 19.2.0, this row plus a standalone Fizz probe):
+        ;;   normal render   → the slot is popped back to the default on exit;
+        ;;   throwing render → the slot is LEFT PUSHED after the throw;
+        ;;   the NEXT render → pops the previous snapshot BEFORE running any
+        ;;                     component, so every render observes the context
+        ;;                     its own tree establishes and nothing else.
+        ;;
+        ;; So the stale value exists between an aborted render and the next
+        ;; one, and no render sees it. That is what the three assertions below
+        ;; pin, in that order — including the residual itself, deliberately, so
+        ;; that a React release which starts popping on the error path turns
+        ;; this row red and sends the next reader to this note rather than
+        ;; letting the repair's real boundary drift out of the record.
+        ;;
+        ;; NOT PINNED, because it is outside the ambient tier's contract: a
+        ;; frame-scoped op performed OUTSIDE any render, inside that window,
+        ;; reads the aborted render's frame. Ambient resolution is a
+        ;; render-time notion on both renderers, and server-side ops carry a
+        ;; frame explicitly or bind one with `with-frame` — which outranks both
+        ;; slots (4b). rf2-5rqn ruled OUT stale-slot heuristics by name; a
+        ;; guard here would be exactly that.
+        ;;
+        ;; The throw is staged here rather than borrowed from 4d, so the render
+        ;; immediately preceding these assertions is the aborted one.
+        (let [thrown (try (frame/call-with-ambient-frame-refused nil
+                            (fn []
+                              (.renderToString react-dom-server
+                                (frame-provider-mount-element
+                                  ssr-ambient-frame (probe-frame-provider-element)))))
+                          nil
+                          (catch :default e e))]
+          (is (some? thrown)
+              "the staged render did abort beneath the provider — without a
+               throw here the rest of this part would prove nothing"))
+        (is (= ssr-ambient-frame
+               (.-_currentValue2 ^js adapter-context/frame-context))
+            "MEASURED RESIDUAL, not a requirement: React 19.2 leaves the
+             secondary slot pushed after an aborted server render. If this
+             assertion fails, React changed its error-path unwinding — that is
+             an improvement, not a regression: re-read this part's note, drop
+             this line, and keep the two below")
+        (reset! probe-frame-provider-observed [])
+        (let [thrown (try (.renderToString react-dom-server
+                            (probe-frame-provider-element))
+                          nil
+                          (catch :default e e))]
+          (is (= :rf.error/no-frame-context (:rf.error/id (ex-data thrown)))
+              "THE LOAD-BEARING ONE: a provider-less render in the SAME runtime
+               still refuses, because the next render pops the abandoned
+               snapshot before any component runs — one aborted request cannot
+               leak its frame into the next"))
+        (is (= adapter-context/no-provider-sentinel
+               (.-_currentValue2 ^js adapter-context/frame-context))
+            "and that render left the slot back at createContext's default, so
+             the window closes at the next render rather than persisting")))))
 
 ;; ---- use-frame — capture-frame in hook position (rf2-y6dz8t) ---------------
 


### PR DESCRIPTION
Closes rf2-5rqn. Implements the ruling of 2026-08-13: disposition **(1) repair, at the reader site**.

## The defect

The spine's 1-arg `use-subscribe` refused a server render with `:rf.error/no-frame-context` — beneath a `frame-provider` that had established a scope, handing the author an error whose recovery ladder told them to do the thing they had already done.

The frame was never absent, only unreachable. React carries two value slots per context; `react-dom/server` writes the **secondary** (`_currentValue2`) while `function-component-current-frame` read only the primary.

## The fix

One expression in `re-frame.adapter.context/function-component-current-frame`: fall back to the secondary slot when the primary holds **exactly** the untouched no-provider sentinel. One line becomes five (net +4 executable lines); the rest of that file's diff is the comment and docstring text the ruling asked to be corrected, which described `_currentValue` as the whole story.

Every ambient consumer funnels through this one reader via the `:adapter/current-frame` late-bind hook, so the single move gives 1-arg `use-subscribe`, `use-frame`, ambient subscribe/dispatch inside render and `rf/current-frame-id` one SSR story — and ends the two-substrate asymmetry with the compiled ViewCell and Hicasso's native tier, which rf2-2rzx0 already repaired.

The frame laws survive by construction rather than by re-implementation, and the tests say so rather than the commit message:

- the **dynamic tier** is still consulted before any slot (part 4b);
- `resolve-current-frame` **withdraws** the reader entirely inside a refusing extent, so the fallback cannot route around it (part 4d);
- the **exact-sentinel gate** keeps a corrupted primary on its own `:rf.error/frame-context-corrupted` path instead of masking it, even with a populated secondary sitting beside it (part 4c);
- under the client renderer the secondary is never written, so the fallback is inert.

## The measured residual, reported rather than patched

Acceptance criterion 5 asked whether an aborted render leaves a stale slot. Measured under React 19.2.0, both in this row and with a standalone Fizz probe:

| render beneath a provider | `_currentValue2` during | after |
| --- | --- | --- |
| normal | the frame | restored to the default |
| **throwing** | the frame | **left pushed** |
| the next render | the default | the default |

So the slot *is* left pushed after a throw, and **no render ever observes it**: Fizz pops the abandoned snapshot before running any component in the next render. The criterion as worded — "a provider-less render in the same runtime still refuses; no stale `_currentValue2` observed" — passes, and part 5 pins all three rows, including the residual itself, so a React release that starts popping on the error path turns the row red and sends the next reader to the note rather than letting the boundary drift out of the record.

The window is between an aborted render and the next one, reachable only by a read taken **outside** any render — which is not what the ambient tier promises on either renderer. A guard there would be the stale-slot heuristic the ruling rejected by name, so there isn't one. Flagged here because the ruling's "revisit if" clause names this check.

## Tests

`assert-use-subscribe-ambient-under-ssr` (the node-lane witness from PR #8002) rewritten as its own header instructed. Part 1 asserted the refusal and now asserts resolution; part 2's slot measurement survives and gains a **direct shared-reader** assertion, so the repair is proven central rather than hook-local; parts 4 and 5 are new.

## Quality gates

Every number below was captured from the runner's own exit code, written to a per-attempt file, not read from a harness summary — the harness reported exit 0 for two of these runs while the captured code was 1.

| gate | attempt | captured exit | result |
| --- | --- | --- | --- |
| `npm run test:cljs` | 1 | 1 | 1 failure — my own over-strict slot assertion (see residual above) |
| `npm run test:cljs` | 2 | **0** | 13861 tests, 70066 assertions, 0 failures |
| `npm run test:cljs` (sabotage) | 3 | 1 | 16 failures, red names the planted value |
| `npm run test:cljs` (fix reverted) | 4 | 1 | **1** failure, and it is this row |
| `scripts/test-fast-pr.sh` | 5 | **0** | full spine on the final rebased base, node tier included |

**Which tree the gates read.** `test-fast-pr.sh` prints `gate root: /c/Users/miket/code/re-frame2-worktrees/ambientframe-5rqn` — this worktree. `test:cljs` prints no root, so the proof there is the red from a planted fault (below), whose failure text names a value that exists only in this checkout.

**Proof the test exercises the server path, not a client approximation.** Two plants, each anchored to one line of the fix:

1. *Substituting a marker for the fallback* (`:rf.planted-fault/wrong-frame`). The shared-reader assertion went red as `(not (= :rf.uix-5rqn/ssr-ambient-frame :rf.planted-fault/wrong-frame))` — the value was produced by the fallback branch mid-`react-dom/server` render and read by the assertion. Same 13861/70066 counts as the green control, so the plant crashed no namespace.

2. *Reverting the fix itself* (the pre-rf2-5rqn `_currentValue`-only read) — this is the discriminating one. Of 13861 tests, **exactly one** failed: `use-subscribe-ambient-under-ssr`, with an uncaught `:rf.error/no-frame-context` from `re-frame.substrate.spine/use-subscribe` — the bead's defect, reproduced verbatim. Every client-lane ambient row stayed green, because the client renderer never needed the fallback. A server-only change reddening only the server row is what makes this a server-path test rather than a client approximation of one.

Both plants restored and verified with `git hash-object` against the committed blob (`8898fd79d1a1599a3399c85568501a4dc1000e20`), not by reading a diff.

**Hot zone: none.** No `spec/**` change — Spec 006's context-resolution chain and the UIx API docs already promise ambient resolution below a provider, so this brings the implementation to the shipped contract rather than changing it. Spec 011 stays agnostic. No workflow, `deps.edn` or `shadow-cljs.edn` change.

## Declined to build

Per the ruling, and none of it is here: renderer-detection machinery, `_currentRenderer*` probes, stale-slot heuristics, feature flags, a generalized renderer abstraction, any new public API or SSR mode. The call-site `useContext`-threading variant stays in reserve as the escape hatch if a future React pin breaks the private slots. rf2-wxnc (the ViewCell's refusal-tier gap) is a separate bead and is untouched here.
