### PR TITLE
fix(migration): make the census's call-site estimand true (rf2-hic-055)

### DIFF
--- a/docs/design/hicasso/draft-guide/20-migration-from-reagent.md
+++ b/docs/design/hicasso/draft-guide/20-migration-from-reagent.md
@@ -67,14 +67,21 @@ contract against the component library's documentation.
 
 Everything above describes the **fixer**, and its population — the `[:>]`
 family — is not what a Reagent codebase is mostly made of. Run over this
-repository's own 81-file example corpus the fixer reports **zero entries**,
+repository's own 88-file example corpus the fixer reports **zero entries**,
 because the corpus crosses into React nowhere. A migrator reading only that
-sees 81 files the report never mentions.
+sees 88 files the report never mentions.
 
 So the same run also emits a **census**, under `:census`, whose population is
 the Reagent API **call site**: `r/atom`, `r/with-let`, `r/create-class`,
 `r/as-element`, `r/cursor`, `r/reactify-component`, root mounting, and the rest
-of the roster. On that same corpus it reports **62 sites across 28 files**.
+of the roster. On that same corpus it reports **59 sites across 28 files**.
+Both figures are measurements of a corpus that keeps growing; these were taken
+at `e337a1d`.
+
+A **call site is source that runs**. `#_(r/atom 0)`, `'(r/atom 0)` and
+`(comment (r/atom 0))` parse into the same nodes a live call does, and the
+census prunes all three rather than counting them. A syntax-quote is not
+pruned: a macro's template emits real call sites at every expansion.
 
 | Half | Population | Addressed at | Verdicts |
 | --- | --- | --- | --- |
@@ -96,6 +103,12 @@ Reagent's — a vendored inlined copy, for instance — is
 `:unresolved-reagent-require` at the `ns` form, and every roster-named call in
 that file is `:unresolved-alias`. The tool does not guess that such a copy is
 `reagent.core`, because a wrong binding rewrites working code.
+
+Every legal way of binding the Reagent name is read: an alias, a `:refer` list,
+`:refer :all`, a `:rename`, and any of them behind a reader conditional. A
+`:rename` reports under the roster name rather than the local spelling, and it
+releases the original — after `:refer [atom] :rename {atom ratom}`, `(ratom 0)`
+is Reagent's and a bare `(atom 0)` is `clojure.core`'s.
 
 What it cannot name it does not count, and says so. A Form-2 component is a
 `defn` returning a `fn` with nothing else marking it, so the census counts the

--- a/migration/reagent-to-hicasso/codemod/README.md
+++ b/migration/reagent-to-hicasso/codemod/README.md
@@ -33,17 +33,19 @@ consumer's code needs a human decision is a tool that gets run once.**
 
 Everything below this section is about the **fixer**, whose population is the
 `[:>]`-family crossing. That population is not a Reagent codebase, and the
-difference is not small. Run over this repository's own 81-file example corpus
+difference is not small. Run over this repository's own 88-file example corpus
 the fixer reports **zero entries** — the corpus crosses into React nowhere — and
-a migrator reading that report sees eighty-one files that are not mentioned.
+a migrator reading that report sees eighty-eight files that are not mentioned.
 
 So the same run also produces a **census**, under `:census` in the report, whose
 population is the **Reagent API call site**: `r/atom`, `r/with-let`,
 `r/create-class`, `r/as-element`, `r/cursor`, `r/reactify-component`, root
 mounting, and the rest of the roster in
 `src/re_frame/migration/hicasso/census.clj`. On that same corpus it reports
-**62 sites across 28 files**, one of them the `with-let` whose teardown no
-mechanical edit can carry.
+**59 sites across 28 files**, one of them the `with-let` whose teardown no
+mechanical edit can carry. Both are measurements of a corpus that keeps
+growing, taken here at `e337a1d`; the corpus was 81 files when the census
+landed.
 
 | Half | Population | Addressed at | Verdicts |
 |---|---|---|---|
@@ -75,6 +77,25 @@ name, such as `day8.re-frame-10x.inlined-deps.reagent.v1v2v0.reagent.core` — i
 roster-named call in the file reported as `:unresolved-alias`. The tool does not
 guess that such a copy is `reagent.core`: a wrong binding rewrites working code,
 which is worse than naming what it cannot resolve.
