### PR TITLE
fix(test): walk nested artefact src roots in both conformance scans (rf2-2cu7f)

### DIFF
--- a/implementation/core/test/re_frame/egress_chokepoint_conformance_test.clj
+++ b/implementation/core/test/re_frame/egress_chokepoint_conformance_test.clj
@@ -33,9 +33,10 @@
 
   ## The ratchet (modelled exactly on error_catalogue_channel_conformance_test)
 
-  SOURCE-SCAN every artefact `src/` tree (reusing `impl-src-roots` /
-  `non-test-source-files` from the error-catalogue test) for the namespaces
-  that CALL either chokepoint, and assert each calling namespace is EITHER:
+  SOURCE-SCAN every artefact `src/` tree — the corpus defined once in
+  `re-frame.impl-source-corpus` and shared with the error-catalogue test —
+  for the namespaces that CALL either chokepoint, and assert each calling
+  namespace is EITHER:
 
     - the `error-emit` chokepoint namespace ITSELF (it defines the fns and its
       `dispatch-frame-teardown-report!` → `dispatch-error-record!` internal
@@ -75,51 +76,22 @@
   JVM-only (`.clj`, NOT `*-cljs-test`): it `slurp`s repo source files, which
   only the JVM `clojure -M:test` runner can do."
   (:require [clojure.test :refer [deftest is testing]]
-            [clojure.java.io :as io]
             [clojure.set :as set]
-            [clojure.string :as str]))
+            [clojure.string :as str]
+            [re-frame.impl-source-corpus :as corpus]))
 
 ;; ---------------------------------------------------------------------------
-;; Source roots + file enumeration (reused verbatim from
-;; error_catalogue_channel_conformance_test — the cmxiss enforcement precedent)
+;; Source roots + file enumeration — `re-frame.impl-source-corpus`, shared with
+;; error_catalogue_channel_conformance_test (the cmxiss enforcement precedent).
+;;
+;; This file used to hold a COPY of that test's enumeration, under a comment
+;; claiming it was "reused verbatim". It was not reused, it was duplicated, and
+;; the duplicate carried the same depth-1 defect: artefact roots enumerated as
+;; `.listFiles(implementation/)` mapped to `<child>/src` never reached the four
+;; adapter artefacts one level deeper, so this ratchet ran on adapter PRs and
+;; walked past 14 production files (rf2-2cu7f). Sharing the definition is what
+;; makes one fix fix both.
 ;; ---------------------------------------------------------------------------
