### PR TITLE
ci(hicasso): arm the guide-sample gate with its own required job

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1170,6 +1170,70 @@ jobs:
       - name: Verify every public name on the door against sections 2.1 and 2.2
         run: python implementation/hicasso/scripts/check_facade_inventory.py
 
+  # rf2-r5iy7 — the guide-sample gate's own unconditional job, the FOURTH
+  # instance of the shape above and the cleanest case of the four.
+  #
+  # `implementation/hicasso/scripts/check_guide_samples.py` reads TWO input
+  # families (measured at the script, not assumed — `GUIDE_DIR` L121 and
+  # `SOURCE_ROOTS` L128-131):
+  #
+  #   docs/core/hicasso/**                        the 25 guide pages whose 188
+  #                                               fenced blocks it pins
+  #   implementation/hicasso/src, .../test_kit/src  the sources it resolves the
+  #                                               34 hicasso verb use-sites against
+  #
+  # It is chained into `npm run test:hicasso-invariants`, whose only hosted
+  # invocation is a step of the `cljs` job under
+  # `needs.detect_changed_surfaces.outputs.cljs_node_test == 'true'`. ONLY THE
+  # SECOND FAMILY ARMS THAT OUTPUT. The guide tree arms NOTHING AT ALL —
+  # `.github/scripts/report-changed-surfaces.sh docs/core/hicasso/00-installation.md`
+  # returns ALL THIRTY-TWO outputs false, exit 0 — so a guide-only PR, which is
+  # precisely the edit this gate exists to police and by far the commonest one
+  # against a documentation tree, runs the check NOWHERE. It would then next
+  # redden on somebody else's source PR, over a block they did not write.
+  #
+  # UNCONDITIONAL, rather than a new classifier output, for the reason the three
+  # jobs above give at length and this one will not restate — with one addition
+  # specific to this checker. Arming the EXISTING output from `docs/core/hicasso/**`
+  # was measured and rejected: `cljs_node_test` is consumed by exactly one job,
+  # the ~10-minute node build, so it would schedule that build on a prose typo.
+  # And a NEW dedicated output would have to widen every time the checker learns
+  # to read another file — it already reads two families across two trees — which
+  # is a fresh chance to make the very mistake being repaired. The work here is
+  # sub-second pure Python (measured 0.31s self-test + 0.61s live, no node, no
+  # JVM), so there is nothing to gate for.
+  #
+  # IT STAYS CHAINED INTO `test:hicasso-invariants` TOO: that chain is the local
+  # spine lane and the artefact's one-command run, and this job is the CI
+  # reachability the chain cannot give it. `scripts/check_fast_pr_gap.py` carries
+  # a matching `SPINE_LANES` entry so these two steps are not over-reported as a
+  # local gap.
+  hicasso-guide-samples:
+    name: Hicasso guide samples (rf2-r5iy7)
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+
+      - name: Set up Python
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
+        with:
+          python-version: '3.12'
+
+      # Self-test first, then the live run — the order every other pure-Python
+      # contract in this workflow uses. It drives each rule red in turn over
+      # synthetic inputs, so a green live run below is a verdict rather than a
+      # checker that has quietly stopped firing.
+      - name: Self-test the guide-sample rules
+        run: python implementation/hicasso/scripts/check_guide_samples.py --self-test
+
+      # The live run PRINTS what it inspected — how many fenced blocks it pinned
+      # across how many pages, how many verb use-sites it resolved, and how many
+      # declared divergences are still live. A gate that cannot say what it
+      # covered is how this class of hole survives a green badge.
+      - name: Verify every fenced guide sample against its pin and the sources
+        run: python implementation/hicasso/scripts/check_guide_samples.py
+
   # rf2-3mh2f — CI arm of the STALE WORKER-SNAPSHOT guard (rf2-ia8o7).
   #
   # `bd` auto-stages the full-database JSONL export in EVERY checkout, so a
@@ -6496,6 +6560,14 @@ jobs:
       # meaning anything — and an advisory gate over that is a gate nobody's
       # merge waits on.
       - hicasso-facade-inventory
