### PR TITLE
fix(hicasso): fold ASCII case on the caret type before refusing the converge (rf2-7ae61)

### DIFF
--- a/implementation/hicasso/src/re_frame/hicasso/impl/controlled.cljs
+++ b/implementation/hicasso/src/re_frame/hicasso/impl/controlled.cljs
@@ -120,8 +120,10 @@
     honours it over the mirror (`:1852-1853`), so the record would be
     the author's constant rather than the rendered value.
   - **A type whose text cursor exists** — `text`, `search`, `url`,
-    `tel`, `password`, or no `:type` at all, which is `text`.
-    `setSelectionRange` is not applicable to the others, and
+    `tel`, `password`, or no `:type` at all, which is `text`. Read at
+    the PLATFORM's spelling rather than the author's, which is the fold
+    [[caret-type?]] carries and [[file-input-value?]] carries for the
+    same attribute. `setSelectionRange` is not applicable to the others, and
     `setDefaultValue` deliberately skips a focused `number` field
     (`:1738`), so the two exclusions are the same exclusion. React's own
     restore still converges the *value* on those types; there was never
@@ -480,7 +482,10 @@
 (def ^:private caret-types
   "The `<input>` types with a text entry cursor — the ones
   `setSelectionRange` applies to. Everything else has no caret to lose,
-  and React's own restore already converges its value."
+  and React's own restore already converges its value.
+
+  Spelled as the PLATFORM spells them, which is why [[caret-type?]] folds
+  a prop before asking rather than widening this set."
   #{"text" "search" "url" "tel" "password"})
 
 (defn- convergeable-tag?
@@ -494,11 +499,58 @@
 (defn- caret-type?
   "Does this element have a text cursor? A `<textarea>` always does; an
   `<input>` does for the five applicable types, and for no `:type` at
-  all, which is `text`."
+  all, which is `text`.
+
+  **The type is folded before it is compared (rf2-7ae61), for the reason
+  [[file-input-value?]] states at length about the same attribute.** An
+  HTML `type` is an enumerated attribute the platform matches ASCII
+  case-insensitively, and this predicate reads the PROPS object — the
+  author's spelling, which
+  [[re-frame.hicasso.impl.codec/convert-prop-value]] hands on unchanged
+  from both the string and the keyword door. So `<input type=\"TEXT\">`
+  is a text field with a caret to the engine, and an exact compare said
+  it was not: [[convergeable?]] answered no, [[install!]] wrapped
+  nothing, and the field fell through to React's own end-of-event
+  restore. The value still converged — one beat later, with the caret
+  thrown to the end of the control. No throw, no id, no warning; a
+  subtly worse cursor and nothing to attribute it to, which is the
+  hardest class of report to act on.
+
+  ONE reading of `type` in this namespace, then, rather than two — and
+  the fold is at the COMPARISON here as well, because `js-props` is what
+  React consumes and the attribute that ships must stay the attribute
+  the author wrote. The `string?` guard is what makes it total:
+  `:type 0` survives `convert-prop-value` as a number, which has no
+  `toLowerCase`, so without the guard a silent miss becomes a thrown
+  render.
+
+  **What it costs, measured rather than assumed** — Chromium 147.0.7727.15,
+  medians of seven runs of 10^6 calls, taken twice (before the fold and
+  after) across four type spellings. The fold is **~8 ns per call** over
+  the exact compare (6.2–8.9 ns across the eight readings), and the loop
+  overhead cancels because only the delta is claimed.
+
+  This predicate is reached TWICE per controlled field per render — once
+  from [[install!]] at codec time, once from [[shadow-component]]'s own
+  body — so ~16 ns per field per render, against a measured **13 µs** for
+  React to render and commit one such field: about **0.1%**, which is why
+  the whole-render measurement could not resolve it at all (the run-to-run
+  spread on that path was two orders of magnitude larger than the effect).
+  And it sits behind exactly the gate [[file-input-value?]]'s fold sits
+  behind ([[controlled-text-tag?]]), so a page with no controlled inputs
+  still pays nothing for either.
+
+  A variant that folded only ON A MISS was measured and REJECTED. It is
+  cheaper only for an already-lowercase caret type (23.6–24.7 ns against
+  the fold's 27.5–27.6) and roughly TWICE the cost for every other type
+  (53–71 ns against 28–30), because a miss then pays a set lookup, a fold
+  and a second lookup. More code, and slower on exactly the controlled
+  fields that are not text fields."
   [tag js-props]
   (or (identical? "textarea" tag)
       (let [t (unchecked-get js-props "type")]
-        (or (nil? t) (contains? caret-types t)))))
+        (or (nil? t)
+            (and (string? t) (contains? caret-types (.toLowerCase t)))))))
 
 (defn- change-slot
   "The slot whose handler runs LAST for one keystroke, or nil when the

--- a/implementation/hicasso/test/re_frame/hicasso/controlled_dom_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/controlled_dom_cljs_test.cljs
@@ -384,6 +384,154 @@
       (testing "as is an input with no `:type` at all, which is text"
         (is (not (identical? f (emitted [:input {:value "x" :on-input f}]))))))))
 
