### PR TITLE
docs(story): say why multi-substrate carries two registry lookups (rf2-77kt2)

### DIFF
--- a/tools/story/src/re_frame/story/ui/multi_substrate.cljs
+++ b/tools/story/src/re_frame/story/ui/multi_substrate.cljs
@@ -151,7 +151,27 @@
   result (a hiccup vector for `:reagent`); a missing substrate yields an
   inline diagnostic hiccup rather than throwing, so the render verb's
   caller always sees *something*. `(fn [variant-id view-id args] …)` is the
-  substrate-render contract."
+  substrate-render contract.
+
+  **There are TWO registry lookups in this namespace and they are not
+  redundant.** `safe-render-cell` carries its own, because the two answer
+  at different levels. This fn returns a render RESULT — a fragment whose
+  caller decides where it lands — so a missing substrate degrades to a
+  bare inline diagnostic, shaped like the missing-VIEW one
+  `reagent-render` returns above it. `safe-render-cell` returns a whole
+  grid CELL, chrome included, so its miss has to be a full error cell,
+  and it spends that cell's body naming the `register-substrate!` call
+  the author is missing. Neither can delegate to the other without losing
+  exactly that: this one would hand the host hook a red bordered cell it
+  is not in a grid to justify, and that one would find its error branch
+  unreachable, taking the remediation off the canvas with it.
+
+  The split is a COVERAGE split too, which is the easier half to trip
+  over. The `:uix` arms in `story/ui/render_shell_cljs_test.cljs` drive
+  the canvas grid, so they reach `safe-render-cell` and never arrive
+  here; this fn is covered on its own terms in
+  `story_multi_substrate_cljs_test.cljs` (rf2-nfwbt). A test that
+  exercises one copy settles nothing about the other."
   [substrate variant-id view-id eff-args]
   (if-let [render-fn (get @substrate->render-fn substrate)]
     (render-fn variant-id view-id eff-args)
@@ -232,6 +252,13 @@
   "Render `view-id` under `substrate` inside a try/catch boundary. Per
   `002-Runtime.md` §Substrate hooks a substrate failure surfaces inline rather than
   aborting the whole grid.
+
+  The registry lookup and the missing-substrate diagnostic below are the
+  CELL-level pair. `render-view` above carries the fragment-level pair
+  for the `render-variant` host hook, and its docstring says why the two
+  are kept apart rather than folded together. A test that drives
+  `multi-substrate-grid` exercises this copy and leaves that one
+  untouched.
 
   Returns a Reagent component."
   [variant-id substrate view-id eff-args]


### PR DESCRIPTION
Triage of rf2-77kt2. The bead asked, first, whether the two copies of the substrate-registry lookup in `multi_substrate.cljs` are MEANT to differ — and only then whether to unify.

## Ruling: they are meant to differ

They answer at different levels, and the difference is structural rather than accidental.

- `render-view` returns a render RESULT — a fragment whose caller places it (the `render-variant` host hook, via `render-decorated-view`). Its missing-substrate diagnostic is a bare inline `:div`, styled to match the missing-VIEW diagnostic `reagent-render` returns twenty lines above it.
- `safe-render-cell` returns a whole grid CELL, chrome included. Its miss therefore has to be a full `:error-cell` with a head and a body — and it spends that body naming the `register-substrate!` call the author is missing.

Neither can delegate to the other. Routing `render-view` through `safe-render-cell` hands the host hook a red bordered cell it is not in a grid to justify. Routing `safe-render-cell` through `render-view` makes its `:error-cell` branch unreachable, taking the actionable remediation off the canvas — and the boundary needs `render-fn` closed over inside `:reagent-render` anyway. Unifying would be a regression, so this PR does not.

## What was actually missing

The bead's coverage premise was true when filed and is now closed: commit `5b3adafadc` (rf2-nfwbt — the same bead whose worker filed this one) added both `render-view` arms to `story_multi_substrate_cljs_test.cljs`, and recorded the split in that namespace's comment block and in `tools/story/spec/015-Test-Coverage.md`. Both copies are exercised today.

What remained was the signal *in the source*. A reader editing `render-view` consults neither the test namespace nor the coverage table, so nothing on the page told them a second lookup exists. Both docstrings now name the sibling, the reason the two are kept apart, and the coverage split that follows: the canvas-grid `:uix` arms reach `safe-render-cell` only, so `render-view` is covered on its own terms.

Prose only — no behaviour change, no test change, no new error id.

## Quality gates

Per `scripts/check_fast_pr_gap.py --list`, the fast spine does not decide 96 required checks; none of the three required contexts (`All required checks passed`, `Lint required`, `Docs required`) is settled locally. Gates run directly in this worktree, foreground, redirected to a log with the runner's exit code captured on the same command line:

| Gate | Command | Exit |
|---|---|---|
| Baseline compile (pre-edit) | `node scripts/compile-node-test.cjs node-test out/node-test.js` | `0` |
| Baseline focused run (pre-edit) | `node out/node-test.js --test=re-frame.story-multi-substrate-cljs-test,re-frame.story.ui.render-shell-cljs-test` | `0` — 20 tests, 45 assertions, 0 failures |
| Compile after edit | `node scripts/compile-node-test.cjs node-test out/node-test.js` | `0` |
| Focused run after edit | same selector as baseline | `0` — 20 tests, 45 assertions, 0 failures |

The compile is the load-bearing gate here: prose inside a CLJS docstring is invisible to a test count, and a stray `"` would terminate the string and silently truncate the docstring. The added prose contains no `"` at all — the only added line carrying one is `render-view`'s docstring terminator, confirmed by reading the added lines rather than counting them.

`--test=` selection was positive-controlled before it was trusted: a bogus namespace exits `1` with `no tests matched --test= selector(s)`, so the 20/45 is a real focused selection rather than a silent zero.

Per `rf2-6t03c` this build id was compiled full and narrowed at RUNTIME; no `--config-merge` `:ns-regexp` override was used against `:node-test`.

Not run locally: the browser lanes and the Story browser scenarios. This diff is a docstring and reaches neither.
