### PR TITLE
fix(hicasso): the walk-profile control must state a prediction before it adjudicates (rf2-1huc)

### DIFF
--- a/implementation/freehand/test/re_frame/bench/hicasso/walk_profile_app.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/walk_profile_app.cljs
@@ -125,7 +125,10 @@
      `window.HICASSO_CONTROL_FAILED` and `run.cjs` exits 1 (rf2-1huc —
      before it, that exit path was dead for this arm, so tables 1-4 were
      guarded against ordering and page fidelity but not against the
-     instrument having signal at all).
+     instrument having signal at all). A control whose own prediction
+     collapses refuses under a SEPARATE heading rather than passing on a
+     bar of zero, which is how the first cut of table 5 failed open
+     (merged-PR audit #8149; see [[tag-cache-floor-row]]).
 
   Owner bead: rf2-y1jkm. Driver: `run.cjs` with
   HICASSO_INIT_FN=re-frame.bench.hicasso.walk-profile-app/-main."
@@ -805,7 +808,29 @@
   row. This control is NEW, so it has no published row to re-adjudicate
   and inherits none of that: it takes the stricter rule from birth, the
   way `hd8-rows` did and for the reason `hd8-rows` gives — a control
-  whose worst round is wrong has caught something."
+  whose worst round is wrong has caught something.
+
+  ## Why a floor of zero or below REFUSES (rf2-1huc, merged-PR audit #8149)
+
+  The first cut of this row asked only `worst >= bar` and shipped FAILING
+  OPEN in the one direction its own subject makes reachable. `bar` is
+  derived from `fresh - hit`, so if those two primitives CONVERGE the bar
+  collapses to zero at the same moment the measured delta does — and
+  `>= 0` is cleared by any reading whatever. Converging primitives are
+  not an odd corner: they are exactly `parse-raw` having stopped being an
+  ablation, which is the thing this row exists to catch. Worse in the
+  other direction, a hit priced above a fresh parse puts the bar BELOW
+  zero, where the slack widens the band downward instead of narrowing it.
+  The audit reproduced both against the compiled function at merge
+  825cd611c8; `walk_profile_control_cljs_test` pins both.
+
+  So the prediction is required to STATE something before it is allowed
+  to adjudicate anything: `:stated?` is `floor > 0`, and a row that does
+  not state a prediction refuses under its own heading rather than
+  passing on a vacuous bar. The planted-fault proof could never have
+  found this — a mutation of the measured ARM leaves the micro table's
+  primitive difference healthy — which is the argument for pinning it by
+  arithmetic in the always-on suite instead."
   [readings census ^js tags micro]
   (let [m       (into {} micro)
         fresh   (:parse-tag-fresh m)
@@ -816,21 +841,37 @@
         bar     (* floor (- 1.0 control-slack))
         deltas  (per-round-delta readings :parse-raw :local)
         worst   (apply min deltas)
-        same?   (= n-tags parses)]
+        same?   (= n-tags parses)
+        ;; STRICTLY positive, so a NaN micro row refuses here too rather
+        ;; than sliding through a comparison that is false either way.
+        stated? (pos? floor)]
     {:row        :tag-cache-floor
      :predicted  (lane/round4 floor)
      :bar        (lane/round4 bar)
      :slack      control-slack
+     :stated?    stated?
      :population {:micro-roster n-tags :walk-parses parses}
      :per-round  (mapv lane/round4 deltas)
      :worst      (lane/round4 worst)
-     :ok?        (and same? (>= worst bar))
+     :ok?        (and same? stated? (>= worst bar))
      :why        (cond
                    (not same?)
                    (str "the micro roster holds " n-tags " tags but the walk parses "
                         parses " — the prediction is per-tag over the roster, so a "
                         "roster that is not the walk's parse population prices the "
                         "wrong thing and no figure in this run is reportable")
+
+                   (not stated?)
+                   (str "the micro table prices a fresh parse at " (fmt fresh 1)
+                        " ns against a cache hit at " (fmt hit 1) " ns over "
+                        n-tags " tags, so the predicted floor is " (fmt floor 4)
+                        " ms/walk and this control states no prediction. A floor "
+                        "at or below zero predicts that parse-raw costs no more "
+                        "than local, which puts the bar where every measurement "
+                        "clears it — including the flat one this row exists to "
+                        "catch. Converged primitives ARE the tag cache having "
+                        "stopped mattering, so this refuses rather than passing "
+                        "on a vacuous bar")
 
                    (>= worst bar)
                    (str n-tags " parses x " (fmt (- fresh hit) 1) " ns fresh-minus-cached "
@@ -873,13 +914,28 @@
                        "work than the eager one by construction, so an inversion "
                        "means the window is not pricing the walk"))}))
 
