### PR TITLE
feat(hicasso): ship re-frame.hicasso.server and h/hydrate!; refute four of the seven (rf2-b6jkj)

### DIFF
--- a/implementation/hicasso/deps.edn
+++ b/implementation/hicasso/deps.edn
@@ -14,14 +14,30 @@
 ;; beside `src/` pins each donor file by digest so that claim stays true;
 ;; `scripts/check_freeze.py` is what checks it.
 ;;
-;; DEPENDENCIES. Core alone. Every substrate namespace the runtime reaches
-;; for — `re-frame.adapter.context`, `re-frame.live-frame`,
-;; `re-frame.late-bind`, `re-frame.registrar`, `re-frame.performance`,
-;; `re-frame.trace`, `re-frame.interop` — is core's, and routing is reached
-;; through core's late-bind registry rather than by dependency, so the
-;; packaging graph stays `hicasso -> core late-bind <- routing` with no
-;; cycle (Conventions §Packaging). React itself is an npm dependency,
-;; declared in implementation/package.json, not here.
+;; DEPENDENCIES. Core, plus ssr for the server module alone. Every substrate
+;; namespace the RUNTIME reaches for — `re-frame.adapter.context`,
+;; `re-frame.live-frame`, `re-frame.late-bind`, `re-frame.registrar`,
+;; `re-frame.performance`, `re-frame.trace`, `re-frame.interop` — is core's,
+;; and routing is reached through core's late-bind registry rather than by
+;; dependency, so the packaging graph stays `hicasso -> core late-bind
+;; <- routing` with no cycle (Conventions §Packaging). React itself is an
+;; npm dependency, declared in implementation/package.json, not here.
+;;
+;; `day8/re-frame2-ssr` arrived with `re-frame.hicasso.server` (rf2-b6jkj)
+;; and is reached by ONE namespace, which the public door names nowhere.
+;; The module hands `:payload` to `re-frame.ssr.payload-policy`'s
+;; fail-closed validator and its app-db to that namespace's own egress
+;; projection, so R0 — *nothing Hicasso-specific touches the payload path*
+;; — is a packaging fact rather than a promise; re-spelling those three
+;; helpers locally to keep the dep list at one entry is precisely how the
+;; wire contract drifts. `ssr` itself depends on core alone, so the graph
+;; is the DAG `hicasso -> ssr -> core`.
+;;
+;; It costs a CLASSPATH entry and no bundle bytes: a browser build that
+;; never requires `re-frame.hicasso.server` reaches no `re-frame.ssr`
+;; namespace, which is the same optional-module property `.forms`,
+;; `.overlay` and `.motion` have and which
+;; `scripts/check_optional_module_reachability.py` checks at the door.
 ;;
 ;; NO :clein / :clein/build, deliberately. This artefact is pre-publication:
 ;; it carries no Maven coordinate and is absent from the lockstep array and
@@ -40,7 +56,8 @@
 ;; Nothing under `resources/` is a loadable namespace: the hook file is data
 ;; that clj-kondo's own SCI reads from the config directory.
 {:paths ["src" "resources"]
- :deps  {day8/re-frame2 {:local/root "../core"}}
+ :deps  {day8/re-frame2     {:local/root "../core"}
+         day8/re-frame2-ssr {:local/root "../ssr"}}
 
  :aliases
  ;; This lane was CLASSPATH-PROBE-ONLY until rf2-0yp7w P0, and the paragraph

--- a/implementation/hicasso/scripts/check_guide_samples.py
+++ b/implementation/hicasso/scripts/check_guide_samples.py
@@ -173,23 +173,20 @@ DIVERGENCES = {
         "`root!` takes the frame keyword positionally and carries no "
         "`:initial-events` option; the guide teaches the intended door",
     ),
-    ("re-frame.hicasso", "hydrate!"): (
-        None,
-        "the hydrating root is built and witnessed but held off the public "
-        "door until a server-render counterpart exists to produce the bytes "
-        "it would adopt",
-    ),
 }
 
 # A namespace the guide `:require`s that does not exist yet.  Same contract as
 # a verb row: R3 requires it to still be absent, so the chapter written
 # against it is forced back open the day it lands.
-ABSENT_NAMESPACES = {
-    "re-frame.hicasso.server": (
-        "chapter 18 is written against the intended `server/render` contract; "
-        "the namespace does not exist yet"
-    ),
-}
+#
+# EMPTY SINCE rf2-b6jkj, and R3 worked exactly as designed on the way out.
+# `re-frame.hicasso.server` was the one entry; the module landed, the row went
+# stale, and R3 red naming it -- which is the whole point of the rule, since
+# prose, a digest and a fixture would each have stayed green while chapter 18
+# quietly became true.  `h/hydrate!` left DIVERGENCES in the same pass and for
+# the same reason: the hold on it was the absent server counterpart, so the two
+# gaps closed together or not at all.
+ABSENT_NAMESPACES = {}
 
 
 # ---------------------------------------------------------------------------

--- a/implementation/hicasso/scripts/check_guide_samples.py
+++ b/implementation/hicasso/scripts/check_guide_samples.py
@@ -417,15 +417,32 @@ def r1_pin_drift(corp: dict[str, list[dict]], roster: dict) -> list[str]:
     return problems
 
 
-def r2_unresolved(uses: dict, exports: dict[str, set[str] | None]) -> list[str]:
-    """R2 — every hicasso verb the guide names is defined, or has a ledger row."""
+def r2_unresolved(
+    uses: dict,
+    exports: dict[str, set[str] | None],
+    divergences: dict | None = None,
+    absent: dict | None = None,
+) -> list[str]:
+    """R2 — every hicasso verb the guide names is defined, or has a ledger row.
+
+    The two ledgers are PARAMETERS defaulting to the live tables, for the
+    reason `check_facade_inventory.py` gives about its own two lists: a
+    self-test that drives the live table stops testing the rule the moment
+    the table empties, which is exactly when the rule is least exercised
+    and most worth keeping honest.  rf2-b6jkj emptied `ABSENT_NAMESPACES`
+    and the absent-namespace arm went from *passing* to *unrunnable* in
+    the same commit; parameterising is what keeps both arms drivable from
+    fixtures forever.
+    """
+    divergences = DIVERGENCES if divergences is None else divergences
+    absent = ABSENT_NAMESPACES if absent is None else absent
     problems: list[str] = []
     for (ns, verb), sites in sorted(uses.items()):
-        if (ns, verb) in DIVERGENCES:
+        if (ns, verb) in divergences:
             continue
         names = exports.get(ns)
         if names is None:
