### PR TITLE
fix(hicasso): fold ASCII case on the file-input type before refusing a :value (rf2-h6qm7)

### DIFF
--- a/implementation/hicasso/src/re_frame/hicasso/impl/controlled.cljs
+++ b/implementation/hicasso/src/re_frame/hicasso/impl/controlled.cljs
@@ -552,10 +552,33 @@
   becomes `\"0\"` and throws like any other non-empty string. `identical?`
   is the right test for exactly that reason — it is React's own `===`
   against the element's empty answer, not a value comparison that would
-  read `0` as empty."
+  read `0` as empty.
+
+  **The TYPE, unlike the value, is folded before it is compared
+  (rf2-h6qm7).** This predicate runs against the props object, which is
+  the author's spelling — `:type \"FILE\"`, or the keyword `:file`
+  spelled `:FILE`, both of which
+  [[re-frame.hicasso.impl.codec/convert-prop-value]] hands on unchanged.
+  The PLATFORM does not read it that way: an HTML `type` attribute is an
+  enumerated attribute matched ASCII case-insensitively, so
+  `<input type=\"FILE\">` is a file input, `.type` answers `\"file\"`,
+  and `element.value = \"budget.csv\"` throws exactly the
+  `InvalidStateError` this refusal exists to replace. An exact compare
+  here refused the one spelling in sixteen that authors happen to write
+  and let the other fifteen through to the engine — worse than no
+  refusal, because the hole is invisible.
+
+  So the fold is at the COMPARISON and nowhere else. Normalising
+  `js-props` would be the other way to close it and is the wrong one:
+  this object is what React consumes and what reaches the DOM, and the
+  attribute that ships must stay the attribute the author wrote. The
+  `string?` guard is what makes the fold total — `:type 0` survives
+  [[re-frame.hicasso.impl.codec/convert-prop-value]] as a number, which
+  has no `toLowerCase`."
   [tag js-props]
   (and (identical? "input" tag)
-       (identical? "file" (unchecked-get js-props "type"))
+       (let [t (unchecked-get js-props "type")]
+         (and (string? t) (identical? "file" (.toLowerCase t))))
        (not (identical? "" (unchecked-get js-props "value")))))
 
 (defn- convergeable?
@@ -755,14 +778,18 @@
   `:rf.error/hicasso-file-input-value-prop`. It is placed there and not
   earlier so that a page with no controlled inputs pays nothing for it:
   everything that is not an `input`/`textarea` carrying a `:value` has
-  already gone out the other arm, and what remains pays one string
-  compare and one property read. Unlike the revision refusal above, this
-  one stands in front of an exception rather than a silence — React's
-  controlled mirror would reach `element.value = …` and the platform
-  would throw `InvalidStateError` from inside the commit, attributing
-  nothing. See [[file-input-value?]] for why the predicate is non-EMPTY
-  rather than non-nil, and `re-frame.hicasso.impl.intent/target-value`
-  for the same control's other half."
+  already gone out the other arm, and what remains pays one property
+  read and one ASCII case fold, which an engine answers by handing back
+  an already-lowercase string unchanged. Unlike the revision refusal
+  above, this one stands in front of an exception rather than a
+  silence — React's controlled mirror would reach `element.value = …`
+  and the platform would throw `InvalidStateError` from inside the
+  commit, attributing nothing. See [[file-input-value?]] for why the
+  predicate is non-EMPTY rather than non-nil and why the TYPE is folded
+  where the value is not, and `re-frame.hicasso.impl.intent/target-value`
+  for the same control's other half — which needs no fold of its own,
+  because it reads the LIVE element and the platform has already
+  normalised the type by the time it looks."
   [tag js-props]
   (when-not (undefined? (unchecked-get js-props revision-slot))
     (js-delete js-props revision-slot)

--- a/implementation/hicasso/test/re_frame/hicasso/file_input_value_dom_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/file_input_value_dom_cljs_test.cljs
@@ -45,6 +45,24 @@
   only model-driven clear away from the author. The predicate is
   non-EMPTY.
 
+  ## The spelling is the platform's, not the author's (rf2-h6qm7)
+
+  The prop refusal shipped comparing the `type` prop exactly, and an HTML
+  `type` is an enumerated attribute the platform matches ASCII
+  case-insensitively. So `:type \"FILE\"` was a file input to the engine
+  and not to the predicate: the refusal did not fire, React took the
+  controlled path anyway, and the engine threw the very
+  `InvalidStateError` the refusal exists to replace — one spelling in
+  sixteen refused, fifteen through. Worse than no refusal, because a hole
+  that shape is invisible from the outside.
+
+  The two readers answer this differently and both answers are right. The
+  PROP predicate reads the author's props object before React builds
+  anything, so a spelling is all it has and it folds. The MARKER reads a
+  LIVE element on an event, where the platform has already resolved the
+  type, and asks `.files` — a property of the resolved control rather
+  than a string anyone spelled. One row below measures each.
+
   ## The platform control stays
 
   The direct `node.value = …` rows are not redundant with the refusals.
@@ -94,12 +112,16 @@
 (defn- id-of [e] (:rf.error/id (ex-data e)))
 
 (defn- file-input!
-  "A real `<input type=file>` in the document."
-  []
-  (let [n (js/document.createElement "input")]
-    (set! (.-type n) "file")
-    (.appendChild js/document.body n)
-    n))
+  "A real `<input type=file>` in the document, at the given SPELLING of
+  the type attribute — `setAttribute`, so the attribute keeps the
+  author's case and only the IDL normalises it, which is the asymmetry
+  rf2-h6qm7 turns on."
+  ([] (file-input! "file"))
+  ([spelling]
+   (let [n (js/document.createElement "input")]
+     (.setAttribute n "type" spelling)
+     (.appendChild js/document.body n)
+     n)))
 
 (defn- drop! [n] (.remove n) nil)
 
@@ -231,6 +253,73 @@
             (thrown-by #(react-dom/flushSync (fn [] (.unmount root))))
             (drop-container! c)))))))
 