+(defn control-status
+  "The label one control row prints under. THREE outcomes, not two,
+  because a refusal that names no cause sends the operator to the wrong
+  place: `FAILED` means the arms did not show what the arithmetic
+  predicted and the repair is the ARM, while `REFUSED — no prediction`
+  means the arithmetic predicted nothing at all and the repair is the
+  MICRO TABLE that priced it (rf2-1huc). Rows that state no prediction —
+  [[lazy-tail-direction-row]], whose claim is a bare ordering — carry no
+  `:stated?` and read as the two-outcome rows they are."
+  [{:keys [ok? stated?]}]
+  (cond
+    ok?              "ok"
+    (false? stated?) "REFUSED — no prediction"
+    :else            "FAILED"))
+
 (defn- control-report!
   "Print every control row, passing or not. A control quoted only when it
   passes is not a control."
   [rows]
   (js/console.log ";; ==== POSITIVE CONTROL (does this instrument see a change it predicts?) ====")
-  (doseq [{:keys [row ok? why]} rows]
-    (js/console.log (str ";;   " (name row) ": " (if ok? "ok" "FAILED") " — " why))))
+  (doseq [{:keys [row why] :as r} rows]
+    (js/console.log (str ";;   " (name row) ": " (control-status r) " — " why))))
 
 (defn ^:export -main []
   (rf/init! uix-adapter/adapter)

--- a/implementation/freehand/test/re_frame/bench/hicasso/walk_profile_control_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/walk_profile_control_cljs_test.cljs
@@ -35,7 +35,18 @@
   disagree on it: overlap passes, every-round refuses. A worker who
   \"simplifies\" the control down to `lane/control-verdict` therefore
   discovers it here, rather than in a bench run six months later that
-  quietly stopped having teeth."
+  quietly stopped having teeth.
+
+  ## The assertions the planted fault could not reach
+
+  Merged-PR audit #8149 then found the control FAILING OPEN on its own
+  prediction: the bar is `n-tags x (fresh - hit)` less slack, and nothing
+  required that difference to be positive, so converged primitives put
+  the bar at zero where every reading clears it. A browser proof cannot
+  find that — mutating the measured ARM leaves the micro table healthy —
+  so [[a-converged-prediction-refuses-however-healthy-the-deltas-look]]
+  and its siblings below pin it by arithmetic instead. That is the second
+  reason this file exists and not merely belt-and-braces either."
   (:require [cljs.test :refer-macros [deftest is testing]]
             [re-frame.bench.hicasso.lane :as lane]
             [re-frame.bench.hicasso.walk-profile-app :as wp]))
@@ -122,6 +133,105 @@
       (is (false? (:ok? strict))
           "the every-round rule REFUSES it, which is the whole difference")
       (is (= 0.03 (:worst strict))))))
