### PR TITLE
feat(ci): arm the hicasso JVM lane so the slot-rule equivalence pin runs in CI (rf2-ipx7h)

### DIFF
--- a/.github/scripts/report-changed-surfaces.sh
+++ b/.github/scripts/report-changed-surfaces.sh
@@ -1463,13 +1463,28 @@ else
         #     reachability check and the complaint-catalogue round trip;
         #   - the bench-lane compile, already an unconditional step there.
         #
-        # NOT implementation_jvm: the artefact's runtime requires React,
-        # so every suite it owns is CLJS. Its `:test` alias is a
-        # classpath probe with `--probe` waiving the test-count floor, it
-        # is deliberately absent from scripts/test-jvm-implementation.sh's
-        # roster, and check_jvm_lane_rosters.py fails BOTH ways — a roster
-        # entry with no required job is its own red. Arm this the same
-        # commit a JVM-runnable suite lands and the roster gains the row.
+        # NOT implementation_jvm — AND THE OLD REASON HAS EXPIRED, so it
+        # is worth being exact about the new one. This row used to read
+        # "every suite it owns is CLJS; its `:test` alias is a classpath
+        # probe with `--probe`; it is deliberately absent from
+        # scripts/test-jvm-implementation.sh's roster. Arm this the same
+        # commit a JVM-runnable suite lands and the roster gains the row."
+        # rf2-0yp7w re-homed the bench harness here, which brought
+        # `test/re_frame/bench/hicasso/front/slot_cljs_test.cljc` — the
+        # `.cljc` equivalence pin for the canonical slot rule (rf2-ani6y)
+        # — so the alias dropped `--probe` and took the test-count floor,
+        # and rf2-ipx7h put the artefact ON that roster with a required
+        # `jvm-hicasso` job.
+        #
+        # The row survives because that job is UNCONDITIONAL, so it needs
+        # no arm, and because arming this root would be wrong twice over:
+        # 22 OTHER jobs read `implementation_jvm`, so a hicasso-only diff
+        # would schedule all of them to run one five-second one-namespace
+        # lane; and the arm would still not cover the lane's own inputs —
+        # `implementation/hicasso/deps.edn` and `test_kit/src/**` are on
+        # its `:test` classpath and are matched by THIS case, which sets
+        # no jvm output. `implementation/scripts/_changed-surfaces.test.cjs`
+        # pins all three facts.
         #
         # NOT cljs_prod / bundle_isolation / ui_gates / ui_smoke: no
         # `-elision-prod-test$` namespace, no example resolves the

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3058,6 +3058,98 @@ jobs:
       - name: Run JVM tests (test-quiet contract suite)
         run: clojure -M:test
 
