### PR TITLE
fix(codemod): an inert Reagent call is not a refusal reason (rf2-0xd6)

### DIFF
--- a/migration/reagent-to-hicasso/codemod/src/re_frame/migration/hicasso/rewrite.clj
+++ b/migration/reagent-to-hicasso/codemod/src/re_frame/migration/hicasso/rewrite.clj
@@ -558,11 +558,27 @@
                                   (not (contains? (set (vals renamed)) h)))))))))))
 
 (defn- subtree-has-reagent-call?
+  "Does this subtree contain a call to Reagent's `sym` that RUNS?
+
+  Live is the whole of it (rf2-0xd6). Both callers use this answer to
+  REFUSE — to decline a site the tool would otherwise repair — so an
+  `r/as-element` sitting in a `(comment …)` inside a live site's props
+  would send a migrator to hand-port a form that never evaluates. The
+  site itself is live either way; only the refusal is wrong, which is
+  what makes this a different question from rf2-xc11's site walk.
+
+  [[inert?]] is consulted here, per node, rather than at the two call
+  sites: the discard, the quote and the `(comment …)` body can sit at
+  any depth in the subtree, and one guard on the recursion answers
+  every caller at every depth. A syntax-quote is deliberately not
+  pruned — see [[inert?]] for why that boundary sits where it does."
   [node sym ctx]
   (boolean
-   (or (reagent-call? node sym ctx)
-       (and (n/inner? node)
-            (some #(subtree-has-reagent-call? % sym ctx) (n/children node))))))
+   (and (not (inert? node))
+        (or (reagent-call? node sym ctx)
+            (and (n/inner? node)
+                 (some #(subtree-has-reagent-call? % sym ctx)
+                       (n/children node)))))))
 
 ;; ---------------------------------------------------------------------------
 ;; Site detection

--- a/migration/reagent-to-hicasso/codemod/test/re_frame/migration/hicasso/inert_source_test.clj
+++ b/migration/reagent-to-hicasso/codemod/test/re_frame/migration/hicasso/inert_source_test.clj
@@ -29,7 +29,16 @@
   A syntax-quote is NOT inert. A macro's template emits a real crossing at
   every expansion, so a site inside one is a site. `census-test` pins that
   boundary for the reporter; [[a-syntax-quote-is-still-a-crossing-site]]
-  pins the same boundary here, on the shared predicate both now consult."
+  pins the same boundary here, on the shared predicate both now consult.
+
+  ## The third population (rf2-0xd6)
+
+  `inert?` answers ONE question about the source, and three walks ask it.
+  Everything above decides what is a SITE. The last section decides a
+  refusal REASON *inside* a site that is live either way: an
+  `r/as-element` in a `(comment …)` in a live site's props once cost the
+  migrator a hand-port of a form that never runs. Pinned from
+  [[an-inert-reagent-call-is-not-a-refusal-reason]] down."
   (:require [clojure.test :refer [deftest is testing]]
             [re-frame.migration.hicasso.codemod :as cm]))
 
@@ -182,3 +191,65 @@
       (is (= :adapt-def-site (:class entry)))
       (is (= [5] (get-in entry [:detail :call-sites-in-this-file]))
           "line 5 is the live call; line 4 is inside the comment"))))
