### PR TITLE
fix(hicasso): a positive control for walk_profile_app, named ceilings on the bare element-waits (rf2-1huc, rf2-vinj); rf2-cujx refused

### DIFF
--- a/implementation/freehand/test/re_frame/bench/hicasso/jsfb_ours_run.cjs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/jsfb_ours_run.cjs
@@ -623,7 +623,9 @@ async function main() {
     for (const arm of ARMS) {
       const p = await browser.newPage();
       await p.goto(url(arm), { waitUntil: 'load', timeout: NAV_TIMEOUT_MS });
-      await p.waitForSelector('#run');
+      // The navigation's own ceiling, not Playwright's anonymous 30s: this
+      // wait is the same page load as the goto above it (rf2-vinj).
+      await p.waitForSelector('#run', { timeout: NAV_TIMEOUT_MS });
       await click(p, '#run');
       await expectRows(p, 1000);
       html[arm] = await p.$eval('#main', canonicalise);

--- a/implementation/freehand/test/re_frame/bench/hicasso/walk_profile_app.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/walk_profile_app.cljs
@@ -116,6 +116,16 @@
      per-prop regex), the reserved-name set lookup vs a primitive
      comparison chain, `cached-parse` hit vs `parse-tag` fresh,
      `convert-prop-value` over the page's own values, `createElement`.
+  5. POSITIVE CONTROL — whether the instrument saw a change its own
+     arithmetic predicts, adjudicated per round and printed pass or fail.
+     [[tag-cache-floor-row]] prices `parse-raw`'s extra parses out of
+     table 4 and requires the arms table to show at least that much;
+     [[lazy-tail-direction-row]] requires the one by-construction
+     ordering whose margin is big enough to assert. A failure sets
+     `window.HICASSO_CONTROL_FAILED` and `run.cjs` exits 1 (rf2-1huc —
+     before it, that exit path was dead for this arm, so tables 1-4 were
+     guarded against ordering and page fidelity but not against the
+     instrument having signal at all).
 
   Owner bead: rf2-y1jkm. Driver: `run.cjs` with
   HICASSO_INIT_FN=re-frame.bench.hicasso.walk-profile-app/-main."
@@ -720,6 +730,157 @@
          "  (" (fmt (* 1e6 (/ d elements)) 0) " ns/el, "
          (fmt (* 100 (/ d ship-p50)) 1) "% of ship)")))
 