+  # rf2-ipx7h — the Hicasso artefact's JVM lane, and the CI half of a pin that
+  # had a local half only.
+  #
+  # WHAT IT RUNS is one namespace: `re-frame.bench.hicasso.front.slot-cljs-test`,
+  # the `.cljc` EQUIVALENCE PIN for the canonical slot rule (rf2-ani6y).
+  # Measured: 3 tests, 92 assertions, ~5s. `front/slot.cljc` has exactly one
+  # definition of `prop-name`, so the failure it hunts is not "someone edited
+  # one copy" — it is the two ways ONE definition still answers two things: a
+  # `#?(:clj … :cljs …)` reader conditional inside the rule or anything it
+  # calls, and a host-differing primitive (the JVM's `str/upper-case` consults
+  # the platform DEFAULT LOCALE, so a Turkish-locale JVM slots `:aria-index` and
+  # `:on-input` differently from every browser). Neither is visible to a single
+  # host, so the same corpus is asserted TWICE against that one implementation:
+  # once by `npm run test:cljs` in Node, once by `clojure -M:test` here. Running
+  # one arm does not halve the coverage, it deletes the mechanism.
+  #
+  # THE HOLE THIS CLOSES. The pin used to live under `implementation/freehand`,
+  # whose JVM lane is rostered and required. rf2-0yp7w re-homed the bench
+  # harness into `implementation/hicasso/test/`, which was on neither
+  # `scripts/test-jvm-implementation.sh` nor this workflow — so the Node arm
+  # kept running on every PR and the JVM arm ran only when somebody typed
+  # `clojure -M:test` by hand. The roster entry lands in the same commit as this
+  # job because `check_jvm_lane_rosters.py` R1/R2 refuse either half alone.
+  #
+  # UNCONDITIONAL — no `needs: detect_changed_surfaces`, no `if:` — and the
+  # reason is a MEASUREMENT, not the precedent of the three hicasso Python jobs
+  # above. `implementation_jvm` is the obvious gate and it is the wrong one
+  # twice over:
+  #
+  #   1. IT DOES NOT COVER THIS LANE'S INPUTS. Probed on this tree, the lane's
+  #      own definition — `implementation/hicasso/deps.edn`, which decides
+  #      whether the pin is discovered at all — measures implementation_jvm
+  #      FALSE, as does `implementation/hicasso/test_kit/src/**`, also on the
+  #      `:test` classpath. The two files that DO arm it (`slot_cljs_test.cljc`
+  #      and its subject `front/slot.cljc`) arm it only INCIDENTALLY, through
+  #      `is_route_path_census_input` — a predicate that exists for the routing
+  #      route-path census and matches `implementation/hicasso/test/*` `.cljs`/
+  #      `.cljc`. Resting this lane on that predicate means the census's roster
+  #      silently owns whether the slot pin is gated.
+  #   2. ARMING IT WOULD COST 23 JOBS TO SCHEDULE ONE. Measured on this tree,
+  #      22 jobs carry `if: … implementation_jvm == 'true'`. A hicasso-only diff
+  #      runs none of them today; arming the artefact root would run all 22 plus
+  #      this one, on every diff to the repo's most actively developed tree, to
+  #      schedule a five-second lane. Unconditional costs one runner.
+  #
+  # A new classifier output of its own was the third option and is rejected for
+  # the reason the complaint-catalogue, budget-ledger and facade-inventory jobs
+  # give at length: the defect being repaired IS a surface gate that did not
+  # cover a checker's inputs, so a new arm is a fresh chance to make the same
+  # mistake and needs re-widening every time the lane learns to read another
+  # file.
+  #
+  # NOT VACUOUS, AND MECHANICALLY SO. The `:test` alias carries no `--probe`, so
+  # it takes the quiet runner's test-count floor: a lane that discovers zero
+  # tests REDS rather than passing green. That floor is what makes this job's
+  # green a verdict rather than a lane that has quietly stopped selecting
+  # anything — the failure mode a `--probe` lane wired to a required job would
+  # have manufactured on purpose.
+  jvm-hicasso:
+    name: JVM hicasso (clojure -M:test)
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    defaults:
+      run:
+        working-directory: implementation/hicasso
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654  # v5.2.0
+        with:
+          distribution: temurin
+          java-version: '21'
+
+      - name: Set up Clojure CLI
+        run: "$GITHUB_WORKSPACE/.github/scripts/install-clojure-cli.sh"
+
+      - name: Cache Maven / gitlibs
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
+        with:
+          path: |
+            ~/.m2/repository
+            ~/.gitlibs
+            ~/.deps.clj
+          key: ${{ runner.os }}-clj-hicasso-${{ hashFiles('implementation/hicasso/deps.edn', 'implementation/core/deps.edn', 'implementation/test-quiet/deps.edn', 'implementation/adapters/uix/deps.edn') }}
+          restore-keys: |
+            ${{ runner.os }}-clj-hicasso-
+            ${{ runner.os }}-clj-
+
+      - name: Run JVM tests (hicasso artefact — the slot-rule equivalence pin)
+        run: clojure -M:test
+
   cljs:
     name: CLJS (shadow-cljs :node-test)
     # rf2-f79t8 — job-level gating (NOT a workflow-trigger path filter:
