### PR TITLE
fix(bench): the alloc window's first work unit is a PRIME, and the refused ratio is possible again (rf2-oiy1, rf2-xxeq)

### DIFF
--- a/docs/design/hicasso/allocation-instrument-rework.md
+++ b/docs/design/hicasso/allocation-instrument-rework.md
@@ -667,6 +667,45 @@ witness together show the operating page is too small for a per-boundary figure
 to be credible — for instance if B lands at 3 or fewer. File it as its own bead
 at that point, with V1's data attached.
 
+## Addendum — the window's first work unit is a PRIME (rf2-oiy1)
+
+Added after V1/V2/V3 ran. It changes the instrument's window shape, so it is
+recorded here rather than left to be read off the source; the validity
+witnesses' own configurations are unchanged in what they ask for.
+
+**What V1/V2/V3 found.** Every one of the 336 arm windows measured, across
+eight browser runs, carried a positive first-leg excess over its own cohort
+median — median 6,966 B, constant in absolute bytes across B ∈ {4, 24, 96} and
+identical under both writes. At τ = 0.25 that refuses every window whose leg
+median is under ≈ 27,900 B, which is every floor window at every page size, and
+`arm − floor` is the quantity every witness here is stated over.
+
+**Which of the two causes it is, from that window's own numbers rather than
+from a new one.** The tail legs of a clean window are byte-identical
+(`[26044, 19256, 19256, 19256, 19256, 19256]`), so steady state arrives after
+*one* work unit inside the window. Eighteen work units already run immediately
+before it — the three full-size warm-up windows this brief specifies — and the
+excess survives all of them. The only thing standing between the last of those
+and leg 1 is the driver's own `gc()`. One work unit *after* the collection
+clears it and eighteen *before* it do not, so the collection is what creates it
+and a fourth warm-up window cannot reach it.
+
+**The repair.** The window drives `ALLOC_WRITES + 1` work units and the first
+is a prime: sampled, reported, and excluded from the leg cohort, from `rise`,
+from `falls`, from `perWrite` and from the certificate. τ is untouched, the
+2τ statement is re-derived unchanged (its derivation is per-leg and never
+referenced how many legs there are), and `ALLOC_MIN_WRITES` still holds six
+*averaged* writes — which is why the window drives seven rather than dropping a
+leg from six. The excess itself is printed beside the figures on every run.
+
+**It also closes the option held in reserve above.** Six single-write windows,
+each with its own forced collection before it, would put the first-leg excess
+on the *only* leg of every one of them — the shape whose leg cohort has nothing
+left to compare against. The reserved option is therefore not available as
+written; it would have to be six *primed two-write* windows, at which point its
+claimed six-fold shrink is a three-fold one and the trigger arithmetic above
+needs redoing.
+
 ## Implementation order
 
 One worker, in this order, so that nothing is measured before the thing that

