### PR TITLE
docs(ui): record why the ViewCell frame read is not gated on the refusal tier (rf2-wxnc)

### DIFF
--- a/implementation/ui/src/re_frame/ui/viewcell.cljs
+++ b/implementation/ui/src/re_frame/ui/viewcell.cljs
@@ -312,12 +312,48 @@
   wins, otherwise the hook value flows through the SHARED sentinel / coercion /
   corruption rules (`adapter-context/context-value->current-frame`) — identical
   to the reader's classification, since on the client `useContext` observes the
-  same value `_currentValue` holds."
+  same value `_currentValue` holds.
+
+  THE AMBIENT-FRAME-REFUSAL TIER IS DELIBERATELY NOT CONSULTED HERE (rf2-wxnc).
+  `frame/resolve-current-frame` withdraws its React-context tier while a
+  substrate has established a refusing extent (rf2-2rtt6.122), and rejects a
+  carried stamp naming some OTHER frame when that extent declared an
+  `:extent-frame` (rf2-nqj22). This two-tier read is not that reader, and the
+  asymmetry is intended rather than an oversight — for three reasons, each
+  sufficient on its own.
+
+  IT CANNOT BE INSIDE A REFUSING EXTENT. Per Spec 002 §The refusal tier, an
+  extent is exactly a substrate's own SYNCHRONOUS render call, and React
+  invokes a child fiber only AFTER the parent's render function has returned —
+  under `react-dom/server` as much as the client renderer, which is why
+  `frame/call-with-ambient-frame-refused` tracks no nesting. So the extent has
+  unwound before React invokes a compiled view, and with it this LEADING hook.
+  A ViewCell mounted anywhere below a refusing body never observes a non-nil
+  `frame/*ambient-frame-refusal*`.
+
+  AND IT MUST NOT BE GATED ON ONE. The question this hook answers is WHICH
+  FRAME THIS COMPONENT IS IN — the same question a substrate answers BEFORE it
+  refuses anything, and whose answer it hands core as `:extent-frame`. The
+  refusing substrate resolves it the same way: `re-frame.hicasso.impl.collector/`
+  `resolve-frame!` reads this very context directly and records that it is
+  deliberately NOT the dynamic-var → context chain. Gating a boundary's own
+  frame on the tier that exists to refuse ambient AUTHOR reads would have a
+  substrate refuse itself. The refusal deletes an ambient FIND written in a
+  body; it was never addressed to the boundary doing the finding — the ambient
+  `(sub …)` sites that ARE addressed by it reach it through
+  `frame/require-current-frame!` as they do under every other substrate.
+
+  NOR IS THE SHARED READER AVAILABLE AS THE ROUTE. `resolve-current-frame`'s
+  React-context tier is `adapter-context/function-component-current-frame` —
+  the private `_currentValue` read rf2-2rzx0 moved this hook OFF, precisely
+  because `react-dom/server` does not populate that slot."
   []
   (let [ctx-frame (react/useContext adapter-context/frame-context)]
     ;; Dynamic binding before React context (the carried-invariant precedence);
     ;; the single `useContext` call above owns the repaint SUBSCRIPTION and now
-    ;; also supplies the renderer-agnostic frame value.
+    ;; also supplies the renderer-agnostic frame value. NOT routed through
+    ;; `frame/resolve-current-frame`, so the refusal tier does not gate it —
+    ;; see the docstring's last three paragraphs (rf2-wxnc).
     (or frame/*current-frame*
         (adapter-context/context-value->current-frame ctx-frame))))
 


### PR DESCRIPTION
Closes rf2-wxnc.

The bead asked a three-step question about a consistency gap between two substrates' frame
laws, and reserved step 3 — record a rationale at the site and close, adding no machinery —
as a legitimate outcome. **Step 1 answered no, so this PR is step 3.** It changes no
behaviour: one docstring section and one three-line comment.

## The observation, verified at source

The bead's premise holds exactly as written, at `origin/main`:

- `implementation/ui/src/re_frame/ui/viewcell.cljs:317-322` — `use-frame-context!` resolves
  with a bare `(or frame/*current-frame* (adapter-context/context-value->current-frame ctx))`
  and never reads `frame/*ambient-frame-refusal*`.
- `implementation/core/src/re_frame/frame.cljc:758-764` — `resolve-current-frame` does
  consult it, collapsing to `carried-frame-admitted-by` while a refusal is in effect.

## Step 1 — intent

**The refusal tier is not meant to bind a substrate's resolution of its own extent frame,
and it cannot reach a ViewCell in any case.** Three independent findings, each sufficient:

**1. A ViewCell can never be inside a refusing extent.** Spec 002
§[The refusal tier](../blob/main/spec/002-Frames.md) scopes an extent to a substrate's own
synchronous render call, and `frame/call-with-ambient-frame-refused` records why it tracks
no nesting: React invokes a child fiber only *after* the parent's render function has
returned — under `react-dom/server` as much as the client renderer. The only producers of a
refusing extent in the tree are Hicasso's `impl/intent/with-frame` (boundary, collector,
overlay, presence-react) and its bench-lane twin; every one binds around a body evaluation
plus `codec/as-element`, which *creates* elements rather than invoking components. A
compiled view is a React function component, so its render — and this leading hook with it —
always runs after the binding has unwound.

**2. Gating it would have a substrate refuse itself.** The question `use-frame-context!`
answers is *which frame is this component in*. That is the same question a substrate answers
**before** it establishes a refusal, and whose answer it hands core as `:extent-frame`. The
refusing substrate resolves it the same way this hook does:
`re-frame.hicasso.impl.collector/resolve-frame!` reads the shared frame context directly and
says so in terms — "Deliberately NOT `frame/require-current-frame!`'s dynamic-var → context
chain … a body's dynamic extent has unwound by the time React renders the component it
returned". The refusal deletes an ambient FIND written *in* a body; it was never addressed
to the boundary doing the finding. The ambient `(sub …)` / `dispatch` sites that *are*
addressed by it already reach it through `require-current-frame!` → `resolve-current-frame`,
under re-frame.ui as under every other substrate.

**3. The bead's suggested route for step 2 is not available.** Step 2's parenthetical says
"route through the shared resolution rather than the bare or-expression". `resolve-current-frame`'s
React-context tier *is* `adapter-context/function-component-current-frame`, the private
`_currentValue` read that rf2-2rzx0 deliberately moved this hook **off** because
`react-dom/server` does not populate that slot — the same defect rf2-5rqn is currently
repairing. Taking step 2 as worded would revert rf2-2rzx0.

No spec text speaks to compiled views under a refusal. What Spec 002 does say cuts the other
way: the motivating case it names is "a compiled-view boundary that must observe every read
to build its dependency edges" — i.e. a substrate that **opts in** by establishing an extent.
re-frame.ui does not; it binds `*current-frame*` around the compiled body precisely so that
ambient reads resolve (`with-current-frame`, rf2-4rwtd). Permitting ambient reads in a
compiled body is re-frame.ui's substrate policy, not an omission, and it is a different
policy from Hicasso's by design. rf2-2rtt6.122 and rf2-nqj22 are both scoped to the Hicasso
body render extent throughout; neither reaches for compiled views elsewhere.

## Step 3 — what landed

The rationale, at the site, as three docstring paragraphs plus a pointer comment at the
`or`. No gate, no witness, no new error id, no spec change.

## No follow-up filed, and why

I checked one adjacent hazard and found it is not one. The ViewCell honours tier-1
precedence, so a host that renders it inside `rf/with-frame :b` beneath a `:a` provider
resolves `:b` — the shape rf2-nqj22 ruled on for Hicasso, and reachable here (a `flushSync`
mount under a scope, `renderToString` under one, or test-support's `:ambient-frame` default).
It is not the same defect: re-frame.ui threads that one resolved value everywhere — the
`with-current-frame` binding, the `events/with-capture` destination, `render-frame` — so the
view is wholly `:b`-consistent, where Hicasso's collector edges and lowered intents came from
the context frame while an ambient read could get the carried one. One frame, not two. Per
EP-0002 the carried stamp wins, and re-frame.ui declares no `:extent-frame` to contradict it.

## Quality gates

| Gate | Result |
| --- | --- |
| `python scripts/lint_kondo.py` (CI's clj-kondo gate, `--fail-level error`; lints `implementation` among others, so it covers the changed file) | **exit 0** — `errors: 0, warnings: 4561`, re-run on the final rebased base |
| Negative control: unbalanced delimiter planted at `viewcell.cljs` `(let [ctx-frame …` | **exit 3** — `errors: 8`, all naming `implementation\ui\src\re_frame\ui\viewcell.cljs` at the planted line (351 post-edit), plus `viewcell.cljs:278:1: error: Found an opening ( with no matching )` |
| Restore verified | `git hash-object` of the working file `= git rev-parse HEAD:…` (`844fa4a6…`), before the plant and after the restore |

Exit codes are the ones captured by the running shell's own `echo $?`, not the harness's
report. On the sabotage run the two **disagreed**: the harness reported exit 0 for a run that
returned 3. Believing the harness there would have read as "the control does not bite" and
inverted the conclusion.

The fault existed only in this worktree, so the red is the discrimination that the gate read
this checkout and not a sibling's.

**Skipped, with reason:** `npm run test:ui` / `npm run test:cljs` and the full
`scripts/test-fast-pr.sh` spine. Each needs a cold shadow-cljs + Closure compile, and an
allocation measurement window is live on the box; the change alters no form — one docstring
and one comment — so the parse is the entire failure mode, and clj-kondo parses the file with
a real reader, demonstrated above. `mkdocs build --strict` and `scripts/check_doc_slugs.py`
are not nominated: nothing under `docs/` or `spec/` changed.
