### PR TITLE
hic-036: the topology tournament — the census publishes, the clock control refuses

### DIFF
--- a/docs/design/hicasso/product/topology-tournament.md
+++ b/docs/design/hicasso/product/topology-tournament.md
@@ -176,9 +176,10 @@ about the machine.**
 |---|---|
 | instrument | `implementation/freehand/test/re_frame/bench/hicasso/topo/census_dom_cljs_test.cljs` |
 | substrate | the bench's **arm-1** runtime, not `implementation/hicasso` |
-| witness | `npm run test:browser` (Chromium, real DOM), 1,500 tests / 9,482 assertions |
+| witness | `npm run test:browser` (Chromium, real DOM), 1,500 tests / 9,482 assertions, 0 failures / 0 errors |
+| clock control | `topo/control_app.cljs` via the lane's generic `run.cjs` — **run, and refused**; see §2.6 |
 | profile | P-DEV-1 |
-| box | `\System\Processor Queue Length` read **0.00** on every sample taken before, during and after |
+| box | `\System\Processor Queue Length` read **0.00** on every sample taken before, during and after both runs |
 
 **The substrate limitation is stated rather than buried.** Every figure below
 is an arm-1 figure and carries no `implementation/hicasso` generalisation. That
@@ -264,38 +265,101 @@ operation** — 20 rows on a bulk commit at every row count, 1 elsewhere. It is
 also the only arm whose figures are about a different page, and the two facts
 are the same fact.
 
-### 2.5 The budget verdict the deterministic half CAN reach
+### 2.5 U5, and an instrument gap in it that this tournament exposed
 
-One registered budget line is deterministic, and this census adjudicates it
-directly:
+One registered budget line is deterministic, so the census can speak to it:
 
 > **U5** — Narrow-update body work scales with changed rows, not all mounted
 > rows. ([budgets §4](budgets.md#the-6-user-visible-budgets), family:
-> **deterministic**)
+> **deterministic**, estimand **boundary bodies run**, pinned as D1–D4)
 
-| arm | U5 on sparse/edit | basis |
-|---|---|---|
-| `fine` | **meets** | 1 row built per 1 row changed, at every `B` |
-| `virtual` | **meets** | 1 row built per 1 row changed |
-| `chunked` | **meets, bounded by k** | 25 rows built, constant in `B` |
-| `coarse` | **BREACHES, at every row count** | `B` rows built for one changed row |
+**Read against its registered estimand, every arm passes — including the one
+that plainly should not.** A narrow update runs exactly one boundary body in
+all four arms:
 
-`coarse` cannot satisfy U5 at any row count, and no amount of tuning changes
-that: rebuilding the whole family from a single view-model **is** the arm. This
-is a verdict on a registered line, taken on the family of budget that needs no
-quiet box, and it is the tournament's firmest result.
+| arm | bodies on a narrow update | rows of markup built | U5 as registered |
+|---|---|---|---|
+| `fine` | 1 | 1 | passes |
+| `virtual` | 1 | 1 | passes |
+| `chunked` | 1 | 25 | passes |
+| `coarse` | 1 | **`B`** | **passes** |
+
+The coarse arm rebuilds a thousand rows for a one-row change and satisfies a
+budget whose English forbids exactly that, because the budget counts *bodies*
+and the arm does its thousand rows **inside one body**.
+
+**This is not a quibble; it is a hole with a known shape.** D3/D4 exist
+precisely to catch a coarse topology — *"coarse shape with closure props moves
+it to 26/101"* — and they catch it because that witness's coarse shape still
+holds per-cell boundaries. **A coarse shape that inlines its rows has no
+boundaries to count, so the same instrument reads 1 and reports a pass.** The
+tournament's coarse arm is that shape, and it is the ordinary spelling of a
+view-model arm rather than an exotic one.
+
+The honest verdict is therefore split, and neither half is allowed to stand in
+for the other:
+
+- **On U5 as registered: no breach, in any arm.** This page does not report one.
+- **On the property U5 is written to protect: `coarse` fails at every row
+  count**, on an exact integer counter, and untunably — rebuilding the family
+  from one view-model *is* the arm.
+
+Closing that gap is `rf2-hic-071`/`rf2-hic-089`'s, since they own turning these
+rows into gates, and it is filed rather than patched here.
 
 ### 2.6 The clock half — REFUSED, and on what
 
-**No clock cell is published, and the refusal is located in the source rather
-than in an opinion about the machine.**
+**No clock cell is published. The control was built, run on a verified-quiet
+box, and REFUSED — so the refusal is a measurement, not an opinion about the
+machine.**
 
-The instrument was built to its pre-registration —
-`topo/control_app.cljs` carries the changed-set doubling, and
-`topo/model.cljs`'s `:topo/bump-stride` is the write it needs. The refusal is
-not that it could not be built. It is that **the control is degenerate on two
-of the four arms, by construction**, and this was discovered from the census's
-own integers rather than from a run:
+#### The run
+
+`topo/control_app.cljs`, driven by the lane's generic `run.cjs`, Chromium
+147.0.7727.15 headless, `:advanced`, `goog.DEBUG false`, 24 threads / 32 GB.
+`\System\Processor Queue Length` read **0.00** on all five samples immediately
+before the run. Page structure was checked before the clock and matched its
+arithmetic exactly: **1,001 boundaries, 2,001 read edges, 5,001 elements.**
+`B = 1000`, `fine` arm, 20 commits under one clock, 12 samples × 5 rounds,
+arms interleaved in `slot-order`.
+
+| round | `d10` p50 (ms/20 commits) | `d5` p50 | ratio |
+|---|---|---|---|
+| 1 | 44.80 | 59.65 | 1.331 |
+| 2 | 44.35 | 61.50 | 1.387 |
+| 3 | 44.45 | 63.30 | 1.424 |
+| 4 | 44.50 | 65.45 | 1.471 |
+| 5 | 48.35 | 64.05 | 1.325 |
+
+**Verdict: `:ok? false` — REFUSED ON THE BAND.** Predicted 2.00, registered
+band [1.60, 2.50], measured 1.325–1.471. Exit code **1**, captured from the
+runner itself.
+
+#### Why this refusal is worth more than a green one would have been
+
+Everything that could have made it dismissible held. The **arm-order guard
+passed** — *"no arm reads differently for its position in the plan"*, both by
+predecessor and by phase, within 10%. The ranges are tight, the five rounds
+agree to within 0.15, and the sign is right in every round. **This is not
+noise; it is a strong, stable signal that is not 2.00.**
+
+So the model behind the prediction is wrong, and the census says where. The
+window contains three costs and only one of them doubles: the event handler
+`reduce-kv`s the whole thousand-row table at both strides, the subscription
+layer re-evaluates all 1,000 `[:topo/row i]` cells at both strides, and only
+the 100→200 rows of markup actually double. **A large constant term is shared
+between the arms, so the ratio is compressed toward 1** — which is precisely
+the failure `rf2-7iqb5` recorded for page-scaling controls, reappearing in the
+control built to replace them.
+
+**The band is not widened to 1.32, and the prediction is not re-derived now
+that the data is in.** Either move would retro-admit every run this gate was
+built to catch. The cell refuses.
+
+#### And the control could not have covered two arms anyway
+
+Independent of the run, and derived from the census's own integers rather than
+from any clock: **the control is degenerate on two of the four arms.**
 
 | arm | markup at stride 10 | at stride 5 | predicted factor |
 |---|---|---|---|
@@ -332,8 +396,15 @@ window produced.
 Pre-registered: **two tuning iterations per red cell.** Spent: **zero**, and
 the reason is recorded rather than convenient — no cell was red *against a line
 the instrument could adjudicate*. The clock lines (U2, U3, C3, C4) went
-unmeasured, so nothing could be above them; the one line that was adjudicated
-(U5) has a breach that is structural rather than tunable.
+unmeasured because the control refused before any cell was taken, so nothing
+could be above them.
+
+**Repairing the control would not have been a tuning iteration, and it was not
+spent as one.** §1.6 defines the allowance as a bounded change to *the arm's
+topology*, and says in terms that a change to the instrument, the band, the
+control or the kill line is not a tuning iteration but a different tournament.
+The control's 2.00 prediction is wrong for a reason the run diagnosed; fixing
+it is `rf2-m6i0`, run as its own window.
 
 Dispositions, one per cell class, with no cell left open:
 
@@ -347,8 +418,13 @@ Dispositions, one per cell class, with no cell left open:
 
 ### 2.8 What was NOT concluded
 
-- **No clock figure at all**, for any arm, operation or row count.
+- **No clock figure at all**, for any arm, operation or row count. The ratios
+  in §2.6's table are the CONTROL's, and a refused control publishes nothing —
+  including itself as a finding about the arms.
 - **No verdict against U1, U2, U3, U4, C3 or C4** — all are millisecond lines.
+- **No breach recorded against U5**, because as registered it is not breached.
+  What is recorded is that its estimand cannot see the arm that fails the
+  property it is written to protect.
 - **No `rf2-hic-080` scoring.** Its phase 2 is deliberately another worker's,
   and a tournament that graded its own blinded predictor would destroy the
   property the split exists to protect. What this page hands over is the

