### PR TITLE
gate(hicasso): L6 verifies every PR-gate witness, not only the DOM ones (rf2-xcaph)

### DIFF
--- a/docs/design/hicasso/product/budgets.md
+++ b/docs/design/hicasso/product/budgets.md
@@ -945,9 +945,9 @@ S7 and U1–U4 where they were, so a later edit cannot quietly promote a
 bench-tree figure by rewriting a cell. *Instrument* names the thing that took
 the reading and, in parentheses, the lane it runs in — `PR gate`,
 `P-DEV-1 evidence run`, or `none`. A deterministic row must name a witness file
-that exists and runs in the first lane; a distributional row may never name the
-first lane at all. *Authority* is the bead that owns the row's disposition
-today. *Disposition* is a link that must resolve to a section naming the row.
+that exists, runs in the first lane, and is *selected by a test build that
+blocks a merge*; a distributional row may never name the first lane at all.
+*Authority* is the bead that owns the row's disposition today. *Disposition* is a link that must resolve to a section naming the row.
 
 **[Amended 2026-08-14, `rf2-mwr2`.] The lane is now verified rather than
 believed.** Until this amendment the gate read that the lane was *spelled*
@@ -976,6 +976,34 @@ assertions do gate on a real DOM, which is a *stated skip under `:node-test`*
 and not a skip in the lane that gates. Should a later worker tighten the
 exclusion to the whole bench tree, the gate reds here instead of silently
 unhooking `U5`'s second counter.
+
+**[Amended 2026-08-14, `rf2-xcaph`.] The verification now covers every `PR gate`
+witness, not only the DOM ones.** The amendment above checked seven of the
+eight witnesses this ledger names and left the eighth class — the plain
+`*_cljs_test` counters — exactly where it found them: lane spelled legally,
+file on disk, lane itself believed. That remainder was not hypothetical.
+`rf2-9vbl1` found `D9` and `U6` naming
+`hicasso/test_kit/src/re_frame/hicasso/test/mounted.cljs`, the test-kit
+**facade** — a real library file, under a real source root, containing no tests
+and compiled into no test build — and the DOM-only rule returned green on it.
+So the rule is now the general one: **every `PR gate` witness must be selected
+by a build that blocks a merge**, and a witness no build compiles reds as a file
+on disk rather than a gate.
+
+Each witness class has exactly one such build and is checked against that one —
+a `*_dom_cljs_test` witness against `:browser-test`, run by `test.yml`'s
+`cljs-browser` job; every other against `:node-test`, run by its `cljs` job
+(*CLJS (shadow-cljs :node-test)*). Both jobs sit in the required
+`all-required-passed` `needs:` list, one line apart, and both are armed
+per-surface by the changed-surface classifier: the node lane blocks a merge on
+precisely the footing the paragraph above established for the browser one. The
+mapping is deliberately **per class** and not *any build that selects it*,
+because `:node-test`'s `cljs-test$` also matches every `*-dom-cljs-test`
+namespace — whose assertions are the stated skip just described. Reading that
+match as satisfaction would weaken the browser arm in the act of closing the
+node one, letting a scheduled-lane DOM witness back through on the node build's
+selector. All eight witnesses pass on arrival; the widening reds nothing here
+and closes the class the last one could not see.
 
 **[Amended 2026-08-14, `rf2-mwr2`.] A row that claims work SCALES has to name
 two counters, and the gate refuses one.** `U5` was registered on boundary

--- a/implementation/hicasso/scripts/check_budget_ledger.py
+++ b/implementation/hicasso/scripts/check_budget_ledger.py
@@ -96,18 +96,31 @@ THE RULES
                      §2 and §7 mechanised, and it is what stops the 5%
                      heap comparison being wired to a hosted runner by a
                      later worker acting in good faith.
