### PR TITLE
fix(hicasso): verify the ledger's PR-gate lane instead of believing it (rf2-mwr2)

### DIFF
--- a/docs/design/hicasso/product/budgets.md
+++ b/docs/design/hicasso/product/budgets.md
@@ -949,6 +949,34 @@ that exists and runs in the first lane; a distributional row may never name the
 first lane at all. *Authority* is the bead that owns the row's disposition
 today. *Disposition* is a link that must resolve to a section naming the row.
 
+**[Amended 2026-08-14, `rf2-mwr2`.] The lane is now verified rather than
+believed.** Until this amendment the gate read that the lane was *spelled*
+legally and that the witness file was *on disk*, and took the `PR gate` claim
+itself on trust — so a row could name a witness that only a scheduled workflow
+ever runs and stay green. A second audit of `rf2-mwr2` reasoned from exactly
+that gap, and concluded `D26`'s counter gated nothing. **The conclusion was
+wrong on the facts and the reasoning was right about the gate**, so the gap is
+what got closed. For a `*_dom_cljs_test` witness the browser lane is decided by
+a single selector, so the gate now reads the two selectors out of
+`implementation/shadow-cljs.edn` and requires the PR-blocking `:browser-test`
+build to select the witness's namespace. A witness reachable only through
+`:browser-test-freehand-bench` — the lane `freehand-bench.yml` drives on
+`schedule` and `workflow_dispatch`, which blocks no merge — now reds. Nineteen
+rows carry a verified lane as a result, `U5` and `D26` among them.
+
+Why the audit's conclusion did not hold, recorded here so it is not re-derived:
+`:browser-test` excludes `re-frame.freehand.bench.*`, and `D26`'s witness lives
+in the bench *tree* but declares the namespace
+`re-frame.bench.hicasso.topo.census-dom-cljs-test`. The exclusion does not
+reach it; the PR-blocking selector matches it; `implementation/freehand/test`
+is on the global `:source-paths`; and the job that runs that build,
+`cljs-browser`, is in `test.yml`'s required `all-required-passed` needs list
+and is armed for this surface by the changed-surface classifier. The witness's
+assertions do gate on a real DOM, which is a *stated skip under `:node-test`*
+and not a skip in the lane that gates. Should a later worker tighten the
+exclusion to the whole bench tree, the gate reds here instead of silently
+unhooking `U5`'s second counter.
+
 **[Amended 2026-08-14, `rf2-mwr2`.] A row that claims work SCALES has to name
 two counters, and the gate refuses one.** `U5` was registered on boundary
 bodies alone, and read `MET` on a coarse view-model arm that rebuilds every

--- a/implementation/hicasso/scripts/check_budget_ledger.py
+++ b/implementation/hicasso/scripts/check_budget_ledger.py
@@ -96,6 +96,18 @@ THE RULES
                      §2 and §7 mechanised, and it is what stops the 5%
                      heap comparison being wired to a hosted runner by a
                      later worker acting in good faith.
+                     AND THE LANE IS VERIFIED, NOT BELIEVED (`rf2-mwr2`).
+                     For a `*_dom_cljs_test` witness the browser lane is
+                     decided by one selector, so the claim is checked
+                     against `implementation/shadow-cljs.edn`: the
+                     PR-blocking `:browser-test` build must select the
+                     witness's namespace. A row whose witness lands only
+                     in `:browser-test-freehand-bench` — the lane
+                     freehand-bench.yml drives on cron and
+                     workflow_dispatch, which gates nothing — is a row
+                     asserting a lane it does not run in, and reds.
+                     Reading a lane claim and never testing it is the
+                     same fail-open shape as L7's, one level up.
   L7  A SCALING CLAIM IS DECIDED ON TWO COUNTERS.
                      A registered line saying work *scales with changed rows*
                      must name a companion ledger row carrying a second,
@@ -298,6 +310,79 @@ _RE_TAGS = re.compile(r"</?[^>]*>")
 _RE_INVALID_SLUG_CHAR = re.compile(r"[^\w\- ]", re.UNICODE)
 
 
