### PR TITLE
docs(hicasso): strike axe from the browser proof suite, per the rf2-5q8o DECLINE (rf2-fgpyj)

### DIFF
--- a/docs/design/hicasso/product/lanes/completeness-audit.md
+++ b/docs/design/hicasso/product/lanes/completeness-audit.md
@@ -36,7 +36,7 @@ Warm-allocation evidence is deliberately absent from the release suites until it
 
 ### Browser and platform
 
-- Chromium, Firefox and WebKit control/IME behavior; structural accessibility assertions plus browser focus and axe checks.
+- Chromium, Firefox and WebKit control/IME behavior; structural accessibility assertions plus browser focus checks over names, roles, keyboard and virtualized/overlay focus. No automated axe sweep: `rf2-5q8o` ruled DECLINE because no acceptance column asks for one, so it is not a witness to re-add here.
 - Lazy load, fallback, error, retry and HMR through the Hicasso boundary-ABI bridge.
 - The complete public-surface SSR/hydration inventory, including deliberate mismatch and overlapping-root witnesses.
 


### PR DESCRIPTION
Closes rf2-fgpyj.

## What changed

One line, one file, one list entry. `docs/design/hicasso/product/lanes/completeness-audit.md`, the "Browser and platform" witness fixture (found by content; it was still at line 39 after PR #8239):

```diff
-- Chromium, Firefox and WebKit control/IME behavior; structural accessibility assertions plus browser focus and axe checks.
+- Chromium, Firefox and WebKit control/IME behavior; structural accessibility assertions plus browser focus checks over names, roles, keyboard and virtualized/overlay focus. No automated axe sweep: `rf2-5q8o` ruled DECLINE because no acceptance column asks for one, so it is not a witness to re-add here.
```

Nothing else in the file is touched: no restructuring, no renumbering, no neighbouring rows.

## The ruling this propagates, verified at source

`rf2-5q8o` is a **RULING**, not a recommendation. Its close reason states it in terms — "Re-closed — the DECLINE stands and nothing has changed it (mayor, 2026-08-14)" and "THE RULING, restated once so it is not re-litigated: the tool is in NO acceptance column anywhere."

The replacement wording is not invented. `specification.md` §7's Accessibility row reads:

| Accessibility | Semantic Hiccup and native controls | Structural a11y assertions plus browser focus tests | Names, roles, keyboard, virtualized/overlay focus |

So the bullet now mirrors the spec row it is supposed to witness — proof column plus acceptance column — where before it named a tool that appears in neither.

**No axe-core, no dependency, no gate.** The DECLINE's reopen condition has not fired.

## Why the DECLINE is recorded rather than the entry merely deleted

This exact one-line propagation has now outlived three owners: `rf2-5q8o` was reopened **twice** for it and closed twice without the edit landing, `rf2-7znnl` was withdrawn as a duplicate, and `dispositions.md` §1.2 records it as an UNOWNED remainder. A bare deletion leaves no trace of *why*, which is how the line returns a fourth time. One sentence naming the ruling and its bead id is the smallest thing that stops that — deliberately a sentence, not a section, and placed in the bullet a re-adder would edit rather than in "Explicit refusals" (which lists product/design refusals, a different category from proof tooling).

**The propagation is done.** `completeness-audit.md` no longer claims the browser proof includes axe.

## Filed, not fixed — out of fence

`rf2-fgpyj`'s fence is `completeness-audit.md` **only** (the correction ledger and `dispositions.md` are the ledger keeper's). Three cells elsewhere still state, as their premise, that this file *lists* axe among the proof suites, and all three name `rf2-7znnl` — a **closed/withdrawn** bead — as owner:

- `checkpoint-4-coverage.md:87` — Accessibility scored **NOT MET** on that basis, while the same cell concedes "names, roles, keyboard and virtualized/overlay focus are all witnessed"
- `checkpoint-4-coverage.md:230` — findings-table row
- `correction-ledger.md:90` — `rf2-hic-048` row, status `open`

Filed as **`rf2-c0agr`** with the fence set to those two files. Untouched here.

## Quality gates

**PASS 3, FAIL 0, SKIP 1.** Every exit code below is the one captured in the same shell as the redirect (`> log 2>&1; echo "EXIT=$?"`), never a harness-reported number.

| Gate | Captured exit | Result |
|---|---|---|
| `scripts/check_doc_slugs.py` (post-rebase, final base) | `0` | PASS |
| `scripts/check_provenance_pins.py --changed-since origin/main` | `0` | PASS — `1 page inspected, 0 cited pins ... 0 findings` |
| `scripts/check_doc_slugs.py` **sabotage control** | `1` | PASS (red as designed — see below) |
| `scripts/test-fast-pr.sh` | — | **SKIPPED**: ~25 min against a 10 min harness ceiling, for a one-line prose diff under `docs/design/**` that reaches no code, build or lint surface. |

`mkdocs build --strict` is **not** nominated: `mkdocs.yml`'s `exclude_docs` keeps `design/hicasso/` out of the site, so it would exit green having verified nothing.

**Fast-spine vs required-CI gap:** `scripts/check_fast_pr_gap.py --list` is the one path (TESTING.md:121). Captured exit `0`; it reports **96 required checks the spine does not run**. That is a fact about the spine, not a census of this PR — and per the above, the spine did **not** run here at all; the two doc checkers were run directly.

### Plant discrimination proof

`check_doc_slugs.py` prints nothing on success, so a green tells you nothing about *which tree it read*. Planted a single-line fault at the line being edited — `[witness](#no-such-anchor-axerow-fgpyj)` — and the gate came back **captured exit 1**, naming exactly what was planted:

```
1 broken anchor link(s) found:
  BROKEN ANCHOR: docs\design\hicasso\product\lanes\completeness-audit.md:39 -> #no-such-anchor-axerow-fgpyj
```

That anchor exists in no other checkout, so a run that had wandered into a sibling worktree would have come back green. Restore verified **by hashing the bytes**, not by reading a diff: `git hash-object` returned `f4036d666bd0e261243534a3e8b21947ea65696e` both before the plant and after the restore, and again unchanged after the rebase.

### By-hand checks (nothing validates this tree's tables, rendering or nav)

- **Table column counts** — the single table (`## Canonical suites`, lines 7–19) is unmodified by this diff, and re-counted anyway: header, separator and all 11 data rows carry **4 pipes → 3 cells** each, uniform. The changed line is a list bullet, not a table row, and introduces **no** `|` character.
- **Anchors** — no heading was added, removed or renamed; all 10 headings are intact. The new text adds **no** links, so no new link target exists to resolve. Existing inbound links to this file's headings are unaffected.
- **Rendering** — the bullet remains a single Markdown list item; the only inline markup added is one backticked bead id, matching the file's existing convention (`rf2-xpq9` at line 18).

### Merge-base diff read for reverts

PR #8239 landed in this same directory minutes before this branch was cut, so the three-dot diff was read specifically for reverts, not conflicts: `git diff origin/main...HEAD` is **1 file, 1 insertion, 1 deletion**, touching only the axe bullet. `react-compatibility-notes.md` and `lanes/README.md` are untouched. Rebased onto the latest `origin/main` (three commits had landed; none touched this file) and both doc gates re-run on that final base.
