### PR TITLE
docs(mkdocs): use the generic system font cascade

### DIFF
--- a/docs/stylesheets/fonts.css
+++ b/docs/stylesheets/fonts.css
@@ -1,0 +1,11 @@
+/* Generic system-UI text face. `theme.font: false` in mkdocs.yml keeps
+ * Material from loading Roboto off Google Fonts; this stack lets every
+ * platform render its native face instead. Material defines
+ * --md-text-font-family on `body` (not :root), so the override must sit on
+ * `body` too — a :root definition would lose to the theme's own. Code blocks
+ * are untouched: --md-code-font-family keeps Material's monospace fallbacks.
+ */
+body {
+  --md-text-font-family: -apple-system, BlinkMacSystemFont, "Segoe UI",
+    Roboto, Oxygen, Ubuntu, Cantarell, "Helvetica Neue", Arial, sans-serif;
+}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -50,6 +50,11 @@ theme:
     logo: material/home
     repo: fontawesome/brands/git-alt
   language: en
+  # No webfont download: `false` stops Material loading its stock Roboto pair
+  # from Google Fonts. The text face is the generic system-UI cascade set in
+  # docs/stylesheets/fonts.css (see extra_css below); code blocks fall back to
+  # Material's stock monospace stack.
+  font: false
   # Light/dark palette toggle (rf2-q0n02). Two schemes share the existing
   # blue brand colour; `media` seeds the initial scheme from the reader's OS
   # preference, and each `toggle` adds a manual switch in the header. The
@@ -150,6 +155,7 @@ extra_javascript:
 
 extra_css:
   - cljs/playground.css
+  - stylesheets/fonts.css
 
 extra:
   generator: false


### PR DESCRIPTION
Sets `theme.font: false` so Material stops loading Roboto / Roboto Mono from Google Fonts, and points the docs text face at the generic system-UI cascade:

```
-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, Ubuntu, Cantarell, "Helvetica Neue", Arial, sans-serif
```

The override lives in a new `docs/stylesheets/fonts.css` (wired via `extra_css`) and sits on `body`, which is where Material defines `--md-text-font-family` — a `:root` definition would lose to the theme's own. Code blocks are untouched and keep Material's stock monospace fallbacks.

Verified locally: `mkdocs build --strict` passes (34s, INFO-only); the built page links `stylesheets/fonts.css` after the theme stylesheet, and carries zero `fonts.googleapis.com` references.