+;; ---------------------------------------------------------------------------
+;; The positive control (rf2-1huc)
+;; ---------------------------------------------------------------------------
+;;
+;; Until rf2-1huc this arm had none, so `run.cjs`'s `HICASSO_CONTROL_FAILED`
+;; exit path was dead here: the run was guarded against ORDERING
+;; (`lane/guard!`, exit 2) and against PAGE FIDELITY ([[parity!]], fatal) but
+;; not against the instrument HAVING SIGNAL AT ALL. A run whose ablations had
+;; stopped biting would still print a full table and exit 0.
+
+(defn- round-p50
+  "Arm `id`'s p50 in ms per WALK inside ONE round.
+
+  [[arm-rows]] pools every round before summarising, which is the right
+  fold for a reported figure and the wrong one for a control: pooling is
+  exactly how a good round vouches for a bad one."
+  [round id]
+  (:p50 (lane/summarise (mapv #(/ % walks-per-sample) (get round id)))))
+
+(defn- per-round-delta
+  "`hi` minus `lo` in ms per walk, one number per round."
+  [readings hi lo]
+  (mapv (fn [r] (- (round-p50 r hi) (round-p50 r lo))) readings))
+
+(def ^:private control-slack
+  "How far BELOW its predicted floor the tag-cache delta may sit and still
+  count as the instrument having seen what it predicts.
+
+  Wider than the arithmetic's own error because the claim is `THE
+  INSTRUMENT HAS SIGNAL`, not `THE MODEL IS EXACT`; narrow enough that an
+  instrument reading near zero — the failure this exists to catch —
+  cannot clear it. Measured headroom is a factor of ~2 (see
+  [[tag-cache-floor-row]]), so the bar sits far from both edges."
+  0.25)
+
+(defn tag-cache-floor-row
+  "THE CONTROL: `parse-raw` must cost at least what the page's own tag
+  parses cost, as this run's OWN micro table prices them.
+
+  `parse-raw` differs from `local` at exactly one site — [[walk-parse]]
+  calls `codec/parse-tag` fresh where `local` calls `codec/cached-parse`
+  — and it does so once per native element. The MICRO table times both
+  primitives over [[collect-roster]]'s tags, which is that same
+  population, element for element. So the extra work `parse-raw` does per
+  walk is predicted, before its clock is read, as
+
+      n-tags x (parse-tag-fresh - cached-parse-hit)
+
+  ## Why a FLOOR and not a band
+
+  The bead's candidate was `lane/control-verdict` — a two-sided band
+  around this prediction. Costed rather than assumed, it does not hold:
+  the micro loop is the CHEAPEST possible arrangement of the same calls
+  (one warm array, one call site, no allocation surviving the loop),
+  while in the walk each fresh parse allocates an object the element then
+  keeps. The walk-embedded cost is therefore bounded BELOW by the micro
+  cost and not estimated by it, and it measures about twice it — 2.11x on
+  this bead's calibration run, 1.81x on the 2026-08-14 re-take. A
+  two-sided +/-slack band wide enough to contain 2x has its LOWER edge
+  below zero, which is a control that cannot fail. One-sided is what the
+  arithmetic actually supports, so one-sided is what this asserts.
+
+  The population equality is checked rather than assumed: a roster that
+  is not the walk's parse population makes the prediction per-tag over
+  the wrong tags, and the number would still look plausible.
+
+  ## Why EVERY ROUND and not an overlap
+
+  `lane/control-verdict` passes a control whose measured range merely
+  OVERLAPS the band, and its own docstring records that as a KNOWN DEFECT
+  against `hd8-rows/positive-control!`'s every-round-inside rule, needing
+  an operator ruling because tightening it re-adjudicates a published
+  row. This control is NEW, so it has no published row to re-adjudicate
+  and inherits none of that: it takes the stricter rule from birth, the
+  way `hd8-rows` did and for the reason `hd8-rows` gives — a control
+  whose worst round is wrong has caught something."
+  [readings census ^js tags micro]
+  (let [m       (into {} micro)
+        fresh   (:parse-tag-fresh m)
+        hit     (:cached-parse-hit m)
+        n-tags  (.-length tags)
+        parses  (:native census)
+        floor   (/ (* n-tags (- fresh hit)) 1e6)
+        bar     (* floor (- 1.0 control-slack))
+        deltas  (per-round-delta readings :parse-raw :local)
+        worst   (apply min deltas)
+        same?   (= n-tags parses)]
+    {:row        :tag-cache-floor
+     :predicted  (lane/round4 floor)
+     :bar        (lane/round4 bar)
+     :slack      control-slack
+     :population {:micro-roster n-tags :walk-parses parses}
+     :per-round  (mapv lane/round4 deltas)
+     :worst      (lane/round4 worst)
+     :ok?        (and same? (>= worst bar))
+     :why        (cond
+                   (not same?)
+                   (str "the micro roster holds " n-tags " tags but the walk parses "
+                        parses " — the prediction is per-tag over the roster, so a "
+                        "roster that is not the walk's parse population prices the "
+                        "wrong thing and no figure in this run is reportable")
+
+                   (>= worst bar)
+                   (str n-tags " parses x " (fmt (- fresh hit) 1) " ns fresh-minus-cached "
+                        "= floor " (fmt floor 4) " ms/walk, bar " (fmt bar 4)
+                        " at -" (fmt (* 100 control-slack) 0) "%; worst round "
+                        (fmt worst 4) " — every round clears it")
+
+                   :else
+                   (str n-tags " parses x " (fmt (- fresh hit) 1) " ns fresh-minus-cached "
+                        "= floor " (fmt floor 4) " ms/walk, bar " (fmt bar 4)
+                        "; worst round " (fmt worst 4) " is BELOW it. The walk cannot "
+                        "see the cost of work it is demonstrably doing, so no phase "
+                        "delta in this run is reportable"))}))
+
+(defn lazy-tail-direction-row
+  "The other prediction that needs no clock to state: `ship-lazy` walks
+  the same page as `ship` and realizes the body's lazy tail INSIDE the
+  window as well, so it does strictly more work, so it must read higher —
+  in every round, not on the pooled median.
+
+  `no-propless` is the third arm that does more work by construction and
+  it is deliberately NOT asserted here. There is no arithmetic that
+  predicts what the propless short-circuit is worth, so the only
+  available rule is a bare direction test on a margin measured at ~5% of
+  `local` — inside the arm-order guard's own 10% tolerance. A refusal
+  that fires on noise is not a control, and this instrument would rather
+  carry two checks that bite than three of which one cries."
+  [readings]
+  (let [deltas (per-round-delta readings :ship-lazy :ship)
+        worst  (apply min deltas)]
+    {:row       :lazy-tail-direction
+     :per-round (mapv lane/round4 deltas)
+     :worst     (lane/round4 worst)
+     :ok?       (pos? worst)
+     :why       (if (pos? worst)
+                  (str "ship-lazy above ship in all " (count deltas)
+                       " rounds, worst margin " (fmt worst 4) " ms/walk")
+                  (str "ship-lazy did NOT read above ship in every round (worst "
+                       (fmt worst 4) " ms/walk) — the lazy arm does strictly more "
+                       "work than the eager one by construction, so an inversion "
+                       "means the window is not pricing the walk"))}))
+
+(defn- control-report!
+  "Print every control row, passing or not. A control quoted only when it
+  passes is not a control."
+  [rows]
+  (js/console.log ";; ==== POSITIVE CONTROL (does this instrument see a change it predicts?) ====")
+  (doseq [{:keys [row ok? why]} rows]
+    (js/console.log (str ";;   " (name row) ": " (if ok? "ok" "FAILED") " — " why))))
+
 (defn ^:export -main []
   (rf/init! uix-adapter/adapter)
   (lane/leave-act-environment!)
@@ -745,7 +906,12 @@
                   gv   (lane/guard! samples "walk-profile arms (in-page ms, diagnostic)")
                   ship (:p50 (get rows :ship))
                   local (:p50 (get rows :local))
-                  micro (micro-table roster)]
+                  micro (micro-table roster)
+                  ;; AFTER the micro table, because the control's prediction
+                  ;; is made out of it — this run's own per-tag prices, not a
+                  ;; constant carried from a previous one.
+                  control [(tag-cache-floor-row readings cs (:tags roster) micro)
+                           (lazy-tail-direction-row readings)]]
               (lane/record! :walk-profile-census cs)
               (lane/record! :walk-profile-arms
                             (into {} (map (fn [[k v]] [k (-> v (update :min lane/round4)
@@ -753,6 +919,7 @@
                                                              (update :p50 lane/round4))])) rows))
               (lane/record! :walk-profile-micro
                             (into {} (map (fn [[k v]] [k (lane/round4 v)])) micro))
+              (lane/record! :walk-profile-control control)
               (js/console.log ";; ==== WALK PROFILE (ms per whole-page walk; diagnostic in-page clock) ====")
               (js/console.log (str ";;   elements " elements
                                    "  walks/sample " walks-per-sample
@@ -783,8 +950,13 @@
               (js/console.log ";; ==== MICRO (ns/op over the page's own literal roster) ====")
               (doseq [[k v] micro]
                 (js/console.log (str ";;   " (name k) ": " (fmt v 1) " ns")))
+              (control-report! control)
               (when (:refuse? gv)
                 (set! (.-HICASSO_GUARD_REFUSED js/window) true))
+              ;; `run.cjs` turns this into exit 1. Until rf2-1huc nothing in
+              ;; this file ever set it, so that exit was unreachable here.
+              (when-not (every? :ok? control)
+                (set! (.-HICASSO_CONTROL_FAILED js/window) true))
               (lane/done!)))))
       (.catch (fn [e]
                 (lane/fail! (or (some-> e .-message) (str e)))

--- a/implementation/freehand/test/re_frame/bench/hicasso/walk_profile_control_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/walk_profile_control_cljs_test.cljs
@@ -1,0 +1,149 @@
+(ns re-frame.bench.hicasso.walk-profile-control-cljs-test
+  "THE WALK PROFILE'S POSITIVE CONTROL MUST REFUSE — pinned (rf2-1huc).
+
+  `walk_profile_app` had no positive control at all until rf2-1huc: it
+  never set `window.HICASSO_CONTROL_FAILED`, so `run.cjs`'s control exit
+  path was dead for this arm and a run whose ablations had stopped biting
+  would still print a full table and exit 0.
+
+  The control now exists, and it was proven against a planted fault —
+  `walk-parse` at `M-PARSE-RAW` swapped back to `codec/cached-parse`, so
+  the arm did exactly the work `local` does. `parse-raw`'s p50 collapsed
+  onto `local`'s, the per-round deltas went to ~0 with one NEGATIVE, and
+  the driver exited 1. That is the proof the exit path is live; it is not
+  a proof anyone will repeat, because it costs an `:advanced` build and a
+  Chromium run.
+
+  So the RULE is pinned here instead, in the always-on `cljs-test$` gate,
+  over synthetic readings. What that buys is narrow and specific: a later
+  worker cannot quietly weaken the adjudication — the failure mode this
+  whole bead is about — without going red in a suite that costs nothing.
+
+  ## The one assertion that carries the design
+
+  [[strict-rule-beats-overlap]] is the reason this file is not merely
+  belt-and-braces. `lane/control-verdict`'s `:ok?` asks whether the
+  measured range OVERLAPS the band; the walk profile's control asks
+  whether EVERY ROUND clears the bar. Its own docstring records the
+  overlap rule as a KNOWN DEFECT reserved to an operator ruling
+  (rf2-egdaq / rf2-2rtt6.1), so this control could not adopt it and could
+  not tighten it either. It took the stricter rule from birth instead —
+  legal precisely because it is NEW and has no published row to
+  re-adjudicate.
+
+  That test drives ONE dataset through BOTH rules and asserts they
+  disagree on it: overlap passes, every-round refuses. A worker who
+  \"simplifies\" the control down to `lane/control-verdict` therefore
+  discovers it here, rather than in a bench run six months later that
+  quietly stopped having teeth."
+  (:require [cljs.test :refer-macros [deftest is testing]]
+            [re-frame.bench.hicasso.lane :as lane]
+            [re-frame.bench.hicasso.walk-profile-app :as wp]))
+
+;; ---------------------------------------------------------------------------
+;; Fixtures — the shapes `-main` actually hands the control
+;; ---------------------------------------------------------------------------
+
+(def ^:private walks-per-sample
+  "`timed-walks` measures a window of K walks and the control divides by
+  K, so a fixture states ms-per-walk and is scaled up here. Kept in step
+  with the app's own constant by [[fixture-scaling-matches-the-app]]."
+  8)
+
+(defn- round
+  "One round's readings from a map of `{arm ms-per-walk}`. Three identical
+  samples, so each arm's p50 is exactly the number asked for and the
+  fixture says what it means."
+  [per-walk]
+  (into {} (map (fn [[id ms]] [id (vec (repeat 3 (* ms walks-per-sample)))])) per-walk))
+
+(def ^:private micro
+  "A micro table with the two rows the prediction is built from. 100 ns of
+  fresh-minus-cached over 1,000 tags is a floor of 0.1 ms/walk, so the
+  bar at the control's 25% slack is 0.075."
+  [[:cached-parse-hit 50.0] [:parse-tag-fresh 150.0]])
+
+(def ^:private census {:native 1000})
+(def ^:private roster (make-array 1000))
+
+(def ^:private floor-ms 0.1)
+(def ^:private bar-ms 0.075)
+
+(defn- healthy
+  "A round whose `parse-raw` sits well clear of the bar and whose
+  `ship-lazy` sits above `ship`."
+  [delta]
+  (round {:local 0.60 :parse-raw (+ 0.60 delta) :ship 0.50 :ship-lazy 1.50}))
+
+;; ---------------------------------------------------------------------------
+;; The fixture's own premises
+;; ---------------------------------------------------------------------------
+
+(deftest fixture-scaling-matches-the-app
+  (testing "the fixture scales by the same K the control divides by — a
+            drifted constant would silently move every bar below"
+    (let [rows (wp/tag-cache-floor-row [(healthy 0.20)] census roster micro)]
+      ;; 1000 tags x 100 ns = 0.1 ms; bar = 0.1 x (1 - 0.25).
+      (is (= floor-ms (:predicted rows)))
+      (is (= bar-ms (:bar rows)))
+      (is (= [0.2] (:per-round rows))
+          "0.2 ms/walk in, 0.2 ms/walk out — so the fixture's K is the app's K"))))
+
+;; ---------------------------------------------------------------------------
+;; The tag-cache floor
+;; ---------------------------------------------------------------------------
+
+(deftest an-instrument-with-signal-passes
+  (testing "every round comfortably above the floor"
+    (let [r (wp/tag-cache-floor-row [(healthy 0.20) (healthy 0.25) (healthy 0.18)]
+                                    census roster micro)]
+      (is (true? (:ok? r)))
+      (is (= 0.18 (:worst r))))))
+
+(deftest an-instrument-with-no-signal-refuses
+  (testing "the planted-fault shape: the ablation stops biting, so the
+            deltas collapse toward zero and the control must refuse"
+    (let [r (wp/tag-cache-floor-row [(healthy 0.01) (healthy 0.02) (healthy -0.01)]
+                                    census roster micro)]
+      (is (false? (:ok? r)))
+      (is (re-find #"BELOW it" (:why r))
+          "and says so in the terms the driver prints"))))
+
+(deftest strict-rule-beats-overlap
+  (testing "ONE dataset, TWO rules, opposite verdicts — this is why the
+            control does not call `lane/control-verdict` (rf2-egdaq)"
+    (let [readings [(healthy 0.20) (healthy 0.20) (healthy 0.03)]
+          strict   (wp/tag-cache-floor-row readings census roster micro)
+          ;; The same three rounds offered to the lane's overlap rule, as
+          ;; the `{:min :max :mean}` range it takes.
+          overlap  (lane/control-verdict floor-ms {:min 0.03 :max 0.20 :mean 0.1433} 0.25)]
+      (is (true? (:ok? overlap))
+          "the overlap rule PASSES it — a good round vouches for a bad one")
+      (is (false? (:ok? strict))
+          "the every-round rule REFUSES it, which is the whole difference")
+      (is (= 0.03 (:worst strict))))))
+
+(deftest a-roster-that-is-not-the-walks-parse-population-refuses
+  (testing "the prediction is per-tag over the micro roster, so a roster
+            that is not what the walk parses prices the wrong thing —
+            and every delta below is otherwise healthy"
+    (let [r (wp/tag-cache-floor-row [(healthy 0.20) (healthy 0.20)]
+                                    {:native 999} roster micro)]
+      (is (false? (:ok? r)))
+      (is (= {:micro-roster 1000 :walk-parses 999} (:population r))))))
+
+;; ---------------------------------------------------------------------------
+;; The lazy-tail direction
+;; ---------------------------------------------------------------------------
+
+(deftest the-lazy-arm-must-read-above-the-eager-one-in-every-round
+  (testing "ship-lazy does strictly more work than ship by construction"
+    (is (true? (:ok? (wp/lazy-tail-direction-row [(healthy 0.2) (healthy 0.2)])))))
+  (testing "a single inverted round refuses, even beside two good ones —
+            an inversion means the window is not pricing the walk"
+    (let [r (wp/lazy-tail-direction-row
+              [(healthy 0.2)
+               (round {:local 0.6 :parse-raw 0.8 :ship 1.50 :ship-lazy 1.40})
+               (healthy 0.2)])]
+      (is (false? (:ok? r)))
+      (is (= -0.1 (:worst r))))))

--- a/implementation/hicasso/testbed/spec.cjs
+++ b/implementation/hicasso/testbed/spec.cjs
@@ -850,6 +850,75 @@ async function waitForArm(page, predicate, arg, whatFailed) {
   }
 }
 
+const TESTBED_ROOT = '[data-testid="hicasso-controlled-testbed"]';
+
+/**
+ * Wait for the app to mount after a re-navigation, under the navigation's own
+ * ceiling, and fail with the one thing the bare wait could not say: WHICH of
+ * the two candidate mechanisms it was (rf2-vinj).
+ *
+ * A single webkit run of this section timed out here at Playwright's anonymous
+ * 30s, having taken about six seconds over the twelve sections before it. The
+ * bead that filed it left slow-versus-hung open, because it could not
+ * reproduce. Forty consecutive local webkit re-navigations, with the same
+ * multi-second idle gap the real section has, put this mount at p50 80ms and
+ * max 108ms with no stalls — so 30,000ms is not a slow mount, it is a stopped
+ * one. What it is NOT is a mechanism, and a ceiling cannot supply one.
+ *
+ * So the failure carries the page's own state at the moment the ceiling fires,
+ * chosen to separate the candidates rather than to describe the page:
+ *
+ *   no `bundle`, !`bundleRan`  main.js never arrived — the fetch stalled, and
+ *                              no ceiling on this line can repair that
+ *   `bundle` but !`bundleRan`  it arrived and never began executing
+ *   `bundleRan`, `appEmpty`    it executed and mounted nothing
+ *   !`appEmpty`, !`rootPresent`  something mounted, but not this testbed
+ *   `rootPresent`, zero box    the mount is fine; `waitForSelector` defaults
+ *                              to state 'visible', so THAT is what was waited
+ *                              on and the wait, not the page, is the bug
+ *   all present                the only reading on which it was merely slow
+ *
+ * `bundleRan` witnesses `shadow$provide`, which main.js declares on its FIRST
+ * line. It deliberately does not witness `window.__TB__`: the runner installs
+ * that via `addInitScript`, so it is present before the page's own script on
+ * every navigation and would report a bundle that never loaded as one that
+ * ran. That is not hypothetical — it is what the first cut of this asserted,
+ * and a 1ms-ceiling run caught it saying `appRan: true` about a document still
+ * in `readyState: 'loading'` with no bundle fetched at all.
+ *
+ * Whichever it is, the next occurrence closes the question instead of filing
+ * the bead again.
+ */
+async function waitForRemount(page, ctx) {
+  try {
+    await page.waitForSelector(TESTBED_ROOT, { timeout: ctx.navTimeoutMs });
+  } catch {
+    const at = await page.evaluate((sel) => {
+      const root = document.querySelector(sel);
+      const box = root && root.getBoundingClientRect();
+      const app = document.getElementById('app');
+      return {
+        readyState: document.readyState,
+        scriptTag: !!document.querySelector('script[src="main.js"]'),
+        bundle: performance.getEntriesByType('resource')
+          .filter((e) => e.name.endsWith('main.js'))
+          .map((e) => ({ ms: Math.round(e.duration), bytes: e.transferSize })),
+        bundleRan: typeof window.shadow$provide !== 'undefined',
+        appEmpty: !app || app.childNodes.length === 0,
+        rootPresent: !!root,
+        rootBox: box ? `${Math.round(box.width)}x${Math.round(box.height)}` : null,
+      };
+    }, TESTBED_ROOT).catch((err) => ({ evaluateFailed: String(err && err.message) }));
+    throw new Error(
+      `the testbed root did not mount within ${ctx.navTimeoutMs}ms of the ` +
+      're-navigation. This is the navigation\'s OWN ceiling and not the lane ' +
+      'budget that wraps the section, so the re-navigation is what failed. ' +
+      'The same mount measures p50 80ms locally, which is why this reads as ' +
+      'a stopped mount rather than a slow one — the state below says which ' +
+      `(rf2-vinj, and the docstring above reads it): ${JSON.stringify(at)}`);
+  }
+}
+
 async function armedEdgesAreWired(page, w, ctx) {
   const before = await page.evaluate(() => ({
     label: window.__TB__.el('armed').textContent,
@@ -902,6 +971,15 @@ async function armedEdgesAreWired(page, w, ctx) {
   // would apply an anonymous 30s default that no lane budget can reach — so a
   // missing ceiling REFUSES here rather than defaulting, which is the same
   // choice `examples/scripts/spec-helpers.cjs` makes for spec-side callers.
+  //
+  // AND SO DOES THE MOUNT-WAIT THAT FOLLOWS IT (rf2-vinj). It was bare until
+  // that bead, which made the paragraph above true of the `goto` and false of
+  // the line under it: `waitUntil` is `'commit'`, so the navigation is only
+  // half done when `goto` returns and the mount-wait is the other half of the
+  // SAME operation — yet it took Playwright's anonymous 30s while the goto
+  // took 60,000. One operation, two budgets, and the second one invisible in
+  // the source. That is the shape this comment already refuses; it just wore
+  // a name the sweep did not police, which is now fixed there too.
   const base = page.url().split('?')[0];
   if (typeof ctx.navTimeoutMs !== 'number') {
     throw new Error(
@@ -911,7 +989,7 @@ async function armedEdgesAreWired(page, w, ctx) {
   }
   await page.goto(`${base}?arm-ms=${ARM_MS}`,
     { waitUntil: ctx.navWaitUntil, timeout: ctx.navTimeoutMs });
-  await page.waitForSelector('[data-testid="hicasso-controlled-testbed"]');
+  await waitForRemount(page, ctx);
 
   const seed = await page.evaluate(() => window.__TB__.model().revision);
   await page.locator('[data-testid="arm-bump"]').click();

--- a/implementation/scripts/_navigation-ceiling-policy.test.cjs
+++ b/implementation/scripts/_navigation-ceiling-policy.test.cjs
@@ -72,17 +72,31 @@ const REPO_ROOT = path.resolve(__dirname, '..', '..');
 const { test, run } = createPolicyTestSuite('navigation-ceiling-policy');
 
 /*
- * Every Playwright navigation API that accepts `{ timeout }` and silently
- * defaults it. `goBack` / `goForward` / `waitForNavigation` have no call in the
- * repo today; they are listed because they are the same defect wearing a
- * different name, and the point of a sweep is to be there first.
+ * Every Playwright API that accepts `{ timeout }` and silently defaults it to
+ * 30s. `goBack` / `goForward` / `waitForNavigation` have no call in the repo
+ * today; they are listed because they are the same defect wearing a different
+ * name, and the point of a sweep is to be there first.
+ *
+ * `waitForSelector` IS THAT ARGUMENT COMING BACK (rf2-vinj). It is not a
+ * navigation, so the sweep did not police it, and the file's name still says
+ * navigation because that is what the six original sites were. But the defect
+ * this suite exists to remove was never "a navigation with no ceiling" — it is
+ * "an anonymous 30s that no lane knob can reach, whose failure line reads like
+ * the lane's own timeout so the fix reached for is a bigger lane timeout,
+ * which cannot move it". A bare element-wait is that, exactly, and unlike the
+ * three hypothetical names above it has actually cost a run: a webkit mount
+ * after a re-navigation in `hicasso/testbed/spec.cjs`, two lines under a
+ * `goto` that carried the ceiling correctly. Three call sites were bare when
+ * this was added and all three were fixed in the same change; the sweep is
+ * what stops a fourth.
  *
  * The lookbehind demands a RECEIVER (`page.goto(`, `dev.goto(`), which is what
  * separates a call from the string literal `'.goto('` that a sibling policy
  * suite scans with. `\s*` inside it tolerates a receiver left on the previous
  * line.
  */
-const NAV_METHODS = ['goto', 'reload', 'goBack', 'goForward', 'waitForNavigation'];
+const NAV_METHODS = ['goto', 'reload', 'goBack', 'goForward', 'waitForNavigation',
+  'waitForSelector'];
 const NAV_CALL_RE = new RegExp(
   `(?<=[\\w$\\)\\]]\\s*)\\.(${NAV_METHODS.join('|')})\\s*\\(`,
   'g',

--- a/tools/re-frame2-pair-mcp/test/live-e2e-fixture.cjs
+++ b/tools/re-frame2-pair-mcp/test/live-e2e-fixture.cjs
@@ -376,7 +376,10 @@ async function main() {
       undefined,
       { timeout: RUNTIME_PRELOAD_TIMEOUT_MS },
     );
-    await page.waitForSelector('#value');
+    // Same number as the two waits above, for the same reason: this is still
+    // the fixture coming up, and an unnamed ceiling here would be Playwright's
+    // anonymous 30s — a third budget for one operation (rf2-vinj).
+    await page.waitForSelector('#value', { timeout: RUNTIME_PRELOAD_TIMEOUT_MS });
     const initial = (await page.textContent('#value')) || '';
     assert(initial.trim() === '5', `fixture did not initialise to 5: got "${initial}"`);
 


### PR DESCRIPTION
Three beads filed last night by gates and a measurement window, each by a worker
who found it and deliberately did not fix it in flight. Two are fixed here; the
third is a refusal, and the refusal is the deliverable.

## rf2-1huc — `walk_profile_app` had no positive control

`run.cjs` exits 1 when a run sets `window.HICASSO_CONTROL_FAILED`. This arm never
set it, so that exit path was dead: the run was guarded against ORDERING
(`lane/guard!`, exit 2) and PAGE FIDELITY (twin parity, fatal) but not against the
instrument having signal at all. A run whose ablations had stopped biting would
print a full table and exit 0.

Two rows now, both adjudicated **per round**:

- **`tag-cache-floor`** — `parse-raw` differs from `local` at exactly one site and
  does so once per native element, and the micro table prices both primitives over
  that same population. So the extra work is predicted before its clock is read:
  `n-tags x (parse-tag-fresh - cached-parse-hit)`.
- **`lazy-tail-direction`** — `ship-lazy` does strictly more work than `ship` by
  construction, so it must read higher in every round.

**The bead's candidate was costed and rejected.** It proposed adapting
`lane/control-verdict` — a two-sided band around that prediction. The micro loop is
the cheapest possible arrangement of the same calls, so the walk-embedded cost is
bounded *below* by it rather than estimated by it, and measures about twice it
(2.11x on my calibration run, 1.81x on the 2026-08-14 re-take). A +/-band wide
enough to contain 2x has its lower edge **below zero** — a control that cannot
fail. One-sided is what the arithmetic supports, so one-sided is what it asserts.

**The rule is every-round, not overlap.** `lane/control-verdict`'s overlap rule is a
KNOWN DEFECT on its own docstring, reserved to an operator ruling because
tightening it re-adjudicates a published row. This control is new, has no published
row, and so takes the stricter rule from birth — the way `hd8-rows/positive-control!`
does, and citing it. Nothing published was touched, re-derived or restated.

`no-propless` is deliberately **not** asserted, and the docstring says why: no
arithmetic predicts what the propless short-circuit is worth, and its measured
margin sits inside the arm-order guard's own tolerance. A refusal that fires on
noise is not a control.

## rf2-vinj — the bare mount-wait: **HUNG, not slow**

The bead left slow-versus-hung open, deliberately, because it could not reproduce.
Established here as **hung**, on three readings:

1. **The CI artefact.** The stack puts the failure inside the spec's own wait, and
   the runner's buffered log for that engine carries **no pageerror**. The app did
   not throw, the `goto` succeeded, the mount never arrived.
2. **A measurement of the operation itself.** 40 consecutive local webkit
   re-navigations, with the same multi-second idle gap the real section has:
   **p50 80ms, max 108ms, zero stalls**. 30,000ms is 375x the median.
3. **The lane had budget.** The spec run is already wrapped in a 90,000ms
   `withTimeout` and only ~6s had been spent, so the anonymous ceiling is what
   ended it, not the lane.

What is **not** established is the mechanism — 0 stalls in 40 local trials. So the
ceiling is named *and* the failure is made self-diagnosing, because a bigger number
alone would leave the next occurrence exactly as uninformative as this one. On
timeout the wait now reports whether the bundle arrived, whether it began
executing, whether anything mounted, and whether the root is present-but-invisible
— which separates every candidate, including the one where `waitForSelector`'s
default `'visible'` state is itself the bug.

The ceiling is `ctx.navTimeoutMs`: under `waitUntil: 'commit'` the navigation is
only half done when `goto` returns and the mount-wait is the other half, which is
the section's own stated principle applied to the half it had not reached. It is
also strictly under the 90,000ms lane budget, so it fires first and names the call
site.

All three bare `waitForSelector` calls repo-wide are fixed, and the sweep now
polices the name. That is the sweep's own argument rather than a widening of it —
it already lists `goBack`/`goForward`/`waitForNavigation`, which have no call in the
repo, "because they are the same defect wearing a different name". This one has
actually cost a run.

## rf2-cujx — REFUSED: this is an operator ruling, and it is a bigger one than the bead asks

No code change. Every premise re-verified at the merge base and all reproduce.
The measurement that the ruling turns on, which the bead did not have — over the
120 most recent merged PRs (one PR is one CI run; the file lists were not
truncated, largest PR 22 files):

| | PRs | tier runs on |
|---|---|---|
| `implementation_jvm=true` today | 51 / 120 | 43% |
| + would flip under the bead's 3-root arm | +10 | **51%** |
| + would flip for the seventh instance's read set | +59 | **92%** |

The bead's own NOTES added a seventh instance, `observation_render_law_drift_test`,
whose census is `git ls-files` over every tracked `.md`/`.clj`/`.cljc`/`.cljs`. Its
read set is not three roots — it is the repository. **So the recommended repair
closes four suites and leaves the fifth open**, while the suites' docstrings and the
bead would both read as though the hole were shut. Today it is at least documented.

The real question is therefore not "arm two busy trees" (10 PRs in 120). It is:
does the repo-wide-walk family justify running the 22-job JVM tier on ~92% of PRs?
Each of the bead's three options — including (c), which decides to *accept* the
exposure — **is** that ruling. A fourth shape is named on the bead for completeness
and explicitly not implemented.

## Quality gates

Every number below is the exit code captured in the running shell, not one reported
about the run.

| gate | result |
|---|---|
| `test:hicasso-controlled` (chromium + firefox + webkit), final base | **exit 0** — PASS all three, 97 checks across 13 sections each (unchanged from CI's passing runs) |
| `scripts/_navigation-ceiling-policy.test.cjs` | **exit 0** — 4 passed |
| `test:cljs` (consolidated node-test, carries the new control pin) | see below |
| walk-profile arm, honest run | **exit 0** — control ok, worst round 0.2062 against a bar of 0.1277 |

**Negative controls — three planted, three bit.**

1. **The new positive control.** `walk-parse` at `M-PARSE-RAW` swapped back to
   `codec/cached-parse`, so the arm did the work `local` does. `parse-raw`'s p50
   collapsed from 0.9562 onto 0.7125 beside `local`'s 0.6625 (positive evidence the
   runtime saw the plant, not merely the source), per-round deltas went to ~0 with
   one **negative**, the control refused and the driver **exited 1**. The
   `lazy-tail` row still passed, which is how the plant is shown to have been
   scoped rather than to have taken out the instrument.
2. **The sweep.** Re-baring one `waitForSelector` reds it (**exit 1**) naming that
   exact call: `jsfb_ours_run.cjs: .waitForSelector('#run')`. A green sweep on its
   own would only have shown the regex matching nothing.
3. **The new failure path**, under a planted 1ms ceiling — because a diagnostic
   that has never executed is a claim. **This caught a real defect in my own first
   cut**: it reported `appRan: true` off `window.__TB__`, a global the runner
   installs with `addInitScript` before the page's own script on every navigation,
   so it would have asserted "the app ran" about a document still in
   `readyState: 'loading'` with no bundle fetched. Rewritten to witness
   `shadow$provide`, which `main.js` declares on its first line, and re-run.

Every restore verified with `git hash-object` against the pre-plant object, never
by reading a diff: `walk_profile_app.cljs` 71f6a43a, `jsfb_ours_run.cjs` e57b2d1f,
`spec.cjs` 6b92ad53 then 729da18a after the diagnostic fix.

**Not run, and why.** `jsfb_ours_run.cjs` and `live-e2e-fixture.cjs` took a
one-argument ceiling each, sourced from the constant the adjacent waits in the same
function already use; their own gates are a JS-framework bench and an nREPL-backed
MCP live lane, and neither can reach a `{ timeout }` literal. The policy sweep is
what covers them, and it is proven above to bite on exactly those lines.

`main` moved under this branch while it ran — two `chore(beads): checkpoint`
commits touching `.beads/issues.jsonl` only. No source file this branch depends on
changed, so the gate evidence above is about the same content as the final base.