+
+**Every legal way of binding the name is read.** An alias, a `:refer` list,
+`:refer :all`, a `:rename`, and any of them behind a reader conditional.
+`:refer :all` and `:rename` are shapes nobody in this repository writes, so
+nothing here reached them and both bound nothing at all — one file's whole
+Reagent surface reading as clean, with no diagnostic (merged-PR audit #8140). A
+renamed call reports under its ROSTER name, which is the only one with a class
+and a recovery sentence, and the rename releases the original: after
+`:refer [atom] :rename {atom ratom}`, `(ratom 0)` is Reagent's and a bare
+`(atom 0)` is `clojure.core`'s again.
+
+**A CALL site is source that RUNS.** `#_(r/atom 0)`, `'(r/atom 0)` and
+`(comment (r/atom 0))` parse into exactly the nodes a live call does, and the
+census used to report all four identically — an advertised estimand with a
+one-line counterexample (merged-PR audit #8140). The three are pruned. A
+syntax-quote deliberately is not: a macro's template emits real call sites at
+every expansion, and its `~unquote`s run outright. The tool stops at the three
+shapes whose whole purpose is to not be code; a `(when false …)` or a dead
+`cond` branch is the general problem and this is not an evaluator.
 
 **What it cannot name, it does not count.** A Form-2 component is a `defn`
 returning a `fn` and nothing else marks it; a structural test for that would
@@ -249,6 +270,14 @@ census against the text it is supposed to outperform: `^:cljstyle/ignore (ns …
 was not being read as an `ns` form at all, so **the whole file's aliases went
 unbound** — W4 and W5 dead in it, every Reagent API in it unnamed, and nothing
 looking wrong.
+
+Merged-PR audit #8140 added five direct controls, because the suite that was
+green over all of the above had no case for any of them: the three inert
+extents, `:refer :all`, and `:rename`. Each is one line of source a reader can
+write, and each is a place the advertised estimand was false — three counted,
+two missed. The controls that PRUNE come paired with controls that the pruning
+does not over-reach, since a walk that skips too much is the first failure
+mode arriving from the other side.
 
 ## One dependency, deliberately
 

--- a/migration/reagent-to-hicasso/codemod/src/re_frame/migration/hicasso/census.clj
+++ b/migration/reagent-to-hicasso/codemod/src/re_frame/migration/hicasso/census.clj
@@ -37,6 +37,11 @@
   one crossing site to the fixer and one call site here; the numbers are
   not double-counted because they are not the same count.
 
+  **A CALL site is source that RUNS**, so `#_(r/atom 0)`, `'(r/atom 0)`
+  and `(comment (r/atom 0))` are not among them and [[inert?]] prunes
+  them. An advertised estimand a reader can construct a counterexample to
+  in one line is worse than a vaguer one honestly stated.
+
   ## The law this file exists to obey
 
   **What cannot be resolved is REPORTED, never skipped.** [[ns-context]]
@@ -74,6 +79,7 @@
   count. A confident wrong number is worse than a stated silence."
   (:require [clojure.string :as str]
             [re-frame.migration.hicasso.rewrite :as rw]
+            [rewrite-clj.node :as n]
             [rewrite-clj.parser :as p]
             [rewrite-clj.zip :as z]))
 
@@ -229,11 +235,53 @@
       (when (symbol? h) h))))
 
 (defn- roster-name
-  "The roster key this node's head spells, whether or not it resolves."
-  [nd]
+  "The roster key this node's head spells, whether or not it resolves.
+
+  Usually the head's own name — `r/atom` and a bare `atom` both spell
+  `atom`. The exception is a `:rename`d referral, where the file bound
+  `reagent.core/atom` to some other spelling and the head is `ratom`; the
+  roster key is then the ORIGINAL name, which is the only one the roster
+  has a class and a recovery sentence for."
+  [nd ctx]
   (when-let [h (head-symbol nd)]
-    (let [k (symbol (name h))]
+    (let [k (or (when-not (namespace h) (get (:renamed ctx) h))
+                (symbol (name h)))]
       (when (contains? surface k) k))))
+
+(def ^:private inert-heads
+  "Heads whose whole form is source that never runs."
+  '#{comment clojure.core/comment quote})
+
+(defn- inert?
+  "Is this node source the reader parses and the program never evaluates?
+
+  A census of CALL SITES must not count one. `#_(r/atom 0)`, `'(r/atom
+  0)` and `(comment (r/atom 0))` each parse into the same nodes a live
+  call does, and an unconditional walk reported all four identically
+  (merged-PR audit #8140). Nothing is being migrated in any of them, so
+  each is a false blocker on a report whose only job is to be believed.
+
+  The three shapes are finite and this is not a Clojure evaluator: a
+  syntax-quote is deliberately NOT here, because a macro's template
+  emits real call sites and its `~unquote`s run at expansion. Neither is
+  a `(when false …)`, a dead `cond` branch or an unreachable `defn` —
+  deciding those is the general problem, and the tool stops at the three
+  shapes whose whole purpose is to not be code."
+  [nd]
+  (or (contains? #{:uneval :quote} (n/tag nd))
+      (contains? inert-heads (head-symbol nd))))
+
+(defn- past-subtree
+  "The next location the walk should visit AFTER this node's subtree, or
+  `nil` when the subtree ends the file.
+
+  Right sibling if there is one, else up until there is — the ordinary
+  way to prune a depth-first walk. Deliberately not `(z/next …)`: `next`
+  descends into a branch, which is the very thing being skipped."
+  [loc]
+  (loop [l loc]
+    (or (z/right l)
+        (when-let [u (z/up l)] (recur u)))))
 
 (defn- entry
   [{:keys [class verdict]} file line col form detail]
@@ -253,7 +301,11 @@
   `:reagent?` is whether the file names a Reagent namespace at all, which
   is what lets the summary distinguish *scanned and clean* from *scanned
   and irrelevant* — the fixer's report already carries `:sites-left-alone`
-  for the same reason."
+  for the same reason.
+
+  **CALL sites, so [[inert?]] subtrees are pruned rather than walked.**
+  The population is what the program runs, and a discard, a quote and a
+  `(comment …)` body are none of it."
   [source file]
   (let [root        (p/parse-string-all source)
         ctx         (rw/ns-context root)
@@ -265,52 +317,54 @@
     (loop [loc      (z/of-string source {:track-position? true})
            entries  []
            ns-said? false]
-      (if (z/end? loc)
+      (if (or (nil? loc) (z/end? loc))
         {:entries entries :reagent? reagent? :unresolved? unresolved?}
-        (let [nd         (z/node loc)
-              k          (roster-name nd)
-              ns-here?   (and unresolved? (not ns-said?) (ns-node? nd))
-              [line col] (when (or k ns-here?) (z/position loc))]
-          (recur
-           (z/next loc)
-           (cond
-             ;; The `ns` form of a file that names Reagent and binds
-             ;; nothing to it. Reported at the form itself, so the fix is
-             ;; where the line number points. Once per file: `ns-form?`
-             ;; sees through metadata, so `^:cljstyle/ignore (ns …)`
-             ;; matches at the meta node AND at the list inside it.
-             ns-here?
-             (conj entries (entry {:class   :unresolved-reagent-require
-                                   :verdict :runtime-blocker}
-                                  file line col (excerpt loc) nil))
+        (if (inert? (z/node loc))
+          (recur (past-subtree loc) entries ns-said?)
+          (let [nd         (z/node loc)
+                k          (roster-name nd ctx)
+                ns-here?   (and unresolved? (not ns-said?) (ns-node? nd))
+                [line col] (when (or k ns-here?) (z/position loc))]
+            (recur
+             (z/next loc)
+             (cond
+               ;; The `ns` form of a file that names Reagent and binds
+               ;; nothing to it. Reported at the form itself, so the fix is
+               ;; where the line number points. Once per file: `ns-form?`
+               ;; sees through metadata, so `^:cljstyle/ignore (ns …)`
+               ;; matches at the meta node AND at the list inside it.
+               ns-here?
+               (conj entries (entry {:class   :unresolved-reagent-require
+                                     :verdict :runtime-blocker}
+                                    file line col (excerpt loc) nil))
 
-             (nil? k) entries
+               (nil? k) entries
 
-             ;; Resolved: this really is Reagent's, through a symbol the
-             ;; `ns` form binds.
-             (rw/reagent-call? nd k ctx)
-             (conj entries (entry (get surface k) file line col (excerpt loc) {:api (str k)}))
+               ;; Resolved: this really is Reagent's, through a symbol the
+               ;; `ns` form binds.
+               (rw/reagent-call? nd k ctx)
+               (conj entries (entry (get surface k) file line col (excerpt loc) {:api (str k)}))
 
-             ;; Unresolvable, in a file we KNOW reaches for Reagent.
-             ;; Reported, never skipped — the tool cannot tell whose symbol
-             ;; this is, and saying so is the whole point.
-             ;;
-             ;; QUALIFIED HEADS ONLY. The thing that could not be bound is
-             ;; an ALIAS, so a call with no alias to bind is not evidence
-             ;; of it: `(atom nil)` is `clojure.core/atom`, and the SSR
-             ;; examples in this repository have one on the line above the
-             ;; `rdc/render` that IS the finding. Reporting both makes the
-             ;; real one harder to see, which is the only thing a census
-             ;; owes anybody.
-             (and unresolved? (namespace (head-symbol nd)))
-             (conj entries (entry {:class   :unresolved-alias
-                                   :verdict :runtime-blocker}
-                                  file line col (excerpt loc)
-                                  {:api    (str k)
-                                   :symbol (str (head-symbol nd))}))
+               ;; Unresolvable, in a file we KNOW reaches for Reagent.
+               ;; Reported, never skipped — the tool cannot tell whose symbol
+               ;; this is, and saying so is the whole point.
+               ;;
+               ;; QUALIFIED HEADS ONLY. The thing that could not be bound is
+               ;; an ALIAS, so a call with no alias to bind is not evidence
+               ;; of it: `(atom nil)` is `clojure.core/atom`, and the SSR
+               ;; examples in this repository have one on the line above the
+               ;; `rdc/render` that IS the finding. Reporting both makes the
+               ;; real one harder to see, which is the only thing a census
+               ;; owes anybody.
+               (and unresolved? (namespace (head-symbol nd)))
+               (conj entries (entry {:class   :unresolved-alias
+                                     :verdict :runtime-blocker}
+                                    file line col (excerpt loc)
+                                    {:api    (str k)
+                                     :symbol (str (head-symbol nd))}))
 
-             :else entries)
-           (or ns-said? ns-here?)))))))
+               :else entries)
+             (or ns-said? ns-here?))))))))
 
 ;; ---------------------------------------------------------------------------
 ;; The summary

--- a/migration/reagent-to-hicasso/codemod/src/re_frame/migration/hicasso/rewrite.clj
+++ b/migration/reagent-to-hicasso/codemod/src/re_frame/migration/hicasso/rewrite.clj
@@ -431,36 +431,70 @@
   the exact roster in `reagent-namespaces` binds, so re-frame-10x's
   vendored `day8.re-frame-10x.inlined-deps.reagent.v1v2v0.reagent.core`
   still binds NOTHING and is still reported unresolved by the census. That
-  is a different case and the tool must not guess at it."
+  is a different case and the tool must not guess at it.
+
+  **`:refer :all` and `:rename` bind too, and both used to go silently
+  missing** (merged-PR audit #8140). They are legal libspec options this
+  repository happens not to write, so nothing here reached them: the tool
+  answered `#{}` for the one and bound the wrong spelling for the other,
+  and a file's whole Reagent surface read as clean. Two more keys carry
+  them, each read as Clojure reads it:
+
+  * `:refer-all? true` — every roster name in this file is Reagent's.
+  * `:renamed {local original}` — `:refer [atom] :rename {atom ratom}`
+    binds `ratom` and leaves `atom` as `clojure.core`'s, so the original
+    is dropped from `:referred` rather than left sitting in it. A
+    `:rename` with no `:refer` binds nothing, which is the effect Clojure
+    gives it."
   [root-node]
   (reduce
    (fn [acc spec]
      (let [spec (if (symbol? spec) [spec] spec)]
        (if (and (sequential? spec) (contains? reagent-namespaces (first spec)))
-         ;; Pairwise rather than `(apply hash-map …)`, and `:refer` taken
-         ;; only when it is a collection: this reads source nobody in this
-         ;; repository wrote, and a lone trailing option or `:refer :all`
+         ;; Pairwise rather than `(apply hash-map …)`: this reads source
+         ;; nobody in this repository wrote, and a lone trailing option
          ;; must leave the tool answering less, never throwing.
-         (let [opts (into {} (comp (partition-all 2) (filter #(= 2 (count %))) (map vec))
-                          (rest spec))]
+         (let [opts       (into {} (comp (partition-all 2) (filter #(= 2 (count %))) (map vec))
+                                (rest spec))
+               refer-all? (= :all (:refer opts))
+               referred   (when (sequential? (:refer opts))
+                            (filter symbol? (:refer opts)))
+               renamed    (when (and (or refer-all? referred) (map? (:rename opts)))
+                            (into {} (for [[from to] (:rename opts)
+                                           :when (and (symbol? from) (symbol? to))]
+                                       [to from])))]
            (cond-> (update acc :aliases conj (first spec))
-             (symbol? (:as opts))          (update :aliases conj (:as opts))
-             (sequential? (:refer opts))   (update :referred into (:refer opts))))
+             (symbol? (:as opts)) (update :aliases conj (:as opts))
+             referred             (update :referred into
+                                          (remove (set (vals renamed)) referred))
+             refer-all?           (assoc :refer-all? true)
+             (seq renamed)        (update :renamed merge renamed)))
          acc)))
-   {:aliases #{} :referred #{}}
+   {:aliases #{} :referred #{} :refer-all? false :renamed {}}
    (map sexpr-safe (some-> (ns-form-node root-node) require-specs))))
 
 (defn reagent-call?
-  "Is `node` a literal call to Reagent's `sym`, through an alias this
-  file's `ns` form actually binds?"
-  [node sym {:keys [aliases referred]}]
+  "Is `node` a literal call to Reagent's `sym`, through a symbol this
+  file's `ns` form actually binds?
+
+  Three ways a bare head can be Reagent's, and only three: the `ns` form
+  `:refer`red the name, it `:refer :all`ed the namespace, or it renamed
+  the name to this spelling. The rename case is the one where the head
+  and the roster key DIFFER — `(ratom 0)` is `reagent.core/atom` — and
+  the same rename is what takes the ORIGINAL spelling away, so under
+  `:refer :all :rename {atom ratom}` a bare `(atom 0)` is
+  `clojure.core`'s again."
+  [node sym {:keys [aliases referred refer-all? renamed]}]
   (and (list-node? node)
        (let [h (sexpr-safe (element-at node 0))]
          (and (symbol? h)
-              (= (name h) (name sym))
               (if-let [q (namespace h)]
-                (contains? aliases (symbol q))
-                (contains? referred sym))))))
+                (and (= (name h) (name sym)) (contains? aliases (symbol q)))
+                (or (= sym (get renamed h))
+                    (and (= (name h) (name sym))
+                         (or (contains? referred sym)
+                             (and refer-all?
+                                  (not (contains? (set (vals renamed)) h)))))))))))
 
 (defn- subtree-has-reagent-call?
   [node sym ctx]

--- a/migration/reagent-to-hicasso/codemod/test/re_frame/migration/hicasso/census_test.clj
+++ b/migration/reagent-to-hicasso/codemod/test/re_frame/migration/hicasso/census_test.clj
@@ -299,6 +299,114 @@
       (is (= [:local-reactive-cell] (classes src "app/util.cljs"))))))
 
 ;; ---------------------------------------------------------------------------
