### PR TITLE
ci(gates): bounded audit of non-local input edges — five armed, one filed (rf2-6ng7)

### DIFF
--- a/.github/scripts/report-changed-surfaces.sh
+++ b/.github/scripts/report-changed-surfaces.sh
@@ -434,6 +434,59 @@ is_route_path_census_input() {
   esac
 }
 
+# rf2-6ng7 — THE re-frame.ui SHADOW CONFIGURATION CONTRACT'S FOUR HOLDERS.
+#
+# `implementation/ui/test/re_frame/ui/shadow_config_contract_jvm_test.clj`
+# contains, by design, NO literal expected value: the expected value IS the
+# repository's real configuration, read at run time from four holders and
+# compared as data. It runs in `jvm-ui`, which only `implementation_jvm`
+# gates — and measured on main before this bead, not one of the four armed
+# that output:
+#
+#   implementation/shadow-cljs.edn                    implementation_jvm=false
+#   implementation/package.json                       implementation_jvm=false
+#   examples/ui/minimal-counter/deps.edn              implementation_jvm=false
+#   skills/re-frame2-setup/references/shadow-cljs.md  implementation_jvm=false
+#
+# So the suite whose entire subject is those four files could not fire on an
+# edit to any of them — the rf2-w9ip shape exactly, one artefact over. The
+# skill reference is the sharpest case: it exists to be a pin rather than a
+# copy free to drift, and drift there was invisible at PR time.
+#
+# `examples/*` does arm `implementation_jvm` already, via the route-path
+# census predicate above — but only for `.cljs`/`.cljc`, which are the
+# census's extensions. The scaffold holder is a `deps.edn`, so it falls
+# through that filter and needs this one.
+#
+# WHY A PREDICATE AND NOT AN ARM OF THE BIG `case` — the rf2-65ajl / rf2-w9ip
+# reason again. All four paths already have arms there
+# (`implementation/shadow-cljs.edn|implementation/package.json|…`,
+# `examples/*`, `skills/re-frame2-setup/*`), so an arm placed after them is
+# shadowed and an arm placed before them would silently narrow what they set.
+# A predicate consulted for every file can only ever SET `implementation_jvm`.
+#
+# WHY `implementation_jvm` and not an output of its own: unchanged from the
+# note above. A second output would have to be taught to
+# `scripts/test-fast-pr.sh` and then held in step with this file, which is a
+# fresh instance of the class rather than a repair of one.
+#
+# HELD IN STEP: `implementation/scripts/_changed-surfaces.test.cjs` reads the
+# `*-rel` holder paths out of the suite's own source and asserts this
+# predicate arms the lane for every one of them. Add a holder over there and
+# the assertion reds here until this list catches up.
+is_shadow_config_contract_holder() {
+  case "$1" in
+    implementation/shadow-cljs.edn|implementation/package.json)
+      return 0 ;;
+    examples/ui/minimal-counter/deps.edn)
+      return 0 ;;
+    skills/re-frame2-setup/references/shadow-cljs.md)
+      return 0 ;;
+    *)
+      return 1 ;;
+  esac
+}
+
 if [ "$files" = "__ALL__" ]; then
   mark_all
 else
@@ -503,6 +556,14 @@ else
     # the `case` below, and it runs in `jvm-routing`, which only
     # `implementation_jvm` gates.
     if is_route_path_census_input "$file"; then
+      implementation_jvm=true
+    fi
+
+    # rf2-6ng7 — same shape, same reason (see the predicate's own note): the
+    # re-frame.ui shadow-configuration contract compares four holders that all
+    # have shadowing arms in the `case` below, and it runs in `jvm-ui`, which
+    # only `implementation_jvm` gates.
+    if is_shadow_config_contract_holder "$file"; then
       implementation_jvm=true
     fi
 
@@ -2267,8 +2328,43 @@ else
         # below (rf2-k9ekz). All NON-spec-md changes (src/test .clj/.cljs,
         # deps.edn, README, EDN, …) still fire the probes conservatively.
         case "$file" in
