### PR TITLE
fix(hicasso): read each lane selector from its own build's map (rf2-mwr2)

### DIFF
--- a/docs/design/hicasso/product/budgets.md
+++ b/docs/design/hicasso/product/budgets.md
@@ -1005,6 +1005,25 @@ node one, letting a scheduled-lane DOM witness back through on the node build's
 selector. All eight witnesses pass on arrival; the widening reds nothing here
 and closes the class the last one could not see.
 
+**[Amended 2026-08-14, `rf2-mwr2`.] Each selector is read out of its own
+build's map, and a build declaring none refuses rather than borrowing.** The
+two amendments above both read a selector by searching on from a build's key
+across the rest of `implementation/shadow-cljs.edn`, which meant a build
+declaring no `:ns-regexp` silently adopted the *next* build's and had its lane
+reported verified against a selector belonging to something else. Nothing was
+green that should have been red — all three builds the gate reads declare their
+own selector — but the failure mode was the one these amendments exist to
+close, rebuilt inside their own machinery, and a config edit was all it needed.
+The search is now bounded at the build's own closing brace. Two details are
+load-bearing and easy to strip by accident: the brace matching skips string
+literals and `;` comments, because this config carries prose holding
+`{:infer-warning false}` inside `:node-test`'s own map and a `--config-merge`
+example inside another's; and comments are **blanked** rather than merely
+skipped, because the same file spells `:ns-regexp "cljs-test$"` in a comment
+two builds below the real declaration. A gate that cannot read a build's
+selector now says which build and why, in both directions — no such build, or
+no selector inside it.
+
 **[Amended 2026-08-14, `rf2-mwr2`.] A row that claims work SCALES has to name
 two counters, and the gate refuses one.** `U5` was registered on boundary
 bodies alone, and read `MET` on a coarse view-model arm that rebuilds every

--- a/implementation/hicasso/scripts/check_budget_ledger.py
+++ b/implementation/hicasso/scripts/check_budget_ledger.py
@@ -379,6 +379,92 @@ def _edn_unescape(literal):
     return "".join(out)
 
 
+# L6.  The EDN string literal a `:ns-regexp` is written as, applied to ONE
+# build's own map (below).  Lifted verbatim out of the single search this
+# replaced, so the values read are unchanged by the isolation.
+_NS_REGEXP_RE = re.compile(r":ns-regexp\s+\"((?:[^\"\\\\]|\\\\.)*)\"")
+
+# L6.  The build id sits alone on its line, optionally behind the `{` that
+# opens the `:builds` map — `:node-test` is that map's FIRST entry and so is
+# written `{:node-test`.  Anchoring on the whole line is what keeps
+# `:target :node-test` and `:node-test-perf-nightly` from being mistaken for
+# the build's own key.  The lookahead leaves the match ending ON the `{` that
+# opens the build's value, which is where the brace matcher starts; a key whose
+# value is not a map therefore does not match at all, and the gate refuses.
+_BUILD_KEY_RE = r"^\s*\{?\s*%s\s*$\s*(?=\{)"
+
+
+def _isolate_build_map(text, build):
+    """`build`'s own map, comments blanked, or `None` if it declares none.
+
+    THE POINT OF THIS FUNCTION IS THE CLOSING BRACE (`rf2-mwr2`).  Reading a
+    selector by searching on from the build's key across the rest of the file
+    lets a build that declares NO `:ns-regexp` silently adopt the next build's
+    — reported as a verified lane, which is the fail-open L6 exists to close,
+    rebuilt inside L6's own machinery.  Bounding the search at the build's own
+    closing brace is what turns that borrow into a refusal.
+
+    Brace matching is comment- and string-aware because this file requires it
+    to be, not as a precaution: `implementation/shadow-cljs.edn` carries
+    ``:warnings {:infer-warning false}`` in prose inside `:node-test`'s own
+    map, and ``--config-merge {:output-dir ... :modules {:main {:init-fn
+    ...}}}`` inside another build's.  Those happen to balance today, so a
+    comment-blind counter would land on the right brace by luck; one prose edit
+    with an unpaired brace would mis-bound the map and restore the borrow.
+    Comments are BLANKED rather than skipped so the `:ns-regexp` search that
+    follows cannot read a value out of prose either — this file spells
+    ``:ns-regexp \\"cljs-test$\\"`` in a comment two builds below the real one.
+
+    This is a brace matcher and not an EDN parser: it knows string literals,
+    `;` comments and `\\x` character literals, and it counts `{` against `}`.
+    Nothing here interprets a form, and nothing here needs to.
+    """
+    key = re.search(_BUILD_KEY_RE % re.escape(build), text, re.M)
+    if not key:
+        return None
+    out, depth, i, end = [], 0, key.end(), len(text)
+    while i < end:
+        char = text[i]
+        if char == '"':
+            out.append(char)
+            i += 1
+            while i < end:
+                out.append(text[i])
+                if text[i] == "\\" and i + 1 < end:
+                    i += 1
+                    out.append(text[i])
+                elif text[i] == '"':
+                    i += 1
+                    break
+                i += 1
+            continue
+        if char == ";":
+            while i < end and text[i] != "\n":
+                out.append(" ")
+                i += 1
+            continue
+        if char == "\\":
+            # An EDN character literal — `\{`, `\}`, `\;`, `\"`.  Blanked
+            # whole, so the brace or quote it names cannot be counted or
+            # opened as a string.
+            out.append(" ")
+            i += 1
+            if i < end:
+                out.append(" ")
+                i += 1
+            continue
+        if char == "{":
+            depth += 1
+        elif char == "}":
+            depth -= 1
+            if depth == 0:
+                out.append(char)
+                return "".join(out)
+        out.append(char)
+        i += 1
+    return None
+
+
 def read_lane_selectors(path=SHADOW_CLJS):
     """`{build-id: compiled ns-regexp}` for the three lanes L6 adjudicates on.
 
@@ -391,23 +477,34 @@ def read_lane_selectors(path=SHADOW_CLJS):
     `rf2-xcaph` widened it out of.
     """
     with open(path, encoding="utf-8") as handle:
-        text = handle.read()
+        return lane_selectors(handle.read(), path)
+
+
+def lane_selectors(text, path=SHADOW_CLJS):
+    """`read_lane_selectors` against config source already in hand.
+
+    Split out so `--self-test` can drive the refusals from a DOCTORED config
+    without writing one to disk.  The control this seam exists for is the one
+    that could not otherwise be written: a build present in the file and
+    declaring no `:ns-regexp` of its own must refuse, rather than adopt the
+    selector of whichever build happens to follow it (`rf2-mwr2`).
+    """
     selectors = {}
     for build in (PR_BLOCKING_DOM_BUILD, SCHEDULED_DOM_BUILD,
                   PR_BLOCKING_NODE_BUILD):
-        # The build id sits alone on its line, optionally behind the `{` that
-        # opens the `:builds` map — `:node-test` is that map's FIRST entry and
-        # so is written `{:node-test`.  Anchoring on the whole line is what
-        # keeps `:target :node-test` and `:node-test-perf-nightly` from being
-        # mistaken for the build's own key.
-        match = re.search(
-            r"^\s*\{?\s*%s\s*$\s*\{.*?:ns-regexp\s+\"((?:[^\"\\\\]|\\\\.)*)\""
-            % re.escape(build), text, re.S | re.M)
+        own_map = _isolate_build_map(text, build)
+        if own_map is None:
+            raise ValueError(
+                "%s declares no build %s bound to a map that closes, so no "
+                "row's `PR gate` lane claim can be verified. This gate "
+                "refuses rather than skipping the check" % (path, build))
+        match = _NS_REGEXP_RE.search(own_map)
         if not match:
             raise ValueError(
-                "%s declares no :ns-regexp for the build %s, so no row's "
-                "`PR gate` lane claim can be verified. This gate refuses "
-                "rather than skipping the check" % (path, build))
+                "%s declares no :ns-regexp inside the build %s's OWN map, so "
+                "no row's `PR gate` lane claim can be verified. This gate "
+                "refuses rather than reading the next build's selector"
+                % (path, build))
         selectors[build] = re.compile(_edn_unescape(match.group(1)))
     return selectors
 
@@ -1108,6 +1205,78 @@ def self_test():
     assert set(read_lane_selectors()) == {
         PR_BLOCKING_DOM_BUILD, SCHEDULED_DOM_BUILD, PR_BLOCKING_NODE_BUILD}, \
         "read_lane_selectors stopped reading a lane L6 adjudicates on"
