### PR TITLE
ci(classifier): fetch the PR base uncapped in report-changed-surfaces.sh (rf2-om08)

### DIFF
--- a/.github/scripts/report-changed-surfaces.sh
+++ b/.github/scripts/report-changed-surfaces.sh
@@ -24,7 +24,29 @@ if [ "$force_all" = true ]; then
 elif [ "${#explicit_paths[@]}" -gt 0 ]; then
   files="$(printf '%s\n' "${explicit_paths[@]}")"
 elif [ "${GITHUB_EVENT_NAME:-}" = "pull_request" ] && [ -n "${GITHUB_BASE_REF:-}" ]; then
-  git fetch --no-tags --depth=100 origin "${GITHUB_BASE_REF}" >/dev/null 2>&1 || true
+  # Fetch the base branch BY NAME, with no depth cap (rf2-om08). Two things
+  # make that the right shape. First, this fetch is load-bearing even though
+  # the sole caller checks out at full depth: a pull_request checkout fetches
+  # `+<sha>:refs/remotes/pull/N/merge` and never creates
+  # refs/remotes/origin/<base>, so this is what puts that name in scope for the
+  # three-dot diff below — and it costs almost nothing, because the objects are
+  # already local from that checkout.
+  # Second, a `--depth` cap here would not merely fetch too little, it would
+  # DESTROY history: `git fetch --depth=N` converts a COMPLETE clone into a
+  # shallow one, grafting the base branch at N and discarding exactly what
+  # test.yml's `fetch-depth: 0` just paid for — the checkout its own comment
+  # calls "what makes the base resolvable without a fetch: it can be
+  # arbitrarily deep". A merge base past that graft then dies `fatal: no merge
+  # base` (measured: exit 128). That fails CLOSED — the diff below is
+  # unswallowed under `set -euo pipefail`, so the classify step reds rather
+  # than classifying an empty change set and skipping every gate — but a
+  # spurious red on a PR with an unusually distant merge base is still worth
+  # not having. docs.yml's `Detect docs surface` step (rf2-ihfw) and lint.yml's
+  # lint-surface classifier (rf2-4sl9) fetch their base the same uncapped way,
+  # for the same reasons. (A `--depth=1` fetch of a SPECIFIC SHA under a
+  # deliberately shallow checkout is a different and legitimate shape — see
+  # portability.yml, which checks out at depth 2.)
+  git fetch --no-tags origin "${GITHUB_BASE_REF}" >/dev/null 2>&1 || true
   # rf2-vxgfnd.137 — `--no-renames` is load-bearing, not cosmetic. Git rename
   # detection collapses a rename to its DESTINATION path only, so a pure rename
   # OUT of a classified surface (e.g. implementation/ui/** -> docs/**) would


### PR DESCRIPTION
Closes rf2-om08. The **fourth and last** member of the depth-cap family, after #8169 (`docs.yml`, rf2-ihfw) and #8171 (`lint.yml`, rf2-4sl9). #8164 fixed a *different* fault in this same file (base resolution) and is untouched here.

## The premise, checked at source

It held, on every limb.

- `.github/scripts/report-changed-surfaces.sh:27` ran `git fetch --no-tags --depth=100 origin "${GITHUB_BASE_REF}"`, in the `pull_request` branch, ahead of an **unswallowed** three-dot `git diff --no-renames --name-only "origin/${GITHUB_BASE_REF}...HEAD"` under `set -euo pipefail`.
- Its caller, `test.yml`'s `detect` job, checks out at `fetch-depth: 0` (`test.yml:103`) and invokes the script at `test.yml:130`.
- `test.yml:120` states the intent the callee defeated: *"The `fetch-depth: 0` above is what makes the base resolvable without a fetch: it can be arbitrarily deep."*

So this is a depth cap applied on top of a **full** checkout — the family's discriminator — and it fails **closed**: a graft-severed merge base reds the classify step rather than classifying an empty change set and silently skipping every gate. P4, as filed.

## The one extra check this bead needed: callers outside `.github/`

The bead asked for it because this is a script, not a workflow step, so its blast radius is wider. **No caller relies on the cap.**

| Caller | Branch it takes | Reaches the fetch? |
|---|---|---|
| `.github/workflows/test.yml:130` | `pull_request` (full checkout) | yes — the defect |
| `.github/workflows/{docs,lint,freehand-conformance}.yml` | none — comment mentions only | no |
| `scripts/test-fast-pr.sh:126` | explicit paths (`GITHUB_OUTPUT='' bash "$classifier" "${_changed_arr[@]}"`) | no |
| `implementation/scripts/_changed-surfaces.test.cjs` | `--all`, explicit paths, and the `push` branch | no |

The gate suite never takes the `pull_request` branch: its one `GITHUB_EVENT_NAME: 'pull_request'` case deliberately omits `GITHUB_BASE_REF` (line 4430, *"GITHUB_BASE_REF is absent here"*), and `classifyViaGitDiscovery` `delete`s both variables. `scripts/check_fast_pr_gap.py` and `scripts/check_donor_inventory.py` name the path as data, they do not execute it.