-          tools/story/spec/*.md|tools/xray/spec/*.md)
-            : # spec doc only — no runtime/JVM/MCP/CLJS/template fan-out
+          # rf2-6ng7 — THE XRAY HALF OF THAT GUARD WAS FALSE. Its premise is
+          # that a spec-md change "cannot affect any JVM unit test"; two
+          # suites under `tools/xray/test/` refute it by reading the spec
+          # markdown as their expected value:
+          #
+          #   coverage_matrix_metadata_test.clj  slurps
+          #     tools/xray/spec/017-Test-Coverage-Matrix.md and
+          #     019-Cross-Cutting-Insight.md, reconciling the feature-matrix
+          #     scenario names against the spec's rows      → jvm-tools-xray
+          #   panel_enum_spec_refs.clj           slurps
+          #     tools/xray/spec/007-UX-IA.md and
+          #     008-Embedding-Contract.md at MACRO-EXPANSION time, emitting
+          #     the spec's `mount-<panel>!` set into
+          #     panel_enum_guard_cljs_test.cljs, which the consolidated
+          #     :node-test build compiles                   → cljs
+          #
+          # Both were armed by their CODE surface and by nothing on the spec
+          # side, so an Xray spec edit that renamed a matrix row or a panel
+          # left the reconciling suite unrun and the red landed on main for
+          # the next unrelated PR — the rf2-61ar incident shape.
+          #
+          # THE TREE, NOT THE FOUR NAMES, and deliberately: naming them here
+          # would be a second copy of a roster that already lives in the two
+          # suites, free to drift the moment a fifth spec file is read or
+          # content moves between files. `mcp_conformance` and
+          # `template_expensive` stay OFF — markdown cannot change an MCP wire
+          # surface or the generated app's compile, and no suite in either
+          # lane reads these files.
+          tools/xray/spec/*.md)
+            tools_jvm=true
+            cljs_node_test=true
+            ;;
+          tools/story/spec/*.md)
+            : # spec doc only — no runtime/JVM/MCP/CLJS/template fan-out.
+              # Story's spec markdown has no counterpart reader: the one
+              # consumer, api-manifest's story_spec_check, runs in lint.yml's
+              # api-manifest job, which `tools/*` already arms (rf2-6ng7).
             ;;
           *)
             tools_jvm=true
@@ -2503,6 +2599,27 @@ else
         # rf2-agi57x — the re-frame2-setup skill carries a structural drift
         # guard (tests/setup_drift_test.clj) gated under skills-structural.
         skills_structural=true
+        # rf2-6ng7 — the skill's REFERENCE snippets are compiled, not merely
+        # linted. `setup-skill-scaffold-compiles-test` in
+        # tools/template/test/day8/re_frame2_template/emitted_test_run_test.clj
+        # materialises a scaffold for each documented substrate SOLELY from
+        # the fenced blocks in this directory (first-counter.md /
+        # shared-dataflow.md + entry-namespace.md + shadow-cljs.md), then runs
+        # `clojure -M:shadow compile app` over it against the in-repo source.
+        # That suite runs in `jvm-tools-template`, which `template_expensive`
+        # gates — and this tree armed only `skills_structural`, so the one
+        # gate that compiles the skill's hand-written greenfield counter never
+        # fired on an edit to it. The structural guard cannot stand in: it
+        # checks shape, not that the snippets still compile.
+        #
+        # `references/` only. The skill's SKILL.md, its tests/ and its other
+        # trees are not materialised into the scaffold, and an expensive
+        # emitted-app compile has no business queueing for them.
+        case "$file" in
+          skills/re-frame2-setup/references/*)
+            template_expensive=true
+            ;;
+        esac
         ;;
       docs/tools/playground/*|docs/cljs/playground.js|docs/cljs/playground.css|scripts/playground-sci-input-digest.mjs)
         # rf2-ee38b.22 — the docs/cljs live-cell playground (CM6 + Scittle

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -55,8 +55,9 @@ on:
       # change to the checker cannot ship without the checker running.
       - 'scripts/check_provenance_pins.py'
       - 'scripts/check_runtime_subsystem_grading.py'
-      - 'scripts/check_inject_cofx_residue.py'
-      - 'scripts/_test_fixtures/check_inject_cofx_residue/**'
+      # (`scripts/check_inject_cofx_residue.py` and its fixtures left this list
+      # with the gate itself — rf2-6ng7 moved it to test.yml's always-on
+      # invariant job, where it needs no path filter to run.)
       # rf2-2oqj59 — the failure-corpus co-edit invariant gate scans
       # errors.md + the testbeds tree for a live retired failure spelling
       # (`:where :cofx`). A drift in either the gate, its fixtures, or the
@@ -168,7 +169,7 @@ jobs:
           while IFS= read -r file; do
             [ -z "$file" ] && continue
             case "$file" in
-              docs/*|spec/*|migration/*|mkdocs.yml|mkdocs_hooks.py|TESTING.md|README.md|CHANGELOG.md|SKILL-REDIRECT.md|AGENTS.md|CLAUDE.md|scripts/test-jvm-implementation.sh|scripts/test-jvm-tools.sh|scripts/test-fast-pr.sh|scripts/test-rigorous-local.sh|requirements.txt|scripts/check_doc_slugs.py|scripts/_test_fixtures/check_doc_slugs/*|scripts/check_provenance_pins.py|scripts/check_runtime_subsystem_grading.py|scripts/check_inject_cofx_residue.py|scripts/_test_fixtures/check_inject_cofx_residue/*|scripts/check_failure_corpus_residue.py|scripts/_test_fixtures/check_failure_corpus_residue/*|testbeds/*|testbeds/*/*|scripts/check_retired_composition_vocab.py|scripts/_test_fixtures/check_retired_composition_vocab/*|tools/*/spec/*|tools/*/spec/*/*|.github/workflows/docs.yml)
+              docs/*|spec/*|migration/*|mkdocs.yml|mkdocs_hooks.py|TESTING.md|README.md|CHANGELOG.md|SKILL-REDIRECT.md|AGENTS.md|CLAUDE.md|scripts/test-jvm-implementation.sh|scripts/test-jvm-tools.sh|scripts/test-fast-pr.sh|scripts/test-rigorous-local.sh|requirements.txt|scripts/check_doc_slugs.py|scripts/_test_fixtures/check_doc_slugs/*|scripts/check_provenance_pins.py|scripts/check_runtime_subsystem_grading.py|scripts/check_failure_corpus_residue.py|scripts/_test_fixtures/check_failure_corpus_residue/*|testbeds/*|testbeds/*/*|scripts/check_retired_composition_vocab.py|scripts/_test_fixtures/check_retired_composition_vocab/*|tools/*/spec/*|tools/*/spec/*/*|.github/workflows/docs.yml)
                 docs_surface=true ;;
             esac
           done <<< "$files"
@@ -405,27 +406,17 @@ jobs:
       - name: Validate runtime-subsystem grading-table coherence
         run: python scripts/check_runtime_subsystem_grading.py --verbose
 
-      # EP-0017 (recordable coeffects, slice A) retired `inject-cofx` /
-      # `inject-cofx*` and renamed the `:rf.world/inputs` dispatch opt to the
-      # flat `:rf.cofx` map — no alias, both hard errors. The runtime throws,
-      # but the EP landing wave left STALE copy-pasteable teaching examples
-      # behind (live `[(rf/inject-cofx :rf.server/request)]` interceptor
-      # entries in spec/Pattern-SSR-Loaders.md + spec/Pattern-FormAction.md,
-      # rf2-d8mvke.3 finding 2). This guard scans docs/core, spec/,
-      # and skills/ markdown for the retired spellings as LIVE recommended API
-      # (inside fenced code blocks) with a narrow file allowlist for the
-      # migration surface (the migration guide page / re-frame-migration skill
-      # / EP docs) where a v1 "before" snippet is legitimate per
-      # docs/core/AUTHORING.md §Delta teaching. Removed-context prose + inline
-      # code spans + masked `;` comments never fire. Self-test first (proves
-      # the gate fires on each live shape + stays green on every
-      # removed-context counterpart + the allowlist exemption), then the live
-      # scan. See scripts/check_inject_cofx_residue.py.
-      - name: Self-test the inject-cofx residue gate
-        run: python scripts/check_inject_cofx_residue.py --self-test --verbose
-
-      - name: Validate no live inject-cofx / :rf.world/inputs residue
-        run: python scripts/check_inject_cofx_residue.py --verbose
+      # THE inject-cofx RESIDUE GATE MOVED OUT OF THIS JOB (rf2-6ng7). It
+      # scanned `docs/core`, `docs/api`, `spec/` AND `skills/` — and `skills/`
+      # is not on this workflow's documentation surface, in either the
+      # `push.paths` filter or the PR-side `detect` classifier, so a skills-only
+      # edit reintroducing a live `(rf/inject-cofx …)` snippet ran the gate
+      # nowhere. Widening the surface to `skills/**` would have bought that with
+      # a ~15-minute MkDocs build on every skills PR; the gate is instead
+      # unconditional in test.yml's `verify-skill-mcp-drift` job, where its
+      # ~0.3s of pure-Python stdlib cannot be skipped past at all. Same remedy
+      # as the hicasso complaint-catalogue and budget-ledger gates before it.
+      # See `.github/workflows/test.yml`, step id `check_inject_cofx_residue`.
 
       # rf2-2oqj59 — the failure corpus (docs/core/errors.md + the
       # failure testbeds) is a TEACHING corpus for the Spec 009 error

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -672,6 +672,42 @@ jobs:
         continue-on-error: true
         run: python scripts/check_gate_scheduling.py --verbose
 
+      # EP-0017 (recordable coeffects, slice A) retired `inject-cofx` /
+      # `inject-cofx*` and renamed the `:rf.world/inputs` dispatch opt to the
+      # flat `:rf.cofx` map — no alias, both hard errors. The runtime throws,
+      # but the EP landing wave left STALE copy-pasteable teaching examples
+      # behind (live `[(rf/inject-cofx :rf.server/request)]` interceptor
+      # entries in spec/Pattern-SSR-Loaders.md + spec/Pattern-FormAction.md,
+      # rf2-d8mvke.3 finding 2). This guard scans docs/core, docs/api, spec/
+      # and skills/ markdown for the retired spellings as LIVE recommended API
+      # (inside fenced code blocks) with a narrow file allowlist for the
+      # migration surface (the migration guide page / re-frame-migration skill
+      # / EP docs) where a v1 "before" snippet is legitimate per
+      # docs/core/AUTHORING.md §Delta teaching. Removed-context prose + inline
+      # code spans + masked `;` comments never fire.
+      #
+      # IT LIVES HERE, NOT IN docs.yml (rf2-6ng7). It ran in docs.yml's
+      # `build` job, gated on that workflow's `docs_surface` classifier — a
+      # `case` list carrying `docs/*`, `spec/*`, `migration/*`, `testbeds/*`
+      # and a dozen named files, but NOT `skills/*`. One of the gate's four
+      # scan roots was therefore outside its own arming, so a skills-only PR
+      # reintroducing a live `(rf/inject-cofx …)` snippet ran it nowhere: the
+      # rf2-6ng7 class, a gate perfectly correct and perfectly scheduled and
+      # never fired on part of what it polices. The cheap repair for a
+      # sub-second pure-stdlib check is not a wider surface (that would buy a
+      # ~15-minute MkDocs build on every skills PR) but no surface at all —
+      # the same remedy the hicasso complaint-catalogue and budget-ledger
+      # gates took. Self-test first, then the live scan.
+      - name: Self-test the inject-cofx residue gate
+        id: check_inject_cofx_residue_selftest
+        continue-on-error: true
+        run: python scripts/check_inject_cofx_residue.py --self-test --verbose
+
+      - name: Validate no live inject-cofx / :rf.world/inputs residue
+        id: check_inject_cofx_residue
+        continue-on-error: true
+        run: python scripts/check_inject_cofx_residue.py --verbose
+
       # The verdict. Every checker above carries `continue-on-error: true`, so
       # the job never short-circuits and its RESULT is decided only here.
       # `toJSON(steps)` is the map of every step that declared an `id`. Each

--- a/implementation/scripts/_changed-surfaces.test.cjs
+++ b/implementation/scripts/_changed-surfaces.test.cjs
@@ -166,10 +166,21 @@ test('Mixed Story src + spec change DOES trigger story_xray_browser (rf2-k9ekz)'
   assert.equal(result.story_xray_browser, 'true');
 });
 
-// rf2-f79t8 (b) — a tools/{story,xray}/spec/**.md MARKDOWN change is a
-// pure doc change: it cannot affect any runtime, JVM unit test, or MCP
-// wire surface, so it must NOT fan out to the JVM/MCP probes (tools_jvm,
-// mcp_conformance). docs.yml + the nightly full matrix cover docs.
+// rf2-f79t8 (b) — a tools/story/spec/**.md MARKDOWN change is a pure doc
+// change: it cannot affect any runtime, JVM unit test, or MCP wire surface,
+// so it must NOT fan out to the JVM/MCP probes (tools_jvm, mcp_conformance).
+// docs.yml + the nightly full matrix cover docs.
+//
+// THE XRAY HALF OF THIS PIN WAS DELETED (rf2-6ng7), because its premise was
+// false. Two suites under `tools/xray/test/` read the Xray spec markdown as
+// their expected value — `coverage_matrix_metadata_test.clj` (jvm-tools-xray)
+// and `panel_enum_spec_refs.clj`, whose macro compiles into the :node-test
+// build (cljs). The assertion below used to name
+// `017-Test-Coverage-Matrix.md` specifically, which is one of the two files
+// the first of those suites slurps: the pin held the classifier to exactly
+// the hole. What replaces it is the derived roster at the foot of this file,
+// which reads both suites' own path lists rather than restating them, plus
+// the surviving Story control here.
 
 test('Story spec-only .md does NOT fan out to tools_jvm / mcp_conformance (rf2-f79t8)', () => {
   const result = classify('tools/story/spec/Spec.md');
@@ -178,11 +189,14 @@ test('Story spec-only .md does NOT fan out to tools_jvm / mcp_conformance (rf2-f
   assert.equal(result.cljs_node_test, 'false');
 });
 
-test('Xray spec-only .md does NOT fan out to tools_jvm / mcp_conformance (rf2-f79t8)', () => {
+test('Xray spec-only .md still does NOT fan out to mcp_conformance / template_expensive (rf2-f79t8, rf2-6ng7)', () => {
+  // The narrowing rf2-6ng7 made is on the PATH axis, not a repeal: markdown
+  // still cannot change an MCP wire surface or the generated app's compile,
+  // and no suite in either lane reads these files.
   const result = classify('tools/xray/spec/017-Test-Coverage-Matrix.md');
-  assert.equal(result.tools_jvm, 'false');
   assert.equal(result.mcp_conformance, 'false');
-  assert.equal(result.cljs_node_test, 'false');
+  assert.equal(result.template_expensive, 'false');
+  assert.equal(result.story_xray_browser, 'false');
 });
 
 test('Story NON-spec change (JVM .clj test) STILL fans out to tools_jvm / mcp_conformance (rf2-f79t8)', () => {
@@ -5639,6 +5653,247 @@ test('jvm-routing stays gated on implementation_jvm, or the census arm schedules
     /if: needs\.detect_changed_surfaces\.outputs\.implementation_jvm == 'true'/,
     'jvm-routing must stay gated on implementation_jvm',
   );
+});
+
+// ---------------------------------------------------------------------------
+// rf2-6ng7 — NON-LOCAL INPUT EDGES ARM THE JOB THAT READS THEM.
+//
+// The bounded audit this bead ruled found three more gates in the rf2-w9ip
+// shape above: a suite whose expected value IS a file somewhere else in the
+// repository, scheduled in a job that the file's own classification never
+// armed. Each is pinned here the way the census is — the roster READ OUT OF
+// the gate's own source, never restated. A restated list is a second thing to
+// keep in step, which is the defect these pins exist to catch.
+//
+// Every one asserts three legs, because two are not enough: the path arms the
+// output, the output still gates the job, and the parse that produced the
+// roster found something (a roster read as empty asserts nothing and reports
+// green).
+// ---------------------------------------------------------------------------
+
+/**
+ * The string literals of the first vector following `(def ^:private <name>`,
+ * read out of Clojure source.
+ *
+ * Same scan as `censusAppRoots` above and for the same reason: the docstring
+ * between the name and the vector quotes paths and namespaces, so the first
+ * `[` that is not inside a string or a line comment is the vector's.
+ */
+function defVectorStrings(source, defName, label) {
+  const start = source.indexOf(`(def ^:private ${defName}`);
+  assert.notEqual(start, -1, `${label} must still define ${defName}`);
+
+  let i = start;
+  let inString = false;
+  let inComment = false;
+  for (; i < source.length; i += 1) {
+    const ch = source[i];
+    if (inString) {
+      if (ch === '\\') i += 1;
+      else if (ch === '"') inString = false;
+      continue;
+    }
+    if (inComment) {
+      if (ch === '\n') inComment = false;
+      continue;
+    }
+    if (ch === '"') inString = true;
+    else if (ch === ';') inComment = true;
+    else if (ch === '[') break;
+  }
+  assert.ok(i < source.length, `${label}: no ${defName} vector found`);
+
+  const end = source.indexOf(']', i);
+  assert.notEqual(end, -1, `${label}: unterminated ${defName} vector`);
+
+  return [...source.slice(i, end).matchAll(/"([^"\\]*)"/g)].map((m) => m[1]);
+}
+
+// --- the re-frame.ui shadow-configuration contract -------------------------
+//
+// `shadow_config_contract_jvm_test.clj` spells no expected value: the expected
+// value is the repository's four real holders, read at run time and compared as
+// data. It runs in `jvm-ui`, which `implementation_jvm` gates, and before this
+// bead not one holder armed that output.
+
+const SHADOW_CONTRACT_REL =
+  'implementation/ui/test/re_frame/ui/shadow_config_contract_jvm_test.clj';
+
+/**
+ * The suite's compared holders: every `(def ^:private <name>-rel "<path>")`
+ * except the repo-root LOCATOR.
+ *
+ * `root-marker-rel` is excluded by name and deliberately. It is the durable
+ * root file the suite walks up to find (`AGENTS.md`) — "deliberately not a
+ * compared holder", as its own comment says. Arming the whole JVM tier on
+ * every AGENTS.md edit would be over-arming for a file the suite only ever
+ * uses as a coordinate; the negative control below pins that it stays cheap.
+ */
+function shadowContractHolders(source) {
+  const rows = [...source.matchAll(/\(def\s+\^:private\s+([a-z0-9-]*-rel)\s+"([^"]+)"\)/g)]
+    .map((m) => ({ name: m[1], rel: m[2] }));
+  assert.ok(
+    rows.length >= 5,
+    `${SHADOW_CONTRACT_REL}: expected at least 5 \`-rel\` path defs, parsed ${rows.length}`,
+  );
+  const marker = rows.find((r) => r.name === 'root-marker-rel');
+  assert.ok(marker, `${SHADOW_CONTRACT_REL} must still define root-marker-rel`);
+
+  const holders = rows.filter((r) => r.name !== 'root-marker-rel');
+  // Cannot pass vacuously: a parse that found only the marker would assert
+  // every holder in an empty list and report green.
+  assert.ok(
+    holders.length >= 4,
+    `${SHADOW_CONTRACT_REL}: expected at least 4 compared holders, parsed ${holders.length}`,
+  );
+  return holders;
+}
+
+test('every shadow-config contract holder arms implementation_jvm (rf2-6ng7)', () => {
+  const source = fs.readFileSync(path.join(REPO_ROOT, SHADOW_CONTRACT_REL), 'utf8');
+  for (const { name, rel } of shadowContractHolders(source)) {
+    assert.equal(
+      classify(rel).implementation_jvm,
+      'true',
+      `${rel} (${name}) must arm implementation_jvm: shadow-config-contract-jvm-test compares it as a holder, and jvm-ui is the only job that runs it`,
+    );
+  }
+});
+
+test('the shadow-config contract locator stays cheap (rf2-6ng7 negative control)', () => {
+  const source = fs.readFileSync(path.join(REPO_ROOT, SHADOW_CONTRACT_REL), 'utf8');
+  const marker = [...source.matchAll(/\(def\s+\^:private\s+root-marker-rel\s+"([^"]+)"\)/g)][0];
+  assert.ok(marker, `${SHADOW_CONTRACT_REL} must still define root-marker-rel`);
+  assert.equal(
+    classify(marker[1]).implementation_jvm,
+    'false',
+    `${marker[1]} is the suite's repo-root LOCATOR, not a compared holder — it must not queue the JVM tier`,
+  );
+});
+
+// --- the Xray spec markdown two suites read --------------------------------
+//
+// The classifier's spec-md guard (rf2-f79t8) excused
+// `tools/{story,xray}/spec/**.md` from every probe on the premise that spec
+// prose "cannot affect any JVM unit test". Two suites under `tools/xray/test/`
+// read exactly that prose as their expected value, so for the Xray half the
+// premise was false.
+
+const XRAY_PANEL_REFS_REL =
+  'tools/xray/test/day8/re_frame2_xray/panel_enum_spec_refs.clj';
+const XRAY_MATRIX_REL =
+  'tools/xray/test/day8/re_frame2_xray/coverage_matrix_metadata_test.clj';
+
+test('the Xray spec files the panel-enum guard reads arm cljs_node_test (rf2-6ng7)', () => {
+  const source = fs.readFileSync(path.join(REPO_ROOT, XRAY_PANEL_REFS_REL), 'utf8');
+  const specFiles = defVectorStrings(source, 'spec-files', XRAY_PANEL_REFS_REL);
+  assert.ok(
+    specFiles.length >= 2,
+    `${XRAY_PANEL_REFS_REL}: expected at least 2 spec-files, parsed ${specFiles.length} (${specFiles.join(', ')})`,
+  );
+  for (const rel of specFiles) {
+    assert.equal(
+      classify(rel).cljs_node_test,
+      'true',
+      `${rel} must arm cljs_node_test: panel-enum-spec-refs slurps it at macro-expansion time into panel_enum_guard_cljs_test.cljs, which the consolidated :node-test build compiles`,
+    );
+  }
+});
+
+test('the Xray spec files the coverage-matrix suite reads arm tools_jvm (rf2-6ng7)', () => {
+  const source = fs.readFileSync(path.join(REPO_ROOT, XRAY_MATRIX_REL), 'utf8');
+  // Segment vectors — `["tools" "xray" "spec" "<file>.md"]` — joined the way
+  // `(apply io/file (find-repo-root) rel)` resolves them.
+  const rels = ['matrix-spec-rel', 'insight-spec-rel'].map((defName) => {
+    const segs = defVectorStrings(source, defName, XRAY_MATRIX_REL);
+    assert.ok(
+      segs.length >= 2,
+      `${XRAY_MATRIX_REL}: ${defName} parsed ${segs.length} segments (${segs.join(', ')})`,
+    );
+    return segs.join('/');
+  });
+  for (const rel of rels) {
+    assert.equal(
+      classify(rel).tools_jvm,
+      'true',
+      `${rel} must arm tools_jvm: coverage-matrix-metadata-test slurps it, and jvm-tools-xray is the only job that runs it`,
+    );
+  }
+});
+
+test('Story spec markdown stays cheap (rf2-6ng7 negative control)', () => {
+  // The guard the Xray arm narrows is still doing its job on the other half:
+  // Story's spec prose has no counterpart reader inside test.yml, so it must
+  // still classify to nothing at all.
+  const verdicts = classify('tools/story/spec/API.md');
+  for (const output of ['tools_jvm', 'cljs_node_test', 'mcp_conformance', 'template_expensive']) {
+    assert.equal(
+      verdicts[output],
+      'false',
+      `tools/story/spec/API.md must not arm ${output} — no test.yml suite reads Story's spec markdown`,
+    );
+  }
+});
+
+// --- the setup skill's reference snippets ----------------------------------
+//
+// `setup-skill-scaffold-compiles-test` materialises a whole scaffold out of
+// the fenced blocks in one directory and compiles it. That suite runs in
+// `jvm-tools-template` under `template_expensive`, and the directory armed
+// only `skills_structural` — a shape guard, which cannot tell whether the
+// snippets still compile.
+
+const TEMPLATE_EMITTED_REL =
+  'tools/template/test/day8/re_frame2_template/emitted_test_run_test.clj';
+
+test('the setup skill reference snippets arm template_expensive (rf2-6ng7)', () => {
+  const source = fs.readFileSync(path.join(REPO_ROOT, TEMPLATE_EMITTED_REL), 'utf8');
+  const m = source.match(
+    /\(def\s+\^:private\s+skill-setup-refs[\s\S]{0,400}?\(io\/file\s+\(repo-root\)\s+"([^"]+)"\)/,
+  );
+  assert.ok(
+    m,
+    `${TEMPLATE_EMITTED_REL} must still resolve skill-setup-refs from a repo-relative literal`,
+  );
+  const dir = m[1];
+  assert.ok(
+    dir.startsWith('skills/'),
+    `${TEMPLATE_EMITTED_REL}: skill-setup-refs resolved to "${dir}", which is not a skills path`,
+  );
+  for (const probe of [`${dir}/rf2_6ng7_probe.md`, `${dir}/nested/rf2_6ng7_probe.md`]) {
+    assert.equal(
+      classify(probe).template_expensive,
+      'true',
+      `${probe} must arm template_expensive: setup-skill-scaffold-compiles-test materialises the scaffold from ${dir} and compiles it, and jvm-tools-template is the only job that runs that suite`,
+    );
+  }
+});
+
+test('the rest of the setup skill stays off template_expensive (rf2-6ng7 negative control)', () => {
+  assert.equal(
+    classify('skills/re-frame2-setup/SKILL.md').template_expensive,
+    'false',
+    'skills/re-frame2-setup/SKILL.md is not materialised into the scaffold — it must not queue the emitted-app compile',
+  );
+});
+
+test('the jobs these arms reach are still gated on the armed outputs (rf2-6ng7)', () => {
+  // The third leg, the one no arming test can supply: arming an output binds
+  // nothing unless the job running the suite is still gated on that output.
+  // (`jvm-ui` / `implementation_jvm` is already pinned by the rf2-61ar test
+  // above, so it is not restated here.)
+  const workflow = fs.readFileSync(WORKFLOW, 'utf8');
+  for (const [job, output] of [
+    ['jvm-tools-xray', 'tools_jvm'],
+    ['cljs', 'cljs_node_test'],
+    ['jvm-tools-template', 'template_expensive'],
+  ]) {
+    assert.match(
+      jobBlock(workflow, job),
+      new RegExp(`if: needs\\.detect_changed_surfaces\\.outputs\\.${output} == 'true'`),
+      `${job} must stay gated on ${output}, or arming it schedules nothing`,
+    );
+  }
 });
 
 let failed = 0;


### PR DESCRIPTION
Closes rf2-6ng7 (the bounded audit) and files rf2-cujx (the one mismatch this PR does not fix).

## What the ruling asked for

Option **(c)-narrow** plus the pin-your-arming codicil: ONE bounded audit of gates with **non-local input edges** — roster, glob, source-walk, manifest, cross-tree read — not all ~80 conditional jobs. Each mismatch gets the cheapest local repair, and every repair pins its own arming in a harness that already exists, in the same patch.

## The audit

Three arming layers gate this repo's PR-time checks, and all three were walked:

1. `.github/scripts/report-changed-surfaces.sh` → 32 boolean outputs → ~80 `if:`-gated jobs in `test.yml`
2. `docs.yml`'s `detect` job → the `docs_surface` `case` glob → 2 conditional jobs
3. `lint.yml`'s `detect` job → the `lint_surface` `case` glob → 2 conditional jobs

Edges were found by their signatures, per the brief: `slurp` / `file-seq` / `.listFiles` over another tree, segment-vector path constants, repo-root walks, cross-tree classpaths, external fixture rosters and workflow-owned target lists. Jobs with **no** `if:` (portability.yml, freehand-conformance.yml, `verify-skill-mcp-drift`, `verify-readme-links`, `js-harness-self-tests`, the two hicasso static gates) are armed unconditionally and cannot exhibit the defect, so they were confirmed unconditional and then set aside. `expensive-tests.yml` is nightly and gates no merge.

### Every audited edge

`probe` = `bash .github/scripts/report-changed-surfaces.sh <path>`, measured at `d70b671b7b`.

| gate | input root(s) | scheduled job (gating output) | probe before | after |
|---|---|---|---|---|
| route-path census (rf2-w9ip) | `examples/`, `implementation/hicasso/test/`, `testbeds/` | `jvm-routing` (`implementation_jvm`) | **true** | true |
| prose roster (rf2-61ar) | `docs/machines/*.md`, `docs/core/freehand/*.md`, `docs/api/re-frame.{adapter.uix,ssr}.md`, `docs/design/hicasso/product/async-routing-recipes.md`, `spec/*` | jvm-core / -machines / -ui / -ssr / -freehand / -routing (`implementation_jvm`) | true | true |
| CLJS conformance corpus | `spec/conformance/fixtures/**` | `cljs` (`cljs_node_test`) | true | true |
| api-manifest CLJS probe | `spec/api-manifest.edn`, `spec/API.md` | `cljs` (`cljs_node_test`) | true | true |
| story-mcp prose catalogue | `tools/story-mcp/spec/API.md` | `jvm-tools-story-mcp` (`tools_jvm`) | true | true |
| playground SCI bundle | `implementation/{core,adapters/reagent-slim,machines,flows}` | `tools-playground` (`playground`) | true | true |
| xray feature-matrix gate | `tools/xray/testbeds/feature_matrix/scenarios.cjs` | `story-xray-browser` (`story_xray_browser`) | true | true |
| template repo-split / emission | `tools/template/spec/*.md` | `jvm-tools-template` (`template_expensive`) | true | true |
| pair-skill preload | `skills/re-frame2-pair/preload/**` | `cljs-examples-compile` (`examples_compile`) | true | true |
| `check_doc_slugs.py` | `docs/`, `spec/`, `migration/`, `mkdocs*` | docs `build` (`docs_surface`) | in list | in list |
| `check_ep_status_sync.py` | `docs/EP/**` | docs `build` (`docs_surface`) | in list | in list |
| `check_runtime_subsystem_grading.py` | `spec/Conventions.md`, `spec/Runtime-Subsystems.md` | docs `build` (`docs_surface`) | in list | in list |
| `check_failure_corpus_residue.py` | `docs/core/errors.md`, `testbeds/**` | docs `build` (`docs_surface`) | in list | in list |
| `check_retired_composition_vocab.py` | `docs/{EP,api,core}`, `tools/*/spec`, root-support `.md`, JVM roster scripts | docs `build` (`docs_surface`) | in list | in list |
| `check_retired_image_keys.py` | `docs/{EP,api,core,cljs,spec}`, `tools/*/spec` | docs `build` (`docs_surface`) | in list | in list |
| `check_provenance_pins.py` | `docs/design/hicasso/**` | docs `provenance-pins` (`docs_surface`) | in list | in list |
| api-manifest's six checkers | `spec/API.md`, `spec/api-manifest*.edn`, `spec/Privacy.md`, `docs/{api,story/api,core}`, `docs/*/concepts.md`, `skills/`, `tools/{story,xray}/spec/API.md` | `api-manifest` (`lint_surface`) | in list | in list |
| Splint | `implementation`, `tools`, `examples`, `testbeds` | `splint` (`lint_surface`) | in list | in list |
| **shadow-config contract** | `implementation/shadow-cljs.edn`, `implementation/package.json`, `examples/ui/minimal-counter/deps.edn`, `skills/re-frame2-setup/references/shadow-cljs.md` | `jvm-ui` (`implementation_jvm`) | **false ×4** | **true ×4** |
| **xray coverage-matrix** | `tools/xray/spec/017-Test-Coverage-Matrix.md`, `019-Cross-Cutting-Insight.md` | `jvm-tools-xray` (`tools_jvm`) | **false** | **true** |
| **xray panel-enum guard** | `tools/xray/spec/007-UX-IA.md`, `008-Embedding-Contract.md` | `cljs` (`cljs_node_test`) | **false** | **true** |
| **setup-skill scaffold compile** | `skills/re-frame2-setup/references/**` | `jvm-tools-template` (`template_expensive`) | **false** | **true** |
| **`check_inject_cofx_residue.py`** | `docs/core`, `docs/api`, `spec`, **`skills`** | docs `build` (`docs_surface`) | **`skills` not in list** | **job is unconditional** |
| **jvm-core source walks** | `tools/**/src`, `implementation/hicasso/src`, `implementation/ssr-node/src` | `jvm-core` (`implementation_jvm`) | **false ×3** | **filed as rf2-cujx** |

**Mismatch count: 6.** Five fixed here, one filed. That is well under the ~a-dozen reconsideration trigger, so **option (a) is not reopened** and no follow-up recommending it is filed.

## The five fixes, and why each is the cheapest local repair

**1. The re-frame.ui shadow-configuration contract (`jvm-ui`).** `shadow_config_contract_jvm_test.clj` spells no literal expected value by design — the expected value *is* four real holders, read at run time and compared as data. None of the four armed `implementation_jvm`, the only output gating the job that runs it. Repaired with a per-file predicate beside `is_route_path_census_input`, for the same reason that one is a predicate: all four paths already have arms in the big `case`, so an arm after them is shadowed and an arm before them would silently narrow what they set. `examples/*` does arm the tier via the census predicate — but only for `.cljs`/`.cljc`, and the scaffold holder is a `deps.edn`.

**2 + 3. The Xray spec markdown (`jvm-tools-xray`, `cljs`).** The classifier's spec-md guard (rf2-f79t8) excused `tools/{story,xray}/spec/**.md` from every probe, on the stated premise that spec prose "cannot affect any runtime, any JVM unit test, or any MCP wire surface". For the Xray half that premise is false: `coverage_matrix_metadata_test.clj` slurps two of those files as its expected value, and `panel_enum_spec_refs.clj` slurps two more at macro-expansion time into a test the `:node-test` build compiles. The guard is **narrowed, not repealed** — `mcp_conformance`, `template_expensive` and `story_xray_browser` stay off (markdown still cannot change an MCP wire surface or a compile), and the Story half stands, because its only reader is api-manifest's `story_spec_check`, which runs in lint.yml where `tools/*` already arms it.

The tree, not the four filenames: naming them in the classifier would be a second copy of a roster that already lives in the two suites.

**4. The setup skill's reference snippets (`jvm-tools-template`).** `setup-skill-scaffold-compiles-test` materialises a whole scaffold out of the fenced blocks in `skills/re-frame2-setup/references/` and runs `clojure -M:shadow compile app` over it. That tree armed only `skills_structural` — a *shape* guard, which cannot tell whether the snippets still compile. Armed `references/` alone; `SKILL.md` and `tests/` are not materialised and have no business queueing an emitted-app compile.

**5. `check_inject_cofx_residue.py` (docs `build`).** It scans four roots and one of them, `skills`, is on neither `docs.yml` path list — so a skills-only PR reintroducing a live `(rf/inject-cofx …)` snippet ran the gate nowhere. Widening `docs_surface` to `skills/**` would buy that with a ~15-minute MkDocs build on every skills PR. Instead the gate moved to test.yml's always-on `verify-skill-mcp-drift` job, where ~0.3s of pure-stdlib Python cannot be skipped past at all — remedy shape 1 in the ruling's toolkit, the same one the hicasso complaint-catalogue and budget-ledger gates took. Its two `docs.yml` path entries left with it, and `check_ci_reproduce_commands.py` confirms the new step ids parse.

## The codicil: every fix pins its own arming, in the same patch

`implementation/scripts/_changed-surfaces.test.cjs` (always-on `js-harness-self-tests`, and in the local spine) gains seven assertions. Every roster is **read out of the gate's own source**, never restated — a restated list is a second thing to keep in step, which is the disease this bead is about:

- holders parsed from `(def ^:private <name>-rel "…")` in the contract suite, with `root-marker-rel` excluded by name (it is the repo-root locator, "deliberately not a compared holder") and pinned by a negative control that it stays cheap;
- the panel-enum `spec-files` vector and the coverage-matrix `matrix-spec-rel` / `insight-spec-rel` segment vectors, parsed with the same string/comment-aware scan `censusAppRoots` uses;
- the reference directory parsed from `skill-setup-refs`, probed at the top level and one level down;
- negative controls: Story spec markdown stays all-false, `skills/re-frame2-setup/SKILL.md` stays off `template_expensive`, `AGENTS.md` stays off `implementation_jvm`;
- the third leg — `jvm-tools-xray`, `cljs` and `jvm-tools-template` are still gated on the outputs now armed, because arming an output binds nothing if the job stops reading it.

Each parse refuses to pass vacuously (a floor on the count it parsed). **Add a holder or a spec file over there and this reds here until the classifier catches up.**

## rf2-w9ip verified, not rebuilt

Its guard holds. `implementation/hicasso/test/foo.cljs`, `examples/foo/src/app.cljs` and `testbeds/foo/src/app.cljs` all probe `implementation_jvm=true`; the guard reads `app-roots` out of the census source, pins the `#"\.clj[sc]$"` filter, asserts the arm for every root it parses, refuses to pass on fewer than three, and pins `jvm-routing`'s gating. Nothing here touches it. Its design is the model the four new pins copy.

## What was NOT built, and why

- **No universal input-declaration checker.** Rejected by the ruling as a second hand-maintained model with the same rot mode, and the mismatch count (6) is nowhere near the ~dozen that would reopen it.
- **No new surface predicate, output, registry or manifest.** Every repair reuses an output that already exists and a harness that already exists. A remedy that introduces a second thing to keep in step is the disease — the argument instance 4's worker made, verified at source here: `scripts/test-fast-pr.sh` does gate its JVM tier on `implementation_jvm`, so a second output would have to be taught to the spine and then held in step with the classifier.
- **The `jvm-core` source-walk edge is filed, not fixed** (rf2-cujx). Four repo-wide walking suites in `implementation/core/test/` cover `tools/**/src`, `implementation/hicasso/src` and `implementation/ssr-node/src` — three roots that arm nothing for `jvm-core`, while every other implementation artefact's `src` arms it. The cheap repair queues the whole 22-job JVM tier on every edit to two of the busiest trees in the repo, and the alternative splits one invariant across two homes. That is a cost ruling, not a mechanism, and it belongs to the operator.
- **One observation, deliberately not filed:** `doc_api_check.clj`'s docstring claims per-capability `docs/<cap>/api.md` files "are scanned by a one-level glob", and `dir-surfaces` lists only `docs/api/` and `docs/story/api/`. It is a stale docstring rather than an arming defect — the gate does not read those files, so nothing is unarmed. Minutiae; recorded here rather than turned into work.

## Required-check band

**The band does not move: it stays at 93.** No job was added, removed or renamed. Two steps moved from `docs.yml`'s `build` job into `test.yml`'s `verify-skill-mcp-drift` job; both jobs already existed and both are already required. Arming changes never move the band on their own — a skipped job still reports a check.

## Quality gates

Run from `C:/Users/miket/code/re-frame2-worktrees/gatearm-6ng7`, on the rebased base. Each exit code is the runner's own, captured with `echo $? > …exit` on the same command line, never a harness report.

| gate | exit | evidence |
|---|---|---|
| `node implementation/scripts/_changed-surfaces.test.cjs` | **0** | `changed-surfaces tests: 348 passed.` |
| `python scripts/check_gate_scheduling.py --verbose` | **0** | `51 gate commands, 43 scheduled, 8 declared (0 … known holes with beads)` |
| `python scripts/check_fast_pr_gap.py` | **0** | `fast-PR gap map clean: 85 required jobs across 3 workflows` |
| `python scripts/check_ci_reproduce_commands.py --verbose` | **0** | lists `check_inject_cofx_residue` with its real `run:` line |
| `python scripts/check_readme_links.py --ci` | **0** | clean |
| `python scripts/check_inject_cofx_residue.py --self-test --verbose` | **0** | `all 9 self-tests passed.` |
| `python scripts/check_inject_cofx_residue.py --verbose` | **0** | `no live retired-spelling residue on the teaching surface.` |
| `sh scripts/test-fast-pr.sh` | **0** | `PASS fast PR spine` |

`check_gate_scheduling.py` and `check_fast_pr_gap.py` are the two the bead names as the checks that do **not** ask this bead's question; they were run anyway, so this change does not break them.

### The pins were proved by planted faults, not by reading

The gates here classify paths, so a green proves nothing on its own. Three faults were planted in `report-changed-surfaces.sh` simultaneously — the skill holder renamed to a path that does not exist, the xray `tools_jvm=true` flipped to `false`, the references arm narrowed to a subdirectory — and the harness came back **exit 1** naming exactly what was planted:

```
FAIL every shadow-config contract holder arms implementation_jvm (rf2-6ng7)
  skills/re-frame2-setup/references/shadow-cljs.md (skill-rel) must arm implementation_jvm …
FAIL the Xray spec files the coverage-matrix suite reads arm tools_jvm (rf2-6ng7)
  tools/xray/spec/017-Test-Coverage-Matrix.md must arm tools_jvm …
FAIL the setup skill reference snippets arm template_expensive (rf2-6ng7)
  skills/re-frame2-setup/references/rf2_6ng7_probe.md must arm template_expensive …
```

The faults existed only in this worktree, so a run that had wandered into another checkout would have come back green. Restored and verified by `git hash-object` against the committed object (`b5c6243ce6c…`, identical), not by reading a diff.

### Behavioural before/after, quoted

Before (at `d70b671b7b`):

```
implementation/shadow-cljs.edn                    implementation_jvm=false
implementation/package.json                       implementation_jvm=false
examples/ui/minimal-counter/deps.edn              implementation_jvm=false
skills/re-frame2-setup/references/shadow-cljs.md  implementation_jvm=false
tools/xray/spec/007-UX-IA.md                      <every output false>
tools/xray/spec/017-Test-Coverage-Matrix.md       <every output false>
skills/re-frame2-setup/references/first-counter.md  template_expensive=false
```

After:

```
implementation/shadow-cljs.edn                     implementation_jvm=true
implementation/package.json                        implementation_jvm=true
examples/ui/minimal-counter/deps.edn               implementation_jvm=true
skills/re-frame2-setup/references/shadow-cljs.md   implementation_jvm=true  template_expensive=true
tools/xray/spec/007-UX-IA.md                       tools_jvm=true  cljs_node_test=true
tools/xray/spec/017-Test-Coverage-Matrix.md        tools_jvm=true  cljs_node_test=true
skills/re-frame2-setup/references/first-counter.md template_expensive=true
skills/re-frame2-setup/SKILL.md                    template_expensive=false   (negative control)
tools/story/spec/API.md                            <every output false>       (negative control)
```

And rf2-w9ip's arm, re-measured on this branch, unchanged:

```
implementation/hicasso/test/foo.cljs   implementation_jvm=true
examples/foo/src/app.cljs              implementation_jvm=true
testbeds/foo/src/app.cljs              implementation_jvm=true
```