@@ -6484,6 +6576,13 @@ jobs:
       - jvm-derivation-conformance
       - jvm-event-conformance
       - jvm-test-quiet
+      # rf2-ipx7h — required, and `check_jvm_lane_rosters.py` R1 will not accept
+      # the roster entry without this line: a job absent from this list is
+      # advisory whatever its own gate says. What it carries is the JVM ARM of
+      # the slot-rule equivalence pin, which is only a mechanism while BOTH arms
+      # run — the Node arm alone cannot see a reader conditional or a
+      # locale-sensitive primitive inside the one definition they share.
+      - jvm-hicasso
       - cljs
       - js-harness-self-tests
       - cljs-browser

--- a/implementation/scripts/_changed-surfaces.test.cjs
+++ b/implementation/scripts/_changed-surfaces.test.cjs
@@ -4965,11 +4965,18 @@ test('implementation/hicasso/** stays OFF the gates no hicasso suite reaches (rf
   // gate that runs not one line of the changed surface is worse than none
   // because it reads as coverage.
   //
-  //   implementation_jvm — the runtime requires React, so every suite the
-  //     artefact owns is CLJS; its `:test` alias is a `--probe` classpath
-  //     check and it is deliberately off scripts/test-jvm-implementation.sh's
-  //     roster. Arm it the same commit a JVM-runnable suite and the roster row
-  //     land together (check_jvm_lane_rosters.py fails both ways).
+  //   implementation_jvm — NOT because the artefact has no JVM lane. It has
+  //     one: rf2-ipx7h put `implementation/hicasso` on
+  //     scripts/test-jvm-implementation.sh and added the required
+  //     `jvm-hicasso` job, and its `:test` alias dropped `--probe` and took
+  //     the test-count floor. The reason this row survives is that the job is
+  //     UNCONDITIONAL, so it needs no arm — and arming this root would be
+  //     actively wrong: 22 OTHER jobs read `implementation_jvm`, so every
+  //     hicasso-only diff would schedule all of them to run one five-second
+  //     one-namespace lane. The release condition that used to be written here
+  //     ("arm it the same commit a JVM-runnable suite lands") is therefore
+  //     RETIRED rather than pending; the pin that replaces it is the
+  //     `jvm-hicasso is UNCONDITIONAL` test below.
   //   cljs_prod — no `-elision-prod-test$` namespace.
   //   bundle_isolation / ui_gates / ui_smoke — no example resolves the
   //     artefact and it mounts no testbed those smokes drive.
@@ -4989,8 +4996,110 @@ test('implementation/hicasso/** stays OFF the gates no hicasso suite reaches (rf
     'ui_gates',
     'ui_smoke',
   ]) {
-    assert.equal(result[key], 'false', `hicasso must not arm ${key} yet`);
+    assert.equal(result[key], 'false', `hicasso must not arm ${key}`);
   }
