### PR TITLE
fix(test): widen the gate-naming ratchet to every artefact test tree (rf2-sk5hf)

### DIFF
--- a/implementation/core/test/re_frame/prod_gate_naming_drift_test.clj
+++ b/implementation/core/test/re_frame/prod_gate_naming_drift_test.clj
@@ -183,13 +183,21 @@
     (when (str/starts-with? fp (str rp "/"))
       (first (str/split (subs fp (inc (count rp))) #"/")))))
 
-(defn- claiming-artefacts
-  "The artefacts contributing at least one file to the domain — `core`,
+(defn- artefacts-of
+  "The artefacts contributing at least one of `files` to the domain — `core`,
   `epoch`, `freehand`, `routing`, `ssr` as measured at rf2-sk5hf."
-  []
-  (if-let [root (implementation-root)]
-    (into (sorted-set) (keep #(artefact-of root %)) (claiming-files))
+  [^java.io.File root files]
+  (if root
+    (into (sorted-set) (keep #(artefact-of root %)) files)
     (sorted-set)))
+
+(defn- rel
+  "`f` relative to `implementation/`, for a failure message that can name four
+  files called `prod_gate_lane_pin_test.clj`."
+  [^java.io.File root ^java.io.File f]
+  (if root
+    (subs (posix f) (inc (count (posix root))))
+    (posix f)))
 
 (defn- honest? [^java.io.File f]
   (let [content (slurp f)]
@@ -211,28 +219,35 @@
             a real offender was sitting. A floor on whether the walk found
             ANYTHING says nothing about whether it found EVERYTHING, so the
             coverage claim below is about the walk's REACH."
-    (is (some? (core-test-anchor-dir))
-        (str "could not resolve `implementation/core/test/re_frame` from the "
-             "classpath via `re_frame/prod_gate_lane_pin_test.clj` — has the "
-             "anchor file been renamed or the test root moved?"))
-    (is (some? (implementation-root))
-        (str "resolved the classpath anchor but three parents above it is not "
-             "`implementation/` — nothing there carries `core/src`. The "
-             "positive identification is deliberate (see `implementation-root`); "
-             "a recursive walk from the wrong root is worse than no walk."))
-    (is (< 1 (count (claiming-artefacts)))
-        (str "the domain spans ONE artefact. That is the rf2-sk5hf fail-open "
-             "exactly: this ratchet is armed by `implementation_jvm`, which "
-             "every artefact's test tree arms, so a walk confined to one of "
-             "them runs and reports green over the others. Found: "
-             (pr-str (vec (claiming-artefacts)))))
-    (is (<= 8 (count (claiming-files)))
-        (str "collapse detector, calibrated at 8 against the 11 files measured "
-             "at rf2-sk5hf — deliberately just above the 7 that a walk narrowed "
-             "back to `core/test/re_frame` returns, so that specific regression "
-             "reds here as well as above. The artefact-reach claim is the "
-             "durable one; this number will need moving. Found: "
-             (mapv #(.getName ^java.io.File %) (claiming-files))))))
+    ;; The corpus is walked ONCE and read four times. `claiming-files` is a
+    ;; recursive `file-seq` now, and `is`'s message argument is evaluated
+    ;; whether or not the assertion fails.
+    (let [root      (implementation-root)
+          files     (claiming-files)
+          artefacts (artefacts-of root files)]
+      (is (some? (core-test-anchor-dir))
+          (str "could not resolve `implementation/core/test/re_frame` from the "
+               "classpath via `re_frame/prod_gate_lane_pin_test.clj` — has the "
+               "anchor file been renamed or the test root moved?"))
+      (is (some? root)
+          (str "resolved the classpath anchor but three parents above it is "
+               "not `implementation/` — nothing there carries `core/src`. The "
+               "positive identification is deliberate (see "
+               "`implementation-root`); a recursive walk from the wrong root "
+               "is worse than no walk."))
+      (is (< 1 (count artefacts))
+          (str "the domain spans ONE artefact. That is the rf2-sk5hf fail-open "
+               "exactly: this ratchet is armed by `implementation_jvm`, which "
+               "every artefact's test tree arms, so a walk confined to one of "
+               "them runs and reports green over the others. Found: "
+               (pr-str (vec artefacts))))
+      (is (<= 8 (count files))
+          (str "collapse detector, calibrated at 8 against the 11 files "
+               "measured at rf2-sk5hf — deliberately just above the 7 that a "
+               "walk narrowed back to `core/test/re_frame` returns, so that "
+               "specific regression reds here as well as above. The "
+               "artefact-reach claim is the durable one; this number will need "
+               "moving. Found: " (mapv #(rel root %) files))))))
 
 (deftest every-gate-claiming-namespace-is-honest-about-the-gate
   (testing "rf2-f7qj4 — a test file whose NAME says it exercises the JVM
@@ -249,10 +264,7 @@
                "it nor disclaim it: "
                ;; Paths, not names: the domain spans artefacts (rf2-sk5hf), and
                ;; four of them ship a file called `*prod_gate_lane_pin_test`.
-               (mapv #(if root
-                        (subs (posix %) (inc (count (posix root))))
-                        (posix %))
-                     liars)
+               (mapv #(rel root %) liars)
                "\n\nFix by one of:"
                "\n  a. run in the real lane — tag the deftests `^:prod-gate`"
                "\n     (see re-frame.prod-gate-lane-pin-test) and add the ns to"

--- a/implementation/core/test/re_frame/prod_gate_naming_drift_test.clj
+++ b/implementation/core/test/re_frame/prod_gate_naming_drift_test.clj
@@ -19,19 +19,55 @@
   rf2-f7qj4 re-docstringed the three offenders. A docstring decays; this test
   is what stops the next one being written.
 
+  ## There was a fourth offender, and the walk could not see it (rf2-sk5hf)
+
+  This scan used to enumerate `implementation/core/test/re_frame` with
+  `.listFiles` — one artefact's test tree, at depth 1. Both narrowings were
+  invisible in the same way: the sanity test below floored on \"at least three
+  files\", seven satisfied it, and a floor on whether the walk found ANYTHING
+  says nothing about whether it found EVERYTHING.
+
+  The DEPTH narrowing was latent. Six directories nest under
+  `core/test/re_frame` (`adapter`, `bench`, `bench/lane_cache_fixtures`,
+  `substrate`, `trace`, `views`) and not one of them held a claiming file, so
+  the subtree and the depth-1 listing returned the same seven.
+
+  The ARTEFACT narrowing was not. `implementation/epoch/test/re_frame/`
+  `epoch_jvm_prod_gate_test.clj` NAMES the JVM production gate in its filename
+  and pins it entirely with `with-redefs` — the precise shape rf2-f7qj4 exists
+  to stop — and it had sat outside the walk since rf2-f7qj4 landed, because
+  that bead's sweep only ever looked at core. It is not a tree this ratchet
+  fails to be responsible for, either: an epoch test file arms
+  `implementation_jvm` (`.github/scripts/report-changed-surfaces.sh`), which is
+  the SAME condition `jvm-core` gates on, so this suite was armed, ran, walked
+  past `implementation/epoch/` and reported green. Three more artefacts
+  (`freehand`, `routing`, `ssr`) carry claiming files too; those were honest
+  already, by real lanes.
+
+  Sharper still, `re-frame.interop-debug-gate-test`'s docstring asserted the
+  epoch suite \"carries the same caveat\". It did not. A cross-reference is not
+  a check.
+
+  So the domain is now every artefact's `test/` tree, walked recursively from
+  one positively-identified root. See `implementation-root` for why the root is
+  identified by what it CARRIES rather than by where it sits.
+
   ## The rule
 
-  DOMAIN — every `.clj` / `.cljc` file under `implementation/core/test/` whose
-  FILE NAME contains `prod_gate`, `jvm_gate`, or `debug_gate`. Those three
-  tokens are the ones that assert, in the file listing itself, \"this exercises
-  the JVM production/debug gate\". Deliberately narrow: `trace_gate` and the
-  `prod_elision` suites make a different claim and are out of scope.
+  DOMAIN — every `.clj` / `.cljc` file under any artefact's `test/` tree
+  beneath `implementation/`, whose FILE NAME contains `prod_gate`, `jvm_gate`,
+  or `debug_gate`. Those three tokens are the ones that assert, in the file
+  listing itself, \"this exercises the JVM production/debug gate\".
+  Deliberately narrow in the TOKEN dimension: `trace_gate` and the
+  `prod_elision` suites make a different claim and are out of scope. Not narrow
+  in the TREE dimension, and rf2-sk5hf is why.
 
   A file in the domain is HONEST when it does at least one of:
 
-    a. carries `^:prod-gate` metadata — it belongs to the real
-       `jvm-core-prod-gate` lane, which puts `-Dre-frame.debug=false` on the
-       JVM command line via the `:prod-gate` alias's `:jvm-opts`;
+    a. carries `^:prod-gate` metadata — it belongs to a real prod-gate lane,
+       which puts `-Dre-frame.debug=false` on the JVM command line via that
+       artefact's `:prod-gate` alias `:jvm-opts` (`jvm-core-prod-gate` and its
+       `freehand` / `routing` / `ssr` siblings);
     b. contains the literal `-Dre-frame.debug=false` — it relaunches a child
        JVM with the property on the command line (the
        `re-frame.prod-gate-dispatch-jvm-test` pattern);
@@ -65,28 +101,95 @@
 (def ^:private prod-gate-tag "^:prod-gate")
 (def ^:private jvm-property "-Dre-frame.debug=false")
 
-(defn- test-namespace-dir
-  "The on-disk `test/re_frame` directory, resolved off the CLASSPATH rather
-  than the process CWD — `clojure -M:test` and the `jvm-core-prod-gate` lane
-  both run from `implementation/core`, but nothing guarantees a third caller
-  will. Anchored on a file that exists ONLY under `test/` so the `src/`
-  `re_frame` directory cannot win the lookup."
+(defn- posix
+  "`f`'s path with forward slashes, so one path predicate reads the same on
+  Windows and POSIX."
+  [^java.io.File f]
+  (str/replace (.getPath f) "\\" "/"))
+
+(defn- core-test-anchor-dir
+  "The on-disk `implementation/core/test/re_frame` directory, resolved off the
+  CLASSPATH rather than the process CWD — `clojure -M:test` and the
+  `jvm-core-prod-gate` lane both run from `implementation/core`, but nothing
+  guarantees a third caller will. Anchored on a file that exists ONLY under
+  `test/` so the `src/` `re_frame` directory cannot win the lookup.
+
+  This is no longer the tree that gets walked; it is how the tree that DOES get
+  walked is found."
   ^java.io.File []
   (some-> (io/resource "re_frame/prod_gate_lane_pin_test.clj")
           io/as-file
           .getParentFile))
 
+(defn- implementation-root
+  "`implementation/` — the tree the domain spans — three parents above the
+  classpath anchor (`re_frame` → `test` → `core` → `implementation`).
+
+  IDENTIFIED POSITIVELY, by carrying `core/src`, rather than trusted as a
+  relative position. That is rf2-2cu7f's discipline and it was learnt the hard
+  way: the enumeration that bead fixed listed the repo ROOT among its bases,
+  which was inert against a depth-1 listing and would have swept `tools/`,
+  `examples/` and `migration/` into two ratchets scoped to `implementation/`
+  the moment the walk went recursive. A walk with a blast radius has to know
+  what it is standing on.
+
+  `re-frame.impl-source-corpus/implementation-root` answers the same question
+  for the production-source corpus and is deliberately NOT reused here: it
+  resolves from the process CWD, and this namespace's whole reason for using a
+  classpath anchor is that the CWD is not guaranteed. Same discipline,
+  different anchor — not a second copy of one definition."
+  ^java.io.File []
+  (when-let [anchor (core-test-anchor-dir)]
+    (let [root (some-> anchor .getParentFile .getParentFile .getParentFile)]
+      (when (and root (.isDirectory (io/file root "core" "src")))
+        root))))
+
+(defn- domain-file?
+  "A candidate for the domain: a `.clj` / `.cljc` source living in some
+  artefact's `test/` tree.
+
+  `node_modules` is excluded. A vendored file's name is not this repo's claim
+  to make, and a developer who has run `npm ci` would otherwise put tens of
+  thousands of files in front of the token match."
+  [^java.io.File f]
+  (let [p (posix f)]
+    (and (.isFile f)
+         (some? (re-find #"\.cljc?$" (.getName f)))
+         (str/includes? p "/test/")
+         (not (str/includes? p "/node_modules/")))))
+
 (defn- claiming-files
-  "Every file in the domain: a `.clj` / `.cljc` source under `test/re_frame`
-  whose name contains one of `claim-tokens`."
+  "Every file in the domain: a `.clj` / `.cljc` source under any artefact's
+  `test/` tree whose name contains one of `claim-tokens`.
+
+  ONE recursive walk from ONE positively-identified root, selected by a path
+  predicate. There is no root enumeration and no depth here, so there is
+  nothing left for a later edit to narrow silently — which is what rf2-sk5hf
+  found this doing in both dimensions at once."
   []
-  (->> (some-> (test-namespace-dir) .listFiles seq)
-       (filter #(.isFile ^java.io.File %))
-       (filter #(re-find #"\.cljc?$" (.getName ^java.io.File %)))
+  (->> (some-> (implementation-root) file-seq)
+       (filter domain-file?)
        (filter (fn [^java.io.File f]
                  (some #(str/includes? (.getName f) %) claim-tokens)))
-       (sort-by #(.getName ^java.io.File %))
+       (sort-by posix)
        vec))
+
+(defn- artefact-of
+  "The artefact a domain file belongs to — the first path segment under
+  `implementation/`."
+  [^java.io.File root ^java.io.File f]
+  (let [rp (posix root)
+        fp (posix f)]
+    (when (str/starts-with? fp (str rp "/"))
+      (first (str/split (subs fp (inc (count rp))) #"/")))))
+
+(defn- claiming-artefacts
+  "The artefacts contributing at least one file to the domain — `core`,
+  `epoch`, `freehand`, `routing`, `ssr` as measured at rf2-sk5hf."
+  []
+  (if-let [root (implementation-root)]
+    (into (sorted-set) (keep #(artefact-of root %)) (claiming-files))
+    (sorted-set)))
 
 (defn- honest? [^java.io.File f]
   (let [content (slurp f)]
@@ -95,20 +198,40 @@
         (str/includes? content disclaimer))))
 
 (deftest the-domain-scan-still-finds-files
-  (testing "rf2-f7qj4 — the guard on the guard. If `test-namespace-dir` stops
-            resolving (a moved test root, a packaged classpath) or the token
-            match stops hitting, the check below passes VACUOUSLY and the
-            naming lie is free to come back. A silently-empty scan is the
-            failure mode this whole namespace exists to prevent, so it is a
-            hard red."
-    (is (some? (test-namespace-dir))
-        (str "could not resolve `test/re_frame` from the classpath via "
-             "`re_frame/prod_gate_lane_pin_test.clj` — has the anchor file "
-             "been renamed or the test root moved?"))
-    (is (<= 3 (count (claiming-files)))
-        (str "expected at least the three known gate-claiming files "
-             "(prod_gate_lane_pin_test, prod_gate_dispatch_jvm_test, "
-             "jvm_prod_gate_integration_test); found "
+  (testing "rf2-f7qj4 — the guard on the guard. If the root stops resolving (a
+            moved test root, a packaged classpath) or the token match stops
+            hitting, the check below passes VACUOUSLY and the naming lie is
+            free to come back. A silently-empty scan is the failure mode this
+            whole namespace exists to prevent, so it is a hard red.
+
+            AND `(<= 3 (count ...))` WAS NOT THAT GUARD — rf2-sk5hf is the
+            proof. For as long as this scan listed `core/test/re_frame` at
+            depth 1 it found seven files, passed here comfortably, and reached
+            neither a nested directory nor another artefact's test tree, where
+            a real offender was sitting. A floor on whether the walk found
+            ANYTHING says nothing about whether it found EVERYTHING, so the
+            coverage claim below is about the walk's REACH."
+    (is (some? (core-test-anchor-dir))
+        (str "could not resolve `implementation/core/test/re_frame` from the "
+             "classpath via `re_frame/prod_gate_lane_pin_test.clj` — has the "
+             "anchor file been renamed or the test root moved?"))
+    (is (some? (implementation-root))
+        (str "resolved the classpath anchor but three parents above it is not "
+             "`implementation/` — nothing there carries `core/src`. The "
+             "positive identification is deliberate (see `implementation-root`); "
+             "a recursive walk from the wrong root is worse than no walk."))
+    (is (< 1 (count (claiming-artefacts)))
+        (str "the domain spans ONE artefact. That is the rf2-sk5hf fail-open "
+             "exactly: this ratchet is armed by `implementation_jvm`, which "
+             "every artefact's test tree arms, so a walk confined to one of "
+             "them runs and reports green over the others. Found: "
+             (pr-str (vec (claiming-artefacts)))))
+    (is (<= 8 (count (claiming-files)))
+        (str "collapse detector, calibrated at 8 against the 11 files measured "
+             "at rf2-sk5hf — deliberately just above the 7 that a walk narrowed "
+             "back to `core/test/re_frame` returns, so that specific regression "
+             "reds here as well as above. The artefact-reach claim is the "
+             "durable one; this number will need moving. Found: "
              (mapv #(.getName ^java.io.File %) (claiming-files))))))
 
 (deftest every-gate-claiming-namespace-is-honest-about-the-gate
@@ -119,15 +242,21 @@
             sentinel in its docstring. `with-redefs` on
             `re-frame.interop/debug-enabled?` is neither: the flag is read
             once at namespace-load time, so a rebind cannot reach it."
-    (let [liars (remove honest? (claiming-files))]
+    (let [root  (implementation-root)
+          liars (remove honest? (claiming-files))]
       (is (empty? liars)
           (str "these files NAME the production/debug gate but neither reach "
                "it nor disclaim it: "
-               (mapv #(.getName ^java.io.File %) liars)
+               ;; Paths, not names: the domain spans artefacts (rf2-sk5hf), and
+               ;; four of them ship a file called `*prod_gate_lane_pin_test`.
+               (mapv #(if root
+                        (subs (posix %) (inc (count (posix root))))
+                        (posix %))
+                     liars)
                "\n\nFix by one of:"
                "\n  a. run in the real lane — tag the deftests `^:prod-gate`"
                "\n     (see re-frame.prod-gate-lane-pin-test) and add the ns to"
-               "\n     scripts/test-core-prod-gate.sh's lane;"
+               "\n     your artefact's scripts/test-<artefact>-prod-gate.sh lane;"
                "\n  b. relaunch a child JVM with `" jvm-property "` on its"
                "\n     command line (see re-frame.prod-gate-dispatch-jvm-test);"
                "\n  c. state in the ns docstring that the suite is `"

--- a/implementation/epoch/test/re_frame/epoch_jvm_prod_gate_test.clj
+++ b/implementation/epoch/test/re_frame/epoch_jvm_prod_gate_test.clj
@@ -1,5 +1,57 @@
 (ns re-frame.epoch-jvm-prod-gate-test
-  "The epoch artefact's dev-only surfaces — `register-epoch-listener!`,
+  "rf2-sk5hf — READ THIS FIRST. Despite the namespace's name, this suite is
+  NOT THE LOAD-TIME GATE. Every test below rebinds
+  `re-frame.interop/debug-enabled?` with `with-redefs`, which happens after the
+  framework has loaded; the gate itself is read ONCE at `re-frame.interop` load
+  time from `-Dre-frame.debug` / `RE_FRAME_DEBUG`, long before any of this
+  runs. What is pinned here is that the epoch surfaces honour a REBOUND flag —
+  a real contract, and not the production posture.
+
+  rf2-9c2jf is why the distinction is worth a paragraph: a TOTAL
+  `dispatch-sync` failure under the documented gate, handler run ZERO times,
+  green for as long as it existed, camouflaged by a roster of suites whose
+  NAMES said `prod_gate` while not one of them ran under it.
+
+  The lanes that DO reach the load-time gate:
+
+    * `jvm-core-prod-gate` / `sh scripts/test-core-prod-gate.sh` — the core
+      suite with the `re-frame.debug` property genuinely set false on the JVM
+      command line, and `test-freehand-prod-gate.sh` /
+      `test-routing-prod-gate.sh` / `test-ssr-prod-gate.sh` for those
+      artefacts.
+
+      (Spelled without the literal `-D...=false` on purpose: that literal is
+      itself one of the three honesty markers the drift ratchet greps for, and
+      a file that mentions it only in PROSE ABOUT OTHER LANES would pass for
+      the wrong reason. This file's honesty rests on the disclaimer sentence
+      above, and on nothing else.)
+    * `re-frame.prod-gate-lane-pin-test` and its per-artefact siblings — each
+      asserts the property really arrived in that lane's JVM and that the
+      framework honoured it.
+    * `re-frame.prod-gate-dispatch-jvm-test` — the child-JVM pattern for a
+      defect that only reproduces at load time.
+
+  THE EPOCH ARTEFACT HAS NO SUCH LANE. There is no `:prod-gate` alias in
+  `implementation/epoch/deps.edn`, no `scripts/test-epoch-prod-gate.sh` and no
+  lane pin, so the surfaces below have never executed under the posture they
+  are about — which bites harder here than elsewhere, the whole security
+  rationale (rf2-vnjfg / rf2-0la4f) being that the ring must not retain
+  `:db-before` / `:db-after` / raw `:trace-events` in a production heap. Filed
+  as rf2-bo8lq. This docstring makes the file listing honest; it does not make
+  the coverage exist.
+
+  HOW THIS WENT UNSAID FOR SO LONG, worth recording because the mechanism is
+  general. rf2-f7qj4 re-docstringed the three core suites in exactly this shape
+  and wrote a ratchet — `re-frame.prod-gate-naming-drift-test` — to stop the
+  next one. That ratchet enumerated core's test tree only, so it never saw this
+  file; `re-frame.interop-debug-gate-test`'s docstring meanwhile asserted that
+  the epoch suite \"carries the same caveat\", which was simply not true. A
+  cross-reference is not a check. rf2-sk5hf widened the walk to every
+  artefact's `test/` tree, and this file is the one thing it found.
+
+  ## What this suite pins
+
+  The epoch artefact's dev-only surfaces — `register-epoch-listener!`,
   `restore-epoch!`, `replace-frame-state!`,
   the per-frame ring buffer carrying `:db-before` / `:db-after` /
   raw `:trace-events` — MUST honour the JVM-side production gate


### PR DESCRIPTION
Closes rf2-sk5hf.

`claiming-files` in `prod_gate_naming_drift_test` was
`.listFiles(implementation/core/test/re_frame)` — one artefact's test tree, at
depth 1. Two narrowings, invisible in the same way: the sanity test floored on
`(<= 3 (count (claiming-files)))`, seven satisfied it, and a floor on whether
the walk found ANYTHING says nothing about whether it found EVERYTHING.

## The depth narrowing was latent, as the bead said — re-measured here

Six directories nest under `core/test/re_frame` (`adapter`, `bench`,
`bench/lane_cache_fixtures`, `substrate`, `trace`, `views`); none holds a
claiming file, so the subtree and the depth-1 listing return the same seven
files. Still true on this branch. On its own that is not worth a diff.

## The artefact narrowing was not latent

`implementation/epoch/test/re_frame/epoch_jvm_prod_gate_test.clj` NAMES the JVM
production gate in its filename and pins it entirely with
`with-redefs [interop/debug-enabled? false]` — the precise shape rf2-f7qj4
exists to stop. It had sat outside the walk since that bead landed, because its
sweep only ever looked at core: `02c8a02f41` touched three core files and the
new ratchet, and nothing else.

Nor is it a tree this ratchet is not responsible for. An epoch test file arms
`implementation_jvm` — measured with
`.github/scripts/report-changed-surfaces.sh` — which is the same condition
`jvm-core` gates on. So this suite was armed, ran, walked past
`implementation/epoch/` and reported green. Same shape as rf2-2cu7f's adapters.

Sharper still: `interop_debug_gate_test`'s docstring asserted that the epoch
suite "carries the same caveat". It did not. A cross-reference is not a check.

## Measured by calling the suite's own `claiming-files`

```
before    7 files   1 artefact   (core)
after    11 files   5 artefacts  (core epoch freehand routing ssr)
```

The four newly covered are epoch's offender plus the `freehand` / `routing` /
`ssr` lane pins, which were honest already through real lanes. `freehand`'s sits
at `freehand/test/re_frame/freehand/prod_gate_lane_pin_test.clj` — nested — so
the depth fix earns its keep in the widened tree even though it earned nothing
in the old one.

## The fix, and the trap it avoids

One recursive pass from one positively-identified root, selected by a path
predicate. No root enumeration and no depth left for a later edit to narrow.

`implementation-root` is accepted only if it carries `core/src`. That is
rf2-2cu7f's discipline: the enumeration that bead fixed listed the repo ROOT
among its bases — inert under a `.listFiles`, a three-tree blast radius the
moment the walk went recursive. `impl-source-corpus/implementation-root` is
deliberately NOT reused: it resolves from the process CWD, and this namespace
uses a classpath anchor precisely because the CWD is not guaranteed. Same
discipline, different anchor — not a second copy of one definition.

`node_modules` is excluded from the domain: a vendored file's name is not this
repo's claim to make.

## The floor

`(<= 3 (count ...))` is replaced by the claim that actually failed — the domain
must span more than one artefact. The count floor stays as a collapse detector,
recalibrated to 8: just above the 7 a walk narrowed back to `core/test/re_frame`
returns, so that specific regression reds twice.

A second differently-shaped enumeration (the `corpus-cross-check` pattern
rf2-2cu7f added) is deliberately NOT built here. There it cross-checked a root
ENUMERATION against a path predicate, two genuinely different shapes. After this
change there is no root enumeration left — one root, one predicate — so a second
walk sharing that root and differing only in how it decides a file is under a
test tree would be ceremony, not a check.

## Mutation proof

| mutation | result |
| --- | --- |
| walk narrowed back to `.listFiles(core/test/re_frame)` | exit `1` — artefact-reach reds `Found: ["core"]`, count floor reds `(not (<= 8 7))` naming all seven |
| epoch docstring reverted to `origin/main`, walk kept | exit `1` — honesty test reds `["epoch/test/re_frame/epoch_jvm_prod_gate_test.clj"]` |
| neither (positive control) | exit `0` — 2 tests, 5 assertions |

## The epoch file

Takes rf2-f7qj4's remedy (c): the `NOT THE LOAD-TIME GATE` disclaimer, naming
what it does pin (a rebound Var — a real contract) and what has never run (the
posture). Its honesty rests on the disclaimer ALONE — the `-D...=false` literal
is spelled around, because that literal is itself one of the three markers and
prose about other lanes must not pass for it.

**Epoch has no real prod-gate lane at all** — no `:prod-gate` alias, no
`scripts/test-epoch-prod-gate.sh`, no lane pin, while `core` / `freehand` /
`routing` / `ssr` each have all three. Filed as **rf2-bo8lq** (P2), together with
the observation that `spec/Security.md:264,275` and `spec/Tool-Pair.md:157` cite
this file and `interop_debug_gate_test.clj` as the JVM gate's verification when
both now disclaim it. Hot zone; not this PR.

`implementation/epoch/test/re_frame/epoch_test.clj:146` uses the same
`.listFiles` idiom over `re_frame/epoch/`, which is five `.cljc` siblings and
zero subdirectories — flat by construction, correct as written, re-verified and
left alone per the bead.

## Quality gates

Run directly in this worktree, exit codes captured:

| gate | exit | result |
| --- | --- | --- |
| `clojure -M:test` in `implementation/core` | `0` | 2243 tests / 11686 assertions |
| the same at the merge base | `0` | 2243 tests / 11684 assertions |
| `clojure -M:test` in `implementation/epoch` | `0` | 539 tests / 7133 assertions |
| `bash scripts/test-core-prod-gate.sh` | `0` | 178 of 190 namespaces, 1986 tests / 8701 assertions — this namespace is on that lane's roster |
| `clj-kondo --lint` both changed files | `0` | errors 0, warnings 0 |
| `clojure -M:test -n re-frame.prod-gate-naming-drift-test` | `0` | positive control, 2 tests / 5 assertions |

`+0 tests / +2 assertions` is exactly accounted for: the sanity test went from
two `is` forms (anchor, count floor) to four (anchor, positively-identified
root, artefact reach, count floor). The honesty test is unchanged at one.

`scripts/check_fast_pr_gap.py --list` names 96 required checks the fast-PR spine
does not decide. This diff is two `test/` files, so the surfaces it arms are the
JVM/CLJS tiers; the two JVM suites that load these namespaces are run above.

Also filed from that lane run: **rf2-oucxu** (P4) — `RF2_MIN_TESTS` is 1920
against 1986 observed, a slack of 66 where `test-core-prod-gate.sh` mandates ~33,
which quietly doubles the budget for coverage-reducing `^:requires-debug` tags.
Pre-existing and not touched here; this diff adds no test to that lane.
