### PR TITLE
test(hicasso): a UIx parent for the bridge, and a source gate for the "nor UIx" clause (rf2-ap7w, rf2-b3gy)

### DIFF
--- a/implementation/hicasso/scripts/check_optional_module_reachability.py
+++ b/implementation/hicasso/scripts/check_optional_module_reachability.py
@@ -57,6 +57,67 @@ only `n/$` with literal props leaves none at all.  THIS gate is the one
 that decides the property exhaustively, because a `:require` is a
 `:require` whether or not Closure keeps anything from it.
 
+THE FORBIDDEN IMPORT, WHICH IS A DIFFERENT SHAPE
+------------------------------------------------
+Everything above is a RELATIVE claim — module `m` is unreachable from
+everything that is not `m` — and the roster names both sides of each
+edge.  The native-boundary law's other half is ABSOLUTE and has only
+one side: *an interpreted-only production dependency graph and bundle
+contain neither native-tier runtime **nor UIx code***
+(`docs/design/hicasso/product/lanes/design-laws.md`, clause 6).  UIx is
+not a Hicasso module that must stay unreached; it is a library this
+package must never require AT ALL, from anywhere in `src/`.
+
+That clause fell through the seam between two honest artefacts
+(rf2-b3gy).  `check_bundle_isolation.cjs` declines it in terms and says
+why — the measured `:hicasso-release` bundle CONTAINS UIx and that is
+correct, because Hicasso ships no reactive adapter and the exemplar
+consumer picks one — and it refers the clause here, to "the source-side
+gate's kind of question".  This file's `native` row then quoted the law
+in full and called itself "the DEPENDENCY-GRAPH half of that sentence"
+while asking only the module question.  Each file was right about
+itself; the clause was measured by neither.  So it is measured here
+now, in TWO ARMS, which is the shape
+`implementation/scripts/check-ui-adapter-isolation.cjs` already uses
+for the same claim about `re-frame2-ui`:
+
+  1. **SOURCE** — no namespace under `src/` requires UIx.  Read off
+     `:require` forms by the same parser the module rows use, so the
+     seventeen places this package's docstrings NAME UIx stay legal:
+     prose is provenance, and `impl/controlled.cljs` citing
+     `uix/compiler/input.cljs` by line number is exactly the kind of
+     provenance that must not redden a gate.
+  2. **COORDINATE** — the production `:deps` of `hicasso/deps.edn`
+     names no UIx artefact.  This arm has a live subject rather than a
+     theoretical one: the `:test` alias DOES declare
+     `day8/re-frame2-uix`, legally and necessarily — the Node lane's
+     suites need a reactive substrate, and plain-atom has none — so the
+     property is not "the file never says uix" but "the PRODUCTION map
+     never does".  A gate that grepped the file would be red today, and
+     promoting that test dependency into `:deps` is the realistic way
+     this clause breaks.
+
+WHAT THE SECOND CLAUSE NEEDED, AND WHY IT DID NOT NEED A BUNDLE
+---------------------------------------------------------------
+Row 6 of the conformance matrix carries a second clause — *native
+bundles contain no UIx unless the application imports it* — and it was
+read as owing a native-tier release build, which does not exist: there
+is exactly one release build, `:hicasso-release`, and it is the
+interpreted-only one.
+
+It owes no such build.  Split the clause and it is two conjuncts: what
+the APPLICATION imports is the application's own affair and nothing
+this package can assert about, and what remains is *the native tier's
+own source drags no UIx in* — which is arm 1, over `native.cljc` along
+with every other file in `src/`, decided exhaustively.  A release build
+would weigh the same claim in bytes and add confidence about the
+COMPILER, and the paragraph above already says why this gate declines
+that instrument for the module rows: reachability is decided in the
+source, and the compiler is not what regresses here.  The clause is
+therefore measured, and by the arm that can see the parts of the tier a
+bundle cannot — a consumer who writes only `n/$` with literal props
+leaves no production footprint at all.
+
 SELF-TEST
 ---------
 `--self-test` runs the detector over synthetic sources first, because a
@@ -66,6 +127,12 @@ mention is NOT — and asserts the roster's own premise: every module
 door and engine file named below must exist, so a renamed file fails
 here rather than reporting a green absence for a namespace nobody
 compiles any more.
