### PR TITLE
bench(topo): a rendered-scale positive control — three topology arms certified, the windowed arm refuses

### DIFF
--- a/docs/design/hicasso/product/topology-tournament.md
+++ b/docs/design/hicasso/product/topology-tournament.md
@@ -434,7 +434,7 @@ rests on, which is where the changed-set control was degenerate:
 Exit code **1**, captured from the runner itself — a control that refuses any
 arm refuses the run.
 
-**The diagnosis of the first refusal is confirmed by the third arm here.**
+**The diagnosis of the first refusal is confirmed directly.**
 `fine` is the one arm both controls could address, and it moved from 1.325–1.471
 under the changed-set form to 1.9331–2.2588 under this one. The only thing that
 changed is that the handler and the subscription layer now scale with the

--- a/docs/design/hicasso/product/topology-tournament.md
+++ b/docs/design/hicasso/product/topology-tournament.md
@@ -93,19 +93,33 @@ ordering wearing a clock's clothes.
 Each arm carries both. A published clock figure requires **both** to pass for
 that arm at that row count; either failing withholds the figure.
 
-**Positive control — the changed-set doubling.** Page size is held fixed and
-the *changed set* is doubled: update every 10th row, then every 5th row, on the
-same table. Element count, layout and paint are constant; only the commit-side
-work doubles, so the prediction is **2.00x**, adjudicated on a band registered
-here before the run: **[1.60x, 2.50x]**, and the difference and the slope must
-both be **positive** (a control certifying that more dirty work reads *faster*
-is refused on the sign, which is the fix `rf2-7iqb5` landed in PR #7634).
+**Positive control — the rendered-scale doubling** (`rf2-m6i0`; it replaces the
+changed-set doubling registered here first, which was run, refused, and is
+recorded with its refusal in [§2.6](#26-the-clock-half--the-first-control-refused-the-replacement-certifies-three-arms-of-four)).
+The arm's **rendered page** is doubled and every 5th rendered row is written by
+index, so the event handler, the subscription layer and the render all scale
+together. The predicted factor is **derived from `model/elements-for`** at the
+two rendered row counts rather than assumed to be 2.00 — the `ul` does not
+double — and it is adjudicated on the lane's standing `CONTROL_SLACK` of ±25%
+under the strict rule that **every** round must sit inside:
 
-This is deliberately not the control this lane used before. Every earlier
-positive control for a bulk or update row **scaled the page**, and `rf2-7iqb5`
-records why that cannot certify an update row: the work does not scale with the
-page, so even a perfect instrument reads below the predicted factor. The
-changed-set form is that bead's own prescribed repair.
+| arm | scaled | small → large | predicted | band |
+|---|---|---|---|---|
+| `fine` | `B` | 500 → 1000 | 1.9996 | [1.4997, 2.4995] |
+| `coarse` | `B` | 500 → 1000 | 1.9996 | [1.4997, 2.4995] |
+| `chunked` | `B` | 500 → 1000 | 1.9996 | [1.4997, 2.4995] |
+| `virtual` | `w` | 20 → 40 | 1.9901 | [1.4926, 2.4876] |
+
+The measured ratio must also be **positive** in every round (a control
+certifying that more work reads *faster* is refused on the sign, which is the
+fix `rf2-7iqb5` landed in PR #7634), and the run must read back **0 unverified
+of M** cell-addressed probes, or the clock measured a page that did not commit.
+
+**Why the scaled quantity is `rendered-rows` and not `B`.** Doubling `B` on the
+windowed arm moves nothing it renders, so that arm's page is its *window* and
+the window is what doubles. This is the mirror image of the fault that refused
+the changed-set control, and it is why no single scaled quantity serves all
+four arms.
 
 **Sabotage control — the topology witness must bite.** The deterministic census
 is itself the sabotage detector for the arms: an arm is planted with a defect
@@ -167,8 +181,16 @@ There is no third disposition, and no cell carries "needs more investigation".
 
 Two halves were attempted and they came back differently, which is the honest
 headline: **the deterministic half is complete at all 48 cells and publishes;
-the clock half does not publish, and the reason is a control, not a judgement
-about the machine.**
+the clock half still publishes no cell, and the reason is a control and a
+missing driver, not a judgement about the machine.**
+
+That second clause has moved once since this page was first published, and
+only part of the way. `rf2-m6i0` replaced the refused control with one that
+**passes on three of the four arms** ([§2.6](#26-the-clock-half--the-first-control-refused-the-replacement-certifies-three-arms-of-four)),
+so *want of a control* no longer withholds `fine`, `coarse` and `chunked`.
+What withholds every cell now is narrower and more ordinary: **the tournament's
+clock cells were never instrumented.** Only the control was built, it refused
+first, and no driver for the 4 arms × 4 operations table exists to run.
 
 ### 2.1 What ran, and on what
 
@@ -176,8 +198,8 @@ about the machine.**
 |---|---|
 | instrument | `implementation/freehand/test/re_frame/bench/hicasso/topo/census_dom_cljs_test.cljs` |
 | substrate | the bench's **arm-1** runtime, not `implementation/hicasso` |
-| witness | `npm run test:browser` (Chromium, real DOM), 1,500 tests / 9,482 assertions, 0 failures / 0 errors |
-| clock control | `topo/control_app.cljs` via the lane's generic `run.cjs` — **run, and refused**; see §2.6 |
+| witness | `npm run test:browser` (Chromium, real DOM), 1,507 tests / 9,533 assertions, 0 failures / 0 errors |
+| clock control | `topo/control_app.cljs` via the lane's generic `run.cjs` — the changed-set form **refused**; its rendered-scale replacement **certifies `fine`, `coarse` and `chunked`, and refuses `virtual`**; see §2.6 |
 | profile | P-DEV-1 |
 | box | `\System\Processor Queue Length` read **0.00** on every sample taken before, during and after both runs |
 
@@ -307,13 +329,15 @@ for the other:
 Closing that gap is `rf2-hic-071`/`rf2-hic-089`'s, since they own turning these
 rows into gates, and it is filed rather than patched here.
 
-### 2.6 The clock half — REFUSED, and on what
+### 2.6 The clock half — the first control refused; the replacement certifies three arms of four
 
-**No clock cell is published. The control was built, run on a verified-quiet
-box, and REFUSED — so the refusal is a measurement, not an opinion about the
-machine.**
+**No clock cell is published, and two different things are responsible at two
+different times.** The control registered first was built, run on a
+verified-quiet box, and REFUSED. Its replacement (`rf2-m6i0`) was built, run on
+a verified-quiet box, and **passes on `fine`, `coarse` and `chunked` while
+refusing `virtual`**. Both are measurements, not opinions about the machine.
 
-#### The run
+#### The first control's run — the changed-set doubling
 
 `topo/control_app.cljs`, driven by the lane's generic `run.cjs`, Chromium
 147.0.7727.15 headless, `:advanced`, `goog.DEBUG false`, 24 threads / 32 GB.
@@ -371,10 +395,69 @@ from any clock: **the control is degenerate on two of the four arms.**
 `coarse` and `chunked` rebuild every row whichever stride runs, so doubling the
 changed set doubles nothing they do. A control predicting 2.00x on those arms
 would refuse a healthy instrument; a control predicting 1.00x on them
-discriminates nothing and certifies nothing. **Either way those two arms have
-no positive control, so no clock figure of theirs may publish** — and since
-every interesting comparison in this tournament crosses between a fine-family
-arm and a coarse-family one, that withholds the clock table entire.
+discriminates nothing and certifies nothing. **Either way those two arms had no
+positive control at all**, and since every interesting comparison in this
+tournament crosses between a fine-family arm and a coarse-family one, that
+withheld the clock table entire.
+
+That table is measured rather than argued, and it stays measured:
+`topo/control_witness_dom_cljs_test.cljs` asserts it as exact integers on every
+PR, so the degeneracy above cannot quietly stop being true.
+
+#### The replacement — the rendered-scale doubling (`rf2-m6i0`)
+
+Same lane, same driver, same box discipline: Chromium 147.0.7727.15 headless,
+`:advanced`, `goog.DEBUG false`, 24 threads / 32 GB, `\System\Processor Queue
+Length` **0.00** on every sample before, during and after. 20 commits under one
+clock, 12 samples × 5 rounds, the two page sizes interleaved in `slot-order`,
+**the arm-order guard `[ok] by predecessor` on all four arms**, and **0
+unverified of 300** probes on all four.
+
+Each arm's page was checked against its own arithmetic before its clock started,
+and each matched exactly — including the rows-of-markup asymmetry the prediction
+rests on, which is where the changed-set control was degenerate:
+
+| arm | boundaries | read edges | elements | markup built per commit |
+|---|---|---|---|---|
+| `fine` | 501 → 1001 | 1001 → 2001 | 2501 → 5001 | 100 → 200 |
+| `coarse` | 1 → 1 | 1 → 1 | 2501 → 5001 | 500 → 1000 |
+| `chunked` | 21 → 41 | 21 → 41 | 2501 → 5001 | 500 → 1000 |
+| `virtual` | 21 → 41 | 41 → 81 | 101 → 201 | 4 → 8 |
+
+| arm | predicted | band | round ratios | verdict |
+|---|---|---|---|---|
+| `fine` | 1.9996 | [1.4997, 2.4995] | 1.9331 / 2.0296 / 2.0856 / 2.2588 / 2.0972 | **PASS** |
+| `coarse` | 1.9996 | [1.4997, 2.4995] | 2.1029 / 2.0024 / 2.0459 / 1.9853 / 2.0877 | **PASS** |
+| `chunked` | 1.9996 | [1.4997, 2.4995] | 2.0236 / 2.0816 / 2.1415 / 2.1876 / 2.1802 | **PASS** |
+| `virtual` | 1.9901 | [1.4926, 2.4876] | 1.5490 / 1.5577 / 1.5200 / 1.4600 / 1.5111 | **REFUSED ON THE BAND** |
+
+Exit code **1**, captured from the runner itself — a control that refuses any
+arm refuses the run.
+
+**The diagnosis of the first refusal is confirmed by the third arm here.**
+`fine` is the one arm both controls could address, and it moved from 1.325–1.471
+under the changed-set form to 1.9331–2.2588 under this one. The only thing that
+changed is that the handler and the subscription layer now scale with the
+manipulation instead of standing still. That is the shared constant term being
+removed, watched directly.
+
+**Why `virtual` refuses, and why it is not the same fault.** Its ratios are
+tight (1.46–1.5577 across five rounds), correctly signed, guard-clean and
+fully verified — a stable signal that is not 1.99, exactly as the first refusal
+was. But its cause is the clock rather than the model: the windowed arm's whole
+commit is **0.125 ms** at `w = 20` and **0.195 ms** at `w = 40`, which is one
+to two of Chrome's 100 µs `performance.now()` quanta. The per-commit floor —
+dispatch, the `flushSync` boundary, the commit React schedules regardless — does
+not double, and on a commit this small it is a large fraction of the reading.
+Its *work* doubles exactly (4 → 8 rows of markup, 21 → 41 boundaries, 41 → 81
+read edges); the instrument cannot resolve that at this size.
+
+**Nothing is widened and nothing is re-derived.** `virtual`'s band was
+registered before the run, from the same `elements-for` arithmetic as the other
+three, and it stands. The windowed arm's clock cells remain unpublished and the
+arm needs a different instrument — a larger window, or many more operations
+under one clock — which is filed rather than attempted here, because adding a
+rung between runs would make the series two instruments.
 
 This sits on top of a refusal the lane already carried, which this window
 verified rather than assumed:

--- a/implementation/freehand/test/re_frame/bench/hicasso/topo/arms.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/topo/arms.cljs
@@ -176,13 +176,14 @@
   `:boundaries` counts registrations holding at least one read edge — the
   list plus, per arm, its row or chunk boundaries. A `coarse` page is one
   boundary because there is nothing beneath it holding a read."
-  [arm b]
-  (let [rendered (m/rendered-rows arm b)]
-    {:rendered-rows rendered
-     :elements      (m/elements-for rendered)
-     :edges         (inc (m/memberships arm b))
-     :boundaries    (case arm
-                      :fine    (inc b)
-                      :coarse  1
-                      :chunked (inc (long (Math/ceil (/ b m/chunk-size))))
-                      :virtual (inc (min b m/window-size)))}))
+  ([arm b] (expected arm b m/window-size))
+  ([arm b w]
+   (let [rendered (m/rendered-rows arm b w)]
+     {:rendered-rows rendered
+      :elements      (m/elements-for rendered)
+      :edges         (inc (m/memberships arm b w))
+      :boundaries    (case arm
+                       :fine    (inc b)
+                       :coarse  1
+                       :chunked (inc (long (Math/ceil (/ b m/chunk-size))))
+                       :virtual (inc (min b w)))})))

--- a/implementation/freehand/test/re_frame/bench/hicasso/topo/control_app.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/topo/control_app.cljs
@@ -1,6 +1,8 @@
 (ns re-frame.bench.hicasso.topo.control-app
-  "**THE TOURNAMENT'S CLOCK CONTROL** — the changed-set doubling
-  `rf2-7iqb5` prescribed and nobody built (rf2-hic-036).
+  "**THE TOURNAMENT'S CLOCK CONTROL** — one positive control per arm, each
+  doubling the quantity THAT arm's commit cost is proportional to
+  (rf2-m6i0, replacing the changed-set control rf2-hic-036 built and
+  refused).
 
   Driven by the lane's generic driver, so it adds no driver of its own:
 
@@ -26,48 +28,124 @@
   refuses, the tournament's clock half refuses with it and the cells are
   never taken — which is a result, not a failure.
 
-  ## The control, and why it is not the one this lane already had
+  ## THE TWO CONTROLS THIS ONE REPLACES, AND THE ONE FAULT THEY SHARE
 
-  Every earlier positive control for an update row **scaled the page**.
-  `rf2-7iqb5` records precisely why that cannot certify one: on an update
-  row the work does not scale with the page, so even a perfect instrument
-  reads below the predicted factor — and its own run failed high at
-  13.696 / 13.583 / 13.112x against a registered 8–13x band.
+  Both predecessors were correct about their own arm and degenerate
+  elsewhere, and the reason is the same in both directions: **a
+  manipulation certifies an instrument only when EVERY cost in the
+  measured window moves with it.** Whatever does not move is a shared
+  constant, and a shared constant compresses the measured ratio toward 1
+  — which reads exactly like an instrument that cannot see.
 
-  Its prescribed repair is this one: **hold page size fixed and double
-  the CHANGED SET.** Element count, layout and paint are then constant
-  between the two halves, and only commit-side work moves.
+  1. **Page-scaling** (every control this lane had before `rf2-7iqb5`).
+     Refused for update rows in general, and rightly: on an update row
+     the work does not scale with the page, so even a perfect instrument
+     reads below the prediction. `rf2-7iqb5`'s own run failed high at
+     13.696 / 13.583 / 13.112x against a registered 8–13x band.
+
+  2. **Changed-set doubling** (`rf2-7iqb5`'s prescribed repair, built by
+     `rf2-hic-036` over `:topo/bump-stride`). Hold the page fixed, double
+     the changed set, predict 2.00x. It was **degenerate on `coarse` and
+     `chunked`**, which rebuild every row whichever stride runs — and it
+     **REFUSED on `fine`**, the arm where its markup arithmetic is not
+     degenerate, measuring 1.331 / 1.387 / 1.424 / 1.471 / 1.325 against
+     a [1.60, 2.50] band on a quiet box with the order guard clean.
+
+     `rf2-m6i0`'s diagnosis of that refusal is the design input for this
+     file. Three costs sat in the measured window and only ONE doubled:
+     `:topo/bump-stride` `reduce-kv`s the whole thousand-row table at
+     both strides, the subscription layer answers for every row at both
+     strides, and only the 100→200 rows of markup actually doubled. The
+     page-scaling failure had reappeared *inside the control built to
+     replace it*.
+
+  ## THE REPAIR: double the arm's RENDERED PAGE, with an INDEXED write
+
+  Two changes, and each one closes one of the two leaks above.
+
+  **The write is indexed.** `:topo/bump-indexed` `update-in`s the rows it
+  moves instead of rebuilding the table, so the handler costs
+  `limit/stride` rather than `B`. That is the diagnosis's first
+  condition: the event handler now costs in proportion to the changed
+  set.
+
+  **The manipulation scales the arm's own rendered page.** With the page
+  doubled, the subscription layer and the render both double as well —
+  the diagnosis's second condition — because there are twice as many rows
+  to answer for and twice as many to build. Page-scaling is invalid for
+  an update row *in general*, exactly as `rf2-7iqb5` says; it is valid
+  HERE because the manipulation doubles the changed set too. Nothing in
+  the window is held constant, which is precisely what the two refused
+  controls each got wrong from opposite ends.
+
+  ## WHY THE SCALED QUANTITY IS `rendered-rows` AND NOT `B`
+
+  One rule, four instantiations, and the fourth is why the rule is stated
+  in terms of `model/rendered-rows` rather than `B`:
+
+  | arm | scaled | small → large | rendered |
+  |---|---|---|---|
+  | `fine` | `B` | 500 → 1000 | 500 → 1000 |
+  | `coarse` | `B` | 500 → 1000 | 500 → 1000 |
+  | `chunked` | `B` | 500 → 1000 | 500 → 1000 |
+  | `virtual` | `w` | 20 → 40 | 20 → 40 |
+
+  **Doubling `B` on the windowed arm is degenerate** — it renders `w`
+  rows however large the table is, so its subscription layer, its markup
+  and its DOM would all be constant across the manipulation and only the
+  handler would move. That arm's page is its WINDOW, and doubling the
+  window is the same control applied to the page the arm actually has.
+  This is the mirror image of the changed-set control's degeneracy on
+  `coarse`/`chunked`, and it is the reason no single scaled quantity can
+  serve all four arms.
 
   ## The predicted factor is DERIVED, never assumed to be 2.00
 
-  This is the half a flat prediction gets wrong, and this lane already
-  knows it: `census_clock_arms/ctl-predicted` computes 1.9759 / 1.9944 /
-  1.7255 from element arithmetic rather than printing 2.00, because the
-  page chrome does not double.
+  `census_clock_arms/ctl-predicted` computes 1.9759 / 1.9944 / 1.7255
+  from element arithmetic rather than printing 2.00, because the page
+  chrome does not double. The same discipline here, against the same
+  committed function: the prediction is the ratio of
+  [[re-frame.bench.hicasso.topo.model/elements-for]] at the two rendered
+  row counts, and the `ul` that does not double is why it is 1.9996 and
+  1.9901 rather than 2.
 
-  Here the same care lands somewhere sharper. The predicted factor is the
-  ratio of **rows of markup built**, which the deterministic census
-  measures as exact integers, and it is *arm-specific*:
-
-  | arm | markup at stride 10 | at stride 5 | predicted |
-  |---|---|---|---|
-  | `fine` | `B/10` | `B/5` | **2.00** |
-  | `coarse` | `B` | `B` | **1.00 — degenerate** |
-  | `chunked` (k=25) | `B` | `B` | **1.00 — degenerate** |
-
-  `coarse` and `chunked` rebuild every row whichever stride runs, so
-  their changed-set control **cannot discriminate at all**. That is a
-  fact about those topologies, not about the instrument, and it is why
-  this file certifies on `fine` alone and says so rather than quietly
-  averaging a null control into a pass.
+  The band is the lane's standing `CONTROL_SLACK` of ±25%
+  (`shapes/census_clock_run.cjs`) under its strict rule — EVERY round
+  inside, so one bad round refuses rather than being averaged away.
+  **This is not a widening**: ±25% of 1.9996 floors at 1.4997, and the
+  refused changed-set run measured 1.331–1.471. The band that admits this
+  control still refuses that one.
 
   ## The sign rule, which is the fix that landed in PR #7634
 
-  A band alone admits a control certifying that MORE DIRTY WORK READS
-  FASTER: `rf2-7iqb5` proved it live, capturing `num=-1.194 den=-0.594
+  A band alone admits a control certifying that MORE WORK READS FASTER:
+  `rf2-7iqb5` proved it live, capturing `num=-1.194 den=-0.594
   measured=2.0101x band=[1.5076,2.5126] ok=TRUE` against a decreasing
-  fixture. [[verdict]] therefore requires the measured difference to be
-  positive as well as in band, and refuses on the sign."
+  fixture. [[verdict]] therefore requires the measured ratio to exceed
+  1.0 in every round as well as sit in band, and refuses on the sign.
+
+  ## The read-back, which the predecessor claimed and did not perform
+
+  Its `window!` said the clock stops after the last drain and *\"the
+  read-back happens afterwards\"*, and then returned elapsed time without
+  reading anything (rf2-m6i0's audit of PR #8160). A control that never
+  looks at the page can adjudicate a no-op from event and subscription
+  work alone.
+
+  So every window here banks TWO cell-addressed probes into
+  `lane/tally`, outside the clock, and [[lane/assert-verified!]] — the
+  lane's one meaning of *verified* — turns any miss into a throw and a
+  non-zero exit:
+
+      row 5   CHANGED    n must have advanced by exactly one per commit
+      row 6   UNCHANGED  n must still read its seed value
+
+  The unchanged probe is the half that makes the pair load-bearing: a
+  write that reached every row, or a page rebuilt from a stale seed,
+  passes the changed probe alone. Both are addressed by their own
+  `data-testid`, so neither can be satisfied by a neighbour's commit.
+  `topo/control_witness_dom_cljs_test` mounts a real arm, withholds the
+  commit, and asserts this refuses."
   (:require [re-frame.adapter.uix :as uix-adapter]
             [re-frame.bench.hicasso.arm1.mount :as mount]
             [re-frame.bench.hicasso.arm1.runtime :as rt]
@@ -77,12 +155,43 @@
             [re-frame.core :as rf]))
 
 ;; ---------------------------------------------------------------------------
-;; Pre-registered, and matching `topology-tournament.md` §1.5 exactly
+;; Pre-registered — the whole of the control's arithmetic, before any run
 ;; ---------------------------------------------------------------------------
 
-(def band
-  "Registered before the run: predicted 2.00x, admitted in [1.60, 2.50]."
-  {:lo 1.60 :hi 2.50 :predicted 2.00})
+(def scale
+  "The factor the control multiplies the arm's rendered page by. Two,
+  because a control's claim is `THE INSTRUMENT HAS SIGNAL` and two is the
+  smallest factor that is unambiguously signal."
+  2)
+
+(def stride
+  "Every `stride`-th rendered row moves. A STATED CONSTANT, held at both
+  halves of the manipulation — this control does not vary it, which is
+  the entire difference from the changed-set control it replaces.
+
+  Five, and not one: rows that do NOT move are what the unchanged probe
+  reads, and a write touching every row would leave nothing to read. It
+  is below [[re-frame.bench.hicasso.topo.model/chunk-size]] so that every
+  chunk of the chunked arm contains a moved row at both page sizes, which
+  is what keeps that arm's markup proportional to its page."
+  5)
+
+(def base-rows
+  "`B` for the un-windowed arms' SMALL page; the large page is twice it,
+  landing on 1000 — the tournament's own largest size, so the control is
+  taken in the regime the clock table most wants to publish."
+  500)
+
+(def base-window
+  "`w` for the windowed arm's SMALL page — the committed
+  [[re-frame.bench.hicasso.topo.model/window-size]] — with the large page
+  at twice it. `B` is held at [[virtual-rows]] throughout, so the ONLY
+  thing that moves for this arm is the size of the page it renders."
+  m/window-size)
+
+(def virtual-rows
+  "The table the windowed arm windows. Fixed across its manipulation."
+  1000)
 
 (def sampling {:warmup 3 :samples 12})
 (def rounds 5)
@@ -99,104 +208,347 @@
   separately-clamped readings."
   20)
 
-(def row-count
-  "The control runs at the tournament's largest size, because that is
-  where a difference statistic has the most room and where a refusal is
-  therefore most informative."
-  1000)
+(def slack
+  "The lane's standing `CONTROL_SLACK` (`shapes/census_clock_run.cjs`),
+  applied to a DERIVED prediction under the strict every-round rule."
+  0.25)
+
+(def changed-probe
+  "A row the write moves — `(mod changed-probe stride)` is zero. Rendered
+  by all four arms at both page sizes, which is what makes it a probe
+  rather than four probes."
+  5)
+
+(def unchanged-probe
+  "A row the write does not move. Also rendered by every arm at both
+  sizes, and adjacent to [[changed-probe]] so that a page which rebuilt
+  the wrong region fails one of the two."
+  6)
+
+(defn sizes
+  "The two pages `arm`'s control mounts, small first, as `{:b :w}`.
+
+  The windowed arm scales `w`; every other arm scales `b`. See the
+  namespace docstring for why that is forced rather than chosen."
+  [arm]
+  (if (= :virtual arm)
+    [{:b virtual-rows :w base-window}
+     {:b virtual-rows :w (* scale base-window)}]
+    [{:b base-rows :w m/window-size}
+     {:b (* scale base-rows) :w m/window-size}]))
+
+(defn rendered-of
+  "How many rows `arm` renders on page `size` — the control's scale
+  parameter, read from the model rather than restated here."
+  [arm {:keys [b w]}]
+  (m/rendered-rows arm b w))
+
+(defn predicted
+  "`arm`'s predicted factor, from `model/elements-for` at the two rendered
+  row counts.
+
+  Not 2.00: the `ul` does not double. 1.9996 for the un-windowed arms
+  (5001/2501) and 1.9901 for the windowed one (201/101)."
+  [arm]
+  (let [[small large] (sizes arm)]
+    (/ (m/elements-for (rendered-of arm large))
+       (m/elements-for (rendered-of arm small)))))
+
+(defn band-of
+  "`arm`'s registered band — ±[[slack]] of its own [[predicted]]."
+  [arm]
+  (let [p (predicted arm)]
+    {:predicted p :lo (* p (- 1.0 slack)) :hi (* p (+ 1.0 slack))}))
+
+(defn markup-expected
+  "The rows of markup a single commit builds on `arm`'s page `size` —
+  exact integers, and the DETERMINISTIC half of this control's claim.
+
+  `fine` and `virtual` rebuild only the rows the indexed write moved.
+  `coarse` rebuilds its whole view-model and `chunked` rebuilds every
+  chunk, because [[stride]] is below `chunk-size` so no chunk is spared.
+  All four are therefore proportional to the arm's rendered page, which
+  is what [[run-arm!]] checks BEFORE it starts a clock."
+  [arm size]
+  (let [rendered (rendered-of arm size)]
+    (case arm
+      (:fine :virtual) (long (Math/ceil (/ rendered stride)))
+      (:coarse :chunked) rendered)))
 
 ;; ---------------------------------------------------------------------------
-;; The arms — two strides on ONE page size, interleaved
-;; ---------------------------------------------------------------------------
-
-(def ^:private frame-id ::control)
-
-(defn- window!
-  "`batch-k` commits under one clock. The clock stops after the last
-  drain; the read-back happens afterwards, which is the batched shape
-  `lane/verified-writes!` documents."
-  [stride]
-  (let [t0 (lane/now-ms)]
-    (dotimes [_ batch-k]
-      (rt/dispatch! frame-id [:topo/bump-stride stride])
-      (mount/settle!))
-    (- (lane/now-ms) t0)))
-
-(def arms
-  "Two arms, one page. `:d10` moves every 10th row, `:d5` every 5th — so
-  the changed set doubles and nothing else does."
-  [{:id :d10 :stride 10}
-   {:id :d5  :stride 5}])
-
-;; ---------------------------------------------------------------------------
-;; The verdict
+;; The verdict — pure, and exported for its own exit-path test
 ;; ---------------------------------------------------------------------------
 
 (defn verdict
-  "Adjudicate the control. STRICT: in band AND positive in sign, on the
-  ROUND-WISE ratios rather than on a pooled mean, so one round outside
-  the band refuses the control rather than being averaged away.
+  "Adjudicate one arm's control. STRICT on three counts, any of which
+  refuses:
 
-  Pure, and exported for its own exit-path test — the gate arithmetic has
-  to be checkable without a headless Chromium."
-  [round-ratios]
-  (let [rs      (vec round-ratios)
+  - **in band**, round-wise rather than pooled, so one bad round refuses
+    instead of being averaged away (`census_clock_run/controlVerdict`'s
+    rule, and the stricter half of `lane/control-verdict`'s known defect);
+  - **positive in sign**, which is PR #7634's fix — a band alone admits a
+    control certifying that more work reads faster;
+  - **verified**, which is the audit obligation on this file: `0
+    unverified of M` probes, or the numbers describe a page nobody read.
+
+  Pure, and exported so the gate arithmetic is checkable without a
+  headless Chromium."
+  [arm round-ratios {:keys [writes unverified] :as verification}]
+  (let [{:keys [predicted lo hi]} (band-of arm)
+        rs      (vec round-ratios)
         every?* (fn [p] (and (seq rs) (every? p rs)))
-        in-band (every?* (fn [r] (and (>= r (:lo band)) (<= r (:hi band)))))
-        signed  (every?* (fn [r] (> r 1.0)))]
-    {:rounds    rs
-     :predicted (:predicted band)
-     :band      [(:lo band) (:hi band)]
-     :in-band?  in-band
-     :positive? signed
-     :ok?       (boolean (and in-band signed))
-     :why       (cond
-                  (empty? rs)   "no rounds — a control that measured nothing cannot certify anything"
-                  (not signed)  "REFUSED ON THE SIGN — a round read the doubled changed set as no slower, which is a control certifying that more dirty work costs less"
-                  (not in-band) "REFUSED ON THE BAND — a round fell outside [1.60, 2.50] around the derived 2.00"
-                  :else         "in band and positive in every round")}))
+        in-band (every?* (fn [r] (and (>= r lo) (<= r hi))))
+        signed  (every?* (fn [r] (> r 1.0)))
+        clean   (and (pos? (long (or writes 0))) (zero? (long (or unverified 0))))]
+    {:arm          arm
+     :rounds       rs
+     :predicted    (lane/round4 predicted)
+     :band         [(lane/round4 lo) (lane/round4 hi)]
+     :verification verification
+     :in-band?     in-band
+     :positive?    signed
+     :verified?    clean
+     :ok?          (boolean (and in-band signed clean))
+     :why          (cond
+                     (empty? rs)   "no rounds — a control that measured nothing cannot certify anything"
+                     (not clean)   (str "REFUSED ON THE READ-BACK — " (or unverified 0)
+                                        " unverified of " (or writes 0)
+                                        " probes; the clock measured a page that did not commit what it claims")
+                     (not signed)  "REFUSED ON THE SIGN — a round read the doubled page as no slower, which is a control certifying that more work costs less"
+                     (not in-band) (str "REFUSED ON THE BAND — a round fell outside ["
+                                        (lane/round4 lo) ", " (lane/round4 hi) "] around the derived "
+                                        (lane/round4 predicted))
+                     :else         "in band, positive and verified in every round")}))
+
+;; ---------------------------------------------------------------------------
+;; One measured window
+;; ---------------------------------------------------------------------------
+
+(defn n-at
+  "The `n` cell of row `i` inside `container`, as text, or nil.
+
+  Cell-addressed by `data-testid`, not by the row's `data-i`: the row's
+  own text node concatenates label, `n`, draft and the button's caption,
+  so a probe reading it could be satisfied by any of them moving."
+  [container i]
+  (some-> (.querySelector container (str "[data-testid=\"n-" i "\"]")) (.-textContent)))
+
+(defn probe-misses
+  "Which of the two probes `container` fails, given `commits` commits of
+  [[stride]]-indexed writes since the seed. A seq of maps, empty when the
+  page committed what it claims.
+
+  Pure arithmetic over the model's own seed: row `i`'s `n` starts at
+  `(:n (model/row i))`, and the changed probe advances by exactly one per
+  commit because the write is an `inc`."
+  [container commits]
+  (let [want-changed   (str (+ (:n (m/row changed-probe)) commits))
+        want-unchanged (str (:n (m/row unchanged-probe)))]
+    (remove nil?
+            [(let [got (n-at container changed-probe)]
+               (when-not (= want-changed got)
+                 {:probe :changed :row changed-probe :want want-changed :got got}))
+             (let [got (n-at container unchanged-probe)]
+               (when-not (= want-unchanged got)
+                 {:probe :unchanged :row unchanged-probe :want want-unchanged :got got}))])))
+
+(defn window!
+  "`batch-k` commits under ONE clock, then — with the clock stopped — read
+  the two probes back and BANK them in `t`.
+
+  The read-back is outside the window and after the last drain, which is
+  the batched shape [[lane/verified-writes!]] documents and defends: no
+  macrotask runs between the first write and the last drain, so a commit
+  React has parked cannot land inside the window however many microtasks
+  pass. What the batch relaxes is microtask-scale lateness, on a
+  tolerance the unbatched window already grants.
+
+  Answers the elapsed milliseconds for the whole batch. `committed` is
+  the page's running commit count, which the probe arithmetic needs and
+  which is why it is a page-scoped atom rather than a local."
+  [t {:keys [frame-id container limit committed]}]
+  (let [t0 (lane/now-ms)]
+    (dotimes [_ batch-k]
+      (rt/dispatch! frame-id [:topo/bump-indexed limit stride])
+      (mount/settle!))
+    (let [ms     (- (lane/now-ms) t0)
+          total  (swap! committed + batch-k)
+          misses (probe-misses container total)]
+      ;; `lane/verified-writes!`'s own `bank!`, over this control's probes:
+      ;; one tally, one meaning of "verified", one `assert-verified!`.
+      (swap! t (fn [{:keys [of bad]}]
+                 {:of (+ of 2) :bad (+ bad (count misses))}))
+      (when (seq misses)
+        (js/console.error (str ";; PROBE MISS — " (pr-str misses))))
+      ms)))
+
+;; ---------------------------------------------------------------------------
+;; One arm's control
+;; ---------------------------------------------------------------------------
+
+(def ^:private frame-ids
+  (into {} (for [arm arms/arm-ids tag [:small :large]]
+             [[arm tag] (keyword "topo.control" (str (name arm) "-" (name tag)))])))
+
+(defn- mount-page!
+  "Seed a frame at `size`, mount `arm` over it, and answer the page map
+  the rest of this file passes around."
+  [arm tag size]
+  (let [{:keys [b w]} size
+        frame-id (get frame-ids [arm tag])]
+    (m/make-frame! frame-id b w)
+    (m/reseed! frame-id b w)
+    (let [handle (mount/root! (mount/fresh-container!) frame-id [(arms/view-of arm) {}])]
+      {:tag       tag
+       :size      size
+       :frame-id  frame-id
+       :handle    handle
+       :container (:container handle)
+       :limit     (rendered-of arm size)
+       :committed (atom 0)})))
+
+(defn- structure-of
+  "`page`'s own structure. `:boundaries` and `:edges` come from a DELTA
+  against the runtime's live table, because two pages are mounted at once
+  and `rt/stats` counts every live cell in the process rather than one
+  container's."
+  [page before]
+  (let [{:keys [boundaries edges]} (rt/stats)
+        container (:container page)]
+    {:boundaries    (- boundaries (:boundaries before))
+     :edges         (- edges (:edges before))
+     :elements      (lane/element-count container)
+     :rendered-rows (.-length (.querySelectorAll container "li.topo-row"))}))
+
+(defn- markup-of
+  "Rows of markup ONE commit builds on `page` — measured, on the counters,
+  outside every clock. The control refuses if this disagrees with
+  [[markup-expected]], which is how a page that is not doing the work its
+  arithmetic predicts is caught BEFORE a clock reads it."
+  [arm page]
+  (arms/reset-counters!)
+  (rt/dispatch! (:frame-id page) [:topo/bump-indexed (:limit page) stride])
+  (mount/settle!)
+  (swap! (:committed page) inc)
+  (:markup (arms/runs)))
+
+(defn run-arm!
+  "One arm's whole control: mount both pages, check each is the arm it
+  claims, check the work asymmetry the prediction rests on, then
+  interleave the two under the clock.
+
+  Answers `{:verdict :per-round :structure :markup :guard}`. Both pages
+  are released before the next arm mounts, so the document holds one
+  arm's two pages and never eight."
+  [arm]
+  (let [[small large] (sizes arm)
+        t      (lane/tally)
+        base   (rt/stats)
+        p-s    (mount-page! arm :small small)
+        st-s   (structure-of p-s base)
+        mid    (rt/stats)
+        p-l    (mount-page! arm :large large)
+        st-l   (structure-of p-l mid)
+        want-s (select-keys (arms/expected arm (:b small) (:w small))
+                            [:boundaries :edges :elements :rendered-rows])
+        want-l (select-keys (arms/expected arm (:b large) (:w large))
+                            [:boundaries :edges :elements :rendered-rows])]
+    (try
+      (cond
+        (not= want-s st-s)
+        {:fatal (str arm "'s SMALL page is not the arm it claims: expected "
+                     (pr-str want-s) ", mounted " (pr-str st-s))}
+
+        (not= want-l st-l)
+        {:fatal (str arm "'s LARGE page is not the arm it claims: expected "
+                     (pr-str want-l) ", mounted " (pr-str st-l))}
+
+        :else
+        (let [mk-s (markup-of arm p-s)
+              mk-l (markup-of arm p-l)
+              want-mk-s (markup-expected arm small)
+              want-mk-l (markup-expected arm large)]
+          (if (or (not= mk-s want-mk-s) (not= mk-l want-mk-l))
+            {:fatal (str arm "'s commit does not build the markup its arithmetic "
+                         "predicts, so the prediction the clock is about to be judged "
+                         "against is not this page's: expected small=" want-mk-s
+                         " large=" want-mk-l ", built small=" mk-s " large=" mk-l)}
+            (let [pages {:small p-s :large p-l}
+                  {:keys [readings samples]}
+                  (lane/rounds! [{:id :small} {:id :large}]
+                                sampling rounds
+                                (fn [a] (window! t (get pages (:id a))))
+                                (fn [a] (str (name arm) "-" (name (:id a)))))
+                  ratios (mapv (fn [r]
+                                 (let [p (fn [id] (:p50 (lane/summarise (get r id))))]
+                                   (lane/round4 (/ (p :large) (p :small)))))
+                               readings)
+                  ;; PUBLISHED BEFORE ADJUDICATED: `assert-verified!` throws, and
+                  ;; the evidence a reader needs has to be on the console first.
+                  vv     (lane/tally-value t)
+                  v      (verdict arm ratios vv)
+                  gv     (lane/guard! samples (str "topo rendered-scale control (" (name arm) ")"))]
+              {:verdict   v
+               :guard     gv
+               :structure {:small st-s :large st-l}
+               :markup    {:small mk-s :large mk-l
+                           :ratio (lane/round4 (/ mk-l mk-s))}
+               :per-round (mapv (fn [r] {:small (lane/summarise (get r :small))
+                                         :large (lane/summarise (get r :large))})
+                                readings)
+               :tally     t}))))
+      (finally
+        (mount/release! (:handle p-s))
+        (mount/release! (:handle p-l))))))
 
 ;; ---------------------------------------------------------------------------
 ;; The run
 ;; ---------------------------------------------------------------------------
-
-(defn- round-ratio [reading]
-  (let [p (fn [id] (:p50 (lane/summarise (get reading id))))]
-    (/ (p :d5) (p :d10))))
 
 (defn ^:export -main []
   (rf/init! uix-adapter/adapter)
   (lane/leave-act-environment!)
   (lane/self-test!)
   (try
-    (m/make-frame! frame-id row-count)
-    (m/reseed! frame-id row-count)
-    (arms/reset-counters!)
-    (let [handle (mount/root! (mount/fresh-container!) frame-id [(arms/view-of :fine) {}])
-          struct {:boundaries (:boundaries (rt/stats))
-                  :edges      (:edges (rt/stats))
-                  :elements   (lane/element-count (:container handle))}
-          want   (select-keys (arms/expected :fine row-count) [:boundaries :edges :elements])]
-      (lane/record! :page (assoc struct :expected want))
-      (if (not= want struct)
-        (do (set! (.-HICASSO_CONTROL_FAILED js/window) true)
-            (lane/fail! (str "the control's page is not the arm it claims: expected "
-                             (pr-str want) ", mounted " (pr-str struct))))
-        (let [{:keys [readings samples]}
-              (lane/rounds! arms sampling rounds (fn [{:keys [stride]}] (window! stride)))
-              ratios (mapv round-ratio readings)
-              v      (verdict ratios)
-              gv     (lane/guard! samples "topo changed-set control (fine, B=1000)")]
-          (lane/record! :runtime (lane/runtime-label))
-          (lane/record! :batch-k batch-k)
-          (lane/record! :per-round (mapv (fn [r] {:d10 (lane/summarise (get r :d10))
-                                                  :d5  (lane/summarise (get r :d5))}) readings))
-          (lane/record! :control v)
-          (when (:refuse? gv) (set! (.-HICASSO_GUARD_REFUSED js/window) true))
-          (when-not (:ok? v)
-            (set! (.-HICASSO_CONTROL_FAILED js/window) true)
-            (js/console.error (str ";; CONTROL REFUSED — " (:why v))))
-          (mount/release! handle))))
+    (lane/record! :design
+                  {:scale scale :stride stride :batch-k batch-k
+                   :rounds rounds :sampling sampling :slack slack
+                   :probes {:changed changed-probe :unchanged unchanged-probe}
+                   :arms (into {} (map (fn [arm]
+                                         (let [[s l] (sizes arm)]
+                                           [arm {:small s :large l
+                                                 :rendered [(rendered-of arm s) (rendered-of arm l)]
+                                                 :markup [(markup-expected arm s) (markup-expected arm l)]
+                                                 :band (band-of arm)}])))
+                                 arms/arm-ids)})
+    (lane/record! :runtime (lane/runtime-label))
+    (let [results (reduce
+                    (fn [acc arm]
+                      (let [r (run-arm! arm)]
+                        (if-let [f (:fatal r)]
+                          (do (set! (.-HICASSO_CONTROL_FAILED js/window) true)
+                              (lane/fail! f)
+                              (reduced (assoc acc arm {:fatal f})))
+                          (do (lane/record! (keyword (str "control-" (name arm)))
+                                            (select-keys r [:verdict :structure :markup :per-round]))
+                              (when (:refuse? (:guard r))
+                                (set! (.-HICASSO_GUARD_REFUSED js/window) true))
+                              (when-not (:ok? (:verdict r))
+                                (set! (.-HICASSO_CONTROL_FAILED js/window) true)
+                                (js/console.error (str ";; CONTROL REFUSED (" (name arm) ") — "
+                                                       (:why (:verdict r)))))
+                              ;; The lane's ONE adjudication of a read-back. It throws,
+                              ;; and it is called AFTER the record above is published.
+                              (lane/assert-verified! (:tally r)
+                                                     (str "topo rendered-scale control (" (name arm) ")"))
+                              (assoc acc arm (:verdict r))))))
+                    {}
+                    arms/arm-ids)]
+      (lane/record! :summary
+                    (into {} (map (fn [[arm v]]
+                                    [arm (select-keys v [:predicted :band :rounds :ok? :why])]))
+                          results)))
     (catch :default e
-      (lane/fail! (str "topo control threw: " (.-message e)))))
+      (set! (.-HICASSO_CONTROL_FAILED js/window) true)
+      (lane/fail! (str "topo control threw: " (or (ex-message e) (.-message e))))))
   (lane/done!))

--- a/implementation/freehand/test/re_frame/bench/hicasso/topo/control_witness_dom_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/topo/control_witness_dom_cljs_test.cljs
@@ -1,0 +1,288 @@
+(ns re-frame.bench.hicasso.topo.control-witness-dom-cljs-test
+  "**THE CONTROL'S OWN DETERMINISTIC HALF** — why the changed-set control
+  was degenerate, why the rendered-scale one is not, and the witness in
+  which its read-back refuses (rf2-m6i0).
+
+  ## Why this file needs no quiet box, and the clock run does
+
+  [The budgets page](../../../../../../../docs/design/hicasso/product/budgets.md)
+  sorts performance rows into two families, and its own sentence is the
+  fence: a counter *\"reads the same on a loaded box\"*. Everything
+  asserted here is an integer on a monotone counter or a string read out
+  of the DOM, so contention cannot move any of it. This file is an
+  ordinary blocking gate that runs in CI on every PR and is repeatable by
+  anyone.
+
+  What it establishes is exactly the half a clock session cannot
+  establish for itself:
+
+  1. **The degeneracy premise, at source.** `:topo/bump-stride` — the
+     write the refused control used — builds the same rows of markup at
+     stride 10 and stride 5 on `coarse` and `chunked`. The claim that
+     those two arms had no positive control is a MEASUREMENT here, not an
+     argument, and it stays measured.
+  2. **The replacement discriminates on all four arms**, in exact
+     integers, before any clock is started.
+  3. **The read-back bites.** A page whose writes do not commit is
+     mounted for real and the control refuses it.
+
+  It is **not** a substitute for the clock. Whether the instrument can
+  SEE the asymmetry counted here is a timing question and belongs to the
+  quiet-box run.
+
+  ## The non-commit witness is a real page, not a patched file
+
+  A planted source fault proves the source changed; it does not prove the
+  runtime observed the plant. So the witness below mounts a real arm and
+  drives [[re-frame.bench.hicasso.topo.control-app/window!]] itself — the
+  same function the clock run calls, banking into the same
+  `lane/tally` — with the ONE difference that the write's `limit` is
+  zero, so `(range 0 0 stride)` is empty and no row moves. Everything
+  else is the control: twenty dispatches, twenty settles, one clock, and
+  the probes read afterwards. There is nothing to restore and nothing to
+  hash.
+
+  Runtime: `-dom-cljs-test`. Under `:node-test` every claim degrades to a
+  stated skip."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [re-frame.adapter.uix :as uix-adapter]
+            [re-frame.bench.hicasso.arm1.mount :as mount]
+            [re-frame.bench.hicasso.arm1.runtime :as rt]
+            [re-frame.bench.hicasso.lane :as lane]
+            [re-frame.bench.hicasso.topo.arms :as arms]
+            [re-frame.bench.hicasso.topo.control-app :as ctl]
+            [re-frame.bench.hicasso.topo.model :as m]
+            [re-frame.test-support :as test-support]))
+
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture
+    {:adapter       uix-adapter/adapter
+     :ambient-frame nil
+     :async?        true
+     :init-fn       (fn [] (rt/reset-runtime!))}))
+
+(defn- skip! [why]
+  (is true (str "the topology control witness needs a real React DOM — " why)))
+
+(def ^:private frame-id ::witness)
+
+(defn- fresh! [b w]
+  (lane/leave-act-environment!)
+  (m/make-frame! frame-id b w)
+  (m/reseed! frame-id b w)
+  (arms/reset-counters!)
+  frame-id)
+
+(defn- reseed! [b w]
+  (rt/dispatch! frame-id [:topo/seed b w])
+  (mount/settle!)
+  (arms/reset-counters!)
+  nil)
+
+(defn- markup-caused-by
+  "Rows of markup ONE dispatch of `event` builds on a standing mount."
+  [event]
+  (arms/reset-counters!)
+  (rt/dispatch! frame-id event)
+  (mount/settle!)
+  (:markup (arms/runs)))
+
+;; ---------------------------------------------------------------------------
+;; 1 — the degeneracy premise, measured rather than asserted
+;; ---------------------------------------------------------------------------
+
+(def ^:private premise-b
+  "The premise is about the SHAPE of each arm's response, which is the
+  same at every row count, so it is measured at the cheapest one."
+  100)
+
+(deftest the-changed-set-control-is-degenerate-on-the-coarse-family
+  (testing "rf2-hic-036 built rf2-7iqb5's prescribed changed-set doubling over
+           `:topo/bump-stride` and predicted 2.00x. This is the measurement
+           that says it could never have certified two of the four arms:
+           `coarse` and `chunked` rebuild every rendered row whichever stride
+           runs, so doubling the changed set doubles nothing they do. A
+           control predicting 2.00x there refuses a healthy instrument; one
+           predicting 1.00x discriminates nothing"
+    (if-not (mount/browser?)
+      (skip! ":node-test has no DOM")
+      (doseq [arm arms/arm-ids]
+        (fresh! premise-b m/window-size)
+        (let [handle (mount/root! (mount/fresh-container!) frame-id [(arms/view-of arm) {}])]
+          (try
+            (reseed! premise-b m/window-size)
+            (let [d10 (markup-caused-by [:topo/bump-stride 10])
+                  _   (reseed! premise-b m/window-size)
+                  d5  (markup-caused-by [:topo/bump-stride 5])
+                  rendered (m/rendered-rows arm premise-b)]
+              (if (contains? #{:coarse :chunked} arm)
+                (do (is (= rendered d10 d5)
+                        (str arm "/bump-stride at B=" premise-b " must build every rendered
+                             row at BOTH strides — that is the degeneracy, and it is why
+                             this arm had no positive control"))
+                    (is (= 1 (/ d5 d10))
+                        (str arm "'s changed-set ratio is 1.00 — the manipulation moves
+                             nothing this arm does")))
+                (is (= 2 (/ d5 d10))
+                    (str arm "/bump-stride does double its markup (" d10 " -> " d5 "),
+                         which is the half of the premise that holds"))))
+            (finally (mount/release! handle))))))))
+
+;; ---------------------------------------------------------------------------
+;; 2 — the replacement discriminates on every arm
+;; ---------------------------------------------------------------------------
+
+(deftest every-arm-carries-a-prediction-bounded-away-from-one
+  (testing "the acceptance criterion, as arithmetic: each arm's predicted
+           factor is derived from `model/elements-for` and is bounded away
+           from 1.00. Neither number is 2.00, because the `ul` does not
+           double — which is `census_clock_arms/ctl-predicted`'s discipline"
+    (doseq [arm arms/arm-ids]
+      (let [p (ctl/predicted arm)
+            {:keys [lo hi]} (ctl/band-of arm)]
+        (is (> p 1.9) (str arm "'s predicted factor is " p))
+        (is (< p 2.0) (str arm "'s prediction must be BELOW 2.00 — the chrome does
+                           not double, and a control printing a round 2.00 is one
+                           that did not derive it"))
+        (is (> lo 1.0)
+            (str arm "'s band floor " lo " must exclude 1.00, or the control admits
+                 an instrument that saw nothing"))
+        (is (< 1.471 lo)
+            (str arm "'s band must still REFUSE the changed-set run this replaces,
+                 whose worst round was 1.471. A band that admitted it would be a
+                 widening wearing a new control's clothes"))))))
+
+(deftest the-rendered-scale-control-doubles-the-work-on-every-arm
+  (testing "THE REPLACEMENT'S DISCRIMINATING POWER, in exact integers and
+           before any clock. On each arm the control's large page builds
+           exactly twice the rows of markup its small page does — including
+           `coarse` and `chunked`, where the changed-set control built the
+           same number twice"
+    (if-not (mount/browser?)
+      (skip! ":node-test has no DOM")
+      (doseq [arm arms/arm-ids]
+        (let [[small large] (ctl/sizes arm)]
+          (doseq [[tag size] [[:small small] [:large large]]]
+            (let [{:keys [b w]} size
+                  limit (ctl/rendered-of arm size)]
+              (fresh! b w)
+              (let [handle (mount/root! (mount/fresh-container!) frame-id
+                                        [(arms/view-of arm) {}])]
+                (try
+                  (reseed! b w)
+                  (let [built (markup-caused-by [:topo/bump-indexed limit ctl/stride])]
+                    (is (= (ctl/markup-expected arm size) built)
+                        (str arm "/" tag " must build the markup its arithmetic
+                             predicts — this is the number the clock's prediction
+                             rests on, and the control checks it on the page before
+                             it starts a clock")))
+                  (finally (mount/release! handle))))))
+          (is (= 2 (/ (ctl/markup-expected arm large) (ctl/markup-expected arm small)))
+              (str arm "'s control doubles the rows of markup a commit builds —
+                   the property the changed-set control lacked on this arm")))))))
+
+(deftest the-indexed-write-moves-only-what-it-claims
+  (testing "the write the whole control rests on: every `stride`-th rendered row
+           advances by one per commit and no other row moves. Read out of the
+           DOM, on the same cells the control's probes address"
+    (if-not (mount/browser?)
+      (skip! ":node-test has no DOM")
+      (let [b 100]
+        (fresh! b m/window-size)
+        (let [handle (mount/root! (mount/fresh-container!) frame-id
+                                  [(arms/view-of :fine) {}])
+              container (:container handle)]
+          (try
+            (reseed! b m/window-size)
+            (dotimes [_ 3]
+              (rt/dispatch! frame-id [:topo/bump-indexed b ctl/stride])
+              (mount/settle!))
+            (is (= (str (+ (:n (m/row ctl/changed-probe)) 3))
+                   (ctl/n-at container ctl/changed-probe))
+                "the changed probe advanced by exactly one per commit")
+            (is (= (str (:n (m/row ctl/unchanged-probe)))
+                   (ctl/n-at container ctl/unchanged-probe))
+                "the unchanged probe did not move at all")
+            (is (empty? (ctl/probe-misses container 3))
+                "so the control's own read-back reports no miss on a page that
+                 committed what it claims")
+            (finally (mount/release! handle))))))))
+
+;; ---------------------------------------------------------------------------
+;; 3 — the read-back bites
+;; ---------------------------------------------------------------------------
+
+(deftest the-control-refuses-a-page-whose-writes-do-not-commit
+  (testing "THE NON-COMMIT WITNESS, and the audit obligation on this control
+           (rf2-m6i0). The predecessor's `window!` said the read-back happened
+           after the clock and then returned elapsed time without reading
+           anything, so it could have adjudicated a no-op from event and
+           subscription work alone.
+
+           Here a real `fine` page is mounted and the control's OWN `window!`
+           drives it — same twenty dispatches, same settles, same clock, same
+           tally — with the write's `limit` at zero, so nothing commits. The
+           tally must report every probe unverified and `assert-verified!`
+           must throw"
+    (if-not (mount/browser?)
+      (skip! ":node-test has no DOM")
+      (let [b 100]
+        (fresh! b m/window-size)
+        (let [handle (mount/root! (mount/fresh-container!) frame-id
+                                  [(arms/view-of :fine) {}])
+              container (:container handle)]
+          (try
+            (reseed! b m/window-size)
+            (let [t    (lane/tally)
+                  page {:frame-id frame-id :container container
+                        :limit 0 :committed (atom 0)}
+                  _ms  (ctl/window! t page)
+                  v    (lane/tally-value t)]
+              (is (= 2 (:writes v)) "both probes were read")
+              (is (= 1 (:unverified v))
+                  "the CHANGED probe must miss — twenty commits were counted and
+                   the row's `n` never moved. The unchanged probe is correctly
+                   satisfied, which is what makes the pair discriminate between
+                   `nothing committed` and `everything committed`")
+              (is (thrown? js/Error (lane/assert-verified! t "non-commit witness"))
+                  "and the lane's ONE adjudication of a read-back turns that into
+                   a throw, which the driver turns into a non-zero exit")
+              (is (false? (:ok? (ctl/verdict :fine [1.99 1.99 1.99] v)))
+                  "so a verdict over perfectly in-band, correctly-signed round
+                   ratios still REFUSES on the read-back — the numbers describe a
+                   page that did not commit what it claims")
+              (is (re-find #"READ-BACK" (:why (ctl/verdict :fine [1.99 1.99 1.99] v)))
+                  "and it says which of the three gates refused"))
+            (finally (mount/release! handle))))))))
+
+;; ---------------------------------------------------------------------------
+;; 4 — the verdict arithmetic, without a browser
+;; ---------------------------------------------------------------------------
+
+(def ^:private clean {:writes 120 :unverified 0})
+
+(deftest the-verdict-refuses-on-band-sign-and-read-back
+  (testing "three gates, any of which refuses. The sign gate is PR #7634's fix:
+           a band alone admits a control certifying that MORE WORK READS
+           FASTER, which rf2-7iqb5 captured live"
+    (let [{:keys [predicted]} (ctl/band-of :fine)]
+      (is (:ok? (ctl/verdict :fine (repeat 5 predicted) clean))
+          "a run measuring exactly its prediction passes")
+      (is (not (:ok? (ctl/verdict :fine [predicted predicted 1.40 predicted predicted] clean)))
+          "ONE round below the band refuses the whole control — the strict rule,
+           so a good round cannot vouch for a bad one")
+      (is (not (:ok? (ctl/verdict :fine (repeat 5 0.5) clean)))
+          "a negative-sign run refuses on the sign, not merely on the band")
+      (is (re-find #"SIGN" (:why (ctl/verdict :fine (repeat 5 0.5) clean))))
+      (is (not (:ok? (ctl/verdict :fine [] clean)))
+          "and a control that measured nothing certifies nothing"))))
+
+(deftest the-refused-changed-set-run-would-still-refuse-here
+  (testing "the one test that says this control is not a widening. The run this
+           replaces measured 1.331 / 1.387 / 1.424 / 1.471 / 1.325 and refused.
+           Fed to the NEW verdict on every arm, it refuses again"
+    (let [measured [1.331 1.387 1.424 1.471 1.325]]
+      (doseq [arm arms/arm-ids]
+        (is (not (:ok? (ctl/verdict arm measured clean)))
+            (str "the replacement's band on " arm " must not retro-admit the
+                 refusal it replaces"))))))

--- a/implementation/freehand/test/re_frame/bench/hicasso/topo/model.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/topo/model.cljs
@@ -101,12 +101,19 @@
    :n     (mod (* 7 i) 23)})
 
 (defn seed-db
-  "`b` rows, in index order, with empty drafts."
-  [b]
-  {:rows   (into {} (map (fn [i] [i (row i)])) (range b))
-   :order  (vec (range b))
-   :draft  {}
-   :b      b})
+  "`b` rows, in index order, with empty drafts.
+
+  `w` is the windowed arm's window, seeded rather than read from
+  [[window-size]] so that a control can scale the ONE quantity that arm's
+  cost is proportional to. It defaults to [[window-size]], so every
+  caller that does not care reads exactly the numbers it read before."
+  ([b] (seed-db b window-size))
+  ([b w]
+   {:rows   (into {} (map (fn [i] [i (row i)])) (range b))
+    :order  (vec (range b))
+    :draft  {}
+    :b      b
+    :w      w}))
 
 ;; ---------------------------------------------------------------------------
 ;; Subscriptions — the four topologies' reads
@@ -150,13 +157,13 @@
 ;; different lever from how many read edges exist (the worksheet's N2).
 (rf/reg-sub :topo/visible
   (fn [db _]
-    (subvec (:order db) 0 (min (count (:order db)) window-size))))
+    (subvec (:order db) 0 (min (count (:order db)) (:w db window-size)))))
 
 ;; ---------------------------------------------------------------------------
 ;; Events — the four operations, plus the seed and the control's write
 ;; ---------------------------------------------------------------------------
 
-(rf/reg-event :topo/seed (fn [_ [_ b]] {:db (seed-db b)}))
+(rf/reg-event :topo/seed (fn [_ [_ b w]] {:db (seed-db b (or w window-size))}))
 
 (rf/reg-event :topo/bump
   ;; **SPARSE.** One row's data moves. Nothing else in app-db is touched,
@@ -200,6 +207,28 @@
                    (reduce-kv (fn [m i r] (assoc m i (cond-> r (zero? (mod i stride)) (update :n inc))))
                               {} rs)))}))
 
+(rf/reg-event :topo/bump-indexed
+  ;; **THE RENDERED-SCALE CONTROL'S WRITE** (rf2-m6i0).
+  ;;
+  ;; Every `stride`-th row below `limit` moves, written by INDEX rather
+  ;; than by rebuilding the table. That is the whole difference from
+  ;; [[:topo/bump-stride]] above, and it is the difference the tournament's
+  ;; refused control turned on: `bump-stride` `reduce-kv`s all `B` rows
+  ;; whichever stride runs, so its handler costs the same at both halves of
+  ;; the manipulation and contributes a shared constant that compresses the
+  ;; measured ratio toward 1. This handler costs `limit/stride` — it is
+  ;; proportional to the CHANGED SET, which is the first of the two
+  ;; conditions rf2-m6i0's diagnosis named.
+  ;;
+  ;; `limit` is the arm's own RENDERED row count, never `B`: on the
+  ;; windowed arm a write striding over all `B` rows would again be a
+  ;; constant term, because that arm renders `w` rows however large the
+  ;; table is.
+  (fn [{:keys [db]} [_ limit stride]]
+    {:db (reduce (fn [d i] (update-in d [:rows i :n] inc))
+                 db
+                 (range 0 limit stride))}))
+
 (rf/reg-event :topo/noop-write
   ;; **THE NEGATIVE CONTROL.** Moves a key no arm reads, so a witness that
   ;; counts zero bodies here is counting rather than failing to look.
@@ -210,18 +239,21 @@
 ;; ---------------------------------------------------------------------------
 
 (defn make-frame!
-  "Create (or idempotently replace) `frame-id`, seeded with `b` rows."
-  [frame-id b]
-  (rf/make-frame {:id frame-id :initial-events [[:topo/seed b]]})
-  frame-id)
+  "Create (or idempotently replace) `frame-id`, seeded with `b` rows and
+  a window of `w` (default [[window-size]])."
+  ([frame-id b] (make-frame! frame-id b window-size))
+  ([frame-id b w]
+   (rf/make-frame {:id frame-id :initial-events [[:topo/seed b w]]})
+   frame-id))
 
 (defn reseed!
   "Return the frame to its seeded state. `make-frame!` is idempotent and
   will NOT replay its initial events for an id that already exists, so
   both halves are needed."
-  [frame-id b]
-  (rf/with-frame frame-id (rf/dispatch-sync [:topo/seed b]))
-  nil)
+  ([frame-id b] (reseed! frame-id b window-size))
+  ([frame-id b w]
+   (rf/with-frame frame-id (rf/dispatch-sync [:topo/seed b w]))
+   nil))
 
 ;; ---------------------------------------------------------------------------
 ;; The arithmetic a witness predicts rather than accepts
@@ -244,19 +276,25 @@
 
 (defn rendered-rows
   "How many rows an arm puts in the DOM at `b`. Three arms render every
-  row; the windowed arm renders at most [[window-size]] — which is the
-  arm's entire purpose and the reason it is not DOM-comparable with the
-  other three."
-  [arm b]
-  (if (= :virtual arm) (min b window-size) b))
+  row; the windowed arm renders at most `w` — which is the arm's entire
+  purpose and the reason it is not DOM-comparable with the other three.
+
+  **This function is also the control's scale parameter** (rf2-m6i0). A
+  positive control has to double the quantity the arm's commit cost is
+  proportional to, and this is that quantity: `B` for three arms, `w` for
+  the fourth. Doubling `B` on the windowed arm moves nothing it renders,
+  which is why one page-size control cannot serve all four."
+  ([arm b] (rendered-rows arm b window-size))
+  ([arm b w] (if (= :virtual arm) (min b w) b)))
 
 (defn memberships
   "The read edges the arm's row family contributes at `b` — the
   worksheet's `B·R` column, computed from the same arithmetic so the two
   can be compared rather than asserted equal."
-  [arm b]
-  (case arm
-    :fine    (* 2 b)
-    :coarse  0
-    :chunked (long (Math/ceil (/ b chunk-size)))
-    :virtual (* 2 (min b window-size))))
+  ([arm b] (memberships arm b window-size))
+  ([arm b w]
+   (case arm
+     :fine    (* 2 b)
+     :coarse  0
+     :chunked (long (Math/ceil (/ b chunk-size)))
+     :virtual (* 2 (min b w)))))


### PR DESCRIPTION
Closes nothing. `rf2-m6i0` stays **open** — the control passes on three arms of four, and its acceptance criterion is all four.

`rf2-hic-036` pre-registered `rf2-7iqb5`'s changed-set doubling, built it over `:topo/bump-stride`, and it came back degenerate on `coarse`/`chunked` and **refused on `fine`** at 1.331–1.471 against a [1.60, 2.50] band. This is the replacement, run as its own quiet-box measurement window.

## The premise held at source, and is now pinned

The bead's degeneracy table was a claim; it is now a measurement. `:topo/bump-stride` `reduce-kv`s the whole table at either stride (`model.cljs`), and `:topo/view-model` / `:topo/chunk` rebuild every row on any write. Measured at `B = 100`:

| arm | markup at stride 10 | at stride 5 | ratio | |
|---|---|---|---|---|
| `fine` | 10 | 20 | 2.00 | discriminating |
| `virtual` | 2 | 4 | 2.00 | discriminating |
| `coarse` | 100 | 100 | **1.00** | DEGENERATE |
| `chunked` | 100 | 100 | **1.00** | DEGENERATE |

`control_witness_dom_cljs_test.cljs` asserts this on every PR, so the degeneracy cannot quietly stop being true.

**One correction to the brief's table.** It classes `virtual` as "discriminating" alongside `fine`. That is true of markup and false of the clock: 2→4 rows of markup sits under the same shared constant that compressed `fine` to 1.33, only far worse. The measured run below confirms it — `virtual` is the one arm that still refuses.

## The repair: double the arm's RENDERED page, with an INDEXED write

Both predecessors were right about one arm and degenerate elsewhere, and the fault is one fault in two directions: **a manipulation certifies an instrument only when every cost in the window moves with it.** Whatever stands still is a shared constant, and a shared constant compresses the ratio toward 1 — which reads exactly like an instrument that cannot see.

Two changes, one per leak:

- **`:topo/bump-indexed`** `update-in`s the rows it moves instead of rebuilding the table, so the handler costs `limit/stride` rather than `B`. That is the diagnosis's first condition.
- **The manipulation scales `model/rendered-rows`**, so the subscription layer and the render double too — the second condition. Page-scaling is invalid for an update row *in general*, exactly as `rf2-7iqb5` says; it is valid here because the manipulation doubles the changed set as well.

**Why the scaled quantity is `rendered-rows` and not `B`:** doubling `B` on the windowed arm moves nothing it renders, so that arm's page is its *window*. That is the mirror image of the changed-set control's degeneracy on the coarse family, and it is why no single scaled quantity serves all four arms.

Predictions are derived from `model/elements-for`, per `census_clock_arms/ctl-predicted`, never a flat 2.00 — the `ul` does not double. The band is the lane's standing `CONTROL_SLACK` of ±25% (`shapes/census_clock_run.cjs`) under its strict every-round rule.

**This is not a widening.** ±25% of 1.9996 floors at 1.4997 and the run it replaces measured 1.331–1.471; every band here still refuses that run, and a test asserts exactly that on all four arms.

## Pre-registered before measuring

Commit `0f08b495ba` carries the predictions, the bands, the probes and the verdict function, and states in its message that no measurement had been run against any of it. The run is in `8fe565c163`.

## The run

Quiet box — `\System\Processor Queue Length` **0.00** on every sample before, during and after (certified over 12 consecutive 1 s samples: max 1, mean 0.08; 0.00 throughout the run). Chromium 147.0.7727.15 headless, `:advanced`, `goog.DEBUG false`, 24 threads / 32 GB. 20 commits under one clock, 12 samples × 5 rounds, page sizes interleaved in `slot-order`. **Arm-order guard `[ok] by predecessor` on all four arms. 0 unverified of 300 probes on all four.** Every one of the eight mounted pages matched its own `boundaries / edges / elements / rendered-rows` arithmetic before its clock started.

| arm | predicted | band | round ratios | verdict |
|---|---|---|---|---|
| `fine` | 1.9996 | [1.4997, 2.4995] | 1.9331 / 2.0296 / 2.0856 / 2.2588 / 2.0972 | **PASS** |
| `coarse` | 1.9996 | [1.4997, 2.4995] | 2.1029 / 2.0024 / 2.0459 / 1.9853 / 2.0877 | **PASS** |
| `chunked` | 1.9996 | [1.4997, 2.4995] | 2.0236 / 2.0816 / 2.1415 / 2.1876 / 2.1802 | **PASS** |
| `virtual` | 1.9901 | [1.4926, 2.4876] | 1.5490 / 1.5577 / 1.5200 / 1.4600 / 1.5111 | **REFUSED ON THE BAND** |

The two arms this bead was filed for now sit on 1.9853–2.1029 and 2.0236–2.1876 around a derived 1.9996.

**The diagnosis is confirmed directly.** `fine` is the one arm both controls could address, and it moved from 1.325–1.471 to 1.9331–2.2588. The only thing that changed is that the handler and the subscription layer now scale with the manipulation. That is the shared constant term being removed, watched.

**`virtual` refuses, and not from the same fault.** Tight (1.46–1.5577 over five rounds), correctly signed, guard-clean, fully verified, and its *work* doubles exactly (4→8 markup, 21→41 boundaries, 41→81 edges). Its whole commit is **0.125 ms** at `w = 20` and **0.195 ms** at `w = 40` — one to two of Chrome's 100 µs `performance.now()` quanta. The per-commit floor does not double and is a large fraction of a reading that small. Nothing was widened and nothing re-derived; the band stands and the arm needs a different instrument. Filed as `rf2-4t36` with three candidate repairs, none attempted — adding a rung between runs would make the series two instruments.

## The read-back the audit demanded

PR #8160's `window!` said the read-back happened after the clock and then returned elapsed time without reading anything, so it could have adjudicated a no-op from event and subscription work alone. Every window now banks two **cell-addressed** probes into `lane/tally` outside the clock — a CHANGED row that must advance by exactly one per commit, and an UNCHANGED row that must still read its seed — and `lane/assert-verified!` (the lane's one meaning of *verified*) turns any miss into a throw and a non-zero exit. `the-control-refuses-a-page-whose-writes-do-not-commit` mounts a real `fine` page, drives the control's own `window!` with nothing committing, and asserts the tally reads 1 unverified of 2, that `assert-verified!` throws, and that a verdict over perfectly in-band, correctly-signed ratios still refuses.

## Quality gates

Ran directly, each exit code captured from the runner itself on the same command line:

| gate | captured exit |
|---|---|
| `npm run test:browser` (Chromium, real DOM) — 1507 tests / 9533 assertions, 0 failures, 0 errors | **0** |
| `freehand/.../hicasso/compile_gate.cjs` — 131 lane namespaces, 0 warnings | **0** |
| `topo/control_app.cljs` via `run.cjs` (the measurement) | **1** — `virtual` refused, as reported above |
| `python scripts/check_doc_slugs.py` | **0** |
| `python scripts/check_provenance_pins.py --changed-since origin/main --verbose` (CI's form) | **0** |
| `sh scripts/test-fast-pr.sh` (the full spine, on the final base) | **0** |

**A harness/runner exit-code disagreement was hit and is worth recording.** The harness reported exit **0** for the control run; the runner's own captured code was **1**. Believing the reported zero would have inverted this PR's conclusion. Every number in the table above is the captured one.

**Sabotage proofs, because a green run is only evidence once you know the gate read your tree.**
- Compile gate: a single-line `:undeclared-var` planted in `control_witness_dom_cljs_test.cljs` → **exit 1**, warning naming my file at my worktree path. Restored and verified with `git hash-object` against the committed object (identical).
- Slug checker: my new anchor broken deliberately → **exit 1**, both references caught by line. Restored and verified byte-for-byte against a pre-plant copy.
- Browser lane: printed its root as my worktree, and my namespace is present in `out/browser-test/js/cljs-runtime/` **and registered in `shadow.test.browser.js`** — so it ran rather than being silently absent.

Gates re-run on the final base after rebasing onto `10c7f5eb83`. A one-sentence prose fix landed after the spine started, so both doc gates — the only gates covering that file — were re-run afterwards and are green on the final tree.

The 20 `FAIL`-matching lines in the spine log are self-test *expectations* (`→ FAILED` is the asserted outcome) and informational clj-kondo warnings on files this diff does not touch; CI's kondo job fails on ERROR only, and my local kondo is not the pinned 2026.04.15 build, so I claim nothing from it either way.

`python scripts/check_fast_pr_gap.py --list` is the canonical fast-spine-versus-required-CI gap and reports **96** required checks the spine does not decide. That is a statement about the spine's coverage, not a list of what I did or did not run — what I ran is the table above.

Doc gates: `mkdocs build --strict` does **not** cover `docs/design/**`, so it is not the gate for the page edit. `check_doc_slugs.py` and `check_provenance_pins.py` are, and both ran. **Table column counts and the new anchor were verified by hand**: all three new tables are 5 columns in header, separator and every row, and the `§2.6` anchor is exercised by two in-page links that the slug checker resolves (and reds when broken).

## What was NOT concluded

- **`rf2-m6i0` is not closed.** Its acceptance is a positive control on *all four* arms; `virtual` refuses. Left open, with the refusal recorded on it.
- **No clock cell of the tournament is published by this PR, and after this the reason is no longer a control.** `rf2-hic-036`'s lane has **no clock driver at all** — `topo/` holds the model, the arms, the census and the control, and the 4 arms × 4 operations timing table was never instrumented. The control refused first, so the cells were never taken. That is `rf2-hic-036`'s scope, noted on that bead; the page headline has been corrected so "want of a control" no longer stands as the reason.
- **Nothing is concluded about `virtual`'s clock cells**, and no repair for them was attempted (`rf2-4t36`).
- **No claim that the three passing arms' clock figures are correct** — a positive control certifies the instrument can see a change its arithmetic predicts. It does not certify any unpredicted number, and none was taken.
- **Nothing about `implementation/hicasso`.** These are arm-1 bench figures. The 8 compiler warnings in the browser-test build are pre-existing in `implementation/hicasso/` (PR #8163's surface), untouched and unreachable from this diff.
- **The additive-constant treatment was not applied.** `census_clock_run.cjs` computes an `additiveConstant`; whether subtracting it would rescue `virtual` is untested and is one of `rf2-4t36`'s candidates.
