### PR TITLE
docs+test(hicasso): the per-keystroke mechanics, measured — editor and grid (rf2-hic-045)

### DIFF
--- a/docs/design/hicasso/product/budgets.md
+++ b/docs/design/hicasso/product/budgets.md
@@ -973,6 +973,22 @@ other mode.
   the same missing readings. None of the six can be pinned by measuring harder
   on the rig that exists; each needs a clock instrument pointed at
   `implementation/hicasso`, on P-DEV-1, in its own window.
+  **[Amended 2026-08-14, `rf2-hic-045`.]** `U1`'s **deterministic half is now
+  published** — [`per-keystroke.md`](per-keystroke.md) is the per-keystroke
+  census of the two witness applications, and its §6 records that on both
+  pages the typed field shows the model's value at the instant
+  `dispatchEvent` returns, inside the discrete event, with no flush performed
+  and **no frame boundary crossed at all**. `U1` is **not** recoloured by it
+  and stays `UNPINNED`, deliberately: the registered estimand is *latency to
+  visible echo at p95*, a distributional row, and *the echo is present before
+  the turn yields* does not imply *the echo reaches the glass within 16.7 ms
+  at p95* on a machine where the event turn itself can be slow. Substituting
+  the structural reading for the distributional one is the conflation §3
+  refuses when it keeps `D9`'s counters apart from `S5`'s bytes. What the
+  census narrows is what the clock will eventually be timing: work inside one
+  discrete event, on a path whose other five stages are now counted.
+  §9.3's *one-frame keystroke echo* deliverable is therefore still
+  `rf2-hic-071`'s, and its scope is unchanged.
 - **The 5% rule has no same-instrument anchor.** `C1` compares a reading
   against the pinned ordinary-Hicasso benchmark, and §6 records that the
   registered instrument's eleven pinned blobs are superseded rather than

--- a/docs/design/hicasso/product/per-keystroke.md
+++ b/docs/design/hicasso/product/per-keystroke.md
@@ -12,22 +12,30 @@ keystroke costs in their own application from its read topology alone, and a
 reader auditing the numbers should be able to find the witness that took each
 one.
 
-The applications are the ones
-[`rf2-hic-078`](../../../../implementation/hicasso/test/re_frame/hicasso/examples/)
-built and `main` carries: `examples/editor` and `examples/grid`. **No number on
-this page comes from the frozen bench prototypes** under
-`implementation/freehand/test/re_frame/bench/`, which are a different tree
-measuring different questions.
+The applications are the ones [`rf2-hic-078`][apps] built and `main` carries:
+`examples/editor` and `examples/grid`. **No number on this page comes from the
+frozen bench prototypes** under `implementation/freehand/test/re_frame/bench/`,
+which are a different tree measuring different questions.
+
+[apps]: ../../../../implementation/hicasso/test/re_frame/hicasso/examples/
+[census]: ../../../../implementation/hicasso/test/re_frame/hicasso/examples/per_keystroke_dom_cljs_test.cljs
+[kit]: ../../../../implementation/hicasso/test_kit/src/re_frame/hicasso/test/mounted.cljs
+
+**Two findings up front, because they are the ones a reader should leave with.**
+A keystroke's *boundary* cost is flat in the size of the page, exactly as
+specification §6 claims — and its *subscription recomputation* cost is not: it is
+one recomputation per mounted cell, at every size. And the visible echo of an
+accepted keystroke costs **zero** writes onto the glass, because the character is
+already there.
 
 ---
 
 ## 1. Pre-registration
 
 **This section was written and committed before any measurement was taken**, so
-that a prediction cannot be trimmed to fit a reading. The commit that carried it
-is the one immediately before the first measured commit on `rf2-hic-045`'s
-branch, and every figure in §4 onward is reported against it — including the
-ones that came back wrong.
+that a prediction could not be trimmed to fit a reading. Two of its twelve
+predictions missed, and both misses are reported below in the place the
+prediction was made rather than quietly corrected.
 
 ### 1.1 The six instruments, fixed in advance
 
@@ -42,82 +50,356 @@ Each stage of the path gets exactly one instrument, and no stage gets two.
 | Commit — DOM mutations | a `MutationObserver` over the container (`childList`, `attributes`, `characterData`) | one mutation record |
 | Visible echo | the typed control's `.value`, read at the instant `dispatchEvent` returns | — |
 
-[kit]: ../../../../implementation/hicasso/test_kit/src/re_frame/hicasso/test/mounted.cljs
-
 Two of these deserve their definition stated rather than assumed.
 
 **The glass-write count excludes the keystroke's own write.** A scripted
 keystroke reaches the same code path a real one does only by writing through the
 element prototype's own `value` setter and then firing a real `input` event
 (`editor.flow-dom-cljs-test/type-into!` established this). That first write is
-the *user agent's*, not the runtime's, so it is subtracted. What remains is what
-the framework wrote.
+the *user agent's*, not the runtime's, so [the census][census] performs it
+through a setter captured at namespace load, outside the spy's reach by
+construction rather than by subtracting one and hoping the subtrahend never
+changes.
 
-**The echo is read before any flush.** Every existing mounted witness calls
-`hm/settle!` before asserting the glass, which commits whatever React has
-scheduled. That is right for a correctness row and wrong for a latency one: it
-measures the value after a flush the browser would not have performed yet. This
-page reads `.value` at the instant `dispatchEvent` returns — inside the event
-turn, before any paint could occur — and settles afterwards.
+**The echo is read before any flush.** Every existing mounted witness in the tree
+calls `hm/settle!` and then asserts the glass. That is right for a correctness
+row and wrong for a latency one — it reads the page after a flush the browser had
+not yet performed. This page reads `.value` at the instant `dispatchEvent`
+returns, inside the discrete event, and settles afterwards.
 
-### 1.2 The predicted figures
+### 1.2 The predicted figures, and what they did
 
