### PR TITLE
fix(hicasso): close the zero-rent guard gaps — server roster row, motion/overlay bundle sentinels, stale JVM-arm comment (rf2-2a0ju, rf2-ot28g, rf2-h2h25)

### DIFF
--- a/implementation/hicasso/deps.edn
+++ b/implementation/hicasso/deps.edn
@@ -77,15 +77,15 @@
  ;; is gone and the floor applies: 3 tests, and the runner refuses if that ever
  ;; becomes 0.
  ;;
- ;; THE JVM ARM IS NOW UNGATED, AND THAT IS A REAL COST, NOT A DETAIL. The pin
- ;; used to be discovered by `implementation/freehand`'s `:test` alias, which
- ;; is on `scripts/test-jvm-implementation.sh` AND has a required `test.yml`
- ;; job. This artefact is on neither — deliberately, per the "NOT HERE, ON
- ;; PURPOSE" note in that roster script — because `check_jvm_lane_rosters.py`
- ;; R1 refuses a roster entry with no CI job, and the missing half is a
- ;; `jvm-hicasso` job in `.github/workflows/test.yml`, which is hot-zone and
- ;; sequential. So the pin's Node arm still runs on every PR and its JVM arm
- ;; runs only when somebody types `clojure -M:test` here. Filed, not hidden.
+ ;; THE JVM ARM IS GATED, ON EVERY PR. It was not, for one hour and forty-two
+ ;; minutes: this alias landed ungated because `check_jvm_lane_rosters.py` R1
+ ;; refuses a roster entry with no CI job, so the artefact could not join
+ ;; `scripts/test-jvm-implementation.sh` until `.github/workflows/test.yml` —
+ ;; hot-zone and sequential — carried a job to match. `f4c3c53d04` landed both
+ ;; halves together, which is the only way R1/R2 accept either. The artefact is
+ ;; now on that roster and `test.yml` runs `jvm-hicasso` unconditionally, in
+ ;; `all-required-passed`'s `needs:`, so the slot-rule pin's JVM arm no longer
+ ;; waits for somebody to type `clojure -M:test` here (rf2-h2h25).
  ;;
  ;; The lint export's witness (rf2-hic-022) is still NOT a JVM suite. It is
  ;; `scripts/check_lint_export.py`, run by `npm run test:hicasso-lint`, for the