-
-(def ^:private impl-src-roots
-  "Every artefact's non-test source root, resolved from the JVM test CWD
-  (`implementation/core/` per rf2-0hxm → repo root is `../../`). Falls back to
-  the pre-split `../implementation/...` layout for a transitional REPL run from
-  `implementation/`. Only existing dirs are kept."
-  (let [bases ["../../implementation" "../implementation" "../.."]]
-    (->> bases
-         (mapcat (fn [base]
-                   (let [d (io/file base)]
-                     (when (.isDirectory d)
-                       (->> (.listFiles d)
-                            (filter #(.isDirectory %))
-                            (map #(io/file % "src")))))))
-         (filter #(.isDirectory %))
-         distinct
-         vec)))
-
-(def ^:private source-file-exts
-  #{".clj" ".cljc" ".cljs"})
-
-(defn- non-test-source-files
-  "Every `.clj` / `.cljc` / `.cljs` file under the artefact src roots. src roots
-  carry only production source; we guard with a `/test/` path check anyway."
-  []
-  (->> impl-src-roots
-       (mapcat (fn [root] (file-seq root)))
-       (filter #(.isFile %))
-       (filter (fn [f]
-                 (let [n (.getName f)]
-                   (some #(str/ends-with? n %) source-file-exts))))
-       (remove (fn [f]
-                 (let [p (str/replace (.getPath f) "\\" "/")]
-                   (or (str/includes? p "/test/")
-                       (str/ends-with? (.getName f) "_test.clj")
-                       (str/ends-with? (.getName f) "_test.cljc")
-                       (str/ends-with? (.getName f) "_test.cljs")))))))
 
 ;; ---------------------------------------------------------------------------
 ;; The always-on union-record fan-out chokepoints + the routing primitive
@@ -190,7 +162,7 @@
             acc)
           acc)))
     {}
-    (non-test-source-files)))
+    (corpus/non-test-source-files)))
 
 ;; ---------------------------------------------------------------------------
 ;; The self-honest structural-only allow-list (rf2-mrtis6 census B1-B7)
@@ -360,11 +332,29 @@
             the known always-on fan-out chokepoint callers. A zero / tiny
             result means the src roots did not resolve from the test CWD (a
             path-layout change) — fail loudly rather than vacuously passing the
-            coverage invariant below with an empty caller set."
-    (let [roots   impl-src-roots
-          callers (chokepoint-caller-namespaces)]
+            coverage invariant below with an empty caller set.
+
+            `(seq roots)` alone is NOT that guard, and rf2-2cu7f is the proof:
+            for as long as this scan enumerated roots at depth 1 it resolved 16
+            of them, walked 377 files, reached not one of the four nested
+            adapter artefacts, and passed here. A floor on whether the walk
+            found ANYTHING says nothing about whether it found EVERYTHING, so
+            the coverage claim is the cross-check — this corpus against the
+            independently-shaped one the repo's other source-scanning lints
+            use."
+    (let [roots   corpus/src-roots
+          callers (chokepoint-caller-namespaces)
+          {:keys [missing extra]} (corpus/corpus-cross-check)]
       (is (seq roots)
           "at least one artefact src root resolved from the JVM test CWD")
+      (is (empty? missing)
+          (str "the scan MISSED production source that the path-shaped "
+               "enumeration of implementation/**/src/ finds — an artefact root "
+               "the walk does not reach, which is exactly how the adapters went "
+               "unscanned (rf2-2cu7f). Missing: " (pr-str (vec missing))))
+      (is (empty? extra)
+          (str "the scan reached source OUTSIDE implementation/**/src/: "
+               (pr-str (vec extra))))
       ;; The chokepoint definer + at least the SSR caller family must be found.
       (is (contains? callers chokepoint-def-ns)
           (str chokepoint-def-ns " (the chokepoint definer) is among the "

--- a/implementation/core/test/re_frame/error_catalogue_channel_conformance_test.clj
+++ b/implementation/core/test/re_frame/error_catalogue_channel_conformance_test.clj
@@ -120,6 +120,11 @@
             ;; aliased `malli`, not `m` — `parse-tags-schemas` binds a local
             ;; `m` for its matcher and a shadowed alias reads as a bug.
             [malli.core :as malli]
+            ;; The shared definition of the implementation source corpus
+            ;; (rf2-2cu7f). This scan and the egress-chokepoint scan used to
+            ;; carry a copy each; the copies enumerated artefact roots at
+            ;; depth 1 and so walked past all four nested adapter artefacts.
+            [re-frame.impl-source-corpus :as corpus]
             ;; The dual-runtime exercise leg's always-on literal — Test A
             ;; pins it against the parsed catalogue (invariant #4), Test B
             ;; iterates it. Requiring it here closes the coupling in code.
@@ -277,44 +282,14 @@
 ;; form, so coverage is high; widening to follow helper indirection is a
 ;; future tightening, not a correctness gap in the ratchet's promise.
 
-(def ^:private impl-src-roots
-  "Every artefact's non-test source root, resolved from the JVM test CWD
-  (`implementation/core/` per rf2-0hxm → repo root is `../../`). Falls
-  back to the pre-split `../implementation/...` layout for a transitional
-  REPL run from `implementation/`. Only existing dirs are kept."
-  (let [bases ["../../implementation" "../implementation" "../.."]]
-    (->> bases
-         (mapcat (fn [base]
-                   (let [d (io/file base)]
-                     (when (.isDirectory d)
-                       (->> (.listFiles d)
-                            (filter #(.isDirectory %))
-                            (map #(io/file % "src")))))))
-         (filter #(.isDirectory %))
-         distinct
-         vec)))
-
-(def ^:private source-file-exts
-  #{".clj" ".cljc" ".cljs"})
-
-(defn- non-test-source-files
-  "Every `.clj` / `.cljc` / `.cljs` file under the artefact src roots.
-  src roots carry only production source (tests live in sibling `test/`
-  dirs), so no path-based test exclusion is needed; we guard with a
-  `/test/` path check anyway in case a root ever nests one."
-  []
-  (->> impl-src-roots
-       (mapcat (fn [root] (file-seq root)))
-       (filter #(.isFile %))
-       (filter (fn [f]
-                 (let [n (.getName f)]
-                   (some #(str/ends-with? n %) source-file-exts))))
-       (remove (fn [f]
-                 (let [p (str/replace (.getPath f) "\\" "/")]
-                   (or (str/includes? p "/test/")
-                       (str/ends-with? (.getName f) "_test.clj")
-                       (str/ends-with? (.getName f) "_test.cljc")
-                       (str/ends-with? (.getName f) "_test.cljs")))))))
+;; Source roots + file enumeration come from `re-frame.impl-source-corpus`,
+;; which `re-frame.egress-chokepoint-conformance-test` shares. This file
+;; used to define them and that file used to copy them; both copies
+;; enumerated roots at depth 1, so both walked past the four nested adapter
+;; artefacts — 14 production files, invisible to two armed and running
+;; ratchets (rf2-2cu7f). One definition, one depth-independent walk, and
+;; `corpus/corpus-cross-check` as the coverage floor the sanity test below
+;; now asserts.
 
 ;; The keyword char class includes the apostrophe so categories like
 ;; `:rf.warning/large-value-unschema'd` parse whole (NOT truncated at the
@@ -392,7 +367,7 @@
   the first literal keyword arg of `throw-error!` / `thrown-ex-info`, which
   the original emit-only scan was blind to."
   []
-  (->> (non-test-source-files)
+  (->> (corpus/non-test-source-files)
        (mapcat (fn [f]
                  (let [src (slurp f)]
                    (concat (map second (re-seq emit-error-re src))
@@ -426,7 +401,7 @@
   the code fans onto the always-on axis regardless of their catalogue Channel
   cell (rf2-h4f0n)."
   []
-  (->> (non-test-source-files)
+  (->> (corpus/non-test-source-files)
        (mapcat (fn [f] (map second (re-seq always-on-mechanism-re (slurp f)))))
        (map (fn [s] (keyword (subs s 1))))
        set))
@@ -708,11 +683,30 @@
             finds the known emit chokepoints. A zero / tiny result means
             the src roots did not resolve from the test CWD (a path-layout
             change) — fail loudly rather than vacuously passing the
-            coverage invariant below with an empty emitted set."
-    (let [roots impl-src-roots
-          cats  (emitted-categories)]
+            coverage invariant below with an empty emitted set.
+
+            `(seq roots)` alone is NOT that guard, and rf2-2cu7f is the
+            proof: for as long as this scan enumerated roots at depth 1 it
+            resolved 16 of them, walked 377 files, reached not one of the
+            four nested adapter artefacts, and passed here. A floor on
+            whether the walk found ANYTHING says nothing about whether it
+            found EVERYTHING, so the coverage claim is the cross-check —
+            this corpus against the independently-shaped one the repo's
+            other source-scanning lints use."
+    (let [roots      corpus/src-roots
+          cats       (emitted-categories)
+          {:keys [missing extra]} (corpus/corpus-cross-check)]
       (is (seq roots)
           "at least one artefact src root resolved from the JVM test CWD")
+      (is (empty? missing)
+          (str "the scan MISSED production source that the path-shaped "
+               "enumeration of implementation/**/src/ finds — an artefact "
+               "root the walk does not reach, which is exactly how the "
+               "adapters went unscanned (rf2-2cu7f). Missing: "
+               (pr-str (vec missing))))
+      (is (empty? extra)
+          (str "the scan reached source OUTSIDE implementation/**/src/: "
+               (pr-str (vec extra))))
       (is (>= (count cats) 50)
           (str "source scan found the diagnostic/error/advisory emit "
                "vocabulary (>= 50 categories), not a broken / empty scan; "

--- a/implementation/core/test/re_frame/impl_source_corpus.clj
+++ b/implementation/core/test/re_frame/impl_source_corpus.clj
@@ -1,0 +1,151 @@
+(ns re-frame.impl-source-corpus
+  "THE IMPLEMENTATION SOURCE CORPUS — every artefact's production
+  `.clj` / `.cljc` / `.cljs` source, and the ONE definition of it that the
+  source-scanning conformance ratchets share.
+
+  ## Why this namespace exists (rf2-2cu7f)
+
+  Two ratchets scan this corpus for the emit / fan-out sites they govern:
+  `re-frame.error-catalogue-channel-conformance-test` (every emitted
+  `:rf.*` diagnostic category carries a Spec 009 catalogue row) and
+  `re-frame.egress-chokepoint-conformance-test` (every always-on
+  union-record fan-out caller routes through `project-egress`). Both used
+  to carry their OWN copy of the enumeration — the second one's comment
+  said \"reused verbatim from error_catalogue_channel_conformance_test\",
+  which is exactly how a copy drifts and exactly how one fix leaves the
+  other broken. They now share this.
+
+  Both copies enumerated artefact roots as `.listFiles(implementation/)`
+  mapped to `<child>/src` — DEPTH 1. The four adapter artefacts nest one
+  level deeper, at `implementation/adapters/<name>/src`, so they were not
+  roots and were never walked: 14 production files invisible to both
+  ratchets. `implementation/adapters/*/src` DOES arm the `implementation`
+  JVM tier, so on an adapter PR both suites were armed, ran, walked past
+  the adapter tree entirely, and reported green — an uncatalogued
+  `:rf.error/*` channel or an unrouted payload-bearing fan-out added in an
+  adapter passed both ratchets. Measured at the fix: 377 files walked with
+  zero adapter files, against 425 / 14 for the repo's other two
+  source-scanning lints over the same tree.
+
+  `src-roots` therefore finds roots by RECURSIVE SEARCH for directories
+  named `src`, which cannot re-drift when the next artefact nests, and
+  `corpus-cross-check` is the floor that would have caught the original —
+  the suites' sanity tests asserted only `(seq roots)`, which 16 roots and
+  zero adapter files satisfy perfectly well.
+
+  ## JVM-only
+
+  This is `file-seq` + `slurp` over the repo, so only the JVM
+  `clojure -M:test` runner can use it. It is a `test/` support namespace,
+  not a test: it declares the namespace its path spells (the runner's
+  discovery rule) and holds no `deftest`, so discovery loads it and
+  reports nothing for it."
+  (:require [clojure.java.io :as io]
+            [clojure.string :as str]))
+
+(defn- posix
+  "`f`'s path with forward slashes, so one path predicate reads the same on
+  Windows and POSIX."
+  [^java.io.File f]
+  (str/replace (.getPath f) "\\" "/"))
+
+(def implementation-root
+  "`implementation/`, resolved from the JVM test CWD.
+
+  The JVM lane runs each artefact's tests from that artefact's own
+  directory (rf2-0hxm), so from `implementation/core/` the tree is `..` —
+  the same anchor `no-rf-default-floor-lint-test` and
+  `warn-once-clear-governance-test` already use. The other candidates
+  cover a REPL run from a different working directory.
+
+  A candidate is accepted only if it actually CARRIES `core/src`. The walk
+  below is recursive and so has a blast radius: the enumeration this
+  replaced also tried `../..` — the repo ROOT — which was inert against a
+  depth-1 `.listFiles` (no top-level directory has a `src` child) but under
+  recursion would have swept `tools/`, `examples/` and `migration/` into
+  two ratchets scoped to `implementation/`. Identifying the root positively
+  is what makes the recursion safe."
+  (->> ["../../implementation" ".." "../implementation"]
+       (map io/file)
+       (filter #(.isDirectory (io/file % "core" "src")))
+       first))
+
+(def src-roots
+  "Every artefact's non-test source root under `implementation/`, found by
+  recursive search for directories named `src`.
+
+  Depth-independent BY CONSTRUCTION (rf2-2cu7f): `implementation/core/src`
+  sits at depth 1, `implementation/adapters/reagent/src` at depth 2, and a
+  future artefact may nest deeper still. A `src` directory reached through
+  a `test/` path is not production source and is dropped."
+  (when implementation-root
+    (->> (file-seq implementation-root)
+         (filter #(.isDirectory ^java.io.File %))
+         (filter #(= "src" (.getName ^java.io.File %)))
+         (remove #(str/includes? (posix %) "/test/"))
+         (sort-by posix)
+         vec)))
+
+(def ^:private source-file-exts
+  #{".clj" ".cljc" ".cljs"})
+
+(defn- source-file?
+  [^java.io.File f]
+  (let [n (.getName f)]
+    (boolean (some #(str/ends-with? n %) source-file-exts))))
+
+(defn- test-source?
+  "True for anything that is test material rather than production source.
+  `src` roots carry only production source, so this is belt-and-braces
+  against a root that ever nests a `test/` tree or a stray `*_test` file."
+  [^java.io.File f]
+  (let [p (posix f)
+        n (.getName f)]
+    (or (str/includes? p "/test/")
+        (boolean (some #(str/ends-with? n (str "_test" %)) source-file-exts)))))
+
+(defn non-test-source-files
+  "Every production `.clj` / `.cljc` / `.cljs` file under the artefact src
+  roots. A pure filesystem walk — no classpath load — so it sees every
+  artefact regardless of which are on the running suite's classpath."
+  []
+  (->> src-roots
+       (mapcat file-seq)
+       (filter #(.isFile ^java.io.File %))
+       (filter source-file?)
+       (remove test-source?)))
+
+(defn- path-shaped-corpus
+  "The same corpus computed the OTHER way — the shape
+  `no-rf-default-floor-lint-test` and `warn-once-clear-governance-test`
+  use: walk `implementation/` whole and keep files whose path contains
+  `/src/`. It never asks where a root is, so it cannot inherit a depth
+  assumption from `src-roots`."
+  []
+  (->> (file-seq implementation-root)
+       (filter #(.isFile ^java.io.File %))
+       (filter source-file?)
+       (filter #(str/includes? (posix %) "/src/"))
+       (remove test-source?)))
+
+(defn corpus-cross-check
+  "Where the two enumerations DISAGREE, as
+  `{:missing #{path…} :extra #{path…}}` — both empty when they agree.
+
+  `:missing` is source the path-shaped walk finds and `src-roots` does not:
+  the rf2-2cu7f failure exactly, and against the depth-1 enumeration it
+  names all 14 adapter files. `:extra` is the converse — a root reaching
+  outside `implementation/**/src/`.
+
+  This is the floor the two suites lacked. Their sanity tests asserted
+  `(seq roots)` and nothing about coverage, so a walk that found 16 of 20
+  roots and skipped an entire artefact family passed as readily as a
+  correct one. Two enumerations of two different shapes over one corpus is
+  a claim a silent narrowing cannot satisfy — and it also pins these two
+  ratchets to the same corpus as the repo's other source-scanning lints,
+  so the four cannot drift apart about what `implementation/` means."
+  []
+  (let [ours   (into #{} (map posix) (non-test-source-files))
+        theirs (into #{} (map posix) (path-shaped-corpus))]
+    {:missing (into (sorted-set) (remove ours) theirs)
+     :extra   (into (sorted-set) (remove theirs) ours)}))


### PR DESCRIPTION
Closes rf2-2cu7f.

## The defect

`impl-src-roots` enumerated artefact source roots as `.listFiles(implementation/)` mapped to `<child>/src` — **depth 1 only**. The four adapter artefacts nest one level deeper, at `implementation/adapters/{reagent,reagent-slim,uix,test-react}/src`, so they were never roots and were never walked.

`implementation/adapters/*/src` **does** arm `implementation_jvm`. So on an adapter PR both source-scanning ratchets were armed, `jvm-core` ran, both suites executed, walked past the adapter tree entirely, and reported green. An uncatalogued `:rf.error/*` channel or an unrouted payload-bearing egress fan-out added in an adapter passed both ratchets. This is the fail-open that happens **while the gate is running**, not one that needs an unarmed tier.

## The walk, measured by calling the suites' own `non-test-source-files`

| | roots | files walked | adapter files |
|---|---|---|---|
| before | 16 | 377 | **0** |
| after | 25 | **425** | **14** |
| independent walker (`no-rf-default-floor-lint`, `warn-once-clear-governance` shape) | — | **425** | **14** |

The corrected walk lands exactly on what the repo's other two source-scanning lints already see over the same tree.

## What the corrected walk found

**Four previously unscanned emit sites**, all from `implementation/adapters/test-react/src/re_frame/adapter/test_react.cljc` via the `throw-error!` / `thrown-ex-info` arm:

- `:rf.error/mount-child-outside-render`
- `:rf.error/sync-unmount-during-render`
- `:rf.error/test-react-not-installed`
- `:rf.error/update-after-unmount`

All four are **already present in the Spec 009 catalogue**, so nothing needed fixing and nothing needed filing. `emitted-categories` goes 335 → 339; the egress scan's caller set is unchanged at 9. **No new finding, no red, and no suppression** — the hole was live and exploitable but had not yet been exploited. Worth stating plainly, because "the fix produced no findings" is the claim most worth doubting: the mutation proof below is what makes it checkable rather than assertable.

Adjacent context that explains the luck: `scripts/check_keyword_catalogue_drift.py` and `scripts/check_thrown_error_messages.py` both `os.walk` `implementation/` recursively, so the adapters were already inside those gates' corpora. The two JVM ratchets were the outliers.

## The repair

Both suites carried their **own copy** of the enumeration — the egress one under a comment claiming it was `reused verbatim from error_catalogue_channel_conformance_test`. It was not reused, it was duplicated, which is precisely how fixing one would have left the other broken. The definition now lives once, in the new `re-frame.impl-source-corpus`, and finds roots by recursive search for directories named `src`, so it cannot re-drift when the next artefact nests.

**The recursion made an existing base newly dangerous.** The old enumeration tried three bases, one of which was `../..` — the repo **root**. Under a depth-1 `.listFiles` that was inert (no top-level directory has a `src` child, measured). Under recursion it would have swept `tools/`, `examples/` and `migration/` into two ratchets scoped to `implementation/`. `implementation-root` is now identified **positively**, by carrying `core/src`, so the walk's blast radius is bounded by construction.

## The floor that was missing

Both sanity tests asserted only `(is (seq roots))` — which 16 roots and zero adapter files satisfy perfectly well. That is why this was invisible for as long as it was: *did the walk find anything* is not *did the walk find everything*.

`corpus-cross-check` now compares this corpus against a **differently-shaped** enumeration of the same tree (a path predicate over a whole-tree walk, versus a directory-name search), and both suites assert they agree file-for-file. That also pins these two ratchets to the same corpus as `no-rf-default-floor-lint-test` and `warn-once-clear-governance-test`, so the four walkers cannot drift apart about what `implementation/` means.

**Mutation-proven.** Narrowing `src-roots` back to `.listFiles` reds both suites (exit `1`, 2 failures) with a diagnostic naming all 14 adapter files; reverting greens them (exit `0`). A floor that cannot red is theatre, so this was measured, not assumed.

## Quality gates

Run directly in this worktree, exit codes captured on the runner's own line:

| gate | command | exit | result |
|---|---|---|---|
| `jvm-core` (**after**) | `clojure -M:test` in `implementation/core` — the job's exact command | `0` | 2243 tests / **11684** assertions, 0 failures |
| `jvm-core` (**before**, merge-base overlay) | same, both suites overlaid from `origin/main` | `0` | 2243 tests / **11680** assertions, 0 failures |
| the two suites (after) | `-n error-catalogue… -n egress-chokepoint…` | `0` | 30 tests / **139** assertions |
| the two suites (before) | same, merge-base overlay | `0` | 30 tests / **135** assertions |
| mutation proof | `src-roots` narrowed to `.listFiles` | `1` | 2 failures, naming all 14 adapter files |
| `scripts/test-fast-pr.sh` | full spine | `1` | see below |
| `scripts/check_test_lane_bijection.py` | | `0` | 1949 test-defining files, 50 lanes, every file selected |
| `scripts/check_keyword_catalogue_drift.py` | | `0` | silent |
| `scripts/check_thrown_error_messages.py` | | `0` | silent |
| `scripts/check_fast_pr_gap.py` | | `0` | |

**Count change accounted exactly**: +0 tests, +4 assertions — the four new `is` forms (a `missing`/`extra` pair in each suite's sanity test). Both sides measured, neither inferred.

**The fast-PR spine's `1` is an unmet local prerequisite, not a finding.** Its sole `FAIL` is `CLJS node integration`, which cannot resolve `shadow-cljs/cli/runner.js`: this worktree has no `implementation/node_modules` (deliberately — the junction that has twice emptied the mayor's real tree was never created). Everything before it passed, including **clj-kondo under CI's own pinned command** (`--fail-level error`) at **errors: 0**, and `JVM implementation/core` at 2243 / 11684 inside the spine itself.

That lane cannot be affected by this diff regardless: all three files are `.clj`, and a `.clj` on a CLJS source path is a macro namespace loaded only via `:require-macros`. Nothing requires `re-frame.impl-source-corpus` except the two JVM suites, and nothing `:require-macros` it anywhere in the repo (both verified by grep, not assumed — the sibling `conformance_fixtures.clj` in the same directory *is* reached that way, so the mechanism is real and this file is simply not on it).

**Not decided here.** `scripts/check_fast_pr_gap.py --list` enumerates the **96** required checks this spine does not run; green locally is not green in CI. This diff sits under `implementation/core/`, which `.github/scripts/report-changed-surfaces.sh` classifies into the broad surface set (`implementation_jvm`, `cljs_node_test`, `cljs_browser`, `cljs_prod`, `ui_gates`, `bundle_isolation`, `tools_jvm`, `mcp_conformance`, … — 15 surfaces armed), so CI runs the full matrix over it.

Also verified, since a new file lands in `implementation/core/test/`: it is invisible to `verify_roster` in `scripts/test-core-prod-gate.sh` (which counts only `*_test.clj{,c}`) and to `check_test_lane_bijection.py` (which counts only files defining tests) — checked by reading both and then by running the bijection gate.

## Out of fence, filed not fixed

**rf2-sk5hf (P3)** — `prod_gate_naming_drift_test.clj`'s `claiming-files` is `.listFiles` over `test/re_frame`, depth 1, with six nested test directories beneath it. Same shape, same weak floor (`>= 3` claiming files, which a narrowed walk satisfies): a gate-claiming suite in a nested directory would never be checked for honesty about the production gate. **Latent, not live** — measured, the full-subtree and depth-1 enumerations return the same seven files today.

Also looked at and deliberately **not** beaded: `epoch_test.clj:146`'s `.listFiles` is the same idiom but scans a package directory that is flat by construction, so there is no nesting for it to miss. Recorded on the bead so the next reader does not re-derive it.