-                     AND THE LANE IS VERIFIED, NOT BELIEVED (`rf2-mwr2`).
-                     For a `*_dom_cljs_test` witness the browser lane is
-                     decided by one selector, so the claim is checked
-                     against `implementation/shadow-cljs.edn`: the
-                     PR-blocking `:browser-test` build must select the
-                     witness's namespace. A row whose witness lands only
-                     in `:browser-test-freehand-bench` — the lane
+                     AND THE LANE IS VERIFIED, NOT BELIEVED (`rf2-mwr2`,
+                     widened past the DOM by `rf2-xcaph`). EVERY `PR gate`
+                     witness must be SELECTED BY A TEST BUILD THAT BLOCKS A
+                     MERGE, checked against the `:ns-regexp`s read out of
+                     `implementation/shadow-cljs.edn`. Each witness class
+                     has exactly one such build and is checked against
+                     that one: a `*_dom_cljs_test` witness against
+                     `:browser-test` (run by test.yml's `cljs-browser`
+                     job), every other against `:node-test` (run by its
+                     `cljs` job) — both jobs sit in `all-required-passed`'s
+                     `needs:` list. A row whose DOM witness lands only in
+                     `:browser-test-freehand-bench` — the lane
                      freehand-bench.yml drives on cron and
                      workflow_dispatch, which gates nothing — is a row
-                     asserting a lane it does not run in, and reds.
-                     Reading a lane claim and never testing it is the
-                     same fail-open shape as L7's, one level up.
+                     asserting a lane it does not run in, and reds; so is
+                     a row naming a file no build compiles at all, which
+                     is what `rf2-9vbl1` found D9 and U6 doing and the
+                     DOM-only rule could not see. Reading a lane claim and
+                     never testing it is the same fail-open shape as L7's,
+                     one level up.
+                     The mapping is PER CLASS rather than "any build that
+                     selects it" because `:node-test`'s `cljs-test$` also
+                     matches the DOM namespaces, whose assertions are a
+                     stated skip there — reading it as satisfaction would
+                     weaken the browser arm to close the node one.
   L7  A SCALING CLAIM IS DECIDED ON TWO COUNTERS.
                      A registered line saying work *scales with changed rows*
                      must name a companion ledger row carrying a second,
@@ -310,10 +323,10 @@ _RE_TAGS = re.compile(r"</?[^>]*>")
 _RE_INVALID_SLUG_CHAR = re.compile(r"[^\w\- ]", re.UNICODE)
 
 
-# L6.  The build config the browser DOM lanes are declared in, read ONLY.
-# This gate never writes it: `implementation/shadow-cljs.edn` is a hot-zone
-# file with one toucher, and the point here is to READ the lane assignment a
-# row asserts rather than to change it.
+# L6.  The build config the test lanes are declared in, read ONLY.  This gate
+# never writes it: `implementation/shadow-cljs.edn` is a hot-zone file with one
+# toucher, and the point here is to READ the lane assignment a row asserts
+# rather than to change it.
 SHADOW_CLJS = os.path.join(REPO_ROOT, "implementation", "shadow-cljs.edn")
 
 # L6.  The two browser DOM lanes, by build id.  The first blocks a pull
@@ -323,6 +336,25 @@ SHADOW_CLJS = os.path.join(REPO_ROOT, "implementation", "shadow-cljs.edn")
 # lands only in the second is a row asserting a lane it does not run in.
 PR_BLOCKING_DOM_BUILD = ":browser-test"
 SCHEDULED_DOM_BUILD = ":browser-test-freehand-bench"
+
+# L6.  The PR-blocking lane for every OTHER witness (`rf2-xcaph`).  `:node-test`
+# is run by test.yml's `cljs` job — *CLJS (shadow-cljs :node-test)*, which does
+# `npx shadow-cljs compile node-test && node out/node-test.js` — and that job
+# sits in `all-required-passed`'s `needs:` list one line above `cljs-browser`,
+# so the two lanes block a merge on exactly the same footing.  Both are armed
+# per-surface by `detect_changed_surfaces` (`cljs_node_test` / `cljs_browser`)
+# and the aggregator treats a surface-skip as OK; that too is common to both,
+# and it is the standard `rf2-mwr2` verified for the browser lane.
+#
+# WHY THE MAPPING IS PER CLASS AND NOT "any build that selects it".
+# `:node-test`'s `cljs-test$` also matches every `*-dom-cljs-test` namespace, so
+# a rule reading *some* build would let a DOM witness reachable only through the
+# scheduled bench lane pass on the node build's selector — and those namespaces
+# are a STATED SKIP under `:node-test`, their assertions gating on a real DOM
+# (budgets.md sec. 9.1).  That would weaken the browser arm this rule already
+# holds.  Each witness class therefore has exactly one PR-blocking build that
+# owns it, and the row's claim is checked against that one.
+PR_BLOCKING_NODE_BUILD = ":node-test"
 
 _DOM_WITNESS_RE = re.compile(r"_dom_cljs_test\.cljs$")
 _NS_ROOT_RE = re.compile(r"(?:^|/)(re_frame/.*)\.clj[sc]?$")