+# L6.  The build config the browser DOM lanes are declared in, read ONLY.
+# This gate never writes it: `implementation/shadow-cljs.edn` is a hot-zone
+# file with one toucher, and the point here is to READ the lane assignment a
+# row asserts rather than to change it.
+SHADOW_CLJS = os.path.join(REPO_ROOT, "implementation", "shadow-cljs.edn")
+
+# L6.  The two browser DOM lanes, by build id.  The first blocks a pull
+# request (`cljs-browser` in test.yml's `all-required-passed` needs list);
+# the second is the scheduled bench lane freehand-bench.yml drives on cron
+# and workflow_dispatch, and it gates nothing.  A `PR gate` row whose witness
+# lands only in the second is a row asserting a lane it does not run in.
+PR_BLOCKING_DOM_BUILD = ":browser-test"
+SCHEDULED_DOM_BUILD = ":browser-test-freehand-bench"
+
+_DOM_WITNESS_RE = re.compile(r"_dom_cljs_test\.cljs$")
+_NS_ROOT_RE = re.compile(r"(?:^|/)(re_frame/.*)\.clj[sc]?$")
+
+
+def _edn_unescape(literal):
+    """The characters an EDN string literal stands for.
+
+    Only the two escapes a `:ns-regexp` can carry matter here: `\\\\` for a
+    backslash — every `\\.` in these patterns is written `\\\\.` in the EDN —
+    and `\\"` for a quote.
+    """
+    out, i = [], 0
+    while i < len(literal):
+        ch = literal[i]
+        if ch == "\\" and i + 1 < len(literal):
+            out.append(literal[i + 1])
+            i += 2
+        else:
+            out.append(ch)
+            i += 1
+    return "".join(out)
+
+
+def read_dom_lane_selectors(path=SHADOW_CLJS):
+    """`{build-id: compiled ns-regexp}` for the two browser DOM lanes.
+
+    Raises rather than returning a partial map.  A gate that cannot read the
+    lane assignment must REFUSE, not report green: silently skipping the
+    check when the config moves would reintroduce, in this rule's own
+    machinery, exactly the fail-open the rule exists to close.
+    """
+    with open(path, encoding="utf-8") as handle:
+        text = handle.read()
+    selectors = {}
+    for build in (PR_BLOCKING_DOM_BUILD, SCHEDULED_DOM_BUILD):
+        match = re.search(
+            r"^\s*%s\s*$\s*\{.*?:ns-regexp\s+\"((?:[^\"\\\\]|\\\\.)*)\""
+            % re.escape(build), text, re.S | re.M)
+        if not match:
+            raise ValueError(
+                "%s declares no :ns-regexp for the build %s, so no row's "
+                "`PR gate` lane claim can be verified. This gate refuses "
+                "rather than skipping the check" % (path, build))
+        selectors[build] = re.compile(_edn_unescape(match.group(1)))
+    return selectors
+
+
+def witness_namespace(witness):
+    """The ClojureScript namespace a witness path declares, or `None`.
+
+    Derived from the path below its `re_frame/` source root, which is how
+    every source root on this repo's `:source-paths` lays its namespaces out.
+    """
+    match = _NS_ROOT_RE.search(witness.replace("\\", "/"))
+    if not match:
+        return None
+    return match.group(1).replace("/", ".").replace("_", "-")
+
+
 def slugify(text):
     """The heading slug mkdocs mints, `pymdownx.slugs.slugify(case=lower)`.
 
@@ -429,7 +514,7 @@ def _numbers(text):
     return int(text.replace(",", ""))
 
 
-def check(rows, registered, sections, existing_files):
+def check(rows, registered, sections, existing_files, selectors=None):
     """Every rule, against already-read inputs.
 
     Pure, so `--self-test` drives each red by doctoring one input of a
@@ -441,9 +526,13 @@ def check(rows, registered, sections, existing_files):
     `sections` maps a `file.md#anchor` target to the section body it names,
     or to None when it names nothing.  `existing_files` is the set of
     repo-relative paths, among those the ledger cites, that exist.