+;; A call SITE is source that runs (merged-PR audit #8140)
+;; ---------------------------------------------------------------------------
+
+(deftest inert-source-is-not-a-call-site
+  (testing "MERGED-PR AUDIT #8140's first finding. The walk advanced with an
+            unconditional `z/next`, so a discard, a quote and a `(comment …)`
+            body — each of which parses into the same nodes a live call does —
+            reported IDENTICALLY to the live call. None is a call site, and a
+            census of call sites that cannot tell them apart is a census whose
+            every number is an upper bound nobody stated."
+    (let [hdr "(ns app.p\n  (:require [reagent.core :as r]))\n"]
+      (is (= [:local-reactive-cell] (classes (str hdr "(def a (r/atom 0))\n") "app/p.cljs"))
+          "the live call is the control this is measured against")
+      (is (= [] (classes (str hdr "(def a '(r/atom 0))\n") "app/p.cljs"))
+          "reader quote")
+      (is (= [] (classes (str hdr "(def a (quote (r/atom 0)))\n") "app/p.cljs"))
+          "the `quote` special form spells the same thing")
+      (is (= [] (classes (str hdr "(def a 1)\n#_(r/atom 0)\n") "app/p.cljs"))
+          "`#_` discard")
+      (is (= [] (classes (str hdr "(comment (r/atom 0))\n") "app/p.cljs"))
+          "`(comment …)` body")))
+
+  (testing "pruning a subtree must not prune what FOLLOWS it — the walk resumes
+            at the next sibling, and at the enclosing form's next sibling when
+            the inert form was last"
+    (let [hdr "(ns app.p\n  (:require [reagent.core :as r]))\n"]
+      (is (= [:local-reactive-cell]
+             (classes (str hdr "#_(r/atom 0)\n(comment (r/atom 1))\n'(r/atom 2)\n"
+                           "(def z (r/atom 3))\n")
+                      "app/p.cljs"))
+          "three inert forms in a row, then the live one")
+      (is (= [:with-let]
+             (classes (str hdr "(defn f []\n  (comment (r/atom 0))\n"
+                           "  (r/with-let [_ 1] [:div]))\n")
+                      "app/p.cljs"))
+          "inert form NESTED inside a live one")
+      (is (= [:local-reactive-cell]
+             (classes (str hdr "(def z (r/atom 3))\n(comment (r/atom 0))\n") "app/p.cljs"))
+          "the inert form ends the file: the walk terminates rather than looping"))))
+
+(deftest a-syntax-quote-is-still-a-call-site
+  (testing "the boundary, stated as a test so it is a decision and not an
+            oversight. `#_`, `'` and `(comment …)` exist to NOT be code. A
+            syntax-quote is a macro's template: the form it emits is a real
+            call site at every expansion, and its `~unquote`s run outright.
+            The tool prunes the three and stops."
+    (let [src (str "(ns app.p\n  (:require [reagent.core :as r]))\n"
+                   "(defmacro m [] `(r/atom 0))\n")]
+      (is (= [:local-reactive-cell] (classes src "app/p.clj"))))))
+
+;; ---------------------------------------------------------------------------
+;; Legal libspec options that bound nothing (merged-PR audit #8140)
+;; ---------------------------------------------------------------------------
+
+(deftest refer-all-binds-the-whole-roster
+  (testing "`:refer :all` is legal and this repository writes none, so nothing
+            reached it: `ns-context` took `:refer` only when it was a
+            collection, `:all` fell through, and every bare Reagent call in
+            such a file went unreported with no diagnostic at all."
+    (let [src (str "(ns app.p\n"
+                   "  (:require [reagent.core :refer :all]))\n"
+                   "\n"
+                   "(def a (atom 0))\n"
+                   "(defn f [] (with-let [_ 1] [:div]))\n")]
+      (is (= [:local-reactive-cell :with-let] (classes src "app/p.clj")))))
+
+  (testing "and it binds only the namespace it is written on"
+    (let [src (str "(ns app.p\n"
+                   "  (:require [clojure.string :refer :all]))\n"
+                   "\n"
+                   "(def a (atom 0))\n")]
+      (is (= [] (classes src "app/p.clj"))))))
+
+(deftest a-rename-binds-the-new-spelling-and-releases-the-old
+  (testing "`:refer [atom] :rename {atom ratom}` binds `ratom` to
+            `reagent.core/atom`. The tool bound `atom` — a name the file no
+            longer uses for Reagent — so the finding was missed at the call
+            AND invented at the one place `clojure.core/atom` still lives."
+    (let [src (str "(ns app.p\n"
+                   "  (:require [reagent.core :refer [atom] :rename {atom ratom}]))\n"
+                   "\n"
+                   "(def a (ratom 0))\n"
+                   "(def b (atom 0))\n")
+          {:keys [entries]} (census/scan src "app/p.clj")]
+      (is (= [:local-reactive-cell] (mapv :class entries)))
+      (is (= [4] (mapv :line entries)) "the renamed call, not the core one")
+      (testing "and it is reported under the ROSTER name, which is the only one
+                with a class and a recovery sentence"
+        (is (= {:api "atom"} (:detail (first entries)))))))
+
+  (testing "the two compose: `:refer :all` binds everything the rename did not
+            take away"
+    (let [src (str "(ns app.p\n"
+                   "  (:require [reagent.core :refer :all :rename {atom ratom}]))\n"
+                   "\n"
+                   "(def a (ratom 0))\n"
+                   "(def b (atom 0))\n")]
+      (is (= [4] (mapv :line (:entries (census/scan src "app/p.clj")))))))
+
+  (testing "a `:rename` with no `:refer` binds nothing, which is the effect
+            Clojure gives it"
+    (let [src (str "(ns app.p\n"
+                   "  (:require [reagent.core :as r :rename {atom ratom}]))\n"
+                   "\n"
+                   "(def a (ratom 0))\n")]
+      (is (= [] (classes src "app/p.clj"))))))
+
+;; ---------------------------------------------------------------------------
 ;; Determinism, and a summary that cannot hide an empty bucket
 ;; ---------------------------------------------------------------------------
 


### PR DESCRIPTION
Merged-PR audit #8140 on rf2-hic-055 named a bounded repair: the census
advertises its population as **Reagent API call sites**, and a reader could
construct a counterexample to that in one line — five of them, in fact. Three
things it counted are not call sites; two things it missed are. This makes the
advertised estimand true for those five finite cases, and adds the five direct
controls the suite did not have. It does not broaden into a general Clojure
parser, and it does not touch the shadow-comparison half (rf2-kyum, landed).

## What was wrong, verified by direct probe at `e337a1d`

Probes run against the tip before any edit:

| Source | Reported before | Is it a call site? |
| --- | --- | --- |
| `(def a (r/atom 0))` | `:local-reactive-cell` line 3 | yes — the control |
| `(def a '(r/atom 0))` | `:local-reactive-cell` line 3 | no |
| `#_(r/atom 0)` | `:local-reactive-cell` line 4 | no |
| `(comment (r/atom 0))` | `:local-reactive-cell` line 3 | no |
| `:refer [atom] :rename {atom ratom}` then `(ratom 0)` | nothing | yes |
| `:refer :all` then `(atom 0)` | nothing | yes |

*(3 columns; 6 body rows — hand-counted, see the note on tables below.)*

**One premise in the audit did not hold.** It says `:refer :all` "throws from
`(into … :all)`" and that `run-file` relabels the file a parse error. It does
not throw at this tip: commit `5f1d5d8b5e` (rf2-m4hm, 2026-08-12 — before the
audited merge `2dd6791`) already guarded the `into` with
`(sequential? (:refer opts))`. The consequence the audit describes is real and
worse than a throw, because a throw is at least visible: `:all` fell through
the guard silently and bound no name at all, so the file's whole Reagent
surface read as clean. Repaired as the audit intended; the mechanism it names
is not the one that was there.

## What changed

**Code extent — `census/inert?` and `census/past-subtree`.** A `#_` discard, a
quote (reader `'` and the `quote` special form) and a `(comment …)` body parse
into exactly the nodes a live call does. Each is pruned at its own node and the
walk resumes at the next sibling, or at the enclosing form's next sibling when
the inert form was last. Deliberately **not** `(z/next …)` on the skipped node:
`next` descends into a branch, which is the thing being skipped.

A **syntax-quote is not pruned**, and that is a decision with a test on it: a
macro's template emits real call sites at every expansion and its `~unquote`s
run outright. Nor does anything here decide `(when false …)`, a dead `cond`
branch or an unreachable `defn` — that is the general problem, and this is not
an evaluator. The tool stops at the three shapes whose whole purpose is to not
be code.

**Legal libspec options — `rw/ns-context` and `rw/reagent-call?`.** The context
grows two keys, each read as Clojure reads it:

- `:refer-all? true` — every roster name in the file is Reagent's.
- `:renamed {local original}` — `:refer [atom] :rename {atom ratom}` binds
  `ratom` and *releases* `atom` back to `clojure.core`, so the original is
  dropped from `:referred` rather than left sitting in it. The two compose:
  under `:refer :all :rename {atom ratom}` a bare `(atom 0)` is core's again.
  A `:rename` with no `:refer` binds nothing, which is the effect Clojure gives
  it.

A renamed call reports under its **roster** name, not the local spelling —
`:api "atom"` for `(ratom 0)` — because the roster name is the only one with a
class and a recovery sentence attached.

**Counts re-derived, not copied.** Both published figures were stale from
corpus drift, and both are corrected in the README and the draft guide:

| Claim | Published | Re-derived at `e337a1d` |
| --- | --- | --- |
| example corpus | 81 files | **88 files** |
| census | 62 sites across 28 files | **59 sites across 28 files** |

*(3 columns; 2 body rows.)*

The repair does not move that number — the example corpus has no Reagent call
inside an inert extent — so the drift is the corpus growing, not the fix.
Determinism re-checked: two full runs over `examples/` byte-identical,
sha256 `54ca9b4bb9a6d105c0793714590279b2e0c7daeabd5b90d2dc4524f9c4d4d763`.

## Controls

The five the audit asked for, plus the failure arriving from the other side —
a walk that prunes too much:

- three inert extents, each against the live call as its control;
- the live call **after** three inert forms in a row;
- an inert form **nested inside** a live one;
- an inert form as the file's **last** form (the walk terminates rather than
  looping);
- the syntax-quote boundary, asserted as reported;
- `:refer :all`, and that it binds only the namespace it is written on;
- `:rename` — the renamed call found, the released original *not* found, and
  the roster-name reporting;
- `:refer :all` + `:rename` composed;
- `:rename` with no `:refer` binding nothing.

## Quality gates

| Gate | Command | Exit | Result |
| --- | --- | --- | --- |
| codemod JVM suite | `cd migration/reagent-to-hicasso/codemod && clojure -M:test` | `0` | **47 tests, 452 assertions, 0 failures, 0 errors** (was 40/403) |
| codemod JVM, sabotage 1 | same, with `inert?` forced false and the rename lookup misspelled | `1` | **11 failures**, in `inert-source-is-not-a-call-site` and `a-rename-binds-the-new-spelling-and-releases-the-old` only |
| codemod JVM, sabotage 2 | same, with `refer-all?` matching `:all-SABOTAGE` | `1` | **2 failures**, in `refer-all-binds-the-whole-roster` and the composed rename case |
| doc slugs | `python scripts/check_doc_slugs.py` | `0` | clean |
| doc slugs, sabotage | same, with a broken link appended to the guide | `1` | `BROKEN TARGET: …20-migration-from-reagent.md:348 -> ./no-such-page-migreport-hic055.md` |
| provenance pins | `python scripts/check_provenance_pins.py --changed-since origin/main --verbose` | `0` | `1 files, 1 cited pins (1 landed, 0 stranded, 0 unresolvable, 0 foreign)` |
| corpus census | `clojure -M:run …/examples`, twice | `0`, `0` | 59 sites / 28 files / 88 scanned; reports byte-identical |

*(4 columns; 7 body rows.)*

Every exit code above is the runner's own, captured to a `.exit` file beside
its log — no pipeline, no filter, one command line each.

Both source files were restored from backup after each sabotage and the restore
verified with `git hash-object`, not by reading a diff: `census.clj`
`c4e5fa7be0df88aba28ba0f5f29cf57c49937e02`, `rewrite.clj`
`5618503da1ef5dbfa47dd9cbeef81cd115cd0f56`, guide
`4ec91afbd96336c569949728faeaec55b78e651c` — each matching its pre-sabotage
hash exactly. The green suite ran against those exact bytes.

**`mkdocs build --strict` is not the gate for the guide edit.** `mkdocs.yml`'s
`exclude_docs` names `design/hicasso/`, so the page is never staged into the
site. `check_doc_slugs.py` and `check_provenance_pins.py` are what cover it, and
both were run — the first proved live against this tree by the planted broken
link above.

**Nothing validates the tables under `docs/design/`, so they were hand-verified.**
The guide holds six tables, with 3, 4, 3, 2, 4 and 3 columns; every row in each
matches its header. The codemod README holds two, 4 columns each, likewise
uniform. No table row in either file was added or altered by this change — both
edits are prose and two numerals.

Branch is on `origin/main` at `e337a1d` with no rebase, and the diff was read
for what it would revert: the deletions in `census.clj` are the re-indentation
of the `cond` block by one level, nothing else.

## Filed, not fixed

The fixer next door has the same code-extent blindness — it reports
`:computed-value` for `(comment [:> Foo {:on-click f}])` — but its estimand is
a different population (`[:>]`-family crossing **sites**), the audit scoped
this repair to the reporter, and "do not broaden" is on the bead. Filed as its
own bead rather than folded in here.
