### PR TITLE
docs(hicasso): C8's population is escapes taken FOR A BENEFIT (rf2-m7xx0)

### DIFF
--- a/docs/design/hicasso/product/budgets.md
+++ b/docs/design/hicasso/product/budgets.md
@@ -516,7 +516,7 @@ and its verdict is recorded there.
 | C5 | R=0 shell meets the frozen byte-exact `1,024 B` line | **not** governed by baseline-plus-10%; see §5 |
 | C6 | Per-read retained ≤ 10% regression on same pinned witness | governed by the K3 disposition (`rf2-hic-070`) |
 | C7 | Native island within 5% or 1 ms of the same component mounted directly | co-instrumented against both handwritten React and UIx |
-| C8 | An escape recovers ≥ 20%, saves ≥ 2 ms p95, or converts a failed budget to a pass | an island missing its threshold is simplified or removed — **thresholds do not widen to keep it** |
+| C8 | An escape **taken for a benefit** recovers ≥ 20%, saves ≥ 2 ms p95, or converts a failed budget to a pass. An **interoperability** escape — one whose alternative is not a slower spelling but no spelling at all — is outside the population | an island missing its threshold is simplified or removed — **thresholds do not widen to keep it** |
 
 ---
 
@@ -1038,7 +1038,7 @@ it reads the cell for **shape, not for life**, and says so in its own output.
 | C5 | 1,024 B byte-exact, not governed by baseline-plus-10% | 1,100 B / 1,095 B [1,087–1,107] | package | `BREACH` | P0 heap ladder, package candidate arm (P-DEV-1 evidence run) | `rf2-0xx2` | [§9.2](budgets.md#92-what-each-not-green-row-is-waiting-on); scoped acceptance 2026-08-13, [§5](budgets.md#5-the-read-free-boundary-shell-the-byte-exact-line-now-frozen-at-1024-b) — ceiling unchanged at 1,024 B, accepted to 1,107 B / 1,101 B |
 | C6 | ≤ 10% per-read regression on the same pinned witness | see S3 / S4 | package | `UNRESOLVED` | P0 heap ladder, package candidate arm (P-DEV-1 evidence run) | `rf2-hic-071` | [§9.2](budgets.md#92-what-each-not-green-row-is-waiting-on) |
 | C7 | a native island within 5% or 1 ms of the same component mounted directly | — | — | `UNPINNED` | — (none) | `rf2-hic-071` | [§9.2](budgets.md#92-what-each-not-green-row-is-waiting-on) |
-| C8 | an escape recovers ≥ 20%, saves ≥ 2 ms p95, or flips a failed budget | — | — | `UNPINNED` | — (none) | `rf2-hic-071` | [§9.2](budgets.md#92-what-each-not-green-row-is-waiting-on) |
+| C8 | an escape taken for a benefit recovers ≥ 20%, saves ≥ 2 ms p95, or flips a failed budget; an interoperability escape is outside the population | — | — | `UNPINNED` | — (none) | `rf2-hic-071` | [§9.2](budgets.md#92-what-each-not-green-row-is-waiting-on) |
 | I9 | ≤ 2 React hooks per boundary shell, invariant in read count | 2 | package | `MET` | `implementation/hicasso/test/re_frame/hicasso/hook_budget_cljs_test.cljs` (PR gate) | `rf2-hic-018` | — |
 
 <!-- rf2-hic-089: end-ledger -->
@@ -1195,6 +1195,18 @@ other mode.
   so removing the escape would *add* a rejection branch around otherwise-total
   handling — machinery, where C8 exists to prevent it. `C8` stays `UNPINNED`
   until a real site supplies its population.
+  **[Clarified 2026-08-14, `rf2-m7xx0`; the ruling above is unchanged and no
+  threshold moves.]** *Every landed escape* scopes the ruling over the escapes
+  it was taken about — the ones taken **for a benefit**. An
+  **interoperability** escape is outside it, because its alternative is not a
+  slower spelling but no spelling at all: there is nothing for *"simplify or
+  remove"* to name, and a gate adjudicating it would demand a removal with no
+  destination. The one `h/as-element` call in the shipped example applications
+  is exactly that one — `examples/ledger/views.cljs`, the ledger screen's
+  `:render-row` handing a view to a vendor virtualizer whose callback contract
+  is `(index, offsetPx) => ReactNode` — so
+  [§4's `C8` row](#the-comparative-and-regression-rules) now states the
+  population rather than leaving the gate author to infer it.
 - **`S7` has no publishable claim to pin.** No fitted allocation series clears
   the quality floor. This is a property of the readings rather than of the
   rig, so it is `UNPINNED` rather than `UNRESOLVED`: nothing crossed a line,
@@ -1327,10 +1339,13 @@ quietly carried:
   **for a benefit** has landed in an application: the one `h/as-element` call
   in the shipped examples is the ledger screen handing a view to a vendor
   virtualizer's `renderRow`, which is interoperability rather than an escape
-  claiming recovered time. That distinction is worth stating before the gate is
-  built, because a `C8` gate written over *every* landed escape would demand
+  claiming recovered time. That distinction is now stated in the rule itself
+  ([§4's `C8` row](#the-comparative-and-regression-rules), `rf2-m7xx0`),
+  because a `C8` gate written over *every* landed escape would demand
   the removal of an escape with no alternative — the mirror of the fail-open
-  `L7` just closed, and a fail-closed one.
+  `L7` just closed, and a fail-closed one. Stating it moved no threshold and
+  built no gate: `C8` stays `UNPINNED`, still waiting on a site inside the
+  population.
 
 **What this leaves.** Every deterministic budget this corpus has measured is
 now a ledger row with a witness a pull request runs, and every remaining gate


### PR DESCRIPTION
`rf2-m7xx0` — **a row-wording fix, not a gate build.** `C8` stays `UNPINNED`.

## The defect, verified at source

`budgets.md` §4 registered `C8` over **"An escape"**, full stop, while its
disposition demands that an escape missing `≥ 20%` / `≥ 2 ms p95` / a budget
flip be *"simplified or removed"*. Ruling 2 (`rf2-5yn9`) makes the population
site-level: *every landed escape*.

The premise **holds**. `git grep as-element` over the shipped example
applications returns exactly one call:
`implementation/hicasso/test/re_frame/hicasso/examples/ledger/views.cljs:226`,
inside the `:render-row` `h/hfn` handed to the `rows` host. The vendor's own
contract is `renderRow = {(index, offsetPx) => ReactNode}`
(`examples/ledger/vendor.cljs:77-80`), and the `h/defhost rows` docstring says
what the crossing is for: *"the declared door onto the virtualizer … what the
callback returns is the vendor's render output"*. Nothing there claims
recovered time. The two other `h/as-element` hits under `examples/` are in
`ledger/virtualized_dom_cljs_test.cljs` — a test's own rig, not an application
site.

So a `C8` gate written over *every landed escape* would adjudicate an
**interoperability** crossing against a threshold it was never taken to meet,
find it missing, and demand under its own acceptance a removal with **no
destination**. Fail-CLOSED — the exact mirror of the fail-open `L7`/`U5`
defect (`rf2-mwr2`, PR #8177) closed on this page an hour earlier.

## The repair: a stated POPULATION, not a moved line

§4's `C8` rule cell now reads:

> An escape **taken for a benefit** recovers ≥ 20%, saves ≥ 2 ms p95, or
> converts a failed budget to a pass. An **interoperability** escape — one
> whose alternative is not a slower spelling but no spelling at all — is
> outside the population

**Why this phrasing.** `taken for a benefit` is the bead's own words and it
keys on the reason the escape was written, which is the thing a site can state
and a gate author can read. The exclusion is given by its *test* — *the
alternative is not a slower spelling but no spelling at all* — rather than by
naming virtualizers, so a second foreign API with the same shape is covered
without another patch. It does not impose a new site-declaration obligation:
that would be a requirement this PR cannot discharge inside its fence, and
`rf2-hic-071` owns whatever the gate ends up keying on.

Three other places move, all `C8`'s own:

- §9's ledger row carries the same scoping in its **registered-line** cell.
- **Ruling 2's recorded text is unchanged.** A dated, attributed
  *`[Clarified 2026-08-14, rf2-m7xx0]`* note is appended beneath it — the
  page's own C6 idiom. Rewriting a ruling to look as though it had always
  known the answer is what §5 of this page forbids.
- §9.4's `C8` bullet said the distinction was *"worth stating"*; it now points
  at where it is stated, and says in terms that stating it moved no threshold
  and built no gate.

## Made checkable, as #8177 did

`#8177` changed U5's *estimand* column and left its budget cell byte-identical.
The same shape here, machine-verified against `HEAD`:

| Check | Result |
|---|---|
| §4 `C8` row cell count | 3 → 3 |
| §4 `C8` **Disposition** cell | **byte-identical** |
| §4 `C8` three disjuncts `recovers ≥ 20%, saves ≥ 2 ms p95, or converts a failed budget to a pass` | **verbatim** |
| §9 `C8` ledger row cell count | 8 → 8 |
| §9 `C8` cells 3–8 (Current, Population, Status, Instrument, Authority, Disposition) | **byte-identical** |
| Table rows changed anywhere on the page | **2** — both `C8`, out of 166 table lines |
| Threshold-token census `≥ 20%` / `≥ 2 ms p95` / `20%` / `2 ms` / `1.25x` / `1.10x` / `1,024 B` | 4/4/8/5/6/7/32 → **unchanged** |

`U5`, `L7`, `D26` and `D17`–`D25` are untouched; `git diff` shows one file,
+20/−5.

**Hand verification, stated as required.** Both edited rows were counted by
hand and by script: §4's comparative table is `# | Rule | Disposition` (3
columns, 3 cells) and §9's ledger is 8 columns (the gate raises on any other
count). No `|` was introduced inside any cell. The two new links both target
`#the-comparative-and-regression-rules`, which is the slug of the existing
`### The comparative and regression rules` heading — the same anchor line 428
already uses — and `check_doc_slugs.py` resolves both (sabotage S5 below
proves it reaches them).

## Quality gates

`mkdocs build --strict` does **not** cover this change, confirmed at source:
`mkdocs.yml`'s `exclude_docs` block lists `design/hicasso/` (lines 32–37). It
is not nominated here.

**Fast-spine-vs-required-CI gap**: `scripts/check_fast_pr_gap.py --list` is the
canonical statement — 96 required checks the fast spine does not decide. Stated
plainly: **the fast spine was not run.** This is a docs-only change to one
markdown file under `docs/design/hicasso/product/`, which reaches no CLJS, JVM,
lint or MkDocs surface; the gates that *do* own this file were run directly and
to completion, in the foreground, each redirected to its own log with the
runner's own exit code echoed.

| Gate | Exit |
|---|---|
| `python implementation/hicasso/scripts/check_budget_ledger.py` | **0** |
| `python implementation/hicasso/scripts/check_budget_ledger.py --self-test` | **0** |
| `python scripts/check_doc_slugs.py` | **0** |
| `python scripts/check_provenance_pins.py --changed-since origin/main --verbose` | **0** (1 file, 5 cited pins, 5 landed, 0 stranded) |

All four re-run **after** the rebase onto current `origin/main`, on the final
base.

### The covering gate reaches this row — five live-document sabotages

`check_budget_ledger.py` **does** cover both edited rows: its L4 round-trip
reads §4's `C8` registration and the §9 ledger row, and L5 reads the
registered-line and population cells. Proven rather than asserted — each
sabotage captured red, each restore hash-verified with `git hash-object`
against `33ab3678be34d5fdbe1b1c11efc0ca48573ad2d7`:

| # | Sabotage | Gate | Exit | Message |
|---|---|---|---|---|
| S1 | rename §4's `C8` id, leaving the ledger row | ledger | **1** | `L4 C8 has a ledger row and is registered nowhere` |
| S2 | drop the leading `\|` of the ledger row (cell-count/structure) | ledger | **1** | `L4 C8 is registered in budgets.md and has no ledger row` |
| S3 | promote the ledger row's Population cell `—` → `package` | ledger | **1** | `L5 C8 is pinned to the — population and reads 'package'` |
| S4 | write the new registered line as a proposal | ledger | **1** | `L5 C8 writes its registered line as a proposal` |
| S5 | break one of the two new `#the-comparative-and-regression-rules` anchors | slugs | **1** | `BROKEN ANCHOR: budgets.md:1208 -> #the-comparative-and-regression-rulez` |

All five restores returned the file to the baseline hash exactly.

## Scope

No measurement was taken and none was needed. No threshold moved. No gate was
built — `C8` remains `UNPINNED`, waiting on a site **inside** the population.
`requirements-mine.md`, `correction-ledger.md`, `per-keystroke.md`, the
conformance matrix, `implementation/hicasso/**` and every hot-zone path are
untouched.
