### PR TITLE
test(hicasso): P12 reads a field whose model DISAGREES with it (rf2-hic-045)

### DIFF
--- a/docs/design/hicasso/product/per-keystroke.md
+++ b/docs/design/hicasso/product/per-keystroke.md
@@ -303,6 +303,30 @@ with no flush performed and no opportunity for the browser to paint. The census
 reads it there and settles afterwards, which is the opposite order from every
 other mounted witness in the tree.
 
+**The reading that carries that claim is the one where the model DISAGREES with
+the field, and it has to be.** A scripted keystroke reaches the same code path a
+real one does only by writing the accepted text onto the control and then firing
+the event (§1.1), so on a keystroke the model takes *verbatim* the model's value
+and the census's own pre-event write are the same string — and a reading taken
+at dispatch return cannot tell an echo from its own setup. Those readings are
+still taken and still reported, because *the character survived the converge* is
+a real fact whose opposite is a real regression, but they are not what proves
+this section. Each page carries a second reading typed into a field whose model
+answers something else:
+
+| Page | Field, and its policy | Typed onto the control | The model's value | Read at dispatch return |
+|---|---|---|---|---|
+| editor | `:slug`, which **normalises** | `intents-are-data, World` | `intents-are-data-world` | `intents-are-data-world` |
+| grid | cell `[3 4]`, which **refuses** | `34x` | `34` | `34` |
+
+**Neither echoed string could have come from the census's own pre-event write,
+and neither needed a flush to arrive.** That is the whole of the claim. The
+slug's normalisation is length-changing on purpose — a normalisation that
+preserved length could be satisfied by a field that echoed nothing at all
+(`editor.events/slugify`) — and the grid's refusal is the case where the
+converge has actual work to do, which is why it is also the one glass write §5
+counts.
+
 That is a stronger fact than the one [`U1`](budgets.md#9-the-budget-line-reconciliation-ledger)
 is written about. `U1` asks that controlled updates be *echoed within one 60 Hz
 frame at p95*; what the measurement shows is that **no frame boundary is crossed
@@ -365,6 +389,9 @@ needed a quiet box are the ones §6 refuses.
 | 6 | **sabotage** — P7's `111` inverted to `112` | `1` | captured red naming the line, below |
 | 7 | restored, plus the per-subscription attributions | `0` | 1,491 / 9,337, 0 failures |
 | 8 | **re-taken after rebasing onto `b44c5e854c`** | `0` | 1,502 / 9,508, 0 failures — no figure moved |
+| 9 | control on this page's current base, before P12's rows | `0` | 1,509 / 9,559, 0 failures |
+| 10 | **sabotage** — P12's two new rows asserting the PRE-EVENT text | `1` | captured red naming both lines, below |
+| 11 | P12's discriminating rows, corrected | `0` | 1,509 / 9,561, 0 failures — no census figure moved |
 
 The node lane (`npm run test:cljs`) was run on the same tree and returns `0` at
 13,875 tests / 70,108 assertions. It is not where these figures come from — every
@@ -376,7 +403,10 @@ it, which is a defect this census had and fixed.
 census's rows degrade to stated skips off the browser lane, so a green aggregate
 alone would not distinguish *ran and passed* from *skipped*. Run 1 to run 5 is
 `+2` tests and `+23` assertions, exactly the assertions the two new `deftest`s
-then contained; run 7 added three per-subscription attributions for `+26`.
+then contained; run 7 added three per-subscription attributions for `+26`. Run 9
+to run 11 is `+0` tests and `+2` assertions — P12's two discriminating rows,
+which live inside the two `deftest`s that already existed, so the test count
+does not move and the assertion count moves by exactly the rows added.
 
 **Run 8's arithmetic is checkable against a figure this page did not produce.**
 `rf2-hic-036`'s tournament landed on `main` between run 7 and the rebase, and
@@ -408,8 +438,35 @@ passing assertion being the thing that reports them. The file was restored and
 its content hash (`git hash-object`, not a byte digest — this checkout
 translates line endings) matched its pre-sabotage value exactly, at
 `7197902f6ed8054daf627122a993eb22ae24ed33`. That hash pins the file **as it
-stood between runs 5 and 6**; it has had one commit since, the `delay` in the
-node-lane fix above, and run 8 is the reading that covers the file as it ships.
+stood between runs 5 and 6**; it has had three commits since — the `delay` in
+the node-lane fix above, the attribute-trace correction §5 is drawn through, and
+P12's discriminating rows — and **run 11** is the reading that covers the file as
+it ships.
+
+**Run 10 is the second sabotage, and it is the one that retired P12's
+fail-open.** Both new rows were first asserted against the text the census
+writes onto the control *before* the event — which is precisely what the earlier
+reading could not tell an echo apart from — and both came back red, printing the
+model's value beside it:
+
+```
+FAIL in (the-editors-per-keystroke-census)
+  (re_frame/hicasso/examples/per_keystroke_dom_cljs_test.cljs:450:23)
+expected: (= "intents-are-data, World" echo)
+  actual: (not (= "intents-are-data, World" "intents-are-data-world"))
+
+FAIL in (the-grids-per-keystroke-census-at-two-sizes)
+  (re_frame/hicasso/examples/per_keystroke_dom_cljs_test.cljs:580:23)
+expected: (= "34x" (clojure.core/deref echo))
+  actual: (not (= "34x" "34"))
+```
+
+A red naming both lines proves both rows **execute**, and the printed right-hand
+sides witness the model's values from the failure path rather than from the
+passing assertion — run 6's technique, doing double duty here, because the
+sabotage value *is* the reading the pre-repair row would have accepted. (The
+line numbers pin the sabotage tree, in which the corrected expectations had not
+yet been written.)
 
 ### What would falsify this page
 

--- a/docs/design/hicasso/product/per-keystroke.md
+++ b/docs/design/hicasso/product/per-keystroke.md
@@ -392,6 +392,7 @@ needed a quiet box are the ones §6 refuses.
 | 9 | control on this page's current base, before P12's rows | `0` | 1,509 / 9,559, 0 failures |
 | 10 | **sabotage** — P12's two new rows asserting the PRE-EVENT text | `1` | captured red naming both lines, below |
 | 11 | P12's discriminating rows, corrected | `0` | 1,509 / 9,561, 0 failures — no census figure moved |
+| 12 | re-taken after rebasing onto `cd58aec50a` | `0` | 1,509 / 9,561, 0 failures — identical to run 11 |
 
 The node lane (`npm run test:cljs`) was run on the same tree and returns `0` at
 13,875 tests / 70,108 assertions. It is not where these figures come from — every
@@ -440,7 +441,7 @@ translates line endings) matched its pre-sabotage value exactly, at
 `7197902f6ed8054daf627122a993eb22ae24ed33`. That hash pins the file **as it
 stood between runs 5 and 6**; it has had three commits since — the `delay` in
 the node-lane fix above, the attribute-trace correction §5 is drawn through, and
