### PR TITLE
docs(hicasso): the per-keystroke attribute trace reports old values, not observed transitions (rf2-hic-045)

### DIFF
--- a/docs/design/hicasso/product/per-keystroke.md
+++ b/docs/design/hicasso/product/per-keystroke.md
@@ -380,9 +380,13 @@ then contained; run 7 added three per-subscription attributions for `+26`.
 
 **Run 8's arithmetic is checkable against a figure this page did not produce.**
 `rf2-hic-036`'s tournament landed on `main` between run 7 and the rebase, and
-[its own §2.1](topology-tournament.md) publishes the lane at **1,500 tests /
+[its own §2.1](topology-tournament.md) published the lane at **1,500 tests /
 9,482 assertions** on that base. Run 8 reads 1,502 / 9,508 — the same `+2` and
-`+26`, arrived at from a control another worker measured.
+`+26`, arrived at from a control another worker measured. **That page has since
+re-taken its own lane** on a later base and now publishes a larger total, so the
+cross-check reproduces against the reading quoted here rather than against its
+current head. The `+2` and `+26` are the claim; the absolute totals are only the
+two endpoints the difference was measured between.
 
 **Run 6 is the sabotage control, and it is why run 5 and run 7 mean anything.**
 Inverting one figure produced a captured failure naming it:

--- a/docs/design/hicasso/product/per-keystroke.md
+++ b/docs/design/hicasso/product/per-keystroke.md
@@ -47,7 +47,7 @@ Each stage of the path gets exactly one instrument, and no stage gets two.
 | Subscription recomputations | a counting wrapper installed on the registrar's `:handler-fn` before mount, removed after | one invocation of the author's own computation fn |
 | Boundary runs | [`hm/bodies-run`][kit] | one `defview` body React actually ran |
 | Commit — glass writes | a spy on the `value` property setter of `HTMLInputElement.prototype` / `HTMLTextAreaElement.prototype`, restored in a `finally` | one write of a value onto a live control |
-| Commit — DOM mutations | a `MutationObserver` over the container (`childList`, `attributes`, `characterData`) | one mutation record |
+| Commit — DOM mutations | a `MutationObserver` over the container (`childList`, `attributes`, `attributeOldValue`, `characterData`) | one mutation record |
 | Visible echo | the typed control's `.value`, read at the instant `dispatchEvent` returns | — |
 
 Two of these deserve their definition stated rather than assumed.
@@ -57,9 +57,15 @@ keystroke reaches the same code path a real one does only by writing through the
 element prototype's own `value` setter and then firing a real `input` event
 (`editor.flow-dom-cljs-test/type-into!` established this). That first write is
 the *user agent's*, not the runtime's, so [the census][census] performs it
-through a setter captured at namespace load, outside the spy's reach by
-construction rather than by subtracting one and hoping the subtrahend never
-changes.
+through a setter captured **on first browser use, before the spy** — the spy
+forces the capture at its own top, ahead of replacing any descriptor. Both
+halves of that ordering are load-bearing. Capturing at namespace load instead
+takes the node lane down with it — §7 records that this census had exactly that
+defect and fixed it — and capturing lazily on the first *keystroke* would capture
+the spy's own setter, because every keystroke here is typed inside one, turning
+the accepted keystroke's measured zero into a one. So the user agent's write is
+outside the count by construction rather than by subtracting one and hoping the
+subtrahend never changes.
 
 **The echo is read before any flush.** Every existing mounted witness in the tree
 calls `hm/settle!` and then asserts the glass. That is right for a correctness
@@ -226,11 +232,30 @@ They are attributed by an experiment the census can run because the grid refuses
 non-digits: **a refused keystroke runs zero bodies**, so React commits nothing —
 and three of the seven records appear anyway.
 
