### PR TITLE
ci(docs): fetch the PR base uncapped in the docs-surface classifier (rf2-ihfw)

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -163,7 +163,23 @@ jobs:
             echo "Non-PR event (${GITHUB_EVENT_NAME}): running MkDocs build unconditionally."
             exit 0
           fi
-          git fetch --no-tags --depth=100 origin "${GITHUB_BASE_REF}" >/dev/null 2>&1 || true
+          # Fetch the base branch BY NAME, with no depth cap (rf2-ihfw). Two
+          # things make that the right shape. First, this fetch is load-bearing
+          # even under the `fetch-depth: 0` checkout above: a pull_request
+          # checkout fetches `+<sha>:refs/remotes/pull/N/merge` and never
+          # creates refs/remotes/origin/<base>, so this is what puts that name
+          # in scope for the three-dot diff below — and it costs almost nothing,
+          # because the objects are already local from that checkout.
+          # Second, a `--depth` cap here would not merely fetch too little, it
+          # would DESTROY history: `git fetch --depth=N` converts a COMPLETE
+          # clone into a shallow one, grafting the base branch at N and
+          # discarding exactly what `fetch-depth: 0` just paid for. A merge base
+          # past that graft then dies `fatal: no merge base` (measured: exit
+          # 128). That fails CLOSED — the diff below is unswallowed, so the job
+          # reds rather than misclassifying the PR as docs-irrelevant — but a
+          # spurious red on a long-lived branch is still worth not having.
+          # `provenance-pins` below fetches this same base the same uncapped way.
+          git fetch --no-tags origin "${GITHUB_BASE_REF}" >/dev/null 2>&1 || true
           files="$(git diff --name-only "origin/${GITHUB_BASE_REF}...HEAD")"
           docs_surface=false
           while IFS= read -r file; do


### PR DESCRIPTION
Closes rf2-ihfw.

## The premise held, and is stronger than the bead stated

`docs.yml`'s `Detect docs surface` step checks out at `fetch-depth: 0` (line 144) and then immediately runs `git fetch --depth=100` against the base branch. The bead's claim was that this assumes the merge base lies within 100 commits, and that the assumption is unstated. Both are true. What the bead did not know is that the cap is not merely redundant against the full checkout — it actively **destroys** history the job has already paid for.

`git fetch --depth=N` converts a **complete** clone into a shallow one. Measured on a synthetic 20-commit repo (not inferred from the flag name):

| | walkable history | `is-shallow-repository` | three-dot diff past the graft |
|---|---|---|---|
| full clone (control) | 20 | `false` | `prfile.txt`, **exit 0** |
| after `git fetch --depth=5` | 5 | `true` | `fatal: no merge base`, **exit 128** |

So on a long-lived branch the step discards exactly what `fetch-depth: 0` fetched, and the following `git diff` dies.

**It still fails CLOSED**, which is why this is P4 and not the shape of rf2-34yg / rf2-8oh5. The `|| true` sits on the fetch, the `git diff` is unswallowed, and the default `bash -e {0}` shell propagates the non-zero status out of the `files="$(…)"` assignment. The job reds; it never misclassifies a docs PR as docs-irrelevant. The cost is a spurious red, not a vacuous pass.

## The change

Drop `--depth=100`, leaving a fetch **by name** at full depth, and state the assumption's absence in a comment. One command line and its comment block; nothing else.

The fetch is still load-bearing under `fetch-depth: 0`: a `pull_request` checkout fetches `+<sha>:refs/remotes/pull/N/merge` and never creates `refs/remotes/origin/<base>`, so this step is what puts that name in scope for the three-dot diff. Uncapped it costs almost nothing, because the objects are already local from the checkout. This is also what the `provenance-pins` job in this same file already does (line 583) — the remedy was sitting 400 lines below the defect.

Deliberately NOT done, per the bead's triage guidance: no restructuring, no re-arming, no surface-mapping change (that is rf2-cujx and it is the operator's), no new policy assertion pinning this line.

## Out of fence, for a follow-up bead

`lint.yml`'s `detect` job (line 169) carries the **byte-identical** line under the **same** `fetch-depth: 0` checkout. It is the same defect with the same remedy. `.github/**` is one-toucher-at-a-time, so it is left untouched here and wants its own bead.

## Quality gates

I did **not** run `scripts/test-fast-pr.sh`. `scripts/check_fast_pr_gap.py --list` is the canonical fast-spine-versus-required-CI gap — it derives which required steps the spine does not run, and does not inspect what I ran. The gates below were run directly, in the foreground, each exit code captured by the runner itself rather than read from a harness report:

| gate | exit |
|---|---|
| `python -c` YAML parse of `docs.yml` (jobs enumerate; `detect` checkout `fetch-depth: 0` confirmed) | **0** |
| `bash -n` on the `detect` step's `run:` body, extracted from the committed YAML | **0** |
| `node implementation/scripts/_docs-workflow-policy.test.cjs` | **0** (5 passed) |
| `python scripts/check_gate_scheduling.py --verbose` | **0** (51 gate commands, 43 scheduled, 8 declared) |
| edited step executed end-to-end against real history (`GITHUB_EVENT_NAME=pull_request`, `GITHUB_BASE_REF=main`, `bash -e`) | **0** |

**No safe discriminating plant exists on this line.** `_docs-workflow-policy.test.cjs` asserts only on the concurrency block and the `deploy` job's push-only gate; it never reads the fetch. `check_gate_scheduling.py` asks whether gate commands have a scheduled home. Neither would move if this line were reverted, so a plant would prove nothing.

What was verified by hand instead is a genuine control pair on the mechanism itself:

- **Capped** fetch on a complete clone → `is-shallow-repository: true`, merge-base diff **exit 128**.
- **Uncapped** fetch on a complete clone (this branch's line, run against real repo history) → `is-shallow-repository: false`, classifier **exit 0**, output `docs_surface=true` — correct, since the diff reaches `.github/workflows/docs.yml`, which is in the classifier's own case list.

That last point means this PR arms the `detect` job on itself: CI runs the edited classifier over this very diff, and the full MkDocs build behind it.