-P12's discriminating rows — and **run 11** is the reading that covers the file as
+P12's discriminating rows — and **run 12** is the reading that covers the file as
 it ships.
 
 **Run 10 is the second sabotage, and it is the one that retired P12's

--- a/implementation/hicasso/test/re_frame/hicasso/examples/per_keystroke_dom_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/examples/per_keystroke_dom_cljs_test.cljs
@@ -61,11 +61,24 @@
   Every other mounted witness in this tree calls `hm/settle!` and then
   asserts the glass. That is right for a correctness row and wrong for a
   latency one — it reads the page after a flush the browser had not yet
-  performed. [[echo-before-flush]] reads `.value` at the instant
+  performed. [[type-into!]] reads `.value` at the instant
   `dispatchEvent` returns, which is inside the discrete event, before any
   paint could occur. What that measures is not *the echo arrived within a
   frame*; it is the stronger and simpler fact that **no frame boundary is
   crossed at all**.
+
+  **But the reading only DISCRIMINATES where the model disagrees with the
+  field.** A scripted keystroke reaches the real code path only by writing
+  the accepted text onto the control and then firing the event, so on a
+  keystroke the model takes VERBATIM the model's value and this file's own
+  pre-event write are the same string — and a reading taken at dispatch
+  return cannot tell an echo from its own setup. Those rows are kept,
+  because the character surviving the converge is a real fact whose
+  opposite is a real regression, but they are not what proves the claim.
+  Each page therefore carries a second row typed into a field whose model
+  answers something ELSE: the editor's `:slug`, which normalises, and the
+  grid's cell, which refuses. Neither echoed string could have come from
+  the pre-event write, and neither needed a flush to arrive.
 
   ## What this file does NOT measure, and could not
 
