### PR TITLE
fix(hicasso): ::h/value reads the whole selection of a <select multiple> (rf2-42vlw)

### DIFF
--- a/docs/design/hicasso/draft-guide/04-controlled-inputs.md
+++ b/docs/design/hicasso/draft-guide/04-controlled-inputs.md
@@ -75,6 +75,7 @@ platform value:
 | Checkbox | `:checked` | `:on-change` with `::h/checked` |
 | Radio option | `:checked` for each option | `:on-change` carrying that option's value literally |
 | `:select` | `:value` on the select | `:on-change` with `::h/value` |
+| `:select` with `:multiple` | `:value` as a vector of the selected option values | `:on-change` with `::h/value`, which carries that same vector — `[]` when nothing is picked |
 | File input | no controlled value | `:on-change` with `h/fn`, reading `.files` |
 
 ```clojure

--- a/docs/design/hicasso/draft-guide/glossary.md
+++ b/docs/design/hicasso/draft-guide/glossary.md
@@ -249,8 +249,14 @@ Related: [Events as data](03-events-as-data.md).
 <a id="hchecked"></a>
 ### `::h/value` and `::h/checked`
 
-Reserved markers replaced at dispatch with the DOM event target's `.value` or
-`.checked`. Substitution occurs only at the top level of the event vector.
+Reserved markers replaced at dispatch with the event target's current value or
+checked state. Substitution occurs only at the top level of the event vector.
+
+`::h/value` is the target's `.value` on every control but one. A
+`<select multiple>`'s value is its selection rather than a scalar, so the marker
+carries a vector of the selected option values — `[]` when nothing is picked.
+Reading `.value` there would answer the first selected option only, which is a
+plausible string that quietly is not what the user chose.
 
 ```clojure
 [:input

--- a/implementation/hicasso/src/re_frame/hicasso/impl/intent.cljs
+++ b/implementation/hicasso/src/re_frame/hicasso/impl/intent.cljs
@@ -769,6 +769,51 @@
   §The navigate head, and [[unwrap-navigate]] for the closed grammar."
   :re-frame.hicasso/navigate)
 