@@ -347,20 +379,29 @@ def _edn_unescape(literal):
     return "".join(out)
 
 
-def read_dom_lane_selectors(path=SHADOW_CLJS):
-    """`{build-id: compiled ns-regexp}` for the two browser DOM lanes.
+def read_lane_selectors(path=SHADOW_CLJS):
+    """`{build-id: compiled ns-regexp}` for the three lanes L6 adjudicates on.
 
     Raises rather than returning a partial map.  A gate that cannot read the
     lane assignment must REFUSE, not report green: silently skipping the
     check when the config moves would reintroduce, in this rule's own
-    machinery, exactly the fail-open the rule exists to close.
+    machinery, exactly the fail-open the rule exists to close.  That applies
+    to the node build no less than the two browser ones — a rule that fell
+    back to "unverified" for the seven non-DOM witnesses would be the rule
+    `rf2-xcaph` widened it out of.
     """
     with open(path, encoding="utf-8") as handle:
         text = handle.read()
     selectors = {}
-    for build in (PR_BLOCKING_DOM_BUILD, SCHEDULED_DOM_BUILD):
+    for build in (PR_BLOCKING_DOM_BUILD, SCHEDULED_DOM_BUILD,
+                  PR_BLOCKING_NODE_BUILD):
+        # The build id sits alone on its line, optionally behind the `{` that
+        # opens the `:builds` map — `:node-test` is that map's FIRST entry and
+        # so is written `{:node-test`.  Anchoring on the whole line is what
+        # keeps `:target :node-test` and `:node-test-perf-nightly` from being
+        # mistaken for the build's own key.
         match = re.search(
-            r"^\s*%s\s*$\s*\{.*?:ns-regexp\s+\"((?:[^\"\\\\]|\\\\.)*)\""
+            r"^\s*\{?\s*%s\s*$\s*\{.*?:ns-regexp\s+\"((?:[^\"\\\\]|\\\\.)*)\""
             % re.escape(build), text, re.S | re.M)
         if not match:
             raise ValueError(
@@ -409,6 +450,20 @@ def _cells(line):
 def _bare(cell):
     """`cell` with markdown backticks stripped, for a cell holding one token."""
     return cell.replace("`", "").strip()
+
+
+def instrument_parts(cell):
+    """`(witness, lane)` from an instrument cell, or `(None, None)`.
+
+    The cell names *what took the reading* and then, in parentheses at the
+    end, the lane it ran in.  Split once, here, so L6 and its self-test read
+    the cell the same way: a self-test that re-derives the split is one that
+    can go on agreeing with a rule it has stopped describing.
+    """
+    match = _LANE_RE.search(cell)
+    if not match:
+        return None, None
+    return _bare(cell[:match.start()]), match.group(1).strip()
 
 
 def read_ledger(path):
@@ -526,13 +581,14 @@ def check(rows, registered, sections, existing_files, selectors=None):
     `sections` maps a `file.md#anchor` target to the section body it names,
     or to None when it names nothing.  `existing_files` is the set of
     repo-relative paths, among those the ledger cites, that exist.
-    `selectors` maps the two browser DOM build ids to their compiled
-    `:ns-regexp`, read from `implementation/shadow-cljs.edn` when not given.
+    `selectors` maps the two browser DOM build ids and the node build id to
+    their compiled `:ns-regexp`, read from `implementation/shadow-cljs.edn`
+    when not given.
     """
     failures = []
     by_id = {}
     if selectors is None:
-        selectors = read_dom_lane_selectors()
+        selectors = read_lane_selectors()
 
     for row in rows:
         rid = row["id"]