## The change

One token deleted, the fetch kept **by name**, plus a comment — the shape #8169 and #8171 landed.

```diff
-  git fetch --no-tags --depth=100 origin "${GITHUB_BASE_REF}" >/dev/null 2>&1 || true
+  # …22 lines of comment…
+  git fetch --no-tags origin "${GITHUB_BASE_REF}" >/dev/null 2>&1 || true
```

The fetch stays load-bearing even under a full checkout: a `pull_request` checkout fetches `+<sha>:refs/remotes/pull/N/merge` and never creates `refs/remotes/origin/<base>`, so this is what puts that name in scope for the three-dot diff — and uncapped it costs almost nothing, the objects being already local.

Nothing else moved. The base-resolution block #8164 added is untouched, no classifier `case` arm changed, no output re-mapped (that is rf2-cujx, an open cost decision for the operator), and no policy assertion was added pinning the line.

## Quality gates

I did **not** run `scripts/test-fast-pr.sh`. The canonical statement of what the fast spine does not cover is `scripts/check_fast_pr_gap.py --list`, which derives the required-CI steps the spine does not run — it inspects the workflows, **not** what I ran. It reports **96** required checks the spine does not decide (exit 0).

Gates run directly, each redirected to its own log with the runner's own exit code echoed on the same command line (never piped, never the harness's number):

| Gate | Captured exit |
|---|---|
| `node scripts/_changed-surfaces.test.cjs` (the covering suite, **358 passed**) | `CHANGED_SURFACES_EXIT=0` |
| `bash -n .github/scripts/report-changed-surfaces.sh` | `BASH_N_EXIT=0` |
| `node scripts/_lint-workflow-policy.test.cjs` | `LINT_WORKFLOW_POLICY_EXIT=0` |
| `node scripts/_docs-workflow-policy.test.cjs` | `DOCS_WORKFLOW_POLICY_EXIT=0` |
| `python scripts/check_fast_pr_gap.py --list` | `GAP_EXIT=0` |

### The plant: attempted, and it proves the gate does NOT reach this line

`_changed-surfaces.test.cjs` covers this script directly, so a plant was worth attempting. I replaced the fetch line — a single line — with a command that does not exist and is not `|| true`-guarded, which under `set -euo pipefail` aborts the script with 127 if reached:

```
  rf2_om08_plant_this_line_must_red_if_reached
```

The suite still reported **358 passed, exit 0**. So **no covering gate reaches the fetch line** — consistent with the caller table above, since no test takes the `pull_request` branch. Restored and verified byte-identical: `git hash-object` gives `82b332a6b2e6cb73725e683ca97b3decd0ce7dec` before the plant and after the restore.

### So the mechanism was verified by a control pair instead

Per the bead's safety rule, **not** in a worktree — linked worktrees share one object store with the mayor checkout and every other live worker, so a `--depth` fetch there would shallow the repository for everyone. The control ran in a throwaway clone of this repository's real history, outside the worktree tree, deleted afterwards.

Both arms on the same clone, uncapped first, against a synthetic PR tip built 250 commits back from `origin/main`:

| Arm | `is-shallow` | walkable | three-dot diff |
|---|---|---|---|
| `git fetch --no-tags origin main` (patched shape) | `false` | 21898 | **exit 0** |
| `git fetch --no-tags --depth=100 origin main` (removed shape) | `true` | **100** | **exit 128**, `fatal: origin/main...refs/heads/prtip: no merge base` |

This reproduces the measurement the bead carried over from rf2-4sl9's worker. After deleting the clone, both stores were re-checked and are complete: mayor `is-shallow false`, 21898 commits; this worktree `is-shallow false`, 21896 commits.

### Diff reviewed against the merge base for reverts

`git diff origin/main...HEAD` (three-dot, merge base `52ebb46fe9`) is **23 insertions, 1 deletion in one file**, and the sole removed line is the capped fetch itself. This file was modified today by #8164, so this was worth checking specifically: nothing of that fix is reverted.

## Is the family closed?

**Yes.** Swept the whole tree again rather than trusting the count. Every live `git fetch` invocation in tracked files:

- `report-changed-surfaces.sh:49`, `docs.yml:182`, `docs.yml:599`, `lint.yml:186` — all uncapped.
- `portability.yml:248` and `post-merge-workflow-sanity.yml:123` — `--depth=1` of a **specific SHA**, both under a deliberate `fetch-depth: 2` checkout (`portability.yml:209`, `post-merge-workflow-sanity.yml:97`). These are the documented-legitimate shape (rf2-uol6) and are correctly left alone.
- `implementation/scripts/_post-merge-sanity-base.test.cjs` — a `--depth=2` clone as a test **fixture**, plus an assertion pinning the `--depth=1` line above. Not a CI checkout.

**Zero remaining depth caps applied over a full checkout.**