+(deftest the-type-spelling-is-the-platforms-not-the-authors
+  (testing "an HTML `type` is an enumerated attribute matched ASCII
+           case-insensitively, so every spelling below IS a file input as
+           far as the engine is concerned, and every one of them used to
+           walk past a refusal that compared the string exactly
+           (rf2-h6qm7). The keyword spellings are here because
+           `convert-prop-value` hands React `(name kw)` unchanged, so the
+           author's case survives into the props object either way."
+    (doseq [[what hiccup]
+            [["the shouted string, which is the spelling the audit found"
+              [:input {:type "FILE" :value "budget.csv"
+                       :on-change noop-change}]]
+             ["the shouted keyword, the same attribute by the other door"
+              [:input {:type :FILE :value "budget.csv"
+                       :on-change noop-change}]]
+             ["title case, which is what a form generator emits"
+              [:input {:type "File" :value "budget.csv"
+                       :on-change noop-change}]]
+             ["and a mixed spelling, since the fold is total rather than a
+               list of the plausible ones"
+              [:input {:type "fIlE" :value "budget.csv"
+                       :on-change noop-change}]]]]
+      (is (= :rf.error/hicasso-file-input-value-prop
+             (id-of (thrown-by #(codec/as-element hiccup))))
+          what)))
+  (testing "and the empty value stays the reset idiom at EVERY spelling —
+           the fold widened which controls the predicate recognises, not
+           which values it refuses"
+    (is (nil? (thrown-by #(codec/as-element
+                           [:input {:type "FILE" :value ""
+                                    :on-change noop-change}])))))
+  (testing "a type that merely CONTAINS the letters is not the control"
+    (doseq [hiccup [[:input {:type "profile" :value "x" :on-change noop-change}]
+                    [:input {:type "filename" :value "x" :on-change noop-change}]]]
+      (is (nil? (thrown-by #(codec/as-element hiccup))))))
+  (testing "and a non-string :type, which `convert-prop-value` leaves as a
+           number, is asked the question without being handed to a string
+           method"
+    (is (nil? (thrown-by #(codec/as-element
+                           [:input {:type 0 :value "x"
+                                    :on-change noop-change}]))))))
+
+(deftest mounting-a-shouted-file-input-never-reaches-the-platform-write
+  (testing "the same measurement as the row above, at the shouted
+           spelling — and the reason this one is worth its own mount.
+           Before the fold the engine's `InvalidStateError` did not even
+           arrive at the caller: React caught it inside its own commit
+           and re-reported it as an UNCAUGHT page error, so the author
+           had neither an id nor an exception to catch."
+    (if-not (browser?)
+      (skip! "React's assignment needs React's own commit")
+      (let [c    (container!)
+            root (react-dom-client/createRoot c)]
+        (try
+          (let [t (thrown-by
+                   #(react-dom/flushSync
+                     (fn []
+                       (.render root (codec/as-element
+                                      [:input {:type "FILE" :value "budget.csv"
+                                               :on-change noop-change}])))))]
+            (is (= :rf.error/hicasso-file-input-value-prop (id-of t))
+                "the refusal arrives, and it arrives at the call site")
+            (is (not (instance? js/DOMException t))))
+          (finally
+            (thrown-by #(react-dom/flushSync (fn [] (.unmount root))))
+            (drop-container! c)))))))
+
 ;; ---------------------------------------------------------------------------
 ;; 2 — THE MARKER (rf2-lhsvs)
 ;; ---------------------------------------------------------------------------
@@ -322,3 +411,32 @@
                                [:app/upload :re-frame.hicasso/value]
                                (ev n)))))))))
         (finally (drop! n))))))
