### PR TITLE
docs(hicasso): U5's second counter, the per-keystroke ledger rows, and the L7 gate rule (rf2-mwr2, rf2-w6d9)

### DIFF
--- a/docs/design/hicasso/product/budgets.md
+++ b/docs/design/hicasso/product/budgets.md
@@ -123,9 +123,11 @@ had to be taken later, alone, in a window of its own.
 
 ## 3. Deterministic rows, pinned on the moved package
 
-These are pinned **on `implementation/hicasso`** — the moved package itself,
-not a donor — at commit `0c0aa22898`, through the supported test-kit facade
-`re-frame.hicasso.test.mounted`. No `impl/` reach-through is involved.
+`D1`–`D25` are pinned **on `implementation/hicasso`** — the moved package
+itself, not a donor — at commit `0c0aa22898`, through the supported test-kit
+facade `re-frame.hicasso.test.mounted`. No `impl/` reach-through is involved.
+**`D26` is the one row in this section taken on the bench tree**, and the note
+below it says why that is the only place it can be taken.
 
 The instrument for body counts is [`hm/bodies-run`][kit], which is page-wide,
 handle-free, and takes its reading as a delta on the runtime's monotone
@@ -152,6 +154,16 @@ it exists to make assertable.
 | D14 | Wrappers between the element type React reconciles and the author's own function, declared island | **0** | `three_way_parity_cljs_test` | the `:client-only` default answers a gate instead; UIx's route answers a generated component |
 | D15 | Slots on the props object React carries, and they are the author's own | **1** | as D14 | UIx's route also reads 1 — but the slot is `argv`, which the author never wrote |
 | D16 | Unwrapping hops per render, per component, native and handwritten React | **0** | as D14 | the UIx route reads 1 — the `argv` carrier being opened |
+| D17 | Subscription recomputations per keystroke, four-field editor | **10** | `per_keystroke_dom_cljs_test` | D20 — a refused keystroke reads 0 |
+| D18 | Subscription recomputations per keystroke, grid 5×5 | **31** | as D17 | D19 — the same measurement at 10×10 reads 111 |
+| D19 | Subscription recomputations per keystroke, grid 10×10 | **111** | as D17 | D18 — quartering the grid moves it to 31 |
+| D20 | Subscription recomputations for a *refused* keystroke | **0** | as D17 | D19 — an accepted keystroke reads 111 |
+| D21 | Glass writes (`value` property) for an *accepted* keystroke | **0** | as D17 | D22 — a refused keystroke reads 1 |
+| D22 | Glass writes for a *refused* keystroke | **1** | as D17 | D21 — an accepted keystroke reads 0 |
+| D23 | DOM mutation records per keystroke, editor | **7** | as D17 | D25 — a refusal reads 3 |
+| D24 | DOM mutation records per keystroke, grid | **8** | as D17 | D23 — the editor reads 7; the grid's extra one is the row total's text node |
+| D25 | DOM mutation records for a *refused* keystroke | **3** | as D17 | D23 — an accepted keystroke reads 7 |
+| D26 | Rows of markup built for a one-row write, fine topology | **1** at `B` = 100, 300 and 1,000 | `topo/census_dom_cljs_test` | the coarse arm builds `B` — 100, 300, 1,000 |
 
 **These figures are cited, not re-derived.** D1–D8 were established by the two
 witness apps that landed on `main` ahead of this page; re-deriving them here
@@ -264,6 +276,83 @@ section rather than §4. And **they are the deterministic half of C7 only**: the
 say there is no interposed work, never how long a render takes, so C7 stays
 `UNPINNED` and its clock half remains `rf2-hic-071`'s, along with the ladder re-pin
 and the package-resident clock instrument that half needs.
