### PR TITLE
docs(hicasso): clear the 7 studio provenance-pin findings, and rule on the scoping (rf2-g7m6y)

### DIFF
--- a/docs/design/hicasso/studio/controlled-input-two-implementations.md
+++ b/docs/design/hicasso/studio/controlled-input-two-implementations.md
@@ -20,8 +20,8 @@ identifier, and `git log --oneline --all -- <path>` plus
 `git rev-parse <candidate>:<path>` finds a commit carrying the blob.
 **Measured** 2026-08-01 AUSEST
 
-**The arm's own witnesses** (`rf2-fki5d`, measured 2026-08-02 AUSEST, same
-runtime): `22e7e6f456fd1ac9a1628fd985588ff87e68532d`
+**The arm's own witness content hashes** (`rf2-fki5d`, measured 2026-08-02
+AUSEST, same runtime): `22e7e6f456fd1ac9a1628fd985588ff87e68532d`
 (`…/hicasso/arm1/controlled_grid_dom_cljs_test.cljs`) and
 `176442a54e1be2ea346e7cfee460f4583bf10233`
 (`…/hicasso/front/controlled_dom_cljs_test.cljs`). The mechanism is

--- a/docs/design/hicasso/studio/heap-fan-out-sweep.md
+++ b/docs/design/hicasso/studio/heap-fan-out-sweep.md
@@ -146,8 +146,10 @@ never to the guard.
 
 Committed as `cd99cded82` — this page's first revision — **before** the
 published rungs were measured, so this page is not a record of only the