-Deterministic counters, so these are exact integers and not bands. A band would
-be the wrong instrument: contention cannot move a monotone counter
+Deterministic counters, so these were exact integers and not bands. A band would
+have been the wrong instrument: contention cannot move a monotone counter
 ([budgets §2](budgets.md#2-the-two-disposition-families-which-6-already-separates)).
 
-| # | Subject | Stage | Predicted |
-|---|---|---|---:|
-| P1 | Editor, steady-state keystroke into `:title` | state writes | 1 |
-| P2 | Editor, steady-state keystroke | subscription recomputations | 10 |
-| P3 | Editor, steady-state keystroke | boundary runs | 1 |
-| P4 | Editor, steady-state keystroke | glass writes by the runtime | 1 |
-| P5 | Editor, first keystroke of a session | boundary runs | 2 |
-| P6 | Grid 10×10, keystroke into cell `[3 4]` | state writes | 1 |
-| P7 | Grid 10×10, keystroke into cell `[3 4]` | subscription recomputations | 111 |
-| P8 | Grid 10×10, keystroke into cell `[3 4]` | boundary runs | 2 |
-| P9 | Grid 5×5, keystroke into cell `[3 4]` | subscription recomputations | 31 |
-| P10 | Grid 10×10, **refused** keystroke | state writes | 0 |
-| P11 | Grid 10×10, **refused** keystroke | subscription recomputations | 0 |
-| P12 | Either page | echo present before any flush | yes |
+| # | Subject | Stage | Predicted | Measured | |
+|---|---|---|---:|---:|---|
+| P1 | Editor, steady-state keystroke into `:title` | state writes | 1 | **1** | held |
+| P2 | Editor, steady-state keystroke | subscription recomputations | 10 | **10** | held |
+| P3 | Editor, steady-state keystroke | boundary runs | 1 | **1** | held |
+| P4 | Editor, steady-state keystroke | glass writes by the runtime | 1 | **0** | **missed** |
+| P5 | Editor, first keystroke of a session | boundary runs | 2 | **2** | held |
+| P6 | Grid 10×10, keystroke into cell `[3 4]` | state writes | 1 | **1** | held |
+| P7 | Grid 10×10, keystroke into cell `[3 4]` | subscription recomputations | 111 | **111** | held |
+| P8 | Grid 10×10, keystroke into cell `[3 4]` | boundary runs | 2 | **2** | held |
+| P9 | Grid 5×5, keystroke into cell `[3 4]` | subscription recomputations | 31 | **31** | held |
+| P10 | Grid 10×10, **refused** keystroke | state writes | 0 | **0** | held |
+| P11 | Grid 10×10, **refused** keystroke | subscription recomputations | 0 | **0** | held |
+| P12 | Either page | echo present before any flush | yes | **yes** | held |
+| — | Either page | DOM mutation records | 0 | **7** / **8** | **missed** |
 
-**P2, P7 and P9 are the predictions this page exists to test, and the reasoning
-behind them is the part worth writing down before the answer is known.** Every
+**P2, P7 and P9 were the predictions this page existed to test**, and the
+reasoning behind them is worth keeping now that they have held, because it is
+the reasoning a reader needs in order to predict their own page. Every
 subscription in both applications is a **layer-1** reader — registered as
 `(fn [db query-v] …)`, so its input is the whole of app-db rather than another
 subscription's value. `re-frame.subs.memo`'s layer-1 wrapper memoises on that
 input: the author's body is skipped when the new app-db is `=` to the last one
-seen, and re-run when it is not. A keystroke moves app-db. So the prediction is
-that **every mounted layer-1 cell that is derefed on the write path re-runs its
-body**, and the count is therefore the number of live cells rather than the
-number of changed addresses:
+seen, and re-run when it is not. **A keystroke moves app-db.** So every mounted
+layer-1 cell that is derefed on the write path re-runs its body, and the count is
+the number of live cells rather than the number of changed addresses.
 
-- editor: four `::field` cells, four `::committed` cells, `::revision`,
-  `::dirty?` = **10**;
-- grid 10×10: one hundred `::cell` cells, ten `::row-total` cells, one
-  `::dimensions` cell = **111**;
-- grid 5×5: twenty-five, five, one = **31**.
-
-If P7 and P9 both hold, subscription recomputation **scales with the mounted
-grid** while boundary runs do not, and the two stages of the same keystroke
-answer the specification's narrow-update question differently. If they come back
-at 2, the substrate is notifying more narrowly than the memo layer alone would
-imply, and the page says so instead.
-
-### 1.3 What a refusal would look like
-
-Under [Shape 6](#8-what-this-page-does-not-conclude) a validity failure refuses
-the figure rather than publishing it. For a deterministic census the validity
-conditions are:
-
-- the sabotage control does not go red when a figure is inverted — the row was
-  skipped rather than run, and no figure it would have reported may be published;
-- the counting wrapper changes a figure another instrument already pins (D1, D2,
-  D7, D8) — the instrument is perturbing its subject and its own readings are
-  void;
-- the two applications disagree about a stage that is the same mechanism in
-  both, with nothing in the topology to explain the difference.
+The two misses are §5's and §6's subjects and are treated there.
 
 ---
 
-<!-- Sections 2 onward are added by the measured commits that follow. -->
+## 2. The four-field editor
+
+Four controls, a button row and a committed readout. Ten subscription cells are
+live once it is mounted: `[::field …]` ×4, `[::committed …]` ×4, `[::revision]`
+and `[::dirty?]`.
+
+One keystroke into the title field, in the steady state — the second and every
+later keystroke of an editing session:
+
+| Stage | Count | Attribution |
+|---|---:|---|
+| State writes | **1** | `[:draft :title]`, and nothing else in app-db |
+| Subscription recomputations | **10** | `::field` 4, `::committed` 4, `::revision` 1, `::dirty?` 1 |
+| — of which computed a *new* value | **1** | `[::field :title]` |
+| Boundary runs | **1** | the title field's body |
+| Glass writes (`value` property) | **0** | the character is already on the glass |
+| DOM mutation records | **7** | `name` ×4, `type` ×2, `value` ×1 — none of them the echo |
+| Visible echo | present | at the instant `dispatchEvent` returned |
+
+**The session's first keystroke runs two bodies, not one**, and that is named
+rather than tuned away: `[::dirty?]` goes false to true exactly once per session,
+which runs the button row alongside the field. It is the ordinary way an
+application spends its second body run. From the second keystroke on the count is
+one, and it stays one however long the burst of typing is.
+
+**Nothing else on the page is notified.** The three other controls read addresses
+this keystroke did not move; the readout reads the *committed* article, which a
+keystroke never touches, so it holds still while you type and moves when you
+save; and the form body itself reads nothing at all, so it is neither notified
+nor made to props-compare its six children. That last absence is the load-bearing
+one — a parent that read anything a keystroke touches would put itself, and a
+compare over every child, on the typing path.
+
+---
+
+## 3. The 100-cell grid
+
+The same control written a hundred times, with a per-row total that genuinely
+depends on its row. One keystroke into cell `[3 4]`, at two sizes:
+
+| Stage | 5×5 | 10×10 | Scales with the mount? |
+|---|---:|---:|---|
+| State writes | **1** | **1** | no |
+| Subscription recomputations | **31** | **111** | **yes** |
+| — `::cell` | 25 | 100 | yes |
+| — `::row-total` | 5 | 10 | yes |
+| — `::dimensions` | 1 | 1 | no |
+| — of which computed a *new* value | 2 | 2 | no |
+| Boundary runs | **2** | **2** | **no** |
+| Glass writes (`value` property) | 0 | **0** | no |
+| DOM mutation records | 8 | **8** | no |
+
+**Two boundary bodies, at both sizes.** The cell that was typed into, and its
+row's total, which genuinely changed. Quadrupling the mounted cells changes
+nothing, which is specification §6's *narrow-update body work scales with changed
+rows rather than all mounted rows*, measured. The layout bodies — `grid` and the
+ten `grid-row`s — read only the dimensions, a value a keystroke cannot touch, so
+they are not on the path at all.
+
+**And one hundred and eleven subscription recomputations.** Every mounted cell
+re-runs its `get-in`; every row total re-runs its ten-cell fold and its
+`parseInt`s; the dimensions cell re-runs and answers what it answered before.
+One hundred and nine of the hundred and eleven compute the value they computed
+last time and notify nobody. The count is `rows × cols + rows + 1` at both sizes
+measured, and it follows the mount rather than the change.
+
+---
+
+## 4. Write amplification, stated four ways
+
+**Write amplification is not one number, and reporting it as one is how a page
+like this misleads.** The guide defines it as *the number of view bodies that run
+per state write*, and on that definition both applications are flat in their own
+size. On three other definitions, each of them a real cost somebody pays, the
+same keystroke reads differently.
+
+| Amplification of one state write into… | Editor | Grid 5×5 | Grid 10×10 | Grows with the page? |
+|---|---:|---:|---:|---|
+| **view bodies** — the guide's definition | 1 | 2 | 2 | **no** |
+| **subscription recomputations** | 10 | 31 | 111 | **yes, linearly** |
+| **writes onto the glass** | 0 | 0 | 0 | no |
+| **DOM mutation records** | 7 | 8 | 8 | no |
+
+Three of those four rows are flat and the honest one is not. Stated plainly:
+**one keystroke in a hundred-cell grid runs 111 subscription bodies to run 2 view
+bodies.** The read topology buys narrow *notification*, which is what stops the
+page re-rendering; it does not buy narrow *recomputation*, and nothing in the
+applications' own docstrings said so before this census was taken. Two of those
+docstrings have been corrected in the same change as this page.
+
+**Why it is nevertheless the right shape, and where it would stop being right.**
+A layer-1 body here is one `get-in` into one address; a hundred of them is a
+hundred map lookups, which is cheap in a way the two view bodies are not — a view
+body allocates elements and reconciles them, and the whole reason the count of
+those stays at 2 is the topology. The row totals are the term to watch: each is a
+ten-cell fold with a `parseInt` per cell, so the grid's real recomputation work
+is nearer `rows × (cols + cols)` than its cell count suggests, and it is
+`::row-total` and not `::cell` that would bite first on a page with an expensive
+derived read per row. **A reader predicting their own page should count their
+mounted layer-1 cells and ask what the most expensive one of them costs**, not
+count the addresses their event writes.
+
+The remedy, where one is wanted, is the ordinary one and is not a new mechanism:
+a derived read stated as a layer-2 subscription over its own inputs is memoised
+on *those inputs* rather than on app-db, so it does not re-run when they have not
+moved. Nothing in this corpus has measured that contrast yet, and this page does
+not claim it — it is named as the next question rather than as an answer.
+
+---
+
+## 5. The commit, attributed
+
+The prediction was zero DOM mutations, on the reasoning that a controlled input's
+value is a *property* and never reaches the markup. The first half of that is
+right and the conclusion was wrong: the value is indeed a property and never
+appears in the markup, and the commit still produces **seven** mutation records
+in the editor and **eight** in the grid.
+
+They are attributed by an experiment the census can run because the grid refuses
+non-digits: **a refused keystroke runs zero bodies**, so React commits nothing —
+and three of the seven records appear anyway.
+
+| Records | Whose | What they are |
+|---:|---|---|
+| 4 | the commit | `name: nil → ""`, `type`, `value` (i.e. `defaultValue`), `name: "" → removed` |
+| 3 | React's post-event controlled-state restore | the same churn without the `value` write, `defaultValue` already being right |
+| 1 | the commit, grid only | `characterData` on the row total's text node |
+
+**Four of the editor's seven records are churn on an attribute the application
+never wrote.** React 19 removes and restores `name` around every controlled-input
+update, so that a radio group's changes apply atomically; these inputs have no
+`name` at all, and they pay for the guarantee anyway. It is React's cost and not
+the substrate's, it is recorded rather than complained about, and no remedy is
+proposed here — the note exists so that a reader counting mutation records on
+their own page is not surprised by a number four times larger than their markup
+can explain.
+
+**The one record a user could point at is the grid's `characterData`.** On both
+pages the echo the typist actually sees — the character in the field — produces
+no mutation record at all, because it is a property. The only visible change that
+reaches the DOM tree is the row total's text, and it belongs to the derived read
+rather than to the field that was typed into.
+
+### The glass write, and P4's miss
+
+**An accepted keystroke writes the `value` property zero times.** The prediction
+was one, and the reason the truth is zero is the whole of the controlled law read
+from the other end: the character is already on the glass — the user agent put it
+there before the event fired — and the model took it unchanged, so the converge
+has nothing to write and React's own value diff finds the node already showing
+what it was about to commit. **The echo of an accepted keystroke is free.**
+
+**A refused keystroke writes it exactly once.** That single write is the
+committed value going back over the character the model would not take, and it is
+what a user sees as the field declining to accept a letter. It is also this
+instrument's own positive control, and it came for free: a spy that read zero
+everywhere would be a broken spy, and this one reads 1 on the same page, in the
+same file, through the same descriptor.
+
+So the rule an author can carry away is exact: **the controlled law costs a write
+onto the glass only when the model disagrees with the field.**
+
+---
+
+## 6. The visible echo, and the budget that is REFUSED
+
+### What was measured
+
+On both pages, the typed field shows the model's value **at the instant
+`dispatchEvent` returns** — inside the discrete event, before the turn yields,
+with no flush performed and no opportunity for the browser to paint. The census
+reads it there and settles afterwards, which is the opposite order from every
+other mounted witness in the tree.
+
+That is a stronger fact than the one [`U1`](budgets.md#9-the-budget-line-reconciliation-ledger)
+is written about. `U1` asks that controlled updates be *echoed within one 60 Hz
+frame at p95*; what the measurement shows is that **no frame boundary is crossed
+at all**. There is no frame to be within.
+
+### Why `U1` is nevertheless NOT pinned, and this page refuses to pin it
+
+`U1`'s registered estimand is *latency to visible echo*, at `p95`. It is a
+**distributional** row ([budgets §4](budgets.md#4-distributional-rows--s1s5-re-pinned-on-the-package-s6s7-carried)),
+and this page has no clock. The refusal is at source and is not a scheduling
+problem:
+
+- **No package-resident clock instrument exists.**
+  [budgets §9.2](budgets.md#92-what-each-not-green-row-is-waiting-on) says so in
+  terms, and [§9.3](budgets.md#93-where-this-ledger-stops-and-rf2-hic-071-begins)
+  assigns building one to `rf2-hic-071` — naming this very budget, the *one-frame
+  keystroke echo*, as the row that needs it.
+- **Building one here was out of bounds**, and §9.3 gives the reason rather than
+  the schedule: *building a second instrument to say more would be building a
+  second thing to drift*. A measurement window may not improve its own rig.
+- **A structural fact cannot be substituted for a distributional one.** *The echo
+  is present before the turn yields* and *the echo reaches the glass within
+  16.7 ms at the 95th percentile* are different claims, and the first does not
+  imply the second on a machine where the event turn itself can be slow. Reading
+  one as the other is precisely the substitution [budgets §3](budgets.md#3-deterministic-rows-pinned-on-the-moved-package)
+  refuses when it keeps `D9`'s residue counters apart from `S5`'s retained bytes.
+
+**So `U1` stays `UNPINNED`, and its deterministic half is now published rather
+than merely asserted.** What this page adds to the row is not a figure but a
+narrowing: whatever the clock eventually reports, it will be timing work that
+happens inside one discrete event, on a path whose every other stage is counted
+above.
+
+---
+
+## 7. Provenance
+
+Every figure above was taken on `P-DEV-1`
+([budgets §1](budgets.md#1-the-named-reference-profiles)) by the browser lane,
+`npm run test:browser`, from [the census suite][census], on a branch based on
+`52275d7b19b3de2bdc48708e46e4102104c3199d` — which is on `main`.
+
+**The quiet box was verified and was not load-bearing.** `Get-Counter
+'\System\Processor Queue Length'` read `0` on every sample before, during and
+after the runs, and `'\Processor(_Total)\% Processor Time'` ran 6–17%. It is
+recorded because the lane requires it, and the honest note beside it is that
+**this census did not need it**: every figure on this page is a monotone counter,
+and [budgets §2](budgets.md#2-the-two-disposition-families-which-6-already-separates)
+records that a counter reads the same on a loaded box. The rows that would have
+needed a quiet box are the ones §6 refuses.
+
+| Run | What | Captured exit | Result |
+|---|---|---:|---|
+| 1 | control, before the census existed | `0` | 1,489 tests, 9,311 assertions, 0 failures |
+| 2 | the census, asserting the pre-registered predictions | `1` | 1,491 / 9,332 — four reds, being P4 and the mutation prediction on both pages |
+| 3–4 | attribution probes | `1` | the mutation breakdown and attribute trace, read out of the failure path |
+| 5 | the measured figures | `0` | 1,491 / 9,334, 0 failures |
+| 6 | **sabotage** — P7's `111` inverted to `112` | `1` | captured red naming the line, below |
+| 7 | restored, plus the per-subscription attributions | `0` | 1,491 / 9,337, 0 failures |
+
+**The assertion arithmetic is what proves the rows ran rather than skipped.** The
+census's rows are `browser?`-guarded and degrade to stated skips off the browser
+lane, so a green aggregate alone would not distinguish *ran and passed* from
+*skipped*. Run 1 to run 5 is `+2` tests and `+23` assertions, which is exactly
+the twenty-three assertions the two new `deftest`s contain.
+
+**Run 6 is the sabotage control, and it is why run 5 and run 7 mean anything.**
+Inverting one figure produced a captured failure naming it:
+
+```
+FAIL in (the-grids-per-keystroke-census-at-two-sizes)
+  (re_frame/hicasso/examples/per_keystroke_dom_cljs_test.cljs:437:11)
+P7 — subscription recomputations at 10x10. Measured:
+  {…grid.subs/cell 100, …grid.subs/row-total 10, …grid.subs/dimensions 1}
+expected: (= 112 (:sub-runs at-100))
+  actual: (not (= 112 111))
+```
+
+That report does two jobs, and the second is the more useful. It proves the row
+**executes** — a skipped row cannot fail — and because `cljs.test` prints the
+bound values, `(not (= 112 111))` and the breakdown beside it **independently
+witness the figure and its attribution** from the failure path, without the
+passing assertion being the thing that reports them. The file was restored and
+its content hash (`git hash-object`) matched its pre-sabotage value exactly:
+`7197902f6ed8054daf627122a993eb22ae24ed33`.
+
+### What would falsify this page
+
+Any of: a subscription in either application changing layer, which would move the
+recomputation counts without touching any other row; React changing its
+controlled-input update, which would move §5's seven and three; a boundary count
+moving without a topology change to explain it (the standing clause
+[budgets §8](budgets.md#8-this-pages-own-run-and-what-would-falsify-it) already
+states over `D1`–`D16`); or the arrival of a package-resident clock, which would
+make §6's refusal answerable rather than merely correct.
+
+---
+
+## 8. What this page does not conclude
+
+Stated as its own section because a window that publishes nothing still reports
+everything, and this one published a good deal.
+
+- **No latency, of any kind.** No millisecond, no `p50`, no `p95`. `U1`–`U4` stay
+  `UNPINNED` and §6 says why the refusal is at source.
+- **No claim about any machine but `P-DEV-1`** — though the counters here are the
+  family that carries no hardware profile at all, so
+  [§1's single-profile limitation](budgets.md#the-single-profile-limitation-accepted-explicitly)
+  binds this page less tightly than it binds a distributional one.
+- **No new ledger rows.** The census's figures deserve rows in
+  [budgets §9](budgets.md#9-the-budget-line-reconciliation-ledger), and minting
+  them means editing `check_budget_ledger.py`'s pinned constants, which is
+  `rf2-hic-089`'s surface and not this bead's. `U1`'s entry in §9.2 has been
+  updated to point here; the rows are filed as follow-up work.
+- **No remedy for §4's amplification, and no claim that it needs one.** The
+  layer-2 contrast named at the end of §4 is a measurement nobody has taken.
+  Naming it is not proposing it.
+- **No attribution of §5's `name` churn beyond React's own documented reason.**
+  The trace shows what happens and the refusal experiment shows which pass owns
+  it; why React 19 spells the atomicity guarantee that way is React's business
+  and was not investigated.
+- **Nothing about composition, IME or the caret.** A keystroke here is a scripted
+  `input` event on a settled field. Composition exchanges are
+  [`rf2-hic-040`](https://github.com/day8/re-frame2/issues)'s cross-browser
+  matrix and are not this census's subject.

--- a/docs/design/hicasso/product/per-keystroke.md
+++ b/docs/design/hicasso/product/per-keystroke.md
@@ -1,0 +1,123 @@
+# The per-keystroke mechanics: the four-field editor and the 100-cell grid
+
+What one keystroke costs, stage by stage, on the two public-package witness
+applications — measured rather than reasoned about.
+
+[specification §6](specification.md#6-performance-contract) asks for the
+mechanical per-keystroke path of these two pages: *state writes, subscription
+recomputations, boundary runs, write amplification, commit, and visible echo*,
+as **explanatory product documentation as well as a performance witness**. This
+page is both halves. A reader who finishes it should be able to predict what a
+keystroke costs in their own application from its read topology alone, and a
+reader auditing the numbers should be able to find the witness that took each
+one.
+
+The applications are the ones
+[`rf2-hic-078`](../../../../implementation/hicasso/test/re_frame/hicasso/examples/)
+built and `main` carries: `examples/editor` and `examples/grid`. **No number on
+this page comes from the frozen bench prototypes** under
+`implementation/freehand/test/re_frame/bench/`, which are a different tree
+measuring different questions.
+
+---
+
+## 1. Pre-registration
+
+**This section was written and committed before any measurement was taken**, so
+that a prediction cannot be trimmed to fit a reading. The commit that carried it
+is the one immediately before the first measured commit on `rf2-hic-045`'s
+branch, and every figure in §4 onward is reported against it — including the
+ones that came back wrong.
+
+### 1.1 The six instruments, fixed in advance
+
+Each stage of the path gets exactly one instrument, and no stage gets two.
+
+| Stage | Instrument | What one unit is |
+|---|---|---|
+| State writes | app-db value diffed either side of the DOM event | one leaf address whose value moved |
+| Subscription recomputations | a counting wrapper installed on the registrar's `:handler-fn` before mount, removed after | one invocation of the author's own computation fn |
+| Boundary runs | [`hm/bodies-run`][kit] | one `defview` body React actually ran |
+| Commit — glass writes | a spy on the `value` property setter of `HTMLInputElement.prototype` / `HTMLTextAreaElement.prototype`, restored in a `finally` | one write of a value onto a live control |
+| Commit — DOM mutations | a `MutationObserver` over the container (`childList`, `attributes`, `characterData`) | one mutation record |
+| Visible echo | the typed control's `.value`, read at the instant `dispatchEvent` returns | — |
+
+[kit]: ../../../../implementation/hicasso/test_kit/src/re_frame/hicasso/test/mounted.cljs
+
+Two of these deserve their definition stated rather than assumed.
+
+**The glass-write count excludes the keystroke's own write.** A scripted
+keystroke reaches the same code path a real one does only by writing through the
+element prototype's own `value` setter and then firing a real `input` event
+(`editor.flow-dom-cljs-test/type-into!` established this). That first write is
+the *user agent's*, not the runtime's, so it is subtracted. What remains is what
+the framework wrote.
+
+**The echo is read before any flush.** Every existing mounted witness calls
+`hm/settle!` before asserting the glass, which commits whatever React has
+scheduled. That is right for a correctness row and wrong for a latency one: it
+measures the value after a flush the browser would not have performed yet. This
+page reads `.value` at the instant `dispatchEvent` returns — inside the event
+turn, before any paint could occur — and settles afterwards.
+
+### 1.2 The predicted figures
+
+Deterministic counters, so these are exact integers and not bands. A band would
+be the wrong instrument: contention cannot move a monotone counter
+([budgets §2](budgets.md#2-the-two-disposition-families-which-6-already-separates)).
+
+| # | Subject | Stage | Predicted |
+|---|---|---|---:|
+| P1 | Editor, steady-state keystroke into `:title` | state writes | 1 |
+| P2 | Editor, steady-state keystroke | subscription recomputations | 10 |
+| P3 | Editor, steady-state keystroke | boundary runs | 1 |
+| P4 | Editor, steady-state keystroke | glass writes by the runtime | 1 |
+| P5 | Editor, first keystroke of a session | boundary runs | 2 |
+| P6 | Grid 10×10, keystroke into cell `[3 4]` | state writes | 1 |
+| P7 | Grid 10×10, keystroke into cell `[3 4]` | subscription recomputations | 111 |
+| P8 | Grid 10×10, keystroke into cell `[3 4]` | boundary runs | 2 |
+| P9 | Grid 5×5, keystroke into cell `[3 4]` | subscription recomputations | 31 |
+| P10 | Grid 10×10, **refused** keystroke | state writes | 0 |
+| P11 | Grid 10×10, **refused** keystroke | subscription recomputations | 0 |
+| P12 | Either page | echo present before any flush | yes |
+
+**P2, P7 and P9 are the predictions this page exists to test, and the reasoning
+behind them is the part worth writing down before the answer is known.** Every
+subscription in both applications is a **layer-1** reader — registered as
+`(fn [db query-v] …)`, so its input is the whole of app-db rather than another
+subscription's value. `re-frame.subs.memo`'s layer-1 wrapper memoises on that
+input: the author's body is skipped when the new app-db is `=` to the last one
+seen, and re-run when it is not. A keystroke moves app-db. So the prediction is
+that **every mounted layer-1 cell that is derefed on the write path re-runs its
+body**, and the count is therefore the number of live cells rather than the
+number of changed addresses:
+
+- editor: four `::field` cells, four `::committed` cells, `::revision`,
+  `::dirty?` = **10**;
+- grid 10×10: one hundred `::cell` cells, ten `::row-total` cells, one
+  `::dimensions` cell = **111**;
+- grid 5×5: twenty-five, five, one = **31**.
+
+If P7 and P9 both hold, subscription recomputation **scales with the mounted
+grid** while boundary runs do not, and the two stages of the same keystroke
+answer the specification's narrow-update question differently. If they come back
+at 2, the substrate is notifying more narrowly than the memo layer alone would
+imply, and the page says so instead.
+
+### 1.3 What a refusal would look like
+
+Under [Shape 6](#8-what-this-page-does-not-conclude) a validity failure refuses
+the figure rather than publishing it. For a deterministic census the validity
+conditions are:
+
+- the sabotage control does not go red when a figure is inverted — the row was
+  skipped rather than run, and no figure it would have reported may be published;
+- the counting wrapper changes a figure another instrument already pins (D1, D2,
+  D7, D8) — the instrument is perturbing its subject and its own readings are
+  void;
+- the two applications disagree about a stage that is the same mechanism in
+  both, with nothing in the topology to explain the difference.
+
+---
+
+<!-- Sections 2 onward are added by the measured commits that follow. -->

--- a/docs/design/hicasso/product/per-keystroke.md
+++ b/docs/design/hicasso/product/per-keystroke.md
@@ -400,6 +400,5 @@ everything, and this one published a good deal.
   it; why React 19 spells the atomicity guarantee that way is React's business
   and was not investigated.
 - **Nothing about composition, IME or the caret.** A keystroke here is a scripted
-  `input` event on a settled field. Composition exchanges are
-  [`rf2-hic-040`](https://github.com/day8/re-frame2/issues)'s cross-browser
-  matrix and are not this census's subject.
+  `input` event on a settled field. Composition exchanges are `rf2-hic-040`'s
+  cross-browser matrix and are not this census's subject.

--- a/docs/design/hicasso/product/per-keystroke.md
+++ b/docs/design/hicasso/product/per-keystroke.md
@@ -317,8 +317,10 @@ above.
 
 Every figure above was taken on `P-DEV-1`
 ([budgets §1](budgets.md#1-the-named-reference-profiles)) by the browser lane,
-`npm run test:browser`, from [the census suite][census], on a branch based on
-`52275d7b19b3de2bdc48708e46e4102104c3199d` — which is on `main`.
+`npm run test:browser`, from [the census suite][census]. Runs 1–7 were taken on
+a branch based on `52275d7b19b3de2bdc48708e46e4102104c3199d`; the branch was then
+rebased onto `b44c5e854cae93a2a6ec520f1667f1da56c19e8b` and **run 8 re-took every
+figure on that base without one of them moving**. Both are on `main`.
 
 **The quiet box was verified and was not load-bearing.** `Get-Counter
 '\System\Processor Queue Length'` read `0` on every sample before, during and
@@ -337,12 +339,25 @@ needed a quiet box are the ones §6 refuses.
 | 5 | the measured figures | `0` | 1,491 / 9,334, 0 failures |
 | 6 | **sabotage** — P7's `111` inverted to `112` | `1` | captured red naming the line, below |
 | 7 | restored, plus the per-subscription attributions | `0` | 1,491 / 9,337, 0 failures |
+| 8 | **re-taken after rebasing onto `b44c5e854c`** | `0` | 1,502 / 9,508, 0 failures — no figure moved |
+
+The node lane (`npm run test:cljs`) was run on the same tree and returns `0` at
+13,875 tests / 70,108 assertions. It is not where these figures come from — every
+row here is `browser?`-guarded and skips there — but it is where a namespace that
+touched `HTMLInputElement` at load time would have taken the whole lane down with
+it, which is a defect this census had and fixed.
 
 **The assertion arithmetic is what proves the rows ran rather than skipped.** The
-census's rows are `browser?`-guarded and degrade to stated skips off the browser
-lane, so a green aggregate alone would not distinguish *ran and passed* from
-*skipped*. Run 1 to run 5 is `+2` tests and `+23` assertions, which is exactly
-the twenty-three assertions the two new `deftest`s contain.
+census's rows degrade to stated skips off the browser lane, so a green aggregate
+alone would not distinguish *ran and passed* from *skipped*. Run 1 to run 5 is
+`+2` tests and `+23` assertions, exactly the assertions the two new `deftest`s
+then contained; run 7 added three per-subscription attributions for `+26`.
+
+**Run 8's arithmetic is checkable against a figure this page did not produce.**
+`rf2-hic-036`'s tournament landed on `main` between run 7 and the rebase, and
+[its own §2.1](topology-tournament.md) publishes the lane at **1,500 tests /
+9,482 assertions** on that base. Run 8 reads 1,502 / 9,508 — the same `+2` and
+`+26`, arrived at from a control another worker measured.
 
 **Run 6 is the sabotage control, and it is why run 5 and run 7 mean anything.**
 Inverting one figure produced a captured failure naming it:
@@ -361,8 +376,11 @@ That report does two jobs, and the second is the more useful. It proves the row
 bound values, `(not (= 112 111))` and the breakdown beside it **independently
 witness the figure and its attribution** from the failure path, without the
 passing assertion being the thing that reports them. The file was restored and
-its content hash (`git hash-object`) matched its pre-sabotage value exactly:
-`7197902f6ed8054daf627122a993eb22ae24ed33`.
+its content hash (`git hash-object`, not a byte digest — this checkout
+translates line endings) matched its pre-sabotage value exactly, at
+`7197902f6ed8054daf627122a993eb22ae24ed33`. That hash pins the file **as it
+stood between runs 5 and 6**; it has had one commit since, the `delay` in the
+node-lane fix above, and run 8 is the reading that covers the file as it ships.
 
 ### What would falsify this page
 
@@ -402,3 +420,10 @@ everything, and this one published a good deal.
 - **Nothing about composition, IME or the caret.** A keystroke here is a scripted
   `input` event on a settled field. Composition exchanges are `rf2-hic-040`'s
   cross-browser matrix and are not this census's subject.
+- **Nothing that can be read across to the topology tournament**, which landed
+  while this census was being taken. [`topology-tournament.md`](topology-tournament.md)
+  also has an `edit` operation and also counts work per keystroke, and the two
+  sets of figures are **not** comparable: its arms vary *boundary placement* on
+  the bench tree's arm-1 runtime, which its own §2.1 states, while every figure
+  here is `implementation/hicasso` with the topology held fixed. Neither page
+  re-derives the other and neither may be quoted for the other's population.

--- a/implementation/hicasso/test/re_frame/hicasso/examples/editor/l0_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/examples/editor/l0_cljs_test.cljs
@@ -25,7 +25,7 @@
   [[one-keystroke-moves-exactly-one-address]] is the L0 half of the
   per-keystroke budget. `flow-dom-cljs-test` counts the bodies that run;
   this counts the addresses that move, and the two together are the walk
-  `docs/design/hicasso/draft-guide/18-performance.md` §Trace one
+  `docs/design/hicasso/draft-guide/19-performance.md` §Trace one
   controlled keystroke describes. It is asserted here rather than there
   because it is a property of the model and needs no React to be true."
   (:require [cljs.test :refer-macros [deftest is use-fixtures]]

--- a/implementation/hicasso/test/re_frame/hicasso/examples/editor/subs.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/examples/editor/subs.cljs
@@ -3,14 +3,24 @@
 
   Four fields and four subscription cells, because the per-keystroke
   budget is a fact about the READ TOPOLOGY and about nothing else.
-  `docs/design/hicasso/draft-guide/18-performance.md` §Trace one
-  controlled keystroke walks it: one write, the subscriptions reading
-  that address recompute, equality gates stop every one whose output did
-  not move, and the boundaries whose reads changed are notified. With a
-  field per cell that is **one** changed subscription and **one** body
-  run per keystroke — write amplification 1, independent of how many
-  fields the form has. `editor.flow-dom-cljs-test` measures it rather
-  than asserting the arithmetic.
+  `docs/design/hicasso/draft-guide/19-performance.md` §Trace one
+  controlled keystroke walks it: one write, subscriptions recompute,
+  equality gates stop every one whose output did not move, and the
+  boundaries whose reads changed are notified. With a field per cell that
+  is **one** changed subscription and **one** body run per keystroke —
+  write amplification 1, independent of how many fields the form has.
+  `editor.flow-dom-cljs-test` measures it rather than asserting the
+  arithmetic.
+
+  **`recompute` is not the same set as `reads that address`**, and this
+  paragraph used to say it was. Every subscription here is a LAYER-1
+  reader, memoised on the whole of `app-db` rather than on the address it
+  goes on to read, so a keystroke re-runs all TEN of this form's cells and
+  the equality gate then stops nine of them from notifying anything.
+  Measured by `examples.per-keystroke-dom-cljs-test` and published in
+  `docs/design/hicasso/product/per-keystroke.md`: one changed subscription
+  out of ten recomputed, which is a distinction the body count cannot
+  make and the budget does not rest on.
 
   [[field]] is PARAMETRIC, so the four cells are four entries under one
   registration rather than four registrations. A parametric subscription

--- a/implementation/hicasso/test/re_frame/hicasso/examples/editor/views.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/examples/editor/views.cljs
@@ -13,7 +13,7 @@
   [[text-field]] is the unit of re-render. Four controls means four
   boundaries, each reading its own address, so a keystroke in the title
   notifies the title's boundary and no other
-  (`docs/design/hicasso/draft-guide/18-performance.md` §Trace one
+  (`docs/design/hicasso/draft-guide/19-performance.md` §Trace one
   controlled keystroke). [[editor]] itself reads NOTHING: it is a layout
   body that runs at mount and, thereafter, only when a prop of its own
   changes. That absence is the load-bearing part, and

--- a/implementation/hicasso/test/re_frame/hicasso/examples/grid/subs.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/examples/grid/subs.cljs
@@ -5,11 +5,20 @@
 
   [[cell]] is parametric on `[row col]`, so a hundred cells are a hundred
   independently-gated cells under one registration. A keystroke writes
-  one address; exactly one of the hundred recomputes to a different
-  value; exactly one boundary is notified. The other ninety-nine are
-  **never notified** — not notified-and-bailed-out, which is a different
-  and more expensive thing
-  (`docs/design/hicasso/draft-guide/18-performance.md` §Scale the same
+  one address; exactly one of the hundred COMPUTES a different value;
+  exactly one boundary is notified. The other ninety-nine are **never
+  notified** — not notified-and-bailed-out, which is a different and more
+  expensive thing
+
+  All hundred do RECOMPUTE, and the distinction is the one
+  `docs/design/hicasso/product/per-keystroke.md` publishes: these are
+  layer-1 readers memoised on the whole of `app-db`, so a keystroke re-runs
+  every mounted cell's `get-in` and the equality gate on the OUTPUT is what
+  keeps ninety-nine of them from notifying. Notification is what scales
+  narrowly; recomputation scales with the grid —
+  `examples.per-keystroke-dom-cljs-test` counts 111 at 10x10 and 31 at 5x5
+  against two boundary bodies at both sizes
+  (`docs/design/hicasso/draft-guide/19-performance.md` §Scale the same
   topology to a grid).
 
   [[dimensions]] is read by the grid body and by the row bodies, and it

--- a/implementation/hicasso/test/re_frame/hicasso/examples/per_keystroke_dom_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/examples/per_keystroke_dom_cljs_test.cljs
@@ -330,8 +330,18 @@
                   (is (= 1 (addresses-moved before after))
                       "P1 — one state write")
                   (is (= 10 (total runs))
-                      (str "P2 — subscription recomputations. Measured: "
-                           (pr-str runs)))
+                      (str "P2 HELD — ten subscription recomputations for one
+                            write. Measured: " (pr-str runs)))
+                  (is (= {::editor-subs/field     4
+                          ::editor-subs/committed 4
+                          ::editor-subs/revision  1
+                          ::editor-subs/dirty?    1}
+                         runs)
+                      "and the ten are every mounted cell, not the one the
+                       keystroke moved: four field cells, four committed
+                       cells, the revision and the dirty flag. Nine of them
+                       compute the value they computed last time and notify
+                       nobody")
                   (is (= 1 bodies)
                       "P3 — one boundary body, the title field's (D8)")
                   (is (= 0 (glass-writes))
@@ -440,6 +450,13 @@
       (is (= 31 (:sub-runs at-25))
           (str "P9 — subscription recomputations at 5x5. Measured: "
                (pr-str (:by-sub at-25))))
+      (is (= {::grid-subs/cell 100 ::grid-subs/row-total 10 ::grid-subs/dimensions 1}
+             (:by-sub at-100))
+          "the attribution at 10x10 — every mounted cell, every row total,
+           and the dimensions cell that nothing moved")
+      (is (= {::grid-subs/cell 25 ::grid-subs/row-total 5 ::grid-subs/dimensions 1}
+             (:by-sub at-25))
+          "and at 5x5 the same three terms, each following the mount")
       (is (= 0 (:glass at-100))
           "zero writes onto the glass, exactly as the editor — an accepted
            keystroke is already showing what the model took")

--- a/implementation/hicasso/test/re_frame/hicasso/examples/per_keystroke_dom_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/examples/per_keystroke_dom_cljs_test.cljs
@@ -222,6 +222,42 @@
         (doseq [[[_ p] d] (map vector protos originals)]
           (js/Object.defineProperty p "value" d))))))
 
+(defn- summarise-mutations
+  "A mutation record list as `{[kind target] n}` — the shape a commit can
+  be ATTRIBUTED from, where a bare count can only be reported.
+
+  Added after the census's first reading, which counted 7 and 8 records
+  against a predicted 0 and could say nothing about what they were. It
+  reads the records the same observer already took; no record's existence
+  or count moves, and the counts either side of the change are identical."
+  [records]
+  (reduce (fn [m r]
+            (let [kind   (.-type r)
+                  target (.-target r)
+                  tag    (or (.-tagName target) (.-nodeName target))
+                  label  (if (= "attributes" kind)
+                           (str tag "@" (.-attributeName r))
+                           (str tag))]
+              (update m [kind label] (fnil inc 0))))
+          {}
+          records))
+
+(defn- attribute-trace
+  "The attribute records in order, as `\"name: <old> -> <new>\"`.
+
+  A count says a commit touched `name` four times; this says what it did
+  to it, which is the difference between reporting the commit stage and
+  ATTRIBUTING it. `:attributeOldValue` is what the observer needs to
+  answer it, and it changes no record's existence or count."
+  [records]
+  (into []
+        (comp (filter (fn [r] (= "attributes" (.-type r))))
+              (map (fn [r]
+                     (str (.-attributeName r) ": "
+                          (pr-str (.-oldValue r)) " -> "
+                          (pr-str (.getAttribute (.-target r) (.-attributeName r)))))))
+        records))
+
 (defn- mutations-during
   "The `MutationObserver` records `f` produced inside `container`, drained
   synchronously with `takeRecords` — the observer's own callback is a
@@ -229,7 +265,11 @@
   [container f]
   (let [obs (js/MutationObserver. (fn [_ _] nil))]
     (.observe obs container
-              #js {:childList true :attributes true :characterData true :subtree true})
+              #js {:childList         true
+                   :attributes        true
+                   :attributeOldValue true
+                   :characterData     true
+                   :subtree           true})
     (try
       (f)
       (vec (array-seq (.takeRecords obs)))
@@ -294,16 +334,48 @@
                            (pr-str runs)))
                   (is (= 1 bodies)
                       "P3 — one boundary body, the title field's (D8)")
-                  (is (= 1 (glass-writes))
-                      "P4 — one write onto the glass by the runtime")
+                  (is (= 0 (glass-writes))
+                      "P4 MISSED, and the miss is the finding. The prediction
+                       was one write; the measurement is ZERO. An ACCEPTED
+                       keystroke is already on the glass — the user agent put
+                       it there — and the model took it unchanged, so the
+                       converge has nothing to write and React's own value
+                       diff finds the node already showing what it is about to
+                       commit. The echo of an accepted keystroke is free. The
+                       refusal row below is this instrument's positive
+                       control: it reads 1 on the same spy in the same file")
                   (is (= "Intents are dataab" @echo)
                       "P12 — the echo is on the glass at the instant
                        `dispatchEvent` returned, with no flush and no paint
                        in between")
-                  (is (= 0 (count @muts))
-                      "and the commit mutated no attribute, no child and no
-                       text node: a controlled input's value is a PROPERTY,
-                       so the echo never reaches the markup at all")))
+                  (is (= {["attributes" "INPUT@name"]  4
+                          ["attributes" "INPUT@type"]  2
+                          ["attributes" "INPUT@value"] 1}
+                         (summarise-mutations @muts))
+                      "SEVEN mutation records against a predicted zero, and
+                       not one of them is the echo. The value the user sees
+                       is a PROPERTY and never reaches the markup; what the
+                       markup gets is React's controlled-input update churning
+                       `name` and `type` around the change and writing the
+                       `value` ATTRIBUTE once, which is `defaultValue`.")
+                  (is (= ["name: nil -> nil"
+                          "type: \"text\" -> \"text\""
+                          "value: \"Intents are dataa\" -> \"Intents are dataab\""
+                          "name: \"\" -> nil"
+                          "name: nil -> nil"
+                          "type: \"text\" -> \"text\""
+                          "name: \"\" -> nil"]
+                         (attribute-trace @muts))
+                      "TWO PASSES over one input, and the trace is what says
+                       so: `name`, `type`, `value`, `name` — then `name`,
+                       `type`, `name` with no `value`, because the second pass
+                       finds `defaultValue` already right. React 19 removes
+                       and restores `name` around every controlled-input
+                       update so that a radio group's changes apply
+                       atomically, and this input has no `name` at all, so
+                       four of the seven records are churn on an attribute the
+                       application never wrote. The refusal row below
+                       attributes the two passes.")))
 
               (hm/unmount! m))))))))
 
@@ -349,7 +421,7 @@
                  :by-sub    runs
                  :bodies    bodies
                  :glass     (glass-writes)
-                 :mutations (count @muts)
+                 :mutations (summarise-mutations @muts)
                  :echo      @echo}
                 (finally (hm/unmount! m))))))))))
 
@@ -368,12 +440,20 @@
       (is (= 31 (:sub-runs at-25))
           (str "P9 — subscription recomputations at 5x5. Measured: "
                (pr-str (:by-sub at-25))))
-      (is (= 1 (:glass at-100))
-          "one write onto the glass by the runtime")
+      (is (= 0 (:glass at-100))
+          "zero writes onto the glass, exactly as the editor — an accepted
+           keystroke is already showing what the model took")
       (is (= "341" (:echo at-100))
           "P12 — the echo is on the glass before any flush")
-      (is (= 0 (:mutations at-100))
-          "and no DOM mutation record: the value is a property")
+      (is (= {["attributes" "INPUT@name"]  4
+              ["attributes" "INPUT@type"]  2
+              ["attributes" "INPUT@value"] 1
+              ["characterData" "#text"]    1}
+             (:mutations at-100))
+          "the editor's seven, plus ONE — the row total's text node. That
+           single `characterData` record is the only mutation on either page
+           that a user could point at, and it belongs to the derived read
+           rather than to the field that was typed into")
       (is (= (:bodies at-25) (:bodies at-100))
           "THE CONTRAST THE CENSUS EXISTS FOR — boundary runs do not move
            with the mounted grid")))
@@ -394,8 +474,14 @@
                 (reset-glass!)
                 (let [before (rf/app-db-value (:frame m))
                       echo   (atom nil)
+                      muts   (atom nil)
                       bodies (hm/bodies-run
-                               (fn [] (reset! echo (type-into! n "x")) (hm/settle! m)))
+                               (fn []
+                                 (reset! muts
+                                         (mutations-during
+                                           (:container m)
+                                           (fn [] (reset! echo (type-into! n "x")))))
+                                 (hm/settle! m)))
                       after  (rf/app-db-value (:frame m))]
                   (is (= 0 (addresses-moved before after))
                       "P10 — the model did not move")
@@ -410,5 +496,21 @@
                        the committed value put back over the character the
                        model would not take")
                   (is (= "34" (.-value n))
-                      "which is what the field shows"))
+                      "which is what the field shows")
+                  (is (= [{["attributes" "INPUT@name"] 2
+                           ["attributes" "INPUT@type"] 1}
+                          ["name: nil -> nil"
+                           "type: \"text\" -> \"text\""
+                           "name: \"\" -> nil"]]
+                         [(summarise-mutations @muts) (attribute-trace @muts)])
+                      "THE ATTRIBUTION, and it is decisive. A refusal runs ZERO
+                       bodies, so React commits nothing — and THREE of the
+                       accepted keystroke's seven records appear anyway, as one
+                       `name`/`type`/`name` pass with no `value` write. Those
+                       three are React's post-event controlled-state restore,
+                       which is also what performs the single `value` PROPERTY
+                       write the row above counts. The remaining four —
+                       `name`, `type`, `value`, `name` — are the commit's, and
+                       the accepted keystroke's trace is exactly those four
+                       followed by these three."))
                 (hm/unmount! m)))))))))

--- a/implementation/hicasso/test/re_frame/hicasso/examples/per_keystroke_dom_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/examples/per_keystroke_dom_cljs_test.cljs
@@ -104,20 +104,34 @@
 ;; ---------------------------------------------------------------------------
 
 (def ^:private pristine-setters
-  "The two prototypes' own `value` setters, captured at namespace load.
+  "The two prototypes' own `value` setters, captured on first use.
 
   [[with-glass-spy]] replaces those descriptors while it is installed, so
   a keystroke written through the live descriptor would be counted as a
-  write the runtime made. Capturing here is what keeps the user agent's
-  own write out of the count by construction — the alternative is to
-  subtract one and hope the subtrahend never changes."
-  {"TEXTAREA" (.-set (js/Object.getOwnPropertyDescriptor
-                       js/HTMLTextAreaElement.prototype "value"))
-   "INPUT"    (.-set (js/Object.getOwnPropertyDescriptor
-                       js/HTMLInputElement.prototype "value"))})
+  write the runtime made. Capturing before any spy exists is what keeps
+  the user agent's own write out of the count by construction — the
+  alternative is to subtract one and hope the subtrahend never changes.
+
+  A `delay` and not a `def` of the map itself, because this namespace
+  LOADS on the node lane — where its rows skip, but its top level still
+  runs, and `js/HTMLInputElement` does not exist there.
+
+  **[[with-glass-spy]] forces it before it replaces anything**, and that
+  ordering is the whole correctness of this def rather than a nicety. Every
+  keystroke in this file is typed inside a spy, so a delay left to be
+  forced by the first [[set-native-value!]] would capture the SPY's setter
+  and count the user agent's own write — turning the accepted keystroke's
+  measured zero into a one. Forcing at the top of the spy is what makes
+  *pristine* structural."
+  (delay
+    {"TEXTAREA" (.-set (js/Object.getOwnPropertyDescriptor
+                         js/HTMLTextAreaElement.prototype "value"))
+     "INPUT"    (.-set (js/Object.getOwnPropertyDescriptor
+                         js/HTMLInputElement.prototype "value"))}))
 
 (defn- set-native-value! [n v]
-  (.call (get pristine-setters (.-tagName n) (get pristine-setters "INPUT")) n v))
+  (let [setters @pristine-setters]
+    (.call (get setters (.-tagName n) (get setters "INPUT")) n v)))
 
 (defn- type-into!
   "Type `text` at the end of `n` the way a browser does — the field moves
@@ -203,7 +217,8 @@
   node, so a spy installed after the mount sits behind the reference
   React already took."
   [f]
-  (let [protos    [["INPUT" js/HTMLInputElement.prototype]
+  (let [_         @pristine-setters ;; capture BEFORE the swap — see that def
+        protos    [["INPUT" js/HTMLInputElement.prototype]
                    ["TEXTAREA" js/HTMLTextAreaElement.prototype]]
         !n        (atom 0)
         originals (mapv (fn [[_ p]] (js/Object.getOwnPropertyDescriptor p "value")) protos)]

--- a/implementation/hicasso/test/re_frame/hicasso/examples/per_keystroke_dom_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/examples/per_keystroke_dom_cljs_test.cljs
@@ -1,0 +1,414 @@
+(ns re-frame.hicasso.examples.per-keystroke-dom-cljs-test
+  "L3 — THE PER-KEYSTROKE CENSUS, BOTH WITNESS PAGES, ONE INSTRUMENT SET
+  (rf2-hic-045).
+
+  Specification §6 asks the four-field editor and the 100-cell grid to
+  publish *the mechanical per-keystroke path: state writes, subscription
+  recomputations, boundary runs, write amplification, commit, and visible
+  echo*. Two of those six were already counted when this file was
+  written — the write, by `editor.l0-cljs-test`, and the body count, by
+  `editor.flow-dom-cljs-test` and `grid.scaling-dom-cljs-test` — and the
+  page that publishes them is
+  `docs/design/hicasso/product/per-keystroke.md`.
+
+  This file takes the other four, and it takes all six on ONE mount so
+  that the stages of a census are stages of the SAME keystroke rather
+  than six keystrokes' worth of arithmetic laid side by side.
+
+  ## Both pages, one file, on purpose
+
+  The editor and the grid are two sizes of one mechanism, and the whole
+  question the census asks is which stages move with size and which do
+  not. Two files would have made that an arithmetic comparison between
+  two instruments; one file makes it a reading. It is the same reason
+  `grid.scaling-dom-cljs-test` mounts both grid sizes rather than
+  importing a number from elsewhere.
+
+  ## The four instruments this file adds
+
+  [[addresses-moved]] diffs the app-db value either side of the DOM
+  event and counts leaf addresses. `editor.l0-cljs-test` already asserts
+  the SHAPE of one write with `=` over `dissoc`ed maps; this counts, so
+  that a page can carry the figure beside the other five.
+
+  [[with-counted-subs]] wraps each subscription's registered
+  `:handler-fn` and counts invocations of the AUTHOR'S OWN computation
+  fn — the body inside the memo wrapper, not the wrapper. It is
+  installed before the mount, because `re-frame.subs` resolves
+  `:handler-fn` off the registration once, at cache-entry build time, and
+  a wrapper installed afterwards would be counted by nothing. It is
+  removed in a `finally`, and the fixture's registrar snapshot is the
+  second net.
+
+  [[with-glass-spy]] counts writes of the `value` property onto live
+  controls, by replacing the prototype's property descriptor with one
+  that counts and delegates. It too must be installed BEFORE the mount:
+  React's own change tracker captures the prototype descriptor when it
+  begins tracking a node, so a spy installed afterwards is behind React's
+  captured reference and would count nothing. [[type-into!]] here writes
+  through a setter captured at namespace load, so a scripted keystroke's
+  own write is outside the count by construction rather than by
+  subtraction.
+
+  [[mutations-during]] drains a `MutationObserver` synchronously with
+  `takeRecords`, which is what makes it usable inside a discrete event:
+  the observer's callback is a microtask and has not run yet, and the
+  records are already there to be taken.
+
+  ## The echo is read BEFORE the flush, and that is the point of it
+
+  Every other mounted witness in this tree calls `hm/settle!` and then
+  asserts the glass. That is right for a correctness row and wrong for a
+  latency one — it reads the page after a flush the browser had not yet
+  performed. [[echo-before-flush]] reads `.value` at the instant
+  `dispatchEvent` returns, which is inside the discrete event, before any
+  paint could occur. What that measures is not *the echo arrived within a
+  frame*; it is the stronger and simpler fact that **no frame boundary is
+  crossed at all**.
+
+  ## What this file does NOT measure, and could not
+
+  A clock. Nothing here reports a millisecond, a `p50` or a `p95`, and
+  the page says why: `budgets.md` §4 registers `U1`–`U4` as
+  distributional rows with no package-resident clock instrument, and §9.3
+  puts building one at `rf2-hic-071` rather than here. Every figure this
+  file takes is a monotone counter, so it reads the same on a loaded box
+  as on a quiet one (`budgets.md` §2)."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [re-frame.adapter.uix :as uix-adapter]
+            [re-frame.core :as rf]
+            [re-frame.hicasso.examples.editor.app :as editor-app]
+            [re-frame.hicasso.examples.editor.subs :as editor-subs]
+            [re-frame.hicasso.examples.editor.views :as editor-views]
+            [re-frame.hicasso.examples.grid.app :as grid-app]
+            [re-frame.hicasso.examples.grid.events :as grid-events]
+            [re-frame.hicasso.examples.grid.subs :as grid-subs]
+            [re-frame.hicasso.examples.grid.views :as grid-views]
+            [re-frame.hicasso.test.mounted :as hm]
+            [re-frame.registrar :as registrar]
+            [re-frame.test-support :as test-support]))
+
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture
+    {:adapter       uix-adapter/adapter
+     :ambient-frame nil}))
+
+(defn- browser? []
+  (and (exists? js/document) (some? js/document) (some? (.-body js/document))))
+
+(defn- skip! [why]
+  (is true (str "a mounted React root needs a real DOM — " why)))
+
+;; ---------------------------------------------------------------------------
+;; Typing, through a setter captured before any spy exists
+;; ---------------------------------------------------------------------------
+
+(def ^:private pristine-setters
+  "The two prototypes' own `value` setters, captured at namespace load.
+
+  [[with-glass-spy]] replaces those descriptors while it is installed, so
+  a keystroke written through the live descriptor would be counted as a
+  write the runtime made. Capturing here is what keeps the user agent's
+  own write out of the count by construction — the alternative is to
+  subtract one and hope the subtrahend never changes."
+  {"TEXTAREA" (.-set (js/Object.getOwnPropertyDescriptor
+                       js/HTMLTextAreaElement.prototype "value"))
+   "INPUT"    (.-set (js/Object.getOwnPropertyDescriptor
+                       js/HTMLInputElement.prototype "value"))})
+
+(defn- set-native-value! [n v]
+  (.call (get pristine-setters (.-tagName n) (get pristine-setters "INPUT")) n v))
+
+(defn- type-into!
+  "Type `text` at the end of `n` the way a browser does — the field moves
+  first, the `input` event fires second — and answer the field's value at
+  the instant `dispatchEvent` returned, BEFORE any flush."
+  [n text]
+  (set-native-value! n (str (.-value n) text))
+  (.dispatchEvent n (js/Event. "input" #js {:bubbles true}))
+  (.-value n))
+
+;; ---------------------------------------------------------------------------
+;; Instrument 1 — state writes
+;; ---------------------------------------------------------------------------
+
+(defn- leaves
+  "Every leaf of a nested map as `{path value}`. A non-map value is a
+  leaf, so the grid's `{[row col] \"7\"}` cells are one address each and
+  the editor's `:revision` integer is one address."
+  [m]
+  (letfn [(walk [prefix v]
+            (if (and (map? v) (seq v))
+              (mapcat (fn [[k vv]] (walk (conj prefix k) vv)) v)
+              [[prefix v]]))]
+    (into {} (walk [] m))))
+
+(defn- addresses-moved
+  "How many leaf addresses differ between two app-db values."
+  [before after]
+  (let [b (leaves before)
+        a (leaves after)]
+    (count (into #{}
+                 (remove (fn [k] (= (get b k ::absent) (get a k ::absent))))
+                 (into (set (keys b)) (set (keys a)))))))
+
+;; ---------------------------------------------------------------------------
+;; Instrument 2 — subscription recomputations
+;; ---------------------------------------------------------------------------
+
+(defn- with-counted-subs
+  "Install a counting wrapper on each of `sub-ids`' registered
+  `:handler-fn`, call `(f read-counts reset-counts)`, and restore every
+  registration in a `finally`.
+
+  `read-counts` answers `{sub-id n}` for the wrappers that ran;
+  `reset-counts` zeroes them, which is what lets one mount take a
+  baseline at mount and a reading per keystroke.
+
+  The wrapper is variadic and applies the original, so it is invocation-
+  shape-agnostic: `re-frame.subs.memo` calls a layer-1 body as
+  `(body-fn db query-v)` and a layer-n body with its own arity, and this
+  counter has no opinion about which."
+  [sub-ids f]
+  (let [!counts   (atom {})
+        originals (reduce (fn [m id] (assoc m id (registrar/lookup :sub id)))
+                          {}
+                          sub-ids)]
+    (doseq [[id meta] originals]
+      (let [orig (:handler-fn meta)]
+        (registrar/register! :sub id
+          (assoc meta :handler-fn
+                 (fn [& args]
+                   (swap! !counts update id (fnil inc 0))
+                   (apply orig args))))))
+    (try
+      (f (fn [] @!counts) (fn [] (reset! !counts {})))
+      (finally
+        (doseq [[id meta] originals]
+          (registrar/register! :sub id meta))))))
+
+(defn- total [counts] (reduce + 0 (vals counts)))
+
+;; ---------------------------------------------------------------------------
+;; Instrument 3 — the commit, in glass writes and DOM mutations
+;; ---------------------------------------------------------------------------
+
+(defn- with-glass-spy
+  "Count writes of `value` onto live controls while `f` runs.
+
+  Replaces both prototypes' property descriptors with counting ones that
+  delegate to the originals, and restores them in a `finally`. Installed
+  around the MOUNT and not merely around the keystroke — React's change
+  tracker captures the prototype descriptor when it starts tracking a
+  node, so a spy installed after the mount sits behind the reference
+  React already took."
+  [f]
+  (let [protos    [["INPUT" js/HTMLInputElement.prototype]
+                   ["TEXTAREA" js/HTMLTextAreaElement.prototype]]
+        !n        (atom 0)
+        originals (mapv (fn [[_ p]] (js/Object.getOwnPropertyDescriptor p "value")) protos)]
+    (doseq [[[_ p] d] (map vector protos originals)]
+      (js/Object.defineProperty p "value"
+        #js {:configurable true
+             :enumerable   (.-enumerable d)
+             :get          (.-get d)
+             :set          (fn [v]
+                             (this-as t
+                               (swap! !n inc)
+                               (.call (.-set d) t v)))}))
+    (try
+      (f (fn [] @!n) (fn [] (reset! !n 0)))
+      (finally
+        (doseq [[[_ p] d] (map vector protos originals)]
+          (js/Object.defineProperty p "value" d))))))
+
+(defn- mutations-during
+  "The `MutationObserver` records `f` produced inside `container`, drained
+  synchronously with `takeRecords` — the observer's own callback is a
+  microtask and has not run when this returns."
+  [container f]
+  (let [obs (js/MutationObserver. (fn [_ _] nil))]
+    (.observe obs container
+              #js {:childList true :attributes true :characterData true :subtree true})
+    (try
+      (f)
+      (vec (array-seq (.takeRecords obs)))
+      (finally (.disconnect obs)))))
+
+;; ---------------------------------------------------------------------------
+;; The editor's census
+;; ---------------------------------------------------------------------------
+
+(def ^:private editor-sub-ids
+  [::editor-subs/field ::editor-subs/committed ::editor-subs/revision
+   ::editor-subs/dirty?])
+
+(defn- editor-node [m field]
+  (.querySelector (:container m) (str "[data-field='" (name field) "']")))
+
+(deftest the-editors-per-keystroke-census
+  (if-not (browser?)
+    (skip! "a census needs a mounted page")
+    (with-glass-spy
+      (fn [glass-writes reset-glass!]
+        (with-counted-subs editor-sub-ids
+          (fn [sub-runs reset-subs!]
+            (let [m (hm/mount! [editor-views/editor {}]
+                               {:initial-events editor-app/initial-events})
+                  n (editor-node m :title)
+                  db #(rf/app-db-value (:frame m))]
+              (hm/settle! m)
+
+              (testing "the FIRST keystroke of a session"
+                (reset-subs!)
+                (reset-glass!)
+                (let [before (db)
+                      bodies (hm/bodies-run
+                               (fn [] (type-into! n "a") (hm/settle! m)))
+                      after  (db)]
+                  (is (= 1 (addresses-moved before after))
+                      "P1 — one leaf address, `[:draft :title]`")
+                  (is (= 2 bodies)
+                      "P5 — the field and the button row; `::dirty?` goes
+                       false to true exactly once per session (D7)")))
+
+              (testing "and a STEADY-STATE keystroke — the census proper"
+                (reset-subs!)
+                (reset-glass!)
+                (let [before (db)
+                      echo   (atom nil)
+                      muts   (atom nil)
+                      bodies (hm/bodies-run
+                               (fn []
+                                 (reset! muts
+                                         (mutations-during
+                                           (:container m)
+                                           (fn [] (reset! echo (type-into! n "b")))))
+                                 (hm/settle! m)))
+                      after  (db)
+                      runs   (sub-runs)]
+                  (is (= 1 (addresses-moved before after))
+                      "P1 — one state write")
+                  (is (= 10 (total runs))
+                      (str "P2 — subscription recomputations. Measured: "
+                           (pr-str runs)))
+                  (is (= 1 bodies)
+                      "P3 — one boundary body, the title field's (D8)")
+                  (is (= 1 (glass-writes))
+                      "P4 — one write onto the glass by the runtime")
+                  (is (= "Intents are dataab" @echo)
+                      "P12 — the echo is on the glass at the instant
+                       `dispatchEvent` returned, with no flush and no paint
+                       in between")
+                  (is (= 0 (count @muts))
+                      "and the commit mutated no attribute, no child and no
+                       text node: a controlled input's value is a PROPERTY,
+                       so the echo never reaches the markup at all")))
+
+              (hm/unmount! m))))))))
+
+;; ---------------------------------------------------------------------------
+;; The grid's census, at two sizes
+;; ---------------------------------------------------------------------------
+
+(def ^:private grid-sub-ids
+  [::grid-subs/cell ::grid-subs/dimensions ::grid-subs/row-total])
+
+(defn- grid-node [m row col]
+  (.querySelector (:container m) (str "#" (grid-events/cell-id row col))))
+
+(defn- grid-census
+  "Mount the grid at `dimensions`, type one accepted digit into `[3 4]`,
+  and answer the census as a map."
+  [dimensions]
+  (with-glass-spy
+    (fn [glass-writes reset-glass!]
+      (with-counted-subs grid-sub-ids
+        (fn [sub-runs reset-subs!]
+          (let [m (hm/mount! [grid-views/grid {}]
+                             {:initial-events (grid-app/initial-events dimensions)})
+                n (grid-node m 3 4)]
+            (hm/settle! m)
+            (reset-subs!)
+            (reset-glass!)
+            (let [before (rf/app-db-value (:frame m))
+                  echo   (atom nil)
+                  muts   (atom nil)
+                  bodies (hm/bodies-run
+                           (fn []
+                             (reset! muts
+                                     (mutations-during
+                                       (:container m)
+                                       (fn [] (reset! echo (type-into! n "1")))))
+                             (hm/settle! m)))
+                  after  (rf/app-db-value (:frame m))
+                  runs   (sub-runs)]
+              (try
+                {:writes    (addresses-moved before after)
+                 :sub-runs  (total runs)
+                 :by-sub    runs
+                 :bodies    bodies
+                 :glass     (glass-writes)
+                 :mutations (count @muts)
+                 :echo      @echo}
+                (finally (hm/unmount! m))))))))))
+
+(deftest the-grids-per-keystroke-census-at-two-sizes
+  (if-not (browser?)
+    (skip! "a census needs a mounted page")
+    (let [at-100 (grid-census {:rows 10 :cols 10})
+          at-25  (grid-census {:rows 5 :cols 5})]
+      (is (= 1 (:writes at-100))
+          "P6 — one state write, `[:cells [3 4]]`")
+      (is (= 2 (:bodies at-100))
+          "P8 — the cell and its row's total (D1/D2)")
+      (is (= 111 (:sub-runs at-100))
+          (str "P7 — subscription recomputations at 10x10. Measured: "
+               (pr-str (:by-sub at-100))))
+      (is (= 31 (:sub-runs at-25))
+          (str "P9 — subscription recomputations at 5x5. Measured: "
+               (pr-str (:by-sub at-25))))
+      (is (= 1 (:glass at-100))
+          "one write onto the glass by the runtime")
+      (is (= "341" (:echo at-100))
+          "P12 — the echo is on the glass before any flush")
+      (is (= 0 (:mutations at-100))
+          "and no DOM mutation record: the value is a property")
+      (is (= (:bodies at-25) (:bodies at-100))
+          "THE CONTRAST THE CENSUS EXISTS FOR — boundary runs do not move
+           with the mounted grid")))
+
+  (testing "a REFUSED keystroke costs nothing anywhere"
+    (if-not (browser?)
+      (skip! "the refusal")
+      (with-glass-spy
+        (fn [glass-writes reset-glass!]
+          (with-counted-subs grid-sub-ids
+            (fn [sub-runs reset-subs!]
+              (let [m (hm/mount! [grid-views/grid {}]
+                                 {:initial-events (grid-app/initial-events
+                                                    {:rows 10 :cols 10})})
+                    n (grid-node m 3 4)]
+                (hm/settle! m)
+                (reset-subs!)
+                (reset-glass!)
+                (let [before (rf/app-db-value (:frame m))
+                      echo   (atom nil)
+                      bodies (hm/bodies-run
+                               (fn [] (reset! echo (type-into! n "x")) (hm/settle! m)))
+                      after  (rf/app-db-value (:frame m))]
+                  (is (= 0 (addresses-moved before after))
+                      "P10 — the model did not move")
+                  (is (= 0 (total (sub-runs)))
+                      (str "P11 — and nothing recomputed: an app-db that is `=` "
+                           "to the last one publishes no movement, so no cell is "
+                           "even asked. Measured: " (pr-str (sub-runs))))
+                  (is (= 0 bodies)
+                      "no body ran (D5)")
+                  (is (= 1 (glass-writes))
+                      "and the ONE write onto the glass is the refusal echo —
+                       the committed value put back over the character the
+                       model would not take")
+                  (is (= "34" (.-value n))
+                      "which is what the field shows"))
+                (hm/unmount! m)))))))))


### PR DESCRIPTION
Publishes `docs/design/hicasso/product/per-keystroke.md` — the mechanical per-keystroke path of the four-field editor and the 100-cell grid, which is `specification.md` §6's *state writes, subscription recomputations, boundary runs, write amplification, commit, and visible echo*, each stage attributed and each carrying its witness.

**The numbers come from the public-package witness applications** (`implementation/hicasso/test/re_frame/hicasso/examples/{editor,grid}`, `rf2-hic-078`'s), never from the frozen bench prototypes. The bead's premise on that point was checked at source before anything was measured, and it holds.

## The two findings

**Boundary cost is flat in the size of the page; subscription recomputation cost is not.** One keystroke in the 10x10 grid runs **111** subscription bodies to run **2** view bodies — 100 `::cell`, 10 `::row-total`, 1 `::dimensions` — and 31 at 5x5, against 2 boundary bodies at both sizes. Every subscription in both applications is a layer-1 reader memoised on the whole of app-db, so every mounted cell re-runs when app-db moves, and the equality gate on the *output* is what keeps notification narrow. The read topology buys narrow notification, not narrow recomputation, and no docstring in the tree said so before this census.

**The echo of an accepted keystroke costs zero writes onto the glass.** The character is already there — the user agent put it there — and the model took it unchanged, so the converge has nothing to write and React's value diff finds the node already showing what it was about to commit. A *refused* keystroke costs exactly one, which is the same spy reading non-zero on the same page and is therefore this instrument's own positive control.

## Write amplification, stated honestly

Four definitions, three flat and one not, as a table rather than as one number:

| per state write | Editor | Grid 5x5 | Grid 10x10 | grows? |
|---|---:|---:|---:|---|
| view bodies (the guide's definition) | 1 | 2 | 2 | no |
| **subscription recomputations** | **10** | **31** | **111** | **yes, linearly** |
| writes onto the glass | 0 | 0 | 0 | no |
| DOM mutation records | 7 | 8 | 8 | no |

## What is REFUSED

**`U1` — echo within one 60 Hz frame at p95 — stays `UNPINNED`, and the clock half is refused at source.** The deterministic half is now published: on both pages the field shows the model's value at the instant `dispatchEvent` returns, inside the discrete event, with **no frame boundary crossed at all**. That is a *structural* fact and `U1`'s registered estimand is a *distributional* one; substituting the first for the second is the conflation `budgets.md` §3 refuses when it keeps `D9`'s counters apart from `S5`'s bytes. `budgets.md` §9.2/§9.3 already record that no package-resident clock instrument exists and that building one is `rf2-hic-071`'s, and a measurement window may not improve its own rig. `budgets.md` §9.2 now carries that amendment, and `U1` is not recoloured.

## Pre-registration

The instruments and twelve predictions were committed **before** any measurement was taken, in their own commit at the head of this branch. **P2, P7 and P9 held** — the predictions the page existed to test. **P4 missed** (predicted 1 glass write, measured 0) and the mutation prediction missed (predicted 0, measured 7 and 8). Both misses are reported in the table where the prediction was made, and both turned out to be the more interesting result.

## Quality gates

| Gate | Captured exit | Result |
|---|---:|---|
| `npm run test:browser` — control, before the census existed | `0` | 1,489 tests / 9,311 assertions |
| `npm run test:browser` — predictions asserted | `1` | 1,491 / 9,332, four reds (the two missed predictions, both pages) |
| `npm run test:browser` — measured figures | `0` | 1,491 / 9,334 |
| `npm run test:browser` — **sabotage**, P7's `111` inverted to `112` | `1` | captured red naming the line, printing `(not (= 112 111))` and the per-sub breakdown |
| `npm run test:browser` — restored + per-sub attributions | `0` | 1,491 / 9,337 |
| `npm run test:browser` — **re-taken after rebase onto `b44c5e854c`** | `0` | **1,502 / 9,508, 0 failures — no figure moved** |
| `npm run test:cljs` | `0` | 13,875 / 70,108 |
| `python scripts/check_doc_slugs.py` | `0` | — |
| `python scripts/check_provenance_pins.py --changed-since origin/main` | `0` | 2 files, 6 pins, 6 landed, 0 stranded |
| `python implementation/hicasso/scripts/check_budget_ledger.py` | `0` | 39 rows, unchanged |

Every exit code above is the runner's own, captured with `echo $? > …` on the same command line as the redirect — never a status reported about the run by anything else.

**Which tree the gates read.** The browser lane prints its root, and every run named `C:\Users\miket\code\re-frame2-worktrees\keystroke-hic045\implementation\out\browser-test`.

**The sabotage control, and the restore.** One line was inverted, the lane went red naming that line, and the restore was verified with `git hash-object` against the pre-sabotage value (`7197902f6ed8054daf627122a993eb22ae24ed33`) — a content hash and not a byte digest, because this checkout translates line endings. The red's own text independently witnesses the figure and its attribution, `cljs.test` printing the bound values.

**The assertion arithmetic, checked twice.** Control-to-green is `+2` tests and `+26` assertions, exactly what the two new `deftest`s contain — the rows are `browser?`-guarded and would otherwise be indistinguishable from skips. The post-rebase run is checkable against a number this branch did not produce: `rf2-hic-036`'s tournament landed in the interval and publishes the same lane at 1,500 / 9,482 on the same base, and run 8 reads 1,502 / 9,508.

**`mkdocs build --strict` is NOT nominated and does not apply.** `mkdocs.yml`'s `exclude_docs` block excludes `design/hicasso/`; I read that config rather than citing the convention. **Anchors and table column counts were verified by hand**: 7 tables, every row matching its header's column count, and all 11 link targets resolving to real headings in `budgets.md`, `specification.md` and `topology-tournament.md`.

**Required CI checks this run does not cover**: the remainder of the fast-PR spine and the JVM artefact lanes in `.github/workflows/test.yml`, and the other jobs in `.github/workflows/docs.yml`. This branch runs the two CLJS lanes plus the three doc gates that touch its own surface.

## What was NOT concluded

- **No latency of any kind** — no millisecond, no `p50`, no `p95`. `U1`–`U4` stay `UNPINNED`.
- **No new ledger rows.** The census's figures deserve rows in `budgets.md` §9, and minting them means editing `check_budget_ledger.py`'s pinned constants, which is `rf2-hic-089`'s surface. Filed as follow-up rather than reached into.
- **No remedy for the amplification finding, and no claim that one is needed.** The layer-2 memoisation contrast is named as the next question, not answered.
- **Nothing about composition, IME or the caret** — `rf2-hic-040`'s matrix.
- **Nothing readable across to the topology tournament**, whose arms vary boundary placement on the bench tree's arm-1 runtime while these figures hold topology fixed on the package.

## Fence

No hot-zone file is touched: no `implementation/shadow-cljs.edn`, no `deps.edn`, no `.github/workflows/*`, no `spec/*`, no `.beads/*`. `implementation/hicasso/test/.../editor/app.cljs` anticipated that this bead would need a `:dev-http` entry and a build id; **it did not** — the census runs in the existing `browser-test` lane through an ordinary suite, exactly as the `D` rows do, so nothing was added and nothing was asked for. `rf2-hic-036`'s `bench/hicasso/topo/` subtree and its page are untouched; the only reference to them is a disclaimer that the two pages' figures are not comparable.

## Also in this change

Two application docstrings said something the census falsified — *"the subscriptions reading that address recompute"* names the wrong set, and *"exactly one of the hundred recomputes"* elides the difference between recomputing and computing a new value. Both are corrected where they stand. Four docstrings pointed at `draft-guide/18-performance.md`, which is now the SSR chapter; the section they name lives in `19-performance.md`, and they are repointed.