-            if ns in ABSENT_NAMESPACES:
+            if ns in absent:
                 continue
             problems.append(
                 f"{ns}/{verb} — the guide requires a namespace with no source "
@@ -442,14 +459,21 @@ def r2_unresolved(uses: dict, exports: dict[str, set[str] | None]) -> list[str]:
     return problems
 
 
-def r3_stale_ledger(exports: dict[str, set[str] | None]) -> list[str]:
+def r3_stale_ledger(
+    exports: dict[str, set[str] | None],
+    divergences: dict | None = None,
+    absent: dict | None = None,
+) -> list[str]:
     """R3 — every declared divergence still describes reality.
 
     The rule that catches a gap CLOSING, which is the failure prose, a digest
-    and a fixture all miss alike.
+    and a fixture all miss alike.  Both ledgers are parameters for
+    [[r2_unresolved]]'s reason.
     """
+    divergences = DIVERGENCES if divergences is None else divergences
+    absent = ABSENT_NAMESPACES if absent is None else absent
     problems: list[str] = []
-    for (ns, verb), (exported_as, note) in sorted(DIVERGENCES.items()):
+    for (ns, verb), (exported_as, note) in sorted(divergences.items()):
         names = exports.get(ns)
         if names is None:
             problems.append(
@@ -468,7 +492,7 @@ def r3_stale_ledger(exports: dict[str, set[str] | None]) -> list[str]:
                 f"DIVERGENCES[{ns}/{verb}] IS STALE — it says {ns} exports "
                 f"`{exported_as}` instead, and {ns} defines no such name"
             )
-    for ns, note in sorted(ABSENT_NAMESPACES.items()):
+    for ns, note in sorted(absent.items()):
         if namespace_source(ns) is not None:
             problems.append(
                 f"ABSENT_NAMESPACES[{ns}] IS STALE — the namespace now exists, so "
@@ -743,32 +767,50 @@ def self_test() -> int:
     check("trailing whitespace does not", d("(h/sub [:x])   ") == d("(h/sub [:x])"))
 
     # ---- R2 -----------------------------------------------------------
+    #
+    # Both ledgers are FIXTURES here and never the live tables.  The live
+    # `ABSENT_NAMESPACES` is empty since rf2-b6jkj shipped
+    # `re-frame.hicasso.server`, and a self-test reading it would have gone
+    # from proving the rule to proving nothing, silently -- the same rot
+    # `check_facade_inventory.py` parameterises its two lists against.
+    fx_div = {("re-frame.hicasso", "fn"): ("hfn", "an open naming decision")}
+    fx_abs = {"re-frame.hicasso.server": "not yet built, in this fixture"}
     exports = {"re-frame.hicasso": {"sub", "defview", "hfn", "hframe", "root!"},
                "re-frame.hicasso.server": None}
+    r2 = lambda uses, exp=exports: r2_unresolved(uses, exp, fx_div, fx_abs)
     check("R2 silence when every verb resolves",
-          r2_unresolved({("re-frame.hicasso", "sub"): ["x.md block 1"]}, exports) == [])
+          r2({("re-frame.hicasso", "sub"): ["x.md block 1"]}) == [])
     check("R2 catches a MOVED verb",
-          any("defined nowhere" in p for p in r2_unresolved(
-              {("re-frame.hicasso", "subscribe"): ["x.md block 1"]}, exports)))
+          any("defined nowhere" in p for p in r2(
+              {("re-frame.hicasso", "subscribe"): ["x.md block 1"]})))
     check("R2 lets a DECLARED divergence through",
-          r2_unresolved({("re-frame.hicasso", "fn"): ["x.md block 1"]}, exports) == [])
+          r2({("re-frame.hicasso", "fn"): ["x.md block 1"]}) == [])
     check("R2 lets a DECLARED absent namespace through",
-          r2_unresolved({("re-frame.hicasso.server", "render"): ["x.md"]}, exports) == [])
+          r2({("re-frame.hicasso.server", "render"): ["x.md"]}) == [])
     check("R2 catches an UNDECLARED absent namespace",
-          any("no source" in p for p in r2_unresolved(
+          any("no source" in p for p in r2(
               {("re-frame.hicasso.ghost", "boo"): ["x.md block 1"]},
               {**exports, "re-frame.hicasso.ghost": None})))
 
     # ---- R3 -----------------------------------------------------------
+    r3 = lambda exp: r3_stale_ledger(exp, fx_div, {})
     live = {"re-frame.hicasso": {"hfn", "hframe", "root!", "sub"}}
-    check("R3 silence while every gap is still open", r3_stale_ledger(live) == [])
+    check("R3 silence while every gap is still open", r3(live) == [])
     closed = {"re-frame.hicasso": {"fn", "hfn", "hframe", "root!", "sub"}}
     check("R3 catches a gap that has CLOSED",
-          any("IS STALE" in p and "gap has CLOSED" in p
-              for p in r3_stale_ledger(closed)))
+          any("IS STALE" in p and "gap has CLOSED" in p for p in r3(closed)))
     renamed = {"re-frame.hicasso": {"hframe", "root!", "sub"}}
     check("R3 catches the replacement itself being renamed",
-          any("no such name" in p for p in r3_stale_ledger(renamed)))
+          any("no such name" in p for p in r3(renamed)))
+    # The absent-namespace arm of R3, which the live table can no longer
+    # drive: a namespace that EXISTS while a row still claims it does not.
+    # This is the rule that red on `re-frame.hicasso.server` landing.
+    check("R3 catches an absent-namespace row whose namespace now EXISTS",
+          any("IS STALE" in p and "namespace now exists" in p
+              for p in r3_stale_ledger(
+                  {"re-frame.hicasso": {"hfn", "hframe", "root!", "sub"}},
+                  {},
+                  {"re-frame.hicasso.server": "this fixture claims it is absent"})))
 
     # ---- masking ------------------------------------------------------
     check("mask blanks a `;` comment", mask(["(h/sub) ; h/ghost"])[0].strip()

--- a/implementation/hicasso/src/re_frame/hicasso.cljc
+++ b/implementation/hicasso/src/re_frame/hicasso.cljc
@@ -586,24 +586,32 @@
      ;; the caller did not name. That is the property rf2-31xm restored and
      ;; the reason `release!` is no longer among them.
      ;;
-     ;; **The HYDRATING door is not here, and the absence is held rather
-     ;; than overlooked** (rf2-k1mp). `impl.mount/hydrate-root!` is built,
-     ;; witnessed, and takes `:identifier-prefix` exactly as `root!` does
-     ;; (rf2-hic-046). What is missing is the OTHER half of the pair: a
-     ;; hydrating door adopts bytes something produced, and this package
-     ;; publishes no server-render door to produce them — `server/render`
-     ;; is taught in the draft guide and rostered in naming-ledger row 22,
-     ;; and `re-frame.hicasso.server` does not exist. `dispositions.md`
-     ;; HS-11 measures what an improvised counterpart does: the adoption
-     ;; closer rides as a SIBLING of the app subtree (`impl.mount/tree`,
-     ;; rf2-6tmu) and React derives a `useId` from tree POSITION as well
-     ;; as from the prefix, so bytes a consumer can bake today hydrate
-     ;; into a text mismatch. Both candidate repairs — a matching
-     ;; server-render entry, or making the closer a wrapper — change
-     ;; behaviour, and neither is ruled. The spelling is open too:
-     ;; naming-ledger row 13 holds `hydrate-root!`→`hydrate!` for the
-     ;; operator's sitting, so an export now would freeze a name the
-     ;; ledger is deliberately keeping open.
+     ;; **The HYDRATING door is HERE now, and rf2-k1mp's hold is lifted**
+     ;; (rf2-b6jkj). The hold was never about the door: `hydrate-root!`
+     ;; was built, witnessed, and took `:identifier-prefix` exactly as
+     ;; `root!` does (rf2-hic-046). What was missing was the OTHER half
+     ;; of the pair — a hydrating door adopts bytes something produced,
+     ;; and this package published no server-render door to produce
+     ;; them. `dispositions.md` HS-11 measured what an improvised
+     ;; counterpart did: the adoption closer rides as a SIBLING of the
+     ;; app subtree (`impl.mount/tree`, rf2-6tmu), React derives a
+     ;; `useId` from tree POSITION as well as from the prefix, and bytes
+     ;; a consumer could bake hydrated into a text mismatch.
+     ;;
+     ;; `re-frame.hicasso.server` is HS-11's first candidate repair and
+     ;; it takes it by CALLING `impl.mount/tree` — one function deciding
+     ;; the root's shape for both halves — so the counterpart now exists
+     ;; and emits the tree this door adopts, position for position.
+     ;;
+     ;; The SPELLING is naming-ledger row 13's recommendation
+     ;; (`hydrate-root!`→`hydrate!`) applied as a default, which is what
+     ;; the ledger header says a recommendation does before the sitting
+     ;; and the route rows 21 and 23 already took (rf2-mo4o, rf2-0ckh).
+     ;; The CONTRACT SHAPE is row 20's `(node config view)` with
+     ;; `:frame` + `:identifier-prefix`, kept as taught. Row 13's other
+     ;; half — `root!`→`mount!` — is NOT taken here: it is a rename of a
+     ;; door that already has an inventory row (HS-10, `h/root!`), so it
+     ;; travels with that row rather than with this addition.
 
      (def ^{:doc "Associate a DOM container, a frame keyword and a hiccup
   tree; returns the handle [[render!]] and [[unmount!]] take. HD-021(b)'s
@@ -627,6 +635,59 @@
   spelled.
   [[re-frame.hicasso.impl.mount/root!]]."}
        root! impl-mount/root!)
+
+     (def ^{:doc "`h/hydrate!` — **adopt a container's existing
+  server-rendered DOM** rather than replacing it; [[root!]]'s hydrating
+  twin, and the client half of every SSR route (rf2-b6jkj):
+
+      (h/hydrate! (js/document.getElementById \"app\")
+                  {:frame :app/main :identifier-prefix \"main\"}
+                  [views/page {}])
+
+  `(node config view)`, and the config carries `:frame` — the frame
+  keyword this root scopes — and optionally `:identifier-prefix`.
+  Returns the handle [[render!]] and [[unmount!]] take, unchanged.
+
+  **State comes first, and it is a different door.** This adopts DOM;
+  `re-frame.ssr/hydrate!` installs the server's app-db through
+  `:rf/hydrate` and must run BEFORE this, so the first client render
+  sees the state the server rendered from:
+
+      (ssr/hydrate! {:frame :app/main})   ;; 1. state
+      (h/hydrate! node {:frame :app/main} [views/page {}])   ;; 2. DOM
+
+  **Hand `:identifier-prefix` the same string the server render used.**
+  React numbers `useId` per root and prefixes it with this option, so a
+  hydrating root given a different prefix — or none, where the server
+  had one — resolves every id in the tree differently from the bytes it
+  is adopting. `re-frame.hicasso.server/render` takes the same key.
+
+  **It returns BEFORE adoption finishes.** React adopts concurrently
+  and nothing here forces it synchronously, so the DOM on the next line
+  is still the server's. A witness waits for the adoption window to
+  close rather than for a flush.
+
+  Root-scoped, like every door in this section: each hydrating root owns
+  its own container, prefix, adoption window and recoverable-error
+  stream, so one root's mismatch is reported against that root and
+  cannot silence a sibling's.
+  ## Why this one is a `defn` where its siblings are aliases
+
+  Every other var here is an alias, because the impl name and the door
+  name mean the same call. This door does not: `impl.mount/hydrate-root!`
+  is `(container frame-kw hiccup opts)` — the prototype's positional
+  shape — and naming-ledger row 20 keeps the guide's `(node config
+  view)` config map, because a config map is what lets
+  `:identifier-prefix` join without a second arity. So the adaptation is
+  three lines here rather than a second signature down in impl, and impl
+  keeps one caller shape for its own witnesses to drive.
+  [[re-frame.hicasso.impl.mount/hydrate-root!]]."}
+       hydrate!
+       ;; `config` reaches `hydrate-root!` as the opts map WHOLE rather
+       ;; than re-built from `:identifier-prefix` — impl reads the keys
+       ;; it owns and a config key added later needs no edit here.
+       (fn hydrate! [container config hiccup]
+         (impl-mount/hydrate-root! container (:frame config) hiccup config)))
 
      (def ^{:doc "Re-render a mounted root in place, synchronously, and
   answer its handle — **the hot-reload door** (rf2-e2al):

--- a/implementation/hicasso/src/re_frame/hicasso/impl/mount.cljs
+++ b/implementation/hicasso/src/re_frame/hicasso/impl/mount.cljs
@@ -72,10 +72,22 @@
 
 (declare adoption-window-closer)
 
-(defn- tree
+(defn tree
   "The root element for `handle`'s next render — **the one place the root
   tree's SHAPE is decided**, and the reason it is a function of the
   handle rather than of its two callers.
+
+  **Public because the SERVER half calls it too** (rf2-b6jkj).
+  `re-frame.hicasso.server/render` builds its element from this exact
+  function, with a handle carrying a per-request `:adoption` window, so
+  the bytes it emits and the tree [[hydrate-root!]] adopts are the same
+  shape by CONSTRUCTION rather than by two implementations agreeing.
+  That is HS-11 obstruction 2's first candidate repair — *a matching
+  server-render entry* — and taking it here is what makes it a repair
+  rather than a second renderer: were the server to build its own
+  element, the fork this function decides would have to be mirrored in a
+  place nothing forces to follow it, which is the shape of the bug, not
+  of the fix.
 
   A hydrated root carries [[adoption-window-closer]] and its own
   adoption-window provider as a Fragment around the app subtree, and it
@@ -422,27 +434,32 @@
   `react-dom/server`'s own render and the same string here — the
   [[root-options]] section comment is where that is set out.
 
-  **Matching root STRUCTURE is the other half, and today nothing on this
-  arm produces it** (`dispositions.md` HS-11, obstruction 2, MEASURED;
-  obstruction 1 was the prefix and rf2-hic-046 cleared it). React derives
-  a `useId` from tree POSITION as well as from the prefix, and a
-  hydrating root's tree is NOT the app subtree: [[tree]] wraps it in a
-  Fragment whose first child is [[adoption-window-closer]], with the
-  adoption-window provider around the app. The only server path this
-  package has — a hand-rolled `renderToString`, rf2-ggnp's census —
-  emits no counterpart to that fork, so bytes a consumer can bake today
-  hydrate into a text mismatch whose two ids agree on the prefix and
-  differ after it. The same fork is where `:adoption` comes from, and the
-  provider presence reads to start an adopted child `:present` rather
-  than `:mounting` has no server counterpart either.
+  **Matching root STRUCTURE was the other half, and it is now produced**
+  (`dispositions.md` HS-11 obstruction 2, MEASURED; obstruction 1 was
+  the prefix and rf2-hic-046 cleared it). React derives a `useId` from
+  tree POSITION as well as from the prefix, and a hydrating root's tree
+  is NOT the app subtree: [[tree]] wraps it in a Fragment whose first
+  child is [[adoption-window-closer]], with the adoption-window provider
+  around the app. For as long as this package's only server path was a
+  hand-rolled `renderToString` (rf2-ggnp's census) that emitted no
+  counterpart to that fork, bytes a consumer could bake hydrated into a
+  text mismatch whose two ids agreed on the prefix and differed after
+  it.
 
-  **So this door is built and witnessed but NOT on the
-  `re-frame.hicasso` facade** (rf2-k1mp), and the section comment there
-  is the roster's own record of the absence. HS-11 names two candidate
-  repairs — a matching server-render entry of this arm's own, or making
-  the closer a wrapper rather than a sibling — and rules on neither.
-  Until one lands, a caller reaching in here is hydrating against bytes
-  no door in this package emits.
+  `re-frame.hicasso.server/render` is HS-11's first candidate repair —
+  *a matching server-render entry of this arm's own* — and it takes the
+  repair by calling [[tree]], the same function this door calls, with a
+  handle carrying its own per-request window (rf2-b6jkj). So the fork is
+  decided once for both halves, the closer occupies the same tree
+  position on both sides, and the adoption provider presence reads to
+  start an adopted child `:present` rather than `:mounting` has its
+  server counterpart. `hydration-tree-parity-ssr-dom-cljs-test` is the
+  witness, and it fails on the pre-repair shape.
+
+  **So this door is now on the `re-frame.hicasso` facade, as
+  `h/hydrate!`** (rf2-b6jkj lifting rf2-k1mp's hold, under naming-ledger
+  row 13's `hydrate-root!`→`hydrate!` recommendation and row 20's
+  `(node config view)` contract shape).
 
   ## The handle carries `:adoption` — this root's OWN window (rf2-6tmu)
 

--- a/implementation/hicasso/src/re_frame/hicasso/server.cljs
+++ b/implementation/hicasso/src/re_frame/hicasso/server.cljs
@@ -1,0 +1,389 @@
+(ns re-frame.hicasso.server
+  "HICASSO ON THE SERVER — one request in, one document out (rf2-b6jkj).
+
+  The optional module `docs/core/hicasso/18-ssr-and-hydration.md` is
+  written against, and the fourth in the family beside
+  [[re-frame.hicasso.forms]], [[re-frame.hicasso.overlay]] and
+  [[re-frame.hicasso.motion]] (naming-ledger rows 5, 6, 16, 17, 22).
+  The door names it nowhere, so a browser build that never requires it
+  carries none of it — `scripts/check_optional_module_reachability.py`
+  is what keeps that true.
+
+      (ns app.server
+        (:require [re-frame.hicasso.server :as server]))
+
+      (:document (server/render {:hiccup [views/page {}] …}))
+
+  ## There is ONE renderer, and this is not a second one
+
+  The server engine is **the Hicasso runtime itself**, run under Node's
+  `react-dom/server`. No JVM string emitter, no parallel hiccup walker,
+  no server-only codec. Hydration parity is by construction or it is a
+  claim, and the difference is a whole class of bug the adapters have
+  already paid for.
+
+  Running THIS runtime under `renderToString` was verified rather than
+  assumed, in the 2026-08-04 SSR design programme and again by the
+  prototype this module is the product form of
+  (`test/re_frame/bench/hicasso/ssr/entry.cljs`):
+
+  - every shell hands `(.-snapshot entry)` as BOTH the client and the
+    server snapshot, so `useSyncExternalStore` calls the server snapshot
+    and **never calls `subscribe`** — no registration is minted;
+  - every [[re-frame.hicasso/sub]] read is therefore the mutation-free
+    cold probe: a pure compute against one coherent frame-state
+    snapshot, with no cache entry, no ref-count, no watch and no
+    disposal obligation;
+  - commits and effects never run. The whole render is HD-002's
+    *abandoned render* by design.
+
+  ## THE TREE IS `impl.mount/tree`'S, AND THAT IS THE WHOLE POINT
+
+  This module exists because a hydrating root's tree is not the app
+  subtree. `impl.mount/hydrate-root!` wraps the app in a Fragment whose
+  first child is the adoption-window closer, with the adoption-window
+  provider around the app — and **React derives a `useId` from tree
+  POSITION as well as from the `identifierPrefix`**. A server that
+  emitted the bare app subtree would hand the client bytes whose ids
+  agree on the prefix and differ after it, on every page that reads
+  `useId` at all. That was `dispositions.md` HS-11's obstruction 2,
+  measured and unrepaired, and it is why `h/hydrate!` was held off the
+  public door under rf2-k1mp.
+
+  HS-11 named two candidate repairs and ruled on neither: *a matching
+  server-render entry of this arm's own*, or *making the closer a
+  wrapper rather than a sibling*. This module is the first. It does not
+  reimplement the fork — it calls
+  [[re-frame.hicasso.impl.mount/tree]], the same function the hydrating
+  door calls, with a handle carrying this request's own window. The
+  shape is therefore decided in ONE place for both halves of every SSR
+  route, and a later change to the root's shape moves both sides at
+  once. Mirroring the fork here instead would have re-created the exact
+  failure the repair is for, one file further along.
+
+  The second candidate stays unruled and is not foreclosed: making the
+  closer a wrapper would change the client tree and this module would
+  follow it for free, because it does not know what the shape is.
+
+  ## The adoption window is OPEN around `renderToString`
+
+  A server render is the FIRST HALF OF AN ADOPTION, so it runs in the
+  window the client's hydrating half runs in — one window per request,
+  scoped over that request's tree. `impl.roots/open-adoption-window!`
+  names this module as the second minter and records it as *decided,
+  not built*; this is the building.
+
+  Without it the two halves disagree about motion. Presence starts a
+  child `:mounting` and applies that child's `::h/mounting` attribute
+  overrides while it is in that phase, so a windowless server render
+  ships the ENTER appearance — the class, and the `opacity: 0`, an
+  animation is about to move off. The hydrating client's first pass
+  renders those same children `:present`, and React then reports a
+  mismatch on every presence-managed node.
+
+  **The window is per-request and unreachable from anywhere else**, so
+  a render that throws leaks nothing: the window it opened is dropped
+  with the request. Nothing module-level is set, which is what makes
+  concurrent requests safe here — see §Concurrency.
+
+  ## Concurrency: the frame is per-request, and so is everything else
+
+  One fresh frame per request under a `gensym` id, destroyed in a
+  `finally`. Two concurrent requests cannot read each other's app-db,
+  and the id never reaches the wire — [[render-twice]] is the standing
+  proof of both, since the two renders take different gensyms and are
+  compared byte-for-byte.
+
+  `renderToString` is synchronous, so one request's render completes
+  before the next begins on that thread.
+
+  ## The payload path is the FRAMEWORK'S, untouched
+
+  `:payload` is `re-frame.ssr.payload-policy`'s fail-closed contract
+  verbatim — a non-empty allowlist vector of top-level app-db keys, or
+  `:rf.ssr.payload/whole-app-db` as an explicit opt-in — and absence
+  raises `:rf.error/ssr-missing-payload-policy` from the framework's own
+  validator, because this module hands the value straight to it and
+  adds no check of its own. Nothing Hicasso-specific touches the
+  payload path.
+
+  **The wire frame id is the caller's `:client-frame-id`, never the
+  per-request gensym.** Stamping the gensym guarantees
+  `:rf.error/hydration-frame-id-mismatch` on every real page
+  (rf2-lm2yzy). Omitting `:client-frame-id` omits the key, which is the
+  anonymous-server-frame shape.
+
+  ## THIS ROOT SHIPS NO RENDER HASH, by Spec 011's own tiering
+
+  The payload carries no `:rf/render-hash` and the document stamps no
+  `data-rf-render-hash`. Spec 011 §Hydration-mismatch detection tiers
+  detection **by render-tree representation, not by adapter brand**: the
+  hash channel belongs to the HICCUP tier, whose views are pure fns
+  returning a hashable data tree. Every root that reaches React as an
+  ELEMENT is in the other tier and verifies by React-native adoption —
+  the client's `onRecoverableError`, which
+  `impl.mount/hydration-reporter` surfaces as
+  `:rf.ssr/hydration-mismatch`. 011 says of that tier, in as many words,
+  that it \"deliberately carries **no** such hash\".
+
+  This module is that tier: `codec/root-element` hands React an element
+  and the tree is walked INSIDE `renderToString`, so at no point does a
+  data tree describing the page exist for anything to hash. The
+  prototype measured what a hash here would be worth — the dogfood
+  screen and a ~1,200-element feed page both hashed `83b865f8`, because
+  the root's canonical form is `[#fn[] {}]` — and a constant that always
+  agrees is a fail-open gate wearing the shape of a check.
+
+  ## `defhost`'s `:server` policy needs nothing here
+
+  A reader looking for where the server honours `:client-only` and
+  `{:fallback …}` will not find it, and that is the design. `mint-host!`
+  mints ONE gate per declaration whose single `useSyncExternalStore`
+  answers `false` from its SERVER snapshot, so under `renderToString`
+  the gate renders the declaration's pre-walked fallback element — or
+  nothing — **because it is the element's own type**. The policy is
+  honoured by rendering, at every position including inside a boundary
+  body, which a pre-walk over the handed-in tree could never reach.
+
+  ## What this is NOT
+
+  Not a production HTTP host. Spec 011's response contract — the
+  response accumulator, cookies, redirects, CRLF fail-fast — is
+  `re-frame.ssr.ring`'s, and nothing under `implementation/ssr` or
+  `implementation/ssr-ring` is touched by this module. [[document]]
+  mirrors that shell's envelope closely enough to be recognisable and
+  is deliberately minimal: no head model, no attribute bags, no
+  `:body-end` hook. **No streaming** — `renderToPipeableStream` is out
+  of scope per the adversarial review, and out of scope here means
+  absent, not deferred."
+  (:require [re-frame.core :as rf]
+            [re-frame.hicasso.impl.mount :as mount]
+            [re-frame.hicasso.impl.roots :as roots]
+            [re-frame.ssr.constants :as ssr-constants]
+            [re-frame.ssr.html-helpers :as ssr-html]
+            [re-frame.ssr.payload-policy :as payload-policy]
+            ["react-dom/server" :as rdom-server]))
+
+;; ---------------------------------------------------------------------------
+;; The per-request frame
+;; ---------------------------------------------------------------------------
+
+(defn fresh-frame-id
+  "A frame id no other request holds. `gensym` rather than a UUID because
+  the id is a projection target that lives for one synchronous render and
+  is destroyed before [[render]] returns — it needs to be unique in this
+  process and nothing more, and it never reaches the wire."
+  []
+  (keyword "hicasso.ssr" (str (gensym "request-"))))
+
+(defn setup-events
+  "The construction-time setup vector for one request.
+
+  Both doors are the framework's own. `:rf/set-db` is the reserved
+  app-db seeding event (EP-0027) and is the SNAPSHOT-IN door — a host
+  that already has the request's state as a map hands it over whole.
+  Anything else the request needs (a route, a fetch already resolved)
+  rides `:initial-events` as ordinary events, in the order given, after
+  the snapshot."
+  [snapshot initial-events]
+  (cond-> []
+    (some? snapshot)     (conj [:rf/set-db snapshot])
+    (seq initial-events) (into initial-events)))
+
+;; ---------------------------------------------------------------------------
+;; The document envelope
+;; ---------------------------------------------------------------------------
+
+(defn payload-script
+  "The id-pinned `<script type=\"application/edn\">` carrying the
+  already-`pr-str`'d hydration payload.
+
+  Byte-for-byte the shape `re-frame.ssr.ring.shell/payload-script-tag`
+  emits, and it must stay that way: the id is
+  `re-frame.ssr.constants/payload-script-id` — the contract with the
+  client bootstrap's `getElementById` read — and the body goes through
+  the framework's EDN-aware escaper, which keeps `<` readable in token
+  position, escapes it inside string literals, and fails loud on a
+  genuine `</script` breakout. That shell namespace is JVM-only, so the
+  three lines are re-spelled here rather than required; the two
+  CONSTANTS they are made of are shared, which is the part that could
+  drift."
+  [payload-edn]
+  (str "<script id=\"" ssr-constants/payload-script-id "\" type=\"application/edn\">"
+       (ssr-html/escape-edn-script-body payload-edn)
+       "</script>"))
+
+(defn document
+  "One page. The payload script follows the app root's close and the
+  bootstrap `<script src>` is last — the order `ssr-ring`'s
+  non-streaming shell writes, so a fixture baked here is recognisable to
+  anyone who has read that one.
+
+  **No `data-rf-render-hash` on the app root.** That marker is the
+  hiccup tier's and this is an adoption-tier root — see the namespace
+  docstring's §This root ships no render hash."
+  [{:keys  [html app-element-id script-src title]
+    script :payload-script}]
+  ;; `or`, not `:or` — a caller who threads `nil` through for an option
+  ;; it did not set (which is every caller with one options map) supplies
+  ;; the KEY, so destructuring defaults never fire and the page silently
+  ;; gets `id=""`.
+  (str "<!DOCTYPE html>"
+       "<html lang=\"en\">"
+       "<head><meta charset=\"utf-8\"><title>"
+       (ssr-html/escape-html (or title "Hicasso SSR")) "</title></head>"
+       "<body>"
+       "<div id=\"" (ssr-html/escape-attr (or app-element-id "app")) "\">"
+       html
+       "</div>"
+       script
+       (when script-src
+         (str "<script src=\"" (ssr-html/escape-attr script-src) "\"></script>"))
+       "</body></html>"))
+
+;; ---------------------------------------------------------------------------
+;; The render entry
+;; ---------------------------------------------------------------------------
+
+(defn- render-options
+  "`renderToString`'s options object, or nil.
+
+  ONE key, `:identifier-prefix` — React's own `identifierPrefix`, handed
+  over untouched, exactly as `impl.mount/root-options` hands it to
+  `createRoot` and `hydrateRoot` (rf2-hic-046). **Hand the hydrating
+  root the same string**: `useId` is numbered per root and prefixed by
+  this option, so the two sides agree on it or every generated id in the
+  tree diverges.
+
+  A string key through `unchecked-set`, for `root-options`' reason: it
+  is what keeps the property off Closure's renamer under `:advanced`,
+  and an `identifierPrefix` renamed is a prefix React never sees."
+  [identifier-prefix]
+  (when (some? identifier-prefix)
+    (let [o #js {}]
+      (unchecked-set o "identifierPrefix" identifier-prefix)
+      o)))
+
+(defn render
+  "Render one request. Returns
+
+      {:frame-id       the per-request gensym (destroyed by the time you
+                       read it — it is here to be asserted on, not used)
+       :html           the app root's INNER markup
+       :payload        the `:rf/hydration-payload` map
+       :payload-edn    that map, `pr-str`'d
+       :payload-script the `__rf_payload` <script> element
+       :document       the whole page}
+
+  `opts`:
+
+      :hiccup            REQUIRED. The root hiccup form.
+      :snapshot          a map seeded whole through `:rf/set-db`.
+      :initial-events    ordinary events, run after the snapshot.
+      :payload           REQUIRED, and the framework's fail-closed
+                         hydration-payload policy verbatim — see the
+                         namespace docstring's §The payload path.
+      :client-frame-id   the STABLE wire `:rf/frame-id`, or absent to
+                         omit the key (the anonymous-server-frame shape).
+      :identifier-prefix React's `identifierPrefix`. **The hydrating
+                         root must be handed the same string.**
+      :app-element-id    :script-src  :title   the document envelope's.
+      :frame-opts        merged UNDER the id and the setup vector, so a
+                         request needing `:images`, `:url-strategy` or
+                         `:fx-overrides` declares them the way any other
+                         frame does. `:id` and `:initial-events` are
+                         this module's and cannot be overridden.
+      :version           :schema-digest   passed to `build-payload`.
+
+  The eight spellings `18-ssr-and-hydration.md` teaches are the first
+  eight above (naming-ledger row 22, which settles them as a set).
+
+  **The tree is `impl.mount/tree`'s and the window is open around the
+  render** — the two facts this module exists for; both are the
+  namespace docstring's. The window is closed and the frame destroyed in
+  a `finally`, in that order, so a render that threw leaks no more than
+  one that returned."
+  [{:keys [hiccup snapshot initial-events payload frame-opts client-frame-id
+           identifier-prefix version schema-digest app-element-id script-src title]}]
+  (let [frame-id (fresh-frame-id)
+        ;; Per REQUEST, and reachable from nothing else — the second
+        ;; minter `impl.roots/open-adoption-window!` names. Never a
+        ;; module-level flag: that is what would make one request's throw
+        ;; leave every later request born-present.
+        window   (roots/open-adoption-window!)]
+    (try
+      (rf/make-frame (assoc frame-opts
+                            :id             frame-id
+                            :initial-events (setup-events snapshot initial-events)))
+      (let [;; The hiccup as WRITTEN — there is no server-only tree here.
+            ;; `defhost`'s `:server` policy is honoured by the gate that
+            ;; is the host element's own type.
+            ;;
+            ;; THE HANDLE IS THE HYDRATING SHAPE. `:adoption` is what
+            ;; `tree` branches on, so this is the Fragment-plus-closer
+            ;; tree `hydrate-root!` will adopt, position for position.
+            element     (mount/tree {:frame frame-id :adoption window} hiccup)
+            ropts       (render-options identifier-prefix)
+            html        (if ropts
+                          (rdom-server/renderToString element ropts)
+                          (rdom-server/renderToString element))
+            policy-opts (cond-> {:payload payload}
+                          (some? client-frame-id) (assoc :client-frame-id client-frame-id)
+                          (some? version)         (assoc :version version)
+                          (some? schema-digest)   (assoc :schema-digest schema-digest))
+            payload-map (payload-policy/build-payload
+                          ;; WIRE id — the caller's stable one or nil.
+                          ;; NEVER `frame-id`.
+                          (:client-frame-id policy-opts)
+                          (payload-policy/project-app-db-egress
+                            (payload-policy/apply-policy (rf/app-db-value frame-id) policy-opts)
+                            ;; PROJECTION frame — the real per-request one.
+                            frame-id)
+                          ;; NO RENDER HASH — nil, and `build-payload`
+                          ;; omits the key.
+                          nil
+                          policy-opts)
+            payload-edn (pr-str payload-map)
+            script      (payload-script payload-edn)]
+        {:frame-id       frame-id
+         :html           html
+         :payload        payload-map
+         :payload-edn    payload-edn
+         :payload-script script
+         :document       (document {:html           html
+                                    :payload-script script
+                                    :app-element-id app-element-id
+                                    :script-src     script-src
+                                    :title          title})})
+      (finally
+        ;; The window first — `destroy-frame!` is the per-request cleanup
+        ;; that may itself throw, and the window must already be shut when
+        ;; it runs.
+        (roots/close-adoption-window! window)
+        (rf/destroy-frame! frame-id)))))
+
+(defn render-twice
+  "[[render]] the same request twice and compare the documents
+  byte-for-byte — the determinism check, run where the renderer is
+  rather than trusted to a docstring.
+
+  Two renders in one process take two DIFFERENT gensym frame ids, so
+  this is also the standing proof that the per-request id is invisible
+  on the wire. Returns `{:first :second :identical? :differs-at}`, where
+  `:differs-at` is the index of the first differing character (nil when
+  identical) — a diff position is what makes a red run diagnosable."
+  [opts]
+  (let [a (render opts)
+        b (render opts)
+        x (:document a)
+        y (:document b)]
+    {:first      a
+     :second     b
+     :identical? (= x y)
+     :differs-at (when (not= x y)
+                   (let [n (min (count x) (count y))]
+                     (loop [i 0]
+                       (cond
+                         (= i n)                            n
+                         (not= (.charAt x i) (.charAt y i)) i
+                         :else                              (recur (inc i))))))}))

--- a/implementation/hicasso/test/re_frame/hicasso/server_render_ssr_dom_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/server_render_ssr_dom_cljs_test.cljs
@@ -1,0 +1,323 @@
+(ns re-frame.hicasso.server-render-ssr-dom-cljs-test
+  "THE SERVER-RENDER ENTRY, AND THE OBSTRUCTION IT CLEARS (rf2-b6jkj).
+
+  `re-frame.hicasso.server/render` is `dispositions.md` HS-11's first
+  candidate repair — *a matching server-render entry of this arm's own*
+  — and this file is what measures that it IS one.
+
+  ## The claim, and the row that would catch it being false
+
+  `identifier_prefix_ssr_dom_cljs_test` established the obstruction on
+  the server side alone, with no DOM in sight: one prefix, two tree
+  SHAPES, two ids. Its `server-html!` is *the tree a consumer can spell
+  today* — the frame provider over the root element — and its
+  `root-shaped-server-html!` reproduces `impl.mount/tree`'s hydrating
+  shape BY HAND as a measurement, explicitly *not offered as a product
+  path*. The ids disagree, and that disagreement is the whole of
+  obstruction 2.
+
+  So the repair has exactly one thing to prove, and §1 proves it:
+  **`server/render`'s bytes carry the SHAPED id, not the plain one.**
+  Both directions are asserted, because either alone is a green that
+  means nothing — agreeing with the shaped id while also agreeing with
+  the plain one would say the shapes had stopped differing rather than
+  that this entry picked the right one, and §1 pins that premise first.
+
+  A witness that only hydrated and looked for silence would not do this
+  job. **The closer renders no DOM**, so the markup the two shapes
+  produce is byte-identical everywhere except inside a `useId`, which is
+  precisely why the package shipped this bug with every markup-reading
+  row green.
+
+  ## Why the entry does not reproduce the shape, and why that is testable
+
+  It calls [[re-frame.hicasso.impl.mount/tree]] — the same function
+  `hydrate-root!` calls. §1's last row is the standing guard on that:
+  it renders the entry's element and the door's element and compares the
+  ids. Were the entry ever to grow its own copy of the fork, that row
+  reds the moment the two drift, which a row comparing the entry against
+  a hand-written expectation could not do.
+
+  ## The runtime split
+
+  Rows that only render to a string need no DOM and run under
+  `:node-test` too. The hydration rows need a real React DOM and say so
+  with `sup/skip!` rather than degrading to a false green."
+  (:require [cljs.test :refer-macros [async deftest is testing use-fixtures]]
+            [clojure.string :as str]
+            [re-frame.adapter.uix :as uix-adapter]
+            [re-frame.core :as rf]
+            [re-frame.hicasso :as h]
+            [re-frame.hicasso.impl.codec :as codec]
+            [re-frame.hicasso.impl.collector :as collector]
+            [re-frame.hicasso.impl.mount :as mount]
+            [re-frame.hicasso.impl.roots :as roots]
+            [re-frame.hicasso.native :as n]
+            [re-frame.hicasso.roots-frames-support :as sup]
+            [re-frame.hicasso.server :as server]
+            [re-frame.ssr.constants :as ssr-constants]
+            [re-frame.test-support :as test-support]
+            ["react" :as react]
+            ["react-dom/server" :as react-dom-server]))
+
+(def ^:private wire-frame ::app-main)
+
+;; Registered ABOVE `use-fixtures` for the sibling suites' reason: the
+;; reset fixture captures its source-store baseline when the
+;; `use-fixtures` form is EVALUATED, so a registration written below it
+;; is erased before the first row runs.
+
+(rf/reg-sub ::label (fn [db _] (:label db)))
+(rf/reg-sub ::secret (fn [db _] (:secret db)))
+(rf/reg-event ::relabel (fn [{:keys [db]} [_ label]] {:db (assoc db :label label)}))
+
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture
+    {:adapter       uix-adapter/adapter
+     :ambient-frame nil
+     :async?        true
+     :init-fn       (fn [] (collector/reset-runtime!))}))
+
+;; ---------------------------------------------------------------------------
+;; The probe — a `useId` that reaches the server bytes
+;; ---------------------------------------------------------------------------
+;;
+;; `useId` is a React hook, so it is written where React hooks are
+;; written: a native island, declared `{:server :render}` under a
+;; `{:server :render}` host — the only spelling that puts a native body
+;; into a server response. The island is the vehicle and never the
+;; subject: what is under test is the TREE the entry renders, and the
+;; island is the smallest legal thing that makes React's answer to it
+;; visible.
+
+(n/defcomponent id-probe
+  "One `useId`, rendered as text, beside a prop that changes."
+  {:server :render}
+  [^js props]
+  (n/$ :span #js {"className" "island"}
+       (n/$ :b #js {"className" "probe"} (react/useId))
+       (n/$ :i #js {"className" "label"} (.-label props))))
+
+(h/defhost id-host id-probe {:server :render})
+
+(h/defview id-page
+  "The page both sides render. One subscription read, so the root
+  acquires a frame-keyed cell and its commit is observable at all; one
+  island, so the page has an id in it."
+  [_]
+  [:div.page
+   [:p.value (h/sub [::label])]
+   [id-host {:label (h/sub [::label])}]])
+
+;; ---------------------------------------------------------------------------
+;; Harness
+;; ---------------------------------------------------------------------------
+
+(def ^:private snapshot {:label "alpha" :secret "do-not-ship"})
+
+(defn- request
+  "One request's options, with `extra` merged over the defaults. The
+  allowlist is `[:label]` — `:secret` is in the snapshot and must not be
+  on the wire, which is what makes the payload rows non-vacuous."
+  [& {:as extra}]
+  (merge {:hiccup            [id-page {}]
+          :snapshot          snapshot
+          :payload           [:label]
+          :client-frame-id   wire-frame
+          :identifier-prefix "pfx-a-"}
+         extra))
+
+(defn- id-in-html
+  "The id inside `html`, read straight off the bytes.
+
+  A string match rather than a parse, because these rows run under
+  `:node-test` too and there is no `document` there. It matches
+  [[id-probe]]'s OWN markup, so recognising it is reading back what this
+  file wrote; it assumes nothing about the id's SHAPE — the capture is
+  `.*?` and every assertion compares ids to each other."
+  [html]
+  (second (re-find #"<b class=\"probe\">(.*?)</b>" html)))
+
+(defn- plain-server-html!
+  "*The tree a consumer can spell today* — the frame provider over the
+  root element, handed to `renderToString`. `identifier_prefix_ssr_dom`'s
+  `server-html!`, re-spelled here so this file's premise row does not
+  reach into another suite's private."
+  [frame-kw hiccup prefix]
+  (react-dom-server/renderToString
+    (mount/provider frame-kw (codec/root-element frame-kw hiccup))
+    #js {"identifierPrefix" prefix}))
+
+(defn- door-shaped-html!
+  "The bytes for the element the PRODUCT DOOR would hydrate — built by
+  calling `impl.mount/tree` with a hydrating handle, which is what
+  `hydrate-root!` does with the handle it mints.
+
+  This is the cross-check for §1's last row, and it is deliberately not
+  a copy of the fork: if `tree` changes, this moves with it and so does
+  the entry, which is the property being asserted."
+  [frame-kw hiccup prefix]
+  (react-dom-server/renderToString
+    (mount/tree {:frame frame-kw :adoption (roots/open-adoption-window!)} hiccup)
+    #js {"identifierPrefix" prefix}))
+
+;; ---------------------------------------------------------------------------
+;; 1 — THE REPAIR: the entry emits the tree the door adopts
+;; ---------------------------------------------------------------------------
+
+(deftest the-entry-emits-the-hydrating-shape-and-not-the-plain-one
+  (testing "the premise first: the two shapes still disagree. Every row
+            below is about which one the entry picked, and all of them
+            would go vacuously green if the shapes had merely stopped
+            differing"
+    (let [plain (id-in-html (plain-server-html! ::probe-frame [id-page {}] "pfx-a-"))
+          door  (id-in-html (door-shaped-html!  ::probe-frame [id-page {}] "pfx-a-"))]
+      (is (some? plain) "premise: the island is IN the bytes, so there is an id to read")
+      (is (some? door))
+      (is (not= plain door)
+          (str "premise: the hydrating shape's fork must still move the id — "
+               "if these agree, obstruction 2 has some other cause and this "
+               "whole file is measuring nothing; got " (pr-str plain) " both times"))
+
+      (testing "and the entry's bytes carry the DOOR's id"
+        (let [entry (id-in-html (:html (server/render (request))))]
+          (is (some? entry))
+          (is (= door entry)
+              (str "server/render must emit the tree hydrate-root! adopts; got "
+                   (pr-str entry) " against the door's " (pr-str door)))
+          (is (not= plain entry)
+              (str "and it must NOT emit the plain provider-over-root tree — "
+                   "that is the shape whose bytes mismatch, and the one this "
+                   "entry exists to replace")))))))
+
+(deftest the-entry-honours-the-identifier-prefix
+  (testing "`:identifier-prefix` reaches React's own option — the half a
+            hydrating root must be handed the same string for"
+    (let [a (id-in-html (:html (server/render (request :identifier-prefix "pfx-a-"))))
+          b (id-in-html (:html (server/render (request :identifier-prefix "pfx-b-"))))
+          n (id-in-html (:html (server/render (request :identifier-prefix nil))))]
+      (is (str/includes? a "pfx-a-") (str "got " (pr-str a)))
+      (is (str/includes? b "pfx-b-") (str "got " (pr-str b)))
+      (is (not= a b) "two prefixes, two ids")
+      (is (some? n) "naming no prefix is not an error")
+      (is (not (str/includes? n "pfx-a-")) "an unprefixed render carries no prefix"))))
+
+;; ---------------------------------------------------------------------------
+;; 2 — the request: isolation, determinism, and the frame that must not leak
+;; ---------------------------------------------------------------------------
+
+(deftest two-renders-of-one-request-are-the-same-bytes
+  (testing "same bundle + same snapshot ⇒ byte-identical document, and the
+            per-request gensym is INVISIBLE on the wire — the two renders
+            take different ids, so a document that mentioned one could not
+            be byte-identical to the other"
+    (let [{:keys [identical? differs-at first second]} (server/render-twice (request))]
+      (is identical?
+          (str "two renders of one request differed at character " differs-at))
+      (is (not= (:frame-id first) (:frame-id second))
+          "premise: the two renders really did take different frame ids, so
+           the comparison above is a proof about the gensym and not an
+           accident of it being reused")
+      (is (not (str/includes? (:document first) (name (:frame-id first))))
+          "the per-request id must not appear in the document"))))
+
+(deftest the-request-frame-is-destroyed-even-when-the-render-throws
+  (testing "the happy path leaves no frame behind"
+    (let [{:keys [frame-id]} (server/render (request))]
+      (is (thrown? :default (rf/app-db-value frame-id))
+          "the per-request frame must be gone by the time render returns")))
+
+  (testing "and so does a render that threw — the `finally` is the whole
+            claim, since a leaked frame per failed request is a leak per
+            request under any real load"
+    (let [seen (atom nil)]
+      (is (thrown? :default
+                   (server/render (request :hiccup [(fn [] (throw (js/Error. "boom")))]))))
+      ;; The id is not observable from outside a successful render, so the
+      ;; standing proof is that the NEXT request still renders cleanly: a
+      ;; leaked frame would not stop it, but a runtime left mid-render
+      ;; would.
+      (reset! seen (:html (server/render (request))))
+      (is (str/includes? @seen "alpha")
+          "a request after a failed one still renders"))))
+
+;; ---------------------------------------------------------------------------
+;; 3 — the payload path is the framework's, fail-closed
+;; ---------------------------------------------------------------------------
+
+(deftest the-payload-is-fail-closed-and-allowlisted
+  (testing "omitting `:payload` raises the framework's own refusal — this
+            module adds no check, it hands the value straight to
+            `payload-policy`, and this row is what says so"
+    (is (thrown? :default (server/render (dissoc (request) :payload)))))
+
+  (testing "an allowlisted key rides and an un-allowlisted one does not.
+            `:secret` is in the snapshot the page rendered FROM, so a
+            green here is the allowlist working rather than the key being
+            absent"
+    (let [{:keys [payload document]} (server/render (request))
+          db (:rf/app-db payload)]
+      (is (contains? db :label) (str "the allowlisted key must ride; got " (pr-str db)))
+      (is (not (contains? db :secret)) (str "and the other must not; got " (pr-str db)))
+      (is (not (str/includes? document "do-not-ship"))
+          "and its value must not reach the document by any other route")))
+
+  (testing "the wire frame id is the CALLER's stable one and never the
+            per-request gensym (rf2-lm2yzy: stamping the gensym
+            guarantees :rf.error/hydration-frame-id-mismatch on every
+            real page)"
+    (let [{:keys [payload frame-id]} (server/render (request))]
+      (is (= wire-frame (:rf/frame-id payload)))
+      (is (not= frame-id (:rf/frame-id payload)))))
+
+  (testing "and omitting `:client-frame-id` omits the key — the
+            anonymous-server-frame shape, not a nil stamped on the wire"
+    (let [{:keys [payload]} (server/render (dissoc (request) :client-frame-id))]
+      (is (not (contains? payload :rf/frame-id))))))
+
+(deftest the-document-carries-the-pinned-payload-script
+  (let [{:keys [document payload-edn]}
+        (server/render (request :app-element-id "app" :script-src "/js/app.js" :title "The feed"))]
+    (is (str/includes? document (str "id=\"" ssr-constants/payload-script-id "\""))
+        "the script id is the framework CONSTANT the client bootstrap reads")
+    (is (str/includes? document "<div id=\"app\">"))
+    (is (str/includes? document "<script src=\"/js/app.js\"></script>"))
+    (is (str/includes? document "<title>The feed</title>"))
+    (is (some? payload-edn))
+    (testing "the payload script follows the app root's close and the
+              bootstrap is last — `ssr-ring`'s own order"
+      (is (< (.indexOf document "</div>")
+             (.indexOf document (str "id=\"" ssr-constants/payload-script-id "\""))
+             (.indexOf document "/js/app.js"))))))
+
+;; ---------------------------------------------------------------------------
+;; 4 — the far side: the bytes hydrate through the PUBLIC door
+;; ---------------------------------------------------------------------------
+
+(deftest the-entry-s-bytes-hydrate-through-h-hydrate-without-a-mismatch
+  (if-not (mount/browser?)
+    (sup/skip! "adoption is React's own DOM business")
+    (async done
+      (let [{:keys [html]} (server/render (request))
+            container      (sup/stamp-server-nodes! (sup/server-dom! html))
+            watch          (sup/watch-mismatches!)
+            handle         (h/hydrate! container
+                                       {:frame wire-frame :identifier-prefix "pfx-a-"}
+                                       [id-page {}])]
+        (rf/make-frame {:id wire-frame :initial-events [[:rf/set-db snapshot]]})
+        (-> (sup/adopted! handle)
+            (.then (fn [shut?]
+                     (is shut? "the root's own adoption window shut")
+                     (testing "the page is the SERVER's nodes — an expando
+                               survives adoption and does not survive a
+                               replacement, which is the entire difference
+                               between adopted and re-rendered"
+                       (is (sup/every-server-node? container ".page")))
+                     (testing "and the framework reported no hydration mismatch"
+                       (is (= [] ((:stop! watch)))))
+                     (testing "the handle is the one every other door takes"
+                       (is (some? (:root handle)))
+                       (is (= wire-frame (:frame handle)))
+                       (is (nil? (h/unmount! handle))))
+                     (done)))
+            (.catch (fn [e] (is false (str "hydration row threw: " e)) (done))))))))

--- a/implementation/hicasso/test/re_frame/hicasso/server_render_ssr_dom_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/server_render_ssr_dom_cljs_test.cljs
@@ -223,9 +223,17 @@
 
 (deftest the-request-frame-is-destroyed-even-when-the-render-throws
   (testing "the happy path leaves no frame behind"
+    ;; `app-db-value` answers nil for a frame that is gone AND for one that
+    ;; never existed, so the nil below is only evidence beside a control
+    ;; that a LIVE frame answers something. Without it this row would stay
+    ;; green under a `render` that never made a frame at all.
     (let [{:keys [frame-id]} (server/render (request))]
-      (is (thrown? :default (rf/app-db-value frame-id))
-          "the per-request frame must be gone by the time render returns")))
+      (rf/make-frame {:id ::control :initial-events [[:rf/set-db snapshot]]})
+      (is (some? (rf/app-db-value ::control))
+          "control: a live frame answers its app-db, so nil below means gone")
+      (is (nil? (rf/app-db-value frame-id))
+          "the per-request frame must be gone by the time render returns")
+      (rf/destroy-frame! ::control)))
 
   (testing "and so does a render that threw — the `finally` is the whole
             claim, since a leaked frame per failed request is a leak per


### PR DESCRIPTION
Mike ruled (2026-08-14): *"make sure the product (hicasso) is complete."* The seven
documented-but-missing forms get **built, not withdrawn**. This is stage-1 work.

**All seven were re-derived at source first, and four of the seven turned out not to be
gaps at all.** The list was hours old; the details are below, because a claim that
dissolves on inspection is a finding worth as much as one that holds.

## What was actually missing, and what shipped

**1. `server/render` — GENUINELY ABSENT. Shipped.**
`re-frame.hicasso.server` now exists: one request in, one document out, the fourth
optional module beside `.forms` / `.overlay` / `.motion` (naming-ledger row 22, *"keep
as taught"*). The door names it nowhere, so a browser build that never requires it
carries none of it — proven by the release-bundle gate below, which stayed green with
the new `day8/re-frame2-ssr` dependency on the classpath.

**2. `h/hydrate!` — built but held off the door. Shipped, and the hold is properly
lifted rather than overridden.** rf2-k1mp did not hold this on taste. It held it because
`dispositions.md` HS-11 obstruction 2 was *measured*: a hydrating root's tree is
`Fragment[closer, adoption-provider[app]]`, React derives `useId` from tree POSITION as
well as from `identifierPrefix`, and the package's only server path emitted no
counterpart to that fork — so bytes a consumer could bake hydrated into a text mismatch.

HS-11 named two candidate repairs and ruled on neither. **This PR takes the first — *a
matching server-render entry* — and the way it takes it is the load-bearing part**: the
server module does not reproduce the fork, it *calls* `impl.mount/tree`, the same
function `hydrate-root!` calls. The root's shape is decided in one place for both halves
of every SSR route. Mirroring it would have re-created the exact bug one file along.

The **spelling** is naming-ledger row 13's recommendation applied as a default — what the
ledger header says a recommendation does before the sitting, and the route rows 21 and 23
already took (rf2-mo4o, rf2-0ckh). The **contract shape** is row 20's `(node config view)`,
kept as taught.

## Three claims refuted at source, and one double-counted

**3. `ssr/hydrate!` — EXISTS.** `re-frame.ssr/hydrate!` ships at
`implementation/ssr/src/re_frame/ssr.cljc:68` (→ `boot/hydrate!`), takes `{:frame …}`,
raises the two errors chapter 18 names, and returns the applied payload or nil. Chapter
18's client-boot sample is true today. Nothing to build.

**4. The key-map position restriction — REAL.** The guide says supplying an intent *or
key map* to a `:handler` / `:render` position raises
`:rf.error/hicasso-intent-at-a-non-event-contract`. `impl/intent.cljs`'s
`refuse-dispatching-carrier!` refuses **both carriers** at **both contracts**, and
`intent_cljs_test.cljs:640` already witnesses it driving `{"Enter" [:host/changed 3]}`
across the full cross-product. The sentence is true as written.

**5. `merge` versus `:&` — shipped, and this is the same item as one of the three
"omissions", counted twice.** `:&` and the owned-literal law are fully built
(`impl/codec.cljs`, HD-023). The guide teaches a plain `merge` with owned keys last,
which *works* — so this is not a missing form, it is the `:& owned-literal law` omission
the bead already assigns to **stage-4 docs**. It is one item on both lists.
(There is a real difference worth the docs bead's attention: plain `merge` lets a caller
smuggle `::h/revision` through a forwarded map, which the `:&` door refuses loudly.)

**6. `h/fn` — REFUSED, on a recorded decision.** Naming-ledger row 1 rules it out in as
many words: *"never `fn` (shadows `cljs.core/fn` for `:refer` users)"*. Its recommendation
is `h/event`; `h/handler` is the other candidate; both stand for the sitting. `h/hfn`
already ships the capability — this is a rename question the ledger is deliberately
holding, not a missing form. Row 18 likewise recommends *retiring* `hframe` rather than
minting `h/frame`. Shipping either would have contradicted a written ruling, so neither
shipped. **Both stay in the guide-gate's `DIVERGENCES` ledger, still live.**

**7. The install coordinate — ALREADY FIXED** (PR #8204). `00-installation.md` now
carries a pre-alpha "no Clojars coordinate" warning and a `:local/root` snippet. Verified.

## `h/mount!` — the one buildable item NOT shipped, and why

Rows 13 + 20 recommend `root!` → `mount!` with the config-map shape, and I would have
taken it with `hydrate!`. It is **a rename of a door that already carries an inventory
row** — HS-10, whose `Public surface` cell reads `` `h/root!` `` — so it reds
`check_facade_inventory.py` unless that row is rewritten in `dispositions.md`, which this
bead's fence puts out of bounds. `h/hydrate!` needed no such edit: **HS-11 was already
written against the `h/hydrate!` spelling**, so the addition landed green with the
inventory untouched. `h/mount!` is a clean follow-up: one rename, one row.

## The omission gap — my judgement, and I did not close it

Neither gate catches an omission, and I am **not** proposing a third. The honest reading
is that the guide gate's R2 already covers this class going forward: it resolves every
verb the guide names against shipped source, so a form that is *documented and absent*
reds the moment it is written down. All four name-resolution items here predate it. What
R2 cannot see is a form that is **shipped and undocumented** — and that is not an
omission a code gate can find, because nothing in the source knows the guide should have
mentioned it. A checker for it would be a checker with a hand-maintained list of things
someone decided were important, which rots the day it stops being read.

**One real gap I did find and did close**, because it was about to bite silently: the
guide gate's R2/R3 self-tests drove the *live* `ABSENT_NAMESPACES` table. Emptying that
table — which shipping the server module does — took the absent-namespace arm from
*passing* to *unrunnable*, and the rule would have gone untested exactly when it was least
exercised. Both ledgers are now parameters defaulting to the live tables, with the
self-test driving fixtures, which is the shape `check_facade_inventory.py` already uses
for its own two lists. A new R3 row now covers the arm the live table can no longer drive.

## Facade inventory

`check_facade_inventory.py`, before → after: **15 names / 43 rows → 16 names / 43 rows**,
exit 0 both times. The added name is `h/hydrate!`, attributed BY NAME to the row that was
already waiting for it (HS-11). No `DECLARED` or `HELD` entry was needed.

## Notes for the mayor

- **No new error id**, so no `spec/009` row and no complaint-catalogue row are owed. The
  server module reuses `:rf.error/ssr-missing-payload-policy` from the framework's own
  validator — it hands `:payload` straight to `payload-policy` and adds no check of its own.
- **`docs/core/hicasso/index.md`'s Status block is now stale** — it still says `h/hydrate!`
  "is not exported" and that `re-frame.hicasso.server` does "not exist yet". Both are false
  as of this PR. The guide is fenced (stage-4, another bead's), so **this needs a
  follow-up docs edit** and nothing reds in the meantime.
- **Naming-ledger row 22 calls the module "a JVM-side module"; it is Node-side CLJS.** It
  has to be: chapter 18 itself says *"React renders the server output; there is no parallel
  JVM string emitter"*, and the engine is the Hicasso runtime under `react-dom/server`.
  Worth correcting in the ledger.
- **`implementation/hicasso/deps.edn` gained `day8/re-frame2-ssr`**, which moves it off
  "core alone". Deliberate and documented in the file: the module hands the payload to
  `re-frame.ssr.payload-policy`'s fail-closed validator, so R0 — *nothing Hicasso-specific
  touches the payload path* — stays a packaging fact. `ssr` depends on core alone, so the
  graph is the DAG `hicasso -> ssr -> core`. Costs a classpath entry and zero bundle bytes.
- The prototype at `test/re_frame/bench/hicasso/ssr/entry.cljs` is **untouched and still
  frozen**; the new module is its product form on the package's own impl namespaces.

## Quality gates

`scripts/check_fast_pr_gap.py --list` reports **96 required checks the fast-PR spine does
not run**. Gates run directly, all foreground to completion:

| Gate | Exit |
| --- | --- |
| `npm run test:hicasso-invariants` (incl. facade-inventory + guide-samples, both with `--self-test`) | `0` |
| `npm run test:hicasso-lint` | `0` |
| `node-test-hicasso` — 1203 tests, 4896 assertions, 0 failures, 0 errors | `0` |
| `:browser-test` narrowed to this suite — 7 tests, 37 assertions, 0 failures | `0` |
| `npm run build:hicasso-release` (:advanced erasure + bundle isolation) | `0` |
| `clojure -M:test` in `implementation/hicasso` — 3 tests, 92 assertions | `0` |
| `scripts/test-fast-pr.sh` — clj-kondo tier **errors: 0**; timed out in the JVM `core` tier at 10m | `143` (timeout) |

The spine timed out rather than failed, in `implementation/core`'s JVM suite — a tier this
diff does not touch. Its hicasso half was run directly and is in the table above.

**The witness fails without the code.** Red-state probe: swapping the server module's
`mount/tree` call for the plain provider-over-root tree — the shape a consumer can spell
today — reds `the-entry-emits-the-hydrating-shape-and-not-the-plain-one` with **2 failures,
exit 1**, on exactly the two assertions that say the entry must emit the door's shape and
not the plain one. Restored to green and re-run (exit 0) before commit.

The parity witness also pins its own premise first — that the two tree shapes still
produce different ids — because every row after it would go vacuously green if they had
merely stopped differing. The frame-teardown row carries a positive control for the same
reason: `app-db-value` answers nil for a frame that is gone *and* for one that never
existed, so the nil is only evidence beside a live frame that answers something.

Closes rf2-b6jkj.