+;; ---------------------------------------------------------------------------
+;; The type is the PLATFORM's spelling, not the author's (rf2-7ae61)
+;; ---------------------------------------------------------------------------
+;;
+;; An HTML `type` is an enumerated attribute the platform matches ASCII
+;; case-insensitively, and this predicate reads the author's PROPS object,
+;; where a spelling is all there is. So the rows below are the second half
+;; of the statement `file_input_value_dom_cljs_test` makes about the same
+;; attribute (rf2-h6qm7): ONE reading of `type` in this namespace rather
+;; than two, and the one the platform uses.
+;;
+;; What they replace was silent, which is why it is worth a section. A
+;; shouted spelling failed the guard, so no wrapper was installed and the
+;; field fell through to React's own end-of-event restore: the value still
+;; converged, and the caret went to the end of the control. No throw, no
+;; id, no warning — a subtly worse cursor and nothing to attribute it to.
+
+(defn- attribute-typed!
+  "A real `<input>` whose type ATTRIBUTE keeps the author's case, left as
+  a React render that put `rendered` on it would leave it.
+
+  `setAttribute` rather than the `.type` setter, so the platform's own
+  normalisation stays visible instead of being done for us — that
+  asymmetry between the attribute and the IDL is what these rows turn on,
+  and it is the same one `file_input_value_dom_cljs_test/file-input!`
+  reads on the other control."
+  [spelling rendered]
+  (let [n (js/document.createElement "input")]
+    (.setAttribute n "type" spelling)
+    (.appendChild js/document.body n)
+    (set! (.-defaultValue n) rendered)
+    (set! (.-value n) rendered)
+    n))
+
+(deftest every-spelling-of-a-caret-type-is-the-same-control
+  (let [f       (fn [_e])
+        emitted (fn [hiccup] (slot (codec/as-element hiccup) "onInput"))
+        wrapped? (fn [hiccup] (not (identical? f (emitted hiccup))))]
+    (testing "every caret-bearing type, shouted — each of these IS a text
+             entry control to the engine, and each used to walk past the
+             guard because the comparison was exact"
+      (doseq [t ["TEXT" "SEARCH" "URL" "TEL" "PASSWORD"]]
+        (is (wrapped? [:input {:type t :value "x" :on-input f}])
+            (str "type=" t))))
+    (testing "and the fold is total rather than a list of the plausible
+             spellings — title case is what a form generator emits, and a
+             mixed spelling is the same attribute again"
+      (doseq [t ["Text" "tExT" "Password" "Url"]]
+        (is (wrapped? [:input {:type t :value "x" :on-input f}])
+            (str "type=" t))))
+    (testing "the keyword door reaches the same place: `convert-prop-value`
+             hands React `(name kw)` unchanged, so the author's case
+             survives into the props object either way"
+      (is (wrapped? [:input {:type :TEXT :value "x" :on-input f}]))
+      (is (wrapped? [:input {:type :Password :value "x" :on-input f}])))
+    (testing "while a type with NO caret stays refused at every spelling —
+             the fold widened which spellings the predicate recognises, not
+             which controls it accepts. `setSelectionRange` still throws on
+             these, so a fold that leaked one through would be worse than
+             the hole it closed"
+      ;; `file` is deliberately absent: a controlled `:value` on one is
+      ;; REFUSED outright at every spelling, which is
+      ;; `file_input_value_dom_cljs_test`'s subject and not this row's.
+      (doseq [t ["number" "NUMBER" "Number" "checkbox" "CHECKBOX" "radio"
+                 "RADIO" "date" "DATE" "color" "range" "SUBMIT"]]
+        (is (not (wrapped? [:input {:type t :value "1" :on-input f}]))
+            (str "type=" t))))
+    (testing "a type that merely CONTAINS a caret type's letters is not one"
+      (doseq [t ["textarea" "context" "SEARCHER" "urls"]]
+        (is (not (wrapped? [:input {:type t :value "x" :on-input f}]))
+            (str "type=" t))))
+    (testing "and a non-string `:type`, which `convert-prop-value` leaves as
+             it found it, is asked the question without being handed to a
+             string method. This is the `string?` guard, and it is
+             load-bearing: `(.toLowerCase 0)` is a TypeError, so a fold
+             written without it turns a silent miss into a thrown render"
+      (is (not (wrapped? [:input {:type 0 :value "x" :on-input f}])))
+      (is (not (wrapped? [:input {:type 1 :value "x" :on-input f}])))
+      (is (not (wrapped? [:input {:type true :value "x" :on-input f}]))))))
+
+(deftest a-shouted-type-converges-in-turn-with-the-caret-where-the-edit-left-it
+  (testing "THE DEFECT, on the control it was about. The field held
+           `12345`, the user typed `z` at 2, and the model REFUSED it — so
+           the element still renders `12345` and the converge has a
+           character to take off the screen inside the event.
+
+           Before the fold this row read `{:value \"12z345\" :caret [3 3]}`:
+           no wrapper was installed, so nothing ran, and the field was left
+           holding the refused character until React's own end-of-event
+           restore removed it a beat later with the caret at the end. The
+           lowercase companion is
+           `a-controlled-field-converges-through-the-handler-the-codec-emitted`,
+           and the whole of the difference between them was the spelling."
+    (if-not (browser?)
+      (skip! ":node-test has no DOM")
+      (let [!ran (atom 0)
+            node (attribute-typed! "TEXT" "12345")]
+        (try
+          (is (= "TEXT" (.getAttribute node "type"))
+              "the attribute keeps the author's case")
+          (is (= "text" (.-type node))
+              "and the IDL answers the platform's — this IS a text input,
+               with a caret, which is why the miss was a defect rather than
+               a taste")
+          (typed! node "z" 2)
+          (is (= {:value "12345" :caret [2 2]}
+                 (fire! [:input {:type     "TEXT"
+                                 :value    "12345"
+                                 :on-input (fn [_e] (swap! !ran inc))}]
+                        "onInput" node))
+              "the refused character is off the screen in-turn, and the
+               caret is at the position before it")
+          (is (= 1 @!ran) "and the author's own handler ran, once")
+          (finally (drop! node))))))
+  (testing "a shouted `password` field is the same control and the same
+           converge — the row above is not a special case for `text`"
+    (if-not (browser?)
+      (skip! ":node-test has no DOM")
+      (let [node (attribute-typed! "PASSWORD" "12345")]
+        (try
+          (is (= "password" (.-type node)))
+          (typed! node "z" 2)
+          (is (= {:value "12345" :caret [2 2]}
+                 (fire! [:input {:type "PASSWORD" :value "12345"
+                                 :on-input (fn [_e])}]
+                        "onInput" node)))
+          (finally (drop! node)))))))
+
+(deftest the-element-type-does-not-move-when-the-type-is-shouted
+  (testing "the safety property, and the reason the fold cannot cost a
+           remount. The component is chosen by `controlled-text-tag?`,
+           which is deliberately type-BLIND, so widening the CARET question
+           moves nothing React keys off. A field re-rendered from `text` to
+           `TEXT` — or the other way — keeps its element type, and
+           therefore its node, its focus and any composition in flight.
+
+           This row reads the same in both states, before the fold and
+           after, which is what makes it a statement about the design
+           rather than about the repair."
+    (let [f   (fn [_e])
+          typ (fn [t] (.-type (codec/as-element
+                               [:input (cond-> {:value "1" :on-input f}
+                                         (some? t) (assoc :type t))])))]
+      (is (identical? (typ "text") (typ "TEXT")))
+      (is (identical? (typ "TEXT") (typ "NUMBER")))
+      (is (identical? (typ "TEXT") (typ nil)))
+      (is (identical? (typ "PASSWORD") (typ "checkbox"))))))
+
 (deftest a-controlled-field-with-no-change-handler-has-nothing-wrapped
   (testing "there is no slot to install into, and the codec does not mint
            one — an element with no handler comes out with no handler"


### PR DESCRIPTION
Closes rf2-7ae61.

`impl.controlled/caret-type?` compared the HTML `type` prop exactly against
`#{"text" "search" "url" "tel" "password"}`. An HTML `type` is an enumerated
attribute the platform matches **ASCII case-insensitively**, so
`<input type="TEXT">` is a text field with a caret to the engine and was not
one to the predicate. `caret-type?` is a conjunct of `convergeable?`, so the
miss meant `install!` wrapped no change handler and the field fell through to
React's own end-of-event restore.

This is the second and last exact comparison of that attribute in the file;
rf2-h6qm7 / #8216 closed the first one, on `file-input-value?`. The namespace
now has **one** reading of `type` rather than two.

## The defect, reproduced before the fold

`a-shouted-type-converges-in-turn-with-the-caret-where-the-edit-left-it`, on a
real `<input>` whose type **attribute** is `TEXT` and whose IDL `.type`
answers `text`. The field held `12345`, the user typed `z` at 2, the model
refused it:

```
expected: (= {:value "12345", :caret [2 2]} (fire! [:input {:type "TEXT", ...}] "onInput" node))
  actual: (not (= {:value "12345", :caret [2 2]} {:value "12z345", :caret [3 3]}))
```

The refused character stayed on screen and the caret sat one further along —
no throw, no id, no warning, and React's own restore removed it a beat later
with the caret at the end of the control. A subtly worse cursor with nothing
to attribute it to.

Red state: 13 failures + 2 errors across the new rows. Green: 0.

## The cost, which was the actual question

The bead filed this as a **cost decision, not a bug hunt** — the sibling
worker declined to fold it in because a case fold here was thought to sit on
a hotter path. So it was measured rather than argued.

Chromium 147.0.7727.15, medians of seven runs of 10^6 calls, taken twice
(before the fold and after) across four type spellings:

| | ns/call |
|---|---|
| exact compare (before) | 18.7 – 21.9 |
| folded compare (after) | 27.5 – 30.2 |
| **fold delta** | **6.2 – 8.9 (~8)** |

The predicate is reached **twice** per controlled field per render — once
from `install!` at codec time, once from `shadow-component`'s own body — so
~16 ns per field per render. A real React render + commit of one such field
measured **13 µs**. The fold is about **0.1%** of it, and the whole-render
measurement could not resolve the effect at all: the run-to-run spread on
that path was two orders of magnitude larger than the effect. That
non-result is reported as the finding rather than dressed up as a delta.

### The "hotter path" premise does not survive reading `install!`

`file-input-value?` already runs its `.toLowerCase` for **every** controlled
`<input>` with a string type, not only file ones — the fold is the thing
being compared, so it is evaluated before the `"file"` test can fail. Both
predicates sit behind the identical `controlled-text-tag?` gate, so a page
with no controlled inputs still pays nothing for either. They differ in call
count (2 against 1), not in population.

### A fold-only-on-a-miss variant was measured and rejected

`(or (contains? s t) (and (string? t) (contains? s (.toLowerCase t))))` is
cheaper only for an already-lowercase caret type (23.6–24.7 ns against the
unconditional fold's 27.5–27.6) and roughly **twice** the cost for every
other type (53–71 ns against 28–30), because a miss then pays a set lookup,
a fold and a second lookup. More code, slower on exactly the controlled
fields that are not text fields.

## The `string?` guard is load-bearing

`convert-prop-value`'s `:else` arm hands a number through unchanged, so
`:type 0` reaches the props object as a number and `(.toLowerCase 0)` is a
`TypeError`. Without the guard the fold would turn a silent miss into a
thrown render. Three rows pin it (`0`, `1`, `true`), and they pass in **both**
states — they witness the guard, not the fix.

## What passes in both states, and therefore proves a path was already sound

- **Non-caret types stay refused at every spelling** — `number`, `NUMBER`,
  `Number`, `checkbox`, `CHECKBOX`, `radio`, `RADIO`, `date`, `DATE`,
  `color`, `range`, `SUBMIT`. `setSelectionRange` still throws on these, so a
  fold that leaked one through would be worse than the hole it closed.
- **Non-string types** — `0`, `1`, `true` (above).
- **Types that merely contain the letters** — `textarea`, `context`,
  `SEARCHER`, `urls`.
- **`the-element-type-does-not-move-when-the-type-is-shouted`** — the safety
  property. The component is chosen by `controlled-text-tag?`, which is
  type-blind, so widening the caret question moves nothing React keys off and
  the fold cannot cost a remount.
- **The reset path** — `revision_dom_cljs_test`'s 13 rows are unchanged and
  green; `install!`'s revision acceptance uses the same type-blind
  `controlled-text-tag?`, so the widening does not reach it.
- **The file-input suite** — `file_input_value_dom_cljs_test`'s 12 rows,
  including both case-fold rows from #8216, unchanged and green.

`file` is deliberately absent from the non-caret list above: a controlled
`:value` on one is refused outright at every spelling, which is the other
suite's subject and not this row's.

## Not touched, and why

`test/re_frame/bench/hicasso/front/controlled.cljs` is the frozen bench arm.
Its freeze-manifest row was retired by rf2-hic-007, so `impl/controlled.cljs`
is no longer pinned to it and the two are deliberately allowed to diverge —
which is also how #8216 landed as a one-file change. `npm run
test:hicasso-invariants` (which runs `check_freeze.py`) is green.

No new error id, so no Spec 009 row and no complaint-catalogue row is owed.

## Filed, not fixed

**rf2-z7cfs (P4)** — measured while costing this one, on live elements:
the HTML `type` attribute's *invalid value default* is `text`, so
`<input type="bogus">`, `<input type="">` and `<input type="seach">` all
answer `.type` = `"text"` with a working caret, and `caret-type?` still says
no. Same silent symptom, wider cause, and a genuine design question
(resolve-unknown-to-text, or invert to a deny-list) rather than a widening.
The bead carries the measurement **and the argument for closing it as
minutiae**, so it can be ruled on in one read: `:type "TEXT"` is correct
authoring that silently loses a feature, whereas `:type "seach"` is already
an author error with a visible symptom.

## Quality gates

`scripts/check_fast_pr_gap.py --list` reports **96 required checks the fast
spine does not run**. The diff is two `.cljs` files under
`implementation/hicasso/` (one `src`, one `test`), so the gates that decide it
are the CLJS lanes and the hicasso-owned browser gates. Every one below was
run **directly, in the foreground, to completion**, with the runner's own exit
code captured on the same command line.

| gate | result | exit |
|---|---|---|
| `npm run test:cljs` (`:node-test`, the always-on lane) | Ran 13912 tests / 70278 assertions, 0 failures, 0 errors | `0` |
| `npm run test:browser` (`:browser-test`, headless Chromium — **caches cleared first**) | Ran 1542 tests / 9783 assertions, 0 failures, 0 errors | `0` |
| `npm run test:hicasso-controlled` (controlled-input testbed, Chromium + Firefox + WebKit) | pass | `0` |
| `npm run build:hicasso-release` (`:advanced`, `goog.DEBUG false`, + production-erasure + bundle-isolation checks) | pass | `0` |
| `npm run test:hicasso-invariants` (freeze, complaint catalogue, budget ledger, facade inventory, guide samples) | pass | `0` |
| `scripts/test-fast-pr.sh` | see below | see below |

The full `:browser-test` lane was run **after** the narrowed iteration runs,
from a cleared `.shadow-cljs/builds/browser-test` and `out/browser-test`, so
no `--config-merge` residue could decide it.

Baseline before any change, same two namespaces: 23 tests / 78 assertions,
0 failures (node lane).
