### PR TITLE
ci(classifier): arm the gates that actually load the two spec-helpers modules

### DIFF
--- a/.github/scripts/report-changed-surfaces.sh
+++ b/.github/scripts/report-changed-surfaces.sh
@@ -836,22 +836,40 @@ else
         mcp_conformance=true
         mcp_live=true
         ;;
-      examples/scripts/spec-helpers.cjs|examples/scripts/examples-port.cjs)
-        # rf2-bxdk8 + rf2-cjp0i — the adapter-smoke harness moved to
-        # implementation/adapters/scripts/ (its own case above), but two
-        # of the helpers it imports still live under examples/scripts/
-        # because the example dev runner and the Story launchers share
-        # them: spec-helpers.cjs (the Playwright assertion matchers the
-        # adapter specs use) and examples-port.cjs (rf2-y9o5e3 — the port
-        # resolver the orchestrator's main() calls before any compile/serve;
-        # a break there false-greens the adapter smoke gate). A change to
-        # either still drives the adapter-testbed-smokes job. The rest of
-        # examples/** is test-free per rf2-8cevm. (port-resolver.cjs is
+      examples/scripts/spec-helpers.cjs)
+        # rf2-bxdk8 + rf2-cjp0i — the shared Playwright assertion matchers.
+        # The adapter-smoke harness moved to implementation/adapters/scripts/
+        # (its own case above), but this helper stays under examples/scripts/
+        # because FOUR gate families require it: the adapter smokes + the
+        # re-frame.ui smoke (both testbed spec.cjs files import the matchers;
+        # ui_smoke per rf2-nojiwy — same orchestrator), the Story/Xray
+        # PR-smoke tier (serve-and-run-story-play-scripts.cjs and
+        # tools/xray/testbeds/feature_matrix/scenarios.cjs — the module the
+        # Xray feature gate loads — both require it; the full-gate roster's
+        # is_story_full_gate_path comment above already assumed the shared
+        # helpers were armed for story_xray_browser), and the tenant-switcher
+        # smoke (testbeds/tenant_switcher/spec.cjs requires it). Before the
+        # rf2-6ng7-class fix this case armed only the first pair, so a break
+        # confined to the Story/Xray-only exports (navigate, reloadPage, …)
+        # or the tenant spec's matchers merged green and was caught only by
+        # the nightly. Fire every gate that actually loads the file.
+        adapter_testbed_smokes=true
+        ui_smoke=true
+        story_xray_browser=true
+        tenant_switcher_smoke=true
+        ;;
+      examples/scripts/examples-port.cjs)
+        # rf2-y9o5e3 — the port resolver the adapter-smoke orchestrator's
+        # main() calls before any compile/serve; a break there false-greens
+        # the adapter smoke gate. Its consumers are the adapter-smoke
+        # orchestration + dev runners only (no Story/Xray/tenant edge — the
+        # Story launchers use story-feature-load-port.cjs), so unlike
+        # spec-helpers.cjs above it stays scoped to the smoke pair. The rest
+        # of examples/** is test-free per rf2-8cevm. (port-resolver.cjs is
         # shared with the Story launchers and is handled in its own case
         # below so it fires BOTH gates; examples-staging.cjs likewise.)
         # ui_smoke fires too (rf2-nojiwy): the re-frame.ui smoke rides the
-        # same orchestrator, so a break in these helpers breaks it
-        # identically.
+        # same orchestrator.
         adapter_testbed_smokes=true
         ui_smoke=true
         ;;
@@ -2402,6 +2420,21 @@ else
         # the transitive CLJS-source coverage every other testbed gets.
         cljs_browser=true
         tenant_switcher_smoke=true
