### PR TITLE
ci(gates): the fifth repo-wide walk joins the unconditional lane; the naming-drift walk pins its reach and prunes before descent (rf2-n4a2b, rf2-sk5hf, rf2-in6c4, rf2-skvce)

### DIFF
--- a/.github/scripts/report-changed-surfaces.sh
+++ b/.github/scripts/report-changed-surfaces.sh
@@ -640,7 +640,13 @@ else
       # roster above. (`.cljc` is listed for the same reason the route-path
       # census predicate lists it — a testbed is free to be reader-conditional
       # — and plain `.clj` is absent for the same reason it is absent there:
-      # shadow does not compile it into a browser build.)
+      # shadow does not compile it into a browser build. Re-measured at
+      # rf2-in6c4's close: the tracked tree is 14 .md, 13 .html, 13 .cljs,
+      # 2 .cjs, 1 .json and ZERO .clj, so an arm on that extension would fire
+      # for no diff this repository can produce and compile nothing extra if
+      # it did. Nesting was re-measured too — a POSIX `case` glob spans `/`,
+      # so `testbeds/deep_machine/core.cljs` arms and `testbeds/README.md`,
+      # `testbeds/spec-helpers.cjs` do not.)
       testbeds/*.cljs|testbeds/*.cljc)
         examples_compile=true
         ;;

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3214,9 +3214,18 @@ jobs:
       - name: Run JVM tests (hicasso artefact — the slot-rule equivalence pin)
         run: clojure -M:test
 
-  # rf2-cujx — the four REPO-WIDE SOURCE WALKS that live in
+  # rf2-cujx — the REPO-WIDE SOURCE WALKS that live in
   # `implementation/core/test/` but are not core tests, given a lane whose
   # scheduling does not depend on a read-set model of what they walk.
+  #
+  # THE STANDING RULE, stated once here rather than built into a checker
+  # (rf2-n4a2b). A repo-wide walk parked in `implementation/core/test/` joins
+  # this lane as ONE MORE STEP. That is the whole policy. Two walks widened
+  # without their arming following in a single day — rf2-2cu7f
+  # (impl-source-corpus/src-roots) and rf2-n4a2b — and rf2-6ng7 has already
+  # REJECTED a universal input-declaration checker as over-engineering; that
+  # rejection stands. The cheap answer is this lane, because a step here has no
+  # read-set model to be wrong about.
   #
   # THE HOLE. Each of these suites discovers its inputs by `file-seq` over
   # trees OUTSIDE its own artefact, and every one of them ran only in
@@ -3229,6 +3238,20 @@ jobs:
   #                                            implementation/, recursively
   #   error-catalogue-channel-conformance-test the same corpus
   #   warn-once-clear-governance-test          file-seq over implementation/
+  #   prod-gate-naming-drift-test              every artefact's test/ tree
+  #                                            under implementation/ (rf2-n4a2b)
+  #
+  # THE FIFTH ARRIVED THE SAME DAY (rf2-n4a2b). rf2-sk5hf widened
+  # prod-gate-naming-drift-test from a depth-1 `.listFiles` over one artefact's
+  # test tree to a recursive walk from the implementation root, which made it
+  # this exact shape; rf2-cujx named four suites and could not take it because
+  # the file was fenced behind that PR. Its hole is measured with the probes
+  # its OWN domain needs — the walk reads `test/` trees, not `src/`:
+  # `implementation/hicasso/test/x_prod_gate_test.clj` and
+  # `implementation/ssr-node/test/x_prod_gate_test.clj` both read
+  # implementation_jvm FALSE, while `implementation/epoch/test/...` reads true.
+  # So a dishonestly-named gate suite landing in hicasso or ssr-node merged
+  # green and redded main for the next unrelated implementation PR.
   #
   # Measured on this tree with `.github/scripts/report-changed-surfaces.sh`,
   # `tools/{xray,story,mcp-base}/src`, `implementation/hicasso/src` and
@@ -3258,12 +3281,12 @@ jobs:
   # second output must also be taught to `scripts/test-fast-pr.sh` and held in
   # step with the classifier forever after.
   #
-  # WHY FOUR STEPS AND NOT ONE `-n`-LIST, which is the part that is easy to
-  # get wrong. A missing namespace inside a multi-`-n` selector is SILENT:
-  # measured on this tree, `-n <valid> -n <does-not-exist>` exits 0 having run
-  # only the valid one, with no warning. One combined step therefore rests
-  # entirely on the quiet runner's TOTAL test-count floor, and these four
-  # namespaces are lopsided — 1 / 3 / 27 / 1 tests. A total floor cannot tell
+  # WHY ONE STEP PER NAMESPACE AND NOT ONE `-n`-LIST, which is the part that is
+  # easy to get wrong. A missing namespace inside a multi-`-n` selector is
+  # SILENT: measured on this tree, `-n <valid> -n <does-not-exist>` exits 0
+  # having run only the valid one, with no warning. One combined step therefore
+  # rests entirely on the quiet runner's TOTAL test-count floor, and these
+  # namespaces are lopsided — 1 / 3 / 27 / 1 / 2 tests. A total floor cannot tell
   # "the 1-test floor lint stopped selecting" from "the 27-test catalogue
   # gained a test", so the guard would silently stop guarding the moment the
   # big suite grew. Run per namespace and each takes the runner's DEFAULT
@@ -3271,7 +3294,7 @@ jobs:
   # REDS (measured: exit 1). That also leaves no calibrated number to
   # maintain, so there is no count here to go stale.
   #
-  # These four also still run inside `jvm-core`, and that duplication is
+  # These also still run inside `jvm-core`, and that duplication is
   # deliberate: this lane exists to schedule them when `jvm-core` does not.
   jvm-repo-source-walks:
     name: JVM repo-wide source walks (clojure -M:test)
@@ -3317,6 +3340,9 @@ jobs:
 
       - name: Warn-once-clear governance (file-seq over implementation/)
         run: clojure -M:test -n re-frame.warn-once-clear-governance-test
+
+      - name: Production-gate naming drift (every artefact's test/ tree)
+        run: clojure -M:test -n re-frame.prod-gate-naming-drift-test
 
   cljs:
     name: CLJS (shadow-cljs :node-test)

--- a/implementation/core/test/re_frame/prod_gate_naming_drift_test.clj
+++ b/implementation/core/test/re_frame/prod_gate_naming_drift_test.clj
@@ -52,6 +52,17 @@
   one positively-identified root. See `implementation-root` for why the root is
   identified by what it CARRIES rather than by where it sits.
 
+  The audit of that landing sent the bead back for two things, and both are the
+  same lesson twice. The reach was CLAIMED and not CHECKED — the guard counted
+  artefacts and files over a corpus lopsided enough that dropping any one of
+  the four small trees passed both (`required-artefacts`). And the exclusion of
+  `node_modules` was STATED and not PERFORMED — it filtered results after
+  `file-seq` had already descended through the tree, so it cost the walk
+  everything it claimed to save and reached 6% of the entries that actually
+  needed excluding (`source-bearing-dir?`). A claim in a docstring is not a
+  property of the code, which is the whole thesis of this namespace turned back
+  on itself.
+
   ## The rule
 
   DOMAIN — every `.clj` / `.cljc` file under any artefact's `test/` tree
@@ -101,6 +112,24 @@
 (def ^:private prod-gate-tag "^:prod-gate")
 (def ^:private jvm-property "-Dre-frame.debug=false")
 
+(def ^:private required-artefacts
+  "The artefacts this walk MUST reach — a required SUBSET, not a census.
+
+  rf2-sk5hf's first landing widened the walk to every artefact and guarded
+  that with `(> artefact-count 1)` and `(>= file-count 8)`, which is not a
+  guard on the claim it was written for: the tracked corpus is core=7,
+  epoch=1, freehand=1, routing=1, ssr=1, so dropping epoch, freehand, routing
+  OR ssr leaves 10 files across 4 artefacts and BOTH assertions stay green
+  while the honesty test goes blind to the omitted tree. The audit of that PR
+  measured exactly that.
+
+  A SUBSET rather than an equality: a new artefact with a claiming file must
+  be scanned the moment it lands, and having to edit this set first would be
+  the failure mode inverted — the walk narrowed by a red that looks like the
+  gate working. So the set below is a floor on reach, and growth is silent by
+  design. Removing an artefact from the repo is what edits it."
+  #{"core" "epoch" "freehand" "routing" "ssr"})
+
 (defn- posix
   "`f`'s path with forward slashes, so one path predicate reads the same on
   Windows and POSIX."
@@ -146,17 +175,44 @@
 
 (defn- domain-file?
   "A candidate for the domain: a `.clj` / `.cljc` source living in some
-  artefact's `test/` tree.
-
-  `node_modules` is excluded. A vendored file's name is not this repo's claim
-  to make, and a developer who has run `npm ci` would otherwise put tens of
-  thousands of files in front of the token match."
+  artefact's `test/` tree."
   [^java.io.File f]
-  (let [p (posix f)]
-    (and (.isFile f)
-         (some? (re-find #"\.cljc?$" (.getName f)))
-         (str/includes? p "/test/")
-         (not (str/includes? p "/node_modules/")))))
+  (and (.isFile f)
+       (some? (re-find #"\.cljc?$" (.getName f)))
+       (str/includes? (posix f) "/test/")))
+
+(defn- source-bearing-dir?
+  "Is `f` a directory this walk should DESCEND INTO?
+
+  The exclusions are build outputs and vendored dependencies — trees that
+  hold no authored repository source, so nothing in them can be a naming
+  claim this repo is answerable for. Excluding them at DESCENT rather than
+  after the fact is rf2-sk5hf's second repair, and the reason is measured on
+  this tree: `implementation/` is 2,738 entries in a fresh checkout and
+  55,059 in a developer checkout that has built and installed — `.shadow-cljs`
+  37,322, `out` 10,310, `node_modules` 3,412, `target` 874. The predicate this
+  replaced named only `node_modules` and named it in `domain-file?`, i.e.
+  AFTER `file-seq` had already walked every one of those entries: a stated
+  exclusion that reached 6% of what it was there to exclude, and a walk whose
+  cost grew with whatever the developer happened to have built.
+
+  Dot-directories go by prefix rather than by name so the caches nobody has
+  invented yet are covered too. A narrowing here is not silent: the coverage
+  assertion in `the-domain-scan-still-finds-files` pins the five artefacts
+  this walk must reach, so a prune that swallowed a real test tree reds
+  naming it."
+  [^java.io.File f]
+  (let [n (.getName f)]
+    (and (.isDirectory f)
+         (not (str/starts-with? n "."))
+         (not (contains? #{"node_modules" "out" "target"} n)))))
+
+(defn- source-tree-seq
+  "`file-seq` over `root`, pruned by `source-bearing-dir?`. `file-seq` is
+  itself a `tree-seq` whose branch predicate is bare `.isDirectory`; this is
+  that one predicate made choosier, which is the whole of the mechanism."
+  [^java.io.File root]
+  (tree-seq source-bearing-dir? #(seq (.listFiles ^java.io.File %)) root))
 
 (defn- claiming-files
   "Every file in the domain: a `.clj` / `.cljc` source under any artefact's
@@ -165,9 +221,11 @@
   ONE recursive walk from ONE positively-identified root, selected by a path
   predicate. There is no root enumeration and no depth here, so there is
   nothing left for a later edit to narrow silently — which is what rf2-sk5hf
-  found this doing in both dimensions at once."
+  found this doing in both dimensions at once. The walk is pruned at descent
+  (`source-bearing-dir?`); the reach that pruning must not cost is pinned by
+  `required-artefacts`."
   []
-  (->> (some-> (implementation-root) file-seq)
+  (->> (some-> (implementation-root) source-tree-seq)
        (filter domain-file?)
        (filter (fn [^java.io.File f]
                  (some #(str/includes? (.getName f) %) claim-tokens)))
@@ -218,10 +276,17 @@
             neither a nested directory nor another artefact's test tree, where
             a real offender was sitting. A floor on whether the walk found
             ANYTHING says nothing about whether it found EVERYTHING, so the
-            coverage claim below is about the walk's REACH."
+            coverage claim below is about the walk's REACH.
+
+            AND NEITHER WAS `(> artefact-count 1)`, which is what the first
+            rf2-sk5hf landing left here. Same lesson one turn later: a count
+            over a lopsided corpus (core=7, the other four one apiece) is
+            satisfied by dropping any single artefact. The reach claim is now
+            made against `required-artefacts` by NAME, so a failure says which
+            tree stopped being scanned."
     ;; The corpus is walked ONCE and read four times. `claiming-files` is a
-    ;; recursive `file-seq` now, and `is`'s message argument is evaluated
-    ;; whether or not the assertion fails.
+    ;; recursive walk now, and `is`'s message argument is evaluated whether or
+    ;; not the assertion fails.
     (let [root      (implementation-root)
           files     (claiming-files)
           artefacts (artefacts-of root files)]
@@ -235,12 +300,18 @@
                "positive identification is deliberate (see "
                "`implementation-root`); a recursive walk from the wrong root "
                "is worse than no walk."))
-      (is (< 1 (count artefacts))
-          (str "the domain spans ONE artefact. That is the rf2-sk5hf fail-open "
-               "exactly: this ratchet is armed by `implementation_jvm`, which "
-               "every artefact's test tree arms, so a walk confined to one of "
-               "them runs and reports green over the others. Found: "
-               (pr-str (vec artefacts))))
+      (is (empty? (remove artefacts required-artefacts))
+          (str "the walk no longer reaches every artefact that carries a "
+               "claiming file. MISSING: "
+               (pr-str (vec (sort (remove artefacts required-artefacts))))
+               " — found only " (pr-str (vec artefacts)) ". That is the "
+               "rf2-sk5hf fail-open exactly: this ratchet is armed by "
+               "`implementation_jvm`, which every artefact's test tree arms, "
+               "so a walk confined to some of them runs and reports green "
+               "over the rest. A count is not the guard — with core at seven "
+               "files, dropping any ONE of the other four leaves 10 files "
+               "across 4 artefacts, which every count-shaped assertion here "
+               "passes. See `required-artefacts` for why this is a subset."))
       (is (<= 8 (count files))
           (str "collapse detector, calibrated at 8 against the 11 files "
                "measured at rf2-sk5hf — deliberately just above the 7 that a "

--- a/implementation/scripts/_changed-surfaces.test.cjs
+++ b/implementation/scripts/_changed-surfaces.test.cjs
@@ -420,6 +420,93 @@ test('implementation/core/src still arms implementation_jvm (rf2-cujx control)',
   assert.equal(classify('implementation/core/src/foo.clj').implementation_jvm, 'true');
 });
 
+// rf2-n4a2b — THE FIFTH WALK, and the assertion the other four never had.
+//
+// `prod-gate-naming-drift-test` became this shape the same day rf2-cujx landed:
+// rf2-sk5hf widened it from a depth-1 `.listFiles` over one artefact's test
+// tree to a recursive walk from the implementation root, and it too ran only in
+// `jvm-core`. Its census needs DIFFERENT probes from the four above, because
+// its domain is every artefact's `test/` tree and not `src/` — so the src rows
+// above say nothing about it either way.
+//
+// AND THE COVERAGE CLAIM ITSELF IS NOW PINNED. The census above excuses a false
+// arm by naming the unconditional lane, which is only true while the lane
+// actually runs the namespace. Nothing checked that: delete a step and every
+// assertion up there goes on passing, asserting a coverage that has gone. This
+// is the rf2-6ng7 codicil applied to a repair whose "arming" is a workflow step
+// rather than a classifier output.
+const REPO_SOURCE_WALK_NAMESPACES = Object.freeze([
+  're-frame.no-rf-default-floor-lint-test',
+  're-frame.egress-chokepoint-conformance-test',
+  're-frame.error-catalogue-channel-conformance-test',
+  're-frame.warn-once-clear-governance-test',
+  're-frame.prod-gate-naming-drift-test',
+]);
+
+test('hicasso + ssr-node TEST trees read implementation_jvm false — the naming-drift walk reads them anyway (rf2-n4a2b)', () => {
+  for (const p of [
+    'implementation/hicasso/test/foo_prod_gate_test.clj',
+    'implementation/ssr-node/test/foo_prod_gate_test.clj',
+  ]) {
+    assert.equal(classify(p).implementation_jvm, 'false', p);
+  }
+  // The control that makes the two rows above mean something: an artefact test
+  // tree that DOES arm. Without it a classifier returning false for everything
+  // would read as this census passing.
+  assert.equal(
+    classify('implementation/epoch/test/re_frame/foo_prod_gate_test.clj').implementation_jvm,
+    'true',
+  );
+});
+
+test('the unconditional walk lane runs every namespace whose false arm it excuses (rf2-n4a2b)', () => {
+  const workflow = fs.readFileSync(WORKFLOW, 'utf8');
+  const block = jobBlock(workflow, 'jvm-repo-source-walks');
+
+  assert.doesNotMatch(
+    block,
+    /^\s+if:/m,
+    'jvm-repo-source-walks must stay UNCONDITIONAL — a condition here is a ' +
+      'read-set model of what the walks walk, which is the defect the lane exists ' +
+      'to avoid rather than relocate',
+  );
+  assert.match(
+    workflow,
+    /^\s+- jvm-repo-source-walks$/m,
+    'jvm-repo-source-walks must stay in all-required-passed needs: — a job absent ' +
+      'from that list is advisory whatever its own gate says',
+  );
+
+  for (const ns of REPO_SOURCE_WALK_NAMESPACES) {
+    assert.match(
+      block,
+      new RegExp(`clojure -M:test -n ${ns.replace(/[.]/g, '[.]')}\\s*$`, 'm'),
+      `${ns} is a repo-wide source walk parked in implementation/core/test/, and ` +
+        'this lane is the only scheduling it has that does not depend on a read-set ' +
+        'model. It must be a step here.',
+    );
+  }
+
+  // ONE STEP PER NAMESPACE, which is not decoration: a namespace missing from a
+  // multi-`-n` selector is SILENT (exit 0, runs the rest, no warning), so a
+  // combined step would rest entirely on a total test-count floor across suites
+  // of 1 / 3 / 27 / 1 / 2 tests. Per-namespace steps each take the runner's own
+  // default floor of 1 and red alone.
+  const runs = block.match(/^\s+run: clojure -M:test[^\n]*/gm) || [];
+  assert.equal(
+    runs.length,
+    REPO_SOURCE_WALK_NAMESPACES.length,
+    `expected one clojure step per walked namespace, found ${runs.length}`,
+  );
+  for (const run of runs) {
+    assert.equal(
+      (run.match(/ -n /g) || []).length,
+      1,
+      `"${run.trim()}" selects more than one namespace in a single step`,
+    );
+  }
+});
+
 // rf2-1sd8h — the BROWSER half of the same two trees. Story/Xray
 // `*_dom_cljs_test.{cljs,cljc}` namespaces are selected by BOTH CLJS builds:
 // the consolidated `:node-test` (`cljs-test$` matches a `-dom-cljs-test`