+    `selectors` maps the two browser DOM build ids to their compiled
+    `:ns-regexp`, read from `implementation/shadow-cljs.edn` when not given.
     """
     failures = []
     by_id = {}
+    if selectors is None:
+        selectors = read_dom_lane_selectors()
 
     for row in rows:
         rid = row["id"]
@@ -583,6 +672,38 @@ def check(rows, registered, sections, existing_files):
                 failures.append(
                     "L6 %s names the witness %s, which does not exist"
                     % (rid, witness))
+            elif _DOM_WITNESS_RE.search(witness):
+                # The `PR gate` cell is a CLAIM, and until this check it was
+                # never tested: L6 read that the lane was spelled legally and
+                # that the file was on disk, and took the lane itself on
+                # trust.  `rf2-mwr2`'s second audit reasoned from that gap —
+                # that D26's counter sat in the scheduled bench lane and so
+                # gated nothing — and the reasoning was sound even though the
+                # conclusion was wrong on the facts.  A row asserting a lane
+                # nothing verifies is the same shape of fail-open as an
+                # estimand blind to its own failure, one level up.  For a
+                # `*_dom_cljs_test` witness the assignment is exact and
+                # mechanical, so it is checked rather than believed.
+                namespace = witness_namespace(witness)
+                if namespace is None:
+                    failures.append(
+                        "L6 %s names the DOM witness %s, whose namespace "
+                        "cannot be derived: no `re_frame/` source root in the "
+                        "path, so its lane cannot be verified" % (rid, witness))
+                elif not selectors[PR_BLOCKING_DOM_BUILD].search(namespace):
+                    scheduled = selectors[SCHEDULED_DOM_BUILD].search(namespace)
+                    failures.append(
+                        "L6 %s claims the `PR gate` lane, but %s selects "
+                        "nothing for its witness %s (namespace %s). %s A "
+                        "deterministic row must run in a lane that blocks a "
+                        "merge, and this one runs in %s"
+                        % (rid, PR_BLOCKING_DOM_BUILD, witness, namespace,
+                           "It is selected by %s, which freehand-bench.yml "
+                           "drives on schedule and workflow_dispatch only."
+                           % SCHEDULED_DOM_BUILD if scheduled
+                           else "No browser DOM lane selects it at all.",
+                           "the scheduled bench lane" if scheduled
+                           else "no browser lane"))
         else:
             if lane == "PR gate":
                 failures.append(
@@ -831,6 +952,43 @@ def self_test():
     # ...and a lane nobody registered.
     red("L6", rows=patched("D1", instrument="`x` (some other lane)"))
 
+    # L6 — the lane claim itself, which until `rf2-mwr2`'s second audit was
+    # believed rather than checked.  A witness that exists, in a row spelled
+    # legally, whose namespace the PR-blocking browser build does not select:
+    # green under every earlier reading of this rule, and gating nothing.
+    bench_witness = ("implementation/freehand/test/re_frame/freehand/bench/"
+                     "b1_dom_cljs_test.cljs")
+    assert os.path.isfile(os.path.join(REPO_ROOT, bench_witness)), \
+        "the L6 lane control needs a real scheduled-lane witness"
+    red("L6",
+        rows=patched("D26", instrument="`%s` (PR gate)" % bench_witness),
+        existing_files=existing | {bench_witness})
+    # ...a DOM witness whose namespace cannot be derived at all, which is the
+    # way this check would otherwise pass by being unable to run...
+    kit_witness = "implementation/hicasso/test_kit/src/mounted_dom_cljs_test.cljs"
+    red("L6",
+        rows=patched("D1", instrument="`%s` (PR gate)" % kit_witness),
+        existing_files=existing | {kit_witness})
+    # ...and the eager direction: D26's real witness lives in the bench TREE
+    # but its namespace is `re-frame.bench.*`, not `re-frame.freehand.bench.*`,
+    # so the PR-blocking build does select it.  That distinction is the whole
+    # of the audit's refutation, and a later worker tightening the exclusion
+    # to the whole bench tree would red HERE rather than silently unhook U5's
+    # second counter.
+    green()
+
+    # L6 — and the gate REFUSES when it cannot read the lane assignment,
+    # rather than skipping the check.  A missing build id must not degrade to
+    # a pass; that would rebuild the fail-open inside the rule that closes it.
+    try:
+        read_dom_lane_selectors(os.path.join(REPO_ROOT, "mkdocs.yml"))
+    except ValueError:
+        pass
+    else:
+        raise AssertionError(
+            "read_dom_lane_selectors accepted a file declaring no browser "
+            "DOM build, so an unreadable lane assignment would pass")
+
     # L7 — the fail-open `rf2-mwr2` found, driven from every direction a
     # later edit could reopen it.  The first is the defect as it stood: U5
     # registered on bodies alone, its second counter absent from the ledger.
@@ -893,10 +1051,13 @@ def main(argv=None):
           "a bead id and a disposition that resolves;")
     print("no band crossing its line is recorded as a pass; no distributional "
           "row is wired to a pull-request gate;")
-    print("no row claiming that work SCALES is decided on one counter.")
+    print("no row claiming that work SCALES is decided on one counter;")
+    print("and no deterministic row asserts a `PR gate` lane its DOM witness "
+          "does not actually run in.")
     print("An Authority cell is read for SHAPE, not for life. This gate reads "
-          "two markdown files and has no tracker access, so it cannot see "
-          "that a named bead has closed:")
+          "two markdown files plus the browser lane selectors in "
+          "implementation/shadow-cljs.edn, and has no tracker access, so it "
+          "cannot see that a named bead has closed:")
     print("a row can name a bead reference and have no live owner. Whether "
           "the named beads are open is a question for a reader, and it is not "
           "certified here.")


### PR DESCRIPTION
Reopened by the merged-PR audit of #8177, which found L7's companion row `D26` registered against a witness no required gate runs, and asked for either a package-resident second counter or a narrowing of `U5` and `D26`.

**Checked at source, the audit's conclusion does not hold, so neither offered repair is made.** What the audit was right about is the *gate*, not the row — and that is what this PR closes.

## The four premise limbs, at source

| # | Audit limb | Verdict |
|---|---|---|
| 1 | `implementation/shadow-cljs.edn` excludes `re-frame.freehand.bench.*` from `:browser-test` | **True of the file, refuted as applied.** The exclusion is real (`shadow-cljs.edn:1395`). `D26`'s witness lives in the bench *tree* but declares `re-frame.bench.hicasso.topo.census-dom-cljs-test` — prefix `re-frame.bench.`, not `re-frame.freehand.bench.`. The negative lookahead does not reach it. Verified by evaluating both selectors against the namespace: PR-blocking `True`, scheduled `False`. |
| 2 | `census_dom_cljs_test`'s `D26` assertions skip without a browser | **True, not load-bearing.** Every assertion gates on `(mount/browser?)`, which is `(exists? js/document)`. That is a *stated skip under `:node-test`*, by the suite's own docstring — not a skip in the lane that gates, which is headless Chromium. |
| 3 | `.github/workflows/freehand-bench.yml` is `schedule` / `workflow_dispatch` only | **True, irrelevant.** Confirmed at its `on:` block. But it is not the witness's only lane: `:browser-test` runs in `test.yml`'s `cljs-browser` job. |
| 4 | `arm1`'s runtime sits off every production source path, while `U5`'s ledger population is `package` | **True, and already recorded.** Package `src` references `arm1` only in docstrings, never `:require`. budgets.md §3 already names `D26`'s population `bench-tree` and says why. No misalignment to repair. |

**So the charge — "the second counter is registered against a witness that never runs on a PR" — is refuted.** `implementation/freehand/test` is on the global `:source-paths`; the PR-blocking selector matches the namespace; and `cljs-browser` is in `test.yml`'s required `all-required-passed` needs list, armed for this surface by the changed-surface classifier (verified by running `.github/scripts/report-changed-surfaces.sh` on all three relevant paths — `cljs_browser=true` for each).

## Which repair, and why the other was rejected

**Neither, as offered.** Narrowing `U5`/`D26` would retreat from a claim that is *true*, trading a real gate for a smaller false one. A package-resident second counter is unnecessary — the existing counter already runs on a required PR gate.

**What was actually wrong is one level up again.** `L6` read that a lane was spelled legally and that the witness file was on disk, then took the `PR gate` claim itself **on trust**. A row naming a witness only a scheduled workflow runs would have stayed green. That is `L7`'s fail-open shape applied to `L6`, and it is the real defect the audit was reaching for.

So `L6` now **verifies** the lane. For a `*_dom_cljs_test` witness the browser lane is decided by a single selector, so the gate reads both selectors out of `implementation/shadow-cljs.edn` and requires the PR-blocking `:browser-test` build to select the witness's namespace. **19 rows carry a verified lane as a result**, `U5` and `D26` among them. When the gate cannot read the lane assignment it **refuses** rather than skipping, so the rule cannot fail open inside its own machinery.

## Evidence that `U5`'s line is not widened — checkable, not asserted

**No ledger table row is touched at all.** The budgets.md diff is 28 insertions, 0 deletions, entirely prose in §9.

```
$ git diff -U0 origin/main...HEAD -- docs/design/hicasso/product/budgets.md | grep -E "^[+-]\|"
(no output — no table row on either side of the diff)

$ git show origin/main:docs/design/hicasso/product/budgets.md | grep -E "^\| (U5|D26) \|" | git hash-object --stdin
cb7756ba0418ad98ef984ef753840dc39ae04aca
$ grep -E "^\| (U5|D26) \|" docs/design/hicasso/product/budgets.md | git hash-object --stdin
cb7756ba0418ad98ef984ef753840dc39ae04aca
```

Both rows are byte-identical to `main`. No threshold moved; no estimand widened.

## Hot zone

**Not needed, and not touched.** `implementation/shadow-cljs.edn` is **read**, never written — the repair is about which gate runs a counter, not about changing the exclusion. It is absent from `git status` and from the diff, hash-verified below. `.github/workflows/*`, `spec/*` and `implementation/deps.edn` are untouched.

One stale comment noted and **left alone** as hot zone: `test.yml:1000` says this gate "reads THREE input families"; it now reads a fourth (`implementation/shadow-cljs.edn`). The job is **unconditional** and required, so the count is stale but the scheduling decision it documents already covers the new read — no classifier arm is needed. Flagged for whoever next holds `test.yml`.

## Quality gates

Baseline established **before** any edit, on my own runs: `check_budget_ledger.py` exit `0`, 49 rows (31 MET, 5 BREACH, 3 UNRESOLVED, 10 UNPINNED).

Exit codes captured by redirecting to a log and echoing the runner's own `$?` on one command line — never piped through a filter.

| Gate | Exit |
|---|---|
| `check_budget_ledger.py` (live) | `0` |
| `check_budget_ledger.py --self-test` | `0` |
| `scripts/check_doc_slugs.py` | `0` |
| `scripts/check_provenance_pins.py --changed-since origin/main` (**after** commit) | `0` |

Provenance gate run **after** committing, per the known `rf2-qfrrp` vacuous-green defect — a pre-commit run inspects zero files and returns `0` indistinguishably from a real pass. Post-commit it reports **1 file, 5 cited pins (5 landed, 0 stranded, 0 unresolvable, 0 foreign)** — non-vacuous.

**Spine:** I did **not** run `scripts/test-fast-pr.sh`. The diff is one Python contract gate plus one markdown page — no CLJS, no build config, no workflow. I ran the targeted gates above directly, which are the ones `hicasso-budget-ledger` and `Docs required` execute verbatim. Per `scripts/check_fast_pr_gap.py --list`, the canonical fast-spine-versus-required-CI gap is **96 required checks the spine does not run** — green locally is not green in CI either way, and the spine would not have decided this diff.

Cwd-independence verified (`REPO_ROOT` derives from `__file__`): the gate exits `0` run from `implementation/` (as `npm run test:hicasso-invariants` does) and from an unrelated directory.

### Red-then-green, hash-verified

Two live-document sabotages, each captured red, each restore hash-verified with `git hash-object`.

**Sabotage 1 — a `PR gate` row whose witness only the scheduled lane runs.** This is precisely the fail-open the audit *imagined*; before this PR it was green.

```
BUDGETS_BEFORE=d45075a24f27dc0f2208b6ea10c5a13e411b8aca
# D26's instrument repointed to .../freehand/bench/b1_dom_cljs_test.cljs (PR gate)
SABOTAGE1_EXIT=1
  L6 D26 claims the `PR gate` lane, but :browser-test selects nothing for its
  witness .../b1_dom_cljs_test.cljs (namespace re-frame.freehand.bench.b1-dom-cljs-test).
  It is selected by :browser-test-freehand-bench, which freehand-bench.yml drives on
  schedule and workflow_dispatch only. A deterministic row must run in a lane that
  blocks a merge, and this one runs in the scheduled bench lane
BUDGETS_AFTER=d45075a24f27dc0f2208b6ea10c5a13e411b8aca   # restore verified
LEDGER_RESTORED_EXIT=0
```

**Sabotage 2 — a later worker tightens the exclusion to the whole bench tree.** This proves the claim the amended §9 makes: the gate reds rather than silently unhooking `U5`'s second counter.

```
SHADOW_BEFORE=951cac1b86e684cffe8d808bd169512315036412
# :browser-test exclusion widened to cover re-frame.bench.* as well
SABOTAGE2_EXIT=1
  L6 D26 claims the `PR gate` lane, but :browser-test selects nothing for its
  witness .../census_dom_cljs_test.cljs (namespace re-frame.bench.hicasso.topo.census-dom-cljs-test).
  No browser DOM lane selects it at all. A deterministic row must run in a lane
  that blocks a merge, and this one runs in no browser lane
SHADOW_AFTER=951cac1b86e684cffe8d808bd169512315036412    # restore verified, byte-identical
```

The self-test carries both directions as permanent controls, plus a witness whose namespace cannot be derived, plus a refusal control proving the gate reds rather than skipping when the build config declares no browser DOM build.

### Diff read for reverts

`git diff origin/main...HEAD` (three-dot, against merge base `514aec1afe`) removes exactly four lines, all of them mine and all intentional: the `check()` signature I extended, and two report lines I rewrote for accuracy. This page changed four times today; nothing from those changes is reverted, and `dispositions.md`, `requirements-mine.md`, `correction-ledger.md`, `C8`, `L4`–`L6`'s registry entries and `D17`–`D25` are untouched.