+
+;; ---------------------------------------------------------------------------
+;; A refusal REASON computed inside a live site (rf2-0xd6)
+;; ---------------------------------------------------------------------------
+
+(deftest an-inert-reagent-call-is-not-a-refusal-reason
+  (testing "rf2-0xd6. The site here is live and was always reported
+            correctly; what was wrong is the EXTRA refusal beside it.
+            `subtree-has-reagent-call?` recursed through `n/children`
+            without consulting `inert?`, so an `r/as-element` inside a
+            `(comment …)` in a live site's props read as an as-element
+            island and the tool declined a repair it could have made."
+    (is (= [:computed-value]
+           (classes "[:> Foo {:x (comment (r/as-element [:div]))}]\n"))
+        "the bead's own probe. `:computed-value` STAYS — that value really
+         is one the tool cannot read — and only `:as-element-island` goes")
+    (is (= [:computed-value]
+           (classes "[:> Foo {:x #_(r/as-element [:div]) 1}]\n"))
+        "`#_` discard")
+    (is (= []
+           (classes "[:> Foo {:x '(r/as-element [:div])}]\n"))
+        "reader quote. A quoted form IS readable off the text, so once the
+         island goes there is no `:computed-value` left behind it")
+    (is (= [:computed-value]
+           (classes "[:> Foo {:x (clojure.core/comment (r/as-element [:div]))}]\n"))
+        "a fully-qualified `comment` is the same head"))
+
+  (testing "the guard went INSIDE the shared predicate rather than at either
+            call site, so the second caller — the Reagent-API arm, which
+            passes a collection of symbols through the same walk — is
+            answered by the same one call"
+    (is (= [:computed-value]
+           (classes "[:> Foo {:x (comment (r/atom 0))}]\n"))
+        "an inert `r/atom` is not API residue either")
+    (is (= [:computed-value]
+           (classes "[:> Foo {:x (comment (r/with-let [a 1] a))}]\n"))
+        "nor is an inert form-3 shape")))
+
+(deftest a-live-reagent-call-is-still-a-refusal-reason
+  (testing "ADVERSARIAL, and the arm that carries the weight: a fix which
+            simply stopped reporting islands would pass every assertion
+            above. Each case here puts the same call somewhere it RUNS."
+    (is (= [:as-element-island]
+           (classes "[:> Foo {:x (fn [] (r/as-element [:div]))}]\n"))
+        "the live island, unchanged")
+    (is (= [:reagent-api-residue]
+           (classes "[:> Foo {:x (fn [] (r/atom 0))}]\n"))
+        "and the live API residue, unchanged")
+    (is (= [:as-element-island :computed-value]
+           (classes (str "[:> Foo {:x (comment (r/as-element [:div]))\n"
+                         "         :y (fn [] (r/as-element [:span]))}]\n")))
+        "one inert and one LIVE `r/as-element` in the SAME props map. The
+         prune is per-node, so it takes the `(comment …)` and nothing
+         around it; a guard that skipped the map wholesale would lose the
+         live one and report no island at all"))
+
+  (testing "the syntax-quote boundary, restated on the refusal arm. `inert?`
+            is one predicate and every population consults it, so a
+            boundary that moved would move for all of them at once — and a
+            macro's template emits a real `r/as-element` per expansion."
+    (is (= [:as-element-island :computed-value]
+           (classes "[:> Foo {:x `(r/as-element [:div])}]\n")))))


### PR DESCRIPTION
Closes rf2-0xd6.

`subtree-has-reagent-call?` recursed through `n/children` without consulting
`inert?`, so an `r/as-element` sitting in a `(comment …)` inside a **live**
site's props read as an as-element island. The bead's probe, at this branch's
merge base:

```clojure
(cm/scan-string "(ns a (:require [reagent.core :as r]))\n[:> Foo {:x (comment (r/as-element [:div]))}]\n" "a.cljs")
=> [:as-element-island :computed-value]   ; before
=> [:computed-value]                      ; after
```

The site is live either way and was always reported correctly. The defect was
the extra refusal beside it, which sent the migrator to hand-port a form that
never runs. No incorrect edit resulted — the fixer's *write* walk was already
pruned by rf2-xc11 (PR #8154). This is a different population from that bead:
rf2-xc11 settled which nodes are SITES, and its walk is untouched here.

## Where the guard went, and why

Inside the predicate, not at either call site. Both callers ask the same
question and both spend the answer on a REFUSAL, and the inert form can sit at
any depth in the subtree — so one check on the recursion answers both callers
at every depth.

That turned out to matter rather than being merely tidy: the **second** call
site (`rewrite.clj:1196`, the Reagent-API arm that passes a collection of
symbols through the same walk) carried the identical bug, which the bead did
not name. Verified on the merge base before the fix:

```clojure
[:> Foo {:x (comment (r/atom 0))}]  =>  [:reagent-api-residue :computed-value]
```

It is now `[:computed-value]`, fixed by the same one call. A guard placed at
the `as-element` call site would have left it.

The prune stays per-node, so a props map carrying one inert and one live
`r/as-element` still reports the island. `inert?` itself is unchanged — a
syntax-quote is still live source, since a macro's template emits a real call
at every expansion.

## Tests

Two deftests in `inert_source_test.clj`, which is where the shared predicate's
controls already live. They fail in **opposite** directions, which is the point:

- `an-inert-reagent-call-is-not-a-refusal-reason` — 6 assertions. The bead's
  probe, `#_`, reader quote, fully-qualified `comment`, plus both arms of the
  second call site.
- `a-live-reagent-call-is-still-a-refusal-reason` — 4 assertions. Adversarial.
  A fix that simply stopped reporting islands would pass every assertion in the
  first deftest; each case here puts the same call somewhere it RUNS, including
  one props map holding an inert *and* a live `r/as-element`, and the
  syntax-quote boundary restated on the refusal arm.

## Quality gates

`clojure -M:test` from `migration/reagent-to-hicasso/codemod/` — the artefact's
own JVM suite, and exactly the CI lane for this surface
(`jvm-migration-hicasso-codemod`, `.github/workflows/test.yml:5221`, a required
check).

| Run | Tree | Ran | Failures / errors | Captured exit |
|---|---|---|---|---|
| 1 — control, before any change | merge base `d43a383d` | 52 tests / 479 assertions | 0 / 0 | `0` |
| 2 — fix + tests | pre-rebase | 54 tests / 489 assertions | 0 / 0 | `0` |
| 3 — **sabotage** | guard removed | 54 tests / 489 assertions | **6 / 0** | **`1`** |
| 4 — final | rebased on `69e02c9b` | 54 tests / 489 assertions | 0 / 0 | `0` |

Control arithmetic: +2 tests and +10 assertions over the control run, matching
the two deftests' 6 + 4 exactly — so no namespace aborted and every assertion
written actually ran.

Run 3 removed `(not (inert? node))` alone and went red on exactly the 6
assertions of the first deftest, reproducing the bead's `[:as-element-island
:computed-value]` verbatim; the adversarial deftest stayed green under it,
because sabotage restores the pre-fix behaviour that deftest pins. The guard
exists only in this branch, so the red is also what proves the gate read this
worktree. Restore verified by `git hash-object` against the committed blob
(`7f082a80…` for `rewrite.clj`), not by reading a diff.

**Not covered locally**: everything else gated by `.github/workflows/test.yml`
and `.github/workflows/docs.yml`. This change is confined to one JVM artefact
that loads no CLJS build, so the untouched surfaces are expected to be
unaffected rather than merely unrun.