+
+(deftest the-marker-needed-no-fold-of-its-own
+  (testing "the prop refusal had to be taught the platform's
+           case-insensitive `type` matching (rf2-h6qm7); this one did not,
+           and the difference is WHERE each looks. The prop predicate runs
+           against the author's props object before React builds anything,
+           so the author's spelling is all it has. The marker runs against
+           a LIVE element on an event, by which time the platform has
+           already resolved the type — and it asks `.files`, which is a
+           property of the resolved control rather than a string anyone
+           spelled. Two readers of one control, and only one of them can
+           be fooled by shouting."
+    (if-not (browser?)
+      (skip! "only a live element can carry the platform's own normalisation")
+      (let [n (file-input! "FILE")]
+        (try
+          (is (= "FILE" (.getAttribute n "type"))
+              "the attribute keeps the author's case")
+          (is (= "file" (.-type n))
+              "and the IDL answers the platform's, which is the whole asymmetry")
+          (is (some? (.-files n))
+              "so the discriminator the marker reads is present, unshouted")
+          (is (= :rf.error/hicasso-file-input-value-marker
+                 (id-of (thrown-by
+                         #(intent/materialize
+                           [:app/upload :re-frame.hicasso/value] (ev n)))))
+              "and the marker refusal fires at this spelling exactly as at
+               the lowercase one — it always did")
+          (finally (drop! n)))))))


### PR DESCRIPTION
Closes rf2-h6qm7.

## The hole

`impl.controlled/file-input-value?` identified a file control with
`(identical? "file" (unchecked-get js-props "type"))` — an exact compare, against
the author's props object, before React builds anything. An HTML `type` is an
enumerated attribute the platform matches **ASCII case-insensitively**, and
`codec/convert-prop-value` hands strings on unchanged and a keyword on as
`(name kw)`, so `:type "FILE"` and `:type :FILE` both arrived spelled the way the
author wrote them and missed the refusal. One spelling in sixteen refused,
fifteen through.

Reproduced in Chromium before the fix, at the merge base, in the real
`:browser-test` lane. The engine's own message, verbatim:

```
InvalidStateError: Failed to set the 'value' property on 'HTMLInputElement': This input element accepts a filename, which may only be programmatically set to the empty string.
    at setInitialProperties (…/react_dom_client_development.js:10689:11)
    at completeWork (…:6816:24)
```

It is worse than the bead recorded, and the new mount row now says so: React
caught that exception inside its own commit and re-reported it as an **uncaught
page error**, so `thrown-by` around the `flushSync` returned `nil`. The author
had neither an `:rf.error/id` nor an exception to catch — only a console entry
naming React's internals.

## The repair

The fold is at the comparison and nowhere else:

```clj
(and (identical? "input" tag)
     (let [t (unchecked-get js-props "type")]
       (and (string? t) (identical? "file" (.toLowerCase t))))
     (not (identical? "" (unchecked-get js-props "value"))))
```

- **Not by normalising `js-props`.** That object is what React consumes and what
  reaches the DOM; the attribute that ships stays the attribute the author wrote.
- **The value predicate is untouched.** Still non-EMPTY, not non-nil, so
  `:value ""` — the reset idiom, and the one write the platform accepts — remains
  accepted, now at every spelling. Its original witness and a new shouted-spelling
  row both assert it.