+
+;; ---------------------------------------------------------------------------
+;; The prediction must STATE something (rf2-1huc, merged-PR audit #8149)
+;; ---------------------------------------------------------------------------
+;;
+;; The control shipped FAILING OPEN in the one direction its own subject
+;; makes reachable. The bar is `n-tags x (fresh - hit)` less 25%, and the
+;; verdict was `worst >= bar` with nothing requiring `fresh - hit` to be
+;; positive. So if the two primitives CONVERGE — which is precisely the
+;; tag cache having stopped mattering, the ablation this row exists to
+;; catch — the prediction collapses to zero or below at the same moment
+;; the measured delta does, the bar lands at or under zero, and any
+;; reading at all clears it. The audit reproduced both directions against
+;; the exact compiled function at merge 825cd611c8:
+;;
+;;   cached 50 ns, fresh 50 ns, delta 0  ->  predicted 0,    bar 0,      ok TRUE
+;;   cached 150 ns, fresh 50 ns, delta 0 ->  predicted -0.1, bar -0.075, ok TRUE
+;;
+;; The planted-fault proof could not have found this: it moved the WALK
+;; call site and left the micro table's primitive difference healthy, so
+;; the prediction stayed positive and the bar stayed real. A control's
+;; own prediction going vacuous is a mode no mutation of the measured arm
+;; can reach, and it is why these cases are pinned by arithmetic here
+;; rather than by a browser run.
+
+(def ^:private micro-converged
+  "The two primitives priced the SAME. Predicted floor 0."
+  [[:cached-parse-hit 50.0] [:parse-tag-fresh 50.0]])
+
+(def ^:private micro-inverted
+  "A cache hit priced ABOVE a fresh parse. Predicted floor -0.1 ms/walk,
+  whose 25% slack makes the bar -0.075 — a bar the arithmetic moves UP
+  from the floor rather than down, which is on its own enough to say the
+  band has stopped meaning anything."
+  [[:cached-parse-hit 150.0] [:parse-tag-fresh 50.0]])
+
+(deftest a-converged-prediction-refuses-however-healthy-the-deltas-look
+  (testing "fresh == cached predicts NO extra cost, so there is nothing for
+            the walk to have seen — and a control with nothing to see must
+            not report that it saw it"
+    (let [r (wp/tag-cache-floor-row [(healthy 0.20) (healthy 0.25)] census roster
+                                    micro-converged)]
+      (is (= 0.0 (:predicted r)) "the fixture really does state a zero floor")
+      (is (false? (:ok? r))
+          "a bar of zero is cleared by any measurement whatever, so passing
+           here is passing on a vacuous test")
+      (is (false? (:stated? r))
+          "and the refusal is attributed to the PREDICTION, not to the arms"))))
+
+(deftest the-audits-exact-converged-case
+  (testing "cached 50 ns, fresh 50 ns, observed delta 0 — reported ok TRUE
+            at merge 825cd611c8"
+    (let [r (wp/tag-cache-floor-row [(healthy 0.0)] census roster micro-converged)]
+      (is (= 0.0 (:predicted r)))
+      (is (= 0.0 (:bar r)))
+      (is (= 0.0 (:worst r)))
+      (is (false? (:ok? r))))))
+
+(deftest the-audits-exact-inverted-case
+  (testing "cached 150 ns, fresh 50 ns, observed delta 0 — reported ok TRUE
+            at merge 825cd611c8, because a NEGATIVE floor puts the bar
+            below every real measurement"
+    (let [r (wp/tag-cache-floor-row [(healthy 0.0)] census roster micro-inverted)]
+      (is (= -0.1 (:predicted r)))
+      (is (= -0.075 (:bar r)))
+      (is (false? (:ok? r)))
+      (is (false? (:stated? r))))))
+
+(deftest a-roster-with-no-tags-refuses
+  (testing "the other route to a vacuous bar: nothing to predict over. The
+            population rule cannot catch it, because an empty roster and a
+            walk that parses nothing agree with each other"
+    (let [r (wp/tag-cache-floor-row [(healthy 0.20)] {:native 0} (make-array 0) micro)]
+      (is (= 0.0 (:predicted r)))
+      (is (false? (:ok? r)))
+      (is (false? (:stated? r))))))
+
+(deftest an-absent-prediction-is-reported-DIFFERENTLY-from-a-missed-bar
+  (testing "two refusals, two causes, two repairs — an operator told only
+            `FAILED` would go looking at the arms, where nothing is wrong"
+    (let [vacuous (wp/tag-cache-floor-row [(healthy 0.20)] census roster micro-converged)
+          missed  (wp/tag-cache-floor-row [(healthy 0.01)] census roster micro)]
+      (is (false? (:ok? vacuous)))
+      (is (false? (:ok? missed)))
+      (is (false? (:stated? vacuous)))
+      (is (true? (:stated? missed))
+          "the missed bar had a real prediction; it is the ARMS that missed it")
+      (is (re-find #"states no prediction" (:why vacuous)))
+      (is (re-find #"BELOW it" (:why missed)))
+      (is (= "REFUSED — no prediction" (wp/control-status vacuous)))
+      (is (= "FAILED" (wp/control-status missed)))
+      (is (= "ok" (wp/control-status (wp/tag-cache-floor-row
+                                       [(healthy 0.20)] census roster micro)))))))
+
+(deftest a-real-prediction-still-passes-on-real-signal
+  (testing "the repair must not have closed the door on the healthy case —
+            the whole point is a control that can still say yes"
+    (is (true? (:ok? (wp/tag-cache-floor-row [(healthy 0.20) (healthy 0.18)]
+                                             census roster micro))))))
 
 (deftest a-roster-that-is-not-the-walks-parse-population-refuses
   (testing "the prediction is per-tag over the micro roster, so a roster


### PR DESCRIPTION
Closes rf2-1huc.

## The bead's title is stale; its newest note is the work

`walk_profile_app.cljs` has had a positive control since `ae3d0744fb`
(*fix(hicasso): give walk_profile_app a positive control (rf2-1huc)*), which is
an ancestor of `main`. `run.cjs`'s `HICASSO_CONTROL_FAILED` exit path is not
dead for this arm and has not been since. What reopened the bead is
**merged-PR audit #8149**, whose finding is the last note on it: the control
that landed **fails open**, and its proportionate repair is spelled out there.
This PR is that repair. Nothing here re-litigates the exit path.

## The defect

`tag-cache-floor-row` predicts `parse-raw`'s extra cost as
`n-tags x (fresh - hit)` out of the run's own micro table, sets the bar 25%
under it, and asked only `worst >= bar`. Nothing required `fresh - hit` to be
positive — and that difference is measured, not structural, so it can go to
zero or below.

When it does, the bar collapses **at the same moment the measured delta does**:

| micro table          | predicted floor | bar      | observed delta | shipped verdict |
|----------------------|-----------------|----------|----------------|-----------------|
| cached 50, fresh 50  | `0`             | `0`      | `0`            | **ok TRUE**     |
| cached 150, fresh 50 | `-0.1` ms/walk  | `-0.075` | `0`            | **ok TRUE**     |

Both rows are audit #8149's own reproductions against the compiled function at
merge `825cd611c8`, and both are now pinned as tests. A negative floor is the
worse of the two: the slack widens the band *downward*, so the bar sits below
every physically possible measurement.

The failure mode matters because converged primitives are not a corner case —
they **are** `parse-raw` having stopped being an ablation, which is precisely
what this row exists to catch. The control was blindest exactly where it was
meant to look.

The PR that landed the control proved it against a planted fault, and that
proof could not have found this: the plant moved the **walk call site** and
left the micro table's primitive difference healthy, so the prediction stayed
positive and the bar stayed real. No mutation of the measured arm can reach a
mode where the control's own arithmetic goes vacuous. That is the argument for
pinning it by arithmetic in the always-on suite rather than by a browser run.

## The repair

- **`:stated?` is `floor > 0`, and it gates the verdict.** Strictly positive, so
  a NaN micro row refuses here too rather than sliding through a comparison
  that is false in both directions. It also closes the second route to a
  vacuous bar — an empty roster — which the population rule structurally
  cannot catch, because an empty roster and a walk that parses nothing agree
  with each other.
- **The refusal is reported under its own heading.** New `control-status` gives
  three outcomes, not two: `FAILED` means the arms missed a real prediction and
  the repair is the **arm**; `REFUSED — no prediction` means the arithmetic
  predicted nothing and the repair is the **micro table** that priced it. An
  operator handed only `FAILED` would go looking at the arms, where nothing is
  wrong. `control-report!` prints through it, so this reaches the run's output.
- **The every-round rule and the population-equality rule are untouched**, as
  the bead requires.

`lane/control-verdict`'s weak overlap rule is neither adopted nor touched — see
below.

## Quality gates

| gate | result | captured exit |
|---|---|---|
| `scripts/test-fast-pr.sh` (full spine, final rebased base) | `PASS fast PR spine` | **0** |
| ├─ `npm run test:cljs` | **13,873 tests / 70,105 assertions, 0 failures, 0 errors** | (in spine) |
| └─ `npm run test:script-helpers` (incl. `inpage_ladder_exit_path.test.cjs`) | pass | (in spine) |
| focused: `walk-profile-control-cljs-test` + `walk-profile-baseline-cljs-test` | **15 tests / 70 assertions, 0 failures, 0 errors** | **0** |
| the same focused pair, **sabotaged** | **6 failures**, 0 errors | **1** |

`test:cljs` moves from the audit's baseline of 13,867 / 70,081 to 13,873 /
70,105 — exactly **+6 tests and +24 assertions**, which is exactly what this PR
adds. That arithmetic is the positive evidence that the runtime observed the
new file, not merely that the source changed.

Every number above is a code I captured myself by redirecting the runner to a
log and echoing its own status on the same command line. Where the harness
reported an exit code for the same run it disagreed — it called the sabotage
run 0 while the runner's own status was 1 — so the harness's number is not
quoted anywhere here.

### The control proven both ways

The property removed is the strict-positivity gate itself: `:ok? (and same?
stated? (>= worst bar))` reverted to `:ok? (and same? (>= worst bar))`, a
single-line anchor, which reconstitutes the shipped verdict exactly.

| step | `git hash-object` of `walk_profile_app.cljs` | focused gate |
|---|---|---|
| repaired | `02a07f780e401097819b53f0330a9afd523de498` | 15 tests, **0 failures**, exit **0** |
| property removed | `55b1717abc5948a99765cf7ec6c7b72f65e5419d` | 15 tests, **6 failures**, exit **1** |
| restored | `02a07f780e401097819b53f0330a9afd523de498` | ✔ byte-identical to the committed blob |

The restore is verified against the committed object with `git hash-object`,
not by reading a diff — a patch that never applied and a clean restore produce
the same diff, and only the hash separates them.

Two further checks on the red, because a red that proves nothing is worse than
no red:

- **The failures are the audit's own finding, reproduced.** All six name the
  fail-open directly — `expected: (false? (:ok? r))` / `actual: (not (false?
  true))` — including both audit rows verbatim.
- **The plant was scoped.** Test and assertion counts are **identical** across
  the red and green runs (15 / 70), so the plant crashed no namespace and
  truncated no suite; only the verdicts moved.

The gate is confirmed to have read *this* worktree by both available routes:
the compile prints
`config: C:\Users\miket\code\re-frame2-worktrees\walkctl-1huc\implementation\shadow-cljs.edn`,
and the planted fault — which exists only in this tree — went red.

### Required CI checks this local gate does not cover

The spine's own gap map reports it: 85 required jobs across 3 workflows, 29
fully covered, 5 partly, 51 not at all. The uncovered ones live in
`.github/workflows/test.yml` (`All required checks passed`, 46 jobs),
`.github/workflows/lint.yml` (`Lint required`, 4 jobs) and
`.github/workflows/docs.yml` (`Docs required`, 1 job); `python
scripts/check_fast_pr_gap.py --list` enumerates them. Of these the browser
lanes in `test.yml` are the ones that could bear on this change, and they do
not exercise `walk_profile_app` — the walk profile is a diagnostic bench arm
run by hand, not a gate row. The clj-kondo pin in `lint.yml` is version-
sensitive by that job's own note.

**No measurement window was run.** Two other workers were live on this box, and
this PR builds an instrument rather than producing a figure. No row is
published, no studio or ladder page is touched, and no published figure is
restated.

## Declined, with reasons

- **A `walk_profile_exit_path.test.cjs` in the `inpage_ladder_exit_path.test.cjs`
  shape.** That shape works there because `inpage_ladder_aggregate.cjs` is a
  pure `.cjs` adjudicator whose decisions are directly callable. `run.cjs` holds
  no adjudication at all for this arm — it reads a window flag and exits — and
  it is a top-level IIFE, so requiring it runs it. A test could therefore only
  regex the driver's source, and the driver is shared by five arms, so such a
  test would pin nothing walk-profile-specific while planting a new claim on a
  file outside this bead. The adjudication is the thing with logic in it, and it
  is pinned, in CLJS, where it lives.
- **Touching `lane/control-verdict`'s known-defect overlap rule.** Out of fence,
  and it is reserved to an operator ruling (rf2-egdaq / rf2-2rtt6.1) because
  tightening it re-adjudicates a published row.
- **Widening the repair to the sibling arms.** Not declined on scope — checked,
  and there is nothing there to repair. See below.

## Not asked about, checked on the way: no sibling carries this hole

The obvious next question is whether the other five flag-setting arms fail open
the same way, so I read their predictions rather than assume. They do not, and
the reason sharpens what the defect actually was.

| arm | predicted quantity | collapsible? |
|---|---|---|
| `coldmount_app` | ratio of `v/m1-elements` / `v/m2-elements` counts | no — structural |
| `p0_converge_app` | same element-count ratio | no — structural |
| `p0_reagent_app` | same element-count ratio | no — structural |
| `inpage_ladder_app` | `arms/ctl-predicted` (1.9759, large-template element arithmetic) | no — structural |
| `direct_return_clock_app` | `2.0 x (p50 of the :hiccup arm)` | no — see below |
| `hd8_rows/positive-control!` | `(3 + 3N) / (3 + 3(N/2))` | no — structural |
| **`walk_profile_app`** | **`n-tags x (fresh - hit)`, both measured** | **yes** |

The distinction is not *measured vs structural* — it is finer than that.
`direct_return_clock_app` predicts from a measured quantity too, but it
**scales** one (`2.0 x p50`), and a scaling cannot produce a vacuous band from
a physically reachable reading. The walk profile's prediction is a
**difference of two measured quantities**, and a difference can go to zero and
through it while both operands stay perfectly ordinary. That is the shape that
collapses, and it is unique to this row across the whole lane.

So no sibling bead is filed: the general rule worth remembering is narrow and
already discharged here — *a control whose bar is a difference of two measured
quantities must assert the difference before it asserts anything about the
arms.*