+
+The forbidden-import arms are pinned the same way, and arm 2 carries a
+PRESENT control of its own: the real `deps.edn`'s `:test` alias must
+still declare the UIx coordinate.  Without that row a green arm 2 could
+mean "the production map is clean" or "nobody mentions uix anywhere any
+more", and only the first is the claim.
 """
 
 import re
@@ -74,6 +141,41 @@ from pathlib import Path
 
 PACKAGE_ROOT = Path(__file__).resolve().parent.parent
 SRC = PACKAGE_ROOT / "src"
+DEPS_EDN = PACKAGE_ROOT / "deps.edn"
+
+# rf2-b3gy.  The libraries no `src/` namespace may require and no production
+# coordinate may name.  One entry today; the list shape is what keeps a second
+# one from being a rewrite.
+#
+# `prefixes` are matched as NAMESPACE SEGMENTS rather than as substrings, so
+# `uix` catches `uix.core` and `uix.dom.server` and does NOT catch a namespace
+# that merely begins with those letters.  There is no such namespace in this
+# tree today; the segment rule is what stops one from being a silent hole
+# later, and it costs a `split(".")`.
+FORBIDDEN_IMPORTS = [
+    {
+        "name": "UIx",
+        "prefixes": ["uix", "re-frame.adapter.uix"],
+        # Any coordinate whose symbol names this library. Matched
+        # case-insensitively over the whole symbol, because a coordinate is a
+        # published name rather than a namespace and `day8/re-frame2-uix`
+        # shares no segment with `uix.core`.
+        "coordinate_marker": "uix",
+        # ASCII only, like every other emitted string in this file. The
+        # message is written to `stderr`, and a `cp1252` console raises
+        # `UnicodeEncodeError` on an em dash -- which would turn this gate's
+        # RED into a traceback on the one platform where a maintainer is
+        # most likely to read it first.
+        "why": (
+            "native-boundary law clause 6 says an interpreted-only production "
+            "dependency graph contains no UIx code. Hicasso ships no reactive "
+            "adapter: the consumer picks one, and this package must not pick "
+            "for them"
+        ),
+    },
+]
+
+NS_FORM = re.compile(r"\(ns\s+([A-Za-z0-9_.*+!?<>=$%&/-]+)")
 
 # Each optional module: its public door, the private namespaces that carry its
 # weight, and the files that must exist for the roster to mean anything.
@@ -112,7 +214,12 @@ MODULES = [
         # reachable; an interpreted-only production dependency graph and
         # bundle contain neither native-tier runtime nor UIx code*
         # (`docs/design/hicasso/product/lanes/design-laws.md`).  This row
-        # is the DEPENDENCY-GRAPH half of that sentence.
+        # is the NATIVE-TIER half of that sentence's dependency graph; the
+        # *nor UIx* half is [[FORBIDDEN_IMPORTS]] below, and it is a
+        # different shape rather than another roster entry — see the
+        # module docstring.  The row used to claim the whole sentence and
+        # ask only this much of it, which is how the clause came to fall
+        # between this file and `check_bundle_isolation.cjs` (rf2-b3gy).
         #
         # NO ENGINE, and the emptiness is the design rather than an
         # omission.  `motion`'s weight is in two private namespaces it
@@ -168,9 +275,6 @@ MODULES = [
         ],
     },
 ]
-
-NS_FORM = re.compile(r"\(ns\s+([A-Za-z0-9_.*+!?<>=$%&/-]+)")
-
 
 def ns_of(text):
     """The namespace a source file declares, or None. Read from code rather
@@ -396,6 +500,126 @@ def scan(sources):
                     )
                 )
     return problems
+
+
+def top_level_value(text, key):
+    """The form following `key` at the TOP LEVEL of `text`'s outermost map.
+
+    `deps.edn` is one map and arm 2 asks about exactly one of its entries.
+    DEPTH is what makes that question answerable at all: `:aliases` holds an
+    `:extra-deps` map that legally names the very coordinate the production
+    `:deps` map may not, so a reader that ignored nesting would fold the two
+    together and report a correct file red.
+
+    Answers None when the key is absent at that depth, and the caller treats
+    that as a FAILURE rather than as a pass — a `deps.edn` this arm could not
+    read is not a clean one.
+    """
+    source = code_only(text)
+    depth, i, n = 0, 0, len(source)
+    while i < n:
+        ch = source[i]
+        if ch in OPENERS:
+            depth += 1
+        elif ch in CLOSERS:
+            depth -= 1
+        elif depth == 1 and source.startswith(key, i):
+            before = source[i - 1] if i else " "
+            after = source[i + len(key)] if i + len(key) < n else " "
+            if before not in SYMBOL_CHARS and after not in SYMBOL_CHARS:
+                start = i + len(key)
+                return source[start:form_end(source, start)]
+        i += 1
+    return None
+
+
+SYMBOL_CHARS = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789_.*+!?<>=$%&/-:"
+SYMBOL_RE = re.compile(r"[A-Za-z][A-Za-z0-9_.*+!?<>=$%&/-]*")
+
+
+def names_library(namespace, prefixes):
+    """Does `namespace` belong to a library named by `prefixes`?
+
+    Compared SEGMENT-wise rather than by `startswith`, so `uix` claims
+    `uix.core` and `uix.dom.server` and does not claim a hypothetical
+    `uixels.foo`. Nothing in this tree is named that way; the rule is what
+    keeps the arm honest if something ever is.
+    """
+    for prefix in prefixes:
+        want = prefix.split(".")
+        if namespace.split(".")[: len(want)] == want:
+            return True
+    return False
+
+
+def scan_forbidden_imports(sources):
+    """ARM 1 (rf2-b3gy). `sources` is `{path: text}`; answer the violations.
+
+    Reuses [[required_namespaces]] rather than grepping, which is the whole
+    reason this arm belongs in this file: seventeen docstrings across `src/`
+    name UIx as provenance — `impl/controlled.cljs` cites
+    `uix/compiler/input.cljs` by line number, `native.cljc` explains that a
+    UIx parent must not have to require the tier — and every one of them
+    must stay legal. A grep-based arm would have to be deleted or exempted
+    file by file within a week of landing.
+    """
+    problems = []
+    for rule in FORBIDDEN_IMPORTS:
+        for path, text in sorted(sources.items()):
+            declared = ns_of(text)
+            for target in sorted(required_namespaces(text)):
+                if names_library(target, rule["prefixes"]):
+                    problems.append(
+                        "{path}: `{declared}` requires `{target}`, which is "
+                        "{name}. Production Hicasso source may not require it, "
+                        "because {why}. Prose naming {name} is provenance and "
+                        "stays legal; a `:require` is not prose.".format(
+                            path=path,
+                            declared=declared,
+                            target=target,
+                            name=rule["name"],
+                            why=rule["why"],
+                        )
+                    )
+    return problems
+
+
+def scan_forbidden_coordinates(deps_text):
+    """ARM 2 (rf2-b3gy): the production `:deps` map names no forbidden library.
+
+    Only the top-level `:deps` map. The `:test` alias's `:extra-deps` names
+    `day8/re-frame2-uix` and MUST go on naming it — the Node lane's suites
+    need a reactive substrate and plain-atom has none, so a subscription
+    under it would never notify and every commit assertion would pass
+    vacuously. The self-test pins that as a present control, because a green
+    arm 2 over a file that had simply stopped mentioning UIx would read
+    identically to the one that matters.
+    """
+    production = top_level_value(deps_text, ":deps")
+    if production is None:
+        return [
+            "deps.edn: no top-level `:deps` map. This arm reads the PRODUCTION "
+            "dependency map and could not find one, so its silence would mean "
+            "nothing — which is the failure an absence check is most exposed to."
+        ]
+    problems = []
+    for rule in FORBIDDEN_IMPORTS:
+        marker = rule["coordinate_marker"].lower()
+        for token in SYMBOL_RE.findall(production):
+            if marker in token.lower():
+                problems.append(
+                    "deps.edn: the production `:deps` map declares `{token}`, "
+                    "which is {name}, and {why}. If a suite needs it, it "
+                    "belongs in the `:test` alias's `:extra-deps`, where it "
+                    "already is.".format(
+                        token=token, name=rule["name"], why=rule["why"]
+                    )
+                )
+    return problems
+
+
+def read_deps_edn():
+    return DEPS_EDN.read_text(encoding="utf-8")
 
 
 def read_src():