- **`string?` is what makes the fold total.** `:type 0` survives
  `convert-prop-value` as a number, which has no `toLowerCase`.
- **No new error id, and no spec/009 or catalogue co-edit.** The two existing ids
  already cover both seams and stay separate, because they have different
  recoveries: `:rf.error/hicasso-file-input-value-prop` (delete the prop) at
  `install!`, `:rf.error/hicasso-file-input-value-marker` (read `.files` in an
  `h/fn`) at `intent/target-value`.

## The other half of the family needs no fold, and a row now proves it

`intent/target-value` reads a **live element** on an event, where the platform
has already resolved the type, and asks `.files` — a property of the resolved
control rather than a string anyone spelled. `the-marker-needed-no-fold-of-its-own`
mounts a real `<input>` with `setAttribute("type", "FILE")` and measures the
asymmetry directly: the attribute answers `FILE`, the IDL answers `file`, `.files`
is present, and the marker refusal fires exactly as at the lowercase spelling. It
passed **red and green**, which is the point — the bug was never there.

## Reported, not fixed

`caret-types` (`controlled.cljs:484`) compares the same `type` attribute exactly
via `(contains? caret-types t)` in `caret-type?`, through the identical door: same
props object, same reader, same unchanged spelling. It is **reachable** —
`caret-type?` is a conjunct of `convergeable?`, so `[:input {:type "TEXT" …}]`
silently loses the same-turn converge and the caret restoration. It is a silent
degradation to React's own restore rather than a throw, folding it costs a
`.toLowerCase` on a hotter path, and rf2-h6qm7 ruled the repair to the file
comparison only — so it is filed as **rf2-7ae61** rather than folded in here.

Two adjacent classes deliberately out of scope, because they are not the same
defect: `(case tag ("input" "textarea"))` compares HTML **tag** names exactly, and
`slot.cljc`'s `#{"aria" "data"}` / `{"class" … "for" … "charset" …}` compare
attribute **names** exactly. React itself keys off those exact strings, so a
shouted spelling never reaches the controlled path at all rather than reaching it
unguarded.

## Quality gates

`scripts/check_fast_pr_gap.py --list` reports **96 required checks the fast spine
does not run** — green locally is not green in CI, and none of those 96 is decided
here. The spine was run, plus the gates below directly.

Captured from my own logs, never the harness's:

| gate | result | exit |
|---|---|---|
| baseline — focused `:browser-test`, merge base, unchanged tree | Ran 9 tests containing 35 assertions. 0 failures, 0 errors. | 0 |
| **RED** — new witnesses, pre-fix source (`3d0c1b037f`) | Ran 12 tests containing 49 assertions. **5 failures**, 0 errors. | 1 |
| **GREEN** — new witnesses, fixed source (`063c77c19e`) | Ran 12 tests containing 49 assertions. 0 failures, 0 errors. | 0 |
| `npm run test:browser` (full lane) | Ran 1545 tests containing 9793 assertions. 0 failures, 0 errors. | 0 |
| `npm run test:cljs` (node lane) | Ran 13944 tests containing 70429 assertions. 0 failures, 0 errors. | 0 |
| `npm run test:hicasso-invariants` | all pass, incl. `check_complaint_catalogue.py` | 0 |
| `npm run test:hicasso-controlled` (testbed) | pass | 0 |
| `scripts/test-fast-pr.sh` | `PASS fast PR spine` | 0 |

The spine exceeds the harness's foreground ceiling, so it was detached and polled
on both its log and its exit file in bounded loops within the same turn. Its
`check_complaint_catalogue` step is the direct confirmation that no id moved:
*76 live, 6 reserved, 1 pending retirement, 1 retired; every live row is emitted
and rowed in Spec 009.*

The five red failures are exactly the five new assertions —
`the-type-spelling-is-the-platforms-not-the-authors` ×4 (shouted string, shouted
keyword, title case, mixed case) and `mounting-a-shouted-file-input-never-reaches-the-platform-write`
×1. The reset-idiom rows, the non-file rows and both marker rows passed in **both**
states, which is what says the fold widened which controls the predicate
recognises rather than which values it refuses.

The four `:infer-warning`s in the browser compile are pre-existing, all in
`native_ssr_dom_cljs_test.cljs`, none in a file this PR touches.

Prose was edited inside a test namespace, so the browser lane was compiled and run
after every prose edit — the green figures above are post-prose.