--- a/implementation/hicasso/scripts/check_bundle_isolation.cjs
+++ b/implementation/hicasso/scripts/check_bundle_isolation.cjs
@@ -1,14 +1,24 @@
 #!/usr/bin/env node
 /*
  * THE ZERO-RENT PROOF FOR EVERY ISOLATED SURFACE, read off a real
- * production bundle (rf2-hic-034; the forms module added by rf2-sh56).
+ * production bundle (rf2-hic-034; the forms module added by rf2-sh56,
+ * motion and overlay by rf2-ot28g).
  *
- * Two surfaces are measured here and the law each answers to is its own:
- * the NATIVE TIER, whose clause is quoted next, and the optional FORMS
- * MODULE, whose clause is `invariants.md` §1 — *optional libraries:
- * named consumer required; zero reachable production code when absent*.
- * They share this file because they share one instrument and one bundle;
- * each surface's own reasoning is with its rows.
+ * Four surfaces are measured here and the law each answers to is its
+ * own: the NATIVE TIER, whose clause is quoted next, and the optional
+ * MOTION, OVERLAY and FORMS modules, whose clause is `invariants.md` §1
+ * — *optional libraries: named consumer required; zero reachable
+ * production code when absent*. They share this file because they share
+ * one instrument and one bundle; each surface's own reasoning is with
+ * its rows.
+ *
+ * THE HEADING MEANS WHAT IT SAYS OF THE MODULE ROSTER, and the one gap
+ * left is named rather than left to be discovered. Every module
+ * `check_optional_module_reachability.py` rows is measured here EXCEPT
+ * `re-frame.hicasso.server` (rf2-2a0ju), which is source-side only: it
+ * is a Node module and the one bundle this gate reads is a browser
+ * build, so its row here is a different question from the other four's
+ * and is filed as its own bead rather than guessed at.
  *
  * > 6. The native namespace is separately reachable. An interpreted-only
  * >    production dependency graph and bundle contain neither native-tier
@@ -173,6 +183,48 @@
  *     event id and an `app-db` key at once, so the module cannot read or
  *     write a draft without it.
  *
+ * ## Motion and overlay: ONE shape and TWO, decided rather than assumed
+ *
+ * rf2-ot28g closed the gap this file had carried since rf2-sh56: the
+ * source-side gate covered four optional surfaces and this one covered
+ * two, so a green here was reported under a heading reading "every
+ * isolated surface" while saying nothing about motion or overlay. The
+ * file already knew both modules existed — `motion/presence` sat in the
+ * near-miss list below as a string the scan is asserted NOT to fire on —
+ * which made the silence a choice rather than an oversight, and the
+ * wrong one.
+ *
+ * All three new rows are stamped `displayName`s, which is not a new
+ * idiom but the one the `hicassoBoundary` control is already read
+ * through: `codec/mark-boundary!` writes its marker with `unchecked-set`
+ * onto a freshly minted component, and each of these modules writes a
+ * NAME onto that same component in the same expression. The pair
+ * therefore differs by reachability and by nothing else — same function,
+ * same bundle, same moment in the namespace's load — which is the
+ * property that makes an absence a statement about the linker.
+ *
+ * The shape question was settled per module rather than answered once:
+ *
+ *   - MOTION HAS ONE. The module's whole product is `presence`, a single
+ *     component minted at `impl.presence-react`'s namespace load. There
+ *     is no second door to reach it by, so one row covers every way in.
+ *   - OVERLAY HAS TWO, and it is the NATIVE TIER's situation rather than
+ *     the forms module's. `popover` and `modal` are two independent
+ *     top-level components in one namespace; Closure's elimination is
+ *     per-var, so a consumer who re-exports `overlay/popover` beside
+ *     `h/portal` drags the anchor machinery in and leaves the dialog's
+ *     inert-backdrop and focus-wrap code behind. Either sentinel alone
+ *     is green against the other's leak.
+ *
+ * A NOTE ON WHAT WAS NOT CHOSEN, because it is the more obvious string
+ * and it is weaker. `--rf-overlay-` — the CSS dashed-ident prefix
+ * `next-anchor-ident` mints — is genuinely load-bearing, and the
+ * reachability gate's own header already records it measuring ZERO on
+ * this bundle. But it is minted inside a ref callback on the ANCHORED
+ * path only, so it is absent from a bundle that carries the whole of
+ * `modal` and an unanchored `popover`. It is a narrower instrument than
+ * the two names above and would have been green on a real leak.
+ *
  * ## The live half is a test, not a comment
  *
  * A sentinel that has quietly stopped being emitted is absent from every
@@ -276,6 +328,59 @@ const SENTINELS = [
       'Same as above for a whole-module leak. If this row is red ALONE, the ' +
       'draft protocol has moved somewhere the public door reaches — which ' +
       'is an architectural change, not a convenience.',
+  },
+  {
+    surface: 'motion module — the presence boundary\'s stamped name (rf2-ot28g)',
+    sentinel: 'hicasso/presence',
+    source: 'src/re_frame/hicasso/impl/presence_react.cljs',
+    premise: '(aset "displayName" "hicasso/presence")',
+    why:
+      'The `displayName` `impl.presence-react` `aset`s onto the presence ' +
+      'component as it mints it, inside the same `codec/mark-boundary!` call ' +
+      'the `hicassoBoundary` control below is read through. It is written at ' +
+      'namespace load, unconditionally and under no `goog.DEBUG` guard, so ' +
+      'the module cannot be reachable and this string be absent.',
+    remedy:
+      'Find the `:require` of `re-frame.hicasso.motion` — or of ' +
+      '`impl.presence` / `impl.presence-react` directly — that made the ' +
+      'module reachable. Nothing under implementation/hicasso/src/ may name ' +
+      'it and the release entry must not either; an application requires it ' +
+      'in the region that wants presence, and ' +
+      '`check_optional_module_reachability.py` decides the source half of ' +
+      'that exhaustively.',
+  },
+  {
+    surface: 'overlay module — the popover boundary\'s stamped name (rf2-ot28g)',
+    sentinel: 'hicasso/popover',
+    source: 'src/re_frame/hicasso/impl/overlay.cljs',
+    premise: '(unchecked-set "displayName" "hicasso/popover")',
+    why:
+      'The `displayName` stamped onto `impl.overlay/popover` at namespace ' +
+      'load, by the same idiom as the two rows above. THE OVERLAY MODULE ' +
+      'HAS TWO REACHABILITY SHAPES, the native tier\'s situation rather ' +
+      'than the forms module\'s: `popover` and `modal` are two independent ' +
+      'top-level components, so a consumer who re-exports one drags that ' +
+      'one in and Closure drops the other. Either sentinel alone is green ' +
+      'against the other\'s leak, which is why there are two.',
+    remedy:
+      'Find the `:require` of `re-frame.hicasso.overlay` — or of ' +
+      '`impl.overlay` directly — that made the module reachable. If this ' +
+      'row is red alone, only the anchored-panel half was re-exported.',
+  },
+  {
+    surface: 'overlay module — the modal boundary\'s stamped name (rf2-ot28g)',
+    sentinel: 'hicasso/modal',
+    source: 'src/re_frame/hicasso/impl/overlay.cljs',
+    premise: '(unchecked-set "displayName" "hicasso/modal")',
+    why:
+      'The second of the overlay module\'s two shapes — the blocking ' +
+      'dialog, stamped at namespace load exactly as `popover` is. It ' +
+      'reaches a bundle by a different route: `modal` is what a consumer ' +
+      'who wants `showModal` and the inert-backdrop machinery drags in, ' +
+      'and none of `popover`\'s anchor-positioning code comes with it.',
+    remedy:
+      'Same as above — the module became reachable. If this row is red ' +
+      'alone, only the dialog half was re-exported.',
   },
 ];
 
@@ -450,7 +555,20 @@ function selfTest() {
     `${green} … "native" nativeEvent isComposing …`,           // React's own plumbing
     `${green} … re-frame.hicasso/revision re-frame.hicasso/clear …`,
     `${green} … drafts buffered-field myapp.forms/buffered-field :app/drafts …`,
-    `${green} … re-frame.hicasso.motion/presence …`,           // a sibling module
+    // rf2-ot28g. This line used to be here because motion was a sibling
+    // module the scan did not cover. Motion is now rowed, and the string
+    // stays for the OPPOSITE reason: `re-frame.hicasso.motion/presence` is
+    // the door's SYMBOL, which `:advanced` renames and which reaches no
+    // bundle even when the module leaks — the real sentinel is the
+    // `displayName` `hicasso/presence`. A row on the symbol would have been
+    // unfalsifiable, and this is what says so.
+    `${green} … re-frame.hicasso.motion/presence …`,
+    // The same distinction for overlay, plus the near-miss that matters
+    // most: an application is entirely free to have a modal and a popover
+    // of its own, and a bundle carrying either must stay green. This is
+    // why all three new sentinels carry the `hicasso/` prefix the minting
+    // namespaces stamp rather than the bare product name.
+    `${green} … re-frame.hicasso.overlay/popover myapp.views/modal popoverTargetAction …`,
   ];
   for (const bundle of legal) {
     const problems = scan(bundle);

--- a/implementation/hicasso/scripts/check_optional_module_reachability.py
+++ b/implementation/hicasso/scripts/check_optional_module_reachability.py
@@ -306,6 +306,35 @@ MODULES = [
             "re_frame/hicasso/forms.cljs",
         ],
     },
+    {
+        # rf2-2a0ju.  The server module — `server/render`, the one-request-in
+        # one-document-out SSR door (rf2-b6jkj) — shipped WITHOUT a row, and
+        # its own docstring already named this file as what keeps it out of a
+        # browser build.  That sentence was false for as long as this row was
+        # missing, which is a sharper defect than a plain gap: a reader who
+        # goes looking is steered to a roster that never mentioned the module.
+        #
+        # NO ENGINE, for the `forms` row's reason and not for a different one.
+        # The module owns exactly one file, and everything it reaches is
+        # somebody else's: `impl.mount` and `impl.roots` are the SHARED
+        # runtime the public door already leads to — naming either here would
+        # forbid the interpreted tier its own mount path — and
+        # `re-frame.ssr.*` is the FRAMEWORK's, whose payload contract this
+        # module hands values to unaltered.  There is one edge to guard and
+        # it is the door.
+        #
+        # The live risk is the same convenience the `forms` row names, and
+        # the cost is higher here than anywhere else on the roster: a
+        # `:require` of this namespace drags `react-dom/server` into the
+        # bundle of every application that ever aliased `h`, for a code path
+        # no browser will ever run.
+        "name": "server",
+        "door": "re-frame.hicasso.server",
+        "engine": [],
+        "files": [
+            "re_frame/hicasso/server.cljs",
+        ],
+    },
 ]
 
 def ns_of(text):

--- a/implementation/hicasso/test/re_frame/bench/hicasso/compile_gate.cjs
+++ b/implementation/hicasso/test/re_frame/bench/hicasso/compile_gate.cjs
@@ -307,10 +307,14 @@ const OUTSIDE_LANE_ENTRIES = [
 const MODULE_ROSTER = 'hicasso/scripts/check_optional_module_reachability.py';
 const MODULE_ROSTER_FLAG = '--module-namespaces';
 
-// Four optional modules today, seven namespaces between them. The floor is a
-// COLLAPSE detector and not a count: it catches an emitter that has started
-// answering nothing while still exiting 0, which is the only way this entry
-// source can contribute silently. Growth is the roster's business.
+// Five optional modules today, eight namespaces between them (rf2-2a0ju added
+// the `server` row). The floor is a COLLAPSE detector and not a count: it
+// catches an emitter that has started answering nothing while still exiting 0,
+// which is the only way this entry source can contribute silently. Growth is
+// the roster's business, and this number is deliberately NOT raised to meet it
+// — a floor that tracked the roster would have to be edited by every author
+// who adds a module, which is the second place to remember that reading the
+// roster exists to abolish.
 const MIN_MODULE_NAMESPACES = 4;
 
 // A CLJS namespace, as the emitter is contracted to print them. Anything else


### PR DESCRIPTION
Three beads on one branch because all three edit `implementation/hicasso/`, where two workers conflict by construction.

## rf2-2a0ju — the server module now has the guard it names

`re-frame.hicasso.server`'s docstring says *"`scripts/check_optional_module_reachability.py` is what keeps that true"*. **Re-derived at this base**, `grep -c 'hicasso.server'` answered **0** against that gate and **0** against `check_bundle_isolation.cjs`. The claim was false from the moment PR #8236 shipped the module.

**Of the two honest repairs — widen the roster, or soften the docstring — this takes the first**, and the roster's own shape is why. `MODULES` is a roster of OPTIONAL MODULES and the server module is one; its docstring says so in terms, naming itself the fourth in the family beside forms, overlay and motion. So the row was missing, not the claim overreaching. (One correction to the brief that dispatched this: the roster names **four** modules — motion, overlay, native, forms — not three. Had it named only three, the docstring repair would have been the right call.)

The row is **door-only** (`engine: []`), for the `forms` row's reason: the module owns one file and everything it reaches belongs to somebody else — `impl.mount` and `impl.roots` are the shared runtime the public door already leads to, `re-frame.ssr.*` is the framework's.

Roster growth also widens the **compile gate**, which reads `--module-namespaces` (rf2-okhdf). `re-frame.hicasso.server` is now compiled under `:advanced` + `:infer-externs :auto` by a warnings-fatal compile **that had never reached it** — and it is clean. `MIN_MODULE_NAMESPACES` is deliberately left at 4: it is a collapse detector, not a census.

## rf2-ot28g — motion and overlay get bundle-side sentinels

**No new machinery**, per rf2-6ng7's standing (c)-narrow ruling. I read the two surfaces that already had sentinels and copied their mechanism exactly: `codec/mark-boundary!` writes `hicassoBoundary` with `unchecked-set` onto a freshly minted component, and each of these modules writes a **name** onto that same component in the same expression. The three new rows are stamped `displayName`s paired with the **existing** `hicassoBoundary` control — same function, same bundle, same moment in namespace load, differing by reachability and nothing else. No control added, no function touched; the diff is data plus header prose.

**The shape question the bead asked was settled per module, not once:**

- **Motion has ONE.** `presence` is the module's whole product, minted at `impl.presence-react`'s namespace load — one row covers every way in.
- **Overlay has TWO** — the native tier's situation, not the forms module's. `popover` and `modal` are independent top-level components and Closure eliminates per var, so a consumer re-exporting one drags that one in and drops the other.

**`--rf-overlay-` was considered and rejected**, and the header says why: it is minted in a ref callback on the anchored path only, so it is absent from a bundle carrying the whole of `modal`. It is the more obvious string and it would have been **green on a real leak**.

## rf2-h2h25 — deps.edn's stale JVM-arm comment

The `:aliases` header claimed *"THE JVM ARM IS NOW UNGATED, AND THAT IS A REAL COST"* and cited a `"NOT HERE, ON PURPOSE"` note as the reason. Verified at this base rather than taken from the bead: `test.yml` carries a `jvm-hicasso` job (line 3183) and lists it in `all-required-passed`'s `needs:` (line 6657); `scripts/test-jvm-implementation.sh` carries `implementation/hicasso` (line 156); **the cited note is gone** — the only surviving occurrence of that phrase is the comment recording that it was replaced; and `check_jvm_lane_rosters.py` is green in its own words (34 rostered artefacts, every roster entry required in CI and every required JVM job rostered).

Comment only. `--probe` is correctly gone and the 3-test floor correctly applies. Re-read at the tip, since #8236 moved this file off "core alone".

## What the bundle-side "aggregate" heading means now

`release-scans.md` section 3 measured **source-side 4 of 5, bundle-side 2 of 5**, and declined to run the bundle gate because a green would certify two surfaces under a heading reading *aggregate*. After this PR:

| instrument | before | after |
|---|---|---|
| source-side (`check_optional_module_reachability.py`) | 4 of 5 | **5 of 5** |
| bundle-side (`check_bundle_isolation.cjs`) | 2 of 5 | **4 of 5** |

**It is not yet 5 of 5 bundle-side, so the heading still overstates by one** — `re-frame.hicasso.server` has no bundle row. That is a genuine design question rather than a missing row (`:hicasso-release` is a browser build; the server module is a Node one, and a leak would show as `react-dom/server`, which is React's own code and precisely the "public-name grep" the file's idiom forbids). rf2-ot28g named it as wanting its own bead; it is now **rf2-fn62g**, with a candidate sentinel and its acceptance test. The gate's header states this one remaining gap explicitly, so it no longer overstates its own reach.

Note also that `release-scans.md` defers its bundle-side run to "after rf2-ot28g and rf2-2a0ju land their rows"; **that run has now been taken, green** (see below). `rf2-hic-087` inherits the page. That page and `checkpoint-2-slice.md` (which records "Isolation: 4 absent, 4 present" from a dated checkpoint run) are both fenced to other live workers and were not edited.

## Quality gates

Every number below is **captured by the runner itself** (`echo $?` on the same command line as the redirect), never read from a harness report. On the planted release build the harness reported exit 0 while my own capture read **1** — quoting the capture.

**PASS 11 / FAIL 0** (plus 2 deliberate sabotage runs that correctly failed).

| gate | captured exit | result |
|---|---|---|
| `scripts/test-fast-pr.sh` (full spine, final base) | 0 | `PASS fast PR spine` |
| `npm run test:hicasso-invariants` (final base) | 0 | motion, overlay, native, forms, **server** unreachable from the door |
| `npm run test:hicasso-lint` (final base) | 0 | 6 checks fire, correct code silent |
| `npm run build:hicasso-release` (final base) | 0 | erasure 5 absent / 3 present; **isolation 7 sentinels absent, 4 controls present** |
| `npm run test:hicasso-compile` (final base) | 0 | 139 namespaces, 0 warnings, **8 optional-module namespaces** (was 7) |
| `clojure -M:test` in `implementation/hicasso` | 0 | 3 tests, 92 assertions, 0 failures |
| `scripts/check_jvm_lane_rosters.py` | 0 | 34 rostered artefacts, bijection holds |
| `check_optional_module_reachability.py --self-test` | 0 | self-test OK |
| `check_bundle_isolation.cjs --self-test` | 0 | 7 sentinels, 4 positive controls |
| `compile_gate.test.cjs` | 0 | 8 passed |
| `npm ci --prefix implementation` | 0 | real directory, not a junction |

### Sentinel plant proofs — a sentinel that cannot be made to fire proves nothing

**rf2-2a0ju.** Planted a `:require` of `re-frame.hicasso.server` in the public door's ns form. Gate **red, exit 1**, naming the `server` module. The discriminating control: **the same plant against the roster at HEAD is green, exit 0** — so the red comes from the new row, and the gate read this worktree. Door restored and verified by hash (`3867ee87`, byte-identical).

**rf2-ot28g.** Re-exported motion and overlay from the public door — the exact defect the rows' own remedy text describes — and rebuilt the real `:advanced` + `goog.DEBUG=false` bundle. Gate **red, exit 1**, naming **all three** new sentinels (`hicasso/presence`, `hicasso/popover`, `hicasso/modal`), while the four pre-existing sentinels **and** the whole production-erasure gate stayed green in the same run. Restored, rebuilt: green, exit 0. Door restored byte-identical.

Both restores were verified by `git hash-object`, not by reading a diff.

### Fast-spine-versus-required-CI gap

`python scripts/check_fast_pr_gap.py --list` is the one path for this, and it reports **100 required checks the spine does not run** (TESTING.md:121). That is a fact about the spine, not a census of this PR: **the spine did run here, green**, plus the targeted gates above run directly.

Per rf2-r5iy7 the hicasso invariants reach CI only via `implementation/hicasso/**` — this diff is entirely in that tree, so CI will run them.

No gate was skipped.

### Verification notes

- Rebased onto `origin/main` past 14 commits and **re-ran** invariants, lint, the release build and the compile gate on the final base; a pre-rebase green is evidence about a tree that no longer exists.
- `git diff origin/main...HEAD` read for reverts: none of the 14 incoming commits touches any of these four files.
- `implementation/hicasso/deps.edn` re-read as EDN after the comment edit (parses).
- No `node_modules` junction was created — `npm ci` produced a real directory (`LinkType` empty, no reparse point). The mayor checkout's `node_modules` held at **101 entries** before and after.

Beads: rf2-2a0ju, rf2-ot28g, rf2-h2h25. Follow-up filed: rf2-fn62g.