--- a/implementation/scripts/_changed-surfaces.test.cjs
+++ b/implementation/scripts/_changed-surfaces.test.cjs
@@ -6767,6 +6767,37 @@ test('the jobs these arms reach are still gated on the armed outputs (rf2-6ng7)'
 // alerter's exposure is bounded by its own in-run --self-test at
 // expensive-tests.yml:648; it stays a declared file-level hole.
 //
+// THAT HOLE WAS RE-PUT AND RE-DECLARED (rf2-skvce, second pass), because "we
+// chose not to" invites re-litigation while a measurement does not. Three
+// findings, all re-checked at source rather than carried forward:
+//
+//   1. The cheap PR-time repair costs a MECHANISM, which is the signal
+//      rf2-6ng7's (c)-narrow ruling names for leaving a hole declared. The
+//      right semantic home is `verify-skill-mcp-drift` ("Repo invariant
+//      checks"), the always-on pure-stdlib spine that took
+//      check_gate_scheduling.py for this very reason — and every step in it is
+//      audited by scripts/check_ci_reproduce_commands.py, which requires a
+//      single-line `run: python scripts/check_<name>.py …` with a matching
+//      `check_*` id. The alerter is `.github/scripts/nightly_failure_alert.py`
+//      and is not a `check_*`, so a step there means teaching that guard a new
+//      path shape. The other always-on job, `verify-readme-links`, would take
+//      it without a fight and is a markdown-slug job; a checker parked in an
+//      unrelated job is how the next reader loses it.
+//
+//   2. THE EXPOSURE IS SMALLER THAN THE FINDING SAID. A broken alerter does
+//      not fail quiet. Its self-test runs `continue-on-error` precisely so the
+//      live arm still tries, and the re-raise step at the bottom of that job
+//      still ends the run RED — same night, in the same run list the nightly
+//      is read from. What is actually at risk is one night's tracking-ISSUE
+//      edit, not the signal that something failed.
+//
+//   3. Going file-level is the rejected option (a) in a new costume: a second
+//      hand-maintained model, of files this time, nagging on every README,
+//      .gitignore and image in the repository.
+//
+// The self-test itself was re-measured rather than assumed: 0.19s, exit 0, pure
+// stdlib. It is cheap; it is the HOME that is not free.
+//
 // "AT LEAST ONE OUTPUT" IS NOT "COVERED", and the declared list is where that
 // distinction is kept honest. Several trees are properly gated at PR time by
 // jobs that are ALWAYS-ON — `beads-pr-boundary`, `verify-skill-mcp-drift`,


### PR DESCRIPTION
Four beads on the CI classification and repo-walk surface, ridden by one agent because two workers there conflict by construction.

Derived at start-up rather than taken from the brief: `gh pr list --state open` returned exactly four PRs (#8247, #8249, #8250, #8251), all under `docs/design/hicasso/product/**`, `docs/core/hicasso/index.md` and `implementation/hicasso/scripts/check_guide_samples.py`. None touches this surface. `lint.yml` and `docs.yml` were left alone (queued for rf2-qpk2l / rf2-yptjt); `test.yml` is this PR's.

## rf2-n4a2b — the fifth repo-wide walk joins the unconditional lane

**Shape chosen: remove-the-conditionality, not arming.** #8242 landed the unconditional `jvm-repo-source-walks` job minutes before this work started, so the cheapest repair is one more step on it. No arming change, no roster change, no new output.

The hole was re-measured with the probes this walk's own domain needs — it reads `test/` trees, not `src/`, so #8242's src census says nothing about it either way:

| path | `implementation_jvm` |
| --- | --- |
| `implementation/hicasso/test/x_prod_gate_test.clj` | `false` |
| `implementation/ssr-node/test/x_prod_gate_test.clj` | `false` |
| `implementation/epoch/test/re_frame/x_prod_gate_test.clj` | `true` (control) |
| `implementation/hicasso/src/x.cljs` | `false` |
| `implementation/ssr-node/src/x.cljs` | `false` |
| `implementation/core/src/x.clj` | `true` (control) |

So a dishonestly-named gate suite landing in `hicasso` or `ssr-node` merged green and the red landed on main for the next unrelated implementation PR.

**And the lane's own coverage claim is now pinned.** The classifier census excuses those `false` arms by naming the unconditional lane — true only while the lane actually runs the namespaces, and nothing checked that. A new harness test requires all five namespaces as steps, one `-n` each, no `if:`, and the job present in `all-required-passed`.

The bead also asked for a standing rule rather than a checker. Stated once in the job comment: a repo-wide walk parked in `implementation/core/test/` joins this lane as one more step. rf2-6ng7 already rejected a universal input-declaration checker; that rejection stands.

## rf2-sk5hf — both recorded repairs done

Reopened by the #8234 merged-PR audit and **not** re-closed as churn. Both repairs are in.

**1. Coverage.** `required-artefacts` pins `#{core epoch freehand routing ssr}` as a required **subset** — new artefacts are still accepted and scanned silently — and the failure names the missing set. No second walker. It replaces `(< 1 (count artefacts))`, which was not a guard on the claim it was written for: the corpus is core=7, epoch=1, freehand=1, routing=1, ssr=1, so dropping any one of the four small trees leaves 10 files across 4 artefacts and every count-shaped assertion stays green.

**2. Prune before descent — and the audit's framing understated it by 16x.** `domain-file?` excluded `/node_modules/` from the *results*, after `file-seq` had already walked through it. Re-measured in **this worktree** and in the mayor checkout (read-only `find`, no edits):

| tree | `implementation/` entries | after prune |
| --- | --- | --- |
| this worktree (no `node_modules`, no builds) | 2,743 | 2,735 |
| mayor checkout (built + `npm ci`) | 55,059 | 2,770 |

The mayor checkout's 55,059 breaks down as `.shadow-cljs` 37,322, `out` 10,310, `node_modules` 3,412, `target` 874. **The audit's `node_modules` figure is right and is 6% of the problem** — the stated exclusion would have reached 3,412 of 51,918 wasted entries. `source-bearing-dir?` now prunes at descent (dot-directories by prefix, plus `node_modules` / `out` / `target`), taking that walk from 55,059 entries to 2,770 — 95% — so it follows tracked source rather than whatever the developer last built. The now-unreachable post-filter is deleted rather than kept as a second belt.

**No `node_modules` junction was created.** This worktree has no `node_modules` at all (the classifier harness is pure Node stdlib), so the mayor's `implementation/node_modules` was read for the count and otherwise untouched: **3,412 entries before, 3,412 after.**

## rf2-in6c4 — verified, no change needed; one widening REFUSED

PR #8189 discharged this: `check-examples-compile.cjs` derives `:testbeds/*` alongside `:examples/*` with a **per-prefix** floor, the classifier arms `testbeds/*.cljs|testbeds/*.cljc`, `_changed-surfaces.test.cjs` pins the arm plus two negative controls, and TESTING.md records it. The bead's own precondition — "verify the builds actually compile cold" — is answered by the gate that swept them: `CLJS (compile every standalone example build, coverage gate)` was **SUCCESS** on #8189's head commit `3e8fa7f`, the run that widened the roster.

**Refused: widening the arm to `testbeds/*.clj`.** Measured on the tracked tree — 14 `.md`, 13 `.html`, 13 `.cljs`, 2 `.cjs`, 1 `.json`, and **zero `.clj`** — and shadow does not compile `.clj` into a browser build. That arm would fire for no diff this repository can produce and compile nothing extra if it did. Nesting re-measured too: a POSIX `case` glob spans `/`, so `testbeds/deep_machine/core.cljs` arms while `testbeds/README.md` and `testbeds/spec-helpers.cjs` do not. The measurement is recorded next to the arm so the question does not reopen.

## rf2-skvce — RULED: `.github/scripts/*.py` stays a declared file-level hole

The tree-claim meta-check landed in #8189 and passes. The bead's one open question was a cost ruling, made here rather than escalated.

**Ruling: the meta-check stays tree-level.** Three findings, each checked at source:

1. **The cheap PR-time repair costs a mechanism**, which is the signal rf2-6ng7's (c)-narrow ruling names for leaving a hole declared. The right semantic home is `verify-skill-mcp-drift` ("Repo invariant checks") — the always-on pure-stdlib spine that took `check_gate_scheduling.py` for exactly this reason. Every step in it is audited by `scripts/check_ci_reproduce_commands.py`, which requires a single-line `run: python scripts/check_<name>.py …` with a matching `check_*` id. The alerter is `.github/scripts/nightly_failure_alert.py` and is neither, so a step there means teaching that guard a new path shape. The other always-on job, `verify-readme-links`, would take it without a fight and is a markdown-slug job — a checker parked in an unrelated job is how the next reader loses it.
2. **The exposure is smaller than the finding said.** A broken alerter does not fail quiet: the self-test is `continue-on-error` so the live arm still tries, and the re-raise at the bottom of that job still ends the run **red** the same night, in the same run list the nightly is read from. What is at risk is one night's tracking-issue edit, not the signal.
3. **File-level is the rejected option (a) in a new costume** — a second hand-maintained model, of files this time, nagging on every README, `.gitignore` and image in the repo.

Re-measured rather than assumed: the self-test is **0.19 s, exit 0, pure stdlib**, and `expensive-tests.yml:648` is exact. It is cheap; it is the *home* that is not free. The reasoning is written into the comment beside the check so "we chose not to" cannot be re-litigated from scratch.

## Jobs that newly fire, and what that costs

- **`jvm-repo-source-walks` gains one step**, `clojure -M:test -n re-frame.prod-gate-naming-drift-test`. That job is unconditional and already runs on every PR, so the marginal cost is **one extra JVM start on an existing runner** — the four existing steps measure ~28 s in total against ~15 s for a single combined run. No new job, no new required check, no roster entry (`check_jvm_lane_rosters.py` clean).
- **This PR itself runs the full matrix**, because it edits `.github/scripts/report-changed-surfaces.sh` and a classifier change arms every output by design (32 outputs `true`). That is the normal cost of a classifier edit and not something this change introduces.

## Quality gates

Every number below is the exit code **captured in the running shell** (`cmd > log 2>&1; echo $?` on one line), not one reported about the run. All re-run on the final rebased base `b4a3ef8756`.

| gate | result | exit |
| --- | --- | --- |
| `node implementation/scripts/_changed-surfaces.test.cjs` | **376 passed**, 0 failed (374 before — 2 new tests) | **0** |
| `clojure -M:test -n re-frame.prod-gate-naming-drift-test` | 2 tests, **5 assertions**, 0 failures, 0 errors | **0** |
| the whole walk lane, one step per namespace, as CI runs it | 34 tests, **146 assertions**, 0 failures — 1 / 3 / 27 / 1 / 2, matching the comment's claim | **0** |
| `python scripts/check_gate_scheduling.py` | 51 gate commands, 43 scheduled, 8 declared, 0 known holes | **0** |
| `python scripts/check_jvm_lane_rosters.py` | 34 rostered artefacts, bijection clean both ways | **0** |
| `python scripts/check_ci_reproduce_commands.py` | 43 checker steps in sync | **0** |
| `bash -n .github/scripts/report-changed-surfaces.sh` | syntax clean | **0** |
| `python -c "yaml.safe_load(test.yml)"` | parses; `jvm-repo-source-walks` = 9 steps, no `if:`, 5 walk steps | **0** |
| `python .github/scripts/nightly_failure_alert.py --self-test` | all checks passed (0.19 s — the rf2-skvce measurement) | **0** |

**Total: 0 failures across every gate run.**

### Discrimination proofs — three planted faults, each restored and hash-verified

A gate that prints no root cannot be shown to have read this worktree by its output, so each was proved by a fault that exists only here. Hash before, hash after, `git hash-object` (line endings are translated on this checkout).

| plant | expected | observed | exit |
| --- | --- | --- | --- |
| **A** — add `"epoch"` to the prune set, so the walk swallows a real artefact | reach assertion reds naming `epoch` | `MISSING: ["epoch"] — found only ["core" "freehand" "routing" "ssr"]` | **1** |
| **B** — narrow the walk root back to `core`, the original rf2-sk5hf regression | reach assertion reds naming four | `MISSING: ["epoch" "freehand" "routing" "ssr"] — found only ["core"]` | **1** |
| **C** — delete the new fifth step from `test.yml` | lane pin reds naming the namespace | `re-frame.prod-gate-naming-drift-test … must be a step here` | **1** |

**Plant A doubles as the audit's own claim, reproduced.** With `epoch` gone the run showed **1 failure out of 5 assertions** — the `(<= 8 (count files))` floor stayed **green** on the surviving 10 files, which is exactly the fail-open the audit measured and exactly what the new pin closes.

Restores verified by hash, not by reading a diff:

- `prod_gate_naming_drift_test.clj` — `fb642113…` before A, `a47f3f18…` planted, `fb642113…` after; same file `fb642113…` before B and after.
- `test.yml` — `980c265b…` before C, `a00e7788…` planted, `980c265b…` after.

### Spine

The pre-checkin spine `scripts/test-fast-pr.sh` **did not run**, and the reason is this diff: it delegates its runtime tier to the very classifier this PR edits, which arms all 32 outputs, so the spine would attempt the entire local matrix — including CLJS/browser lanes needing an `implementation/node_modules` this worktree deliberately does not have (see the rf2-sk5hf measurement, where installing one would have changed the number under test). Targeted gates for all four touched surfaces were run directly instead, and are the table above.

The fast-spine-versus-required-CI gap is not enumerated by hand here: `scripts/check_fast_pr_gap.py --list` is the one path for it (TESTING.md:121). It reports **101 required checks the spine does not run** (exit 0).

### Doc gates

`mkdocs build --strict` was not nominated and no markdown changed — this PR touches one workflow, one shell classifier, one Node harness and one Clojure test namespace.

### Revert check

`git diff origin/main...HEAD` was read for what it would **undo**, not for conflicts. `test.yml` is a large shared document and #8242 landed in it minutes before this branch was cut; the diff confirms the new `jvm-repo-source-walks` job is intact and this change is additive within that region. Rebased onto `b4a3ef8756` and every gate re-run there.