+
+    # L6 — and each selector is read out of THAT BUILD'S OWN MAP (`rf2-mwr2`).
+    # The reader used to search on from a build's key across the rest of the
+    # file, so a build declaring no `:ns-regexp` adopted the NEXT build's and
+    # had its lane reported verified on a selector belonging to something else.
+    # Latent on the shipping config — all three builds L6 reads declare their
+    # own — which is precisely why it needs a control rather than a reader's
+    # attention.  The plant is the defect itself, in the shape the bead
+    # reproduces it: the PR-blocking browser build present but silent, and the
+    # scheduled bench build following it holding the selector that gets
+    # borrowed.  Borrowing THAT one is the false-green direction, because it
+    # certifies a witness only the cron lane runs as blocking a merge.
+    #
+    # Driven through `lane_selectors` on config source held in memory: writing
+    # a doctored copy to disk would make this control depend on a temp file,
+    # and the defect is in the reading, not in the file handling.
+    def three_lanes(browser_selector):
+        return (" :builds\n"
+                " {%s\n"
+                "  {:target    :node-test\n"
+                "   :ns-regexp \"cljs-test$\"}\n"
+                "\n"
+                "  %s\n"
+                "  {:target    :browser-test\n"
+                "   %s:test-dir  \"out/browser-test\"}\n"
+                "\n"
+                "  %s\n"
+                "  {:target    :browser-test\n"
+                "   :ns-regexp \"^bench\\\\..+-dom-cljs-test$\"}}\n"
+                % (PR_BLOCKING_NODE_BUILD, PR_BLOCKING_DOM_BUILD,
+                   browser_selector, SCHEDULED_DOM_BUILD))
+
+    try:
+        lane_selectors(three_lanes(""), "<no selector of its own>")
+    except ValueError:
+        pass
+    else:
+        raise AssertionError(
+            "lane_selectors accepted a build declaring no :ns-regexp of its "
+            "own, so it read the FOLLOWING build's selector and would report "
+            "that build's `PR gate` lane verified against it")
+    # ...and the eager direction, which is what keeps the refusal above honest:
+    # with the one deleted line restored and nothing else changed, the same
+    # config must parse, and each build must get ITS OWN selector rather than
+    # its neighbour's.  Without this half, the refusal could be caused by the
+    # plant being unreadable and would prove nothing about the isolation.
+    intact = lane_selectors(three_lanes(':ns-regexp "-dom-cljs-test$"\n   '),
+                            "<selector restored>")
+    if intact[PR_BLOCKING_DOM_BUILD].pattern != "-dom-cljs-test$":
+        raise AssertionError(
+            "the missing-selector control refuses for the wrong reason: with "
+            "the selector restored, %s reads %r"
+            % (PR_BLOCKING_DOM_BUILD, intact[PR_BLOCKING_DOM_BUILD].pattern))
+    if intact[SCHEDULED_DOM_BUILD].pattern == "-dom-cljs-test$":
+        raise AssertionError(
+            "the plant cannot demonstrate a borrow: both browser builds "
+            "declare the same selector, so adopting one for the other would "
+            "be invisible")
+    # ...and the bound holds on the config as it SHIPS, not only on the plant.
+    # `:node-test` is the `:builds` map's first entry, the longest of the three
+    # maps, and the one carrying prose that names `:ns-regexp` — so exactly one
+    # occurrence proves both halves at once: the matcher stopped at that
+    # build's own closing brace instead of swallowing the builds below it, and
+    # comments were blanked instead of being read as declarations.
+    with open(SHADOW_CLJS, encoding="utf-8") as handle:
+        node_map = _isolate_build_map(handle.read(), PR_BLOCKING_NODE_BUILD)
+    if node_map is None or node_map.count(":ns-regexp") != 1:
+        raise AssertionError(
+            "%s's map is not bounded at its own closing brace, or a commented "
+            "mention of :ns-regexp survived into it: %r occurrences"
+            % (PR_BLOCKING_NODE_BUILD,
+               node_map is not None and node_map.count(":ns-regexp")))
 
     # L7 — the fail-open `rf2-mwr2` found, driven from every direction a
     # later edit could reopen it.  The first is the defect as it stood: U5


### PR DESCRIPTION
Closes the last item on `rf2-mwr2`.

## The defect, verified at source

`read_lane_selectors` searched on from a build's key across the rest of
`implementation/shadow-cljs.edn`. A build declaring no `:ns-regexp` therefore
adopted the **next** build's selector and had its lane reported *verified*
against a selector belonging to something else — the fail-open L6 exists to
close, rebuilt inside L6's own machinery.

The premise was checked by evaluating the code against a real plant, not by
reading the pattern. With `:browser-test`'s `:ns-regexp` line deleted from a
copy of the shipping config and nothing else changed, the landed function
returned:

```
:browser-test                -> '-boundary-prod-test$'
```

borrowed from `:browser-test-schemas-boundary-prod`, the build that follows it.
Confirmed. On the synthetic three-lane plant in the shape the bead reproduces —
`:browser-test` silent, `:browser-test-freehand-bench` next — the landed
function returns **the scheduled bench selector for both build ids**, which is
the false-green direction: it would certify a witness only the cron lane runs
as blocking a merge.

**Nothing was false-green on main.** All three builds L6 reads declare their own
selector, so the defect was latent — which is exactly why it needed a control
rather than a reader's attention.

## The repair

The search is bounded at the build's own closing brace. Two details are
load-bearing rather than defensive, and the config is why:

- **Brace matching skips string literals and `;` comments.** `:node-test`'s own
  map carries prose holding `` :warnings {:infer-warning false} `` split across
  two comment lines, and another build's carries a `--config-merge {:output-dir
  … :modules {:main {:init-fn …}}}` example. Those happen to balance today, so a
  comment-blind counter lands on the right brace by luck; one prose edit with an
  unpaired brace restores the borrow.
- **Comments are blanked, not merely skipped**, so the `:ns-regexp` search
  cannot read a value out of prose either — this file spells
  `` :ns-regexp "cljs-test$" `` in a comment two builds below the real one.

It is a brace matcher, not an EDN parser: string literals, `;` comments, `\x`
character literals, and `{` counted against `}`. The change stayed bounded; no
parser was needed and none was written.

`lane_selectors` is split out of `read_lane_selectors` so `--self-test` can
drive the refusal from doctored config held in memory rather than from a temp
file. `read_lane_selectors(path)` keeps its signature.

**The refusal is the point**, and it extends #8192's behaviour rather than
inventing a different one: the gate already refused when it could not read the
config, and now says which build and why in both directions — no such build
bound to a map that closes, or no selector inside it.

## What is preserved

**The per-class partition survives untouched.** `*_dom_cljs_test` against
`:browser-test`, everything else against `:node-test`. `check()` is not in the
diff — the three hunks are at `_edn_unescape`'s tail, `read_lane_selectors`
itself, and `self_test()`. The self-test's existing per-class controls (a
scheduled-lane DOM witness reds; the test-kit facade and a `-nightly-test`
witness red on the node arm; both eager directions green) all pass unchanged.

**The values read from the shipping config are byte-identical.** Compared old
against new as compiled-pattern source, all three: `'^(?!re-frame\.freehand\.bench\.).*-dom-cljs-test$'`,
`'^re-frame\.freehand\.bench\..+-dom-cljs-test$'`, `'cljs-test$'`. The
`:ns-regexp` string-literal sub-pattern was lifted verbatim so the isolation
changes no value. Each build's search space is now 0.5%–2.2% of the file, and
no other build key leaks into any isolated map.

**No ledger table row is touched.** The §9 ledger block hashes byte-identically
to the merge base, `af32ac6d8f31eb781d84c59733478a4229537c520bf4b2732952d8444315f144`
on both sides. `budgets.md` is 19 insertions, 0 deletions, pure §9 prose; no
line containing a table pipe was added or removed.

**`implementation/shadow-cljs.edn` was read and never written** — absent from
the diff, blob `951cac1b86e684cffe8d808bd169512315036412` on both sides.

## New controls

Added to `--self-test`, driven by the defect itself rather than a synthetic
fault:

1. A build present and declaring no `:ns-regexp`, with the scheduled bench build
   following it holding the selector that would be borrowed — must refuse.
2. The same config with the one line restored — must parse, and each build must
   get **its own** selector. Without this half the refusal could be caused by
   the plant being unreadable and would prove nothing.
3. On the config as it ships: exactly one `:ns-regexp` inside `:node-test`'s
   isolated map. That single count proves the bound *and* the comment blanking
   at once, since that map contains a commented mention of `:ns-regexp`.

The refusals are proved by `raise AssertionError`, not a bare `assert`, which
`python -O` strips (`rf2-uyhh`). Verified: the control reds against the landed
code (which borrows), and reds against a sabotage that restores the unbounded
search — proved by calling `self_test()` directly and observing the
`AssertionError`, not by trusting the harness.

## Quality gates

`scripts/check_fast_pr_gap.py --list` reports **96 required checks the fast
spine does not run** — green locally is not green in CI, and none of the three
required contexts (`All required checks passed`, `Lint required`, `Docs
required`) is decided here.

**I did not run the full fast spine.** This diff is one Python gate script plus
a prose block in `docs/design/`; the spine's clojure, cljs and mkdocs arms
cannot be reached by either, and `mkdocs build --strict` explicitly excludes
`docs/design/**`. I ran the gates that own this diff directly instead, each
redirected to a log with the runner's exit code captured on the same line:

| Gate | Before | After |
| --- | --- | --- |
| `check_budget_ledger.py` | exit 0 — 49 rows, 31 MET, 5 BREACH, 3 UNRESOLVED, 10 UNPINNED | exit 0 — identical tuple |
| `check_budget_ledger.py --self-test` | exit 0 | exit 0 |
| `python -O … --self-test` | exit 1, "assertions are disabled" | exit 1, unchanged |
| `npm run test:hicasso-invariants` (the chain CI runs this gate in) | — | exit 0, all five checkers |
| `scripts/check_doc_slugs.py` | — | exit 0 |
| `scripts/check_provenance_pins.py --changed-since <merge-base>` | — | exit 0 |

The status tuple is unchanged on both sides, taken as my own reading rather
than inherited. Anchors and table column counts in the `budgets.md` addition
were checked by hand as `docs/design/**` requires: the added prose introduces no
markdown link and no table, and `check_doc_slugs.py` passes.