--- a/implementation/core/test/re_frame/bench/p0_ladder_structural.test.cjs
+++ b/implementation/core/test/re_frame/bench/p0_ladder_structural.test.cjs
@@ -53,6 +53,9 @@ const {
   ladderPlan,
   allocArmSizing,
   ALLOC_MIN_WRITES,
+  allocPrimeSplit,
+  ALLOC_PRIME_WRITES,
+  ALLOC_WINDOW_WRITES,
   ALLOC_WRITE_SPECS,
   ALLOC_PLAN_SHAPES,
   allocPlanArms,
@@ -529,8 +532,21 @@ test('the tolerance is CALIBRATED, pinned, and has no dial on it', () => {
   );
   // And the driver reads the module constant at every measurement site: the
   // `tolerance` parameter exists for the τ sweep below and for nothing else.
-  has(/const s = allocSteps\(w\.samples\);/, 'the control windows take the shipped τ');
-  has(/const s = allocSteps\(win\.samples\);/, 'and so do the arm windows');
+  // Both sites split the prime off first (rf2-oiy1) and then adjudicate the
+  // MEASURED region — one adjudicator, one τ, two windows.
+  has(
+    /const \{ primeLegs, measured \} = allocPrimeSplit\(w\.samples\);/,
+    'the control windows split the prime off'
+  );
+  has(
+    /const \{ primeLegs, measured \} = allocPrimeSplit\(win\.samples\);/,
+    'and so do the arm windows'
+  );
+  has(/const s = allocSteps\(measured\);/, 'and what is adjudicated is the measured region');
+  lacks(
+    /allocSteps\(win\.samples\)|allocSteps\(w\.samples\)/,
+    'nothing adjudicates the raw window any more — the prime leg is not a work leg'
+  );
 });
 
 test('the retired masking budget is GONE, not widened', () => {
@@ -677,6 +693,161 @@ test('LEGS AND GAPS are read apart, and only the legs are adjudicated', () => {
   assert.deepStrictEqual(s.legs, [1000, 2000, 3000], 'one leg per iteration');
   assert.deepStrictEqual(s.gaps, [0, 0, 0], 'and nothing happens between them');
   assert.strictEqual(s.rise, 6000, 'rise is unchanged by the split');
+});
+
+// ===========================================================================
+// THE PRIME WORK UNIT — rf2-oiy1
+// ===========================================================================
+//
+// THE DEFECT THIS PINS. rf2-2rtt6.140's V1/V2/V3 window measured 336 arm
+// windows across eight browser runs and every one carried a POSITIVE first-leg
+// excess over its own cohort median — median 6,966 B, constant in absolute
+// bytes across a 24x page range, identical under both writes. At τ = 0.25 a
+// fixed ~7 KB excess refuses every window whose leg median is under ~27,900 B,
+// which is every floor window at every page size; and `arm − floor` is the
+// quantity every witness on this row is stated over, so the ladder went with
+// it.
+//
+// WHICH CAUSE IT IS, FROM THAT WINDOW'S OWN NUMBERS. The tail legs of a clean
+// window are byte-identical, so steady state arrives after ONE work unit
+// inside the window; eighteen work units already run immediately before it, in
+// three full-size warm-up windows, and the excess survives all of them; and
+// the only thing between the last of those and leg 1 is the driver's own
+// `gc()`. One after clears it, eighteen before do not — so the collection
+// creates it, and a fourth warm-up (the bead's branch (a)) cannot reach it.
+//
+// THE REPAIR IS NOT A WIDENING AND NOT A DISCARD. The window drives one extra
+// work unit; the first is a PRIME, sampled and reported and excluded from
+// every published quantity and from the certificate. τ is untouched.
+// `allocSteps` is untouched — every pin above it stands unedited — because the
+// split hands it a shorter stream in the same shape.
+
+test('THE SPLIT — the measured region is a well-formed stream in the same shape', () => {
+  // `[s0, pre0, post0, pre1, post1, ...]`. Dropping `2·prime` leading samples
+  // leaves the last prime leg's `post` standing as the measured region's `s0`,
+  // so nothing is fabricated and nothing is re-based. That is the whole reason
+  // `allocSteps` needs no knowledge of any of this.
+  const raw = stream([9000, 1000, 1000, 1000]);
+  const { primeLegs, measured } = allocPrimeSplit(raw, 1);
+  assert.deepStrictEqual(primeLegs, [9000], 'the prime leg is READ, not thrown away');
+  assert.deepStrictEqual(measured, raw.slice(2));
+  const s = allocSteps(measured);
+  assert.deepStrictEqual(s.legs, [1000, 1000, 1000], 'and the measured legs are the rest');
+  assert.deepStrictEqual(s.gaps, [0, 0, 0], 'including the true gap out of the prime');
+  assert.strictEqual(s.rise, 3000, 'the prime`s 9000 B is in no rising sum');
+  assert.strictEqual(s.falls, 0);
+});
+
+test('THE BEAD`S OWN WINDOW — refused before the prime, certified after', () => {
+  // The B = 4 floor window quoted verbatim on rf2-oiy1:
+  // [26044, 19256, 19256, 19256, 19256, 19256]. Six alike legs with the first
+  // 6,788 B high — 35% of a 19,256 B cohort, against a 25% tolerance.
+  const OBSERVED = [26044, 19256, 19256, 19256, 19256, 19256];
+  // WRONG BEFORE. Adjudicated whole, exactly as the driver did until this
+  // bead, it refuses — and on the first leg, which is the only deviant one.
+  const before = allocSteps(stream(OBSERVED));
+  assert.strictEqual(before.certified, false, 'this is the window the row could not certify');
+  assert.strictEqual(before.refusals.length, 1, JSON.stringify(before.refusals));
+  assert.match(before.refusals[0], /leg 1 of 6/);
+  assert.strictEqual(before.legMedian, 19256);
+
+  // RIGHT AFTER. The same six work units with a prime in front of them: the
+  // prime absorbs the excess, the six measured legs are byte-identical, and
+  // the window certifies. The tail is byte-identical in the MEASURED data —
+  // that is the observation the whole repair rests on, and it is why one
+  // priming unit is enough.
+  const primed = allocPrimeSplit(stream([26044, ...OBSERVED.slice(1), 19256]), 1);
+  const after = allocSteps(primed.measured);
+  assert.deepStrictEqual(primed.primeLegs, [26044]);
+  assert.deepStrictEqual(after.legs, [19256, 19256, 19256, 19256, 19256, 19256]);
+  assert.strictEqual(after.certified, true, 'six repetitions of one work unit certify');
+  assert.strictEqual(after.legWorstDeviation, 0);
+  assert.strictEqual(after.rise, 6 * 19256, 'and the prime is in no published byte');
+  // The excess is still MEASURED. This is what makes the repair a report
+  // rather than a discard, and it is the figure rf2-e9wr's calibration wants.
+  assert.strictEqual(primed.primeLegs[0] - after.legMedian, 6788);
+});
+
+test('THE PRIME IS NOT AN AMNESTY — a deviant MEASURED leg still refuses', () => {
+  // A rule that cannot fail has adjudicated nothing. The prime takes exactly
+  // one work unit out of the cohort; everything the leg witness refused before
+  // it, it refuses after.
+  const masked = allocPrimeSplit(stream([26044, 200000, 200000, 0, 200000], [0, 0, 0, 200000, 0]));
+  const s = allocSteps(masked.measured);
+  assert.strictEqual(s.certified, false, 'a masked leg in the measured region still refuses');
+  assert.ok(s.legWorstDeviation < 0, 'and it is BELOW its cohort, which is the signature');
+  // And a SECOND high leg — one the prime does not cover — refuses too.
+  const twoHigh = allocPrimeSplit(stream([26044, 26044, 19256, 19256, 19256, 19256, 19256]));
+  assert.strictEqual(
+    allocSteps(twoHigh.measured).certified,
+    false,
+    'the prime covers ONE work unit, not "the high ones"'
+  );
+});
+
+test('the prime is CONFIGURED IN ONE PLACE and the divisor is not it', () => {
+  assert.strictEqual(typeof ALLOC_PRIME_WRITES, 'number');
+  assert.ok(ALLOC_PRIME_WRITES >= 1, 'a prime of zero is the shape the bead refutes');
+  assert.strictEqual(
+    ALLOC_WINDOW_WRITES - ALLOC_MIN_WRITES,
+    ALLOC_PRIME_WRITES,
+    'the window drives the averaging floor PLUS the prime'
+  );
+  // THE AVERAGING FLOOR IS UNMOVED (rf2-2rtt6.142). Excluding a leg from a
+  // six-write window would have left five averaged writes, under the floor.
+  // Averaging six means driving seven, and this is the arithmetic that says so.
+  assert.strictEqual(ALLOC_MIN_WRITES, 6);
+  // The published quantity is per MEASURED write. A divisor of
+  // `ALLOC_WINDOW_WRITES` would have folded the prime back into every figure.
+  has(/perWrite: s\.rise \/ ALLOC_WRITES,/, 'the arm figure divides by the measured writes');
+  has(/perIter: s\.rise \/ ALLOC_WRITES,/, 'and so does the control figure');
+  // And the window is driven at the full count at every site, warm-ups
+  // included — a warm-up smaller than the window is the defect the warm-up
+  // pass exists to avoid.
+  lacks(
+    /allocPrepare\(dd?, n\), \[[^\]]*ALLOC_WRITES\]/,
+    'no sample buffer is sized for the measured writes alone'
+  );
+  has(/\[ALLOC_WINDOW_WRITES, drain, ALLOC_WRITE_SPEC\.kind\]/, 'the window drives the full count');
+  // NO DIAL. The prime decides what a window MEANS, so it is a constant for
+  // `ALLOC_LEG_TOLERANCE`'s reason: a knob on it is a knob on the certificate.
+  lacks(/P0_ALLOC_PRIME|P0_ALLOC_WINDOW_WRITES/, 'the prime has no env dial on it');
+});
+
+test('THE PRIME IS LIVE THROUGH THE SHIPPED CONFIGURATION ROUTE, not just declared', () => {
+  // DRIVEN, in a fresh process, through the same env surface an operator
+  // configures: configuration is read exactly once at require, so this is the
+  // shipped derivation rather than a restatement of it. `constUnderEnv` is
+  // hoisted from further down this file — the same helper the write and plan
+  // switches are pinned with.
+  assert.strictEqual(constUnderEnv('ALLOC_PRIME_WRITES', {}), ALLOC_PRIME_WRITES);
+  assert.strictEqual(
+    constUnderEnv('ALLOC_WINDOW_WRITES', {}),
+    ALLOC_MIN_WRITES + ALLOC_PRIME_WRITES,
+    'the default window drives the averaging floor plus the prime'
+  );
+  // And it tracks a stated window rather than sitting at a literal: a run that
+  // asked for more averaging gets more averaging AND its prime, not one of the
+  // two.
+  assert.strictEqual(
+    constUnderEnv('ALLOC_WINDOW_WRITES', { P0_ALLOC_WRITES: '10' }),
+    10 + ALLOC_PRIME_WRITES
+  );
+  assert.strictEqual(constUnderEnv('ALLOC_WRITES', { P0_ALLOC_WRITES: '10' }), 10);
+});
+
+test('the prime is CLAMPED, so a short stream cannot read off the end', () => {
+  // Defensive, and cheap: a window with fewer legs than the prime yields no
+  // measured legs rather than an undefined subtraction.
+  const short = allocPrimeSplit(stream([1000]), 1);
+  assert.deepStrictEqual(short.primeLegs, [1000]);
+  assert.deepStrictEqual(allocSteps(short.measured).legs, []);
+  const none = allocPrimeSplit(stream([]), 1);
+  assert.deepStrictEqual(none.primeLegs, [], 'nothing to prime is not a negative index');
+  // A prime of zero is the pre-bead shape, and the split is the identity on it
+  // — which is what lets every `allocSteps` pin above stand unedited.
+  const raw = stream([1000, 1000]);
+  assert.deepStrictEqual(allocPrimeSplit(raw, 0), { primeLegs: [], measured: raw });
 });
 
 // --- the row-level witness the driver actually exits on --------------------
@@ -1239,7 +1410,15 @@ test('the narrow plans SUBTRACT arms — they add none, move none and reorder no
 // The fields `summariseAlloc` reads, and no more. `arms` is what the plan
 // shape decides, so it is the parameter.
 function allocSummaryFor(planName, arms = {}) {
-  const ctl = (perIter) => ({ perIter, ...allocSteps(stream([20000, 20000, 20000, 20000])) });
+  // The control windows carry a prime too and it costs them nothing — the
+  // studio page records their worst leg deviation at <= 1% against the arms'
+  // 26-46%, which is the contrast that located the term in the first place.
+  const ctl = (perIter) => ({
+    perIter,
+    primeLegs: [20000],
+    primeExcess: 0,
+    ...allocSteps(stream([20000, 20000, 20000, 20000])),
+  });
   const row = {
     roots: 4,
     boundaries: 24,
@@ -1247,6 +1426,8 @@ function allocSummaryFor(planName, arms = {}) {
     publishedPerRoot: { grid: 300 },
     arm: { cells: 6, roots: 4, boundaries: 24, writes: 6 },
     writes: 6,
+    primeWrites: ALLOC_PRIME_WRITES,
+    windowWrites: ALLOC_WINDOW_WRITES,
     warmups: 3,
     rounds: 2,
     writeSelector: 'page',
@@ -1286,6 +1467,9 @@ const FLOOR_ARMS = () =>
         reads: 0,
         boundaries: 24,
         ...allocSteps(stream([5000, 5000, 5000, 5000])),
+        // The bead's own excess, 6,788 B, riding on a synthetic floor window.
+        primeLegs: [11788],
+        primeExcess: 6788,
         perWrite: 5000,
         perBoundaryPerWrite: 208,
       },
@@ -1305,6 +1489,11 @@ test("V3's CONTROLS-ONLY summary RUNS, and states absence rather than zero", () 
   assert.strictEqual(row.controlVerdict.ok, true, 'the positive control still decides');
   assert.strictEqual(row.fallsInMeasuredWindows, 0);
   assert.match(out, /control D=1000: predicted 8000 B/);
+  // With no arm mounted the prime is reported off the CONTROL windows, which
+  // is the population a controls-only run has. Their prime costs nothing, and
+  // a run that printed no prime line at all would be hiding the one term this
+  // instrument now has a name for.
+  assert.match(out, /prime excess over the measured cohort median: 0 B mean/);
 });
 
 test("V1's FLOOR-ONLY summary RUNS, prints the floor, and prints no rung", () => {
@@ -1317,6 +1506,22 @@ test("V1's FLOOR-ONLY summary RUNS, prints the floor, and prints no rung", () =>
   assert.doesNotMatch(out, /hicasso\s+\d/, 'but no rung row is');
   assert.match(out, /NO FITTED LINE/, 'and nothing is regressed through one arm');
   assert.match(out, /THE PLAN IS `floor`/);
+  // THE PRIME LEG IS PRINTED, not merely excluded (rf2-oiy1). This is what
+  // separates the repair from "discard leg 1": the term that made every floor
+  // window uncertifiable is still measured, on every window, and is readable
+  // beside the cohort it used to contaminate — which is the figure rf2-e9wr's
+  // τ calibration needs.
+  assert.match(out, /THE PRIME LEG \(excluded from every figure\)/);
+  assert.match(
+    out,
+    /prime excess over the measured cohort median: 6788 B mean \[6788–6788\] across 4 windows/,
+    'the excess is REPORTED, per window, in bytes'
+  );
+  assert.match(
+    out,
+    new RegExp(`The window drives ${ALLOC_WINDOW_WRITES} — the first ${ALLOC_PRIME_WRITES} is a PRIME`),
+    'and the header says how many work units ran against how many are published'
+  );
 });
 
 test('the DRIVER honours both switches — the write, the plan, and the record', () => {
@@ -1327,9 +1532,12 @@ test('the DRIVER honours both switches — the write, the plan, and the record',
   // the more dangerous of the two to lose, because a site warmed under one
   // write and measured under the other reads its settled value for neither.
   // (`b8-alloc`'s driver watched a first window read 5.3x its settled value.)
+  // `ALLOC_WINDOW_WRITES` at both, since rf2-oiy1: the window drives the
+  // measured writes PLUS the prime, and a warm-up shorter than the window is
+  // the very defect the warm-up pass exists to avoid.
   assert.strictEqual(
     (SRC.match(
-      /window\.P0H\.allocWindow\(n, k, d\),\s*\[ALLOC_WRITES, drain, ALLOC_WRITE_SPEC\.kind\]/g
+      /window\.P0H\.allocWindow\(n, k, d\),\s*\[ALLOC_WINDOW_WRITES, drain, ALLOC_WRITE_SPEC\.kind\]/g
     ) || []).length,
     2,
     'the warm-up AND the measured window both drive the SELECTED write'

--- a/implementation/core/test/re_frame/bench/p0_ladder_structural.test.cjs
+++ b/implementation/core/test/re_frame/bench/p0_ladder_structural.test.cjs
@@ -48,6 +48,7 @@ const {
   ladderStructuralFailures,
   allocSteps,
   allocRefusedWindows,
+  allocRefusedWindowCount,
   ALLOC_LEG_TOLERANCE,
   ALLOC_FALL_THRESHOLD_B,
   ladderPlan,
@@ -895,6 +896,71 @@ test('every REFUSED window is named, on every round, with its reason', () => {
   assert.ok(fails.some((f) => f.startsWith('round 2 ')));
 });
 
+test('THE RATIO IS POSSIBLE — refusal REASONS are not counted against WINDOWS', () => {
+  // rf2-xxeq. Every V1 run printed `windows refused: 17 of 12` — and 14, 13,
+  // 14, 16, 13 — because the numerator was `allocRefusedWindows(...).length`,
+  // one entry per refusal REASON, while the denominator counted WINDOWS. A
+  // window with two deviant legs contributed two.
+  //
+  // CONSTRUCTED, not asserted: this window has THREE legs outside tolerance
+  // against a cohort of five, so it yields three reasons and is one window.
+  const THREE_BAD = stream([20000, 20000, 0, 60000, 0]);
+  const three = allocSteps(THREE_BAD);
+  assert.strictEqual(three.certified, false);
+  assert.strictEqual(three.refusals.length, 3, 'one window, three deviant legs');
+
+  const row = allocRowWith(
+    { 'reagent-subs|lad/hicasso#R7': THREE_BAD, 'reagent-subs|lad/reagent#R7': SMALL },
+    2
+  );
+  const reasons = allocRefusedWindows(row);
+  const windows = allocRefusedWindowCount(row);
+  const measured = row.perRound.reduce((a, r) => a + Object.keys(r.arms).length, 0);
+
+  assert.strictEqual(reasons.length, 6, 'three reasons x two rounds — the old numerator');
+  assert.strictEqual(windows, 2, 'and TWO windows were refused, one per round');
+  assert.strictEqual(measured, 4);
+  // THE DEFECT, as arithmetic rather than as an anecdote: the old numerator
+  // overran its own denominator on exactly this row.
+  assert.ok(reasons.length > measured, 'reasons against windows is what printed "17 of 12"');
+  assert.ok(windows <= measured, 'and a window count never can');
+
+  // The two are told apart on the row itself, and the summary prints both.
+  // Two segments x two rounds = four floor windows, every one carrying the
+  // same three deviant legs: four windows, twelve reasons.
+  const refusedFloor = Object.fromEntries(
+    ['reagent-subs', 'uix-subs'].map((seg) => [
+      `${seg}|grid/floor`,
+      {
+        segment: seg,
+        arm: 'grid/floor',
+        rung: 'floor',
+        reads: 0,
+        boundaries: 24,
+        ...three,
+        primeLegs: [26044],
+        primeExcess: 6788,
+        perWrite: 5000,
+        perBoundaryPerWrite: 208,
+      },
+    ])
+  );
+  const { row: summarised, out } = allocSummaryFor('floor', refusedFloor);
+  assert.strictEqual(summarised.refusedWindows, 4, 'the record carries WINDOWS under that name');
+  assert.strictEqual(summarised.refusalReasons, 12, 'and reasons under theirs');
+  assert.match(out, /windows refused: 4 of 4, 12 refusal reasons in all/);
+  assert.ok(
+    summarised.refusedWindows <= 4,
+    'the numerator can no longer overrun the denominator it is printed against'
+  );
+  // And the reason list itself is untouched — naming the counts apart drops
+  // neither.
+  assert.strictEqual((out.match(/^;;   REFUSED /gm) || []).length, 12);
+  // A row with nothing wrong reads 0 of N, and singular/plural is not a bug.
+  assert.strictEqual(allocRefusedWindowCount({ perRound: [] }), 0);
+  assert.strictEqual(allocRefusedWindowCount(allocRowWith({ ok: SMALL })), 0);
+});
+
 // --- the wiring, so this pin cannot drift off the thing that exits ---------
 
 test('the driver exits on THIS function and does not re-derive the verdict', () => {
@@ -907,7 +973,7 @@ test('the driver exits on THIS function and does not re-derive the verdict', () 
   // nothing else ever being. The measurement surface's own exports are pinned
   // in their own test below.
   has(
-    /module\.exports = \{\s*ladderStructuralFailures,\s*allocSteps,\s*allocRefusedWindows,\s*ALLOC_LEG_TOLERANCE,\s*ALLOC_FALL_THRESHOLD_B,\s*ladderPlan,\s*allocArmSizing,\s*ALLOC_MIN_WRITES,\s*ALLOC_ARM,/,
+    /module\.exports = \{\s*ladderStructuralFailures,\s*allocSteps,\s*allocRefusedWindows,(\s*\/\/[^\n]*\n)*\s*allocRefusedWindowCount,\s*ALLOC_LEG_TOLERANCE,\s*ALLOC_FALL_THRESHOLD_B,\s*ladderPlan,\s*allocArmSizing,\s*ALLOC_MIN_WRITES,\s*ALLOC_ARM,/,
     'so this file can drive it'
   );
   has(/if \(out\.alloc\.fallsInMeasuredWindows > 0\) \{/, 'and the falling-step gate still exits');
@@ -1449,7 +1515,11 @@ function allocSummaryFor(planName, arms = {}) {
   const real = console.log;
   console.log = (s) => lines.push(String(s));
   try {
-    summariseAlloc(row, []);
+    // The row's OWN refusals, derived by the shipped function rather than
+    // handed in empty (rf2-xxeq): the summary's numerator and the list under
+    // it are two different counts of the same row, and a fixture that passed
+    // `[]` could not tell them apart.
+    summariseAlloc(row, allocRefusedWindows(row));
   } finally {
     console.log = real;
   }

--- a/implementation/core/test/re_frame/bench/p0_run.cjs
+++ b/implementation/core/test/re_frame/bench/p0_run.cjs
@@ -1590,6 +1590,31 @@ function allocRefusedWindows(row) {
   return out;
 }
 
+// How many DISTINCT arm windows carry at least one refusal — the numerator
+// `windows refused: N of M` needs (rf2-xxeq).
+//
+// THE DEFECT. `allocRefusedWindows` above returns one entry per refusal REASON,
+// and a window with two deviant legs contributes two of them, while the
+// denominator counts WINDOWS. Every V1 run therefore printed a line of the
+// shape `windows refused: 17 of 12` — 17, 14, 13, 14, 16, 13 against a
+// twelve-window floor-only plan — which is not a possible ratio.
+//
+// Nothing was mis-gated: the exit keys off the reason list being non-empty,
+// which is correct under either count, and no published figure moved. But a
+// row whose entire purpose is to be believed may not print an impossible
+// ratio beside its figures, and a reader who took "17 windows were refused"
+// at face value would conclude the run measured more windows than it did.
+//
+// The reason list is unchanged and is still printed underneath, in full: this
+// names the two quantities apart rather than dropping either.
+function allocRefusedWindowCount(row) {
+  let n = 0;
+  for (const r of row.perRound || []) {
+    for (const a of Object.values(r.arms || {})) if (!a.certified) n++;
+  }
+  return n;
+}
+
 async function allocRow(chromium) {
   // THE PREFLIGHT REFUSAL, before a browser is launched and a byte is
   // measured. It refuses only on grounds it can defend WITHOUT a sizing model
@@ -2076,7 +2101,12 @@ function summariseAlloc(row, refused) {
       .map((x) => x.legWorstDeviation)
       .filter((x) => typeof x === 'number')
   );
-  row.refusedWindows = refused.length;
+  // TWO QUANTITIES, NAMED APART (rf2-xxeq). `refusedWindows` is windows and is
+  // what the denominator below is comparable to; `refusalReasons` is the length
+  // of the list printed underneath, which is what the exit code keys off.
+  const refusedCount = allocRefusedWindowCount(row);
+  row.refusedWindows = refusedCount;
+  row.refusalReasons = refused.length;
   console.log(
     `;;   leg tolerance τ = ${(row.legTolerance * 100).toFixed(0)}% of the window's own leg ` +
       'MEDIAN, two-sided. The legs of a window are W repetitions of ONE'
@@ -2127,7 +2157,8 @@ function summariseAlloc(row, refused) {
   }
 
   console.log(
-    `;;   windows refused: ${refused.length} of ${wins}` +
+    `;;   windows refused: ${refusedCount} of ${wins}, ${refused.length} refusal reason` +
+      `${refused.length === 1 ? '' : 's'} in all (a window can fail on more than one leg)` +
       (deviations.length
         ? `  (worst leg deviation observed ${(Math.max(...deviations.map(Math.abs)) * 100).toFixed(1)}%)`
         : '')
@@ -2708,6 +2739,10 @@ module.exports = {
   ladderStructuralFailures,
   allocSteps,
   allocRefusedWindows,
+  // The window count behind the summary's numerator (rf2-xxeq), pure and
+  // exported for `allocRefusedWindows`'s reason: the pin can DRIVE the ratio
+  // rather than assert that it is possible.
+  allocRefusedWindowCount,
   ALLOC_LEG_TOLERANCE,
   ALLOC_FALL_THRESHOLD_B,
   ladderPlan,

--- a/implementation/core/test/re_frame/bench/p0_run.cjs
+++ b/implementation/core/test/re_frame/bench/p0_run.cjs
@@ -1201,6 +1201,82 @@ const ALLOC_MIN_WRITES = 6;
 // than the floor is a measurement configuration's business, not a default's.
 const ALLOC_WRITES = Number(process.env.P0_ALLOC_WRITES || ALLOC_MIN_WRITES);
 
+// ---------------------------------------------------------------------------
+// THE PRIME WORK UNIT — what the driver's own collector costs the first leg
+// (rf2-oiy1)
+// ---------------------------------------------------------------------------
+//
+// THE TERM. rf2-2rtt6.140's V1/V2/V3 window measured 336 arm windows across
+// eight browser runs and EVERY ONE of them carried a positive first-leg excess
+// over its own cohort median — median 6,966 B, p25 6,856, p75 8,056. Constant
+// in ABSOLUTE bytes across B in {4, 24, 96}, identical under `:p0/write-all`
+// and `:p0/write-page` alike, and fatal: at τ = 0.25 a fixed ~7 KB excess
+// refuses every window whose leg median is under ~27,900 B, which is every
+// floor window at every page size. `arm − floor` is the quantity every witness
+// here is stated over, so a floor that never certifies takes the ladder with
+// it.
+//
+// WHICH OF THE TWO CAUSES IT IS, SETTLED FROM THAT WINDOW'S OWN NUMBERS rather
+// than from a new one. The bead left the fork open — warm-up, or re-allocation
+// of something the forced collection reclaimed — and three facts already in
+// the record close it:
+//
+//   1. THE TAIL LEGS ARE BYTE-IDENTICAL. One B = 4 floor window read
+//      [26044, 19256, 19256, 19256, 19256, 19256]. Steady state is therefore
+//      reached after exactly ONE work unit inside the window.
+//   2. EIGHTEEN WORK UNITS ALREADY RUN IMMEDIATELY BEFORE IT — three
+//      full-size warm-up windows of six writes each — and the excess survives
+//      every one of them.
+//   3. The ONLY thing standing between the last warm-up work unit and leg 1 is
+//      `gc()` below: three CDP `HeapProfiler.collectGarbage` calls with an
+//      80 ms beat, which Blink implements as `Isolate::LowMemoryNotification()`
+//      rather than as one collection.
+//
+// One work unit AFTER the collection clears it; eighteen BEFORE it do not. So
+// the excess is created at the collection and re-cleared by the first work
+// unit that follows — the bead's branch (b). Branch (a), a fourth full-size
+// warm-up, is REFUTED rather than merely doubted: another warm-up lands on the
+// wrong side of the collection, where three have already failed.
+//
+// WHAT THE COLLECTION DISCARDS IS NOT IDENTIFIED HERE, and identifying it
+// would take a browser window this package may not spend. It does not have to
+// be: fact 1 says one work unit restores whatever it is.
+//
+// SO THE WINDOW DRIVES ONE EXTRA WORK UNIT AND THE FIRST IS A PRIME. It is
+// SAMPLED, REPORTED and EXCLUDED — from the leg cohort, from `rise`, from
+// `falls`, from `perWrite` and from the certificate. The instrument does not
+// go blind to the term: it publishes it beside the figures as a diagnostic,
+// which is also what puts the number in front of rf2-e9wr's τ calibration.
+//
+// WHY THIS IS NOT A WIDENING, AND WHY IT IS NEITHER OF THE OTHER TWO REPAIRS:
+//
+//   - τ IS UNTOUCHED at its uncalibrated placeholder, and no window refused
+//     today for any other reason is admitted tomorrow. A widening ADMITS the
+//     observation; this removes it from the measured region.
+//   - "DISCARD LEG 1, CERTIFY OVER W − 1" would leave five averaged writes,
+//     under `ALLOC_MIN_WRITES`. Averaging six means driving seven.
+//   - "PRIME OUTSIDE THE WINDOW, UNSAMPLED" costs exactly the same headroom —
+//     the prime's garbage lands in the same uncollected heap either way — and
+//     buys blindness with it. Sampling it is strictly better.
+//
+// WHAT IT COSTS, STATED: one more write's garbage per window, so the heap has
+// ~1/6 more in it before the measured region opens. That is real against the
+// 600,000 B measured collection onset and it is not hidden — a window that
+// then collects is refused by the falls gate exactly as one is today.
+//
+// THE 2τ CERTIFICATE IS RE-DERIVED AND COMES OUT IDENTICAL. Its derivation is
+// per-leg over a cohort of repetitions of one work unit and never referenced
+// how many legs there are or what preceded them. What changes in the
+// antecedent is which region is submitted to the rule — and the prime is what
+// makes "repetitions of ONE work unit" true of that region for the first time.
+// `allocSteps` is not touched: the split hands it a shorter, well-formed
+// sample stream, and every one of its pins stands unedited.
+const ALLOC_PRIME_WRITES = 1;
+
+// What the window actually drives. The DIVISORS stay `ALLOC_WRITES`: the
+// published quantity is per MEASURED write and the prime is not one.
+const ALLOC_WINDOW_WRITES = ALLOC_WRITES + ALLOC_PRIME_WRITES;
+
 // The sizing, as a PURE FUNCTION of the config — the same shape and for the
 // same reason as `allocSteps` and `allocRefusedWindows`: it needs neither a
 // release build nor a Chromium, so it is pinned on every PR by
@@ -1378,8 +1454,33 @@ function median(xs) {
   return s.length % 2 === 1 ? s[mid] : (s[mid - 1] + s[mid]) / 2;
 }
 
+// Split a window's raw samples into the PRIME legs and the MEASURED sample
+// stream (rf2-oiy1). Pure, for `allocSteps`'s reason: the pin can DRIVE it
+// rather than read the source and hope.
+//
+// The stream is `[s0, pre0, post0, pre1, post1, ...]`, so dropping the leading
+// `2·prime` samples leaves `[post_{p−1}, pre_p, post_p, ...]` — WHICH IS THE
+// SAME SHAPE. The last prime leg's `post` becomes the measured region's `s0`,
+// and the measured region's first gap is the true `pre_p − post_{p−1}`.
+// Nothing is fabricated and nothing is re-based, which is exactly why
+// `allocSteps` needs to know none of this and is unchanged by this bead.
+//
+// `prime` is clamped to the legs actually present, so a stream shorter than
+// the prime yields no measured legs rather than reaching off the end. It is a
+// parameter for the pin's benefit; the driver always passes the constant.
+function allocPrimeSplit(samples, prime = ALLOC_PRIME_WRITES) {
+  const p = Math.max(0, Math.min(prime, (samples.length - 1) >> 1));
+  const primeLegs = [];
+  for (let k = 0; k < p; k++) primeLegs.push(samples[2 * k + 2] - samples[2 * k + 1]);
+  return { primeLegs, measured: samples.slice(2 * p) };
+}
+
 // Rising and falling steps, accumulated separately, from one window's raw
 // samples — AND the leg cohort the certificate is read off.
+//
+// IT IS HANDED THE MEASURED REGION, NOT THE WHOLE WINDOW (rf2-oiy1). The
+// window's first work unit is a prime and `allocPrimeSplit` above takes it off
+// before anything here sees it. Everything below is unchanged by that bead.
 //
 // The samples are `[s0, pre0, post0, pre1, post1, ...]`, so leg `k` is
 // `post_k - pre_k` (one per write, the work) and gap `k` is
@@ -1573,10 +1674,10 @@ async function allocRow(chromium) {
   // Without `--enable-precise-memory-info` Chrome quantises the in-page
   // counter to 100 KB buckets and every figure here would be noise. A
   // quantised counter is not a small error; it is a different instrument.
-  await page.evaluate(([d, n]) => window.P0H.allocPrepare(d, n), [ALLOC_D, ALLOC_WRITES]);
+  await page.evaluate(([d, n]) => window.P0H.allocPrepare(d, n), [ALLOC_D, ALLOC_WINDOW_WRITES]);
   const probe = await page.evaluate(
     (n) => window.P0H.allocWindow(n, 'control', 'react'),
-    ALLOC_WRITES
+    ALLOC_WINDOW_WRITES
   );
   const rounded = probe.samples.filter((x) => x % 100000 === 0).length;
   const precise = rounded < probe.samples.length;
@@ -1598,16 +1699,31 @@ async function allocRow(chromium) {
 
     // --- the three controls, in situ, before this round's arms ----------
     const controlOf = async (kind, d) => {
-      await page.evaluate(([dd, n]) => window.P0H.allocPrepare(dd, n), [d, ALLOC_WRITES]);
+      await page.evaluate(([dd, n]) => window.P0H.allocPrepare(dd, n), [d, ALLOC_WINDOW_WRITES]);
       await gc();
       const pre = await read();
       const w = await page.evaluate(
         ([n, k]) => window.P0H.allocWindow(n, k, 'react'),
-        [ALLOC_WRITES, kind]
+        [ALLOC_WINDOW_WRITES, kind]
       );
       const post = await read();
-      const s = allocSteps(w.samples);
-      return { kind, d, ...s, perIter: s.rise / ALLOC_WRITES, cdpBracket: post.cdp - pre.cdp };
+      // The controls take the prime too, and that is the point: one window
+      // shape, not two (rf2-oiy1). Their own first leg carries no measurable
+      // excess — the studio page records the control windows' worst leg
+      // deviation at <= 1% against the arms' 26-46% — so priming them changes
+      // no control figure, and a control taken under a different window shape
+      // from the arms would not be one.
+      const { primeLegs, measured } = allocPrimeSplit(w.samples);
+      const s = allocSteps(measured);
+      return {
+        kind,
+        d,
+        ...s,
+        primeLegs,
+        primeExcess: primeLegs.length ? primeLegs[0] - s.legMedian : null,
+        perIter: s.rise / ALLOC_WRITES,
+        cdpBracket: post.cdp - pre.cdp,
+      };
     };
     const idle = await controlOf('idle', 0);
     const ctl1 = await controlOf('control', ALLOC_D);
@@ -1665,22 +1781,31 @@ async function allocRow(chromium) {
         // varying, and its own instrument pseudo-arm read 9.9x. Warming
         // with anything smaller than the window would leave that inside
         // the first round of every arm.
-        await page.evaluate(([dd, n]) => window.P0H.allocPrepare(dd, n), [0, ALLOC_WRITES]);
+        //
+        // THE WARM-UPS STILL RUN, AND THEY STILL DO NOT REACH THE FIRST LEG
+        // (rf2-oiy1). They land BEFORE the `gc()` below, and the excess this
+        // row carried in 336 of 336 windows survived all three of them. What
+        // clears it is one work unit AFTER the collection, which is what the
+        // window's prime leg is. The warm-ups are what stop the arm's own
+        // cold-start from reaching the window at all, and that job is theirs
+        // still.
+        await page.evaluate(([dd, n]) => window.P0H.allocPrepare(dd, n), [0, ALLOC_WINDOW_WRITES]);
         for (let w = 0; w < ALLOC_WARMUPS; w++) {
           await page.evaluate(
             ([n, d, k]) => window.P0H.allocWindow(n, k, d),
-            [ALLOC_WRITES, drain, ALLOC_WRITE_SPEC.kind]
+            [ALLOC_WINDOW_WRITES, drain, ALLOC_WRITE_SPEC.kind]
           );
         }
         await gc();
         const pre = await read();
         const win = await page.evaluate(
           ([n, d, k]) => window.P0H.allocWindow(n, k, d),
-          [ALLOC_WRITES, drain, ALLOC_WRITE_SPEC.kind]
+          [ALLOC_WINDOW_WRITES, drain, ALLOC_WRITE_SPEC.kind]
         );
         const post = await read();
         await page.evaluate(() => window.P0H.release());
-        const s = allocSteps(win.samples);
+        const { primeLegs, measured } = allocPrimeSplit(win.samples);
+        const s = allocSteps(measured);
         // THE WRITE READ-BACK, and the row exits on it. At R reads of a
         // page whose cells were all written to `v`, a ladder boundary's
         // text is `R·v`; the floor has no subscription and cannot move.
@@ -1703,6 +1828,12 @@ async function allocRow(chromium) {
           boundaries: B,
           text: win.text,
           ...s,
+          // THE PRIME LEG, RECORDED RATHER THAN DISCARDED (rf2-oiy1). It is
+          // in no published quantity and in no certificate, and it is the
+          // term that made every floor window uncertifiable, so the record
+          // carries it and the summary prints it.
+          primeLegs,
+          primeExcess: primeLegs.length ? primeLegs[0] - s.legMedian : null,
           perWrite: s.rise / ALLOC_WRITES,
           perBoundaryPerWrite: s.rise / ALLOC_WRITES / B,
           cdpBracket: post.cdp - pre.cdp,
@@ -1755,6 +1886,12 @@ async function allocRow(chromium) {
     arm: ALLOC_ARM,
     boundaries: B,
     writes: ALLOC_WRITES,
+    // The window drives `writes + primeWrites` and publishes over `writes`
+    // (rf2-oiy1). Both are in the record because a reader of any figure here
+    // has to be able to tell how many work units it was divided by and how
+    // many actually ran.
+    primeWrites: ALLOC_PRIME_WRITES,
+    windowWrites: ALLOC_WINDOW_WRITES,
     warmups: ALLOC_WARMUPS,
     rounds: ALLOC_ROUNDS,
     preciseMemory: precise,
@@ -1790,6 +1927,10 @@ function summariseAlloc(row, refused) {
   console.log(
     `;; ${row.rounds} rounds x ${row.writes} warm bulk writes, after ${row.warmups} full-size ` +
       'warm-up windows. Q = E on every rung.'
+  );
+  console.log(
+    `;; The window drives ${row.windowWrites} — the first ${row.primeWrites} is a PRIME and is in ` +
+      'no figure below (rf2-oiy1).'
   );
   console.log(';; The arm stays MOUNTED across the window: this is what a standing page');
   console.log(';; allocates when it is written to, not what a mount costs.');
@@ -1947,6 +2088,44 @@ function summariseAlloc(row, refused) {
     ';;   above it is a window whose one-work-unit premise failed. An ADMITTED window under-reads'
   );
   console.log(`;;   its true allocation by AT MOST 2τ = ${(row.legTolerance * 200).toFixed(0)}%.`);
+
+  // THE PRIME LEG, PUBLISHED AS A DIAGNOSTIC (rf2-oiy1). It is in no figure
+  // above or below and in no certificate, and printing it is the whole reason
+  // this repair is not "discard leg 1": the term that made every floor window
+  // uncertifiable is still measured, on every window, and is now readable
+  // beside the cohort it used to contaminate. rf2-e9wr's τ calibration wants
+  // exactly this number.
+  const primes = row.perRound.flatMap((r) => {
+    const arms = Object.values(r.arms || {});
+    const from = arms.length ? arms : Object.values(r.controls || {});
+    return from.map((x) => x.primeExcess).filter((x) => typeof x === 'number');
+  });
+  console.log(';;');
+  console.log(
+    `;;   THE PRIME LEG (excluded from every figure): the window's first work unit runs AFTER the`
+  );
+  console.log(
+    `;;   forced collection and before the ${row.writes} measured ones. 336 of 336 windows in the`
+  );
+  console.log(
+    ';;   rf2-2rtt6.140 measurement carried a ~7 KB first-leg excess that three full-size warm-ups'
+  );
+  console.log(
+    ';;   could not reach, because every warm-up lands on the far side of that collection and the'
+  );
+  console.log(
+    ';;   window\'s own tail legs are byte-identical — so ONE work unit after it is what clears it.'
+  );
+  if (primes.length) {
+    const p = stat(primes);
+    console.log(
+      `;;   prime excess over the measured cohort median: ${n0(p.mean)} B mean ` +
+        `[${n0(p.min)}–${n0(p.max)}] across ${primes.length} windows`
+    );
+  } else {
+    console.log(';;   no window carried a prime leg to report.');
+  }
+
   console.log(
     `;;   windows refused: ${refused.length} of ${wins}` +
       (deviations.length
@@ -2535,6 +2714,15 @@ module.exports = {
   allocArmSizing,
   ALLOC_MIN_WRITES,
   ALLOC_ARM,
+  // The prime work unit (rf2-oiy1) — the split as a pure function, and both
+  // counts, so the pin can DRIVE the exclusion rather than read the source and
+  // hope. `ALLOC_WINDOW_WRITES` is what the window drives; `ALLOC_WRITES` is
+  // what every published figure is divided by, and the pin checks they differ
+  // by exactly the prime.
+  allocPrimeSplit,
+  ALLOC_PRIME_WRITES,
+  ALLOC_WRITES,
+  ALLOC_WINDOW_WRITES,
   // The measurement surface (rf2-gxrr), exported so the structural pin can
   // DRIVE it rather than read its source: the tables as values, the plan
   // filter as a pure function, and the two resolved selections so the env


### PR DESCRIPTION
Closes rf2-oiy1 (P1). Closes rf2-xxeq (P3), as a separate trailing commit.

## The diagnosis, and why it did not need a new window

rf2-oiy1 left a fork open: is the fixed ~7 KB first-leg excess **(a)** warm-up a
fourth full-size warm-up window would clear, or **(b)** re-allocation of
something the driver's own forced collection reclaimed? The bead says nobody had
measured which. **Three facts already in the V1/V2/V3 record settle it, and no
browser window was needed to read them:**

1. **The tail legs of a clean window are byte-identical.** The bead quotes one
   B = 4 floor window verbatim: `[26044, 19256, 19256, 19256, 19256, 19256]`.
   Steady state is therefore reached after **exactly one work unit inside the
   window**.
2. **Eighteen work units already run immediately before it** — three full-size
   warm-up windows of six writes each, which `allocRow` drives today — and the
   excess survives every one of them.
3. **The only thing between the last of those and leg 1 is the driver's own
   `gc()`**: three CDP `HeapProfiler.collectGarbage` calls with an 80 ms beat.

One work unit *after* the collection clears it; eighteen *before* it do not.
So the collection creates it, and **branch (a) is refuted rather than merely
doubted** — a fourth warm-up window lands on the wrong side of that collection,
where three have already failed. This is branch (b).

**Corroborating contrast, also already measured.** The control windows go
through the identical `prepare -> gc -> read -> window` sequence and carry no
measurable excess: the studio page records their worst leg deviation at **≤ 1 %**
against the arms' **26 – 46 %**. Whatever the collection discards, it is
proportional to what the work unit touches — a `dispatch-sync` plus a substrate
drain has it, a dropped `.slice()` does not.

**What is NOT identified, stated plainly.** The exact V8/pipeline structure the
collection discards is unknown. A hermetic Node probe (`--expose-gc`, 400
distinct functions, the driver's warm-up/collect/window shape, a sweep of 1 – 10
collections per beat) **failed to reproduce the excess** — a null result, reported
as one. The repair does not depend on identifying the mechanism, because fact 1
says one work unit restores whatever it is.

## The repair — the window's first work unit is a PRIME

The window drives `ALLOC_WRITES + 1` work units. The first is a **prime**:
**sampled, reported, and excluded** from the leg cohort, from `rise`, from
`falls`, from `perWrite` and from the certificate.

`allocPrimeSplit(samples)` drops the leading `2·prime` samples, which leaves
`[post₀, pre₁, post₁, …]` — **the same shape**. The prime's `post` becomes the
measured region's `s0`, and the measured region's first gap is the true
`pre₁ − post₀`. Nothing is fabricated and nothing is re-based, so **`allocSteps`
is not touched by this PR at all** and every existing pin on the leg witness
stands unedited.

### Why the other two repairs are wrong here

- **Widening τ — forbidden, and not done.** `ALLOC_LEG_TOLERANCE` is untouched at
  its uncalibrated 0.25 placeholder. No window refused today for any other
  reason is admitted tomorrow. A widening *admits* the observation; this removes
  it from the measured region.
- **Discarding leg 1 and certifying over `W − 1`** would leave five averaged
  writes, under `ALLOC_MIN_WRITES = 6`. Averaging six means *driving* seven.
  It is also the information-losing option: the prime leg here is **printed on
  every run**, so the instrument does not go blind to the term.
- **Priming outside the window, unsampled** costs *exactly the same* headroom —
  the prime's garbage lands in the same uncollected heap either way, with no
  intervening collection — and buys blindness with it. Sampling it strictly
  dominates.

### The 2τ certificate re-derives identically

Its derivation is per-leg over a cohort of repetitions of one work unit, and it
never referenced how many legs there are or what preceded them. What changes in
the antecedent is **which region is submitted to the rule** — and the prime is
what makes "repetitions of ONE work unit" true of that region for the first time.

### What it costs, stated

One more write's garbage per window: the heap carries ~1/6 more before the
measured region opens. That is real against the 600,000 B measured collection
onset and it is not hidden — a window that then collects is refused by the falls
gate exactly as one is today.

## rf2-xxeq — the impossible ratio

Every V1 run printed `windows refused: 17 of 12` (and 14, 13, 14, 16, 13).
The numerator was `allocRefusedWindows(...).length` — one entry per refusal
**reason** — against a denominator counting **windows**. `allocRefusedWindowCount`
is the window count; `refusalReasons` is the list length; both are on the record
and the reason list is still printed underneath in full.

The pin **constructs** the case rather than asserting it: one window with three
legs outside tolerance, on two segments across two rounds — four refused windows,
twelve reasons — and asserts both that the old numerator overruns its own
denominator and that the new one cannot.

## Quality gates

All exit codes are the ones **captured from the runner** (`> log 2>&1; echo $?`
on one command line), never a harness report.

| gate | result | exit |
|---|---|---|
| `node core/test/re_frame/bench/p0_ladder_structural.test.cjs` (baseline, pre-change) | 59 passed, 0 failed | `0` |
| `node core/test/re_frame/bench/p0_ladder_structural.test.cjs` (final, on the rebased base) | **66 passed, 0 failed** | `0` |
| `bash scripts/test-fast-pr.sh` (docs + JVM + node tiers, all classified true) | **PASS fast PR spine** | `0` |
| `npm run lint:js` (the `eslint` job of `lint.yml`) | clean | `0` |
| `python scripts/check_doc_slugs.py` | clean | `0` |
| `python scripts/check_provenance_pins.py --changed-since origin/main` | clean | `0` |

### Red-then-green — three planted faults, each restored and hash-verified

Every restore verified with `git hash-object` against the pre-plant object, not
by reading a diff.

| plant | gate said | exit | pre-plant = post-restore |
|---|---|---|---|
| `ALLOC_FALL_THRESHOLD_B` `600000` → `600001` (proves the gate reads **this worktree**) | `1/59 failed` — "the retired masking budget is GONE, not widened" | `1` | `7d93c6c747ca25d0617211f4dbcc2ed096a14628` |
| `ALLOC_PRIME_WRITES` `1` → `0` (proves the prime is live, not declared) | `1/65 failed` — "a prime of zero is the shape the bead refutes" | `1` | `2bc6ee2566a1ba1bad18ca5275f4d84b662b3f29` |
| the rf2-xxeq numerator reinstated as `refused.length` | `1/66 failed` — `12 !== 4`, i.e. twelve reasons reported as windows against a denominator of four | `1` | `8bc77d4350686b22fb62987c586be2ee9665a85d` |

Each plant was scoped: the other 58 / 64 / 65 tests still ran and still passed,
so no plant cascaded and none silently stopped a namespace.

**Which tree each gate read.** `scripts/test-fast-pr.sh` prints its own root and
printed `gate root: /c/Users/miket/code/re-frame2-worktrees/legexcess-oiy1`. The
structural pin prints no root, so the discrimination is the **red from the
planted fault**: the fault exists only in this worktree, so a run that had
wandered into a sibling's would have come back green.

**The prime is driven, not read.** Besides the source-shape pins, one new test
resolves `ALLOC_PRIME_WRITES` and `ALLOC_WINDOW_WRITES` **in a fresh process
through the shipped env surface** (`constUnderEnv`), including
`P0_ALLOC_WRITES=10` → `ALLOC_WINDOW_WRITES = 11`.

### Required CI checks these local gates do NOT decide

The spine's own gap report (`scripts/check_fast_pr_gap.py`) enumerates 96.
Naming them by workflow rather than re-listing them:

- **`.github/workflows/test.yml`** — 46 required jobs have no local lane at all
  (browser lanes, prod-elision / bundle-isolation / perf-bundle, adapter probes
  and smokes, Xray feature matrix, mcp-conformance, the tool JVM suites), plus
  steps *inside* jobs the spine does run (`npm run test:ui-isolation`,
  `npm run test:bspine-compile`, `npm run build:hicasso-release`). It also names
  the 22 JVM artefact suites the diff did not touch.
- **`.github/workflows/lint.yml`** — `eslint` **was** run here and is green;
  `clj-kondo` (CI pins 2026.04.15, not installed locally), `splint` and
  `api-manifest` were not. No `.clj`/`.cljc`/`.cljs` is in this diff.
- **`.github/workflows/docs.yml`** — the MkDocs build and the playground-bundle
  rebuild/smoke steps. Note that `mkdocs build --strict` **does not cover
  `docs/design/**`** (`mkdocs.yml`'s `exclude_docs`), so the doc change here is
  gated by `check_doc_slugs.py` and `check_provenance_pins.py`, both run above.
  **The doc's anchors and its one table were checked by hand**: the addendum adds
  a single `##` heading, no links, no table, and no cited SHA.

## What was deliberately NOT done

- **No measurement window was run and no row was published** to any studio or
  ladder page. Three workers were live on this box, so no figure taken here
  would be admissible. The only numbers quoted are the bead's own and a
  hermetic Node probe's, and the probe is labelled a diagnostic and reported as
  a **null result**.
- **`ALLOC_LEG_TOLERANCE` was not touched.** τ is rf2-e9wr's subject.
- **`ALLOC_MIN_WRITES`, `ALLOC_FALL_THRESHOLD_B`, `ALLOC_ROUNDS`,
  `ALLOC_WARMUPS`, `ALLOC_CONTROL_SLACK`, R = 20 — all unchanged.**
- **No `.cljs` was touched.** `p0_heap.cljs`'s `alloc-window!` already takes the
  work-unit count as a parameter, so the whole repair is driver-side.
  `lane.cljs`, `walk_profile_app.cljs` and the walk-profile path in
  `freehand/.../hicasso/run.cjs` were not opened — `worker/walkctl-1huc` holds
  that lane.
- **No hot-zone file** (`spec/*`, `implementation/deps.edn`,
  `implementation/shadow-cljs.edn`, `.github/workflows/*`) was edited.
- **The studio record was not rewritten.**
  `docs/design/hicasso/studio/the-write-halfs-floor-is-the-pipeline.md` is the
  measurement record of a past window and stays exactly as measured.

## What this implies for rf2-e9wr (τ), which is sequenced behind this

**The calibration population changes, in the direction that makes τ pinnable.**
The studio page's finding was that the controls are not a valid calibration
population for the arms "because their work unit is a dropped `.slice()` with no
first-write re-allocation in it and the arms' work unit … has one". **The prime
removes that asymmetry**: the arms' measured cohort no longer contains a
first-write-after-collection leg, so arms and controls are now populations of
the same kind. On the bead's own numbers the arms' measured legs are
byte-identical to one another once leg 1 is out, which is a spread of **0 %** —
inside the controls' ≤ 1 %. A τ calibrated as V3 specifies is therefore expected
to be **pinnable and small**, and rf2-e9wr should re-derive it against a fresh
window taken on this instrument rather than against the pre-prime figures.

**It does not adopt anything on rf2-e9wr's behalf.** τ stays the 0.25 placeholder
and the source still says `THIS VALUE IS AN UNCALIBRATED PLACEHOLDER`.

## One thing found that was not asked about

`docs/design/hicasso/allocation-instrument-rework.md` holds an **option in
reserve**: "six single-write windows, each with its own forced collection before
it, carry the same averaging as one six-write window and are six times smaller".
**This finding closes it as written** — the first-leg excess would land on the
*only* leg of every one of those windows, leaving the leg cohort nothing to
compare against. It would have to become six *primed two-write* windows, at
which point the claimed six-fold shrink is a three-fold one and the trigger
arithmetic beside it needs redoing. Recorded in that page's new addendum, which
also records the diagnosis and the repair so the instrument's own design record
does not go stale.

## Base

Branched and gated off `origin/main` at `c7bf0636f9`; three commits have landed
on `main` since (`a93c1864e4` codemod, plus two beads checkpoints), none of them
touching any file in this diff. `origin/main...HEAD` was read for what it would
**revert**: the 18 deleted lines are all and only the call sites and pins this
PR replaces.