+        ;;
+      testbeds/spec-helpers.cjs)
+        # rf2-6ng7 class — the shared Playwright helper require'd ONLY by
+        # tools/xray/testbeds/feature_matrix/scenarios.cjs, the module BOTH
+        # Xray feature-gate tiers load (implementation/scripts/
+        # serve-and-run-xray-feature-gate.cjs; the PR-smoke tier runs
+        # `test:xray-feature-gate:smoke` under story_xray_browser). The
+        # generic testbeds/* fall-through below arms only cljs_browser — a
+        # CLJS compile-and-test lane that never loads a .cjs — so an edit
+        # breaking this helper red-ded no armed PR job and was caught only
+        # by the nightly full gate. Arm the tier that actually executes it;
+        # cljs_browser is deliberately NOT set (no CLJS source is reachable
+        # from this file — same stop-the-walk reasoning as the Story
+        # launcher arm above).
+        story_xray_browser=true
         ;;
       testbeds/*)
         # rf2-7vsfm + rf2-t5slp — Top-level testbeds/* surfaces are

--- a/implementation/scripts/_changed-surfaces.test.cjs
+++ b/implementation/scripts/_changed-surfaces.test.cjs
@@ -2848,6 +2848,60 @@ test('examples/scripts/port-resolver.cjs (shared resolver) fires BOTH browser ga
   assert.equal(result.story_xray_browser, 'true');
 });
 
+// rf2-6ng7 class — spec-helpers.cjs is the shared Playwright assertion-matcher
+// module with FOUR live gate-family consumers: the adapter/ui smoke specs, the
+// Story/Xray PR-smoke tier (serve-and-run-story-play-scripts.cjs and
+// tools/xray/testbeds/feature_matrix/scenarios.cjs both require it), and the
+// tenant-switcher smoke (testbeds/tenant_switcher/spec.cjs). Its case used to
+// arm only the smoke pair, so a break confined to the Story/Xray-only exports
+// (navigate, reloadPage, …) or the tenant spec's matchers merged green.
+test('examples/scripts/spec-helpers.cjs (shared matchers) fires every gate that loads it (rf2-6ng7 class)', () => {
+  const result = classify('examples/scripts/spec-helpers.cjs');
+  assert.equal(result.adapter_testbed_smokes, 'true');
+  assert.equal(result.ui_smoke, 'true');
+  assert.equal(
+    result.story_xray_browser,
+    'true',
+    'spec-helpers.cjs is require\'d by serve-and-run-story-play-scripts.cjs and the Xray feature-matrix scenarios; it must fire story_xray_browser',
+  );
+  assert.equal(
+    result.tenant_switcher_smoke,
+    'true',
+    'testbeds/tenant_switcher/spec.cjs requires spec-helpers.cjs; it must fire tenant_switcher_smoke',
+  );
+});
+
+test('examples/scripts/examples-port.cjs stays adapter-smoke-scoped after the spec-helpers split (rf2-6ng7 class)', () => {
+  const result = classify('examples/scripts/examples-port.cjs');
+  assert.equal(result.adapter_testbed_smokes, 'true');
+  assert.equal(result.ui_smoke, 'true');
+  assert.equal(
+    result.story_xray_browser,
+    'false',
+    'examples-port.cjs has no Story/Xray consumer (the Story launchers use story-feature-load-port.cjs); the split must not over-arm it',
+  );
+  assert.equal(result.tenant_switcher_smoke, 'false');
+});
+
+// rf2-6ng7 class — testbeds/spec-helpers.cjs is require'd ONLY by
+// tools/xray/testbeds/feature_matrix/scenarios.cjs, which both Xray
+// feature-gate tiers load. The generic testbeds/* fall-through armed only
+// cljs_browser — a CLJS lane that never loads a .cjs — so an edit breaking it
+// red-ded no armed PR job and was caught only by the nightly full gate.
+test('testbeds/spec-helpers.cjs fires the Xray smoke tier, not the CLJS browser lane (rf2-6ng7 class)', () => {
+  const result = classify('testbeds/spec-helpers.cjs');
+  assert.equal(
+    result.story_xray_browser,
+    'true',
+    'the Xray feature-matrix scenarios module requires testbeds/spec-helpers.cjs; it must fire story_xray_browser',
+  );
+  assert.equal(
+    result.cljs_browser,
+    'false',
+    'no CLJS source is reachable from testbeds/spec-helpers.cjs; the CLJS browser lane buys nothing for it',
+  );
+});
+
 // rf2-eqjxya — examples-staging.cjs is the SHARED staging/cleaning helper
 // (stageShared / cleanStageDirs / stageExample) require'd by the adapter-smoke
 // orchestrator (serve-and-run-adapter-smokes.cjs → adapter_testbed_smokes) AND


### PR DESCRIPTION
A 20-PR gating audit (2026-08-14) found two live under-arming holes of the rf2-6ng7 non-local-input class — shared Playwright helper `.cjs` modules whose classifier arms name lanes that never execute them:

**`examples/scripts/spec-helpers.cjs`** armed only `adapter_testbed_smokes` + `ui_smoke`, yet its live consumers also include:
- `examples/scripts/serve-and-run-story-play-scripts.cjs` (PR-smoke tier, `story_xray_browser`)
- `tools/xray/testbeds/feature_matrix/scenarios.cjs` — the module both Xray feature-gate tiers load
- `testbeds/tenant_switcher/spec.cjs:21` (`tenant_switcher_smoke`)

A break confined to the Story/Xray-only exports (`navigate`, `reloadPage`, …) or the tenant spec's matchers merged green and surfaced only at the nightly. The `is_story_full_gate_path` roster comment already *assumed* the shared helpers were armed for `story_xray_browser` — true for `port-resolver.cjs` / `examples-staging.cjs` / `examples-asset-manifest.cjs`, false for this one until now. The joint case is split so `examples-port.cjs` (adapter-smoke-only consumers, verified) is not over-armed by the widening.

**`testbeds/spec-helpers.cjs`** fell through to the generic `testbeds/*` arm (`cljs_browser` — a CLJS lane that never loads a `.cjs`) while its only repo-wide consumer is the Xray scenarios module. It now arms `story_xray_browser`; `cljs_browser` is deliberately dropped (no CLJS source reachable — the classifier's established stop-the-walk reasoning).

Per the rf2-6ng7 standing codicil, both fixes pin their arming in `_changed-surfaces.test.cjs` in the same patch: 3 new pins (the two positive arms + the examples-port negative control).

**Verification (local):**
- `node --test implementation/scripts/_changed-surfaces.test.cjs` → **361 passed, 0 failed** (includes the 3 new pins)
- Classifier probes before/after on all five affected/neighbor paths: `testbeds/spec-helpers.cjs` → `story_xray_browser` only (was `cljs_browser` only); `examples/scripts/spec-helpers.cjs` → smoke pair + `story_xray_browser` + `tenant_switcher_smoke` (was smoke pair only); `examples-port.cjs`, `port-resolver.cjs`, `testbeds/tenant_switcher/spec.cjs` unchanged.

Classifier self-change → CI runs the full mark_all matrix on this PR, as designed.