--- a/docs/design/hicasso/product/topology-tournament.md
+++ b/docs/design/hicasso/product/topology-tournament.md
@@ -1,0 +1,169 @@
+# The topology tournament — pre-registration, then the rung-2 teaching table
+
+Owned by `rf2-hic-036`. This page is written in two parts and they landed in
+that order, which is the only reason the second part is worth reading.
+
+**Part 1 is the pre-registration.** It fixes the arms, the operations, the row
+counts, the estimand, the controls, and — the clause the bead singles out — the
+number of tuning iterations a red cell is allowed before it stops or narrows.
+It was committed **before a single measurement was taken**, on a tree based at
+`101142e395a15a7d278dda9effacc24e3f556124`, which is an ancestor of `main`.
+
+**Part 2 is the result**, added by later commits on the same branch. Where it
+records a refusal, that refusal is the deliverable and is not a failed attempt
+at a number.
+
+The tournament is one of the bounded [decisive
+experiments](lanes/hot-path-architecture.md#decisive-experiments), and
+[the decision brief](decision-brief.md#part-iii--the-plan) closes that set with
+*"no open-ended benchmark programme after it"*. This page is therefore allowed
+to end in *unresolved*; it is not allowed to end in *to be continued*.
+
+---
+
+## Part 1 — the pre-registration
+
+### 1.1 The arms
+
+Four read topologies over one row family, taken from
+[the read-topology guidance](lanes/hot-path-architecture.md#read-topology-guidance).
+Every arm renders the **same rows, the same markup and the same DOM**; only the
+placement of boundaries and reads differs.
+
+| arm | boundary placement | reads | what it is buying |
+|---|---|---|---|
+| `fine` | one boundary per row | each row reads its own cells | sparse invalidation, paid for in mount and heap |
+| `coarse` | one boundary for the whole family | the family boundary reads one view-model | cheap mount and cheap bulk replacement |
+| `chunked` | one boundary per chunk of `k` rows | each chunk reads its chunk's slice | the useful middle for mixed workloads |
+| `virtual` | one boundary per **visible** row, windowed | visible rows only | fewer rows exist in the DOM at all |
+
+`k` is **not derived from a model**. [The counterfactual
+worksheet](counterfactual-topology-prediction.md#what-is-refused-rather-than-predicted)
+refuses to pin a chunk width because the committed evidence carries no value for
+`c` (the cost of one row of markup over the cost of one membership slot), and
+this page does not invent one. `k` is pinned here as a **stated constant, 25**,
+chosen before any run and held fixed across every row count and operation. It is
+a setting of the arm, not a result.
+
+### 1.2 The operations
+
+| operation | what the event does | class |
+|---|---|---|
+| `sparse` | change one field of **one** row | narrow |
+| `bulk` | replace **every** row's data in one commit | broad |
+| `reorder` | permute the row order, same identities and same keys | broad |
+| `edit` | one controlled-input keystroke inside one row | narrow |
+
+### 1.3 The row counts
+
+`B ∈ {100, 300, 1000}`, and `R = 2` reads per row in the `fine` arm — the same
+shape [the counterfactual
+worksheet](counterfactual-topology-prediction.md#1-membership-savings) holds
+fixed while it moves `B`. That worksheet's final caution is repeated here
+because this page is the thing it cautioned about: if the tournament's table
+reads more than two keys per row, every `B·R` figure on that page is low. It
+reads exactly two.
+
+### 1.4 The estimand, and the one substitution that is refused
+
+**The primary estimand is the clock**: main-thread task duration for the
+commit the operation causes, frame-settled, on P-DEV-1. That is the quantity
+[C3 and U3](budgets.md#the-comparative-and-regression-rules) are stated on, and
+it is what "arm A beats arm B" means to a user.
+
+A **deterministic work census** is taken on the same operations — boundary
+bodies run, rows of markup rendered, and read edges touched. It is machine
+insensitive: [§2 of the budgets page](budgets.md#2-the-two-disposition-families-which-6-already-separates)
+establishes that a counter reads the same on a loaded box, so this half needed
+no quiet window and could have been taken at any time.
+
+**The two are never pooled, and the census never stands in for the clock.**
+Pre-registered, so it cannot be softened later: if an arm's clock control
+refuses, that cell is **unresolved on the clock**, and its work census is
+published as a separate row that is explicitly *not* an ordering of the arms by
+speed. [`rf2-hic-080`'s frozen scoring
+rule](counterfactual-topology-prediction.md#scoring-rule-frozen-with-the-predictions)
+already names the correct outcome for that case — *"a prediction the
+tournament's design cannot address is scored unaddressed, never right"* — and
+this page hands such cells over as **unaddressed** rather than as a work-census
+ordering wearing a clock's clothes.
+
+### 1.5 The controls, and what each refuses
+
+Each arm carries both. A published clock figure requires **both** to pass for
+that arm at that row count; either failing withholds the figure.
+
+**Positive control — the changed-set doubling.** Page size is held fixed and
+the *changed set* is doubled: update every 10th row, then every 5th row, on the
+same table. Element count, layout and paint are constant; only the commit-side
+work doubles, so the prediction is **2.00x**, adjudicated on a band registered
+here before the run: **[1.60x, 2.50x]**, and the difference and the slope must
+both be **positive** (a control certifying that more dirty work reads *faster*
+is refused on the sign, which is the fix `rf2-7iqb5` landed in PR #7634).
+
+This is deliberately not the control this lane used before. Every earlier
+positive control for a bulk or update row **scaled the page**, and `rf2-7iqb5`
+records why that cannot certify an update row: the work does not scale with the
+page, so even a perfect instrument reads below the predicted factor. The
+changed-set form is that bead's own prescribed repair.
+
+**Sabotage control — the topology witness must bite.** The deterministic census
+is itself the sabotage detector for the arms: an arm is planted with a defect
+that makes it behave as a different topology (the `fine` arm made to read a
+cell every row shares, so a one-row change invalidates all `B`), and the census
+must **red**. A census that stays green under the plant proves nothing about
+the arms it certifies, and no clock figure guarded by it may publish.
+
+### 1.6 The kill rule, and the iteration count — pre-registered
+
+Registered before any measurement, per
+[the decision brief's kill rules](decision-brief.md#part-iii--the-plan)
+(*"Bulk above its kill line after the allowed iterations stops or narrows"*):
+
+> **Two tuning iterations per red cell. Not three, and not "until it goes
+> green".**
+
+A *tuning iteration* is one bounded change to the arm's topology — chunk width,
+key scheme, memo placement, view-model shape — re-measured on the same
+instrument. It is **not** a change to the instrument, the band, the control, or
+the kill line. Changing any of those is not a tuning iteration; it is a
+different tournament.
+
+The **kill lines**, taken from the ratified budgets rather than chosen here:
+
+| line | source | applies to |
+|---|---|---|
+| broad operation within **100 ms p95** | [U3](budgets.md#the-6-user-visible-budgets) | `bulk`, `reorder` |
+| discrete interaction to next paint within **50 ms p95** | [U2](budgets.md#the-6-user-visible-budgets) | `sparse`, `edit` |
+| broad update ≤ **1.25x** the best arm in the same cell | [C3](budgets.md#the-comparative-and-regression-rules) | `bulk`, `reorder` |
+| sustained > **1.5x** | [C4](budgets.md#the-comparative-and-regression-rules) | all |
+
+A cell still above its line after two iterations takes one of exactly two
+dispositions, written into the table and never left open:
+
+- **STOP** — that topology is not offered for that workload at that row count.
+- **NARROW** — the use-case classification shrinks to the row counts where it
+  passes, stated as a bound rather than as a hope.
+
+There is no third disposition, and no cell carries "needs more investigation".
+
+### 1.7 What this page will not do
+
+- It will not widen a band, a kill line or a tolerance to admit a run. Every
+  gate here exists because something once passed that should not have.
+- It will not add an instrument, a rung or an estimator mid-series. An
+  improvement discovered during the run is filed as its own bead and run as its
+  own window; a rung added between runs makes the series two instruments.
+- It will not restate a published figure on thin evidence. S1–S8 in
+  [the budgets page](budgets.md#4-distributional-rows--s1s5-re-pinned-on-the-package-s6s7-carried)
+  are not this page's to move.
+- It will not score `rf2-hic-080`'s predictions. That is that bead's phase 2,
+  deliberately held by a different worker, and a tournament that graded its own
+  blinded predictor would destroy the property the split exists to protect.
+
+---
+
+## Part 2 — the result
+
+*Added by later commits on this branch. Until then this section is empty by
+construction, and its emptiness is the pre-registration's proof.*

--- a/docs/design/hicasso/product/topology-tournament.md
+++ b/docs/design/hicasso/product/topology-tournament.md
@@ -165,5 +165,195 @@ There is no third disposition, and no cell carries "needs more investigation".
 
 ## Part 2 — the result
 
-*Added by later commits on this branch. Until then this section is empty by
-construction, and its emptiness is the pre-registration's proof.*
+Two halves were attempted and they came back differently, which is the honest
+headline: **the deterministic half is complete at all 48 cells and publishes;
+the clock half does not publish, and the reason is a control, not a judgement
+about the machine.**
+
+### 2.1 What ran, and on what
+
+| | |
+|---|---|
+| instrument | `implementation/freehand/test/re_frame/bench/hicasso/topo/census_dom_cljs_test.cljs` |
+| substrate | the bench's **arm-1** runtime, not `implementation/hicasso` |
+| witness | `npm run test:browser` (Chromium, real DOM), 1,500 tests / 9,482 assertions |
+| profile | P-DEV-1 |
+| box | `\System\Processor Queue Length` read **0.00** on every sample taken before, during and after |
+
+**The substrate limitation is stated rather than buried.** Every figure below
+is an arm-1 figure and carries no `implementation/hicasso` generalisation. That
+is the same discipline [the budgets page](budgets.md#4-distributional-rows--s1s5-re-pinned-on-the-package-s6s7-carried)
+applies to its own rows when it labels S6 and S7 *bench-tree figures* beside
+S1–S5's *package figures*, and it is not softened here.
+
+**The box did not have to be quiet for this half, and saying so is the point.**
+Body runs and rows of markup are integers on monotone counters;
+[§2 of the budgets page](budgets.md#2-the-two-disposition-families-which-6-already-separates)
+establishes that a counter reads the same on a loaded box. The census is
+therefore an ordinary PR gate that anyone can re-run, which is exactly what a
+one-shot clock session on one machine is not.
+
+### 2.2 The rung-2 teaching table — rows of markup built
+
+The quantity that separates the arms. One row of markup is one row's worth of
+element construction; a body that builds none did not run, or ran and bailed.
+
+| operation | `B` | `fine` | `coarse` | `chunked` (k=25) | `virtual` (W=20) |
+|---|---|---|---|---|---|
+| sparse | 100 | **1** | 100 | 25 | **1** |
+| sparse | 300 | **1** | 300 | 25 | **1** |
+| sparse | 1000 | **1** | 1000 | 25 | **1** |
+| bulk | 100 | 100 | 100 | 100 | **20** |
+| bulk | 300 | 300 | 300 | 300 | **20** |
+| bulk | 1000 | 1000 | 1000 | 1000 | **20** |
+| reorder | 100 | **0** | 100 | 100 | 1 |
+| reorder | 300 | **0** | 300 | 300 | 1 |
+| reorder | 1000 | **0** | 1000 | 1000 | 1 |
+| edit | 100 | **1** | 100 | 25 | **1** |
+| edit | 300 | **1** | 300 | 25 | **1** |
+| edit | 1000 | **1** | 1000 | 25 | **1** |
+
+### 2.3 The same table, boundary bodies run
+
+Reported beside it and never instead of it, because the two answer different
+questions and a reader given only one of them draws the wrong conclusion about
+bulk.
+
+| operation | `B` | `fine` | `coarse` | `chunked` | `virtual` |
+|---|---|---|---|---|---|
+| sparse | any | 1 | 1 | 1 | 1 |
+| bulk | 100 | 100 | **1** | 4 | 20 |
+| bulk | 300 | 300 | **1** | 12 | 20 |
+| bulk | 1000 | 1000 | **1** | 40 | 20 |
+| reorder | 100 | 1 | 1 | 4 | 2 |
+| reorder | 300 | 1 | 1 | 12 | 2 |
+| reorder | 1000 | 1 | 1 | 40 | 2 |
+| edit | any | 1 | 1 | 1 | 1 |
+
+Both counters agree with `arm1.runtime/body-runs`, which is incremented inside
+`run-once` and shares no traversal with the census's own. 48 of 48 cells agree.
+
+### 2.4 The four findings
+
+**1. Sparse and edit separate the arms linearly in `B`, and the separation is
+not a clock artefact.** `fine` builds one row for a one-row change at every row
+count; `coarse` builds all `B`. At `B = 1000` that is a factor of 1,000, on an
+exact integer counter, with no interval attached because none is needed.
+
+**2. Bulk does not separate `fine`, `coarse` and `chunked` on markup at all** —
+all three build exactly `B`. This is the finding most likely to be misread.
+Whatever separates those three arms on a bulk commit is **not** the number of
+rows built; it is per-boundary overhead, which at `B = 1000` is 1,000 boundary
+shells against one. The shell is a registered, breached line — `1,100 B` and
+`1,095 B` against a frozen `1,024 B`
+([S1/S2](budgets.md#4-distributional-rows--s1s5-re-pinned-on-the-package-s6s7-carried)) —
+so the bulk question routes into `rf2-hic-018`'s open disposition rather than
+being answerable here.
+
+**3. Reorder is where the arms genuinely invert, and `chunked` is the worst of
+them.** A permutation moves no row's read. Under `fine` the list body re-runs,
+every row's props are unchanged, the memo bails, and **zero rows of markup are
+built for a table that visibly reorders** — React moves DOM nodes and runs no
+row body. Under `coarse` all `B` rows are rebuilt. Under `chunked` all `B` rows
+are rebuilt **and** `⌈B/k⌉` bodies run, because a rotation changes the contents
+of every chunk: at `B = 1000` that is 1,000 rows and 40 bodies, strictly worse
+than both neighbours on both counters.
+
+**4. `virtual` is the only arm whose cost does not scale with `B` on any
+operation** — 20 rows on a bulk commit at every row count, 1 elsewhere. It is
+also the only arm whose figures are about a different page, and the two facts
+are the same fact.
+
+### 2.5 The budget verdict the deterministic half CAN reach
+
+One registered budget line is deterministic, and this census adjudicates it
+directly:
+
+> **U5** — Narrow-update body work scales with changed rows, not all mounted
+> rows. ([budgets §4](budgets.md#the-6-user-visible-budgets), family:
+> **deterministic**)
+
+| arm | U5 on sparse/edit | basis |
+|---|---|---|
+| `fine` | **meets** | 1 row built per 1 row changed, at every `B` |
+| `virtual` | **meets** | 1 row built per 1 row changed |
+| `chunked` | **meets, bounded by k** | 25 rows built, constant in `B` |
+| `coarse` | **BREACHES, at every row count** | `B` rows built for one changed row |
+
+`coarse` cannot satisfy U5 at any row count, and no amount of tuning changes
+that: rebuilding the whole family from a single view-model **is** the arm. This
+is a verdict on a registered line, taken on the family of budget that needs no
+quiet box, and it is the tournament's firmest result.
+
+### 2.6 The clock half — REFUSED, and on what
+
+**No clock cell is published, and the refusal is located in the source rather
+than in an opinion about the machine.**
+
+The instrument was built to its pre-registration —
+`topo/control_app.cljs` carries the changed-set doubling, and
+`topo/model.cljs`'s `:topo/bump-stride` is the write it needs. The refusal is
+not that it could not be built. It is that **the control is degenerate on two
+of the four arms, by construction**, and this was discovered from the census's
+own integers rather than from a run:
+
+| arm | markup at stride 10 | at stride 5 | predicted factor |
+|---|---|---|---|
+| `fine` | `B/10` | `B/5` | **2.00 — discriminating** |
+| `virtual` | 2 | 4 | **2.00 — discriminating** |
+| `coarse` | `B` | `B` | **1.00 — degenerate** |
+| `chunked` | `B` | `B` | **1.00 — degenerate** |
+
+`coarse` and `chunked` rebuild every row whichever stride runs, so doubling the
+changed set doubles nothing they do. A control predicting 2.00x on those arms
+would refuse a healthy instrument; a control predicting 1.00x on them
+discriminates nothing and certifies nothing. **Either way those two arms have
+no positive control, so no clock figure of theirs may publish** — and since
+every interesting comparison in this tournament crosses between a fine-family
+arm and a coarse-family one, that withholds the clock table entire.
+
+This sits on top of a refusal the lane already carried, which this window
+verified rather than assumed:
+
+> bulk-class rows cannot hold a difference-statistic control at the ~3.5% floor
+> a magnitude needs (`rf2-7iqb5`, 28–48% within-block IQR), and the narrow class
+> sits on the clock clamp (`rf2-d2tzk`)
+> — `shapes/census_clock_run.cjs`, refusing its own write rows by construction
+
+**What was NOT done, deliberately.** The obvious move from inside the run is to
+invent a second control for the coarse family — page-doubling works there,
+because coarse's update cost genuinely does scale with the page. That is a new
+rung, and a rung added between runs makes the series two instruments. It is
+filed rather than built, and it is the single highest-value follow-up this
+window produced.
+
+### 2.7 The kill rule, and how many iterations were spent
+
+Pre-registered: **two tuning iterations per red cell.** Spent: **zero**, and
+the reason is recorded rather than convenient — no cell was red *against a line
+the instrument could adjudicate*. The clock lines (U2, U3, C3, C4) went
+unmeasured, so nothing could be above them; the one line that was adjudicated
+(U5) has a breach that is structural rather than tunable.
+
+Dispositions, one per cell class, with no cell left open:
+
+| cell class | disposition | statement |
+|---|---|---|
+| `coarse` / sparse, edit | **NARROW** | Coarse is not offered for workloads with narrow updates at any row count. Its classification narrows to bulk-dominated workloads where boundary-shell cost dominates row-build cost — a condition this tournament cannot itself certify, so the narrowed claim is bounded by `rf2-hic-018`. |
+| `chunked` / reorder | **STOP** | Chunked is not offered for reorder-bearing workloads. It builds every row *and* runs `⌈B/k⌉` bodies, strictly worse than both neighbours on both counters. |
+| `fine` / sparse, edit, reorder | **PASS** | Meets U5; builds 1 row for 1 changed row and 0 for a permutation. |
+| `virtual` / all four | **PASS, on a different page** | Constant in `B`, and every figure is about a DOM that holds `W` rows rather than `B`. |
+| all arms / bulk | **UNRESOLVED** | Not above its kill line; not below it either. The line is in milliseconds and no millisecond here has a control. It is recorded as unresolved and is **not** carried as an open hope: the follow-up is one named, bounded control (§2.6), not a benchmark programme. |
+
+### 2.8 What was NOT concluded
+
+- **No clock figure at all**, for any arm, operation or row count.
+- **No verdict against U1, U2, U3, U4, C3 or C4** — all are millisecond lines.
+- **No `rf2-hic-080` scoring.** Its phase 2 is deliberately another worker's,
+  and a tournament that graded its own blinded predictor would destroy the
+  property the split exists to protect. What this page hands over is the
+  measured ordering on the work census plus the explicit note that the clock
+  orderings are **unaddressed** in that page's own frozen vocabulary.
+- **No package figure.** Everything here is arm-1.
+- **No chunk-width result.** `k = 25` was a stated setting; nothing here is
+  evidence about it, and §1.1's refusal to derive one stands.

--- a/implementation/freehand/test/re_frame/bench/hicasso/topo/arms.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/topo/arms.cljs
@@ -1,0 +1,188 @@
+(ns re-frame.bench.hicasso.topo.arms
+  "THE FOUR TOPOLOGY ARMS — one table, cut four ways (rf2-hic-036).
+
+  The markup is written **once**, in [[row-markup]], and every arm calls
+  it. That is the tournament's fairness guarantee and it is the same
+  discipline [[re-frame.bench.hicasso.shapes.card]] uses to make shapes 2
+  and 3 differ in exactly one authoring decision: if the four arms wrote
+  their own rows, an arm-to-arm difference would be a difference of
+  markup and the tournament would prove nothing about topology.
+
+  | arm | boundaries | reads | what it buys |
+  |---|---|---|---|
+  | `fine` | `B + 1` | `2` per row | sparse invalidation |
+  | `coarse` | `1` | one view-model | cheap mount, cheap bulk |
+  | `chunked` | `⌈B/k⌉ + 1` | one slice per chunk | the middle |
+  | `virtual` | `W + 1` | `2` per VISIBLE row | fewer rows in the DOM |
+
+  ## Three arms are DOM-identical; the fourth is not, by construction
+
+  `fine`, `coarse` and `chunked` render the same `B` rows into the same
+  `<ul>`, so they are canonical-DOM comparable and the census gates them
+  on it. **`virtual` renders `W` rows and cannot be**, because putting
+  fewer rows in the DOM *is* the arm. The counterfactual worksheet says
+  the same thing from the other side when it refuses to predict this arm
+  at all (its N2): virtualization *\"is not a read-topology choice … no
+  quantity on this page is about it.\"*
+
+  So every `virtual` figure is a figure about **a different page**, and
+  this file marks the arm exempt rather than letting a parity gate be
+  quietly widened to admit it. A comparison that crosses that line is
+  reported as crossing it.
+
+  ## Body counts are taken on TWO independent instruments
+
+  [[counters]] is this file's own — incremented at each body and at each
+  row of markup. [[re-frame.bench.hicasso.arm1.runtime/body-runs]] is the
+  runtime's, incremented inside `run-once` where a body is actually
+  invoked. They share no traversal, so the census asserts them against
+  each other: a memo bail-out that this file counted and the runtime did
+  not would be a real disagreement rather than a rounding one."
+  (:require [re-frame.bench.hicasso.arm1.runtime :refer [sub]]
+            [re-frame.bench.hicasso.topo.model :as m])
+  (:require-macros [re-frame.bench.hicasso.arm1.lang :refer [defview]]))
+
+;; ---------------------------------------------------------------------------
+;; The counters
+;; ---------------------------------------------------------------------------
+
+(def counters
+  "`:list` / `:row` / `:chunk` are boundary body runs; `:markup` is rows
+  of MARKUP built, which is the quantity that separates the arms on a
+  sparse write — `fine` builds one row, `coarse` builds `B` in a single
+  body. A witness that counted only bodies would call those two equal."
+  (atom {:list 0 :row 0 :chunk 0 :markup 0}))
+
+(defn reset-counters! [] (reset! counters {:list 0 :row 0 :chunk 0 :markup 0}) nil)
+
+(defn runs [] @counters)
+
+;; ---------------------------------------------------------------------------
+;; The markup — written once
+;; ---------------------------------------------------------------------------
+
+(defn row-markup
+  "One row. A plain function: called from a body it inlines, and it reads
+  NO subscription — every value arrives as data, so the caller decides
+  where the read edge lives and this function cannot tilt an arm.
+
+  `:key` is in the attribute map because the row is a keyed list child in
+  every arm: a direct child under `coarse`/`chunked`, and a boundary's
+  root under `fine`/`virtual`. A key React does not need is a key React
+  ignores, so one spelling serves all four."
+  [{:keys [id label n draft]}]
+  (swap! counters update :markup inc)
+  [:li.topo-row {:key id :data-i id :data-testid (str "row-" id)}
+   [:span.label label]
+   [:em.n {:data-testid (str "n-" id)} n]
+   [:span.draft {:data-testid (str "draft-" id)} draft]
+   [:button.bump {:type "button" :data-testid (str "bump-" id) :on-click [:topo/bump id]} "+"]])
+
+;; ---------------------------------------------------------------------------
+;; Arm 1 — fine
+;; ---------------------------------------------------------------------------
+
+(defview fine-row
+  "One row, as a boundary, holding its own two read edges."
+  [{:keys [i]}]
+  (swap! counters update :row inc)
+  (row-markup (assoc (sub [:topo/row i]) :draft (sub [:topo/draft i]))))
+
+(defview fine-list
+  "`B` row boundaries under one list boundary. The list reads `:order`
+  and nothing else, so no data write reaches it."
+  [_]
+  (swap! counters update :list inc)
+  (into [:ul.topo-list {:data-testid "list"}]
+        (map (fn [i] [fine-row {:key i :i i}]))
+        (sub [:topo/order])))
+
+;; ---------------------------------------------------------------------------
+;; Arm 2 — coarse view-model
+;; ---------------------------------------------------------------------------
+
+(defview coarse-list
+  "ONE boundary, one read. The per-instance join that `fine` spends
+  `B·R` read edges on has moved into the subscription graph, whose
+  internal edges are not memberships."
+  [_]
+  (swap! counters update :list inc)
+  (into [:ul.topo-list {:data-testid "list"}]
+        (map row-markup)
+        (sub [:topo/view-model])))
+
+;; ---------------------------------------------------------------------------
+;; Arm 3 — chunked
+;; ---------------------------------------------------------------------------
+
+(defview chunk-view
+  "One chunk of `k` rows, as a boundary reading its own slice. The rows
+  inside it are inline markup, so the chunk holds ONE read edge for `k`
+  rows."
+  [{:keys [c]}]
+  (swap! counters update :chunk inc)
+  (into [:<>] (map row-markup) (sub [:topo/chunk c])))
+
+(defview chunked-list
+  "`⌈B/k⌉` chunk boundaries under one list boundary."
+  [_]
+  (swap! counters update :list inc)
+  (into [:ul.topo-list {:data-testid "list"}]
+        (map (fn [c] [chunk-view {:key c :c c}]))
+        (range (sub [:topo/chunk-count]))))
+
+;; ---------------------------------------------------------------------------
+;; Arm 4 — windowed / virtualized
+;; ---------------------------------------------------------------------------
+
+(defview virtual-list
+  "Only the visible window exists. Each visible row is a boundary with
+  the same two reads `fine` gives every row — the arm changes how many
+  rows there ARE, not how a row reads."
+  [_]
+  (swap! counters update :list inc)
+  (into [:ul.topo-list {:data-testid "list"}]
+        (map (fn [i] [fine-row {:key i :i i}]))
+        (sub [:topo/visible])))
+
+;; ---------------------------------------------------------------------------
+;; The roster
+;; ---------------------------------------------------------------------------
+
+(def arm-ids
+  "Pre-registered order. `:virtual` is last because it is the one arm
+  whose figures are about a different page."
+  [:fine :coarse :chunked :virtual])
+
+(defn view-of
+  "The root view for an arm."
+  [arm]
+  (case arm
+    :fine    fine-list
+    :coarse  coarse-list
+    :chunked chunked-list
+    :virtual virtual-list))
+
+(defn dom-comparable?
+  "Whether this arm's DOM may be compared against the others'. False for
+  `:virtual`, by construction and not by tolerance."
+  [arm]
+  (not= :virtual arm))
+
+(defn expected
+  "What the census predicts for `arm` at `b`, from arithmetic rather than
+  from a previous run's numbers.
+
+  `:boundaries` counts registrations holding at least one read edge — the
+  list plus, per arm, its row or chunk boundaries. A `coarse` page is one
+  boundary because there is nothing beneath it holding a read."
+  [arm b]
+  (let [rendered (m/rendered-rows arm b)]
+    {:rendered-rows rendered
+     :elements      (m/elements-for rendered)
+     :edges         (inc (m/memberships arm b))
+     :boundaries    (case arm
+                      :fine    (inc b)
+                      :coarse  1
+                      :chunked (inc (long (Math/ceil (/ b m/chunk-size))))
+                      :virtual (inc (min b m/window-size)))}))

--- a/implementation/freehand/test/re_frame/bench/hicasso/topo/census_dom_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/topo/census_dom_cljs_test.cljs
@@ -1,0 +1,390 @@
+(ns re-frame.bench.hicasso.topo.census-dom-cljs-test
+  "**THE TOURNAMENT'S DETERMINISTIC HALF** — the work census, and the
+  eligibility control that decides whether any clock figure guarded by it
+  may publish (rf2-hic-036).
+
+  ## Why this half needed no quiet box
+
+  [The budgets page](../../../../../../../docs/design/hicasso/product/budgets.md)
+  sorts every performance row into two families with opposite operational
+  rules, and the sentence that matters here is its own: a counter *\"reads
+  the same on a loaded box\"*. Boundary body runs and rows of markup are
+  integers on monotone counters, so contention cannot move them. This
+  file is therefore an ordinary blocking gate, runs in CI on every PR,
+  and is repeatable by anyone — which is exactly what a one-shot clock
+  session on one machine is not.
+
+  It is **not** a substitute for the clock, and the tournament page
+  pre-registers that refusal before any measurement was taken: a cell
+  whose clock control refuses is handed to `rf2-hic-080` phase 2 as
+  *unaddressed*, never as a work census wearing a clock's clothes.
+
+  ## What each row establishes
+
+  1. **The arm is the topology it claims** — boundaries, read edges and
+     elements against arithmetic computed from `B`, never against a
+     previous run's numbers.
+  2. **The read sets do not oscillate**, which is a GATE on the coarse
+     arm rather than a tiebreak.
+  3. **The work each operation causes**, per arm, at each row count.
+  4. **The census bites** — [[sabotage-list]] is a real arm with one real
+     defect, mounted for real, and the eligibility check must reject it.
+
+  ## The sabotage control is an ARM, not a patched file
+
+  A planted source fault proves the source changed; it does not prove the
+  runtime ever observed the plant, and a watcher that served a pre-plant
+  compile would return green from a sabotage run and be read as *the
+  control does not bite*. So the defect here is compiled, mounted and
+  exercised on the same door as every other arm: [[sabotage-list]] is
+  `fine` with one extra read per row — the shared view-model — so a
+  ONE-ROW write invalidates all `B` rows. `the-census-rejects-a-broken-arm`
+  asserts the census reds on it. There is nothing to restore afterwards
+  and nothing to hash.
+
+  ## The sparse/edit target is row 0, in every arm
+
+  Stated because it is a design choice and not an accident: row 0 is the
+  only index guaranteed to be in the windowed arm's DOM at every row
+  count, so it is the only target on which all four arms are comparable
+  at all. A middle-index target would measure the windowed arm doing
+  nothing, which is true and useless.
+
+  Runtime: `-dom-cljs-test`. Under `:node-test` every claim degrades to a
+  stated skip."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [re-frame.adapter.uix :as uix-adapter]
+            [re-frame.bench.hicasso.arm1.mount :as mount]
+            [re-frame.bench.hicasso.arm1.runtime :as rt :refer [sub]]
+            [re-frame.bench.hicasso.lane :as lane]
+            [re-frame.bench.hicasso.topo.arms :as arms]
+            [re-frame.bench.hicasso.topo.model :as m]
+            [re-frame.test-support :as test-support])
+  (:require-macros [re-frame.bench.hicasso.arm1.lang :refer [defview]]))
+
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture
+    {:adapter       uix-adapter/adapter
+     :ambient-frame nil
+     :async?        true
+     :init-fn       (fn [] (rt/reset-runtime!))}))
+
+(def ^:private frame-id ::topo)
+
+(def ^:private target
+  "The row `sparse` and `edit` move. See the namespace docstring."
+  0)
+
+(defn- skip! [why]
+  (is true (str "the topology census needs a real React DOM — " why)))
+
+;; ---------------------------------------------------------------------------
+;; The sabotage arm — `fine`, with one real defect
+;; ---------------------------------------------------------------------------
+
+(defview sabotage-row
+  "A `fine` row that also reads the COARSE arm's view-model. Its markup,
+  its DOM and its key scheme are `fine`'s; its read set is not, and the
+  extra read moves whenever any row moves."
+  [{:keys [i]}]
+  (swap! arms/counters update :row inc)
+  (let [_shared (sub [:topo/view-model])]
+    (arms/row-markup (assoc (sub [:topo/row i]) :draft (sub [:topo/draft i])))))
+
+(defview sabotage-list
+  [_]
+  (swap! arms/counters update :list inc)
+  (into [:ul.topo-list {:data-testid "list"}]
+        (map (fn [i] [sabotage-row {:key i :i i}]))
+        (sub [:topo/order])))
+
+;; ---------------------------------------------------------------------------
+;; The door
+;; ---------------------------------------------------------------------------
+
+(defn- fresh! [b]
+  (lane/leave-act-environment!)
+  (m/make-frame! frame-id b)
+  (m/reseed! frame-id b)
+  (arms/reset-counters!)
+  (rt/reset-body-runs!)
+  frame-id)
+
+(defn- mount! [view]
+  (mount/root! (mount/fresh-container!) frame-id [view {}]))
+
+(defn- restore!
+  "Return the frame to its seed and let the commit land, WITHOUT charging
+  it to any operation. Counters are zeroed after the settle, never
+  before."
+  [b]
+  (rt/dispatch! frame-id [:topo/seed b])
+  (mount/settle!)
+  (arms/reset-counters!)
+  (rt/reset-body-runs!)
+  nil)
+
+(defn- operate!
+  "Dispatch one operation and settle. Answers the work it caused, on both
+  instruments."
+  [op b]
+  (case op
+    :sparse  (rt/dispatch! frame-id [:topo/bump target])
+    :bulk    (rt/dispatch! frame-id [:topo/bump-all])
+    :reorder (rt/dispatch! frame-id [:topo/rotate])
+    :edit    (rt/dispatch! frame-id [:topo/edit target (str "k" b)])
+    :noop    (rt/dispatch! frame-id [:topo/noop-write]))
+  (mount/settle!)
+  (let [{:keys [list row chunk markup]} (arms/runs)]
+    {:bodies     (+ list row chunk)
+     :list       list
+     :row-bodies (+ row chunk)
+     :markup     markup
+     :runtime    (rt/body-runs)}))
+
+;; ---------------------------------------------------------------------------
+;; The record every row appends to
+;; ---------------------------------------------------------------------------
+
+(defonce ^:private !record (atom []))
+
+(defn- record! [arm b op work]
+  (swap! !record conj (merge {:arm arm :b b :op op} work))
+  work)
+
+;; ---------------------------------------------------------------------------
+;; 1 — every arm is the topology it claims (the eligibility control)
+;; ---------------------------------------------------------------------------
+
+(defn- structure-of
+  "What the mounted page actually is."
+  [handle]
+  (let [{:keys [boundaries edges]} (rt/stats)]
+    {:boundaries    boundaries
+     :edges         edges
+     :elements      (lane/element-count (:container handle))
+     :rendered-rows (count (.querySelectorAll (:container handle) "li.topo-row"))}))
+
+(deftest every-arm-is-the-topology-it-claims
+  (if-not (mount/browser?)
+    (skip! ":node-test has no DOM")
+    (doseq [b   m/row-counts
+            arm arms/arm-ids]
+      (testing (str arm " at " b " rows")
+        (fresh! b)
+        (let [handle (mount! (arms/view-of arm))]
+          (try
+            (is (= (arms/expected arm b) (structure-of handle))
+                (str arm " at B=" b " must hold exactly the boundaries, read edges,
+                     elements and rendered rows its arithmetic predicts — a number
+                     accepted from the DOM would re-baseline the tournament instead
+                     of gating it"))
+            (finally (mount/release! handle))))))))
+
+(deftest the-row-family-read-set-cannot-oscillate
+  (testing "set stability is a GATE on the coarse arm, not a tiebreak — so it
+           is asserted rather than argued: the same page after every one of the
+           four operations holds the same read-edge count it mounted with"
+    (if-not (mount/browser?)
+      (skip! ":node-test has no DOM")
+      (doseq [arm arms/arm-ids]
+        (let [b 100]
+          (fresh! b)
+          (let [handle (mount! (arms/view-of arm))
+                mounted (:edges (rt/stats))]
+            (try
+              (doseq [op [:sparse :bulk :reorder :edit]]
+                (restore! b)
+                (operate! op b)
+                (is (= mounted (:edges (rt/stats)))
+                    (str arm "'s read set moved under " op " — the coarse arm's
+                         precondition is broken and no arm's figure may publish")))
+              (finally (mount/release! handle)))))))))
+
+;; ---------------------------------------------------------------------------
+;; 2 — the census itself: work per arm, per operation, per row count
+;; ---------------------------------------------------------------------------
+
+(defn- run-census!
+  "Mount each arm once per row count and run all four operations on the
+  standing mount, restoring the seed between them. One mount per
+  `[arm b]` rather than one per cell, because a re-mount would put a
+  fresh page under every operation and the tournament is about what a
+  commit costs on a page that is already there."
+  []
+  (reset! !record [])
+  (doseq [b   m/row-counts
+          arm arms/arm-ids]
+    (fresh! b)
+    (let [handle (mount! (arms/view-of arm))]
+      (try
+        (doseq [op [:sparse :bulk :reorder :edit]]
+          (restore! b)
+          (record! arm b op (operate! op b)))
+        (finally (mount/release! handle)))))
+  @!record)
+
+(defn- ensure-census!
+  "Run the census if it has not run in this process.
+
+  cljs.test does not promise to run a namespace's vars in definition
+  order, so a findings row that assumed the census had already run would
+  read `nil` from an empty record and fail — or, worse, pass vacuously on
+  a `nil` comparison. Every consumer calls this first."
+  []
+  (when (empty? @!record) (run-census!))
+  @!record)
+
+(deftest the-work-census
+  (if-not (mount/browser?)
+    (skip! ":node-test has no DOM")
+    (do
+      (ensure-census!)
+      (doseq [{:keys [arm b op bodies markup runtime]} @!record]
+        (is (= bodies runtime)
+            (str arm "/" op " at B=" b ": this file's body count and the
+                 runtime's own `body-runs` are two instruments sharing no
+                 traversal, and they must agree"))
+        (is (<= markup (m/rendered-rows arm b))
+            (str arm "/" op " at B=" b " built more rows of markup than the page
+                 renders, which is not a topology — it is a bug"))))))
+
+;; ---------------------------------------------------------------------------
+;; 3 — the four findings the census is FOR, asserted rather than eyeballed
+;; ---------------------------------------------------------------------------
+
+(defn- work-at [arm b op]
+  (first (filter #(and (= arm (:arm %)) (= b (:b %)) (= op (:op %))) (ensure-census!))))
+
+(deftest the-sparse-finding
+  (testing "a one-row write builds ONE row of markup under `fine`, and every
+           rendered row under `coarse`. That gap is the tournament's whole
+           sparse result and it grows exactly with B"
+    (if-not (mount/browser?)
+      (skip! ":node-test has no DOM")
+      (doseq [b m/row-counts]
+        (is (= 1 (:markup (work-at :fine b :sparse)))
+            (str "fine/sparse at B=" b))
+        (is (= b (:markup (work-at :coarse b :sparse)))
+            (str "coarse/sparse at B=" b " — the coarse arm has no way to build
+                 fewer, which is the price its cheap bulk is bought with"))
+        (is (<= (:markup (work-at :chunked b :sparse)) m/chunk-size)
+            (str "chunked/sparse at B=" b " is bounded by k, not by B"))))))
+
+(deftest the-bulk-finding
+  (testing "an all-row write builds every rendered row under EVERY un-windowed
+           arm — so on markup alone bulk cannot separate them, and whatever
+           separates them there is not the number of rows built"
+    (if-not (mount/browser?)
+      (skip! ":node-test has no DOM")
+      (doseq [b m/row-counts]
+        (doseq [arm [:fine :coarse :chunked]]
+          (is (= b (:markup (work-at arm b :bulk)))
+              (str arm "/bulk at B=" b)))
+        (is (= (min b m/window-size) (:markup (work-at :virtual b :bulk)))
+            (str "virtual/bulk at B=" b " builds only its window — a different
+                 page, and the only arm whose bulk cost does not scale with B"))))))
+
+(deftest the-reorder-finding
+  (testing "a permutation moves NO row's reads. Under `fine` the list re-runs
+           and every row memo-bails, so zero rows of markup are built for a
+           table that visibly reorders; under `coarse` all B are rebuilt"
+    (if-not (mount/browser?)
+      (skip! ":node-test has no DOM")
+      (doseq [b m/row-counts]
+        (is (= 0 (:markup (work-at :fine b :reorder)))
+            (str "fine/reorder at B=" b " — React moves DOM nodes and runs no
+                 body, which is the strongest single result in this census"))
+        (is (= b (:markup (work-at :coarse b :reorder)))
+            (str "coarse/reorder at B=" b))))))
+
+(deftest the-edit-finding
+  (testing "the write a controlled field's change intent performs lands on the
+           row's own draft cell, so it separates the arms exactly as `sparse`
+           does — the pipeline in front of it is rf2-hic-045's, not this
+           tournament's"
+    (if-not (mount/browser?)
+      (skip! ":node-test has no DOM")
+      (doseq [b m/row-counts]
+        (is (= 1 (:markup (work-at :fine b :edit))) (str "fine/edit at B=" b))
+        (is (= b (:markup (work-at :coarse b :edit))) (str "coarse/edit at B=" b))))))
+
+;; ---------------------------------------------------------------------------
+;; 4 — the controls
+;; ---------------------------------------------------------------------------
+
+(deftest the-negative-control-a-write-no-arm-reads
+  (testing "the counts above are counting rather than failing to look: a commit
+           that moves a key no arm holds moves no body in any arm"
+    (if-not (mount/browser?)
+      (skip! ":node-test has no DOM")
+      (doseq [arm arms/arm-ids]
+        (let [b 100]
+          (fresh! b)
+          (let [handle (mount! (arms/view-of arm))]
+            (try
+              (restore! b)
+              (let [work (operate! :noop b)]
+                (is (= 0 (:bodies work)) (str arm " ran a body on an unread write"))
+                (is (= 0 (:markup work)) (str arm " built markup on an unread write")))
+              (finally (mount/release! handle)))))))))
+
+(deftest the-census-rejects-a-broken-arm
+  (testing "THE SABOTAGE CONTROL. `sabotage-list` is `fine` with one extra read
+           per row — the shared view-model — so a one-row write invalidates all
+           B. Its DOM is byte-identical to `fine`'s, so only the census can tell
+           them apart, and it must"
+    (if-not (mount/browser?)
+      (skip! ":node-test has no DOM")
+      (let [b 100]
+        (fresh! b)
+        (let [handle (mount! sabotage-list)]
+          (try
+            (is (not= (:edges (arms/expected :fine b)) (:edges (rt/stats)))
+                "the structural check rejects it: the broken arm holds more read
+                 edges than fine's arithmetic allows")
+            (restore! b)
+            (let [work (operate! :sparse b)]
+              (is (= b (:markup work))
+                  "and the work census rejects it too — a one-row write built all
+                   B rows, where fine builds exactly one")
+              (is (not= 1 (:markup work))
+                  "which is the assertion `the-sparse-finding` would have made
+                   about a healthy arm, failing here as it must"))
+            (finally (mount/release! handle))))))))
+
+(deftest the-sabotage-arm-really-is-fine-in-every-other-respect
+  (testing "without this the control proves only that a DIFFERENT PAGE behaves
+           differently. The two arms build the same DOM, so the census's red
+           above is about the read topology and nothing else"
+    (if-not (mount/browser?)
+      (skip! ":node-test has no DOM")
+      (let [b 100]
+        (lane/leave-act-environment!)
+        (m/make-frame! frame-id b)
+        (m/reseed! frame-id b)
+        (let [healthy (mount! (arms/view-of :fine))
+              a       (lane/canonical (:container healthy))
+              _       (mount/release! healthy)
+              _       (m/reseed! frame-id b)
+              broken  (mount! sabotage-list)
+              c       (lane/canonical (:container broken))]
+          (mount/release! broken)
+          (is (= a c) "same markup, same keys, same attributes")
+          (is (re-find #"topo-row" a) "and the comparison is of a real table"))))))
+
+;; ---------------------------------------------------------------------------
+;; 5 — the record, emitted for the tournament page
+;; ---------------------------------------------------------------------------
+
+(deftest emit-the-census
+  (testing "the table this file exists to produce, printed as EDN so the
+           tournament page transcribes rather than retypes it"
+    (if-not (mount/browser?)
+      (skip! ":node-test has no DOM")
+      (do
+        (js/console.log (str ";; TOPO-CENSUS "
+                             (pr-str (sort-by (juxt :op :b :arm) (ensure-census!)))))
+        (is (= (* (count arms/arm-ids) (count m/row-counts) 4) (count @!record))
+            "every arm x row count x operation cell is present — a gap in the
+             table must fail here rather than be read as a pass")))))

--- a/implementation/freehand/test/re_frame/bench/hicasso/topo/census_dom_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/topo/census_dom_cljs_test.cljs
@@ -163,7 +163,11 @@
     {:boundaries    boundaries
      :edges         edges
      :elements      (lane/element-count (:container handle))
-     :rendered-rows (count (.querySelectorAll (:container handle) "li.topo-row"))}))
+     ;; `.-length`, not `count`: a `NodeList` implements no CLJS protocol,
+     ;; so `count` throws `ICounted` rather than answering — which errored
+     ;; all twelve structural cells on this file's first run and is worth a
+     ;; comment because the same call reads perfectly in a REPL over a seq.
+     :rendered-rows (.-length (.querySelectorAll (:container handle) "li.topo-row"))}))
 
 (deftest every-arm-is-the-topology-it-claims
   (if-not (mount/browser?)

--- a/implementation/freehand/test/re_frame/bench/hicasso/topo/control_app.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/topo/control_app.cljs
@@ -1,0 +1,202 @@
+(ns re-frame.bench.hicasso.topo.control-app
+  "**THE TOURNAMENT'S CLOCK CONTROL** — the changed-set doubling
+  `rf2-7iqb5` prescribed and nobody built (rf2-hic-036).
+
+  Driven by the lane's generic driver, so it adds no driver of its own:
+
+      HICASSO_INIT_FN=re-frame.bench.hicasso.topo.control-app/-main \\
+      HICASSO_OUT_DIR=out/topo-control \\
+      HICASSO_PORT=8147 \\
+      node implementation/freehand/test/re_frame/bench/hicasso/run.cjs
+
+  ## What this file decides, and why it runs BEFORE any cell
+
+  The topology tournament's four operations are all WRITE rows, and the
+  write rows of this lane's existing clock driver are refused by
+  construction:
+
+  > bulk-class rows cannot hold a difference-statistic control at the
+  > ~3.5% floor a magnitude needs (rf2-7iqb5, 28–48% within-block IQR),
+  > and the narrow class sits on the clock clamp (rf2-d2tzk)
+  > — `shapes/census_clock_run.cjs`
+
+  So the question this window exists to answer is not *what are the
+  numbers* but *can any number here be trusted*. That question is settled
+  by a control, and the control therefore runs first and alone. If it
+  refuses, the tournament's clock half refuses with it and the cells are
+  never taken — which is a result, not a failure.
+
+  ## The control, and why it is not the one this lane already had
+
+  Every earlier positive control for an update row **scaled the page**.
+  `rf2-7iqb5` records precisely why that cannot certify one: on an update
+  row the work does not scale with the page, so even a perfect instrument
+  reads below the predicted factor — and its own run failed high at
+  13.696 / 13.583 / 13.112x against a registered 8–13x band.
+
+  Its prescribed repair is this one: **hold page size fixed and double
+  the CHANGED SET.** Element count, layout and paint are then constant
+  between the two halves, and only commit-side work moves.
+
+  ## The predicted factor is DERIVED, never assumed to be 2.00
+
+  This is the half a flat prediction gets wrong, and this lane already
+  knows it: `census_clock_arms/ctl-predicted` computes 1.9759 / 1.9944 /
+  1.7255 from element arithmetic rather than printing 2.00, because the
+  page chrome does not double.
+
+  Here the same care lands somewhere sharper. The predicted factor is the
+  ratio of **rows of markup built**, which the deterministic census
+  measures as exact integers, and it is *arm-specific*:
+
+  | arm | markup at stride 10 | at stride 5 | predicted |
+  |---|---|---|---|
+  | `fine` | `B/10` | `B/5` | **2.00** |
+  | `coarse` | `B` | `B` | **1.00 — degenerate** |
+  | `chunked` (k=25) | `B` | `B` | **1.00 — degenerate** |
+
+  `coarse` and `chunked` rebuild every row whichever stride runs, so
+  their changed-set control **cannot discriminate at all**. That is a
+  fact about those topologies, not about the instrument, and it is why
+  this file certifies on `fine` alone and says so rather than quietly
+  averaging a null control into a pass.
+
+  ## The sign rule, which is the fix that landed in PR #7634
+
+  A band alone admits a control certifying that MORE DIRTY WORK READS
+  FASTER: `rf2-7iqb5` proved it live, capturing `num=-1.194 den=-0.594
+  measured=2.0101x band=[1.5076,2.5126] ok=TRUE` against a decreasing
+  fixture. [[verdict]] therefore requires the measured difference to be
+  positive as well as in band, and refuses on the sign."
+  (:require [re-frame.adapter.uix :as uix-adapter]
+            [re-frame.bench.hicasso.arm1.mount :as mount]
+            [re-frame.bench.hicasso.arm1.runtime :as rt]
+            [re-frame.bench.hicasso.lane :as lane]
+            [re-frame.bench.hicasso.topo.arms :as arms]
+            [re-frame.bench.hicasso.topo.model :as m]
+            [re-frame.core :as rf]))
+
+;; ---------------------------------------------------------------------------
+;; Pre-registered, and matching `topology-tournament.md` §1.5 exactly
+;; ---------------------------------------------------------------------------
+
+(def band
+  "Registered before the run: predicted 2.00x, admitted in [1.60, 2.50]."
+  {:lo 1.60 :hi 2.50 :predicted 2.00})
+
+(def sampling {:warmup 3 :samples 12})
+(def rounds 5)
+
+(def batch-k
+  "Operations under ONE clock.
+
+  Chrome clamps `performance.now()` to 100 µs, and `rf2-d2tzk` records
+  what that does to a narrow row: HD-008's bulk floor read a p50 of about
+  0.1 ms — ONE quantum — and a yield correction over it consumed the
+  whole window. `rf2-9zysg`'s repair for the narrow row was to batch, and
+  this is that repair, not a new idea: `k` commits share one clock, which
+  lifts the window clear of the clamp and is NOT the same as summing `k`
+  separately-clamped readings."
+  20)
+
+(def row-count
+  "The control runs at the tournament's largest size, because that is
+  where a difference statistic has the most room and where a refusal is
+  therefore most informative."
+  1000)
+
+;; ---------------------------------------------------------------------------
+;; The arms — two strides on ONE page size, interleaved
+;; ---------------------------------------------------------------------------
+
+(def ^:private frame-id ::control)
+
+(defn- window!
+  "`batch-k` commits under one clock. The clock stops after the last
+  drain; the read-back happens afterwards, which is the batched shape
+  `lane/verified-writes!` documents."
+  [stride]
+  (let [t0 (lane/now-ms)]
+    (dotimes [_ batch-k]
+      (rt/dispatch! frame-id [:topo/bump-stride stride])
+      (mount/settle!))
+    (- (lane/now-ms) t0)))
+
+(def arms
+  "Two arms, one page. `:d10` moves every 10th row, `:d5` every 5th — so
+  the changed set doubles and nothing else does."
+  [{:id :d10 :stride 10}
+   {:id :d5  :stride 5}])
+
+;; ---------------------------------------------------------------------------
+;; The verdict
+;; ---------------------------------------------------------------------------
+
+(defn verdict
+  "Adjudicate the control. STRICT: in band AND positive in sign, on the
+  ROUND-WISE ratios rather than on a pooled mean, so one round outside
+  the band refuses the control rather than being averaged away.
+
+  Pure, and exported for its own exit-path test — the gate arithmetic has
+  to be checkable without a headless Chromium."
+  [round-ratios]
+  (let [rs      (vec round-ratios)
+        every?* (fn [p] (and (seq rs) (every? p rs)))
+        in-band (every?* (fn [r] (and (>= r (:lo band)) (<= r (:hi band)))))
+        signed  (every?* (fn [r] (> r 1.0)))]
+    {:rounds    rs
+     :predicted (:predicted band)
+     :band      [(:lo band) (:hi band)]
+     :in-band?  in-band
+     :positive? signed
+     :ok?       (boolean (and in-band signed))
+     :why       (cond
+                  (empty? rs)   "no rounds — a control that measured nothing cannot certify anything"
+                  (not signed)  "REFUSED ON THE SIGN — a round read the doubled changed set as no slower, which is a control certifying that more dirty work costs less"
+                  (not in-band) "REFUSED ON THE BAND — a round fell outside [1.60, 2.50] around the derived 2.00"
+                  :else         "in band and positive in every round")}))
+
+;; ---------------------------------------------------------------------------
+;; The run
+;; ---------------------------------------------------------------------------
+
+(defn- round-ratio [reading]
+  (let [p (fn [id] (:p50 (lane/summarise (get reading id))))]
+    (/ (p :d5) (p :d10))))
+
+(defn ^:export -main []
+  (rf/init! uix-adapter/adapter)
+  (lane/leave-act-environment!)
+  (lane/self-test!)
+  (try
+    (m/make-frame! frame-id row-count)
+    (m/reseed! frame-id row-count)
+    (arms/reset-counters!)
+    (let [handle (mount/root! (mount/fresh-container!) frame-id [(arms/view-of :fine) {}])
+          struct {:boundaries (:boundaries (rt/stats))
+                  :edges      (:edges (rt/stats))
+                  :elements   (lane/element-count (:container handle))}
+          want   (select-keys (arms/expected :fine row-count) [:boundaries :edges :elements])]
+      (lane/record! :page (assoc struct :expected want))
+      (if (not= want struct)
+        (do (set! (.-HICASSO_CONTROL_FAILED js/window) true)
+            (lane/fail! (str "the control's page is not the arm it claims: expected "
+                             (pr-str want) ", mounted " (pr-str struct))))
+        (let [{:keys [readings samples]}
+              (lane/rounds! arms sampling rounds (fn [{:keys [stride]}] (window! stride)))
+              ratios (mapv round-ratio readings)
+              v      (verdict ratios)
+              gv     (lane/guard! samples "topo changed-set control (fine, B=1000)")]
+          (lane/record! :runtime (lane/runtime-label))
+          (lane/record! :batch-k batch-k)
+          (lane/record! :per-round (mapv (fn [r] {:d10 (lane/summarise (get r :d10))
+                                                  :d5  (lane/summarise (get r :d5))}) readings))
+          (lane/record! :control v)
+          (when (:refuse? gv) (set! (.-HICASSO_GUARD_REFUSED js/window) true))
+          (when-not (:ok? v)
+            (set! (.-HICASSO_CONTROL_FAILED js/window) true)
+            (js/console.error (str ";; CONTROL REFUSED — " (:why v))))
+          (mount/release! handle))))
+    (catch :default e
+      (lane/fail! (str "topo control threw: " (.-message e)))))
+  (lane/done!))

--- a/implementation/freehand/test/re_frame/bench/hicasso/topo/model.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/topo/model.cljs
@@ -1,0 +1,262 @@
+(ns re-frame.bench.hicasso.topo.model
+  "THE TOPOLOGY TOURNAMENT'S STATE LAYER — one table, four read
+  topologies, four operations (rf2-hic-036).
+
+  The tournament asks which read topology fits which workload. That is
+  only answerable if the four arms are four *readings of one
+  application*: four hand-written models would make every arm-to-arm
+  difference unattributable, which is the argument
+  [[re-frame.bench.hicasso.shapes.model]] already makes for the tier-1
+  shape roster and `jsfb-model` makes for the js-framework-benchmark
+  pair. So the rows, the markup, the seed and the four events live here,
+  once, and [[re-frame.bench.hicasso.topo.arms]] cuts them four ways.
+
+  ## The row's TWO reads, and why exactly two
+
+  [The counterfactual worksheet](../../../../../../../docs/design/hicasso/product/counterfactual-topology-prediction.md)
+  froze its predictions on `R = 2`, and closed by naming the way this
+  page could invalidate them: *\"if the tournament's table reads more
+  than 2 keys per row, every `B·R` figure on this page is low.\"* It
+  reads exactly two, and they are the worksheet's own pair — one
+  per-instance DATA read and one per-instance UI read:
+
+      [:topo/row i]     the row's data     {:id :label :n}
+      [:topo/draft i]   the row's own edit buffer, a string
+
+  Both are unconditional, so the set has ONE form and cannot oscillate —
+  which matters, because set stability is a **gate** on the coarse arm
+  rather than a tiebreak (`hot-path-architecture.md#read-topology-guidance`:
+  *\"Large oscillating read sets are suspect\"*). The worksheet's §2 found
+  the row family the most stable thing on its page; this family is stable
+  by construction, and `census_dom_cljs_test` asserts it rather than
+  claiming it.
+
+  ## The four operations, and why they are four rather than two
+
+  Each moves a DIFFERENT cell, which is the only reason `sparse` and
+  `edit` are two rows instead of one:
+
+  | op | event | cell moved | rows whose reads move |
+  |---|---|---|---|
+  | `sparse` | `[:topo/bump i]` | `[:topo/row i]` | 1 |
+  | `bulk` | `[:topo/bump-all]` | every `[:topo/row i]` | `B` |
+  | `reorder` | `[:topo/rotate]` | `[:topo/order]` **only** | 0 |
+  | `edit` | `[:topo/edit i s]` | `[:topo/draft i]` | 1 |
+
+  **`reorder` is the interesting one and the easiest to get wrong.** It
+  permutes `:order` and touches no row's data, so no row's reads move at
+  all: every re-render it causes is React reconciling a keyed list whose
+  children are unchanged values in a new sequence. An implementation that
+  rebuilt its children would produce the same DOM and a completely
+  different body count, which is exactly the distinction
+  `shapes/bulk_dom_cljs_test` was written to make.
+
+  ## `edit` is the COMMIT a keystroke causes, not the keystroke
+
+  Stated here so no reader takes the row for more than it is. `edit`
+  writes the row's draft cell — the write a controlled field's change
+  intent performs — and the tournament measures the commit that follows.
+  The pipeline in front of it (keystroke → state write → recomputation →
+  boundary run → commit → visible echo) is **`rf2-hic-045`'s published
+  per-keystroke mechanics**, which owns exactly that ladder for the
+  editor and the grid. Duplicating it here would mint a second,
+  unreconciled witness for a quantity another bead already owns.
+
+  ## Determinism
+
+  Every string is a pure function of an index — no `rand`, no clock — so
+  two seedings of the same `B` build byte-identical DOM and a witness can
+  compare a page against itself across a commit."
+  (:require [re-frame.core :as rf]))
+
+;; ---------------------------------------------------------------------------
+;; The seed
+;; ---------------------------------------------------------------------------
+
+(def row-counts
+  "The tournament's three sizes, pre-registered."
+  [100 300 1000])
+
+(def chunk-size
+  "`k` for the chunked arm — a STATED CONSTANT, not a derived optimum.
+
+  The counterfactual worksheet refuses to pin a chunk width (its N1): the
+  naive `k* = √B` prices one membership slot as one row of markup, which
+  is certainly false, and the committed evidence carries no value for the
+  true ratio. So this is a setting of the arm, chosen before any run and
+  held fixed at every row count and every operation. It is not a result,
+  and no row below may be read as evidence about it."
+  25)
+
+(def window-size
+  "How many rows the windowed arm keeps in the DOM. Fixed, like
+  [[chunk-size]], and for the same reason."
+  20)
+
+(defn row
+  "One row, from its index. `:n` is the field the data writes move."
+  [i]
+  {:id    i
+   :label (str "Row " i)
+   :n     (mod (* 7 i) 23)})
+
+(defn seed-db
+  "`b` rows, in index order, with empty drafts."
+  [b]
+  {:rows   (into {} (map (fn [i] [i (row i)])) (range b))
+   :order  (vec (range b))
+   :draft  {}
+   :b      b})
+
+;; ---------------------------------------------------------------------------
+;; Subscriptions — the four topologies' reads
+;; ---------------------------------------------------------------------------
+
+;; The list boundary's read, shared by the fine, chunked and windowed arms.
+(rf/reg-sub :topo/order (fn [db _] (:order db)))
+
+;; The row family's two reads. Both parametric, both per instance.
+(rf/reg-sub :topo/row (fn [db [_ i]] (get-in db [:rows i])))
+(rf/reg-sub :topo/draft (fn [db [_ i]] (get-in db [:draft i] "")))
+
+(defn- merged
+  "One row of the coarse arm's view-model: the two per-instance reads,
+  already joined. This is the whole of what the coarse arm buys — the
+  join moves from `B` boundary read-sets into ONE subscription, and the
+  worksheet's §1 is the statement that the family then contributes zero
+  memberships instead of `B·R`."
+  [db i]
+  (assoc (get-in db [:rows i]) :draft (get-in db [:draft i] "")))
+
+;; **THE COARSE ARM'S ONE READ.** It recomputes whenever anything the rows
+;; hold moves, which is the price; it holds one membership instead of
+;; `B·R`, which is the purchase.
+(rf/reg-sub :topo/view-model
+  (fn [db _] (mapv (partial merged db) (:order db))))
+
+;; **THE CHUNKED ARM.** `⌈B/k⌉` boundaries, each reading its own slice.
+(rf/reg-sub :topo/chunk-count
+  (fn [db _] (long (Math/ceil (/ (count (:order db)) chunk-size)))))
+
+(rf/reg-sub :topo/chunk
+  (fn [db [_ c]]
+    (mapv (partial merged db)
+          (subvec (:order db)
+                  (min (count (:order db)) (* c chunk-size))
+                  (min (count (:order db)) (* (inc c) chunk-size))))))
+
+;; **THE WINDOWED ARM.** The visible slice of `:order` — the ids that
+;; exist in the DOM at all. Every other row is absent, which is a
+;; different lever from how many read edges exist (the worksheet's N2).
+(rf/reg-sub :topo/visible
+  (fn [db _]
+    (subvec (:order db) 0 (min (count (:order db)) window-size))))
+
+;; ---------------------------------------------------------------------------
+;; Events — the four operations, plus the seed and the control's write
+;; ---------------------------------------------------------------------------
+
+(rf/reg-event :topo/seed (fn [_ [_ b]] {:db (seed-db b)}))
+
+(rf/reg-event :topo/bump
+  ;; **SPARSE.** One row's data moves. Nothing else in app-db is touched,
+  ;; including `:order` — which is what lets a witness assert the list
+  ;; boundary did NOT re-run.
+  (fn [{:keys [db]} [_ i]] {:db (update-in db [:rows i :n] inc)}))
+
+(rf/reg-event :topo/bump-all
+  ;; **BULK.** Every row's data moves, in one commit. `:order` does not,
+  ;; so a fine arm's `B` re-renders are `B` rows answering for themselves
+  ;; and not a parent rebuilding its children.
+  (fn [{:keys [db]} _]
+    {:db (update db :rows (fn [rs] (reduce-kv (fn [m i r] (assoc m i (update r :n inc))) {} rs)))}))
+
+(rf/reg-event :topo/rotate
+  ;; **REORDER.** `:order` rotates by one. Same identities, same keys,
+  ;; same values — only the sequence changes.
+  (fn [{:keys [db]} _]
+    {:db (update db :order (fn [o] (if (empty? o) o (conj (subvec o 1) (nth o 0)))))}))
+
+(rf/reg-event :topo/edit
+  ;; **EDIT.** The write a controlled field's change intent performs.
+  (fn [{:keys [db]} [_ i s]] {:db (assoc-in db [:draft i] s)}))
+
+(rf/reg-event :topo/bump-stride
+  ;; **THE POSITIVE CONTROL'S WRITE** (rf2-7iqb5's prescribed repair).
+  ;;
+  ;; Every `stride`-th row moves, in one commit, on a table whose SIZE
+  ;; does not change. Element count, layout and paint are therefore
+  ;; constant between `stride 10` and `stride 5`, and the only thing that
+  ;; doubles is the changed set — so the prediction on the commit-side
+  ;; work is 2.00x.
+  ;;
+  ;; This is the control this lane did not have. Every earlier positive
+  ;; control for an update row scaled the PAGE, and rf2-7iqb5 records why
+  ;; that cannot certify one: the work does not scale with the page, so
+  ;; even a perfect instrument reads below the predicted factor.
+  (fn [{:keys [db]} [_ stride]]
+    {:db (update db :rows
+                 (fn [rs]
+                   (reduce-kv (fn [m i r] (assoc m i (cond-> r (zero? (mod i stride)) (update :n inc))))
+                              {} rs)))}))
+
+(rf/reg-event :topo/noop-write
+  ;; **THE NEGATIVE CONTROL.** Moves a key no arm reads, so a witness that
+  ;; counts zero bodies here is counting rather than failing to look.
+  (fn [{:keys [db]} _] {:db (update db :unread (fnil inc 0))}))
+
+;; ---------------------------------------------------------------------------
+;; Frame lifecycle
+;; ---------------------------------------------------------------------------
+
+(defn make-frame!
+  "Create (or idempotently replace) `frame-id`, seeded with `b` rows."
+  [frame-id b]
+  (rf/make-frame {:id frame-id :initial-events [[:topo/seed b]]})
+  frame-id)
+
+(defn reseed!
+  "Return the frame to its seeded state. `make-frame!` is idempotent and
+  will NOT replay its initial events for an id that already exists, so
+  both halves are needed."
+  [frame-id b]
+  (rf/with-frame frame-id (rf/dispatch-sync [:topo/seed b]))
+  nil)
+
+;; ---------------------------------------------------------------------------
+;; The arithmetic a witness predicts rather than accepts
+;; ---------------------------------------------------------------------------
+
+(def elements-per-row
+  "`li` + `span.label` + `em.n` + `span.draft` + `button` = 5.
+
+  Written down so a page's element total is arithmetic a witness can
+  PREDICT — `1 + 5B` for the un-windowed arms — rather than a number it
+  has to accept from the DOM it is supposed to be checking. A markup edit
+  that forgets to update it fails a row instead of silently
+  re-baselining the tournament."
+  5)
+
+(defn elements-for
+  "Predicted element count: the `ul` plus five per RENDERED row."
+  [rendered-rows]
+  (+ 1 (* elements-per-row rendered-rows)))
+
+(defn rendered-rows
+  "How many rows an arm puts in the DOM at `b`. Three arms render every
+  row; the windowed arm renders at most [[window-size]] — which is the
+  arm's entire purpose and the reason it is not DOM-comparable with the
+  other three."
+  [arm b]
+  (if (= :virtual arm) (min b window-size) b))
+
+(defn memberships
+  "The read edges the arm's row family contributes at `b` — the
+  worksheet's `B·R` column, computed from the same arithmetic so the two
+  can be compared rather than asserted equal."
+  [arm b]
+  (case arm
+    :fine    (* 2 b)
+    :coarse  0
+    :chunked (long (Math/ceil (/ b chunk-size)))
+    :virtual (* 2 (min b window-size))))


### PR DESCRIPTION
The topology tournament (`rf2-hic-036`), run as a Shape 6 measurement window on a verified-quiet box. It comes back **half published and half refused**, and the refused half is the more useful one.

- **The deterministic work census is complete at all 48 cells** (4 arms × 3 row counts × 4 operations) and publishes as the rung-2 teaching table.
- **The clock half is REFUSED.** The pre-registered positive control was built, run, and failed its band. No clock cell is published, no band was widened, and the prediction was not re-derived after seeing the data.

The bead stays **OPEN**. §2.6 and §2.7 of the page say exactly what remains.

## The pre-registration came first, in its own commit

`7c94e5299f` on this branch (authored as `51e1acef69`, rebased), **before a single measurement**. It fixes the arms, the operations, `B ∈ {100, 300, 1000}`, the estimand, both controls, the kill lines, and the clause the bead singles out:

> **Two tuning iterations per red cell. Not three, and not "until it goes green."**

Spent: **zero**. No cell was red against a line the instrument could adjudicate. Repairing the control would not have been a tuning iteration — §1.6 defines the allowance as a bounded change to *the arm's topology* and says in terms that a change to the instrument, band, control or kill line is a different tournament.

## What the census found

Rows of markup built — the quantity that separates the arms:

| operation | `fine` | `coarse` | `chunked` (k=25) | `virtual` (W=20) |
|---|---|---|---|---|
| sparse / edit | **1** | `B` | 25 | **1** |
| bulk | `B` | `B` | `B` | **20** |
| reorder | **0** | `B` | `B` | 1 |

1. **Sparse and edit separate the arms linearly in `B`** — at `B = 1000` that is a factor of 1,000 on an exact integer counter.
2. **Bulk does not separate `fine`/`coarse`/`chunked` on markup at all.** Whatever separates them there is boundary-shell cost — 1,000 shells against one — which is a *breached* registered line (S1/S2 over the frozen 1,024 B) and routes to `rf2-hic-018` rather than being answerable here.
3. **Reorder inverts the arms, and `chunked` is the worst of them.** `fine` builds **zero** rows for a table that visibly reorders; `chunked` builds all `B` *and* runs `⌈B/k⌉` bodies.
4. **`virtual` is the only arm constant in `B`** — and the only one whose figures are about a different page, which is the same fact.

## The clock control was run, and refused

`B = 1000`, `fine` arm, 20 commits under one clock, 12 samples × 5 rounds interleaved. Page structure checked *before* the clock and exact: 1,001 boundaries / 2,001 edges / 5,001 elements.

| round | 1 | 2 | 3 | 4 | 5 |
|---|---|---|---|---|---|
| ratio | 1.331 | 1.387 | 1.424 | 1.471 | 1.325 |

Predicted 2.00, registered band [1.60, 2.50]. **REFUSED ON THE BAND**, captured exit **1**.

**It is not noise.** Five rounds agree to within 0.15, ranges are tight, the sign is right every round, and the arm-order guard passed both by predecessor and by phase. The model behind the prediction is wrong, and the census says where: the event handler and the subscription layer each walk the whole table at *either* stride, so a large constant term is shared and the ratio compresses toward 1. That is `rf2-7iqb5`'s page-scaling failure reappearing inside the control built to replace it. Diagnosis filed on `rf2-m6i0`.

## A claim this branch corrected against itself

An earlier commit here said the coarse arm **breaches U5**. It does not, as U5 is registered: U5's estimand is *boundary bodies run*, and coarse runs exactly **1** for a narrow update — it does its thousand rows inside that one body. D3/D4 catch a coarse shape only because theirs keeps per-cell boundaries to count; a coarse shape that **inlines** its rows has none, so the instrument reads 1 and reports a pass.

Recorded as an instrument gap (`rf2-mwr2`), not as a breach. **This PR reports no U5 breach.**

## Quality gates

Every number below is the one I captured from the runner, on one command line, in one shell — never the harness's report about the same run. **That distinction bit twice here**: on two separate runs the harness reported exit 0 while my captured code was **1** (browser attempt 1 with 12 real errors; the control run's genuine refusal). Believing the reported zero on the second would have inverted the conclusion — a refused control would have read as a passing one.

| gate | captured exit | result |
|---|---|---|
| `npm run test:browser` (attempt 3, post-rebase) | **0** | 1,500 tests / 9,482 assertions, 0 failures, 0 errors, 0 topo errors |
| `npm run test:browser` (attempt 1, pre-fix) | **1** | same counts, 12 errors — one `NodeList`/`ICounted` bug, all in one assertion |
| `node freehand/…/hicasso/compile_gate.cjs` | **0** | 130 lane namespaces, **zero warnings** (re-run after `control_app.cljs` landed) |
| `node scripts/_browser-dom-lane-partition.test.cjs` | **0** | 3 passed — the new DOM test lands in exactly one lane |
| `python scripts/check_doc_slugs.py` | **0** | |
| `python scripts/check_provenance_pins.py --changed-since origin/main` | **0** | 1 cited pin, landed |
| `topo/control_app.cljs` via `run.cjs` | **1** | **the control refusing, as designed** |
| markdown table column counts (10 tables) | **0** | and the checker was sabotage-tested: a deleted cell reds it at the right line |

**Control run for the assertion counts**: browser attempts 1 and 3 both ran 1,500 tests / 9,482 assertions; the delta is 12 errors → 0. Gates were re-run on the **final rebased base** (15 commits landed under this branch); the pre-rebase green is not what is quoted.

**Which tree the gates read.** Both routes were available and both were taken. The compile gate and the browser server print their root, and both named `…/re-frame2-worktrees/tournament-hic036/implementation`. Independently, the census namespace exists **only** in this worktree, so a run that had wandered into a sibling could not have reported `re-frame.bench.hicasso.topo.census-dom-cljs-test` at all — and attempt 1's 12 errors were reported against it by name.

**The sabotage control is an arm, not a patched file.** `sabotage-list` is `fine` with one extra read per row — compiled, mounted and exercised on the same door, with byte-identical DOM (asserted). A planted source fault proves the source changed and not that the runtime observed it; there was nothing to restore and nothing to hash.

**CI checks these local gates do not cover**: `.github/workflows/test.yml` (the full node-test spine, `test:cljs-isolation`, bundle-isolation, the JVM artefacts) and `.github/workflows/expensive-tests.yml`. `mkdocs build --strict` is **not** the gate for this page — `mkdocs.yml`'s `exclude_docs` keeps `design/hicasso/` out of the site. Table column counts and heading anchors in `topology-tournament.md` were therefore checked by hand as well as by `check_doc_slugs.py`.

## What was NOT concluded

- **No clock figure at all**, for any arm, operation or row count. §2.6's ratios are the *control's*; a refused control publishes nothing, including itself as a finding about the arms.
- **No verdict against U1, U2, U3, U4, C3 or C4** — all millisecond lines.
- **No U5 breach** (see above).
- **No `rf2-hic-080` scoring.** Its phase 2 is deliberately another worker's; a tournament that graded its own blinded predictor would destroy the property the split exists to protect. What is handed over is the measured ordering on the work census, plus the note that the clock orderings are **unaddressed** in that page's own frozen vocabulary.
- **No package figure.** Everything is on the bench's arm-1 runtime, labelled as such — the same discipline `budgets.md` uses when it marks S6/S7 *bench-tree* beside S1–S5's *package*.
- **No chunk-width result.** `k = 25` was a stated setting, not a derived optimum.

## Fence

New files only, plus one new page. `origin/main...HEAD` is **1,481 insertions, 0 deletions** — nothing any sibling landed is reverted.

No hot-zone file touched: `implementation/shadow-cljs.edn` is untouched because the lane's drivers reuse the shared `hicasso-bench` build id via `--config-merge`, so **no new build id or `:dev-http` port was needed**. None of #8155's, #8158's or #8159's files appear in the diff. No `.beads` path is committed.

## Follow-ups filed

- `rf2-m6i0` (P2) — a non-degenerate positive control for the coarse-family arms, carrying this run's diagnosis. **This is what unblocks the clock half.**
- `rf2-mwr2` (P2) — U5's estimand cannot see a coarse arm that inlines its rows.