@@ -652,6 +876,111 @@ def self_test():
             path = SRC / rel
             assert path.exists(), "roster names a missing file: {}".format(path)
 
+    # -----------------------------------------------------------------------
+    # rf2-b3gy — the forbidden-import arms
+    # -----------------------------------------------------------------------
+
+    # ARM 1, the direction that must RED: a require of UIx from `src/`, by
+    # either of the two spellings a real slip would take. `uix.core` is what
+    # an author writing a component reaches for; `re-frame.adapter.uix` is
+    # what an author wiring a substrate reaches for, and it is the likelier
+    # of the two — the test tree requires it in eleven namespaces, so it is
+    # already in the fingers of anyone working here.
+    for spelling in ("uix.core", "uix.dom.server", "re-frame.adapter.uix"):
+        flagged = scan_forbidden_imports(
+            {
+                "src/u.cljs": "(ns re-frame.hicasso.impl.collector\n"
+                "  (:require [{} :as u]))".format(spelling)
+            }
+        )
+        assert len(flagged) == 1, (spelling, flagged)
+        assert spelling in flagged[0], (spelling, flagged)
+        assert "re-frame.hicasso.impl.collector" in flagged[0], (spelling, flagged)
+
+    # ARM 1, the direction that must stay GREEN, and it is the one with teeth:
+    # `src/` names UIx in seventeen docstrings today. This fixture is the
+    # sharpest of them, `impl/controlled.cljs`'s citation of the UIx port by
+    # file and line — a grep-based arm dies on it.
+    clean = scan_forbidden_imports(
+        {
+            "src/c.cljs": '(ns re-frame.hicasso.impl.controlled\n'
+            '  "UIx\'s answer to this is a wrapper\n'
+            '  (`uix/compiler/input.cljs:132-143`); this one is not that\n'
+            '  wrapper. See also [[uix.core/memo]] and\n'
+            '  (:require [uix.core :as uix]) which a CONSUMER writes."\n'
+            "  (:require [re-frame.hicasso.impl.slot :as slot]))"
+        }
+    )
+    assert clean == [], clean
+
+    # And a require the reader discards is not one here either — the arm
+    # inherits [[code_only]] whole, and this row is what says so rather than
+    # leaving it to be assumed from the module rows above.
+    clean = scan_forbidden_imports(
+        {
+            "src/d.cljs": "(ns re-frame.hicasso.impl.codec\n"
+            "  (:require #_[uix.core :as uix]\n"
+            "            ;; (:require [re-frame.adapter.uix :as a])\n"
+            "            [re-frame.hicasso.impl.slot :as slot]))"
+        }
+    )
+    assert clean == [], clean
+
+    # A namespace that merely STARTS with the letters is not the library.
+    clean = scan_forbidden_imports(
+        {"src/s.cljs": "(ns re-frame.hicasso.core\n  (:require [uixels.grid :as g]))"}
+    )
+    assert clean == [], clean
+
+    # ARM 2, the direction that must RED: the coordinate promoted out of the
+    # `:test` alias into the production map, which is the realistic way this
+    # clause breaks.
+    flagged = scan_forbidden_coordinates(
+        '{:paths ["src"]\n'
+        " :deps {day8/re-frame2 {:local/root \"../core\"}\n"
+        '        day8/re-frame2-uix {:local/root "../adapters/uix"}}}'
+    )
+    assert len(flagged) == 1, flagged
+    assert "day8/re-frame2-uix" in flagged[0], flagged
+
+    # ARM 2, the direction that must stay GREEN, and the reason the arm reads
+    # by DEPTH rather than by search: the same coordinate under the `:test`
+    # alias is correct and must not redden. A substring gate over this file
+    # fails here, which is why one was not written.
+    clean = scan_forbidden_coordinates(
+        '{:paths ["src"]\n'
+        " :deps {day8/re-frame2 {:local/root \"../core\"}}\n"
+        " :aliases {:test {:extra-deps {day8/re-frame2-uix\n"
+        '                               {:local/root "../adapters/uix"}}}}}'
+    )
+    assert clean == [], clean
+
+    # ARM 2 fails CLOSED on a file it cannot read, rather than reporting the
+    # green that an empty search would otherwise produce.
+    unreadable = scan_forbidden_coordinates('{:paths ["src"]}')
+    assert len(unreadable) == 1, unreadable
+    assert "no top-level `:deps` map" in unreadable[0], unreadable
+
+    # THE PRESENT CONTROL for arm 2, read off the REAL file (rf2-b3gy). The
+    # live arm is an absence check, and an absence check whose subject has
+    # quietly left the building is a green that means nothing. This asserts
+    # the coordinate is still there to be kept out of production, so the
+    # distinction the arm draws still has two sides.
+    deps_text = read_deps_edn()
+    assert "day8/re-frame2-uix" in code_only(deps_text), (
+        "deps.edn no longer declares the UIx coordinate anywhere, so arm 2's "
+        "green no longer distinguishes a clean production map from a file "
+        "that stopped mentioning UIx at all."
+    )
+    assert scan_forbidden_coordinates(deps_text) == [], (
+        "the real deps.edn must be green: " + repr(scan_forbidden_coordinates(deps_text))
+    )
+    aliases = top_level_value(deps_text, ":aliases")
+    assert aliases is not None and "day8/re-frame2-uix" in aliases, (
+        "the UIx coordinate must live under `:aliases`, which is what makes "
+        "the production map's cleanliness a real distinction"
+    )
+
     print("hicasso optional-module reachability: self-test OK")
     return 0
 