-predictions that came true. `git show cd99cded82` is the receipt.
-[§3](#3-the-prediction-adjudicated) marks each one.
+predictions that came true. The rebase-merge stranded that authored head, so it
+is in no fresh clone; it landed on `main` as `cca5c7ea84`, the commit that adds
+this page, carrying it at the identical blob. `git show cca5c7ea84` is the
+receipt. [§3](#3-the-prediction-adjudicated) marks each one.
 
 - **P1** *(the ruling's own falsifiable claim)* — the fan-out-1 rung lands on
   the ladder's distinct-query family: Reagent ~1,562 B, UIx ~3,807 B at one

--- a/docs/design/hicasso/studio/p0-ratom-spine-narrow-write.md
+++ b/docs/design/hicasso/studio/p0-ratom-spine-narrow-write.md
@@ -19,9 +19,11 @@ commit SHA moved, while the three blobs below did not move at all.
 | `hicasso_narrow_app.cljs` | `a201ff16debe57b2aa297fe6ae7d27a19c3831d2` |
 | `hicasso_narrow_run.cjs` | `cbffc0205675b524060f8c956efe2205f9e3570f` |
 
-Authored as `7c51e77b4f` on `worker/bench-audit-cluster`. **If that SHA does
-not resolve, a rebase moved it and the blobs above are what to trust** — this
-finds a commit carrying them, and confirms it:
+Authored as `7c51e77b4f` on `worker/bench-audit-cluster`. That rebase did happen,
+so the authored head resolves in no fresh clone; it landed on `main` as
+`8742413fc8`, which carries all three blobs above and is the tree to check out.
+**If neither SHA resolves, the blobs are what to trust** — this finds a commit
+carrying them, and confirms it:
 
 ```bash
 P=implementation/adapters/reagent/test/re_frame/bench/hicasso_narrow.cljs

--- a/docs/design/hicasso/studio/raw-escape-design-b-correctness.md
+++ b/docs/design/hicasso/studio/raw-escape-design-b-correctness.md
@@ -68,8 +68,8 @@ interpreted root" but **"this tier carries no such value"** — Spec 011 tiers
 hydration-mismatch detection by render-tree representation rather than by adapter
 brand, and a root React adopts (a compiled `re-frame.ui` root, a native UIx root, or
 a Freehand root) now emits no `:rf/render-hash` and stamps no marker at either end.
-And `83b865f8` was never a fact about the dogfood screen or the Conduit feed: it is
-the FNV-1a-32 of the canonical EDN `[#fn[] {}]`, so **any** unresolved `[<fn> {}]`
+And the hash `83b865f8` was never a fact about the dogfood screen or the Conduit
+feed: it is the FNV-1a-32 of the canonical EDN `[#fn[] {}]`, so **any** unresolved `[<fn> {}]`
 root takes it. This *strengthens* both places the fact is used — O7's fail-open
 obligation, and the §"blind" row below, where the middle column's blindness is
 attributed to canonical EDN rendering every function identically. That attribution

--- a/docs/design/hicasso/studio/uix-spine-per-read-decomposition.md
+++ b/docs/design/hicasso/studio/uix-spine-per-read-decomposition.md
@@ -46,7 +46,8 @@
 > `10c49efbbe731ce02deda6e2ed432b0270d6beb6`, and the fixed spine
 > `implementation/core/src/re_frame/substrate/spine.cljs`
 > `56f7e5480c99330515d525a2bdacf5f86a0db7bd`. Authored as `4367e5d93f` on
-> `worker/spine-2rtt6-13`.
+> `worker/spine-2rtt6-13`, which the rebase-merge stranded; it landed on `main`
+> as `f747b9c667`, carrying all four of the blobs named here.
 
 > **SPINE STAMP — this page's after-run is POST-`rf2-2rtt6.13` and
 > PRE-`rf2-2rtt6.25`.** The landed `.13` commit is **`9df5094816`**, whose
@@ -518,8 +519,9 @@ refusal survives it. Exit 4 is the new code.
 
 Every repair is a refusal, so none of them can move a number — but that is an
 argument, and this page prefers a measurement. Re-run on the repaired
-instrument (blobs in the header; authored as `fa09c5ad7a`), four rounds and two
-snapshot rounds per page, **exit 0 under all six new gates**:
+instrument (blobs in the header; authored as `fa09c5ad7a`, landed on `main` as
+`8768b86c53`), four rounds and two snapshot rounds per page, **exit 0 under all
+six new gates**:
 
 | | published | confirmation run |
 |---|---:|---:|


### PR DESCRIPTION
Fixes the 7 pre-existing provenance-pin findings under `docs/design/hicasso/studio/`, and rules on the scoping question. **The ruling is (b), and the workflow edit is NOT in this PR** — `.github/workflows/*` is fenced to `worker/armfix-cujx`. It is filed as **rf2-qpk2l**.

## Reproduced first

The 7 was a claim measured on another worker's branch. Reproduced on `origin/main` before touching anything:

```
$ python scripts/check_provenance_pins.py          # no --changed-since = full corpus
check_provenance_pins: 107 pages inspected, 481 cited pins — 365 landed, 107 stranded,
  8 unresolvable, 1 foreign; 108 accompanied in scope; 7 findings.
```

**Before: 7 findings / exit 1. After: 0 findings / exit 0.** Same command both times.

```
$ python scripts/check_provenance_pins.py
check_provenance_pins: 107 pages inspected, 482 cited pins — 369 landed, 106 stranded,
  6 unresolvable, 1 foreign; 112 accompanied in scope; 0 findings.
```

The census arithmetic reconciles exactly, which is the check that the diff did what it says and nothing more: `+4` landed (the four landed SHAs added), `−1` stranded (one `git show cd99cded82` citation repointed), `−2` unresolvable (two tokens reclassified as digests) = `481 + 1 = 482`.

## The 2 "unresolvable" findings, read first

Both are **misclassified digests, not broken pins**, and in both the page gave a reader no more to go on than it gave the checker — which is exactly the condition that gate reports ("a sentence a reader cannot classify either, which is the finding"). So the repair is to the prose. No pin was re-pointed and no figure moved.

| page | token | what it actually is | why it misfired |
|---|---|---|---|
| `controlled-input-two-implementations.md:24` | `22e7e6f4…` | **blob** (`git cat-file -t` = blob) | no digest word in left context at all |
| `raw-escape-design-b-correctness.md:71` | `83b865f8` | **FNV-1a-32 of canonical EDN `[#fn[] {}]`**, said so in its own sentence | nearest word left was `stamps`, from "stamps no marker at either end" |

Repairs: "The arm's own witnesses" → "The arm's own witness **content hashes**", matching the convention the same page already sets eight lines above at "**Witness content hash**"; and "And `83b865f8` was never a fact…" → "And **the hash** `83b865f8` was never a fact…". Both read better to a human, which is the point.

## The 5 stranded findings

Each named an authored head the rebase-merge stranded, with no resolvable anchor in its block. The gate refuses to re-pin on purpose — "recovering the landed SHA restores the patch and not necessarily the measured tree, so a human decides each one" — so **every mapping below was verified twice over**: identical `git patch-id --stable`, *and* the blobs the page itself names resolving at the landed SHA. Each landed SHA confirmed `merge-base --is-ancestor` of `origin/main`.

| page | stranded → landed | second check |
|---|---|---|
| `heap-fan-out-sweep.md:147,149` | `cd99cded82` → `cca5c7ea84` | `cca5c7ea84` is verifiably the commit that **adds** this page, at the identical blob |
| `p0-ratom-spine-narrow-write.md:22` | `7c51e77b4f` → `8742413fc8` | all 3 blobs in the page's own table resolve there, via the page's own recipe |
| `uix-spine-per-read-decomposition.md:48` | `4367e5d93f` → `f747b9c667` | all 4 named blobs resolve there, incl. `spine.cljs` `56f7e548…` |
| `uix-spine-per-read-decomposition.md:521` | `fa09c5ad7a` → `8768b86c53` | patch-id; commit touches the ablation instrument it names |

Two are worth calling out. `heap-fan-out-sweep.md` had **already reached this same mapping by the same patch-id argument, 70 lines above**, in its Provenance section — accompaniment is block-scoped, so that never rescued the later citation. It is now restated where the claim is made. And `8742413fc8` answers `p0-ratom`'s own prescribed `git rev-parse <candidate>:$P` recipe exactly. Where a page hedged "if that SHA does not resolve, a rebase moved it", the rebase demonstrably did, so the prose now says so outright.

## The scoping ruling: (b)

**(a) is refuted empirically.** The scoped job responds to exactly one trigger — a page appearing in the PR diff — and *none* of these 7 arrived that way:

1. **Legacy.** All 5 pages were last edited 2026-07-31…08-06; the gate landed 08-06 **22:52** (`4b9ee1f811`). The census repair sweep `ca831062aa` landed **22:14** — 38 minutes *earlier*. So the page that sweep itself repaired still carried a finding, and CI has never once inspected it.
2. **Hardening, and this recurs.** The checker gained rules six times in eight days (`rf2-kqac1` ×3, `rf2-xlsh` ×2, `rf2-styo` ×2, `rf2-dmrm` ×2, `rf2-qfrrp`). Each hardening reclassifies the whole corpus; only touched pages are re-checked. Each one silently mints a fresh backlog.

Neither trigger is a page edit. (a) guarantees an 8th finding, discovered by luck again.

**The documented blocker for a wider gate has now expired.** `docs.yml:561-567` gives the reason for scoping, and it was never cost: *"A full-corpus gate would therefore be red on main from the day it landed … the audit (`python scripts/check_provenance_pins.py`, no flag) reports the backlog for whoever works it off."* That backlog is worked off as of this PR — the corpus is green.

**(b) over (c).** (c) is now *possible*, but it couples every future gate-hardening PR to a corpus-wide repair, and each repair needs a human by design. That is precisely the "punish the careful ones and be routed around within a week" pressure the checker's own docstring names — and it would land hardest on the person improving the gate. (c) also blocks docs PRs on pages they did not touch. A full run is ~58 s, so cost is not the discriminator; blast radius is. (b)'s trigger is time rather than a diff, which is the only shape that catches both vectors above without charging an unrelated PR.

**rf2-qpk2l** carries the edit: one step in `lint.yml`, which already runs nightly and already checks out `fetch-depth: 0` — load-bearing here, since a shallow clone answers "not an ancestor" for perfectly landed pins and reds the whole corpus. No new machinery (rf2-6ng7): no meta-checker, no roster, no drift detector. It also notes the `docs.yml:561-567` comment goes stale once it lands.

## Quality gates

**Pass 6 / fail 0.** Every number below is the exit code captured in the same shell as the run (`cmd > log 2>&1; echo $?`), never a harness report.

| gate | exit | result |
|---|---|---|
| `check_provenance_pins.py` (full corpus) | **0** | 107 pages / 482 pins / **0 findings** (was 7) |
| `check_provenance_pins.py --changed-since origin/main` | **0** | 5 pages / 39 pins / 0 findings |
| `check_provenance_pins.py --self-test` | **0** | pass |
| `check_doc_slugs.py` | **0** | pass |
| `check_provenance_pins.py` **sabotage** | **1** | bites — see below |
| `check_doc_slugs.py` **sabotage** | **1** | bites — see below |

Both checkers print no root, so each was proved to be reading *this* worktree by planting a single-line fault and checking the red named it:

- pins: `8742413fc8` → `deadbeef01` ⇒ exit 1, *"p0-ratom-spine-narrow-write.md:24 `deadbeef01` [UNRESOLVABLE] (commit word 'landed' nearest on the left)"* — a token existing only in this tree.
- slugs: `#3-the-prediction-adjudicated` → `#3-the-prediction-NOPE-adjudicated` ⇒ exit 1, *"BROKEN ANCHOR: heap-fan-out-sweep.md:152 -> #3-the-prediction-NOPE-adjudicated"*.

Both restores verified by `git hash-object` against the pre-plant hash (`4bf427d769…`, `4b3abe23f8…`), not by reading a diff.

**Gates re-run on the final base after rebase.** `origin/main` advanced 10 commits mid-work (incl. #8239); rebased and re-ran all four — the corpus count held at 0. `git diff origin/main...HEAD` (three-dot) reverts nothing: 5 files, +18/−12.

**Spine not run.** `scripts/test-fast-pr.sh` did not run. Reason: the diff is 18 lines of prose in `docs/design/hicasso/studio/`, a tree `mkdocs.yml`'s `exclude_docs` excludes from the site build, so the spine's docs lane reduces to the two checkers already run directly here (both plant-verified) plus the self-test. Running the ~25-minute spine against four other live workers risks the known concurrent-gate wedge for no added signal. Per `scripts/check_fast_pr_gap.py --list` (exit 0), **96** required checks are outside the spine regardless — including `docs.yml` job "Provenance pins" itself, whose PR step is `--changed-since` (green here).

## By-hand checks

`mkdocs build --strict` covers none of this tree and was not nominated. Nothing validates its tables, so by hand across all 5 touched pages:

- **Tables: 41 checked, 0 mismatched.** Header/separator/body cell counts equal in every table, counting `|` outside code spans: controlled-input 5, heap-fan-out 15, p0-ratom 8, raw-escape 5, uix-spine 8. **No edit here touches a table** — all five are prose or blockquote — so every count is unchanged from `origin/main`.
- **Anchors: no heading text changed**, so no incoming anchor can break. The one link inside a hunk, `[§3](#3-the-prediction-adjudicated)`, is preserved verbatim and is the target the slugs plant confirmed live. `check_doc_slugs.py` green corpus-wide.

## Notes for adjacent workers

- **`worker/relscans-hic072`** — you cite figures drawn from studio pages. **No figure, measurement, blob hash, path or claim changes in this PR.** The only semantic additions are landed-SHA accompaniments; the only removal is one `git show cd99cded82` repointed to `git show cca5c7ea84` (same tree, resolvable in a fresh clone). Anything you cite still reads as it did.
- **PR #8235** (donor-arm retirement) touched `README.md`, `hd8-composed-donor-arm.md`, `hd8-freehand-codec-donor-arm.md`, `the-clock-behind-the-published-rows.md` — **zero overlap** with the 5 pages here, verified by `git show --name-only`. No retirement banner is touched, and no pin repaired here points at a retired instrument.