+});
+
+// ---------------------------------------------------------------------------
+// rf2-ipx7h — the hicasso JVM lane, and why it carries no surface gate.
+//
+// `implementation/hicasso/test/re_frame/bench/hicasso/front/slot_cljs_test.cljc`
+// is the `.cljc` EQUIVALENCE PIN for the canonical slot rule (rf2-ani6y): one
+// corpus asserted twice against ONE implementation, once by `npm run test:cljs`
+// in Node and once by `clojure -M:test` on the JVM. Both arms or no mechanism —
+// a reader conditional inside the rule, or the JVM's locale-sensitive
+// `str/upper-case`, is invisible to either host alone.
+//
+// The three rows below are the MEASUREMENT that decided against gating this
+// job on `implementation_jvm`. Each is a file on the lane's JVM classpath that
+// does not arm that output, so each is a PR shape that would have skipped the
+// job — and `deps.edn` is the sharpest, because it is the file that decides
+// whether the pin is discovered AT ALL. They must NOT be "fixed" by widening
+// `implementation_jvm` for the artefact root: 22 other jobs read it, and the
+// scope guard above says so. The repair is the unconditional job asserted
+// underneath.
+// ---------------------------------------------------------------------------
+
+test('the hicasso JVM lane has classpath inputs that arm NO jvm tier (rf2-ipx7h)', () => {
+  for (const file of [
+    // the `:test` alias itself — `:extra-paths`, `:extra-deps`, `:main-opts`
+    'implementation/hicasso/deps.edn',
+    // also on `:extra-paths`, so also scanned for discovery
+    'implementation/hicasso/test_kit/src/re_frame/hicasso/test.cljs',
+  ]) {
+    const result = classify(file);
+    assert.equal(
+      result.implementation_jvm,
+      'false',
+      `${file} is on the hicasso JVM lane's classpath and arms no jvm tier — `
+        + 'which is why jvm-hicasso is unconditional rather than gated on '
+        + 'implementation_jvm',
+    );
+  }
+});
+
+test('the slot pin arms implementation_jvm only INCIDENTALLY (rf2-ipx7h)', () => {
+  // The pin and its subject DO measure true — but through
+  // `is_route_path_census_input`, a predicate that exists for the routing
+  // route-path census and matches `implementation/hicasso/test/*` `.cljs`/
+  // `.cljc`. The `.clj` control below is what makes that legible: same tree,
+  // same artefact, FALSE, because the census filters on the extensions IT
+  // cares about. So the arm belongs to another gate's roster and could
+  // narrow with it — a second reason this job takes no gate at all.
+  for (const file of [
+    'implementation/hicasso/test/re_frame/bench/hicasso/front/slot_cljs_test.cljc',
+    'implementation/hicasso/test/re_frame/bench/hicasso/front/slot.cljc',
+  ]) {
+    assert.equal(classify(file).implementation_jvm, 'true');
+  }
+  assert.equal(
+    classify('implementation/hicasso/test/re_frame/bench/hicasso/arm1/lang.clj')
+      .implementation_jvm,
+    'false',
+    'the .clj control must measure false — the arm is the census predicate, '
+      + 'not a hicasso JVM arm',
+  );
+});
+
+test('jvm-hicasso is UNCONDITIONAL, rostered and required (rf2-ipx7h)', () => {
+  const workflow = fs.readFileSync(WORKFLOW, 'utf8');
+  const block = jobBlock(workflow, 'jvm-hicasso');
+  // Job-level keys sit at exactly four spaces; anchoring there keeps a prose
+  // comment mentioning `needs:` from reading as the key itself.
+  assert.doesNotMatch(
+    block,
+    /^ {4}needs:/m,
+    'jvm-hicasso must not depend on detect_changed_surfaces — the lane\'s own '
+      + 'deps.edn arms no classifier output',
+  );
+  assert.doesNotMatch(
+    block,
+    /^ {4}if:/m,
+    'jvm-hicasso must carry no surface gate; implementation_jvm does not cover '
+      + 'this lane\'s inputs and arming it would schedule 22 other jobs',
+  );
+  assert.match(
+    block,
+    /^ {8}working-directory: implementation\/hicasso$/m,
+    'the job must run in the artefact directory',
+  );
+  assert.match(block, /run: clojure -M:test$/m, 'the job must run the JVM lane');
+  // Required, not advisory: a job absent from the aggregator's `needs:` is
+  // advisory whatever its own gate says, and check_jvm_lane_rosters.py R1
+  // refuses the roster entry without this line.
+  assert.match(
+    jobBlock(workflow, 'all-required-passed'),
+    /^ {6}- jvm-hicasso$/m,
+    'jvm-hicasso must be in all-required-passed\'s needs',
+  );
+  // The local half of the same bijection. R1/R2 check this too, but a reader
+  // of THIS file should not have to run a Python gate to learn that the lane
+  // has a local lane as well as a hosted one.
+  assert.match(
+    fs.readFileSync(path.join(REPO_ROOT, 'scripts', 'test-jvm-implementation.sh'), 'utf8'),
+    /^ {2}implementation\/hicasso$/m,
+    'implementation/hicasso must be on the local JVM roster',
+  );
 });
 
 test('the cljs job runs BOTH hicasso gates the classifier arm schedules (rf2-8a6s)', () => {

--- a/scripts/test-jvm-implementation.sh
+++ b/scripts/test-jvm-implementation.sh
@@ -125,29 +125,35 @@ artefacts=(
   # JVM per deftest (slowest artefact), matching the dedicated
   # `jvm-test-quiet` PR-CI job (test.yml).
   implementation/test-quiet
-  # NOT HERE, ON PURPOSE: `implementation/hicasso` (rf2-hic-022).
+  # rf2-ipx7h — the Hicasso view substrate, and the ONE thing it runs on the
+  # JVM: `re-frame.bench.hicasso.front.slot-cljs-test`, the `.cljc` equivalence
+  # pin for the canonical slot rule (rf2-ani6y). Measured here: 3 tests, 92
+  # assertions, ~5s.
   #
-  # The artefact gained its first JVM-runnable suite with the lint export
-  # (`re-frame.hicasso.lint-export-test` runs clj-kondo in process over
-  # `resources/clj-kondo.exports/`; no React, no DOM, no CLJS compile), and
-  # its `:test` alias correspondingly dropped `--probe` and took the
-  # test-count floor. Adding it to THIS roster is the obvious next step and
-  # was tried — `check_jvm_lane_rosters.py` (rf2-as6bg) refuses it:
+  # THE PIN IS THE WHOLE REASON THE LANE EXISTS. `front/slot.cljc` has exactly
+  # one definition of `prop-name`, and the two ways one definition still answers
+  # two things — a `#?(:clj …:cljs …)` reader conditional inside it, and a
+  # host-differing primitive like the JVM's locale-sensitive `str/upper-case` —
+  # are invisible to any single host. So the same corpus is asserted twice
+  # against that one implementation: once by `npm run test:cljs` in Node, once
+  # by `clojure -M:test` here. A lane that runs only one arm does not merely
+  # halve the coverage, it deletes the mechanism.
   #
-  #   R1 implementation/hicasso: on scripts/test-jvm-implementation.sh, but no
-  #   .github/workflows/test.yml job runs `clojure -M:test` there
+  # Every OTHER suite the artefact owns is CLJS — the runtime is React — so this
+  # is a one-namespace lane and is expected to stay small. The `:test` alias
+  # carries NO `--probe`: it takes the runner's test-count floor, so if the pin
+  # ever stops being discovered the lane reds instead of passing empty.
   #
-  # which is the bijection gate working exactly as intended. A roster entry
-  # with no CI job is a lane that depends on somebody remembering to run a
-  # script. The missing half is a `jvm-hicasso` job in `test.yml`, which is
-  # hot-zone and sequential, so it is a scheduling decision rather than a
-  # detail this bead could take.
-  #
-  # The export ITSELF is gated meanwhile, by `lint.yml`'s required
-  # `clj-kondo` job: `.clj-kondo/config.edn` points `:config-paths` at the
-  # export, so the hooks load over the whole lint surface and the job reds if
-  # they break or begin firing on real code. What is ungated is the fixture
-  # suite that proves each check still FIRES.
+  # This entry landed WITH the `jvm-hicasso` job in `.github/workflows/test.yml`
+  # (unconditional, in `all-required-passed`'s `needs:`), because
+  # `check_jvm_lane_rosters.py` R1/R2 refuse either half alone. It replaces a
+  # "NOT HERE, ON PURPOSE" note that justified the exclusion by naming a JVM
+  # suite `re-frame.hicasso.lint-export-test`: `140620d291` added that deftest,
+  # `dd9f31bbc4` replaced it with `scripts/check_lint_export.py` and restored
+  # `--probe`, and the note was left describing a world that no longer existed.
+  # The lint export is still gated by `lint.yml`'s required `clj-kondo` job and
+  # by `npm run test:hicasso-lint`; it is not a JVM suite and never was one.
+  implementation/hicasso
 )
 
 for artefact in "${artefacts[@]}"; do


### PR DESCRIPTION
Closes rf2-ipx7h.

`implementation/hicasso/test/re_frame/bench/hicasso/front/slot_cljs_test.cljc`
is the `.cljc` **equivalence pin** for the canonical slot rule (rf2-ani6y): one
corpus asserted twice against **one** implementation, once by `npm run test:cljs`
in Node and once by `clojure -M:test` on the JVM. Both arms or no mechanism — a
`#?(:clj … :cljs …)` reader conditional inside `prop-name`, or the JVM's
locale-sensitive `str/upper-case`, is invisible to either host alone.

rf2-0yp7w (PR #8202) re-homed the bench harness out of `implementation/freehand`
— whose JVM lane is rostered and required — into `implementation/hicasso`, which
was on **neither** `scripts/test-jvm-implementation.sh` nor `test.yml`. The Node
arm kept running on every PR; the JVM arm ran only when somebody typed
`clojure -M:test` by hand. This is the missing half.

## What lands

- **`jvm-hicasso` in `test.yml`**, `working-directory: implementation/hicasso`,
  `clojure -M:test`, in `all-required-passed`'s `needs:`.
- **`implementation/hicasso` on `scripts/test-jvm-implementation.sh`** — the same
  commit, because `check_jvm_lane_rosters.py` R1/R2 refuse either half alone.
  This also arms the local spine's JVM tier, which reads that roster.
- **Three pins in `implementation/scripts/_changed-surfaces.test.cjs`** holding
  the shape (details below).
- **Two stale rationale blocks deleted**, both describing worlds that no longer
  exist (details below).

## Unconditional, and the measurement that decided it

The job carries no `needs: detect_changed_surfaces` and no `if:`. That is not
the three sibling hicasso Python jobs' precedent applied by analogy — it is
measured, and `implementation_jvm` is the wrong gate twice over.

**1. It does not cover the lane's inputs.** Probed with
`bash ./.github/scripts/report-changed-surfaces.sh <path>` on this tree:

| path | `implementation_jvm` |
|---|---|
| `implementation/hicasso/deps.edn` | **false** |
| `implementation/hicasso/test_kit/src/**` | **false** |
| `implementation/hicasso/src/**` | **false** |
| `implementation/hicasso/test/**/front/slot_cljs_test.cljc` | true |
| `implementation/hicasso/test/**/front/slot.cljc` | true |
| `implementation/hicasso/test/**/arm1/lang.clj` | **false** |

`deps.edn` is the sharpest row: it is the file that decides whether the pin is
discovered at all, and it arms nothing. And the two rows that *do* arm the output
arm it only **incidentally**, through `is_route_path_census_input` — a predicate
that exists for the routing route-path census and matches
`implementation/hicasso/test/*` `.cljs`/`.cljc`. The `.clj` control in the same
tree measuring false is what makes that legible. Resting this lane on that
predicate would let the census's roster silently own whether the slot pin is
gated.

**2. Arming it would cost 23 jobs to schedule one.** Measured: 22 jobs carry
`if: … implementation_jvm == 'true'`. A hicasso-only diff runs none of them
today; arming `implementation/hicasso/*` would run all 22 plus this one, on every
diff to the repo's most actively developed tree, to schedule a **one-namespace**
lane that this PR's own CI run finished in **26s** end to end (5.28s warm
locally for the suite alone). Unconditional costs one runner.

The three unconditional hicasso contract jobs beside it measure 6.85s / 1.25s /
0.68s, so a JVM lane is an order of magnitude heavier than a Python checker —
and still small enough that there is nothing worth gating for. The number was
taken rather than assumed.

A new classifier output of its own was the third option, rejected for the reason
`hicasso-complaint-catalogue` / `hicasso-budget-ledger` / `hicasso-facade-inventory`
give at length: the defect being repaired *is* a surface gate that did not cover
a checker's inputs, so a new arm is a fresh chance to make the same mistake.

## Not vacuous, and mechanically so

An empty lane wired to a required job would be green by vacuity — the failure
class this bead sits inside. Two measurements, not assurances:

- The lane selects **1 namespace, 3 tests, 92 assertions**, green
  (`clojure -M:test` in `implementation/hicasso`, exit `0`). It is the only
  JVM-loadable `*_test.clj[c]` under `test/` + `test_kit/src`; every other suite
  the artefact owns is CLJS, because the runtime is React.
- The `:test` alias carries **no `--probe`**, so it takes the quiet runner's
  test-count floor. Driven directly at an empty discovery dir
  (`clojure -M:test -d test_kit/src`) it exits **1** with
  `[test-quiet] ERROR: this run executed 0 test(s), below the floor of 1`. A lane
  that stops selecting the pin reds; it cannot pass empty.

## Plant in the watched thing

A `#?(:clj (str (str/lower-case (subs s 0 1)) (subs s 1)) :cljs …)` was planted
inside `capitalize` in `front/slot.cljc` — the pin's subject — and the lane run.
Result: **exit 1, 18 failures across both deftests** (`onClick`/`onclick`,
`viewBox`/`viewbox`, `tabIndex`/`tabindex`, …). File restored byte-exactly
(verified: byte compare + clean `git status`); nothing from the plant is in this
diff.

The plant is deliberately *inside the `:clj` branch*, so the CLJS reader never
sees it and `npm run test:cljs` would stay green. That is the whole point: this
job is the only lane that can catch it. **Proved locally** — the plant was not
pushed, since a deliberately red required matrix costs every reviewer on the
board more than the proof is worth.

**What CI on this PR does and does not prove.** `JVM hicasso (clojure -M:test)`
ran and passed in 26s, and its log shows `Ran 3 tests containing 92 assertions.`
— so the hosted lane selects the pin, not nothing. It does **not** discriminate
unconditional from gated: classified as a set, this PR's own four files measure
`implementation_jvm=true`, because editing the classifier and the workflow
rightly fans out. Claiming otherwise would be the kind of unchecked assertion
this PR is deleting two of. The unconditional case rests on the per-path probes
in the table above, and those are now pinned as tests rather than left as a
paragraph.

## The stale blocks deleted

- **`scripts/test-jvm-implementation.sh`** — a "NOT HERE, ON PURPOSE" note
  justifying the exclusion by naming a JVM suite
  `re-frame.hicasso.lint-export-test`. **That namespace exists nowhere in the
  tree**; the only occurrence of the string was that comment. `140620d291` added
  the deftest, `dd9f31bbc4` replaced it with `scripts/check_lint_export.py` and
  restored `--probe`, and the note was left describing the old world. Its
  *conclusion* was correct until this PR; only its reasoning was false.
- **`.github/scripts/report-changed-surfaces.sh`** — the `NOT implementation_jvm`
  row on the `implementation/hicasso/*` arm, which said the `:test` alias is a
  `--probe` classpath check deliberately off the roster, with the release
  condition "arm this the same commit a JVM-runnable suite lands and the roster
  gains the row". Both halves are now false. The row survives with the measured
  reason above; `_changed-surfaces.test.cjs`'s matching release condition is
  retired the same way.

The classifier arm itself is **unchanged** — no new arm, so no arm-pinning edit
was forced. The `_changed-surfaces.test.cjs` change is the retired rationale plus
three new pins: the un-armed classpath inputs, the incidental arm with its `.clj`
control, and `jvm-hicasso` being unconditional, in `all-required-passed`'s
`needs:`, and on the local roster.

## Band

PR-triggered jobs across `test.yml` (79) + `docs.yml` (5) + `lint.yml` (6) +
`portability.yml` (3) + `freehand-conformance.yml` (1) = **94 → 95**. `test.yml`
79 → 80 jobs; `all-required-passed` `needs:` 78 → 79.

`scripts/check_fast_pr_gap.py --list` is **unchanged at 96** and `jvm-hicasso`
does not appear in it — the `jvm-artefact-suite` lane matches
`^clojure -M:test$` against `@impl-roster`, so putting `implementation/hicasso`
on the roster covered the new job's step with no lane-list edit. `--check` reports
`87 required jobs across 3 workflows` (86 before), which is the one job added.

## Quality gates

The **spine was not run**: this is a fresh worktree with no
`implementation/node_modules`, so its node tier fails for that reason alone and
the result would be noise. Gates run directly instead, each redirected to its own
log with the runner's exit code captured on the same command line. Counts are the
ones captured here, not quoted.

| gate | before | after | exit |
|---|---|---|---|
| `clojure -M:test` in `implementation/hicasso` | (lane did not exist in CI) | 3 tests, 92 assertions, green — 5.28s warm locally, **26s** as the CI job | `0` |
| `clojure -M:test -d test_kit/src` (floor probe) | — | refuses: `executed 0 test(s), below the floor of 1` | `1` (expected) |
| plant in `front/slot.cljc`, lane re-run | — | 18 failures / 92 assertions | `1` (expected) |
| `python scripts/check_jvm_lane_rosters.py` | PASS, 33 rostered | PASS, **34** rostered | `0` |
| `python scripts/check_jvm_lane_rosters.py --self-test` | — | 9/9 cases | `0` |
| `node implementation/scripts/_changed-surfaces.test.cjs` | 369 passed | **372** passed | `0` |
| `python scripts/check_test_lane_bijection.py` | PASS, 1955 files / 49 lanes | PASS, 1955 files / **50** lanes | `0` |
| `python scripts/check_fast_pr_gap.py --list` | 96 | **96** (unchanged) | `0` |
| `python scripts/check_fast_pr_gap.py` | clean | clean, 87 required jobs | `0` |
| `python scripts/check_gate_scheduling.py` | 51 / 43 / 8 | 51 / 43 / 8 (unchanged) | `0` |
| `python scripts/check_ci_reproduce_commands.py` | — | 43 checker steps in sync | `0` |
| `python scripts/check_donor_inventory.py` | — | 224/224 rows | `0` |
| `node implementation/scripts/_reagent-slim-smoke-policy.test.cjs` | — | all passed | `0` |
| `bash -n .github/scripts/report-changed-surfaces.sh` | — | — | `0` |
| `yaml.safe_load` of `test.yml` | 79 jobs | 80 jobs, `jvm-hicasso` has no `needs`/`if` | `0` |

`TESTING.md` needs no edit: its `implementation_jvm` row enumerates the jobs
*that output* schedules, and this job is not one of them.

**Fence.** Nothing under `implementation/hicasso/test/re_frame/bench/hicasso/**`
is in this diff (`worker/helpers-it4y5` owns that area this tick) — the plant was
transient and byte-restored. No `docs/`, no `dispositions.md`, no `tools/xray/`,
no `mkdocs.yml`, no `spec/`, no `implementation/shadow-cljs.edn`.
`implementation/hicasso/deps.edn` was **not** edited: PR #8202 had already
dropped `--probe` and taken the floor, so the vacuity trap was closed before this
PR started.