+
+**On D17–D25 — the per-keystroke census (`rf2-hic-045`).** These are the
+remaining five stages of one keystroke, counted on the two public-package
+witness applications and published in
+[`per-keystroke.md`](per-keystroke.md). They are registered here rather than
+left on that page because they are the only figures in the corpus that **scale
+with the mounted page**, and this section is where a reader finds out which
+budgets do. Their instrument is not `hm/bodies-run`: a counting wrapper on the
+registrar's `:handler-fn` reads the subscriptions, a spy on the `value`
+property setter of the input prototypes reads the glass, and a
+`MutationObserver` over the container reads the commit — each installed around
+the mount and removed in a `finally`, each named in that page's §1.1.
+
+**Two of these nine rows are readings of a LINEAR quantity, and the ledger says
+so rather than implying a flat one.** `D18` and `D19` are the same estimand at
+two mount sizes: subscription recomputations go `31 → 111` as the grid goes
+`5×5 → 10×10`, following `rows × cols + rows + 1`. **The mount size is part of
+the registered line**, and the pair is registered rather than a single figure
+precisely so that neither can be read as a ceiling that holds at another size.
+`D17`'s `10` is likewise the editor's ten live layer-1 cells and not a
+constant: change the page and the figure changes with it, which is the point.
+The other seven — the refused keystroke's `0`, the two glass writes and the
+three mutation-record counts — are flat, and `D24` against `D23` is what makes
+that assertable rather than assumed. **What makes all nine gateable on a hosted
+runner is that they are integers on monotone counters, not that they are
+small**; a linear figure taken at a stated size reads the same on a loaded box
+exactly as a flat one does.
+
+**The contrast these rows exist to keep visible.** One keystroke in the
+hundred-cell grid runs **111 subscription bodies to run 2 view bodies**
+(`D19` against `D2`). The read topology buys narrow *notification* — which is
+what `D1`/`D2` measure and what keeps the page from re-rendering — and it does
+not buy narrow *recomputation*. Registering only the flat half of that would
+have made the ledger say something the census does not.
+
+**On D26 — the second counter `U5`'s estimand was missing (`rf2-mwr2`).**
+`rf2-hic-036`'s topology tournament measured a coarse view-model arm that
+**rebuilds all `B` rows for a one-row change and runs exactly one boundary
+body**, because it does its `B` rows *inside* that body. Read against `U5`'s
+registered estimand — boundary bodies run — that arm **passes**, at every row
+count, untunably: the very behaviour `U5`'s English forbids. `D3`/`D4` do not
+already cover it. They catch a coarse shape because *their* witness keeps
+per-cell boundaries to count; a coarse shape with no boundaries beneath the
+family has nothing for that instrument to see.
+
+**The repair is a second counter, not a wider line.** `U5`'s registered line is
+untouched and no threshold moves. What changes is that the claim is now decided
+on **two** instruments — bodies run (`D1`–`D4`) *and* rows of markup built
+(`D26`) — and [§9's gate](#9-the-budget-line-reconciliation-ledger) refuses a
+row that states a scaling claim and names only one. The counter was already
+built and already cross-checked when this row was registered: the tournament
+increments `:markup` inside the single shared `row-markup` fn every arm calls,
+and its census agrees with `arm1.runtime/body-runs` — two instruments sharing
+no traversal — on all 48 cells.
+
+**`D26` is a `bench-tree` figure, and that is the honest population rather than
+a convenience.** The tournament's four arms are written on
+`re-frame.bench.hicasso.arm1`, the prototype runtime, whose own docstring
+places it *"off every production source path"*; the package ships one topology
+and cannot mount four. So the subject is the bench tree, and this column names
+the subject. **The package's own witness reaches the same limit from the other
+side and already records it**: `scaling_dom_cljs_test`'s
+`the-coarse-shape-with-scalar-props-is-INVISIBLE-to-this-instrument` reads `2`
+at 25 cells and at 100 for a coarse shape whose props are plain values, and
+says in terms that *"this gate CANNOT distinguish the two shapes"* while that
+shape allocates `N` elements and compares `N` props maps per keystroke. Two
+witnesses, two populations, one hole — and `D26` is the counter that closes it.
+
+**`D26`'s own figure is flat and its control is linear**, which is the way
+round a scaling row should read: the fine topology builds **one** row of markup
+for a one-row write at `B` = 100, 300 and 1,000, and the coarse arm builds `B`
+— a factor of a thousand at the largest size, on an exact integer counter with
+no interval attached because none is needed. The chunked arm builds `k` = 25
+and the windowed arm builds 1; both are recorded
+[on the tournament page](topology-tournament.md#22-the-rung-2-teaching-table--rows-of-markup-built)
+and neither is registered here, because a stated arm constant is a setting and
+not a result.
 
 **On D9.** This is teardown residue in **counters and objects**, which is a
 deterministic reading the package can make. It is *not* S5, the teardown row
@@ -395,11 +484,22 @@ single-profile limitation.
 | U2 | Ordinary discrete interactions reach next paint within 50 ms p95 / 100 ms p99 | latency to next paint | distributional |
 | U3 | Broad application operations within 100 ms p95 unless classified background | operation latency | distributional |
 | U4 | Dragging/animation stay inside frame budget | per-frame latency | distributional |
-| U5 | Narrow-update body work scales with changed rows, not all mounted rows | boundary bodies run | **deterministic** — pinned as D1–D4 |
+| U5 | Narrow-update body work scales with changed rows, not all mounted rows | boundary bodies run **and rows of markup built** | **deterministic** — pinned as D1–D4 and D26 |
 | U6 | Teardown residue is zero after quiescence | residue counters / retained bytes | **split** — D9 deterministic, S5 distributional |
 
 U5 and the deterministic half of U6 are pinned on the package today. U1–U4 are
 not, and cannot be until a package-resident clock instrument exists.
+
+**`U5`'s estimand carries two counters as of 2026-08-14 (`rf2-mwr2`), and its
+line is unchanged.** Registered on bodies alone it read `PASS` on a coarse
+view-model arm that rebuilds all `B` rows for a one-row change, because that
+arm does its `B` rows inside one body — the exact behaviour the *Budget* column
+above forbids. Adding `D26`'s rows-of-markup counter beside `D1`–`D4`'s bodies
+is what closes that, and it is a **second counter and not a wider line**: no
+threshold moved, and a coarse arm that is genuinely cheap still passes both.
+The measurement, the four-arm table and the hole's shape are
+[§3's `D26` note](#3-deterministic-rows-pinned-on-the-moved-package) and
+[the tournament's §2.5](topology-tournament.md#25-u5-and-an-instrument-gap-in-it-that-this-tournament-exposed).
 
 ### The comparative and regression rules
 
@@ -722,7 +822,7 @@ and no figure may be scaled from one onto the other.
 
 | Family | Enforcement home |
 |---|---|
-| Deterministic rows D1–D16 | ordinary blocking PR gates; framework in `rf2-hic-089`, full gates in `rf2-hic-071` |
+| Deterministic rows D1–D26 | ordinary blocking PR gates; framework in `rf2-hic-089`, full gates in `rf2-hic-071` |
 | Distributional rows S1–S8, U1–U4 | pinned interleaved evidence runs on P-DEV-1; never converted into flaky PR thresholds |
 | Shell breach disposition | `rf2-0xx2` |
 | K3 per-read record | `rf2-hic-070` — [`k3-disposition.md`](k3-disposition.md), whose §8 makes the 10% same-witness per-read rule executable for `rf2-hic-071` |
@@ -849,6 +949,23 @@ that exists and runs in the first lane; a distributional row may never name the
 first lane at all. *Authority* is the bead that owns the row's disposition
 today. *Disposition* is a link that must resolve to a section naming the row.
 
+**[Amended 2026-08-14, `rf2-mwr2`.] A row that claims work SCALES has to name
+two counters, and the gate refuses one.** `U5` was registered on boundary
+bodies alone, and read `MET` on a coarse view-model arm that rebuilds every
+mounted row for a one-row change — it does its rows *inside* one body, so the
+instrument counts 1 and reports a pass on the behaviour the line forbids. That
+is a **fail-open**: not a row recorded wrongly, but a row that could not be
+recorded wrongly, because its estimand cannot see the failure. So the gate now
+holds a rule of its own for this shape. A registered line stating that work
+scales with changed rows must name a companion ledger row carrying a **second,
+different** work counter; that companion must itself be deterministic, in the
+`PR gate` lane, with a witness file that exists; and the scaling row's *Current
+value* must name it, so a reader following the row reaches both readings. `U5`'s
+companion is `D26`. **Nothing here widens a line** — no threshold moved, and a
+coarse topology that is genuinely cheap passes on both counters. What the rule
+removes is the option of registering a scaling claim that only one instrument
+is asked about.
+
 **[Amended 2026-08-13.]** *Authority* is read in **two modes**, and which one
 applies follows the state of the **disposition**, not the state of the bead.
 While a live transition remains to be made — the `UNPINNED` rows waiting on
@@ -890,6 +1007,16 @@ it reads the cell for **shape, not for life**, and says so in its own output.
 | D14 | 0 wrappers between the element type React reconciles and the author's own function, declared island | 0 — the type is `identical?` to the function, on the native and handwritten-React routes alike; UIx's is a generated component | package | `MET` | `implementation/hicasso/test/re_frame/hicasso/three_way_parity_cljs_test.cljs` (PR gate) | `rf2-hic-034` | — |
 | D15 | 1 slot on the props object React carries, and it is the author's own | 1 — `label`, the name the call site wrote; UIx also reads 1, and it is the `argv` carrier | package | `MET` | `implementation/hicasso/test/re_frame/hicasso/three_way_parity_cljs_test.cljs` (PR gate) | `rf2-hic-034` | — |
 | D16 | 0 unwrapping hops per render, per component, native and handwritten React | 0 — the UIx route reads 1, opening `argv` | package | `MET` | `implementation/hicasso/test/re_frame/hicasso/three_way_parity_cljs_test.cljs` (PR gate) | `rf2-hic-034` | — |
+| D17 | 10 subscription recomputations per keystroke, four-field editor | 10 — `::field` 4, `::committed` 4, `::revision` 1, `::dirty?` 1; one of the ten computes a new value | package | `MET` | `implementation/hicasso/test/re_frame/hicasso/examples/per_keystroke_dom_cljs_test.cljs` (PR gate) | `rf2-hic-045` | — |
+| D18 | 31 subscription recomputations per keystroke, grid at 5×5 — a LINEAR quantity at a stated mount size | 31 — `::cell` 25, `::row-total` 5, `::dimensions` 1 | package | `MET` | `implementation/hicasso/test/re_frame/hicasso/examples/per_keystroke_dom_cljs_test.cljs` (PR gate) | `rf2-hic-045` | — |
+| D19 | 111 subscription recomputations per keystroke, grid at 10×10 — a LINEAR quantity at a stated mount size | 111 — `::cell` 100, `::row-total` 10, `::dimensions` 1; 109 of them compute what they computed last time | package | `MET` | `implementation/hicasso/test/re_frame/hicasso/examples/per_keystroke_dom_cljs_test.cljs` (PR gate) | `rf2-hic-045` | — |
+| D20 | 0 subscription recomputations for a refused keystroke | 0 — the event writes no address, so nothing is invalidated | package | `MET` | `implementation/hicasso/test/re_frame/hicasso/examples/per_keystroke_dom_cljs_test.cljs` (PR gate) | `rf2-hic-045` | — |
+| D21 | 0 glass writes for an accepted keystroke | 0 — the character is already on the glass and the model took it unchanged | package | `MET` | `implementation/hicasso/test/re_frame/hicasso/examples/per_keystroke_dom_cljs_test.cljs` (PR gate) | `rf2-hic-045` | — |
+| D22 | 1 glass write for a refused keystroke | 1 — the committed value going back over the character the model would not take; also this instrument's own positive control | package | `MET` | `implementation/hicasso/test/re_frame/hicasso/examples/per_keystroke_dom_cljs_test.cljs` (PR gate) | `rf2-hic-045` | — |
+| D23 | 7 DOM mutation records per keystroke, editor | 7 — `name` ×4, `type` ×2, `value` ×1; four of them React's churn on an attribute the application never wrote | package | `MET` | `implementation/hicasso/test/re_frame/hicasso/examples/per_keystroke_dom_cljs_test.cljs` (PR gate) | `rf2-hic-045` | — |
+| D24 | 8 DOM mutation records per keystroke, grid | 8 — the editor's seven plus one `characterData` on the row total's text node | package | `MET` | `implementation/hicasso/test/re_frame/hicasso/examples/per_keystroke_dom_cljs_test.cljs` (PR gate) | `rf2-hic-045` | — |
+| D25 | 3 DOM mutation records for a refused keystroke | 3 — `name`/`type`/`name` with no `value` write; the attribution that makes D23's other four the commit's | package | `MET` | `implementation/hicasso/test/re_frame/hicasso/examples/per_keystroke_dom_cljs_test.cljs` (PR gate) | `rf2-hic-045` | — |
+| D26 | 1 row of markup built for a one-row write under a fine topology, at every row count | 1 at B = 100, 300 and 1,000 — the coarse arm builds B, the chunked k=25, the windowed 1 | bench-tree | `MET` | `implementation/freehand/test/re_frame/bench/hicasso/topo/census_dom_cljs_test.cljs` (PR gate) | `rf2-mwr2` | — |
 | S1 | 1,024 B, R=0 shell, Reagent segment | 1,100 B [1,091–1,107] | package | `BREACH` | P0 heap ladder, package candidate arm (P-DEV-1 evidence run) | `rf2-0xx2` | [substrate-decision §5.2](substrate-decision.md#52-the-read-free-boundary-shell--the-disposition); scoped acceptance 2026-08-13, [§5](budgets.md#5-the-read-free-boundary-shell-the-byte-exact-line-now-frozen-at-1024-b) — ceiling unchanged at 1,024 B, accepted to 1,107 B |
 | S2 | 1,024 B, R=0 shell, UIx segment | 1,095 B [1,087–1,101] | package | `BREACH` | P0 heap ladder, package candidate arm (P-DEV-1 evidence run) | `rf2-0xx2` | [substrate-decision §5.2](substrate-decision.md#52-the-read-free-boundary-shell--the-disposition); scoped acceptance 2026-08-13, [§5](budgets.md#5-the-read-free-boundary-shell-the-byte-exact-line-now-frozen-at-1024-b) — ceiling unchanged at 1,024 B, accepted to 1,101 B |
 | S3 | ≤ 10% regression on the same pinned witness | 1,417 vs Reagent 948 per read | package | `UNRESOLVED` | P0 heap ladder, package candidate arm (P-DEV-1 evidence run) | `rf2-hic-071` | [substrate-decision §6](substrate-decision.md#6-what-this-page-does-not-decide) |
@@ -902,7 +1029,7 @@ it reads the cell for **shape, not for life**, and says so in its own output.
 | U2 | ≤ 50 ms p95 and ≤ 100 ms p99 to next paint | — | — | `UNPINNED` | — (none) | `rf2-hic-071` | [§9.2](budgets.md#92-what-each-not-green-row-is-waiting-on) |
 | U3 | ≤ 100 ms p95 for broad operations | — | — | `UNPINNED` | — (none) | `rf2-hic-071` | [§9.2](budgets.md#92-what-each-not-green-row-is-waiting-on) |
 | U4 | dragging and animation inside the frame budget | — | — | `UNPINNED` | — (none) | `rf2-hic-071` | [§9.2](budgets.md#92-what-each-not-green-row-is-waiting-on) |
-| U5 | body work scales with changed rows, not mounted rows | 2 at 25 cells and at 100 | package | `MET` | `implementation/hicasso/test/re_frame/hicasso/examples/grid/scaling_dom_cljs_test.cljs` (PR gate) | `rf2-hic-089` | — |
+| U5 | body work scales with changed rows, not mounted rows | 2 bodies at 25 cells and at 100, and — on the second counter D26 — 1 row of markup for a one-row write where a coarse arm rebuilds every row | package | `MET` | `implementation/hicasso/test/re_frame/hicasso/examples/grid/scaling_dom_cljs_test.cljs` (PR gate) | `rf2-hic-089` | — |
 | U6 | teardown residue zero after quiescence | zero counters (D9); bytes indistinguishable from 0 (S5) | package | `MET` | `implementation/hicasso/test_kit/src/re_frame/hicasso/test/mounted.cljs` (PR gate) | `rf2-hic-089` | — |
 | C1 | ≤ 5% regression on the same witness and instrument | — | — | `UNPINNED` | — (none) | `rf2-hic-071` | [§9.2](budgets.md#92-what-each-not-green-row-is-waiting-on) |
 | C2 | 1.10x cold mount, the registered line | see S6 | bench-tree | `BREACH` | final K1 estimator (P-DEV-1 evidence run) | `rf2-hic-085` | [§9.2](budgets.md#92-what-each-not-green-row-is-waiting-on) |
@@ -916,7 +1043,7 @@ it reads the cell for **shape, not for life**, and says so in its own output.
 
 <!-- rf2-hic-089: end-ledger -->
 
-Thirty-nine rows: the sixteen deterministic figures of §3, the eight distributional
+Forty-nine rows: the twenty-six deterministic figures of §3, the eight distributional
 rows and six user-visible budgets of §4, the eight comparative rules §4 now
 gives ids to, and one row registered off this page — **I9**, the two-hook
 ceiling frozen by

--- a/docs/design/hicasso/product/budgets.md
+++ b/docs/design/hicasso/product/budgets.md
@@ -1295,3 +1295,44 @@ instrument and the U-row gates it makes possible, the ladder re-pin and the 5%
 comparison it makes meaningful, and the escape-benefit rule over the escapes
 its own dependencies land. This ledger is what it will report into — the bead
 owns the status columns from the moment it takes them.
+
+### 9.4 What rf2-hic-071 has taken so far, and what it still cannot take
+
+**Taken, 2026-08-14.** Ten rows and one rule. `D17`–`D25` bring
+[the per-keystroke census](per-keystroke.md)'s five remaining stages under
+`L4`'s round trip, `L5`'s population pin and `L6`'s witness check, so a figure
+that lived in prose on one page now has to keep agreeing with a witness a pull
+request runs. `D26` and `L7` close the fail-open `rf2-hic-036`'s tournament
+exposed in `U5`: a registered scaling claim can no longer be decided on one
+counter, in either direction. Neither needed a measurement — every integer here
+was already measured, published and merged, and this bead transcribed rather
+than re-derived them, on §3's own rule that a second source for one number is a
+second thing to drift.
+
+**Not taken, and the reason is the same reason in three places: each needs a
+measurement window this bead did not open.** They are recorded here rather than
+quietly carried:
+
+- **The user-visible gates** — `U1`–`U4`, and `C3`/`C4` stated on the same
+  readings. §4 says in terms that no package-resident clock instrument exists,
+  and §9.2 records that `rf2-hic-045`'s census narrowed *what* the clock will
+  be timing without supplying one. A threshold guessed rather than measured
+  would be a fabricated line, which is what `UNPINNED` exists to say instead.
+- **The 5% same-instrument regression gate** — `C1`. §6 records that the
+  registered instrument's eleven pinned blobs are superseded rather than
+  repaired, one of its files no longer existing, so *"the same instrument"*
+  still names nothing. The re-pin is a run, not an edit.
+- **The escape-benefit rule** — `C8`, whose population is site-level by
+  [Ruling 2](#92-what-each-not-green-row-is-waiting-on). No escape site taken
+  **for a benefit** has landed in an application: the one `h/as-element` call
+  in the shipped examples is the ledger screen handing a view to a vendor
+  virtualizer's `renderRow`, which is interoperability rather than an escape
+  claiming recovered time. That distinction is worth stating before the gate is
+  built, because a `C8` gate written over *every* landed escape would demand
+  the removal of an escape with no alternative — the mirror of the fail-open
+  `L7` just closed, and a fail-closed one.
+
+**What this leaves.** Every deterministic budget this corpus has measured is
+now a ledger row with a witness a pull request runs, and every remaining gate
+is blocked on an instrument rather than on an edit. That is the honest boundary
+today, and moving it needs a quiet box rather than another pass over this page.

--- a/implementation/hicasso/scripts/check_budget_ledger.py
+++ b/implementation/hicasso/scripts/check_budget_ledger.py
@@ -96,6 +96,24 @@ THE RULES
                      §2 and §7 mechanised, and it is what stops the 5%
                      heap comparison being wired to a hosted runner by a
                      later worker acting in good faith.
+  L7  A SCALING CLAIM IS DECIDED ON TWO COUNTERS.
+                     A registered line saying work *scales with changed rows*
+                     must name a companion ledger row carrying a second,
+                     DIFFERENT work counter — deterministic, in the `PR gate`
+                     lane, with a witness that exists — and must name it where
+                     a reader of the row will reach it. `U5` was registered on
+                     boundary bodies alone and read `MET` on a coarse
+                     view-model arm that rebuilds every mounted row for a
+                     one-row change, because the arm does its rows INSIDE one
+                     body and the instrument counts 1. That is a FAIL-OPEN:
+                     not a row recorded wrongly, but a row that could not be
+                     recorded wrongly, its estimand being blind to the
+                     failure. Both directions are checked — a scaling row
+                     with one counter reds, and so does a registered pair
+                     whose line has been rewritten to stop stating the claim.
+                     The repair is a second counter and never a wider line:
+                     nothing here moves a threshold, and a coarse topology
+                     that is genuinely cheap passes on both readings.
 
 WHAT L6 DELIBERATELY DOES NOT CHECK is that a distributional row's
 instrument is absent from the repository. The P0 heap ladder lives in
@@ -155,18 +173,20 @@ LANES = ("PR gate", "P-DEV-1 evidence run", "none")
 # and D9), which is why they sit on the deterministic side here.
 #
 # This is a REGISTRY, not a rule: it transcribes which ids §3 registers, so it
-# grows when §3 does.  `rf2-hic-033` added D10–D13, the direct-return delta,
-# and `rf2-hic-034` added D14–D16, the island band's structural half — element
-# type identity, props-object slots and the unwrapping hop those two price.
-# §3 states the test this list applies in terms — *they are counts, not
-# clocks, so they are deterministic and carry no hardware profile; that is
-# what lets them sit in this section rather than §4*.  Note which way the
-# entry cuts: a row NAMED here must run in the `PR gate` lane and must name a
-# witness file that exists, while a row omitted from it is merely forbidden
+# grows when §3 does.  `rf2-hic-033` added D10–D13, the direct-return delta;
+# `rf2-hic-034` added D14–D16, the island band's structural half — element
+# type identity, props-object slots and the unwrapping hop those two price;
+# `rf2-hic-045` added D17–D25, the per-keystroke census's remaining five
+# stages; and `rf2-mwr2` added D26, the rows-of-markup counter U5's estimand
+# was missing.  §3 states the test this list applies in terms — *they are
+# counts, not clocks, so they are deterministic and carry no hardware profile;
+# that is what lets them sit in this section rather than §4*.  Note which way
+# the entry cuts: a row NAMED here must run in the `PR gate` lane and must name
+# a witness file that exists, while a row omitted from it is merely forbidden
 # that lane and has its witness checked not at all.  Adding an id tightens
 # this gate; leaving a deterministic id out is the loophole.
 DETERMINISTIC_IDS = frozenset(
-    ["D%d" % n for n in range(1, 17)] + ["U5", "U6", "I9"])
+    ["D%d" % n for n in range(1, 27)] + ["U5", "U6", "I9"])
 
 # L4.  Rows registered somewhere other than budgets.md, with the anchor that
 # registers them.  Held here rather than in a ledger column because it is a
@@ -181,15 +201,25 @@ EXTRA_ROWS = {
 # is a deliberate act — a new measurement window and an edit here — which is
 # the whole point.  D10–D13 and D14–D16 join the D rows' `package` pin on the
 # same terms: `rf2-hic-033` and `rf2-hic-034` took them on
-# `implementation/hicasso` and §3's heading is what they landed under.  An
-# unpinned row is the hole this constant exists to close, so a new row is
-# pinned as it lands rather than later.  `S8` — the direct-return escape's
-# clock, `rf2-5yn9` — is pinned `package` on that rule: the instrument that
-# read it lives in the bench tree, as the P0 heap ladder behind S1–S5 does,
-# but the SUBJECT is `implementation/hicasso`, and this column names the
-# subject rather than the instrument's address.
+# `implementation/hicasso` and §3's heading is what they landed under, and
+# D17–D25 join them on it — `rf2-hic-045`'s per-keystroke census ran on the two
+# public-package witness applications.  An unpinned row is the hole this
+# constant exists to close, so a new row is pinned as it lands rather than
+# later.  `S8` — the direct-return escape's clock, `rf2-5yn9` — is pinned
+# `package` on that rule: the instrument that read it lives in the bench tree,
+# as the P0 heap ladder behind S1–S5 does, but the SUBJECT is
+# `implementation/hicasso`, and this column names the subject rather than the
+# instrument's address.
+#
+# `D26` is the one deterministic row pinned `bench-tree`, and the same rule is
+# what puts it there rather than an exception to it: its subject really is the
+# bench tree.  `rf2-hic-036`'s tournament reads four topologies mounted on the
+# `arm1` prototype runtime, and the package ships one topology and cannot mount
+# four.  Promoting it by rewriting the cell would claim a package reading that
+# nothing took.
 POPULATION_PIN = dict(
-    [("D%d" % n, "package") for n in range(1, 17)]
+    [("D%d" % n, "package") for n in range(1, 26)]
+    + [("D26", "bench-tree")]
     + [("S%d" % n, "package") for n in range(1, 6)]
     + [("S6", "bench-tree"), ("S7", "bench-tree"), ("S8", "package")]
     + [("U%d" % n, "—") for n in range(1, 5)]
@@ -224,6 +254,36 @@ LINE_FORBIDDEN = {
 # registered line, whatever number it carries.
 PROPOSAL_MARKERS = ("subject to ratification", "pending ratification",
                     "proposal", "not yet ratified", "unratified")
+
+# L7.  The shape of a line that claims work SCALES.  This is matched on the
+# line's own English rather than on an id, because the defect it closes is
+# precisely that a row's English claimed more than its estimand could see —
+# so the English is the thing to key on, and a new row spelling the same claim
+# is caught without anyone remembering to add it.
+SCALING_CLAIM_RE = re.compile(r"scales?\s+with\s+changed\s+rows", re.IGNORECASE)
+
+# L7.  Which second counter each scaling row is decided on, alongside its
+# first.  `rf2-hic-036`'s topology tournament measured a coarse view-model arm
+# that rebuilds ALL `B` mounted rows for a one-row change and runs exactly ONE
+# boundary body — it does its rows *inside* that body — so `U5`, registered on
+# boundary bodies alone, read `MET` on the behaviour its own line forbids, at
+# every row count and untunably (`rf2-mwr2`).  D3/D4 do not already cover it:
+# they catch a coarse shape because THEIR witness keeps per-cell boundaries to
+# count, and a coarse shape with no boundaries beneath the family has nothing
+# for that instrument to see.
+#
+# The repair is a SECOND COUNTER, never a wider line.  No threshold moves here
+# and a genuinely cheap coarse topology still passes both readings; what the
+# rule removes is the option of registering a scaling claim that only one
+# instrument is asked about.
+SECOND_COUNTER = {"U5": "D26"}
+
+# L7.  The counter every scaling row is registered on first.  A companion whose
+# own line is another body count would satisfy the rule while measuring the
+# same thing twice — and the arm this rule exists to catch is invisible to that
+# instrument, so two readings of it are worth exactly one.  Both numbers of the
+# noun, because `1 body` and `2 bodies` are the same instrument.
+FIRST_COUNTER_RE = re.compile(r"\bbod(?:y|ies)\b", re.IGNORECASE)
 
 _ROW_ID_RE = re.compile(r"^\|\s*([DSUCI]\d+)\s*\|")
 # L2 reads BYTE ceilings only.  `2 bodies` and `100 ms p95` are not byte
@@ -555,6 +615,47 @@ def check(rows, registered, sections, existing_files):
             failures.append(
                 "L4 %s cites the provenance anchor %s, a section that never "
                 "names it" % (rid, EXTRA_ROWS[rid]))
+
+    # --- L7: a scaling claim is decided on two counters ------------------
+    scaling = set(rid for rid, row in by_id.items()
+                  if SCALING_CLAIM_RE.search(row["line"]))
+    for rid in sorted((set(SECOND_COUNTER) & set(by_id)) - scaling):
+        failures.append(
+            "L7 %s is registered with a second counter and its line no longer "
+            "states the scaling claim. Rewriting the line is the way out from "
+            "under this rule" % rid)
+    for rid in sorted(scaling):
+        row = by_id[rid]
+        companion = SECOND_COUNTER.get(rid)
+        if companion is None:
+            failures.append(
+                "L7 %s registers a scaling claim and names no second counter. "
+                "A body count alone reads 1 on a coarse arm that rebuilds every "
+                "mounted row inside one body, so it passes the line it breaks "
+                "(rf2-mwr2)" % rid)
+            continue
+        other = by_id.get(companion)
+        if other is None:
+            failures.append(
+                "L7 %s names %s as its second counter and %s has no ledger row. "
+                "A counter nothing records is not a second reading"
+                % (rid, companion, companion))
+            continue
+        if companion not in DETERMINISTIC_IDS:
+            failures.append(
+                "L7 %s's second counter %s is not a deterministic row, so "
+                "nothing makes a pull request run it" % (rid, companion))
+        if FIRST_COUNTER_RE.search(other["line"]):
+            failures.append(
+                "L7 %s's second counter %s registers another BODY count. Two "
+                "readings of one instrument are one counter, and the topology "
+                "this rule exists to catch is invisible to that instrument"
+                % (rid, companion))
+        if companion not in row["current"]:
+            failures.append(
+                "L7 %s does not name %s in its current value. A second counter "
+                "a reader of the row never reaches is not a second reading"
+                % (rid, companion))
     return failures
 
 
@@ -730,6 +831,29 @@ def self_test():
     # ...and a lane nobody registered.
     red("L6", rows=patched("D1", instrument="`x` (some other lane)"))
 
+    # L7 — the fail-open `rf2-mwr2` found, driven from every direction a
+    # later edit could reopen it.  The first is the defect as it stood: U5
+    # registered on bodies alone, its second counter absent from the ledger.
+    red("L7", rows=[dict(row) for row in rows if row["id"] != "D26"])
+    # ...the companion present but unreachable from the row a reader is on...
+    red("L7", rows=patched("U5", current="2 bodies at 25 cells and at 100"))
+    # ...the companion demoted to a second reading of the SAME instrument,
+    # which is the way to satisfy this rule while changing nothing...
+    red("L7", rows=patched("D26", line="1 body per one-row write, fine topology"))
+    # ...the scaling claim edited out of the line so the rule stops applying,
+    # which is L2's ceiling-without-a-band from the other end...
+    red("L7", rows=patched("U5", line="body work is narrow"))
+    # ...and a NEW scaling row registered on one counter, which is how a later
+    # worker reintroduces the hole in good faith rather than by evasion.
+    red("L7",
+        rows=rows + [dict(rows[0], id="D42",
+                          line="work scales with changed rows, not mounted rows")],
+        registered=registered | {"D42"})
+    # ...and the eager direction: the rule is about the companion being NAMED,
+    # not about the sentence it is named in, so a differently worded current
+    # value that still reaches D26 must pass.
+    green(rows=patched("U5", current="2 at 25 and at 100 — second counter D26"))
+
     counts = tally(rows)
     print("OK: check_budget_ledger self-test passed "
           "(%d rows: %s)"
@@ -768,7 +892,8 @@ def main(argv=None):
     print("Every registered line has a row; every row that is not MET names "
           "a bead id and a disposition that resolves;")
     print("no band crossing its line is recorded as a pass; no distributional "
-          "row is wired to a pull-request gate.")
+          "row is wired to a pull-request gate;")
+    print("no row claiming that work SCALES is decided on one counter.")
     print("An Authority cell is read for SHAPE, not for life. This gate reads "
           "two markdown files and has no tracker access, so it cannot see "
           "that a named bead has closed:")


### PR DESCRIPTION
Closes rf2-mwr2 and rf2-w6d9. **rf2-hic-071 stays OPEN** — three of its four deliverables need a measurement window this pass did not open, and §9.4 now records which and why.

## What this changes

**rf2-mwr2 — `U5`'s registered estimand was a fail-open, and the repair is a SECOND COUNTER.** `U5` is registered on *boundary bodies run*. `rf2-hic-036`'s tournament measured a coarse view-model arm that rebuilds **all `B` rows for a one-row change** and runs exactly **one** boundary body — it does its rows *inside* that body — so it read `MET` on the behaviour `U5`'s own English forbids, at every row count and untunably. `D3`/`D4` do not cover it: they catch a coarse shape because *their* witness keeps per-cell boundaries to count, and a shape with no boundaries beneath the family reads 1.

- **`D26`** registers rows-of-markup-built: **1** for a one-row write under a fine topology at `B` = 100, 300 and 1,000, where the coarse arm builds `B`. The counter was already built and already cross-checked when this row was registered — `topo/arms.cljs` increments `:markup` inside the single shared `row-markup` fn and its census agrees with `arm1.runtime/body-runs` on all 48 cells.
- **`L7`** is the new gate rule. A registered line claiming work *scales with changed rows* must name a companion ledger row carrying a second, **different** work counter — deterministic, `PR gate` lane, witness file that exists — and must name it in its *Current value* where a reader reaches it. Both directions are held: a scaling row with one counter reds, **and so does a registered pair whose line has been rewritten to stop stating the claim**.
- **`U5`'s line is UNCHANGED.** The *Budget* column in §4 is byte-identical; what gained a second counter is the *Estimand* column. No threshold moved, and a coarse topology that is genuinely cheap passes on both readings. Adding a counter is the opposite of widening a line.
- `D26` is pinned **`bench-tree`**, which is its honest population: the tournament mounts four topologies on the `arm1` prototype runtime (*"off every production source path"*), and the package ships one and cannot mount four. Promoting it by a cell edit now reds under `L5`.

**rf2-w6d9 — the per-keystroke census's figures as ledger rows.** `D17`–`D25` register `rf2-hic-045`'s remaining five stages, all `package`, all `PR gate`, all witnessed by `per_keystroke_dom_cljs_test.cljs`: subscription recomputations 10 (editor) / 31 (grid 5×5) / 111 (grid 10×10) / 0 (refused); glass writes 0 (accepted) / 1 (refused); DOM mutation records 7 / 8 / 3.

**Two of the nine are readings of a LINEAR quantity, and the registered line says so.** `D18` and `D19` are the same estimand at two mount sizes — `31 → 111` as the grid goes `5×5 → 10×10`, following `rows × cols + rows + 1` — so **the mount size is part of the line**, and the pair is registered rather than one figure precisely so neither can be read as a ceiling that holds at another size. The other seven are flat. The contrast worth keeping visible: **one keystroke in a hundred-cell grid runs 111 subscription bodies to run 2 view bodies** (`D19` against `D2`) — narrow *notification*, not narrow *recomputation*. Registering only the flat half would have made the ledger say something the census does not.

**Figures transcribed, never re-derived.** Every integer here was measured, published and merged before this branch existed (`rf2-hic-045` PR #8163, `rf2-hic-036` PR #8160). No measurement window was opened, no bench was run, no clock round was taken — §3's own rule that a second source for one number is a second thing to drift.

The ledger goes 39 rows → **49**.

## What is NOT built, and why (§9.4)

Recorded on the page rather than quietly carried. Each is blocked on an **instrument**, not on an edit:

- **User-visible gates** (`U1`–`U4`, `C3`, `C4`) — §4 says in terms that no package-resident clock instrument exists. A guessed threshold would be a fabricated line; `UNPINNED` is what the ledger says instead.
- **The 5% same-instrument regression gate** (`C1`) — §6 records the registered instrument's eleven pinned blobs as superseded, one file no longer existing, so *"the same instrument"* still names nothing. The re-pin is a run.
- **The escape-benefit gate** (`C8`) — its population is site-level by Ruling 2, and no escape taken *for a benefit* has landed. Checked at source: the only `h/as-element` call in the shipped examples is `examples/ledger/views.cljs:226`, the ledger screen handing a view to a vendor virtualizer's `renderRow`. **That is interoperability, not an escape claiming recovered time**, and a `C8` gate written over *every* landed escape would demand the removal of an escape with no alternative — a fail-**closed** mirror of the fail-open `L7` just closed. Worth settling before that gate is built.

## Quality gates

**The fast-PR spine was run and did NOT complete**, and the number quoted is the one captured, not one the harness reported:

```
$ sh scripts/test-fast-pr.sh   ->  EXIT=1
gate root: /c/Users/miket/code/re-frame2-worktrees/budgetgates-hic071
... ~55 stages green, including "mkdocs --strict build", "docs corpus anchor validator",
    "provenance pins on changed pages", "clj-kondo (pinned, CI's own command)" ...
==> CLJS node integration
compile-node-test: could not resolve shadow-cljs: Cannot find module 'shadow-cljs/cli/runner.js'
FAIL CLJS node integration
```

That is a missing `implementation/node_modules` in a fresh worktree, not a finding about this diff. **The junction was deliberately not created**: it has twice followed itself into the mayor's real `node_modules` and emptied it, and this diff is one markdown page and one Python script — zero CLJS, so the CLJS lane can decide nothing about it. Stated rather than papered over.

**The gate that actually decides this diff comes AFTER that stage in the spine** (`scripts/test-fast-pr.sh:1486` runs `test:hicasso-invariants`; the abort is at `:1451`), so it was run directly, with the spine's own command:

| Gate | Command | Captured exit |
|---|---|---:|
| Hicasso invariants (incl. `check_budget_ledger.py --self-test` + plain run) | `cd implementation && npm run test:hicasso-invariants` | **0** |
| Hicasso lint export | `cd implementation && npm run test:hicasso-lint` | **0** |
| Docs corpus anchors | `python scripts/check_doc_slugs.py` | **0** |
| Provenance pins, changed pages | `python scripts/check_provenance_pins.py --changed-since origin/main` | **0** |

All four were re-run on the **final rebased base** (`75995be80f`) after the rebase, not only before it.

`scripts/check_fast_pr_gap.py --list` is the canonical **fast-spine-versus-required-CI gap** — it derives which required steps the spine does not run and does **not** inspect what was run here. It reports 96 required checks the spine does not decide. None is reached by this diff: `implementation/hicasso/scripts/*.py` and `docs/design/hicasso/**` are the whole surface, the CI job that owns the ledger gate is `cljs` → *"Hicasso invariants gate"* (`test.yml:3031`), and `docs.yml`'s provenance-pin job is the `--changed-since` arm run above. Note that `check_provenance_pins.py` run over the **whole** corpus reports 7 pre-existing findings, all in `docs/design/hicasso/studio/**` and none in a file this branch touches; the CI arm is the changed-pages one, which is green.

### The controls — each gate shown red when the property it protects is removed

Five in-script controls ship with `--self-test` and run on every PR. Four more were driven against the **live document**, restored, and the restore verified by hashing the bytes:

| # | Property removed | Captured exit | The red |
|---|---|---:|---|
| 1 | `D26`'s ledger row deleted | **1** | `L4 D26 is registered in budgets.md and has no ledger row` + `L7 U5 names D26 as its second counter and D26 has no ledger row` |
| 2 | the scaling claim edited out of `U5`'s line cell | **1** | `L7 U5 is registered with a second counter and its line no longer states the scaling claim. Rewriting the line is the way out from under this rule` |
| 3 | `D19`'s witness renamed to a file that does not exist | **1** | `L6 D19 names the witness ...per_keystroke_dom_cljs_test_RENAMED.cljs, which does not exist` |
| 4 | `D26` promoted `bench-tree` -> `package` by a cell edit | **1** | `L5 D26 is pinned to the bench-tree population and reads 'package'` |

Control 1 was re-driven on the final rebased base: same red, captured exit `1`.

**The restore is verified against the committed object, anchored to one line** — `git hash-object` after each restore equals `git rev-parse HEAD:docs/design/hicasso/product/budgets.md` (`0f728428da246c6ef461415cddea061d101fe35c` on the final base), and `git status --porcelain` is empty. "Unchanged" and "not attempted" are the same diff, so the hash is the evidence and not the sentence.

**Which tree the gates read** is not assumed either. The spine printed `gate root: /c/.../budgetgates-hic071`; `check_budget_ledger.py` resolves its inputs from `__file__` and was invoked by path inside this worktree; and control 3's red names a ledger row that exists **only on this branch**, which no sibling worktree could have produced.

The five in-script `L7` controls, all green through `--self-test`: the companion absent from the ledger; the companion present but not named in the row's *Current value*; the companion demoted to a second reading of the same instrument; the scaling claim edited out of the line; and a **new** scaling row registered on one counter — the way a later worker reintroduces this hole in good faith rather than by evasion. Plus one eager green: a differently worded *Current value* that still reaches `D26` must pass.

### Doc-surface gate, by hand

`mkdocs build --strict` is **not** the gate for an edit confined to `docs/design/hicasso/` — `mkdocs.yml`'s `exclude_docs` keeps that tree out of the site. `check_doc_slugs.py` validated every markdown link target and heading anchor (green). Nothing validates tables, so this was **verified by hand**: all 14 table blocks in `budgets.md` are rectangular — the §3 deterministic table's ten new rows carry 5 cells each, §4's amended `U5` row carries 4, and the ledger's ten new rows carry 8, which `check_budget_ledger.py` also enforces structurally (`L0` reds on any row short of a cell). The new `### 9.4` heading needs no nav entry: this tree is not in the site.

## Fence

Touched: `docs/design/hicasso/product/budgets.md` and `implementation/hicasso/scripts/check_budget_ledger.py` — the gate script and its pinned rosters, which this bead owns by its own fence.

**Not touched:** `docs/design/hicasso/product/per-keystroke.md` and `implementation/hicasso/test/.../per_keystroke_dom_cljs_test.cljs` — `worker/transitions-hic045` holds both. Its two unmerged commits were **read** first, to confirm they move no figure this branch pins: they correct the attribute-trace narration (old-value semantics), the setter-capture ordering rationale, and a cross-check phrasing. Every count — 10 / 31 / 111 / 0, 0 / 1, 7 / 8 / 3 — is byte-identical across that diff. No hot-zone file, no `.github/scripts/`, no tracker-database path.

The three-dot diff `origin/main...HEAD` was read for reverts: every deletion is a line deliberately rewritten in place. Nothing on `main` is reverted.