-| Records | Whose | What they are |
+**What a mutation record can and cannot say, because the table below is read
+through it.** A `MutationRecord` for an attribute carries that attribute's value
+*before* the record and nothing else. There is no new-value field, and reading
+one back off the element answers what the attribute holds *now* rather than what
+that record wrote — which is why [the census's][census] raw trace shows its
+`name` records as `nil -> nil`, both sides being the attribute as it finally
+stands. **No arrow the instrument prints is an observed transition, and this page
+does not present one as such.** What the observer does witness, exactly, is the
+*order* of the attribute names and each record's old value; so the table below is
+read forwards through those old values, and what a record did is named by the
+*next* record's.
+
+| Records | Whose | The attributes in order, and what each held before its record |
 |---:|---|---|
-| 4 | the commit | `name: nil → ""`, `type`, `value` (i.e. `defaultValue`), `name: "" → removed` |
-| 3 | React's post-event controlled-state restore | the same churn without the `value` write, `defaultValue` already being right |
+| 4 | the commit | `name` (absent), `type`, `value` — i.e. `defaultValue` — (the pre-keystroke text), `name` (`""`) |
+| 3 | React's post-event controlled-state restore | `name` (absent), `type`, `name` (`""`) — the same churn without the `value` write, `defaultValue` already being right |
 | 1 | the commit, grid only | `characterData` on the row total's text node |
+
+**Read forwards, those old values are what say `name` churns.** It is absent, a
+record writes it, and the record that removes it reports `""` as what it
+removed — so React added an empty `name` and took it away again, once per pass,
+and `name` is absent again by the end. The transient `""` is therefore
+*witnessed*, one record later than the record that wrote it, rather than shown
+as a transition the observer never saw.
 
 **Four of the editor's seven records are churn on an attribute the application
 never wrote.** React 19 removes and restores `name` around every controlled-input

--- a/implementation/hicasso/test/re_frame/hicasso/examples/per_keystroke_dom_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/examples/per_keystroke_dom_cljs_test.cljs
@@ -46,9 +46,10 @@
   React's own change tracker captures the prototype descriptor when it
   begins tracking a node, so a spy installed afterwards is behind React's
   captured reference and would count nothing. [[type-into!]] here writes
-  through a setter captured at namespace load, so a scripted keystroke's
-  own write is outside the count by construction rather than by
-  subtraction.
+  through a setter captured on FIRST BROWSER USE, which
+  [[with-glass-spy]] forces before it replaces anything, so a scripted
+  keystroke's own write is outside the count by construction rather than
+  by subtraction.
 
   [[mutations-during]] drains a `MutationObserver` synchronously with
   `takeRecords`, which is what makes it usable inside a discrete event:
@@ -215,7 +216,11 @@
   around the MOUNT and not merely around the keystroke — React's change
   tracker captures the prototype descriptor when it starts tracking a
   node, so a spy installed after the mount sits behind the reference
-  React already took."
+  React already took.
+
+  It also FORCES [[pristine-setters]] before it replaces anything — see
+  that def; the ordering is what keeps the user agent's own write out of
+  the count."
   [f]
   (let [_         @pristine-setters ;; capture BEFORE the swap — see that def
         protos    [["INPUT" js/HTMLInputElement.prototype]
@@ -258,12 +263,40 @@
           records))
 
 (defn- attribute-trace
-  "The attribute records in order, as `\"name: <old> -> <new>\"`.
+  "The attribute records in order, as
+  `\"<attribute>: <value before this record> -> <value NOW>\"`.
 
-  A count says a commit touched `name` four times; this says what it did
-  to it, which is the difference between reporting the commit stage and
-  ATTRIBUTING it. `:attributeOldValue` is what the observer needs to
-  answer it, and it changes no record's existence or count."
+  A count says a commit touched `name` four times; this says which
+  attribute each of the four was and what it held beforehand, which is
+  the difference between reporting the commit stage and ATTRIBUTING it.
+  `:attributeOldValue` is what the observer needs to answer that, and it
+  changes no record's existence or count.
+
+  **NEITHER SIDE OF THE ARROW IS A NEW VALUE, AND NO ROW HERE IS AN
+  OBSERVED TRANSITION.** A `MutationRecord` carries `oldValue` and no
+  counterpart: a new value has to be read back off the element, and by
+  the time this runs — after every record has been taken — that read
+  answers what the attribute holds now, the FINAL value. Hence the
+  `name: nil -> nil` rows below, printed by records that set `name` to
+  `\"\"`.
+
+  The attribution survives that intact, because it never rested on the
+  right-hand side. It rests on the ORDER of the attribute names and on
+  each record's old value, and those are read FORWARDS: `name`'s removal
+  record carries `oldValue` `\"\"`, and that is the observation — not an
+  inference — that `name` had been set to the empty string. Every caller
+  below reads it that way, and
+  `docs/design/hicasso/product/per-keystroke.md` §5 states the same limit
+  before it presents the table it draws from these records.
+
+  RECONSTRUCTING each record's new value from the NEXT same-attribute
+  record's `oldValue` was weighed and DECLINED (rf2-hic-045, the audit of
+  PR #8163). It would restate what the old values already carry; done
+  correctly it must key on target IDENTITY as well as attribute name, not
+  on the name alone; and the last record of each attribute would still
+  fall back to a final read taken after `hm/settle!`, so the caveat above
+  would survive the change that was supposed to remove it. Naming the
+  limit costs nothing and hides nothing."
   [records]
   (into []
         (comp (filter (fn [r] (= "attributes" (.-type r))))
@@ -391,11 +424,19 @@
                           "type: \"text\" -> \"text\""
                           "name: \"\" -> nil"]
                          (attribute-trace @muts))
-                      "TWO PASSES over one input, and the trace is what says
-                       so: `name`, `type`, `value`, `name` — then `name`,
-                       `type`, `name` with no `value`, because the second pass
-                       finds `defaultValue` already right. React 19 removes
-                       and restores `name` around every controlled-input
+                      "TWO PASSES over one input, and the ORDER of the
+                       attribute names is what says so: `name`, `type`,
+                       `value`, `name` — then `name`, `type`, `name` with no
+                       `value`, because the second pass finds `defaultValue`
+                       already right. The arrows' RIGHT-hand sides carry
+                       nothing: they are the attribute as it finally stands,
+                       not each record's new value, which is why a record that
+                       set `name` to the empty string prints `nil -> nil` (see
+                       [[attribute-trace]]). That empty string is witnessed on
+                       the LEFT of the following `name` record, and that is the
+                       observation it was set and then removed. React 19
+                       removes and restores `name` around every
+                       controlled-input
                        update so that a radio group's changes apply
                        atomically, and this input has no `name` at all, so
                        four of the seven records are churn on an attribute the
@@ -538,7 +579,11 @@
                       "THE ATTRIBUTION, and it is decisive. A refusal runs ZERO
                        bodies, so React commits nothing — and THREE of the
                        accepted keystroke's seven records appear anyway, as one
-                       `name`/`type`/`name` pass with no `value` write. Those
+                       `name`/`type`/`name` pass with no `value` write. It is
+                       the ORDER of those names that carries this, not the
+                       arrows: their right-hand sides are the final attribute
+                       values rather than per-record new ones, so `name` prints
+                       `nil -> nil` here too (see [[attribute-trace]]). Those
                        three are React's post-event controlled-state restore,
                        which is also what performs the single `value` PROPERTY
                        write the row above counts. The remaining four —


### PR DESCRIPTION
Reopen of `rf2-hic-045`, from the merged-PR audit of #8163. The audit found the
published per-keystroke page presenting DOM mutation records' attribute values as
**observed transitions**, when a `MutationRecord` carries no new value at all.

## The finding, confirmed at source

`attribute-trace` builds each row as

```clojure
(str (.-attributeName r) ": " (pr-str (.-oldValue r)) " -> "
     (pr-str (.getAttribute (.-target r) (.-attributeName r))))
```

and every caller applies it to `@muts` **after** `mutations-during` has drained the
observer and after `hm/settle!` has run. So the right-hand side of every arrow is
the attribute's *final* value, not the value that record wrote. The asserted rows
`name: nil -> nil` are printed by records that set `name` to `""` — the very
transient §5's prose said they traced. The audit is right.

## Which repair, and why

**The prose repair, not the reconstruction.** Both were weighed.

The reconstruction (each new value from the *next* same-attribute record's
`oldValue`, the final value for the last) would restate information the trace
already carries. The attribution never rested on the arrow's right-hand side: it
rests on the **order of the attribute names** and on **each record's `oldValue`**,
read forwards. The transient `""` is therefore already *witnessed*, one record
later — it is the `oldValue` the removal record carries. Reconstruction would put
a mechanism in front of an observation that is directly in hand.

Three further things argue against it, and they are recorded in the helper's
docstring rather than only here:

- done correctly it must key on **target identity** as well as attribute name, not
  on the name alone, which the naive "next same-attribute record" rule does not;
- the **last record of each attribute** would still fall back to a final read taken
  after `hm/settle!` — so the caveat it was meant to remove survives it;
- validating it needs a **fresh browser window** on a census that is already
  published, to keep a decorative half of a string.

So §5 now states the instrument's limit *before* the table it draws from these
records, and the table is read forwards through old values instead of drawing
arrows the observer never drew. It still tells the same true story — React 19 adds
an empty `name` and removes it again, once per pass — sourced to the observation
that actually carries it.

**No figure moves and no assertion's expected value is touched.** The census's
numbers are not in question and were not re-run: 1 state write, 10 subscription
recomputations for the editor, 111 for the 10x10 grid, 2 boundary runs, 0 glass
writes, and the write-amplification table all stand exactly as published. The
changes to the witness are docstrings and `is` message strings only — inert for
pass/fail. `git diff` over the file matches no `(= …)` expected value.

## The setter-capture correction

The page said pristine setters are captured at namespace load. Stale: PR #8163's
own follow-up commit (`275dfab69e`) made them a `delay` forced by `with-glass-spy`
*before* it replaces any descriptor, because namespace-load capture broke the node
lane and lazy-on-first-*keystroke* capture would capture the spy's own setter and
turn the accepted keystroke's measured zero into a one.

That commit fixed the `def`'s own docstring and **left the claim stale in two other
places**, both corrected here:

- `docs/design/hicasso/product/per-keystroke.md` §1.1;
- the census's **namespace docstring**, which the audit did not name and which said
  the same wrong thing.

Also added `attributeOldValue` to §1.1's instrument row — the observer does request
it, and it is the field the whole of §5 now rests on.

## A third correction, found while in the page and not asked for

§7 cross-checks run 8's assertion arithmetic against a figure this page did not
produce: `topology-tournament.md` §2.1's browser lane at **1,500 tests / 9,482
assertions**. **PR #8166 merged an hour ago and re-took that page's own lane on a
later base**, so §2.1 now publishes **1,507 / 9,533**. A reader following the link
found a different number and nothing explaining it — the cross-check had quietly
stopped reproducing.

Verified from history rather than assumed: `git show fe72e33a04:…/topology-tournament.md`
(the commit run 8 was taken at) carries `1,500 tests / 9,482 assertions`, and
`43e973453f` is the commit that moved it.

The claim was always the **difference** — `+2` tests and `+26` assertions, arrived
at from a control this page did not measure — and that is untouched. §7 now says
so, and says the absolute totals are the endpoints the difference was measured
between rather than the thing asserted. Same lens as the rest of this PR: no page
should leave a reader holding a check that cannot be reproduced as stated. I did
**not** touch `topology-tournament.md`; only my own page's reference to it.

## Verified by hand

- **Anchors**: every `](#…)` and reference-style link target on the changed page —
  `check_doc_slugs.py` validates this tree, and the sabotage run below proves it
  reads *this* worktree.
- **Table column counts**: all 7 tables on the page parsed; each row's cell count
  equals its header's. The edited table (§5) is 3 columns, header + separator + 3
  rows. No cell contains a raw `|`.
- **`mkdocs build --strict` is NOT nominated** — `mkdocs.yml`'s `exclude_docs`
  block excludes `design/hicasso/`, so it would not read this page at all.
- **Merge-base review**: `git diff origin/main...HEAD` read for reverts. Every
  deleted line is this repair's own; nothing from `main` is undone.

## Quality gates

Fast-spine-versus-required-CI gap: `python scripts/check_fast_pr_gap.py --list`
(captured exit `0`) is the canonical derivation — it reports the required steps the
spine does not run and does **not** inspect what I ran. It lists **96** required
checks outside the spine.

Stated plainly: **I ran the fast-PR spine**, plus the two documentation gates that
own this tree directly. Captured exit codes, each echoed by the runner on the same
command line as its own redirect, never taken from the harness:

| Gate | Captured exit |
|---|---:|
| `scripts/test-fast-pr.sh` — run 1, base `f858d85` | `0` |
| `scripts/test-fast-pr.sh` — run 2, base `4eade73` (post-rebase) | `0` |
| `scripts/test-fast-pr.sh` — run 3, base `4eade73`, covers the §7 correction | `0` |
| `scripts/test-fast-pr.sh` — run 4, base `56d60d1` (final) | `0` |
| `python scripts/check_doc_slugs.py` | `0` |
| `python scripts/check_doc_slugs.py` — **sabotage**, broken anchor planted | `1` |
| `python scripts/check_provenance_pins.py --self-test --verbose` | `0` (61/61) |
| `python scripts/check_provenance_pins.py --changed-since origin/main --verbose` | `0` (3 pins, 3 landed) |
| `python scripts/check_fast_pr_gap.py --list` | `0` |

**The sabotage control, because a green doc gate proves nothing on its own.** A
single-line patch put `[sabotage](budgets.md#no-such-anchor-xyzzy-transitions-hic045)`
into §5. `check_doc_slugs.py` went red at captured exit `1`, naming my plant:

```
BROKEN ANCHOR: docs\design\hicasso\product\per-keystroke.md:237 -> budgets.md#no-such-anchor-xyzzy-transitions-hic045
```

The file was then restored and the restore verified **by hashing the bytes**, not
by reading a diff: `git hash-object` returns `65623491f45b1edfcd5df3c6d6f81c734ef1a954`,
equal to `git rev-parse HEAD:…` for the same path.

**The spine was run once per base**, per "re-run the gates on the final base after
every rebase" — `main` moved under this branch three times while the work was in
flight (#8166 … #8172 and the mayor's beads checkpoints). Runs 2–4 classified as
`--all`: the force-push makes the previous tip unreachable and the classifier
refuses to skip gates it cannot prove are unaffected, so those runs are broader
than a changed-surface run, not narrower.

`main` takes a beads checkpoint every few minutes, so a run can never be the
literal tip by the time it finishes. Run 4's base is `56d60d1`, and the deltas
that landed after it are checkpoints and trees this diff does not touch.

The spine's own PASS line reports the only things it left out: the JVM artefact
suites the diff did not touch, and the CI-only lanes. Inside it, the two runs that
carry this change are

- `:node-test` compiled **2,388 files, 0 warnings**, and ran **13,886 tests /
  70,161 assertions, 0 failures, 0 errors** — the lane that loads this namespace at
  its top level, which is exactly where a malformed docstring or message string
  would have shown up;
- the hicasso invariants, lint-export and bench-lane compile gates all green
  (130 lane namespaces, zero warnings).

**The browser lane was not run and this change does not need it.** No expected
value, no code path and no figure changed: the diff adds and removes **zero** `is`
forms and **zero** `deftest`s, so the census's browser-guarded rows are
byte-identical in behaviour. Gates were re-run on the final base after rebasing
onto `origin/main`.

## Not touched

`docs/design/hicasso/product/correction-ledger.md` — its own protocol forbids
corrective PRs from editing it. No `.beads` database path. No hot-zone file.