@@ -403,9 +416,17 @@
                        refusal row below is this instrument's positive
                        control: it reads 1 on the same spy in the same file")
                   (is (= "Intents are dataab" @echo)
-                      "P12 — the echo is on the glass at the instant
-                       `dispatchEvent` returned, with no flush and no paint
-                       in between")
+                      "the accepted keystroke SURVIVED the converge — the
+                       character is still on the glass at the instant
+                       `dispatchEvent` returned, with no flush and no paint in
+                       between. The row is kept because its opposite is a real
+                       regression: `front/controlled_dom_cljs_test` reproduces a
+                       converge that wipes the character the user just typed.
+                       But it is NOT P12's proof. `:title` takes what is typed,
+                       so this expectation is ALSO the string [[type-into!]]
+                       wrote onto the control before the event, and the reading
+                       would hold even if the model had never moved. The
+                       discriminating row is the slug's, below.")
                   (is (= {["attributes" "INPUT@name"]  4
                           ["attributes" "INPUT@type"]  2
                           ["attributes" "INPUT@value"] 1}
@@ -442,6 +463,28 @@
                        four of the seven records are churn on an attribute the
                        application never wrote. The refusal row below
                        attributes the two passes.")))
+
+              (testing "and P12's DISCRIMINATING reading — the slug NORMALISES"
+                (let [slug  (editor-node m :slug)
+                      typed (str (.-value slug) ", World")
+                      echo  (type-into! slug ", World")]
+                  (is (= "intents-are-data-world" echo)
+                      (str "P12, and THIS is the row that proves it. The
+                            accepted-keystroke readings above are taken on a
+                            field that takes what is typed, so the model's value
+                            and this census's own pre-event write are the same
+                            string and the reading cannot tell them apart.
+                            `:slug` normalises, so the model answers something
+                            else — and what the field shows at the instant
+                            `dispatchEvent` returned is the MODEL's value, with
+                            no flush and no paint in between, so no frame
+                            boundary was crossed. Typed onto the control: "
+                           (pr-str typed) ". The normalisation is
+                            length-CHANGING on purpose
+                            (`editor.events/slugify`): one that preserved length
+                            could be satisfied by a field that echoed nothing at
+                            all."))
+                  (hm/settle! m)))
 
               (hm/unmount! m))))))))
 
