### PR TITLE
docs(hicasso): declare the bench element path frozen, not stale (rf2-u9o8k)

### DIFF
--- a/implementation/hicasso/test/re_frame/bench/hicasso/front/controlled.cljs
+++ b/implementation/hicasso/test/re_frame/bench/hicasso/front/controlled.cljs
@@ -1,5 +1,37 @@
 (ns re-frame.bench.hicasso.front.controlled
-  "THE CONTROLLED-ELEMENT CONVERGE — same turn, caret where the edit left
+  "FROZEN — the MEASURED PROTOTYPE, not the shipped element path. What ships
+  is `re-frame.hicasso.impl.controlled`, which rf2-hic-001 copied out of this
+  file and has moved on without ever since.
+
+  **The divergence is expected and permanent, and back-porting into this file
+  is refused.** `implementation/hicasso/frozen-sources.edn` is the authority
+  for both halves, and it is executable rather than prose: its header rules
+  that a fix landing in the PACKAGE leaves the bench tree the stale copy, and
+  its third retirement dropped this file's digest row rather than re-pin it —
+  because this tree is a measured artefact. The clock rows, the ladders and
+  the SSR spike are readings taken from this exact source, so editing it to
+  carry a facility invented afterwards would invalidate the readings the
+  package's own budgets are set against. Nothing pins this file any more;
+  `front/slot.cljc` is the manifest's last surviving row.
+
+  So do not read this file for what ships, and do not repair it against the
+  package. The divergence is not summarised here, because a summary rots —
+  it is read off git, which cannot:
+
+      git log --oneline 93ec92d491.. -- implementation/hicasso/src/re_frame/hicasso/impl/controlled.cljs
+
+  Every commit listed is a package change this file deliberately does not
+  carry. They are refusals and diagnostics: where the package now complains,
+  this file leaves the engine to throw, and where the package folds ASCII
+  case on a type, this file compares it exactly. That is the freeze working
+  as ruled, not a defect here. Its ELEVEN sibling forks under `front/` and
+  `arm1/` stand in exactly the same relation to their package namespaces;
+  rf2-hic-062 owns the tree-level disposition marker that will say so once,
+  and this paragraph is only this file's share of it. (rf2-u9o8k)
+
+  ---
+
+  THE CONTROLLED-ELEMENT CONVERGE — same turn, caret where the edit left
   it (rf2-fki5d, the residue rf2-n3dxw was left open on), and a live IME
   composition carved out of it (rf2-digtt).
 


### PR DESCRIPTION
Closes rf2-u9o8k.

## The verdict: FROZEN BASELINE, not drift

The bead filed both arms and took no action, which was right — the question is
settled by evidence neither of the two files carries, and the answer is that the
divergence is **deliberate, ruled, and permanent**.

`implementation/hicasso/test/re_frame/bench/hicasso/front/controlled.cljs` is not
a copy someone made of the shipped path. It is the **original**, and the shipped
path is the copy:

- `93ec92d491` — *"copy the runtime into implementation/hicasso/ (rf2-hic-001)"* —
  created `impl/controlled.cljs` **from** this file, at 745 lines, the length the
  bench file still has. Its message: *"The bench tree is untouched and still runs;
  it is COPIED FROM, never moved."*
- `git log --follow` on the two paths shows the shared ancestry directly: eleven
  commits in common, then the package's four fixes on one side only.

The ruling is in `implementation/hicasso/frozen-sources.edn`, which is executable
rather than prose:

- **Header, "What a red run means"** — *"the fix landed in the PACKAGE and the bench
  tree is now the stale copy — **that is expected and permanent** … the honest
  response is to retire the row rather than to re-pin it."*
- **"The third retirement"** names `front/controlled.cljs` among the six rows it
  dropped, and rejects the back-port on the record: *"Porting the change BACKWARDS
  into the bench tree was considered and rejected. The prototype … is a MEASURED
  artefact — the clock rows, the ladders and the SSR spike are all readings taken
  from that exact source — and editing it to carry a diagnostic facility invented
  afterwards would invalidate the readings the package's own budgets are set
  against, to buy a digest."*
- **`rf2-0xgk` disposition** — *"the package is the artefact from that commit forward."*
- `TESTING.md` records that **rf2-hic-062 rules the tree keep-as-evidence**.

So updating the fork was never the fix. It would destroy the comparability the file
exists for, against an explicit standing refusal.

## What changed

One thing: the ns docstring now leads with the declaration, because a reader who
opens the file still cannot reach any of the above. It states the freeze, names the
shipped namespace, points at `frozen-sources.edn` as the authority, and gives the
`git log` invocation that shows the live divergence.

**It deliberately publishes no count of the divergence.** A count is exactly the half
that rots — the same defect at one remove — so the file points at git, which cannot.

## No recorded measurement cites this file

Checked before editing, because a rewrite that falsifies a pinned record is the real
hazard here:

- **Freeze manifest** — `check_freeze.py` reports `1 frozen row(s)`, and it is
  `front/slot.cljc`. This file's row was retired by rf2-hic-007; nothing pins it.
- **Provenance pins** — no page under `docs/design/hicasso/` pins a blob digest or a
  line range into the bench file. The only line-range cite found
  (`checkpoint-1-kernel.md:239`, `impl/controlled.cljs:380-381`) is into the **package**.
- **`.json` measurement records** — no file under `bench/hicasso/data/**` names it.
- `production-server-arm.md:282` records `front/controlled.cljs | 620` lines, but that
  table is explicitly *"measured at this page's base commit"* and was already stale at
  745; it is a dated snapshot, not a live assertion. Untouched.

## Quality gates

`scripts/check_fast_pr_gap.py --list` — exit `0`; it enumerates **96 required checks the
fast-PR spine does not run**, so a green spine is not green in CI. Relevant here: the
`cljs` job's compile steps, which is where this file is decided.

Run directly, each redirected to a log with the runner's own exit code echoed on the
same command line (never piped through a filter):

| gate | result | exit |
|---|---|---|
| `npm run test:hicasso-compile` | `138 namespaces compiled with zero warnings`; shadow-cljs `462 files, 461 compiled, 0 warnings, 24.62s` | `0` |
| `npm run test:hicasso-invariants` (full 7-checker chain, each with its `--self-test`) | freeze + optional-module + complaint-catalogue + budget-ledger + example-fence + facade-inventory + guide-samples all OK | `0` |
| `python hicasso/scripts/check_freeze.py` (baseline, before the edit) | `OK: 1 frozen row(s) match` | `0` |

**The compile is the gate that matters and it was run after the prose edit, deliberately.**
Prose inside a test namespace is invisible to the browser gates — a bare `"` in a
docstring terminates a CLJS string silently — so a docstring change here is a compile
change. `test:hicasso-compile` is the gate that actually reaches this namespace
(`test.yml:3362` and `scripts/test-fast-pr.sh:1519`); its `--list` confirms
`re-frame.bench.hicasso.front.controlled` is row 52 of its 138-namespace roster, and it
treats warnings as failures.

Not run, and why: this is a docstring in a bench test namespace. It touches no doc page
(`check_doc_slugs.py` / `check_provenance_pins.py` have no changed surface), no spec, and
no shipped source. CI's `implementation/hicasso/*` arm schedules `cljs_node_test`,
`cljs_browser`, `hicasso_controlled`, `hicasso_hmr` and `migration_hicasso_codemod`.