@@ -648,20 +704,18 @@ def check(rows, registered, sections, existing_files, selectors=None):
                 break
 
         # --- L6: the lane is legal --------------------------------------
-        lane_match = _LANE_RE.search(row["instrument"])
-        if not lane_match:
+        witness, lane = instrument_parts(row["instrument"])
+        if lane is None:
             failures.append(
                 "L6 %s names no lane. The instrument cell ends in one of (%s)"
                 % (rid, "), (".join(LANES)))
             continue
-        lane = lane_match.group(1).strip()
         if lane not in LANES:
             failures.append(
                 "L6 %s runs in lane %r, which is not one of %s"
                 % (rid, lane, ", ".join(LANES)))
             continue
         deterministic = rid in DETERMINISTIC_IDS
-        witness = _bare(row["instrument"][:lane_match.start()])
         if deterministic:
             if lane != "PR gate":
                 failures.append(
@@ -672,7 +726,7 @@ def check(rows, registered, sections, existing_files, selectors=None):
                 failures.append(
                     "L6 %s names the witness %s, which does not exist"
                     % (rid, witness))
-            elif _DOM_WITNESS_RE.search(witness):
+            else:
                 # The `PR gate` cell is a CLAIM, and until this check it was
                 # never tested: L6 read that the lane was spelled legally and
                 # that the file was on disk, and took the lane itself on
@@ -681,29 +735,45 @@ def check(rows, registered, sections, existing_files, selectors=None):
                 # gated nothing — and the reasoning was sound even though the
                 # conclusion was wrong on the facts.  A row asserting a lane
                 # nothing verifies is the same shape of fail-open as an
-                # estimand blind to its own failure, one level up.  For a
-                # `*_dom_cljs_test` witness the assignment is exact and
-                # mechanical, so it is checked rather than believed.
+                # estimand blind to its own failure, one level up.
+                #
+                # `rf2-mwr2` checked the DOM witnesses, where the mapping is
+                # exact; `rf2-xcaph` extends the same treatment to the rest,
+                # because a rule that verified seven witnesses out of eight
+                # left the loophole open at its own edge.  `rf2-9vbl1` is the
+                # proof it was not hypothetical: D9 and U6 named the test-kit
+                # FACADE, a library file with no tests that no build selects,
+                # and the DOM-only rule returned green on it.
                 namespace = witness_namespace(witness)
                 if namespace is None:
                     failures.append(
-                        "L6 %s names the DOM witness %s, whose namespace "
-                        "cannot be derived: no `re_frame/` source root in the "
-                        "path, so its lane cannot be verified" % (rid, witness))
-                elif not selectors[PR_BLOCKING_DOM_BUILD].search(namespace):
-                    scheduled = selectors[SCHEDULED_DOM_BUILD].search(namespace)
+                        "L6 %s names the witness %s, whose namespace cannot be "
+                        "derived: no `re_frame/` source root in the path, so no "
+                        "build's selector can be applied and its lane cannot be "
+                        "verified" % (rid, witness))
+                elif _DOM_WITNESS_RE.search(witness):
+                    if not selectors[PR_BLOCKING_DOM_BUILD].search(namespace):
+                        scheduled = selectors[SCHEDULED_DOM_BUILD].search(namespace)
+                        failures.append(
+                            "L6 %s claims the `PR gate` lane, but %s selects "
+                            "nothing for its witness %s (namespace %s). %s A "
+                            "deterministic row must run in a lane that blocks a "
+                            "merge, and this one runs in %s"
+                            % (rid, PR_BLOCKING_DOM_BUILD, witness, namespace,
+                               "It is selected by %s, which freehand-bench.yml "
+                               "drives on schedule and workflow_dispatch only."
+                               % SCHEDULED_DOM_BUILD if scheduled
+                               else "No browser DOM lane selects it at all.",
+                               "the scheduled bench lane" if scheduled
+                               else "no browser lane"))
+                elif not selectors[PR_BLOCKING_NODE_BUILD].search(namespace):
                     failures.append(
                         "L6 %s claims the `PR gate` lane, but %s selects "
-                        "nothing for its witness %s (namespace %s). %s A "
-                        "deterministic row must run in a lane that blocks a "
-                        "merge, and this one runs in %s"
-                        % (rid, PR_BLOCKING_DOM_BUILD, witness, namespace,
-                           "It is selected by %s, which freehand-bench.yml "
-                           "drives on schedule and workflow_dispatch only."
-                           % SCHEDULED_DOM_BUILD if scheduled
-                           else "No browser DOM lane selects it at all.",
-                           "the scheduled bench lane" if scheduled
-                           else "no browser lane"))
+                        "nothing for its witness %s (namespace %s). A witness "
+                        "no test build compiles is a file on disk, not a gate: "
+                        "the row's reading is taken by nothing a merge waits "
+                        "on" % (rid, PR_BLOCKING_NODE_BUILD, witness,
+                                namespace))
         else:
             if lane == "PR gate":
                 failures.append(
@@ -963,7 +1033,7 @@ def self_test():
     red("L6",
         rows=patched("D26", instrument="`%s` (PR gate)" % bench_witness),
         existing_files=existing | {bench_witness})
-    # ...a DOM witness whose namespace cannot be derived at all, which is the
+    # ...a witness whose namespace cannot be derived at all, which is the
     # way this check would otherwise pass by being unable to run...
     kit_witness = "implementation/hicasso/test_kit/src/mounted_dom_cljs_test.cljs"
     red("L6",
@@ -977,17 +1047,67 @@ def self_test():
     # second counter.
     green()
 
+    # L6 — the same claim for a NON-DOM witness (`rf2-xcaph`).  The controls
+    # below are the ones the DOM arm has, rebuilt on the node lane, because a
+    # rule with no red control is a rule that passes vacuously (`rf2-uyhh`).
+    #
+    # First, the defect verbatim: the test-kit FACADE `rf2-9vbl1` found in D9
+    # and U6 — a real file, on disk, under `re_frame/`, whose namespace
+    # `re-frame.hicasso.test-kit.mounted` no test build selects because it does
+    # not end in `cljs-test`.  This is the case the DOM-only rule returned
+    # green on, and it is why this bead exists rather than being a formality.
+    facade_witness = ("implementation/hicasso/test_kit/src/re_frame/hicasso/"
+                      "test/mounted.cljs")
+    assert os.path.isfile(os.path.join(REPO_ROOT, facade_witness)), \
+        "the L6 node-lane control needs the real test-kit facade"
+    assert not _DOM_WITNESS_RE.search(facade_witness), \
+        "the L6 node-lane control must not be routed to the browser arm"
+    red("L6",
+        rows=patched("I9", instrument="`%s` (PR gate)" % facade_witness),
+        existing_files=existing | {facade_witness})
+    # ...and the same for a witness whose namespace ends in `-nightly-test`,
+    # which `:node-test`'s `cljs-test$` deliberately excludes: a plausible
+    # spelling for a counter, and one nothing on a pull request would run.
+    nightly_witness = ("implementation/hicasso/test/re_frame/hicasso/"
+                       "hook_budget_emit_nightly_test.cljs")
+    red("L6",
+        rows=patched("I9", instrument="`%s` (PR gate)" % nightly_witness),
+        existing_files=existing | {nightly_witness})
+    # ...and the eager direction, which is the half that would go unnoticed.
+    # Three of the eight `PR gate` witnesses are NOT DOM tests, so the arm
+    # above is the one deciding them; a later worker narrowing `:node-test`'s
+    # selector — to a namespace prefix, say — reds HERE rather than silently
+    # unhooking the hook budget and the direct-return and parity counters.
+    # Asserted rather than assumed: if the ledger ever holds no such row, this
+    # arm is being proved on planted rows alone and says nothing about main.
+    node_lane_rows = [
+        row["id"] for row in rows
+        for witness, lane in [instrument_parts(row["instrument"])]
+        if lane == "PR gate" and witness and not _DOM_WITNESS_RE.search(witness)]
+    assert node_lane_rows, \
+        "the L6 node-lane arm decides no ledger row, so nothing on main tests it"
+    green()
+
     # L6 — and the gate REFUSES when it cannot read the lane assignment,
     # rather than skipping the check.  A missing build id must not degrade to
     # a pass; that would rebuild the fail-open inside the rule that closes it.
+    # Driven from a file declaring no builds at all, so it holds for whichever
+    # of the three ids `read_lane_selectors` looks for first.
     try:
-        read_dom_lane_selectors(os.path.join(REPO_ROOT, "mkdocs.yml"))
+        read_lane_selectors(os.path.join(REPO_ROOT, "mkdocs.yml"))
     except ValueError:
         pass
     else:
         raise AssertionError(
-            "read_dom_lane_selectors accepted a file declaring no browser "
-            "DOM build, so an unreadable lane assignment would pass")
+            "read_lane_selectors accepted a file declaring no test build, "
+            "so an unreadable lane assignment would pass")
+    # ...and it reads ALL THREE ids, so a later worker dropping one from the
+    # loop cannot pass by the other two still being found.  The refusal above
+    # is driven from a file declaring no builds at all and so cannot tell the
+    # difference; this is the half of that control that can.
+    assert set(read_lane_selectors()) == {
+        PR_BLOCKING_DOM_BUILD, SCHEDULED_DOM_BUILD, PR_BLOCKING_NODE_BUILD}, \
+        "read_lane_selectors stopped reading a lane L6 adjudicates on"
 
     # L7 — the fail-open `rf2-mwr2` found, driven from every direction a
     # later edit could reopen it.  The first is the defect as it stood: U5
@@ -1052,10 +1172,10 @@ def main(argv=None):
     print("no band crossing its line is recorded as a pass; no distributional "
           "row is wired to a pull-request gate;")
     print("no row claiming that work SCALES is decided on one counter;")
-    print("and no deterministic row asserts a `PR gate` lane its DOM witness "
-          "does not actually run in.")
+    print("and every `PR gate` witness is selected by a test build that blocks "
+          "a merge -- checked, not believed.")
     print("An Authority cell is read for SHAPE, not for life. This gate reads "
-          "two markdown files plus the browser lane selectors in "
+          "two markdown files plus the test lane selectors in "
           "implementation/shadow-cljs.edn, and has no tracker access, so it "
           "cannot see that a named bead has closed:")
     print("a row can name a bead reference and have no live owner. Whether "


### PR DESCRIPTION
`rf2-mwr2` (PR #8187, `34aa96ef6f`) stopped L6 believing a lane claim — but only
where the mapping was exact. A `*_dom_cljs_test` witness had to be selected by
`:browser-test`; every other `PR gate` witness kept the old fail-open: lane
spelled legally, file on disk, lane itself taken on trust.

`rf2-9vbl1` is the proof that remainder was real rather than hypothetical. D9
and U6 named `hicasso/test_kit/src/re_frame/hicasso/test/mounted.cljs` — the
test-kit **facade**, a library file containing no tests that no build compiles
— and the DOM-only rule returned exit 0 on it.

## The rule, widened

**Every `PR gate` witness must be selected by a test build that blocks a
merge.** Each witness class is checked against the one build that owns it:

| witness | build | job | required? |
|---|---|---|---|
| `*_dom_cljs_test.cljs` | `:browser-test` | `cljs-browser` | `all-required-passed` needs, test.yml:6360 |
| everything else | `:node-test` | `cljs` — *CLJS (shadow-cljs :node-test)* | `all-required-passed` needs, test.yml:6358 |

The decision this bead asked for — *which non-browser build counts as
PR-blocking* — is `:node-test`, and it is verified to the same standard
`34aa96ef6f` used for `cljs-browser`: the `cljs` job runs
`npx shadow-cljs compile node-test && node out/node-test.js` (test.yml:3034)
and sits in the required aggregator's `needs:` list one line above
`cljs-browser`. Both are armed per-surface by `detect_changed_surfaces` and the
aggregator treats a surface-skip as OK; that too is common to both.

**The mapping is per class, not "any build that selects it".** `:node-test`'s
`cljs-test$` also matches every `*-dom-cljs-test` namespace, whose assertions
are a *stated skip* there (budgets.md §9.1, already on record). Reading that
match as satisfaction would let a scheduled-lane DOM witness back through on
the node build's selector — weakening the browser arm in the act of closing the
node one. So each class is checked against its own build.

## Green on arrival, and no row moved

Re-verified at source on this branch's base: **29 `PR gate` rows resolve to 8
distinct witnesses**, three of them non-DOM
(`direct-return-cljs-test`, `three-way-parity-cljs-test`,
`hook-budget-cljs-test`). All eight are selected. The verdict tuple is
identical before and after — **49 rows / 31 MET / 5 BREACH / 3 UNRESOLVED /
10 UNPINNED** — and the §9 ledger table block hashes identically to the merge
base (`sha256 a9389da937fa…`), so **no ledger row is touched**. budgets.md
changes are prose only: one clause in *The other cells*, plus a new §9.1
amendment paragraph pair.

`implementation/shadow-cljs.edn` is **READ, never written** — absent from the
diff. The build-id anchor gains an optional `{` because `:node-test` is the
`:builds` map's first entry and is written `{:node-test`.

## Quality gates

The fast-PR spine does not decide this change. `scripts/check_fast_pr_gap.py
--list` reports **96 required checks the spine does not run**, and its own
header states the claim exactly: *"Green here is not green in CI … NONE of them
is decided here."* Relevant here, the gap listing names `test.yml` job *CLJS
(shadow-cljs :node-test)* steps and the `docs.yml` MkDocs job as spine-invisible.

**The spine was not run.** The gates that own this surface were run directly,
to completion, foreground, each redirected to its own log with the exit code
echoed on the same command line:

| gate | before | after |
|---|---|---|
| `check_budget_ledger.py` | `0` | `0` |
| `check_budget_ledger.py --self-test` | `0` | `0` |
| `npm run test:hicasso-invariants` (the chain the `hicasso-budget-ledger` job runs) | — | `0` |
| `scripts/check_doc_slugs.py` | — | `0` |
| `scripts/check_provenance_pins.py --changed-since origin/main --verbose` | — | `0` (1 file, 5 pins, 0 stranded) |

All four were re-run after the rebase onto `3a34dd5e8c` and stayed `0`.

`mkdocs build --strict` is **not** the gate for this edit: `mkdocs.yml`'s
`exclude_docs` keeps `docs/design/` out of the site. Per CLAUDE.md, the manual
obligation is discharged as follows — **the budgets.md change adds no heading,
no anchor, no link and no table row**; it is two prose paragraphs and one
rewritten clause. Table column counts are unchanged by construction: the ledger
block is byte-identical to the merge base.

### The plant

L6's new arm was sabotaged before being trusted. I9's ledger row was pointed at
the `rf2-9vbl1` facade — a real file on disk, under a real `re_frame/` source
root, whose namespace `re-frame.hicasso.test.mounted` no build selects — as a
single-line edit:

- **committed gate** (`git show HEAD:…`, run in place so `REPO_ROOT` resolves):
  **exit 0**. That is the fail-open, reproduced.
- **widened gate**: **exit 1**, naming it:
  `L6 I9 claims the PR gate lane, but :node-test selects nothing for its
  witness … (namespace re-frame.hicasso.test.mounted). A witness no test build
  compiles is a file on disk, not a gate`.

Restored with `git checkout HEAD --`, verified by `git hash-object` against the
committed object: both `e692b2cd93c060d7e11a8eeaa383873be8971718`.

The three new self-test controls were additionally proved to *produce* failures
rather than pass vacuously — `check()` was called directly and its returned
failure list printed, one L6 failure each, with the unmodified tree returning
zero.

## Found, not asked for

**`read_lane_selectors` carries a known open defect that is not mine to fix.**
`rf2-mwr2` is reopened on exactly it: the search runs `.*?` from a build key
across the rest of the file rather than isolating that build's map, so a build
declared *without* `:ns-regexp` borrows the next build's selector instead of
refusing. This PR adds a third id to that loop and does not change the defect's
shape; today `:node-test` does declare its selector, so nothing is false-green
now. The bounded build-map isolation is explicitly reserved to `rf2-mwr2`
("no new abstraction or Bead"), so it is left alone here — flagged rather than
patched, to avoid two workers in one function.