@@ -660,7 +989,10 @@ def main(argv):
     if "--self-test" in argv:
         return self_test()
 
-    problems = scan(read_src())
+    sources = read_src()
+    problems = scan(sources)
+    problems += scan_forbidden_imports(sources)
+    problems += scan_forbidden_coordinates(read_deps_edn())
     if problems:
         sys.stderr.write("hicasso optional-module reachability: FAIL\n")
         for p in problems:
@@ -668,9 +1000,11 @@ def main(argv):
         return 1
 
     names = ", ".join(m["name"] for m in MODULES)
+    forbidden = ", ".join(r["name"] for r in FORBIDDEN_IMPORTS)
     print(
         "hicasso optional-module reachability: OK "
-        "({} unreachable from the public door)".format(names)
+        "({} unreachable from the public door; {} required by no `src/` "
+        "namespace and named by no production coordinate)".format(names, forbidden)
     )
     return 0
 

--- a/implementation/hicasso/scripts/check_optional_module_reachability.py
+++ b/implementation/hicasso/scripts/check_optional_module_reachability.py
@@ -502,6 +502,10 @@ def scan(sources):
     return problems
 
 
+SYMBOL_CHARS = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789_.*+!?<>=$%&/-:"
+SYMBOL_RE = re.compile(r"[A-Za-z][A-Za-z0-9_.*+!?<>=$%&/-]*")
+
+
 def top_level_value(text, key):
     """The form following `key` at the TOP LEVEL of `text`'s outermost map.
 
@@ -531,10 +535,6 @@ def top_level_value(text, key):
                 return source[start:form_end(source, start)]
         i += 1
     return None
-
-
-SYMBOL_CHARS = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789_.*+!?<>=$%&/-:"
-SYMBOL_RE = re.compile(r"[A-Za-z][A-Za-z0-9_.*+!?<>=$%&/-]*")
 
 
 def names_library(namespace, prefixes):

--- a/implementation/hicasso/test/re_frame/hicasso/native_abi_dom_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/native_abi_dom_cljs_test.cljs
@@ -14,9 +14,11 @@
   | row | what it establishes | the one-line narrowing it catches |
   |---|---|---|
   | [[a-native-parent-mounts-a-view-under-the-frame-it-is-already-in]] | the outward bridge — one root, one frame, no second state owner | a bridge that resolved a frame of its own; the DOM is identical under it |
+  | [[a-uix-parent-mounts-the-same-view-under-the-frame-it-is-already-in]] | the third named parent, on a real fiber, over the SAME minted bridge | UIx's own carrier ABI reaching the bridge — `:argv` where the props should be |
   | [[two-frames-are-two-cells-across-the-bridge]] | frames are isolated contexts on the outward crossing too | resolving the frame anywhere but the surrounding context |
   | [[the-views-memo-wrapper-survives-the-bridge]] | a fresh-but-equal props map still bails the boundary out | a bridge handing the raw object through — every re-render re-runs the body, and the screen is right throughout |
   | [[a-hicasso-body-hosts-a-native-component-through-the-doors-that-exist]] | the inward door, both spellings, with the native ABI intact at the crossing | a door that allocated a props MAP for the island — the second ABI clause 5 forbids |
+  | [[two-frames-are-two-cells-through-the-inward-door-as-well]] | frames are isolated contexts on the INWARD crossing too, which is a different mechanism from the outward one | an island resolving one frame for both roots — one key, four readers, two plausible screens |
   | [[n-memo-bails-out-and-still-carries-its-marker-on-the-second-render]] | the helper across a re-render, which is where a stamp gets lost | copying the marker into a per-render wrapper |
   | [[a-fresh-mint-replaces-the-subtree-and-that-is-the-hmr-contract]] | allocation, never a lookup by name | a helper caching by display name so a component outlives a reload |
   | [[strict-modes-double-mount-crosses-the-bridge-exactly-once]] | acquire is commit-owned on both sides of the crossing | a bridge acquiring during render |
@@ -42,6 +44,7 @@
             [re-frame.hicasso.native :as n]
             [re-frame.hicasso.roots-frames-support :as support]
             [re-frame.test-support :as test-support]
+            [uix.core :as uix :refer-macros [defui]]
             ["react" :as react]))
 
 (def ^:private alpha ::alpha)
@@ -57,9 +60,11 @@
 
 (def ^:private declared-population
   #{:bridge/outward
+    :bridge/outward-uix
     :bridge/two-frames
     :bridge/memo-bail-out
     :bridge/inward
+    :bridge/inward-two-frames
     :helper/memo-across-a-re-render
     :helper/fresh-mint-remounts
     :bridge/strict-mode
@@ -80,11 +85,21 @@
 (defonce ^:private !island-runs (atom 0))
 (defonce ^:private !island-props (atom nil))
 
+(defonce ^:private !bridged-props
+  ;; What the bridged view's body was last handed, held WHOLE. The paint
+  ;; can only show what the body chose to print, and `#7` is what a body
+  ;; reading `:article-id` prints — but it is also what a body would print
+  ;; if the props arrived under some other key and the id happened to be
+  ;; reachable anyway. The UIx row asserts the KEY SET, which is the only
+  ;; reading that separates those. `defonce` takes no docstring.
+  (atom nil))
+
 (h/defview article-card
   "An ordinary boundary. It reads a subscription, so the frame it
   resolved is observable in the cell table rather than only on screen."
   [props]
   (swap! !view-runs inc)
+  (reset! !bridged-props props)
   [:article {:class "card"} (str "#" (:article-id props) " " (h/sub [::label]))])
 
 (def ^:private card
@@ -116,6 +131,53 @@
 (h/defview strict-outward-host
   [{:keys [article-id]}]
   (n/$ react/StrictMode nil (n/$ bridging-parent {:article-id article-id})))
+
+(defui uix-bridging-parent
+  "A UIx parent that renders the very same bridged view (rf2-ap7w).
+
+  The third of the three parents the law names — *Hicasso-native, UIx and
+  raw React parents can render Hicasso* — and until this row it was the
+  unlanded one. `h/as-component` appeared in exactly two test files and
+  under neither did a `defui` sit above it: the native parent bridges on a
+  fiber above, and the raw React parent bridges in the NODE lane only,
+  where `renderToStaticMarkup` means there is no fiber, no commit and so
+  no cell to count.
+
+  It renders [[card]] itself rather than minting a bridge of its own, and
+  that is the point rather than economy: ONE minted component reached from
+  three parents, so a difference the rows find is a difference between the
+  PARENTS and not between three bridges that happened to agree.
+
+  ## What the crossing actually turns on, which is NOT the spelling
+
+  `uix/$` reaches a non-UIx component through `react-component-element`,
+  which camelises keys with `uix.compiler.attributes/dash-to-camel` and
+  passes values by identity. That rule sends BOTH `:article-id` and
+  `:articleId` to the same `articleId` slot, so the bridge cannot tell
+  those two authorings apart and a row written against the spelling would
+  be asserting nothing — measured, not assumed: planting `:articleId` here
+  leaves every assertion in the row green.
+
+  What the crossing does turn on is WHICH ABI arrives. UIx has two, and
+  picks between them on the `uix-component?` flag: a `defui` is handed the
+  carrier `#js {:argv props}`, while an ordinary React function is handed
+  real React props. The minted bridge is an ordinary function and carries
+  no flag, so it must receive the second. If it ever received the first,
+  the bridge would decode `argv` and the body would be handed a props map
+  whose only key is `:argv` — and the `#7` in the paint would go missing
+  in a way that reads like a data problem rather than an ABI one. The key
+  set below is what names it."
+  [{:keys [article-id]}]
+  (uix/$ :div
+         (uix/$ :i {:class "uix-parent"} "uix")
+         (uix/$ card {:article-id article-id})))
+
+(h/defview uix-outward-host
+  "The UIx parent, reached from a Hicasso root — the same rung 3 shape
+  [[outward-host]] has, so the two rows differ by the parent and by
+  nothing else."
+  [{:keys [article-id]}]
+  (uix/$ uix-bridging-parent {:article-id article-id}))
 
 (defn- island-body
   "The island's body, held apart from any mint so a row can allocate two
@@ -161,6 +223,7 @@
                       (reset! !view-runs 0)
                       (reset! !island-runs 0)
                       (reset! !island-props nil)
+                      (reset! !bridged-props nil)
                       (collector/reset-runtime!))}))
 
 (defn- seat!
@@ -172,6 +235,16 @@
 (defn- at [handle sel] (.querySelector ^js (:container handle) sel))
 (defn- text-at [handle sel] (some-> (at handle sel) .-textContent))
 (defn- click! [handle sel] (.click ^js (at handle sel)) (mount/settle!) nil)
+
+(defn- island-texts
+  "The text of every island in `handle`'s container, in document order.
+
+  `array-seq` and not `map` over the `NodeList` directly: a `NodeList` is
+  array-LIKE and ES6-iterable but implements no ClojureScript protocol, so
+  `count` and `seq` throw on it rather than answering."
+  [handle]
+  (mapv #(.-textContent ^js %)
+        (array-seq (.querySelectorAll ^js (:container handle) ".island"))))
 
 (defn- label-key [frame-kw] [frame-kw [::label]])
 (defn- readers-of [sub-key] (inventory/cell-readers sub-key))
@@ -288,6 +361,66 @@
                 (support/teardown-census! handle)
                 nil))
             (.catch (report-failure! "outward bridge"))
+            ;; The single trailing step, which BOTH arms reach: this row's
+            ;; roots go down first, and the single `done` is the last act,
+            ;; with nothing after it.
+            (.then (fn [_] (release-minted!) (done))))))))
+
+(deftest a-uix-parent-mounts-the-same-view-under-the-frame-it-is-already-in
+  (async done
+    (if-not (mount/browser?)
+      (do (support/skip! ":node-test has no React DOM") (done))
+      (do
+        (seat! alpha "seed")
+        (-> (mount-live! alpha [uix-outward-host {:article-id 7}] (label-key alpha) 1)
+            (.then
+              (fn [handle]
+                (testing "the premise: a UIx parent really did render, and the
+                          bridged view is INSIDE its DOM rather than beside it.
+                          Without this the assertions below are satisfied by a
+                          tree that skipped the parent entirely"
+                  (is (= "uix" (text-at handle ".uix-parent")))
+                  (is (some? (at handle ".uix-parent + .card"))))
+
+                (testing "the view painted the props UIx lowered and the bridge
+                          decoded — `:article-id` out through `dash-to-camel`,
+                          `articleId` across, `:article-id` back"
+                  (is (= "#7 seed" (text-at handle ".card"))))
+
+                (testing "and the body was handed REACT props, decoded into its
+                          own map — not UIx's carrier. Narrowing caught: the
+                          bridge reached through UIx's `defui` path, which
+                          hands `#js {:argv props}`; the body's key set would
+                          be `#{:argv}` and the paint would lose its `#7` in a
+                          way that reads like a data problem rather than the
+                          ABI one it is.
+
+                          The key set, not the paint, is what separates those:
+                          the paint can only show what the body chose to
+                          print"
+                  (is (= #{:article-id} (set (keys @!bridged-props)))))
+
+                (testing "its read built ONE cell, under the frame the
+                          SURROUNDING root installed — the bridge resolved no
+                          frame of its own on this parent either. The fixture
+                          seats no ambient frame, so a bridge that failed to
+                          read the context has nothing to fall back to, and
+                          this key is what says which happened"
+                  (is (= #{(label-key alpha)} (support/cell-keys)))
+                  (is (= 1 (count (readers-of (label-key alpha))))))
+
+                (testing "and a write through the surrounding frame reaches the
+                          bridged view, so the crossing is a place in the
+                          application rather than an island of its own state
+                          — the same sentence the native parent's row ends on"
+                  (rf/with-frame alpha (rf/dispatch-sync [::relabel "moved"]))
+                  (mount/settle!)
+                  (is (= "#7 moved" (text-at handle ".card"))))
+
+                (exercised! :bridge/outward-uix)
+                (support/teardown-census! handle)
+                nil))
+            (.catch (report-failure! "outward bridge under a UIx parent"))
             ;; The single trailing step, which BOTH arms reach: this row's
             ;; roots go down first, and the single `done` is the last act,
             ;; with nothing after it.
@@ -429,6 +562,63 @@
                 (support/teardown-census! handle)
                 nil))
             (.catch (report-failure! "inward door"))
+            ;; The single trailing step, which BOTH arms reach: this row's
+            ;; roots go down first, and the single `done` is the last act,
+            ;; with nothing after it.
+            (.then (fn [_] (release-minted!) (done))))))))
+
+(deftest two-frames-are-two-cells-through-the-inward-door-as-well
+  (async done
+    (if-not (mount/browser?)
+      (do (support/skip! ":node-test has no React DOM") (done))
+      (do
+        (seat! alpha "A")
+        (seat! beta "B")
+        (-> (mount-live! alpha [inward-host {:tick 0}] (label-key alpha) 2)
+            (.then (fn [a]
+                     (-> (mount-live! beta [inward-host {:tick 0}] (label-key beta) 2)
+                         (.then (fn [b] [a b])))))
+            (.then
+              (fn [[a b]]
+                (testing "one hosting body, two frames, four islands — and each
+                          island read the frame of the root it was mounted
+                          under, through the door rather than around it"
+                  (is (= ["hosted/A" "raw/A"] (island-texts a)))
+                  (is (= ["hosted/B" "raw/B"] (island-texts b))))
+
+                (testing "and TWO keys, differing only in their frame, with two
+                          readers on each. Narrowing caught: an island
+                          resolving one frame for both roots — there would be
+                          ONE key here carrying four readers, and both screens
+                          would still be full of plausible text.
+
+                          This is the INWARD half of the law's `across two
+                          frames`, and it is a different mechanism from the
+                          outward half above rather than the same one seen
+                          twice: the outward bridge reads the frame in the
+                          minted component's own wrapper, while an island
+                          reads it through `n/use-sub`'s hook on the far side
+                          of a crossing that never names a tier"
+                  (is (= #{(label-key alpha) (label-key beta)}
+                         (support/cell-keys)))
+                  (is (= [2 2]
+                         [(count (readers-of (label-key alpha)))
+                          (count (readers-of (label-key beta)))])))
+
+                (testing "a write to one frame moves one page's islands and
+                          leaves the other's alone. Frames are isolated
+                          contexts, and a foreign React subtree is not a hole
+                          in that"
+                  (rf/with-frame alpha (rf/dispatch-sync [::relabel "A'"]))
+                  (mount/settle!)
+                  (is (= ["hosted/A'" "raw/A'"] (island-texts a)))
+                  (is (= ["hosted/B" "raw/B"] (island-texts b))))
+
+                (exercised! :bridge/inward-two-frames)
+                (support/teardown-census! a)
+                (support/teardown-census! b)
+                nil))
+            (.catch (report-failure! "two frames through the inward door"))
             ;; The single trailing step, which BOTH arms reach: this row's
             ;; roots go down first, and the single `done` is the last act,
             ;; with nothing after it.

--- a/implementation/hicasso/test/re_frame/hicasso/three_way_parity_dom_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/three_way_parity_dom_cljs_test.cljs
@@ -38,7 +38,44 @@
   handwritten React component and a UIx subtree are all foreign React
   components to the interpreted tier, and `native.cljc`'s docstring says
   in terms that this is what keeps native-boundary clause 6 true — the
-  door never names the tier."
+  door never names the tier.
+
+  ## One frame, and why a second would measure nothing HERE (rf2-ap7w)
+
+  Row 4 of the conformance matrix asks for both embedding directions
+  ACROSS TWO FRAMES, and every row below runs under the single
+  `::parity-dom`. That is deliberate, and the reason is a property of
+  this file's subject rather than a budget.
+
+  A frame is a property of what a body READS. None of the three routes
+  here reads anything: [[page]] calls `h/sub` once per arm and hands
+  each route the answer as an ordinary `label` prop, because the axes
+  this file exists to settle — painted DOM, refs, cleanup, element
+  identity across a re-render — are all properties of a route's own
+  rendering, and a subscription inside each route would be three more
+  things that could differ for reasons that are not the ones under
+  test. Mount that tree under two frames and what differs between the
+  two pages is the number React carried down a props chain. That is
+  prop plumbing, and the single-frame run above already settles it for
+  all three routes in one commit.
+
+  So the claim is real but it does not live here, and it is NOT simply
+  covered by the outward bridge's `two-frames-are-two-cells-across-the-
+  bridge` either — that row exercises the minted component's own
+  wrapper, which is the other direction and a different read. The
+  inward two-frame claim belongs where an inward route actually
+  subscribes, and that is
+  `native-abi-dom-cljs-test/two-frames-are-two-cells-through-the-inward-
+  door-as-well`: one hosting body under two roots, four islands reading
+  through `n/use-sub` on the far side of the crossing, two keys, two
+  readers each, and a write that moves one page.
+
+  The raw-React route is why the claim cannot be made three-wide at
+  all. A handwritten React component subscribes through no re-frame2
+  hook by construction — that is what makes it the control it is here —
+  so a three-route reading tree would have to hand it one, and the row
+  would then be measuring a component this file went to some trouble to
+  keep foreign."
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
             [clojure.string :as str]
             [re-frame.adapter.uix :as uix-adapter]


### PR DESCRIPTION
Closes rf2-ap7w and rf2-b3gy — two CHECKPOINT 3 misses on the same seam.

They did **not** unify, and that is the first finding. The brief's hypothesis was that building the UIx-parent case would give the *"nor UIx"* clause something to assert against. It does not: rf2-ap7w is a **runtime fiber** claim living in `test/`, rf2-b3gy is a **source-graph** claim over `src/`. Test code requiring UIx is entirely legal — `three_way_parity_*` already does, and this PR adds another such namespace. If anything the two pull apart: landing more UIx into `test/` makes it *more* important that the gate scopes itself to `src/`. Two separate small pieces was the honest answer.

## Premises, checked at source

All four verified, none refuted.

| premise | verdict |
|---|---|
| `h/as-component` appears in exactly two test files | **Confirmed.** `native_abi_cljs_test` and `native_abi_dom_cljs_test`. The third grep hit is a docstring listing the API surface. |
| No UIx parent renders a bridged view; `defui` is always a CHILD | **Confirmed.** `defui` appears in two Hicasso test files, in both reached through `h/defhost`. The native parent bridges on a fiber; the raw React parent bridges in the NODE lane only (`renderToStaticMarkup` — no fiber, no commit, no cell). |
| The inward three-route tree runs under one frame | **Confirmed.** `::parity-dom`. |
| The "nor UIx" clause has no gate on either side | **Confirmed.** The only `uix` occurrence in `check_optional_module_reachability.py` was inside the quoted-law comment. `src/` names UIx in 17 places, all docstrings. |

## rf2-ap7w — the missing parent, and the missing direction

`a-uix-parent-mounts-the-same-view-under-the-frame-it-is-already-in` mounts a `defui` above the **same** minted `card` the native parent uses — one bridge, three parents, so a difference is a difference between parents rather than between three bridges that agreed.

**The row's narrowing is not the spelling, and that was measured rather than assumed.** The first draft was written against *"a decode tuned to the native macro's spelling"*, and a planted `:articleId` left **every assertion green**: UIx's `dash-to-camel` sends both `:article-id` and `:articleId` to the same `articleId` slot, so the bridge cannot tell those authorings apart and a row written against the spelling asserts nothing. The plant was an equivalent program, not a fault.

What the crossing *does* turn on is **which ABI arrives**. UIx picks on the `uix-component?` flag — a `defui` gets the carrier `#js {:argv props}`, an ordinary React function gets real React props. The minted bridge carries no flag and must receive the second. So the row asserts the decoded **key set** is `#{:article-id}`, which is the only reading that separates them; the paint shows only what the body chose to print. The row was rewritten and re-planted against a key `dash-to-camel` leaves alone.

`two-frames-are-two-cells-through-the-inward-door-as-well` closes the second gap. *"Across two frames"* held for the outward bridge alone. This is a **different mechanism** rather than the same one twice: the outward bridge reads the frame in the minted component's own wrapper, an island reads it through `n/use-sub` on the far side of a crossing that never names a tier.

**The frame-isolation topology did change**, and in the direction the standing rule requires: one app (`inward-host`) mounted into N isolated frames, no frame-ids passed as view arguments, two keys asserted rather than one.

The three-route parity tree **keeps its single frame**, with the reason recorded in its own docstring. Those routes are *prop-fed* — `page` calls `h/sub` once per arm and hands each route the answer — so a two-frame run there compares the number React carried down a props chain, which the single-frame run already settles for all three in one commit. It also cannot be made three-wide at all: a handwritten React component subscribes through no re-frame2 hook by construction, which is exactly what makes it the control it is there.

## rf2-b3gy — a clause that fell through a seam

Nobody wrote anything wrong. `check_bundle_isolation.cjs` declines the clause in terms, explains that the measured bundle **contains** UIx and that this is correct, and refers it on to *"the source-side gate's kind of question"*. The source-side gate's `native` row then quoted the law in full, called itself *"the DEPENDENCY-GRAPH half of that sentence"*, and asked only the module question. Each file was honest about itself.

Gated now in the two arms `check-ui-adapter-isolation.cjs` already uses for the same claim about `re-frame2-ui`:

1. **SOURCE** — no `src/` namespace requires UIx, read off `:require` forms by the parser the module rows already use. That reuse is *why* the arm belongs in this file: a grep-based gate dies on `impl/controlled.cljs` citing `uix/compiler/input.cljs` by line number, and would be exempted away within a week.
2. **COORDINATE** — the production `:deps` of `hicasso/deps.edn` names no UIx artefact. This arm has a live subject: the `:test` alias **does** declare `day8/re-frame2-uix`, legally and necessarily, so the property is not *"the file never says uix"* but *"the PRODUCTION map never does"*. A substring gate would be red today. It reads by bracket depth for exactly that reason.

### A refusal, source-located: row 6's second clause needs no bundle

*"Native bundles contain no UIx unless the application imports it"* was read as owing a native-tier release build. There is exactly one release build (`:hicasso-release`) and it is the interpreted-only one — and a new build id lives in the hot-zone `implementation/shadow-cljs.edn`, which I do not hold.

**It owes no such build.** Split the clause: what the *application* imports is the application's own affair and nothing this package can assert about; what remains is *the native tier's own source drags no UIx in*, which is arm 1 over `native.cljc` along with every other file in `src/`, decided exhaustively. A bundle would add confidence about the **compiler**, and this gate's own docstring already says why it declines that instrument for the module rows: reachability is decided in the source. Arm 1 also sees what a bundle cannot — a consumer writing only `n/$` with literal props leaves no production footprint at all.

So **no hot-zone touch and no matrix amendment are needed**: the clause is measured, not waived. The reasoning is recorded in the gate's docstring rather than left in this PR body. No error id was minted, so no `spec/009` row is owed.

## Quality gates

Baseline established **before** any edit, from this worktree, never quoted from the brief. Every number below is from my own captured `.exit` file — the harness reported exit 0 for three runs my capture recorded as 1, so the harness's numbers are not used.

| gate | baseline | after | captured exit |
|---|---|---|---|
| `npm run test:browser` | 1512 tests / 9622 assertions, 0 failures | **1514 / 9635, 0 failures, 0 errors** | **0** |
| `node-test-hicasso` (compile + node lane) | — | 1153 tests / 4715 assertions, 0 failures | **0** |
| `check_optional_module_reachability.py --self-test` + live | OK / OK | OK / OK, both arms | **0** |
| `sh scripts/test-fast-pr.sh` (full spine, run to completion) | — | CLJS node integration 13904 tests / 70274 assertions, 0 failures; clj-kondo 0 errors | **0** |

`+2` tests and `+13` assertions is exactly the two new rows, and the file's own `the-declared-population-was-actually-exercised` roster row fails if either had silently stopped running.

**Red-then-green, on the live tree rather than only in a self-test:**

- `8986240204` arm 1 — planted `[uix.core :as uix]` into `native.cljc`: **exit 1**, message `src/re_frame/hicasso/native.cljc: re-frame.hicasso.native requires uix.core, which is UIx`. Names the namespace, as the bead requires.
- `8986240204` arm 2 — promoted `day8/re-frame2-uix` into the production `:deps`: **exit 1**, naming the coordinate. Reverted; live gate green.
- `25b8c5d51f` browser — planted `:article_id` in the UIx parent and a one-frame key set in the inward row: **exit 1, 4 failures**, all naming my two rows and their lines, with `actual: (not (= #{:article-id} #{:article_id}))` and `(not (= "#7 seed" "# seed"))`. Reverted; final run green at `450259efa4`.
- The **discarded** plant is reported here rather than quietly dropped: `:articleId` was green, which is what sent the row back to be rewritten.

Which tree each gate read was verified rather than assumed — every shadow-cljs run printed `config: …/re-frame2-worktrees/uixinterop-ap7w/implementation/shadow-cljs.edn`, and the browser runner served this worktree's own `out/browser-test`.

**Fast-spine-versus-required-CI gap:** `python scripts/check_fast_pr_gap.py --list` reports **96 required checks the spine does not run** — `test.yml` (`All required checks passed`), `lint.yml` (`Lint required`, and note CI pins clj-kondo 2026.04.15) and `docs.yml` (`Docs required`). Most are surface-gated and skip on a diff that does not reach them; the claim is that none of them is *decided* locally. I ran the spine to completion **and** ran `test:browser` directly three times, which is the lane that actually decides these rows — `cljs-browser` is on that gap list.

No measurement window was opened. No hot-zone file touched. No `.beads` path committed.
