### PR TITLE
ci: classify a multi-commit push over the whole push, not its tip (rf2-34yg)

### DIFF
--- a/.github/scripts/report-changed-surfaces.sh
+++ b/.github/scripts/report-changed-surfaces.sh
@@ -6,7 +6,9 @@ set -euo pipefail
 #   .github/scripts/report-changed-surfaces.sh [--all] [path ...]
 #
 # With explicit paths, classify those paths. Without paths, derive the changed
-# file list from the GitHub Actions event, or from HEAD^ locally.
+# file list from the GitHub Actions event's ACCEPTED BASE, or from HEAD^
+# locally. See the base-resolution block below for what "accepted base" means
+# on each event shape.
 
 force_all=false
 declare -a explicit_paths=()
@@ -34,7 +36,94 @@ elif [ "${GITHUB_EVENT_NAME:-}" = "pull_request" ] && [ -n "${GITHUB_BASE_REF:-}
   # classified as delete + add; ordinary add/modify/delete are unaffected.
   files="$(git diff --no-renames --name-only "origin/${GITHUB_BASE_REF}...HEAD")"
 else
-  files="$(git diff --no-renames --name-only HEAD^ HEAD 2>/dev/null || git diff --no-renames --name-only HEAD)"
+  # rf2-34yg — THE EVENT'S ACCEPTED BASE, not HEAD^. One push event produces
+  # ONE workflow run, at the tip. On a MULTI-COMMIT push HEAD^ is merely the
+  # push's own second-to-last commit, so commits 1..N-1 are invisible to this
+  # classifier and never get a run of their own — a rebase-merged PR of N
+  # commits has its trunk run classified on commit N alone. This is the
+  # rf2-7hq4l defect, already named and fixed twice here:
+  # .github/workflows/portability.yml resolves the accepted base from
+  # `github.event.before` and passes it to scripts/check-ai-tracking-ratchet.sh
+  # in `AI_RATCHET_BASE_REF`; .github/workflows/post-merge-workflow-sanity.yml
+  # does the same inline. This is the same idiom, one script over.
+  #
+  # MEASURED, on two real merges (both re-run in the PR that added this):
+  #   * PR #8159's 4-commit push — tip was a docs file, so the push armed
+  #     NOTHING. Whole push arms 6. Run 31742435731 reported "All required
+  #     checks passed" across 78 jobs with every surface-gated one skipped.
+  #   * ebd92e12d2 touched expensive-tests.yml AND TESTING.md, both `mark_all`
+  #     triggers, behind a tip arming 0. Tip-only 0; whole push 32. The
+  #     full-matrix run that editing TESTING.md exists to FORCE never happened.
+  # It creates no exposure relative to the PR gate — each of those commits was
+  # fully classified against `base...HEAD` on its own PR. What it degrades is
+  # the POST-MERGE net: the run that catches a semantic conflict between two
+  # PRs green alone, and that honours `mark_all` when CI's own configuration
+  # changes.
+  #
+  # THE CALLER SUPPLIES THE REF, this script only consumes it — portability.yml's
+  # split, and for its stated reason: context values reach the script through
+  # `env:` and are never interpolated into a script body, so the step is
+  # injection-safe whatever the event carries. test.yml maps push ->
+  # `github.event.before`; a pull_request never reaches here (the branch above
+  # takes it, unchanged, and its `base...HEAD` was always correct).
+  #
+  # TWO-DOT, matching post-merge-workflow-sanity.yml and the ratchet's
+  # base-tree comparison. On the ordinary push the base is an ancestor of HEAD
+  # and two- and three-dot agree; on a FORCE-PUSH they do not, and two-dot is
+  # the conservative one — it reports the discarded commits' paths as changed
+  # too, arming more rather than fewer gates.
+  #
+  # FIRST PUSH TO A NEW REF sends the all-zeros sentinel; force-push sends a
+  # tip that may no longer be reachable. Both are handled below, and neither
+  # silently returns to HEAD^ semantics without saying so.
+  base_ref="${CHANGED_SURFACES_BASE_REF:-}"
+  if [ "$base_ref" = '0000000000000000000000000000000000000000' ]; then
+    # The first push to a fresh ref has no "before". post-merge-workflow-
+    # sanity.yml folds this to HEAD^ and portability.yml folds it to empty so
+    # the ratchet's own HEAD^ default stands; both land in the same place, and
+    # so does this. There is no earlier state to have missed, so HEAD^ loses
+    # nothing here.
+    base_ref=''
+  fi
+
+  if [ -z "$base_ref" ]; then
+    files="$(git diff --no-renames --name-only HEAD^ HEAD 2>/dev/null || git diff --no-renames --name-only HEAD)"
+  else
+    # The `^{commit}` peel is REQUIRED, not decorative (rf2-uol6, learnt by the
+    # ai/ ratchet): for a full 40-hex sha `git rev-parse --verify --quiet`
+    # echoes the string back with exit 0 WITHOUT consulting the object store,
+    # so an absent base would sail through and `git diff` would then fail into
+    # a `|| true`, classifying an empty change set as "nothing to run". Peeling
+    # forces the lookup. Guarded so `set -e` does not abort before the message.
+    base_sha="$(git rev-parse --verify --quiet "${base_ref}^{commit}" 2>/dev/null)" || base_sha=''
+    if [ -n "$base_sha" ]; then
+      files="$(git diff --no-renames --name-only "$base_sha" HEAD)"
+    else
+      # UNRESOLVABLE BASE — mark_all, and say so loudly.
+      #
+      # The realistic cause is a FORCE-PUSH to main: `before` is then the
+      # DISCARDED tip, reachable from no ref, so even test.yml's fetch-depth: 0
+      # checkout does not hold it. (portability.yml fetches its base by name
+      # because it checks out at depth 2; the sole caller here is already a
+      # full clone, so a fetch would buy only this one unreachable case and is
+      # deliberately not attempted.)
+      #
+      # WHY mark_all AND NOT HEAD^. The ratchet's rule is that a guard which
+      # cannot see its base must not certify anything — but a RATCHET fails
+      # closed by exiting red, whereas a CLASSIFIER's failure mode is a false
+      # GREEN: skipping gates. Arming everything is this script's fail-closed,
+      # and it is the only branch here that cannot under-arm. Falling back to
+      # HEAD^ would reproduce the very defect above, silently. Erroring out
+      # would red the trunk on a legitimate if abnormal event; a force-push to
+      # main is also exactly when the full matrix is worth running.
+      printf 'report-changed-surfaces.sh: base ref %s does not resolve to a commit.\n' \
+        "$base_ref" >&2
+      printf 'Classifying as --all: a classifier that cannot see its base must not\n' >&2
+      printf 'skip gates. Usual cause: a force-push, whose previous tip is now\n' >&2
+      printf 'unreachable. See rf2-34yg.\n' >&2
+      files="__ALL__"
+    fi
+  fi
 fi
 
 implementation_jvm=false

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -102,8 +102,31 @@ jobs:
         with:
           fetch-depth: 0
 
+      # rf2-34yg — hand the classifier the event's ACCEPTED BASE so a
+      # MULTI-COMMIT push to main is classified over the WHOLE push rather than
+      # over its tip alone. One push produces one run, at the tip, so the
+      # script's HEAD^ default saw only the last commit of a rebase-merged PR
+      # and commits 1..N-1 reached main having armed nothing — measured at 5
+      # code-carrying commits in 60. `github.event.before` is the tip main
+      # pointed at before this push; it is empty on a pull_request (that branch
+      # of the script is unchanged and was always correct) and all-zeros on a
+      # first push to a fresh ref, both of which the script folds back to its
+      # HEAD^ default.
+      #
+      # Via `env:`, never interpolated into the run body — portability.yml's
+      # rule for the same context value on the ai/ ratchet, so the step is
+      # injection-safe whatever the event carries.
+      #
+      # The `fetch-depth: 0` above is what makes the base resolvable without a
+      # fetch: it can be arbitrarily deep. (portability.yml checks out at depth
+      # 2 and so must fetch its base by name; this job need not.) GitHub already
+      # evaluates this workflow's own push `paths-ignore` filter across the
+      # whole push, so the trigger and the classifier now agree about what the
+      # push changed.
       - name: Classify changed surfaces
         id: detect
+        env:
+          CHANGED_SURFACES_BASE_REF: ${{ github.event.before }}
         run: ./.github/scripts/report-changed-surfaces.sh
 
   # PR-time drift detection for the lockstep-version contract

--- a/implementation/scripts/_changed-surfaces.test.cjs
+++ b/implementation/scripts/_changed-surfaces.test.cjs
@@ -4067,7 +4067,12 @@ function writeFileP(root, relPath, contents) {
 // its Git-derived (local, HEAD^ HEAD) discovery mode with NO explicit paths and
 // return the parsed classifier outputs. GITHUB_* is cleared so the script takes
 // the local branch and prints to stdout.
-function classifyViaGitDiscovery(buildHistory) {
+// `envFor` (rf2-34yg) is an OPTIONAL callback run after the history is built
+// and before the script is invoked; it returns extra environment for the run.
+// It is a callback rather than a plain object because the interesting variable
+// — the push's accepted base — is a SHA that does not exist until
+// `buildHistory` has made the commits.
+function classifyViaGitDiscovery(buildHistory, envFor) {
   const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'rf2-changed-surfaces-'));
   try {
     gitIn(tmp, 'init', '-q');
@@ -4092,6 +4097,14 @@ function classifyViaGitDiscovery(buildHistory) {
     delete env.GITHUB_BASE_REF;
     for (const key of Object.keys(env)) {
       if (key.startsWith('GIT_')) delete env[key];
+    }
+    // Applied LAST, so a test can set what the deletions above cleared —
+    // notably GITHUB_EVENT_NAME=push plus the accepted base (rf2-34yg).
+    if (envFor) {
+      Object.assign(
+        env,
+        envFor({ root: tmp, git: (...args) => gitIn(tmp, ...args) }),
+      );
     }
     const out = execFileSync('bash', ['-s'], {
       cwd: tmp,
@@ -4228,6 +4241,151 @@ test('DISCOVERY: ordinary docs-only modify does NOT arm UI gates (scope, unchang
   for (const key of UI_GATE_KEYS) {
     assert.equal(result[key], 'false', `a docs-only modify must NOT arm ${key}`);
   }
+});
+
+// ─── rf2-34yg — A MULTI-COMMIT PUSH IS CLASSIFIED OVER THE WHOLE PUSH ────────
+//
+// One push event produces ONE workflow run, at the tip. Before this, the
+// classifier's non-PR branch diffed `HEAD^ HEAD`, so a PR rebase-merged with N
+// commits had its trunk run classified on commit N ALONE — commits 1..N-1 were
+// invisible and never got a run of their own. This is the rf2-7hq4l defect,
+// already fixed twice in this repo (portability.yml + the ai/ ratchet;
+// post-merge-workflow-sanity.yml), and the classifier was the last holdout.
+//
+// MEASURED on two real merges before the fix:
+//   * PR #8159's 4-commit push (efb1cc781f..858f22fe76) — the tip was a docs
+//     file, so the push armed NOTHING; the whole push arms 6. Run 31742435731
+//     reported "All required checks passed" over 78 jobs with every
+//     surface-gated one skipped.
+//   * ebd92e12d2 touched expensive-tests.yml AND TESTING.md, both `mark_all`
+//     triggers, behind a tip touching only scripts/test-rigorous-local.sh.
+//     Tip-only armed 0; the whole push arms 32.
+//
+// These tests build a REAL multi-commit history and drive the same
+// git-discovery path, so they fail if the base resolution regresses to HEAD^.
+
+// A three-commit "push": a classified file lands in commit 1 and is untouched
+// by commits 2 and 3, so it is present on both sides of a HEAD^ diff and
+// escapes — exactly the shape the two measured merges had.
+function pushHistory({ write, commit }) {
+  write('README.md', '# scratch\n');
+  commit('base — the tip main pointed at BEFORE the push');
+  write(UI_SOURCE, '(ns re-frame.ui.reactive)\n');
+  commit('push commit 1 — the classified change');
+  write('docs/a.md', '# a\n');
+  commit('push commit 2 — docs only');
+  write('docs/b.md', '# b\n');
+  commit('push commit 3 — the TIP, docs only');
+}
+
+test('PUSH: a multi-commit push classifies over the WHOLE push, not the tip (rf2-34yg)', () => {
+  const result = classifyViaGitDiscovery(pushHistory, ({ git }) => ({
+    GITHUB_EVENT_NAME: 'push',
+    // The accepted base: the tip main pointed at before the push, i.e.
+    // `github.event.before`. Three commits back from the tip.
+    CHANGED_SURFACES_BASE_REF: git('rev-parse', 'HEAD~3').toString().trim(),
+  }));
+  for (const key of UI_GATE_KEYS) {
+    assert.equal(
+      result[key],
+      'true',
+      `a UI change in commit 1 of a 3-commit push must arm ${key} on the ` +
+        'push run — reverting the base to HEAD^ makes this fail',
+    );
+  }
+});
+
+test('PUSH: the CONTROL — HEAD^ alone misses that same change (rf2-34yg)', () => {
+  // The defect itself, pinned. Same history, no accepted base, so the script
+  // takes its HEAD^ default and sees only the docs tip. If this ever starts
+  // arming the UI gates the test above has stopped proving anything.
+  const result = classifyViaGitDiscovery(pushHistory);
+  for (const key of UI_GATE_KEYS) {
+    assert.equal(
+      result[key],
+      'false',
+      `HEAD^ sees only the docs tip, so ${key} stays false — this is the ` +
+        'defect rf2-34yg fixes, kept as the control for the test above',
+    );
+  }
+});
+
+test('PUSH: the all-zeros sentinel folds back to HEAD^ (first push to a ref) (rf2-34yg)', () => {
+  // A first push to a fresh ref carries an all-zeros `before`. There is no
+  // earlier state to have missed, so HEAD^ loses nothing — but it must not
+  // be passed to `git diff` as a literal ref. post-merge-workflow-sanity.yml
+  // folds it the same way.
+  const result = classifyViaGitDiscovery(pushHistory, () => ({
+    GITHUB_EVENT_NAME: 'push',
+    CHANGED_SURFACES_BASE_REF: '0'.repeat(40),
+  }));
+  for (const key of UI_GATE_KEYS) {
+    assert.equal(result[key], 'false', `all-zeros must fold to HEAD^, not fail (${key})`);
+  }
+});
+
+test('PUSH: an UNRESOLVABLE base arms everything rather than skipping (rf2-34yg)', () => {
+  // The force-push case: `before` is the DISCARDED tip, reachable from no ref,
+  // so even a full clone need not hold it. A classifier's failure mode is a
+  // false GREEN, so its fail-closed is `mark_all` — never a silent return to
+  // HEAD^, which would reproduce the defect above.
+  const result = classifyViaGitDiscovery(pushHistory, () => ({
+    GITHUB_EVENT_NAME: 'push',
+    CHANGED_SURFACES_BASE_REF: 'dead0000'.repeat(5),
+  }));
+  for (const key of UI_GATE_KEYS) {
+    assert.equal(
+      result[key],
+      'true',
+      `an unresolvable base must arm ${key} — a base it cannot see must not ` +
+        'let it skip gates',
+    );
+  }
+  // Not merely the UI subset: this is mark_all, so every output is true.
+  const falses = Object.entries(result).filter(([, v]) => v !== 'true');
+  assert.deepEqual(falses, [], 'an unresolvable base must arm the FULL matrix');
+});
+
+test('PUSH: a pull_request is unaffected — base...HEAD still wins (rf2-34yg)', () => {
+  // The PR branch was always correct and is deliberately untouched. Even with
+  // a base ref present in the environment, a pull_request event must not take
+  // the push branch. GITHUB_BASE_REF is absent here, so the PR branch's own
+  // guard sends this to the HEAD^ default rather than to the push branch.
+  const result = classifyViaGitDiscovery(pushHistory, () => ({
+    GITHUB_EVENT_NAME: 'pull_request',
+  }));
+  for (const key of UI_GATE_KEYS) {
+    assert.equal(result[key], 'false', `a pull_request must not take the push branch (${key})`);
+  }
+});
+
+test('test.yml hands the classifier the accepted base via env: (rf2-34yg)', () => {
+  // THE CALLER HALF. The script cannot read `github.event.before` on its own —
+  // Actions exports no such variable — so the fix is inert unless test.yml
+  // passes it. Dropping this `env:` would silently restore tip-only
+  // classification with every test above still green, because they supply the
+  // base themselves.
+  const block = jobBlock(fs.readFileSync(WORKFLOW, 'utf8'), 'detect_changed_surfaces');
+  assert.match(
+    block,
+    /CHANGED_SURFACES_BASE_REF:\s*\$\{\{\s*github\.event\.before\s*\}\}/,
+    'detect_changed_surfaces must pass github.event.before as ' +
+      'CHANGED_SURFACES_BASE_REF, or a multi-commit push is classified on its ' +
+      'tip alone (rf2-34yg)',
+  );
+  // Via `env:`, never interpolated into the run body — portability.yml's rule
+  // for the same context value, so the step is injection-safe.
+  assert.doesNotMatch(
+    block,
+    /run:[\s\S]*\$\{\{\s*github\.event\.before/,
+    'the base must arrive through env:, not interpolated into the script body',
+  );
+  // The base can be arbitrarily deep; a shallow checkout would not hold it.
+  assert.match(
+    block,
+    /fetch-depth:\s*0/,
+    'the accepted base can be arbitrarily deep — this job needs full history',
+  );
 });
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes rf2-34yg.

One push event produces **one** workflow run, at the tip SHA. `.github/scripts/report-changed-surfaces.sh` resolved its diff base from the event: the `pull_request` branch used `origin/${GITHUB_BASE_REF}...HEAD` and was correct, but every other event — including `push` to `main` — fell through to a bare `git diff --no-renames --name-only HEAD^ HEAD`.

So a PR rebase-merged with N commits had its trunk run classified on commit N **alone**. Commits 1..N-1 were invisible to the classifier and never got a run of their own.

**What it costs, stated honestly.** No exposure relative to the PR gate — each of those commits was fully classified against `base...HEAD` on its own PR. What it degrades is the **post-merge net**: the run whose job is to catch a semantic conflict between two PRs each green alone, and to honour `mark_all` when CI's own configuration changes. On a multi-commit push that net reported "All required checks passed" over a run that executed no code gate.

## The remedy was already in this repository, twice

This is the **rf2-7hq4l defect**, named and fixed twice here. Nothing was invented:

| | resolves base from | all-zeros sentinel | passes it how | shallow base |
|---|---|---|---|---|
| `portability.yml` :175-250 → `check-ai-tracking-ratchet.sh` | `github.event.before` | → empty, script defaults to `HEAD^` | `env:` (`AI_RATCHET_BASE_REF`) | fetches by name (checkout is depth 2) |
| `post-merge-workflow-sanity.yml` :89-95 | `github.event.before` | → `HEAD^` inline | `${{ }}` interpolated into the run body | none |
| **this change** | `github.event.before` | → empty → `HEAD^` | `env:` (`CHANGED_SURFACES_BASE_REF`) | not needed (checkout is depth 0) |

**They agree on the mechanism and diverge on two points, and I copied the better one each time.** `portability.yml` is the stronger idiom: it passes the context value through `env:` rather than interpolating it into the script body (its own comment states the reason — the step stays injection-safe whatever the event carries), and it splits the work so the *workflow* owns the event→base mapping while the *script* just consumes a ref. `post-merge-workflow-sanity.yml` interpolates. I followed `portability.yml` on both counts.

The `pull_request` branch is untouched — its `base...HEAD` was always correct.

### Edge cases

- **First push to a new ref** — the all-zeros sentinel. Folded back to `HEAD^`. Both existing fixes do this; there is no earlier state to have missed, so `HEAD^` loses nothing.
- **Force-push** — `before` is the *discarded* tip, reachable from no ref, so even a `fetch-depth: 0` checkout need not hold it. The base is peeled to `^{commit}` before use (rf2-uol6's lesson from the ratchet: `git rev-parse --verify --quiet` echoes a 40-hex string back with exit 0 *without consulting the object store*, so an absent base would otherwise sail through and `git diff` would fail into an empty change set — "nothing to run"). An unresolvable base **arms the full matrix** and says so on stderr.
- **Why `mark_all` and not `HEAD^` or a hard error.** A ratchet fails closed by exiting red; a *classifier's* failure mode is a false **green** — skipping gates. `mark_all` is this script's fail-closed and the only branch that cannot under-arm. Falling back to `HEAD^` would reproduce the defect silently; erroring would red the trunk on a legitimate if abnormal event, and a force-push to `main` is exactly when the full matrix is worth running.

## Quality gates

**Before/after arming, both documented reproductions.** Driven through the *real* git-discovery path (`HEAD` parked at the push tip in a `--no-checkout` scratch worktree), not by handing the script paths:

| push | tip-only (`HEAD^`, before) | whole push (accepted base, after) |
|---|---|---|
| PR #8159, 4 commits `efb1cc781f..858f22fe76` | **0** outputs | **6** outputs |
| rf2-mvq7, 3 commits `4a39d84194..74c7d2971f` | **0** outputs | **32** outputs (`mark_all`) |

Both land exactly on the bead's numbers. #8159's six: `implementation_jvm`, `cljs_node_test`, `cljs_browser`, `examples_compile`, `cljs_prod`, `migration_hicasso_codemod`.

**The five named commits that got no run at their SHA, and what each would have armed** (bead acceptance criterion):

| commit | outputs | notably |
|---|---|---|
| `e4863e0a9e` bench(hicasso) topology tournament | **6** | `implementation_jvm`, `cljs_node_test`, `cljs_browser`, `examples_compile`, `cljs_prod`, `migration_hicasso_codemod` |
| `c0edf2b6e2` docs+bench(hicasso) | **6** | same six |
| `b01fd1d3c9` fix(bench) alloc window PRIME | **15** | adds `ui_gates`, `bundle_isolation`, `tools_jvm`, three `tools_*`, `template_expensive`, `mcp_conformance`, `mcp_live`, `playground` |
| `6c31c345d1` docs(testing) Freehand record | **32** | `mark_all` — touched `TESTING.md` + `freehand-conformance.yml` |
| `ebd92e12d2` ci: narrow-armed gates | **32** | `mark_all` — touched `TESTING.md` + `expensive-tests.yml` |

Every one of the five armed something; two would have forced the full matrix. Note the fix does not give these commits their own runs — it makes the *push's* run classify over their union.

**Edge-case probes** (`HEAD` at `74c7d2971f`):

| base | exit | TRUE outputs |
|---|---|---|
| all-zeros sentinel | 0 | 0 (folds to `HEAD^`) |
| empty (PR / dispatch / local) | 0 | 0 (`HEAD^` default) |
| unresolvable `dead0000…` | 0 | **32** + stderr notice |
| accepted base `4a39d84194` | 0 | 32 |

**Captured exit codes.** Each number is the runner's own status, echoed on the same command line as the redirect:

| gate | exit |
|---|---|
| `node implementation/scripts/_changed-surfaces.test.cjs` (354 passed) | **0** |
| `node implementation/scripts/_reagent-slim-smoke-policy.test.cjs` | **0** |
| `node implementation/scripts/_lint-workflow-policy.test.cjs` (4 passed) | **0** |
| `python scripts/check_gate_scheduling.py` (51 gate commands, 43 scheduled, 8 declared) | **0** |
| `sh scripts/_test_fixtures/test_fast_pr_docs_gate/run-self-test.sh` (44/44) | **0** |
| `bash -n` on the classifier | **0** |

All re-run **after** the rebase onto `b44c5e854c`; the table is the post-rebase run.

**Red-then-green control.** A single-line fault planted in the restored base resolution — `files="$(git diff … "$base_sha" HEAD)"` → `HEAD^ HEAD`, so the accepted base is resolved and then ignored:

- classifier blob before sabotage: `1fccd72871d191bb97c5f0d564eb58cac65eac98`
- **sabotaged**: `3d42b274c524ef5fc9725b7406c748ddf9b39904` (differs, so the patch demonstrably applied)
- suite **exit 1**, failing on exactly `a UI change in commit 1 of a 3-commit push must arm implementation_jvm on the push run — reverting the base to HEAD^ makes this fail`
- restored via `git checkout HEAD --`; blob back to `1fccd72871d191bb97c5f0d564eb58cac65eac98`, byte-identical to `git rev-parse HEAD:<path>`
- suite **exit 0**, 354 passed

**Coverage honesty.** `scripts/check_fast_pr_gap.py` is the canonical **fast-spine-versus-required-CI** gap — it derives which required CI steps `scripts/test-fast-pr.sh` does not run, and reports **96**. It does not inspect what I ran locally, so it is not a statement of my coverage in either direction. Stated plainly instead: **I did not run the fast spine.** I ran the five targeted gates in the table above, chosen because this is a shell-script + workflow-YAML + Node-test change and the classifier itself runs in milliseconds; no JVM, npm or browser gate can reach the diff. Deliberately kept light — a measurement window is live on this box.

CI covers the rest at full strength: `.github/scripts/report-changed-surfaces.sh`, `.github/workflows/test.yml` and `TESTING.md` are all `mark_all` triggers, so **this PR runs the complete matrix**. `shellcheck` is not installed locally (exit 127); `lint.yml` runs it.

## Six regression tests

Building a real three-commit history where a classified file lands in commit 1 and is untouched by 2 and 3 — the exact shape both measured merges had:

1. the whole push arms the UI gates
2. **the control**: `HEAD^` alone misses that same change (so test 1 cannot pass vacuously)
3. all-zeros folds to `HEAD^`
4. an unresolvable base arms the full matrix, asserted over *every* output
5. a `pull_request` does not take the push branch
6. **a pin on `test.yml` passing the base** — the script cannot read `github.event.before` on its own (Actions exports no such variable), so dropping that `env:` would silently restore tip-only classification with tests 1-5 still green, because they supply the base themselves

## Scope

Deliberately **not** done: no other workflow touched, no gate re-armed, no job added, and **no change to which surfaces map to which outputs** — rf2-cujx is the open, held cost decision about arming to completion and this stays off it. The change is to how the classifier resolves its base, and nothing else.

## Found while here, not actioned

`post-merge-workflow-sanity.yml` uses `github.event.before` but checks out at `fetch-depth: 2`, so on a push of 2+ commits the base is not in the clone; `git diff` then fails into `|| true` and the step reports "No workflow files changed in this push" — fail-open, defeating the very fix it applies. Same class as this bead, different file, and `.github/**` is one-toucher-at-a-time, so I have not touched it. Worth its own bead.

Also worth recording: GitHub evaluates this workflow's own push `paths-ignore` filter across the **whole push** (`before..after`), so the trigger already used whole-push semantics while the classifier inside it used tip-only. The two now agree.