@@ -517,7 +560,11 @@
           "zero writes onto the glass, exactly as the editor — an accepted
            keystroke is already showing what the model took")
       (is (= "341" (:echo at-100))
-          "P12 — the echo is on the glass before any flush")
+          "the accepted digit survived the converge, read before any flush —
+           and NOT P12's proof, for the editor's reason: a cell takes a digit
+           verbatim, so this is also what `type-into!` wrote onto the control
+           before the event. The refusal below is this page's discriminating
+           reading.")
       (is (= {["attributes" "INPUT@name"]  4
               ["attributes" "INPUT@type"]  2
               ["attributes" "INPUT@value"] 1
@@ -568,8 +615,19 @@
                       "and the ONE write onto the glass is the refusal echo —
                        the committed value put back over the character the
                        model would not take")
+                  (is (= "34" @echo)
+                      "P12's OTHER discriminating reading, and the REFUSAL is
+                       what makes it one. This census wrote \"34x\" onto the
+                       control before the event; the model would not take the
+                       `x`, so the \"34\" the field shows at the instant
+                       `dispatchEvent` returned is the COMMITTED value and could
+                       not have come from the pre-event write. React's
+                       end-of-event restore performs it inside the discrete
+                       event — the same single `value` write the row above
+                       counts — so no frame boundary is crossed here either.")
                   (is (= "34" (.-value n))
-                      "which is what the field shows")
+                      "and the same value after the flush, which is what the
+                       field goes on showing")
                   (is (= [{["attributes" "INPUT@name"] 2
                            ["attributes" "INPUT@type"] 1}
                           ["name: nil -> nil"


### PR DESCRIPTION
Completes **P12**, the one item left open on `rf2-hic-045` by the merged-PR audit of #8175: *"finding 1 from the same audit remains untouched — P12 still reads native text written before dispatch and therefore does not prove the published model-echo/convergence claim."*

**Route taken: COMPLETED, not narrowed.** The claim turned out to be true and cheaply witnessable, so the page keeps it and the witness now proves it.

## What P12 witnessed vs what the page claimed

`type-into!` writes the accepted text onto the native control and *then* fires the `input` event, returning `.value` at the instant `dispatchEvent` returns. Both P12 rows typed into a field that takes what is typed — the editor's `:title` and a digit into a grid cell — so **the expectation was also the setup**: the model's value and the census's own pre-event write were the same string, and the assertion held whether or not the model had moved, the handler had run, or React had committed. It witnessed only *the character was not erased*.

§6 claimed considerably more: that the field shows **the model's value** at dispatch return, and that **no frame boundary is crossed at all**.

## The repair

Both witness applications already carry a discriminating input, built for exactly this purpose — the editor's `:slug` normalises (`slugify`, length-changing by construction) and every grid cell refuses a non-digit. So each page gains **one row** typed into a field whose model answers something *other* than what was typed:

| Page | Field | Typed onto the control | Echo at dispatch return |
|---|---|---|---|
| editor | `:slug`, normalises | `intents-are-data, World` | `intents-are-data-world` |
| grid | cell `[3 4]`, refuses | `34x` | `34` |

Neither string could have come from the pre-event write, and neither needed a flush. The grid's value was **already captured and discarded** — only the assertion was missing.

The two accepted-keystroke rows are **kept**, because a character surviving the converge is a real fact whose opposite is a real regression (`front/controlled_dom_cljs_test` reproduces a converge that wipes it), but their messages now say plainly that they are not P12's proof and point at the row that is. `[[echo-before-flush]]`, a dangling wikilink in the ns docstring, is corrected to `[[type-into!]]`.

**Not done, deliberately:** the mutation-trace repair is untouched (#8175 owns it), no census figure is touched, no measurement window was opened, and §1.2's pre-registered prediction table is unedited.

## Quality gates

**Fast-spine-versus-required-CI gap:** `scripts/check_fast_pr_gap.py --list` is canonical — it reports **96 required checks the fast spine does not decide**. I did **not** run the fast spine; I ran the targeted gates below directly, each foreground-detached and polled to completion, each exit code captured by the runner itself and quoted from that capture (never from the harness, which reported the sabotage run as "exit code 0" while the captured file read `EXIT=1`).

| Gate | Captured exit | Result |
|---|---|---|
| `npm run test:browser` — control, before any edit | `0` | 1,509 tests / 9,559 assertions, 0 failures |
| `npm run test:browser` — **sabotage** | `1` | red naming **both** new lines |
| `npm run test:browser` — corrected | `0` | 1,509 / 9,561, 0 failures |
| `npm run test:browser` — **re-run after rebase onto `cd58aec50a`** | `0` | 1,509 / 9,561, identical |
| `npm run test:cljs` (node lane) | `0` | 13,893 tests / 70,190 assertions, 0 failures |
| `scripts/check_doc_slugs.py` | `0` | green; **red-proved** against a planted broken anchor |
| `scripts/check_provenance_pins.py --changed-since origin/main` | `0` | 4 cited pins, 4 landed |

**Red-then-green.** The sabotage was not arbitrary: both new rows were first asserted against **the pre-event text** — precisely the reading the old row would have accepted — and both came back red, printing the model's value from the failure path:

```
expected: (= "intents-are-data, World" echo)
  actual: (not (= "intents-are-data, World" "intents-are-data-world"))
expected: (= "34x" (clojure.core/deref echo))
  actual: (not (= "34x" "34"))
```

That red proves both rows **execute** (a skipped row cannot fail) and demonstrates the defect being fixed in the same stroke.

**Arithmetic:** control → green is `+0` tests and `+2` assertions, exactly the two rows added; they sit inside `deftest`s that already existed, which is why the test count does not move.

**Which tree the gates read:** every browser run printed `Serving C:\Users\miket\code\re-frame2-worktrees\p12-hic045\implementation\out\browser-test`, and shadow-cljs printed this worktree's `shadow-cljs.edn`.

**Doc-gate scope, confirmed at source:** `mkdocs build --strict` does **not** cover this page — `mkdocs.yml`'s `exclude_docs` lists `design/hicasso/`. `check_doc_slugs.py` and `check_provenance_pins.py` do, and I proved the former is not fail-open by planting a broken anchor (`budgets.md#99-this-anchor-does-not-exist`), confirming exit 1 naming `per-keystroke.md`, then reverting and re-confirming exit 0 with a zero-residue grep.

**Hand-verified, since nothing validates them:** the new §6 table is 5 columns across header, separator and both rows; the three added §7 run rows are 4 columns each, matching the existing header. Anchors: no new links were introduced, and all existing link targets still resolve after the rebase past a `budgets.md` change.

## Fence

Only `docs/design/hicasso/product/per-keystroke.md` and the per-keystroke census were touched. Untouched: `budgets.md`, `requirements-mine.md`, `correction-ledger.md`, the conformance matrix, the native namespace, and all hot-zone files. The 8 pre-existing compiler warnings in `implementation/hicasso/` are unrelated and unaddressed.
