### PR TITLE
docs(method): split the no-safe-plant branch by whether the gate prints a root (rf2-g6jd)

### DIFF
--- a/docs/the-mayor-method/dispatch-prompt-template.md
+++ b/docs/the-mayor-method/dispatch-prompt-template.md
@@ -427,14 +427,20 @@ artefact-naming rule. A one-line documentation edit still runs a link validator,
 
 **Say what a brief whose gate affords no plant does instead, or that gets improvised too** — the improvisation
 was measured on the *enforcing* side, where five dispatches in one session carried five different lengths of
-this one block, nobody having decided to drop anything. Two cases, and they are not the same. Where NO automated
+this one block, nobody having decided to drop anything. Three cases, and they are not the same. Where NO automated
 gate covers the surface, the wording is already settled under *Quality gates — which gate* above: the brief says
 so, and the worker verifies it by hand and reports what it checked and the counts in the change body. Where a
 gate DOES cover the surface but affords no safe discriminating plant, that gate still runs and the unconditional
-four still bite; what lapses is only the planted-fault route to proving which tree was read, so the brief
-nominates the root-banner route instead and the worker says which one it used. Point at that rather than
-restating it, and **scope the block rather than shortening it** — dropping the sanction along with the parts
-that do not apply is the same failure by a shorter road.
+four still bite; what lapses is only the planted-fault route to proving which tree was read, and which route is
+left turns on the gate's *other* capability. If it prints its root, the brief nominates the root-banner route and
+the worker says which one it used. If it prints nothing either, neither route is on offer — the two-route rule
+below is explicit that many gates print nothing, so silent AND unplantable is a real pairing rather than a corner
+— and the brief says exactly that: no discriminating tree-verification route here, or the concrete bounded
+mechanism the gate does afford in place of one. Nominating a route the gate cannot supply is the failure recorded
+further down, where an earlier rule claimed every gate printed a banner and the workers who met it
+improvised. Point at the settled wording rather than restating it, and **scope the block rather than
+shortening it** — dropping the sanction along with the parts that do not apply is the same failure by a
+shorter road.
 
 **Detaching a long gate is CORRECT; ending the turn afterwards is the defect.** Where a harness hard-kills a
 foreground command well below what the full gate needs, "foreground, to completion" is not on offer however


### PR DESCRIPTION
Third iteration on one paragraph of `docs/the-mayor-method/dispatch-prompt-template.md`. The capability-scoping axis that landed in the previous pass is right and is **not** relitigated here; what this fixes is a gap that repair opened.

## The defect

The no-safe-plant branch said that when a covering gate affords no safe discriminating plant, the brief nominates the **root-banner** route instead. But the two-route rule a few dozen lines below is explicit that **many gates print nothing**. A gate that is both silent and unplantable therefore had *neither* route, and the rule handed it an instruction it could not obey — the same defect class as the original (an unsatisfiable instruction makes a reader improvise rather than stop), reintroduced by its own repair.

The section already records that exact failure once, further down: an earlier rule claimed every gate printed a root banner, two workers hit it in one day, and one improvised its way to a negative control unprompted.

## The repair

Split the branch by the gate's *other* capability, in the audit's own minimal form:

- The **root-banner route is nominated only where the gate actually prints one.**
- Where the gate prints nothing either, the brief **states the absence of a discriminating tree-verification route**, or names the concrete bounded mechanism the gate does afford in place of one.
- The requirement to **run the covering gate is unchanged**, and the unconditional four still bite in every branch.
- **No ceremony is added** to gates that are plantable or that print a root — the plantable case is untouched, and the root-printing case gains only a conditional clause.

The enumeration count moves from "Two cases" to "Three cases" accordingly, and `Point at that` becomes `Point at the settled wording` because the intervening text pushed its antecedent out of reach.

One file, +11/−5, confined to that paragraph.

## Layer rule

`docs/the-mayor-method/**` is the generic tree. The added prose carries **no** repository name, bead id, PR number, file path, tool or script name, or OS mechanic — it reuses the tree's own vocabulary (root-banner route, planted fault, the unconditional four). Verified by grepping the added lines for every such token class; no hits.

## Quality gates

**I did not run the fast pre-checkin spine.** This is a prose-only edit to a single markdown file in the generic method tree, and the brief scoped the gates to the doc-link validator. `scripts/check_fast_pr_gap.py --list` is the canonical derivation of which required CI steps the fast spine does not run — it derives that gap from the workflow definitions and does **not** inspect what any worker actually ran, so it is the citation for the gap, not evidence about this change. The required checks are CI's call at merge.

Gates run directly, with exit codes captured by redirect-and-echo on one command line in one shell (never piped, never read from the harness):

| run | gate | captured exit |
|-----|------|---------------|
| baseline | `python scripts/check_doc_slugs.py` | **0** |
| sabotage | `python scripts/check_doc_slugs.py` (planted fault) | **1** |
| restored | `python scripts/check_doc_slugs.py` | **0** |

`scripts/check_provenance_pins.py` does **not** cover this change — its `DEFAULT_ROOT` is `docs/design/hicasso`, and nothing under that tree was touched. Not run, and a run would have verified nothing.

### Which tree the gate read

This gate is **silent on green** — the baseline log is empty — so the banner route is unavailable and the proof is the red from a planted fault. (That is the very asymmetry this paragraph is about.) `docs/the-mayor-method/` is inside the gate's roster: it is under `DEFAULT_ROOTS` and is named in `FENCED_DOC_LINK_TREES`, so the gate does cover the edited surface rather than exiting green over an exclusion.

Planted a broken link target on a line already being edited, anchored to a **single** line:

```
BROKEN TARGET: docs\the-mayor-method\dispatch-prompt-template.md:441 -> gate-plant-plantroute-g6jd-absent.md
    (missing: docs\the-mayor-method\gate-plant-plantroute-g6jd-absent.md)
```

The failure names the plant by a filename unique to this worktree, so the red discriminates: a run that had wandered into a sibling checkout would have come back green.

Restore verified by hash against the committed object, not by eye:

- committed blob `dc8c468c9def762dca3171a002413364104263cc`
- planted     `e4103c687c38ac7e9bed98042080e83983216abb`
- restored    `dc8c468c9def762dca3171a002413364104263cc` — identical to the committed blob

Gate artefacts were named per worktree and per attempt and written to a scratch directory outside the repository; `git status` is clean and no artefact is left in the worktree.

Diffed against the merge base with the three-dot form and read for reverts: no commit has touched this file since the merge base, and the diff contains nothing but the intended paragraph.

## Judgement on stability

Reported with the change: this paragraph now reads as complete — every combination of (covering gate? / plantable? / prints a root?) has a defined instruction, which is what the previous two passes each lacked. It took the fix cleanly as a local edit; it did not resist one. But it is now the longest paragraph in the section and carries its own history inline, and a **fourth** finding here should be taken as the signal the bead already names: rewrite the section whole rather than patch it a fourth time.
