### PR TITLE
docs(gates): the three readers of the build-summary line, and where the optional-module coverage goes (rf2-040s1, rf2-swhjb)

### DIFF
--- a/implementation/hicasso/test/re_frame/bench/hicasso/compile_gate.cjs
+++ b/implementation/hicasso/test/re_frame/bench/hicasso/compile_gate.cjs
@@ -133,6 +133,40 @@
 // over exactly the code it was widened to cover. `compile_gate.test.cjs` pins
 // each refusal.
 //
+// IT IS ALSO THE ONE ENTRY SOURCE HERE THAT IS NOT LANE-SCOPED, and whoever
+// retires this directory owns the consequence (rf2-swhjb). The walk covers this
+// directory and the roster above covers four lane members living elsewhere —
+// both are the bench lane's own business and both should die with it. The
+// optional modules are not: they are PRODUCT code under `hicasso/src/`, and
+// they are compiled here only because this is the one instrument in the
+// repository that would have caught the fault. So if this directory is ever
+// retired, this third entry source must MOVE rather than go with it. Note that
+// neither floor catches that: `MIN_NAMESPACES` reds on the directory EMPTYING
+// and `MIN_MODULE_NAMESPACES` on the roster collapsing, but a gate that has
+// been DELETED reports nothing at all.
+//
+// THAT DECISION IS NOT DUE YET, checked at source rather than assumed
+// (2026-08-14). No retirement covers this directory: rf2-0yp7w retires
+// `implementation/freehand/` and `implementation/ui/`, and hicasso is the
+// survivor of that ruling — a Reagent adapter, a UIx adapter, and hicasso as
+// re-frame2 native. The sibling coupling in rf2-d19nf is live because
+// Freehand's tree has a scheduled deletion; this one does not, and may never.
+//
+// WHAT A RELOCATION WOULD NEED, recorded now so the decision is cheap when it
+// is actually due: somewhere to compile from. This gate takes NO new build id
+// on purpose — see "NO EDIT TO shadow-cljs.edn" above — and rides
+// `:hicasso-bench` through `--config-merge`. A relocated optional-module
+// compile needs either a new build id, which HD-017 makes a hot-zone edit to
+// `implementation/shadow-cljs.edn` and therefore a sequenced dispatch, or
+// another existing id to ride. That is the whole of the design question, and
+// it cannot be answered before the destination exists.
+//
+// NONE OF WHICH IS AN ARGUMENT AGAINST THE WALK, and a later reader must not
+// take it as one. `laneSourceFiles` stays: seeing one directory is this gate's
+// stated point, and a roster in its place would be the staleness class the gate
+// exists to catch. The optional-module entry source added here reads no
+// directory at all — it resolves entirely from the roster.
+//
 // ## `:advanced` — MEASURED, and why there is no nightly release gate
 //
 // This block used to say that an "externs-inference fault" was invisible to a

--- a/implementation/hicasso/test/re_frame/bench/hicasso/lane_build.cjs
+++ b/implementation/hicasso/test/re_frame/bench/hicasso/lane_build.cjs
@@ -65,6 +65,16 @@ const path = require('node:path');
 // text. The lane's build id is a BARE keyword (`[:hicasso-bench]`), unlike the
 // slash-bearing `[:examples/login-uix]` ids `check-examples-compile.cjs`
 // parses — hence a looser bracket match rather than a reuse of that regex.
+//
+// THIS IS THE THIRD OF THREE PARSERS OF THAT LINE, the other two being
+// `scripts/check-examples-compile.cjs` and `scripts/compile-node-test.cjs`. All
+// three refuse an unreadable summary; they are deliberately NOT unified, and
+// `compile-node-test.cjs`'s header holds the roster, the measured reasons and
+// the test for whether a fourth lane should mint its own (rf2-040s1). Note that
+// the bracket is REQUIRED here and optional there: this parser reads zero
+// summaries from a line that carries no `[:id]`, which is fine for a lane that
+// always prints one and is why no single pattern serves all three as they
+// stand.
 const ANSI_RE = /\x1B\[[0-9;]*m/g;
 const COMPLETED_RE = /\[(:[^\]\s]+)\]\s+Build completed\.[^\n]*?(\d+)\s+warnings?/g;
 const FAILED_RE = /\[(:[^\]\s]+)\]\s+Build failed/g;