+      # rf2-r5iy7 — required for the same reason, one gate over, and on the
+      # starkest version of it: the guide tree this gate reads arms NO
+      # classifier output at all, so before this job every guide-only PR ran
+      # the check nowhere. A job absent from this list is advisory whatever its
+      # own gate says, which would leave the 188 pinned samples policed only on
+      # PRs that happen to touch hicasso source — i.e. on somebody other than
+      # the author of the drift.
+      - hicasso-guide-samples
       # rf2-3mh2f — the .beads guard's CI arm. Required, so the tracker
       # database cannot ride a PR past a `--no-verify` or an uninstalled hook.
       - beads-pr-boundary

--- a/scripts/check_fast_pr_gap.py
+++ b/scripts/check_fast_pr_gap.py
@@ -295,6 +295,20 @@ SPINE_LANES = (
         "spine node tier: 'hicasso invariants gate' chains this checker "
         "(`npm run test:hicasso-invariants`), both modes",
     ),
+    # rf2-r5iy7 — the guide-sample gate's own unconditional job, the fourth
+    # instance of the shape above and the starkest: `docs/core/hicasso/**` is
+    # HALF this checker's input and arms no classifier output whatsoever (all
+    # thirty-two measure false), so the npm chain alone left every guide-only
+    # PR running it nowhere.  The spine covers both homes through the chain, so
+    # the job's two steps are not a local gap; without this lane they would be
+    # reported as one, which is the same lie in the opposite direction.
+    Lane(
+        "hicasso-guide-samples",
+        r"^python implementation/hicasso/scripts/check_guide_samples\.py"
+        r"(?: --self-test)?$",
+        "spine node tier: 'hicasso invariants gate' chains this checker "
+        "(`npm run test:hicasso-invariants`), both modes",
+    ),
     Lane(
         "mkdocs-strict",
         r"^mkdocs build --strict$",


### PR DESCRIPTION
Arms `implementation/hicasso/scripts/check_guide_samples.py` in required CI. Closes rf2-r5iy7.

## The hole, re-measured at source

The checker pins 188 fenced blocks across the 25 guide pages and resolves 34 hicasso verb use-sites. It reaches CI only through `npm run test:hicasso-invariants`, whose one hosted invocation is a step of the `cljs` job under `cljs_node_test`.

It reads **two** input families — read off the script rather than assumed (`GUIDE_DIR` L121, `SOURCE_ROOTS` L128-131):

| family | arms |
| --- | --- |
| `docs/core/hicasso/**` — the pages it pins | **nothing at all** |
| `implementation/hicasso/src`, `.../test_kit/src` — the verb sources | `cljs_node_test` |

Measured, exit 0 captured both times:

```
bash .github/scripts/report-changed-surfaces.sh docs/core/hicasso/00-installation.md   -> 32 outputs, ALL false
bash .github/scripts/report-changed-surfaces.sh docs/core/hicasso/02-views-and-reads.md -> 32 outputs, ALL false
```

So a guide-only PR — the commonest edit against a documentation tree, and precisely the class this gate exists to police — ran the check nowhere, and would next redden on somebody else's source PR over a block they did not write.

## Unconditional, and why

`hicasso-guide-samples` is the fourth unconditional hicasso contract job, the same shape as `hicasso-complaint-catalogue`, `hicasso-budget-ledger` and `hicasso-facade-inventory`: checkout, setup-python, `--self-test`, live run, `timeout-minutes: 5`. It is in `all-required-passed`'s `needs:` — a job absent from that list is advisory whatever its own gate says.

The gated alternatives were measured, not assumed:

- **Arming the existing `cljs_node_test` from `docs/core/hicasso/**`** — that output is consumed by exactly **one** job, the ~10-minute node build. Fan-out 1, but it would schedule a ten-minute build on a prose typo. Rejected.
- **A new dedicated classifier output** — fan-out 1 (this job alone), but it costs an arm in `report-changed-surfaces.sh` plus a pin in `_changed-surfaces.test.cjs`, and would need re-widening every time the checker learns to read another file. It already reads two families across two trees. That is a fresh chance to make the very mistake being repaired. Rejected.

The work is sub-second pure Python — **measured 0.31s self-test + 0.61s live, 0.92s total**, no node, no JVM — so there is nothing to gate for. This is the cheapest of the four (siblings measured 6.85s, 1.25s, 0.68s).

Folding the four into one job stays **rejected**, per the bead's recorded refusal: separate named jobs give precise failure attribution on the checks list.

## The band

`scripts/check_fast_pr_gap.py --list` reports **96 both before and after this change** — I measured the baseline myself on `origin/main` @ `5a4c765fc7` rather than trusting a quoted count.

The band is **invariant** here, which is the correct outcome and worth stating precisely: the spine already runs this checker through the chain (`scripts/test-fast-pr.sh:1486`), so the new job's two steps are not a local gap. The matching `SPINE_LANES` entry records that. Without it the band would read **98** — proven by rebuilding the map with the lane removed in memory:

```
WITH lane    -> REQUIRED CHECKS THIS SPINE DOES NOT RUN (96)
WITHOUT lane -> REQUIRED CHECKS THIS SPINE DOES NOT RUN (98)
```

That is the same over-report the three sibling lanes exist to prevent — "the same lie in the opposite direction", in the file's own words.

No classifier arm is added or moved, so `_changed-surfaces.test.cjs` needed no companion edit; it passes unchanged at 372.

## Proof the arming works — planted in the watched thing, not in the gate

Planted drift inside a fenced block of `docs/core/hicasso/02-views-and-reads.md` (`:kind :urgent` -> `:kind :urgentXX`), a **docs-only** change of exactly the class that arms nothing:

```
PLANT_GATE_EXIT=1
FAIL R1 PINNED
  02-views-and-reads.md block 2 has changed - paste (2, "c9aa9499b4fd") (was "118c8d71e8ee")
```

Reverted; `POST_REVERT_EXIT=0`; working tree clean. Proven **locally**; in CI the job is unconditional by construction — no `if:`, no `needs:`, verified by parsing the YAML — so it runs on every diff including this one, and its result on this PR is the CI half of the proof.

## Quality gates

Ran directly, each redirected to its own log with the runner's exit code captured on the same line. **I did not run the full fast-PR spine**: this is a workflow-and-checker change with no CLJS/JVM surface, and a fresh worktree has no `node_modules`, so the spine's node tier would fail for that reason alone rather than for anything in this diff.

| gate | exit |
| --- | --- |
| `python implementation/hicasso/scripts/check_guide_samples.py --self-test` | 0 (0.31s) |
| `python implementation/hicasso/scripts/check_guide_samples.py` (live, on `main`) | 0 (0.61s) — 188 blocks / 25 pages / 34 verb sites |
| `python scripts/check_fast_pr_gap.py --check` | 0 |
| `python scripts/check_fast_pr_gap.py --self-test` | 0 |
| `python scripts/check_fast_pr_gap.py --list` | 0 — band 96 |
| `python scripts/check_gate_scheduling.py` | 0 — 51 gate commands, 43 scheduled, 8 declared |
| `python scripts/check_jvm_lane_rosters.py` | 0 — 34 rostered, bijection holds |
| `python scripts/check_ci_reproduce_commands.py` | 0 — 43 checker steps in sync |
| `python scripts/check_test_lane_bijection.py` | 0 — 1955 files, 50 lanes |
| `node implementation/scripts/_changed-surfaces.test.cjs` | 0 — 372 passed |
| YAML parse + wiring assertion | 0 — 81 jobs, no `if:`/`needs:` on the new job, 80 aggregator needs, no ghosts |

The gate was run against `main` before arming: green, exit 0. Arming it does not red the tree.

Diff is pure addition — 86 insertions, 0 deletions across two files. Nothing in it reverts anything `.github/` has taken this week.