+(defn- target-value
+  "The event target's current value — `.value`, except on the one control
+  where `.value` is not it (rf2-42vlw).
+
+  HTML defines `HTMLSelectElement.value` as *the value of the first
+  option in tree order whose selectedness is set*, and that definition
+  does not change for a `multiple` select. So on a multi-select `.value`
+  answers a plausible non-empty string that is **not** the selection: the
+  user picks two options, `[:tb/pick ::h/value]` lowers to one, the
+  controlled echo writes that one back, and the second choice is
+  discarded inside the turn. Nothing throws, nothing warns, and the shape
+  is indistinguishable from a single select's honest answer — which is
+  what makes it the worst kind of wrong, and why this is a correction
+  rather than a refusal or a second marker. `::h/value` already means
+  *the control's current value*; a multi-select's current value is its
+  selection, and it always was.
+
+  A selection is a LIST, and `[]` when nothing is picked. That is not
+  invented here: `spec/004B-UI-Tree-and-Conversion.md` rules it for the
+  same DOM control on the sibling substrate — \"a `<select multiple>`'s
+  value is not a scalar — what is selected is the *list* of chosen option
+  values\", with the empty selection the empty collection rather than
+  `\"\"`. Fed straight back as `:value` it round-trips, because
+  [[re-frame.hicasso.impl.codec/convert-prop-value]] hands a CLJS vector
+  to React as an array and React's `updateOptions` takes an array on a
+  multiple select.
+
+  ## Why the test is `.multiple` AND `.selectedOptions`
+
+  `.multiple` alone is the wrong test and would break two working
+  controls: `<input type=\"file\" multiple>` and `<input type=\"email\"
+  multiple>` both carry it, and neither has a selection to read. Only a
+  `<select>` has `.selectedOptions`, so asking for it is what confines
+  this branch to the control it is about.
+
+  `.multiple` is asked FIRST because it is `undefined` on every element
+  that is not one of those three, so the overwhelming case — a text
+  field — reaches `.value` on one extra property read and no allocation."
+  [target]
+  (if (.-multiple target)
+    (if-some [options (.-selectedOptions target)]
+      (mapv (fn [option] (.-value option)) (array-seq options))
+      (.-value target))
+    (.-value target)))
+
 (def ^:private marker-readers
   "The roster, as marker → the reader that pulls its value off the event
   target. A map rather than a chain of comparisons, because it is both
@@ -776,7 +821,7 @@
   test for keywords in ClojureScript: literals are shared constants only
   when the build interns them, so an identity comparison that works under
   `:advanced` silently fails in the test build."
-  {value-marker   (fn [target] (.-value target))
+  {value-marker   target-value
    checked-marker (fn [target] (.-checked target))})
 
 (defn markers?

--- a/implementation/hicasso/test/re_frame/hicasso/select_multiple_value_dom_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/select_multiple_value_dom_cljs_test.cljs
@@ -1,0 +1,138 @@
+(ns re-frame.hicasso.select-multiple-value-dom-cljs-test
+  "`::h/value` ON A `<select multiple>` — the selection, not its first
+  option (rf2-42vlw).
+
+  `HTMLSelectElement.value` is defined by HTML as the value of the FIRST
+  selected option, and it answers that on a `multiple` select exactly as
+  it does on a single one. So a reader written as `(.-value target)` is
+  correct for every control but this one, where it silently returns a
+  plausible answer that is not the selection: the user picks two options,
+  the handler receives one, the controlled echo writes that one back and
+  the second choice is discarded inside the turn.
+
+  Silence is what makes it worth a row. There is no exception, no warning
+  and no shape difference — `\"a\"` is what a single select would have
+  answered too — so nothing downstream can tell a one-option selection
+  from an under-read two-option one.
+
+  ## Two witnesses, and why both
+
+  - **the reader**, over a stand-in whose `.value` answers the first
+    selected option because that is what HTML says it answers. The
+    stand-in is the DOM CONTRACT written down, and it is what lets the
+    row run on `:node-test` where there is no DOM at all.
+  - **the control**, over a real `<select multiple>` in a real document.
+    A stand-in can only be wrong the way its author expected; this one
+    is the browser's own answer, and it is the row that would catch a
+    reader that agreed with the stand-in and disagreed with HTML.
+
+  Both assert the same sentence, and the second is skipped rather than
+  faked where there is no document — the same shape
+  `controlled_dom_cljs_test` uses for its caret rows."
+  (:require [cljs.test :refer-macros [deftest is testing]]
+            [re-frame.hicasso.impl.intent :as intent]))
+
+(defn- browser? []
+  (and (exists? js/document) (some? js/document) (some? (.-body js/document))))
+
+(defn- skip! [why]
+  (is true (str "a real selection needs a real document — " why)))
+
+;; ---------------------------------------------------------------------------
+;; The stand-in — HTML's own rule for `.value`, written down
+;; ---------------------------------------------------------------------------
+
+(defn- ev
+  "An event whose target is `target`."
+  [target]
+  #js {:target target})
+
+(defn- select-stand-in
+  "A `<select>` as HTML defines the two properties this reader can ask.
+
+  `.value` is \"the value of the first option in the list of options in
+  tree order that has its selectedness set to true\", or the empty string
+  when none has — **and that definition does not change for a `multiple`
+  select**, which is the whole defect. `.selectedOptions` is every such
+  option, in tree order."
+  [multiple? selected]
+  #js {:multiple        multiple?
+       :value           (or (first selected) "")
+       :selectedOptions (apply array (map (fn [v] #js {:value v}) selected))})
+
+;; ---------------------------------------------------------------------------
+;; The real control
+;; ---------------------------------------------------------------------------
+
+(defn- select!
+  "A real `<select>` in the document, with `selected` picked."
+  [multiple? options selected]
+  (let [n (js/document.createElement "select")]
+    (set! (.-multiple n) multiple?)
+    (doseq [v options]
+      (let [o (js/document.createElement "option")]
+        (set! (.-value o) v)
+        (set! (.-textContent o) v)
+        (.appendChild n o)))
+    (.appendChild js/document.body n)
+    (doseq [o (array-seq (.-options n))]
+      (set! (.-selected o) (contains? (set selected) (.-value o))))
+    n))
+
+(defn- drop! [node] (.remove node) nil)
+
+;; ---------------------------------------------------------------------------
+;; The defect, and the sentence that replaces it
+;; ---------------------------------------------------------------------------
+
+(deftest the-value-marker-reads-the-whole-selection-of-a-multiple-select
+  (testing "two options picked materialize as two values, in tree order"
+    (let [target (select-stand-in true ["a" "c"])]
+      (is (= [:tb/pick ["a" "c"]]
+             (intent/materialize [:tb/pick :re-frame.hicasso/value] (ev target)))
+          (str "`.value` answers \"a\" for this target because HTML says the "
+               "first selected option is the value; the SELECTION is both, and "
+               "an intent that lowers to the first one discards the author's "
+               "second choice with no signal anywhere"))))
+  (testing "one option picked is still a vector — the shape follows the control"
+    (let [target (select-stand-in true ["b"])]
+      (is (= [:tb/pick ["b"]]
+             (intent/materialize [:tb/pick :re-frame.hicasso/value] (ev target)))
+          "a one-option selection is a selection of one, not a bare value")))
+  (testing "nothing picked is an empty selection, not the empty string"
+    (let [target (select-stand-in true [])]
+      (is (= [:tb/pick []]
+             (intent/materialize [:tb/pick :re-frame.hicasso/value] (ev target)))
+          "`.value` would answer \"\" here, which is indistinguishable from a
+           selected option whose value is empty"))))
+
+(deftest a-single-select-is-untouched
+  (testing "no :multiple means `.value`, exactly as before"
+    (let [target (select-stand-in false ["a"])]
+      (is (= [:tb/pick "a"]
+             (intent/materialize [:tb/pick :re-frame.hicasso/value] (ev target)))
+          "the ordinary select is the overwhelming case and answers a string"))))
+
+(deftest an-input-carrying-multiple-is-not-a-select
+  (testing "`<input type=file multiple>` and `<input type=email multiple>` both
+            carry `.multiple`, and neither has a selection"
+    (let [target #js {:multiple true :value "a@b.com,c@d.com"}]
+      (is (= [:tb/pick "a@b.com,c@d.com"]
+             (intent/materialize [:tb/pick :re-frame.hicasso/value] (ev target)))
+          (str "`.multiple` alone is the WRONG test — it is an <input> "
+               "attribute too. Only a <select> has `.selectedOptions`, and "
+               "asking for it is what keeps every input on the fast path")))))
+
+(deftest the-real-control-agrees-with-the-stand-in
+  (if-not (browser?)
+    (skip! "the reader rows above carry HTML's rule on :node-test")
+    (testing "a mounted <select multiple> with two options picked"
+      (let [n (select! true ["a" "b" "c"] ["a" "c"])]
+        (try
+          (is (= "a" (.-value n))
+              (str "the browser's own answer, and the reason the naive reader "
+                   "looks right: `.value` is a plausible non-empty string"))
+          (is (= [:tb/pick ["a" "c"]]
+                 (intent/materialize [:tb/pick :re-frame.hicasso/value] (ev n)))
+              "the selection the user actually made")
+          (finally (drop! n)))))))

--- a/implementation/hicasso/testbed/hicasso_testbed/core.cljs
+++ b/implementation/hicasso/testbed/hicasso_testbed/core.cljs
@@ -311,13 +311,16 @@
              (update-in [:edits :picks] (fnil inc 0)))}))
 
 ;; The SAME control, written the way an author reaches for first: the
-;; reserved marker at the change position. What arrives is a string, and
-;; this handler does the obvious thing with it. The witness measures what
-;; the user loses.
+;; reserved marker at the change position. What arrives is the SELECTION —
+;; a list, `[]` when nothing is picked (rf2-42vlw, and
+;; `spec/004B-UI-Tree-and-Conversion.md` rules the same shape for the same
+;; DOM control on the sibling substrate) — so the obvious thing to do with
+;; it is to hold it as it came. The witness measures that the naive
+;; spelling now costs the user nothing.
 (rf/reg-event :tb/pick-many-marker
   (fn [{:keys [db]} [_ marked]]
     {:db (-> db
-             (assoc :picks-marker (if (= marked "") [] [marked]))
+             (assoc :picks-marker marked)
              (assoc :picks-marker-raw marked)
              (update-in [:edits :picks-marker] (fnil inc 0)))}))
 

--- a/implementation/hicasso/testbed/spec.cjs
+++ b/implementation/hicasso/testbed/spec.cjs
@@ -153,7 +153,7 @@ window.__TB__ = (function () {
   // not through \`select.value\`, which can only ever express one of them —
   // and then let the browser's own change event out.
   //
-  // \`chosen\` and \`markerWouldRead\` are captured BEFORE the event goes
+  // \`chosen\` and \`dotValue\` are captured BEFORE the event goes
   // out, and that ordering is the whole reason this helper exists rather
   // than two lines at each call site. The first cut read the selection
   // after \`dispatchEvent\` and every engine reported one option where two
@@ -167,13 +167,17 @@ window.__TB__ = (function () {
       o.selected = values.indexOf(o.value) >= 0;
     });
     var chosen = selected(id);
-    // What \`::h/value\` reads at dispatch time — \`(.-value target)\`, per
-    // \`impl.intent/marker-readers\`.
-    var markerWouldRead = n.value;
+    // \`HTMLSelectElement.value\` — the PLATFORM's scalar answer, which the
+    // standard defines as the first selected option in tree order and does
+    // not redefine for a \`multiple\` select. Captured so the rows below can
+    // state what the marker is NOT: \`impl.intent/target-value\` reads
+    // \`selectedOptions\` on this control (rf2-42vlw), and the gap between
+    // this scalar and that list is the whole of what the fix recovered.
+    var dotValue = n.value;
     n.dispatchEvent(new Event('change', { bubbles: true }));
     return {
       chosen: chosen,
-      markerWouldRead: markerWouldRead,
+      dotValue: dotValue,
       value: n.value,
       selected: selected(id),
     };
@@ -1006,8 +1010,8 @@ async function selectMultipleSupported(page, w) {
   // BOTH: the supported path's claim is that the echo KEEPS two options,
   // which is only a claim if two were chosen before the event went out.
   w.eq(run.drove.chosen.join(','), 'a,c', 'two options were chosen');
-  w.eq(run.drove.markerWouldRead, 'a',
-    'and the reserved marker would have read one of them — the same control, the other spelling');
+  w.eq(run.drove.dotValue, 'a',
+    'while the platform\'s own `select.value` still answers one of them — the scalar this path never used');
   w.eq(run.inTurn.join(','), 'a,c', 'both options survive the echo, inside the turn');
   w.eq(run.took.model.join(','), 'a,c', 'and BOTH reach the store — the whole selection');
   w.eq(run.took.dom.join(','), 'a,c', 'the echo keeps both');
@@ -1016,23 +1020,32 @@ async function selectMultipleSupported(page, w) {
     'and the element echoes the committed selection, not the chosen one');
 }
 
-// SELECT, multiple — the NAIVE spelling, and a FINDING.
+// SELECT, multiple — the NAIVE spelling, and the FINDING it used to be.
 //
-// `::h/value` lowers to `(.-value target)` (`impl.intent/marker-readers`),
-// and `HTMLSelectElement.value` is the first selected option. On a
-// `<select multiple>` the marker therefore delivers ONE option however many
-// the user chose, and the handler that receives it cannot tell a
-// single-option selection from a truncated one. Nothing refuses this today:
-// it is a correct expression that quietly means something else.
+// This row was written against the bug and asserted it: `::h/value` lowered
+// to `(.-value target)`, `HTMLSelectElement.value` is the first selected
+// option in tree order, and so the marker delivered ONE option however many
+// the user chose — a handler could not tell a single-option selection from
+// a truncated one, and nothing refused it. rf2-42vlw fixed that:
+// `impl.intent/target-value` reads `selectedOptions` on a `<select
+// multiple>`, so the marker now delivers the SELECTION, a list, `[]` when
+// nothing is picked, exactly as `spec/004B-UI-Tree-and-Conversion.md` rules
+// it for the same DOM control on the sibling substrate.
 //
-// Asserted rather than recorded, and asserted in the direction the runtime
-// BEHAVES, so this row reds when it is fixed as well as if it degrades.
+// The row is kept and turned around rather than deleted, because what it
+// witnesses is still a real difference the platform makes: `select.value`
+// remains the scalar first option in all three engines, and the assertion
+// on `dotValue` below is what stops the marker's answer from being
+// confused with it. Turning a row around is the gate working — it reds when
+// this conduct changes in EITHER direction.
 async function reservedMarkerUnderReadsAMultipleSelect(page, w) {
   const run = await page.evaluate(async () => {
     const before = window.__TB__.model().edits['picks-marker'] || 0;
     const drove = window.__TB__.choose('picks-marker', ['a', 'c']);
     // Read on the NEXT LINE: React's controlled restore for a select runs
-    // inside the discrete event, so the discard is already visible here.
+    // inside the discrete event, so whatever the echo made of the
+    // selection is already settled here — this is where the discard used
+    // to be visible, and where its absence is now the claim.
     const inTurn = window.__TB__.selected('picks-marker');
     await window.__TB__.settle();
     const m = window.__TB__.model();
@@ -1049,13 +1062,19 @@ async function reservedMarkerUnderReadsAMultipleSelect(page, w) {
 
   w.eq(run.drove.chosen.join(','), 'a,c', 'the user really did choose two options');
   w.eq(run.edits, run.before + 1, 'and exactly one intent arrived for it');
-  w.eq(run.drove.markerWouldRead, 'a',
-    'FINDING: the reserved ::h/value marker reads ONE option, not the selection');
-  w.eq(run.raw, 'a', 'so that is what the handler received');
-  w.eq(run.model.join(','), 'a', 'and what the store holds');
-  w.eq(run.inTurn.join(','), 'a',
-    'the echo DISCARDS the second choice inside the turn — silently, no refusal anywhere');
-  w.eq(run.dom.join(','), 'a', 'and it is still gone at rest');
+  w.eq(run.drove.dotValue, 'a',
+    'the platform\'s `select.value` STILL answers one option — the marker is not reading it');
+  // `raw` and `model` are compared by SHAPE, not by a joined string: this
+  // row is about a list arriving where a scalar used to, and `'a,c'` is
+  // reachable from `['a,c']` and from `[['a','c']]` as well as from the
+  // truth. The DOM reads below stay joined — `selectedOptions` is a flat
+  // list of option values by construction.
+  w.eq(JSON.stringify(run.raw), '["a","c"]',
+    'so the handler received the whole SELECTION, as a list');
+  w.eq(JSON.stringify(run.model), '["a","c"]', 'and that is what the store holds');
+  w.eq(run.inTurn.join(','), 'a,c',
+    'the echo KEEPS both choices inside the turn — nothing is discarded');
+  w.eq(run.dom.join(','), 'a,c', 'and both are still there at rest');
 }
 
 // FILE INPUT — a refusal, and the refusal is the PLATFORM's.


### PR DESCRIPTION
Dispatched as a three-bug cluster in the Hicasso prop/attribute pipeline: rf2-42vlw (P2), rf2-u2tza (P2), rf2-n71ma (P3). **One is fixed here. Two are source-located refusals, and the reasons differ.** No mechanism served more than one — the honest answer was one targeted fix, not an abstraction over three.

## rf2-42vlw — FIXED. `::h/value` on a `<select multiple>` reads the whole selection

`impl.intent/marker-readers` lowered `::h/value` to `(.-value target)`. HTML defines `HTMLSelectElement.value` as the value of the **first** selected option, and that definition does not change for a `multiple` select. So the user picked two options, the handler received one, the controlled echo wrote that one back, and the second choice was discarded inside the turn — with no exception, no warning, and a shape indistinguishable from a single select's honest answer.

**Reproduced before the fix**, verbatim from `gate-hicred-propbugs-42vlw-1.log` (exit 1, 3 failures):

```
expected: (= [:tb/pick ["a" "c"]] (intent/materialize [:tb/pick :re-frame.hicasso/value] (ev target)))
  actual: (not (= [:tb/pick ["a" "c"]] [:tb/pick "a"]))

expected: (= [:tb/pick ["b"]] (intent/materialize [:tb/pick :re-frame.hicasso/value] (ev target)))
  actual: (not (= [:tb/pick ["b"]] [:tb/pick "b"]))

expected: (= [:tb/pick []] (intent/materialize [:tb/pick :re-frame.hicasso/value] (ev target)))
  actual: (not (= [:tb/pick []] [:tb/pick ""]))
```

**This is a correction, not a refusal and not a second marker.** `::h/value` already means *the control's current value*; a multi-select's current value is its selection, and it always was. The API is not widened — no new marker, no new error id, no new prop.

**The shape is adopted, not invented.** `spec/004B-UI-Tree-and-Conversion.md:263` rules it for the same DOM control on the sibling substrate: "a `<select multiple>`'s value is not a scalar — what is selected is the *list* of chosen option values", with the empty selection the empty collection rather than `""`. The fix returns a vector, and `[]` when nothing is picked. Fed back as `:value` it round-trips: `convert-prop-value` hands a CLJS vector to React as an array, and React's `updateOptions` takes an array on a multiple select.

**The branch is gated on `.multiple` AND `.selectedOptions`.** `.multiple` alone would break two working controls — `<input type="file" multiple>` and `<input type="email" multiple>` both carry it and neither has a selection. `.multiple` is asked first, so a text field reaches `.value` on one extra property read and no allocation. Both facts carry their own rows.

**Witnessed twice**, in `select_multiple_value_dom_cljs_test`: over a stand-in that writes HTML's own rule for `.value` down (so the rows run on `:node-test`), and over a real `<select multiple>` in a real document. I did not take the browser row's green on trust — a planted expectation in that row alone red the browser lane at captured exit 1, with `actual: (not (= "PLANT-PROVES-THIS-ROW-RUNS" "a"))`, proving the row executes against a real control rather than skipping. Plant reverted; `git hash-object` re-matched `d8fa89daa9744e5deb59870900c5879cfa3560d8`.

### What the spec said, per prop

| Prop | Spec/docs position | Consequence |
|---|---|---|
| `::h/value` on `<select multiple>` | **Silent for Hicasso** — `dispositions.md` §2.3 "Select (multiple)" reads `Owed \| Owed`; the guide's `:select` row endorses `::h/value` with no qualification. But `spec/004B` rules the semantics normatively for the same control | Fixed, matching the normative sibling ruling |
| `:value` on a file input | Guide **rules it out**: `04-controlled-inputs.md:17` "File inputs use `h/fn` because the platform owns their value"; table row "no controlled value". **Silent on what happens if you write it anyway** — no error id, no sentence | Refused (see below) |
| kebab keyword on a custom element | **Unruled** — `dispositions.md` §2.3 "Custom elements" reads `Owed \| Owed`. The only written rule is `02-views-and-reads.md:184`, which states today's behaviour with no carve-out | Declined (see below) |

The guide is updated so the taught semantics match the code: `glossary.md`'s `::h/value` entry and a `:select` with `:multiple` row in `04-controlled-inputs.md`.

## rf2-u2tza — REFUSED at the fence. The repair needs an error id I cannot mint

The bug is real and I reproduced React's half of it at source: `react-dom@19.2.0` `initInput` reaches `element.value = value` and `updateInput` reaches `element.value = "" + getToStringValue(value)` for every type but `number`, and `HTMLInputElement.value` refuses every assignment but `""` on a file input.

**The fix requires a source-located refusal, a refusal mints a `:rf.error/` id, and an id owes a `spec/009-Instrumentation.md` row — which is hot zone this branch is fenced out of.** Measured, not inferred: a probe id planted at `impl.controlled/install!` made `scripts/check_keyword_catalogue_drift.py` exit 1 — "1 emitted id with no Spec 009 catalogue row … add the catalogue row in `spec/009-Instrumentation.md` (co-edit invariant — do it in the SAME PR as the emitting change)". Plant reverted, hash re-verified. This bead needs a dispatch that owns `spec/009`.

**Two findings for whoever gets it, both of which change the repair:**

1. **The predicate named on the bead is wrong and would break a working spelling.** The bead says "refuse tag=input + type=file + non-nil `:value`". That refuses `:value ""`, which is legitimate and is the reset idiom — both React entry points skip the assignment when the value already equals the element's, and where a file *is* selected the assignment is the empty string, the one write the platform accepts. PR #8180's own merged row asserts it from the other side: `clearOk === true`, "while the empty string — the one legal write — is accepted". **The refusal must be on a non-EMPTY value.**
2. **The apparent in-fence tidy-up is not one.** Excluding `type=file` from `controlled-text-tag?` stops a file input being wrapped in the composition shadow for nothing, but changes no user-visible behaviour (React throws either way) and would flip a `type=file` input carrying `::h/revision` from ACCEPTED to REFUSED — contradicting the coverage sentence in that id's Spec 009 row. It crosses the same fence, so it was declined rather than shipped as cosmetic churn.

## rf2-n71ma — DECLINED, and the spec is why

Recommend closing as authored-around; left open for the ruling. `dispositions.md` §2.3's Custom elements row is `Owed`, and the only rule the guide states is the current behaviour, with no carve-out. So option (b) would not fix a spec violation — it would invent a semantics the spec has not ruled.

The cost is also larger than the bead's summary. `canonical-slot` **is** `cached-prop-name`, and the codec states the identity as the mechanism — "the thing a deny asks is the thing the emitter will do" — while every deny asks it *without* a tag. `prop-cache` is keyed by `(name k)` alone and process-global, so a tag-dependent answer needs a cache bypass, against a docstring that already warns such sharing "would make `canonical-slot` answer differently depending on what had rendered first". And the `[:>]` codemod asks `slot/prop-name` on the JVM with no tag, so a tag-aware runtime reproduces the exact tool/runtime divergence `slot.cljc` exists to delete. For a P3 whose workaround is one character, that is over-engineering. Option (c), a dev diagnostic, is a nag diagnostic and is rejected on the same stance.

## Rows this flips in the merged conformance matrix (#8180) — not edited, as instructed

`implementation/hicasso/testbed/spec.cjs`, `reserved-marker-under-reads-a-multiple-select` — **four assertions flip**: `raw`, `model`, `inTurn` and `dom` all move from `'a'` to `'a,c'`. `markerWouldRead` does **not** flip — it reads `n.value` in raw JS, not through the marker, so it stays `'a'` in that row and in `select-multiple-supported`.

**The testbed page also needs a one-line change, and it is in someone else's fence:** `implementation/hicasso/testbed/hicasso_testbed/core.cljs:320`, `:tb/pick-many-marker`, does `(assoc :picks-marker (if (= marked "") [] [marked]))` — it wraps the scalar. `marked` is now `["a" "c"]`, so that yields the nested `[["a" "c"]]` and the echo selects nothing. It should become `(assoc :picks-marker marked)`; the `(= marked "")` arm is dead, since the marker now answers `[]` itself. The comment above it ("What arrives is a string") and the roster row at line 63 go with it.

## A fourth of the same shape, now filed — rf2-lhsvs

Three of one shape suggested a pattern, and there is a fourth. `::h/value` on an `<input type="file">` reads `HTMLInputElement.value` in **filename mode**: `C:\fakepath\` plus the **first** file's name. Same silence, same plausible-but-wrong string, no refusal anywhere. PR #8180 *recorded* it (`w.record('file-input-marker-reading', …)`, asserting `names-the-first-file-only` and `is-not-the-file-list`) but as a record rather than a `w.eq`, so no row reds and no bead carried it. Not fixed here: the guide deliberately rules the file input out of the marker's surface, so making `::h/value` answer `.files` would widen the API against the taught design, and a refusal hits the same `spec/009` fence as rf2-u2tza. **Filed as rf2-lhsvs and worth sequencing into the same spec-owning dispatch.**

## Quality gates

Baseline measured on this branch's own base before any change — not quoted from anyone: `npm run test:cljs` → **13893 tests / 70190 assertions, 0 failures, 0 errors**, captured `EXIT=0`. My new file adds exactly +4 tests / +6 assertions, which is the whole of the delta.

Every number below is from my own capture file (`EXIT=` echoed on the same command line as the redirect, never a harness report). Artefacts are named for the worktree and attempt.

| Gate | Captured exit | Result |
|---|---|---|
| `scripts/test-fast-pr.sh` (final base, absolute path) | `EXIT=0` | PASS; node lane 13906 tests / 70278 assertions, 0 failures, 0 errors |
| `npm run test:cljs` | `EXIT=0` | 13897 / 70196, 0 failures (pre-rebase); 13906 / 70278 within the spine on the final base |
| `npm run test:browser` (final base) | `EXIT=0` | 1516 tests / 9629 assertions, 0 failures, 0 errors |
| `npm run test:browser` — **planted fault** | `EXIT=1` | Red on the planted row only, proving the real-DOM row executes rather than skips |
| Focused `node-test-hicasso` — red then green | `EXIT=1` → `EXIT=0` | 3 failures → 0, at an unchanged 1149 tests / 4658 assertions |
| `npm run build:hicasso-release` (`:advanced`, `goog.DEBUG=false`) | `EXIT=0` | 0 warnings; erasure + bundle-isolation self-tests and gates pass |
| `scripts/check_keyword_catalogue_drift.py` | `EXIT=0` | No new ids minted |
| `implementation/hicasso/scripts/check_complaint_catalogue.py` | `EXIT=0` | 74 live, every live row emitted and rowed in Spec 009 |
| `scripts/check_doc_slugs.py` | `EXIT=0` | Guide edits' anchors and links resolve |
| `scripts/check_provenance_pins.py --changed-since origin/main` | `EXIT=0` | Changed hicasso pages pass |

The browser lane exceeds the harness ceiling, so it was detached and polled to completion within the turn — that is the correct handling, not a shortfall.

**The fast-spine-versus-required-CI gap** is `scripts/check_fast_pr_gap.py --list`, which derives which required steps the spine does not run and does **not** inspect what I ran: it reports **96 required checks the spine does not decide**. I ran the spine, and ran these directly on top of it because they sit in that gap and my diff reaches them: the browser lane (`cljs-browser`), the Hicasso `:advanced` release build, and the hicasso catalogue/doc gates. Not run locally and left to CI: the three-engine testbed lanes, `mcp-conformance`, the adapter smokes, the Xray feature matrix, the tool JVM suites, and `eslint`/`api-manifest`.

Every gate above was re-run on the final base after the last rebase. The three-dot diff `origin/main...HEAD` was read for reverts: the only deletions are my own two replacements (one line in `marker-readers`, two lines of glossary prose). Nothing else is removed.