--- a/implementation/scripts/check-examples-compile.cjs
+++ b/implementation/scripts/check-examples-compile.cjs
@@ -208,6 +208,20 @@ function prefixesBelowFloor(builds) {
 // ourselves and treat any non-zero warnings as a failure. A build that
 // errors hard instead prints `Build failed` (and shadow exits non-zero),
 // which we surface separately via the spawn status.
+//
+// TWO OTHER LANES READ THIS SAME LINE, each with its own four-line parser:
+// `scripts/compile-node-test.cjs` (the `:node-test` family) and
+// `hicasso/test/re_frame/bench/hicasso/lane_build.cjs` (`:hicasso-bench`). All
+// three refuse an unreadable summary; they are deliberately NOT unified, and
+// `compile-node-test.cjs`'s header carries the measured reasons and the test
+// for whether a fourth lane should mint its own (rf2-040s1). Read it before
+// generalising anything here.
+//
+// THE SLASH IN THE PATTERN BELOW IS LOAD-BEARING, and not merely an id capture:
+// `reconcileRequestedBuilds` treats a summary whose id was NOT requested as a
+// failure, so widening this to bare-keyword ids would admit every id shadow
+// prints in the invocation and turn that rule into a live question. Anyone
+// sharing this regex owes that measurement first.
 // ---------------------------------------------------------------------------
 
 const COMPLETED_RE =

--- a/implementation/scripts/compile-node-test.cjs
+++ b/implementation/scripts/compile-node-test.cjs
@@ -103,8 +103,43 @@
 // serve this one; two four-line readers in the lanes that own them is the
 // smaller thing, and the divergence is deliberate where they differ: that gate
 // treats a singular `1 warning` as UNPARSEABLE and fails, this one reads it and
-// fails NAMING the count.  Both red; this one says why.  If a third lane ever
-// wants the same line, that is the moment to mint one reader for all three.
+// fails NAMING the count.  Both red; this one says why.
+//
+// THERE ARE THREE OF US, NOT TWO — and this is the one place that says so
+// (rf2-040s1).  The paragraph above used to close by promising that a third lane
+// wanting this line would be the moment to mint one reader for all three.  The
+// third lane already existed when that was written: `lane_build.cjs` has read
+// the line since 2026-08-03, cites the same examples gate, and gives the same
+// slash-anchor reason for not reusing it.  Two authors hit one wall eleven days
+// apart and neither found the other, which is the defect the count was meant to
+// catch and did not.  So the roster is stated, and the other two files point
+// here rather than restate it:
+//
+//     implementation/scripts/check-examples-compile.cjs   :examples/* + :testbeds/*
+//     implementation/scripts/compile-node-test.cjs        :node-test-family (this)
+//     hicasso/test/re_frame/bench/hicasso/lane_build.cjs  :hicasso-bench
+//
+// THE COUNT WAS STILL THE WRONG TRIGGER, so it is replaced rather than
+// incremented.  MEASURED at three, against the live parsers: no single pattern
+// serves all three as they stand — the examples regex matches ZERO bare-keyword
+// ids, and this one reads a summary carrying no `[:id]` bracket at all, which
+// that lane's regex cannot.  Nor is the examples slash merely a capture: it is a
+// FILTER, and that gate fails on any summary whose id was not requested, so an
+// id-agnostic shared pattern would hand it every id shadow prints and re-open a
+// settled question inside a gate over 54 builds.  What actually differs between
+// the three is not the regex but the SELECTION POLICY over the rows it yields:
+// that gate reconciles a requested SET, `lane_build.cjs` requires every row to
+// read zero, and this one takes the LAST row so a dependency's summary is never
+// mistaken for the lane's.  A shared module would remove three regexes and leave
+// three policies.
+//
+// SO THE TEST FOR THE NEXT LANE IS ITS POLICY, NOT THE HEADCOUNT.  A lane whose
+// selection policy one of the three already implements should call that reader's
+// export — all three export their parser — instead of writing a fourth.  A lane
+// with a genuinely new policy writes its own four lines and adds itself above.
+// Duplication is affordable here precisely because the shared property cannot
+// fail quietly: all three refuse an unreadable summary, so a shadow-cljs
+// reformat produces three RED gates and one afternoon's work, never a pass.
 //
 // NOT A NAG, deliberately.  shadow-cljs already prints its own `Build
 // completed. (N files, M compiled, W warnings, Ts)` line on every run, so the


### PR DESCRIPTION
Two follow-ons to the compile-gate work. **Comment-only** — no parser, threshold, refusal or behaviour changes anywhere in the diff.

Both beads were structural observations filed by workers auditing their own contributions, and both resolve as a recorded refusal rather than a refactor.

## rf2-040s1 — two readers of one line

**There are three, not two.** `implementation/hicasso/test/re_frame/bench/hicasso/lane_build.cjs` has parsed the same `Build completed.` line since 2026-08-03 (`d8f4559d3c`), reaches the same verdict (an unreadable summary is a FAILURE), cites the same examples gate, and gives the same slash-anchor reason for not reusing it. `compile-node-test.cjs` said the same thing eleven days later without knowing it existed. So the bead's own trigger — "unify when a THIRD lane wants the line" — had already fired when the bead was filed.

**Unifying is still the wrong call**, and the reasons are measured against the live parsers rather than assumed:

| measurement | result |
| --- | --- |
| examples regex vs `[:hicasso-bench]` / `[:node-test]` | 0 matches |
| `lane_build.cjs` regex vs a summary with no `[:id]` bracket | 0 matches |
| `compile-node-test.cjs` vs that same bracket-less summary | reads it (deliberately) |
| examples gate given a summary whose id was NOT requested | **fails** — the slash is a filter, not just a capture |

So no single pattern serves all three as they stand, and an id-agnostic shared pattern would hand the examples gate every id shadow prints, moving a currently-settled question into a gate over 54 builds. More to the point, what differs between the three is not the regex but the **selection policy** over the rows it yields — reconcile a requested SET / every row must read zero / take the LAST row so a dependency's summary is never mistaken for the lane's. A shared module removes three regexes and leaves three policies.

And the duplication cannot fail quietly: all three refuse an unreadable summary, so a shadow-cljs reformat produces three RED gates and one afternoon's work, never a silent pass.

**The count is therefore replaced by a policy test rather than incremented**: a lane whose selection policy one of the three already implements calls that reader's export (all three export their parser); a lane with a genuinely new policy writes its own four lines and adds itself to the roster. The real defect the count exposed was discovery — two authors, one wall, neither found the other — so the roster is now stated in all three files, with the full argument in `compile-node-test.cjs` (the file whose closing claim was falsified) and short pointers in the other two, so the prose has one owner and cannot drift.

## rf2-swhjb — the coverage's own location coupling

**The decision is not due, and the premise needed correcting at source.** No retirement covers `implementation/hicasso/test/re_frame/bench/hicasso/`. rf2-0yp7w retires `implementation/freehand/` and `implementation/ui/`, and hicasso is the *survivor* of that ruling. The sibling coupling in rf2-d19nf is live because Freehand's tree has a scheduled deletion; this one does not, and may never — so there is no retirement epic to hang the dependency on, and filing it against rf2-0yp7w would aim it at an epic that never reaches this file.

The record therefore goes **in the file**, which is the one place the person who eventually deletes this directory is guaranteed to be reading. It states why this entry source is different from the other two (the walk and the outside-lane roster are the lane's own business and should die with it; the optional modules are product code under `hicasso/src/` and must move instead), why neither floor catches it (`MIN_NAMESPACES` reds on the directory *emptying*, not on the gate being *deleted*), and what a relocation would need — somewhere to compile from, which is either a new build id (HD-017: a hot-zone edit to `implementation/shadow-cljs.edn`, sequenced) or another id to ride. That question cannot be answered before the destination exists.

**The directory walk is untouched and stays.** `laneSourceFiles` still walks `LANE_DIR`; `--list` enumerates 138 namespaces against a floor of 40. The bead warned a later worker would otherwise "fix" the readdir, so the note says explicitly that none of this is an argument against it.

## Quality gates

`scripts/check_fast_pr_gap.py --list` reports 96 required checks the fast-PR spine does not decide.

**I did not run the spine.** This worktree has no `implementation/node_modules`, so its node tier would fail for that reason alone rather than telling me anything. I ran the CI jobs that actually cover this diff's file extensions instead — the diff is four `.cjs` files, all comment-only.

| gate | how it maps to CI | exit |
| --- | --- | --- |
| `npm run lint:js` (repo root, full `eslint .`) | `lint.yml` → **Lint required** | `0` |
| `npm run test:script-policy` (from `implementation/`) | `test.yml:3469` | `0` |
| `npm run test:script-helpers` (from `implementation/`) | `test.yml:3469` | `0` |
| `node hicasso/.../compile_gate.cjs --list` | exercises the walk + roster + emitter for `test:hicasso-compile` | `0` |

`test:script-policy` carries `check-examples-compile.test.cjs` and `_compile-node-test-warnings.test.cjs`; `test:script-helpers` carries `lane_build.test.cjs` and `compile_gate.test.cjs`. Between them every file in this diff has its pinning suite run.

**Not run:** `npm run test:hicasso-compile` in full (`test.yml:3362`). It spawns a ~77s shadow-cljs compile of 138 namespaces and needs `implementation/node_modules`, which this worktree deliberately does not have — creating that junction is the failure mode that has twice emptied the mayor checkout's real `node_modules`. Its pure half (`compile_gate.test.cjs`) and its derivation (`--list`) are both green above, and the file's change is comment-only.

**Positive controls.** A zero from a gate proves nothing unless the gate can say yes as well as no, so each parser was driven both ways before and after the edit. Every reader ACCEPTS a clean summary (examples → 0 problems; `lane_build` → `ok:true`; `compile-node-test` → tally read, 0 warnings) and every reader REFUSES a garbled one (problems reported / `ok:false` / `null` tally, which returns 1). The regex-coverage and singular-`1 warning` rows in the table above come from that same probe. It also confirmed the bead's claimed divergence at source: the examples gate treats `1 warning` as unparseable and fails, the other two read it and fail naming the count.
