### PR TITLE
ci(lint): fetch the PR base uncapped in the lint-surface classifier (rf2-4sl9)

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -166,7 +166,24 @@ jobs:
             echo "Non-PR event (${GITHUB_EVENT_NAME}): running linters unconditionally."
             exit 0
           fi
-          git fetch --no-tags --depth=100 origin "${GITHUB_BASE_REF}" >/dev/null 2>&1 || true
+          # Fetch the base branch BY NAME, with no depth cap (rf2-4sl9). Two
+          # things make that the right shape. First, this fetch is load-bearing
+          # even under the `fetch-depth: 0` checkout above: a pull_request
+          # checkout fetches `+<sha>:refs/remotes/pull/N/merge` and never
+          # creates refs/remotes/origin/<base>, so this is what puts that name
+          # in scope for the three-dot diff below — and it costs almost nothing,
+          # because the objects are already local from that checkout.
+          # Second, a `--depth` cap here would not merely fetch too little, it
+          # would DESTROY history: `git fetch --depth=N` converts a COMPLETE
+          # clone into a shallow one, grafting the base branch at N and
+          # discarding exactly what `fetch-depth: 0` just paid for. A merge base
+          # past that graft then dies `fatal: no merge base` (measured: exit
+          # 128). That fails CLOSED — the diff below is unswallowed, so the job
+          # reds rather than misclassifying the PR as lint-irrelevant — but a
+          # spurious red on a long-lived branch is still worth not having.
+          # docs.yml's `Detect docs surface` step fetches its base the same
+          # uncapped way, for the same reasons (rf2-ihfw).
+          git fetch --no-tags origin "${GITHUB_BASE_REF}" >/dev/null 2>&1 || true
           files="$(git diff --name-only "origin/${GITHUB_BASE_REF}...HEAD")"
           lint_surface=false
           js_surface=false


### PR DESCRIPTION
Closes rf2-4sl9. The twin of #8169 (rf2-ihfw), one workflow over.

## The premise held — checked, not assumed

The bead's central claim was a byte-identity claim, so I hashed both lines rather than eyeballing them. `.github/workflows/lint.yml:169` and the line #8169 removed from `docs.yml` are the same 89 bytes:

```
34ede9acb5c28c27ac4967bf0c3fcab8f5287f7bfa4efa07bbebacb88152290b  docs.yml@2c6e1c4508^ line 166
34ede9acb5c28c27ac4967bf0c3fcab8f5287f7bfa4efa07bbebacb88152290b  lint.yml@main     line 169
```

The surrounding shape matches too: the `detect` job checks out at `fetch-depth: 0` (line 154), and the classifier below is a three-dot `git diff --name-only "origin/${GITHUB_BASE_REF}...HEAD"` with no `|| true` on the diff. So the cap is not load-bearing here for any reason it was not load-bearing next door.

## What changed

One token: `--depth=100` is gone, leaving `git fetch --no-tags origin "${GITHUB_BASE_REF}"` — a fetch still **by name**, which is the part that matters, because a `pull_request` checkout fetches `+<sha>:refs/remotes/pull/N/merge` and never creates `refs/remotes/origin/<base>`. Plus a comment stating why there is no cap, mirroring the one #8169 landed.

Nothing else moves. No fetch added, no step restructured, nothing re-armed, no surface mapping touched (that is rf2-cujx, the operator's), and no policy assertion pinning the line. The three-dot diff against the merge base contains exactly **one** deleted line — the cap itself.

## Quality gates

I did **not** run the fast-PR spine, and it would not have been the relevant gate anyway: `scripts/check_fast_pr_gap.py --list` — the canonical fast-spine-versus-required-CI gap, which derives which required steps the spine does not run and does **not** inspect what any worker actually ran — reports **96** required checks the spine does not decide. What I ran instead, each redirected to a log with the runner's own exit code captured:

| Gate | Exit |
|---|---|
| YAML parse of `lint.yml` + extraction of the `detect` step's `run:` body (PyYAML 6.0.2) | **0** |
| `bash -n` over that extracted `run:` body | **0** |
| `node implementation/scripts/_lint-workflow-policy.test.cjs` — 4 passed | **0** |

The parse also re-asserted the invariants by structure rather than by grep: `fetch-depth: 0` on the checkout, outputs `lint_surface` + `js_surface`, exactly one live `git fetch` line and it carries no `--depth`, and the diff line still three-dot.

### No discriminating plant was available, so a control pair stands in its place

`_lint-workflow-policy.test.cjs` reads only the `.splint.edn` case arm, `needs: detect`, `lint_surface == 'true'` and `--fail-on-errors`; `_changed-surfaces.test.cjs` names `lint.yml` only in a comment. Nothing in any gate reads this fetch line, so no plant on it could discriminate — the same finding #8169's author reported. Rather than manufacture one that proves nothing, I ran the mechanism as a control pair, **against real re-frame2 history** rather than a synthetic repo, in throwaway clones (a `--depth` fetch inside a worktree would shallow the object store shared with every other checkout, so it must never be run there):

| | capped (`--depth=100`) | uncapped (this PR) |
|---|---|---|
| `is-shallow-repository` before | false | false |
| `is-shallow-repository` after | **true** | false |
| walkable history of `origin/main` | 21890 → **100** | 21891, intact |
| the step's own diff line | `fatal: origin/main...HEAD: no merge base` | listed changed files |
| **exit** | **128** | **0** |

Both arms used a synthetic PR tip whose merge base sits 250 commits back — further than the graft reaches. This is the bead's measured mechanism reproduced on this repository: the cap does not merely fetch too little, it **converts a complete clone into a shallow one** and discards precisely the history `fetch-depth: 0` just paid for.

Severity stays P4 because it fails **closed**: the `|| true` is on the fetch, the diff is unswallowed, and the default `bash -e {0}` propagates the non-zero status out of the `files="$(...)"` assignment. The job reds; it never misclassifies a lint-relevant PR as lint-irrelevant. This is not the fail-open shape of rf2-34yg or rf2-8oh5.

## A third instance exists, and it is not beaded

Since this is the second of a family in a day, I swept `.github/` rather than guessing. `git fetch --depth` appears four more times; three are deliberate and documented (`portability.yml:248` and `post-merge-workflow-sanity.yml:123` fetch a specific SHA at `--depth=1` under `fetch-depth: 2` checkouts, per rf2-uol6). The fourth is the same defect:

**`.github/scripts/report-changed-surfaces.sh:27`** runs the identical command (same bytes, different indentation), and its caller `test.yml`'s `detect` job checks out at `fetch-depth: 0` (`test.yml:103`) before invoking it (`test.yml:130`), ahead of a three-dot `git diff --no-renames --name-only "origin/${GITHUB_BASE_REF}...HEAD"` at script line 36 with no `|| true` — so it fails closed the same way and rates the same P4. The irony is in the tree: `test.yml:120` already argues "The `fetch-depth: 0` above is what makes the base resolvable without a fetch: it can be arbitrarily deep", while the script it calls truncates that to 100 one line in. `bd list --status open` and `bd search "depth=100"` return only rf2-4sl9, so nobody has filed it. **Out of my fence — I own `lint.yml` and nothing else — so it is flagged, not fixed**, exactly as rf2-ihfw's author flagged this one.

Fence: `.github/**` is one-toucher-at-a-time and there were **zero** open PRs of any kind when I started (verified per-PR, not assumed).
