### PR TITLE
ci(gates): the provenance corpus gets a scheduled sweep, and the allocation non-claim scan gets a home (rf2-qpk2l, rf2-yptjt)

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -72,6 +72,13 @@ on:
       - 'scripts/_test_fixtures/check_retired_composition_vocab/**'
       - 'scripts/check_retired_image_keys.py'
       - 'scripts/_test_fixtures/check_retired_image_keys/**'
+      # rf2-yptjt — the warm-allocation non-claim scan reads README/CHANGELOG +
+      # docs/** (already armed above) and uses docs/design/** as its positive
+      # control. This line arms it on its OWN source, so a change to the gate —
+      # including one that loosens the claim pattern until it matches nothing —
+      # cannot ship without the gate running. (It builds its fixtures in a
+      # throwaway git tree, so there is no fixture directory to arm.)
+      - 'scripts/check_allocation_non_claim.py'
       # rf2-lq99wc — the retired-composition gate now scans the per-tool spec
       # trees too; a drift there must trigger the gate.
       - 'tools/**/spec/**'
@@ -188,7 +195,7 @@ jobs:
           while IFS= read -r file; do
             [ -z "$file" ] && continue
             case "$file" in
-              docs/*|spec/*|migration/*|mkdocs.yml|mkdocs_hooks.py|TESTING.md|README.md|CHANGELOG.md|SKILL-REDIRECT.md|AGENTS.md|CLAUDE.md|scripts/test-jvm-implementation.sh|scripts/test-jvm-tools.sh|scripts/test-fast-pr.sh|scripts/test-rigorous-local.sh|requirements.txt|scripts/check_provenance_pins.py|scripts/check_runtime_subsystem_grading.py|scripts/check_failure_corpus_residue.py|scripts/_test_fixtures/check_failure_corpus_residue/*|testbeds/*|testbeds/*/*|scripts/check_retired_composition_vocab.py|scripts/_test_fixtures/check_retired_composition_vocab/*|tools/*/spec/*|tools/*/spec/*/*|.github/workflows/docs.yml)
+              docs/*|spec/*|migration/*|mkdocs.yml|mkdocs_hooks.py|TESTING.md|README.md|CHANGELOG.md|SKILL-REDIRECT.md|AGENTS.md|CLAUDE.md|scripts/test-jvm-implementation.sh|scripts/test-jvm-tools.sh|scripts/test-fast-pr.sh|scripts/test-rigorous-local.sh|requirements.txt|scripts/check_provenance_pins.py|scripts/check_runtime_subsystem_grading.py|scripts/check_failure_corpus_residue.py|scripts/_test_fixtures/check_failure_corpus_residue/*|testbeds/*|testbeds/*/*|scripts/check_retired_composition_vocab.py|scripts/_test_fixtures/check_retired_composition_vocab/*|scripts/check_allocation_non_claim.py|tools/*/spec/*|tools/*/spec/*/*|.github/workflows/docs.yml)
                 docs_surface=true ;;
             esac
           done <<< "$files"
@@ -512,6 +519,51 @@ jobs:
 
       - name: Validate no live retired EP-0026 image keys
         run: python scripts/check_retired_image_keys.py --verbose
+
+      # The warm-allocation NON-CLAIM scan (rf2-hic-072, wired by rf2-yptjt).
+      # specification.md section 6 registers one sentence — "no allocation claim
+      # publishes until a fitted series clears the registered quality floor" —
+      # and this gate is that sentence, executable. No fitted series clears it
+      # (rf2-2rtt6.139, rf2-2rtt6.140, rf2-e9wr each measured a different leg of
+      # why), so the obligation is NEGATIVE and the failure it catches is
+      # somebody reaching for one of those refused figures to fill a cell that
+      # wants a number. It shipped unwired because .github/workflows/** was held
+      # when it landed, and present-but-unenforced is the WEAKEST of the three
+      # states — worse than absent, because it reads as covered.
+      #
+      # IT BELONGS IN THIS JOB rather than beside the provenance-pin gate below,
+      # and the two are less alike than they look: that one needs `fetch-depth:
+      # 0` and reads docs/design/hicasso, which is why it is a job of its own,
+      # while this one derives its corpus from `git ls-files` and reads the
+      # PUBLICATION surface — root README/CHANGELOG plus docs/** OUTSIDE
+      # docs/design. Its real siblings are the four repo-wide markdown scans
+      # directly above, which is why it sits with them: same shape, same
+      # self-test-then-live pair, no extra runner, ~0.4s.
+      #
+      # NEITHER STEP MAY BE SOFTENED, and this gate is unusually easy to defeat
+      # by kindness. It fires on a per-write BYTE FIGURE rather than on the word
+      # "allocation", because a word-scan is a gate authors reword their way
+      # around; it PASSES a figure whose own paragraph carries the refusal, so
+      # the rule is "no claim without its qualification" and not "no digits"; it
+      # uses the design record as a POSITIVE CONTROL and reds if the pattern
+      # matches nothing there, because an absence check over a corpus it never
+      # really read is a green that means nothing; and it FAILS ON ITS OWN
+      # PREMISE — if budgets.md's S7 row or evidence-baseline.md's warm-
+      # allocation row stops recording the floor as unmet, the scan reds asking
+      # for re-authorisation, because a guard enforcing a retired rule is worse
+      # than no guard. That last property is a RETIREMENT SIGNAL wearing a red,
+      # so a `continue-on-error` here would hide precisely the message the gate
+      # exists to raise. The self-test proves each of those behaviours in a
+      # throwaway git tree, naming its cases as it runs; running it first is
+      # what stops the live scan's green from meaning "the pattern no longer
+      # matches anything". HOW MANY cases is deliberately not written here, for
+      # rf2-93u6's reason — a count kept in this file is linked to nothing that
+      # would update it, so the next correction is already scheduled.
+      - name: Self-test the warm-allocation non-claim scan
+        run: python scripts/check_allocation_non_claim.py --self-test
+
+      - name: Validate no unqualified warm-allocation claim on the publication surface
+        run: python scripts/check_allocation_non_claim.py
 
       # Stage the spec/ + migration/ trees under docs/ so MkDocs (which
       # requires docs_dir to be a child of the config file) can see them.

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -558,13 +558,27 @@ jobs:
   # ancestor" for pins that are perfectly landed and red the whole corpus.  The
   # MkDocs build next door does not need that history and should not pay for it.
   #
-  # SCOPED TO CHANGED PAGES on purpose.  The corpus still carries the stranded
-  # pins the census catalogued and left standing, because re-pinning restores
-  # the patch and not necessarily the measured tree and each one needs a human.
-  # A full-corpus gate would therefore be red on main from the day it landed.
-  # Scoped, it holds every new and edited page to the rule from today, and the
-  # audit (`python scripts/check_provenance_pins.py`, no flag) reports the
-  # backlog for whoever works it off.
+  # SCOPED TO CHANGED PAGES on purpose, and the reason has CHANGED once already
+  # — so read this paragraph as two reasons, one expired and one standing.
+  #
+  # THE EXPIRED ONE was cost of entry: the corpus still carried the stranded
+  # pins the census catalogued and left standing, so a full-corpus gate would
+  # have been red on main from the day it landed.  rf2-g7m6y worked that backlog
+  # off (PR #8246); the full run is now exit 0 over the whole corpus, so that
+  # objection no longer holds and is no longer why this job is scoped.
+  #
+  # THE STANDING ONE is blast radius.  Full-corpus HERE would couple every
+  # future hardening of the checker to a corpus-wide repair — and the gate
+  # refuses to re-pin by design, so each repair needs a human.  That is the
+  # "punish the careful ones and be routed around within a week" pressure the
+  # checker's own docstring names, and it would red docs PRs on pages they did
+  # not touch.  Cost was never the discriminator (a full run measures ~50s).
+  #
+  # WHAT COVERS THE REST.  Scoping cannot see a page nobody edits, and the
+  # checker gains rules often — each one reclassifying the whole corpus.  So the
+  # full-corpus run is SCHEDULED rather than dropped: `.github/workflows/lint.yml`
+  # runs `python scripts/check_provenance_pins.py` (no flag) on its nightly cron
+  # and on push to main (rf2-qpk2l).  Locally, that same command is the audit.
   provenance-pins:
     name: Provenance pins
     needs: detect

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -656,6 +656,80 @@ jobs:
         run: clojure -M:test
 
   # ---------------------------------------------------------------------------
+  # Full-corpus provenance-pin audit (rf2-qpk2l, closing rf2-g7m6y's ruling).
+  #
+  # docs.yml runs the same checker SCOPED TO CHANGED PAGES, and that scoping is
+  # right: it holds a PR accountable for what it touched, and a corpus-wide
+  # repair is human-decided (the gate refuses to re-pin by design), so coupling
+  # every docs PR to one would punish the careful and be routed around inside a
+  # week. What scoping cannot see is the corpus ROTTING UNDER A PAGE NOBODY
+  # EDITS, and there are two routes in, neither of them a page edit:
+  #
+  #   1. LEGACY. The scoped gate landed after the pages it would have caught.
+  #   2. HARDENING, which RECURS. The checker gained rules six times in eight
+  #      days; each new rule reclassifies the WHOLE corpus, but only touched
+  #      pages are re-read, so each hardening silently mints a fresh backlog.
+  #
+  # This job is the periodic sweep that answers both. It is here rather than in
+  # docs.yml because docs.yml has no `schedule:` trigger and this workflow does
+  # — the 03:30 UTC cron above exists for exactly this shape of question ("is
+  # the gate still honest when no file in its surface changed?").
+  #
+  # NOT ON THE PR PATH, and not in the `Lint required` aggregator below. A
+  # corpus-wide red on a PR that touched none of it is the coupling the scoping
+  # decision rejected; and `scripts/check_fast_pr_gap.py` derives the REQUIRED
+  # set from that aggregator's `needs:`, so listing this job there would report
+  # a ~50s corpus audit as a gap in the local fast-PR spine — a lane no worker
+  # should be told to run before every PR, for a job that never fires on one.
+  #
+  # IT DOES RUN ON PUSH TO MAIN, and that is load-bearing rather than free
+  # breadth (rf2-6ng7). `post-merge-workflow-sanity.yml` re-dispatches a
+  # cron-only workflow after a workflow edit precisely so a typo is not silent
+  # until the next tick — and it EXCLUDES lint.yml on the stated ground that
+  # lint.yml "already runs on push". A schedule-only `if:` here would make that
+  # excuse false for this job while leaving it standing for the workflow, which
+  # is the exact shape rf2-6ng7 names: an arming excuse outliving its coverage.
+  # `!= 'pull_request'` keeps the excuse true — the merge push that edits this
+  # file runs the job within minutes (`.github/workflows/lint.yml` is in the
+  # `push: paths:` filter above) — and mirrors the `detect` job's own idiom.
+  #
+  # `fetch-depth: 0` IS THE WHOLE JOB'S PREMISE and belongs to THIS job: only
+  # `detect` above carries it, every other job here takes the default shallow
+  # clone. The gate asks `merge-base --is-ancestor` about SHAs months old, so a
+  # truncated clone answers "not an ancestor" for pins that are perfectly
+  # landed and reds all 110 pages. It fails CLOSED rather than quietly (the
+  # checker's `assert_usable` exits 2 on a shallow clone), but a red that says
+  # nothing about the corpus is still a red nobody can act on.
+  #
+  # NO FLAG = FULL CORPUS, and the run is unswallowed on purpose: no
+  # `continue-on-error`, no `|| true`. The checker carries its own coverage
+  # floor — an absent corpus root, a root with no markdown, or a repository it
+  # cannot read ancestry from all exit 2 rather than 0 — so this job cannot go
+  # green over a corpus it never opened, and nothing extra is needed here to
+  # pin what it reads. Measured ~50s (110 pages / 509 cited pins, 0 findings).
+  # ---------------------------------------------------------------------------
+  provenance-pins-corpus:
+    name: Provenance pins (full corpus)
+    if: github.event_name != 'pull_request'
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          # Full history: see the note above — a truncated one makes every
+          # landed pin look stranded.
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
+        with:
+          python-version: '3.12'
+
+      - name: Audit provenance pins across the whole corpus
+        run: python scripts/check_provenance_pins.py
+
+  # ---------------------------------------------------------------------------
   # Required-checks aggregator (rf2-aemyt).
   #
   # ONE stable status context — `Lint required` — that is ALWAYS present on

--- a/scripts/check_allocation_non_claim.py
+++ b/scripts/check_allocation_non_claim.py
@@ -253,7 +253,10 @@ def scan(root: Path) -> tuple[list[str], list[str]]:
 # ---------------------------------------------------------------------------
 # self-test
 #
-# Four fixtures, one per way this gate can fail OPEN.  Each is written into a
+# One fixture per way this gate can fail: OPEN on a claim it should catch, or
+# CLOSED on prose it should pass.  The count is deliberately not written down
+# (rf2-93u6) — it already drifted once, and the cases name themselves as they
+# run, which is the copy that cannot.  Each is written into a
 # throwaway tree with its own git repository, because the corpus is derived
 # from `git ls-files` and a fixture that skipped that would not exercise the
 # code path the real run takes.


### PR DESCRIPTION
Two gate-wiring beads that share `.github/workflows/**`, so they ride one PR. Both wire an **existing** script into an **existing** workflow — no new mechanism, per rf2-6ng7's standing (c)-narrow ruling.

## rf2-qpk2l — a scheduled full-corpus provenance-pin audit

`scripts/check_provenance_pins.py` runs in `docs.yml` scoped to changed pages. That scoping is right and stays: a corpus-wide repair is human-decided (the gate refuses to re-pin by design), so making the PR job full-corpus — option (c) — would couple every future hardening of the checker to one. What scoping cannot see is the corpus rotting under a page nobody edits, by either of two routes that are not page edits: pages that predate the gate, and each hardening of the checker, which reclassifies the whole corpus while only touched pages are re-read.

**The documented blocker has expired, and I verified it rather than trusting it.** `docs.yml` recorded that a full-corpus gate "would be red on main from the day it landed". Measured on this branch's final base: **exit 0, 110 pages / 509 cited pins, 0 findings.** So the sweep can land, and `docs.yml`'s comment is rewritten to separate the reason that expired (cost of entry) from the one that stands (blast radius).

**Home: `lint.yml`.** `docs.yml` has no `schedule:` trigger; `lint.yml`'s 03:30 UTC cron exists for exactly this question ("is the gate still honest when nothing in its surface changed?").

**Two premises in the bead needed correcting at source:**

- *"lint.yml already checks out with fetch-depth: 0"* — only the `detect` job does. Every other job there takes the default shallow clone. The new job therefore carries its own `fetch-depth: 0`; without it the gate answers "not an ancestor" for landed pins and reds all 110 pages.
- *"Nightly only"* — as written that would have opened a hole. `post-merge-workflow-sanity.yml` re-dispatches cron-only workflows after a workflow edit so a typo is not silent until the next tick, and it **excludes `lint.yml`** on the stated ground that lint.yml "already runs on push". A schedule-only `if:` would falsify that excuse for this job while leaving it standing for the workflow — rf2-6ng7's *arming excuse outliving its coverage*, exactly. The condition is `github.event_name != 'pull_request'` (the same idiom `detect` already uses), so the merge push that edits `lint.yml` verifies the job within minutes. It is still off the PR path, which is what the bead's constraint protects.

**Not in the `Lint required` aggregator, deliberately.** `scripts/check_fast_pr_gap.py` derives the REQUIRED set from the aggregators' `needs:`, so listing it there would report a ~50s corpus audit as a missing local spine lane — for a job that never fires on a PR. Confirmed: `--list` does not name it.

**Nothing extra pins what it reads.** The checker already refuses rather than passing: absent corpus root, root with no markdown, or a repo it cannot read ancestry from all exit 2. The wiring's job was to not swallow that — no `continue-on-error`, no `|| true`.

## rf2-yptjt — the warm-allocation non-claim scan enters CI

`scripts/check_allocation_non_claim.py` shipped with PR #8244 and nothing ran it. Present-but-unenforced is the weakest of the three states, and no meta-gate reds on it — which is why nothing caught it.

**Placed in `docs.yml`'s `build` job, beside the four repo-wide markdown scans, not beside `check_provenance_pins.py`.** The bead nominated the latter on the premise that the two are "the same shape and the same corpus". Read at source, they are neither: the provenance gate is a job of its own *because* it needs `fetch-depth: 0`, and it reads `docs/design/hicasso`; this one derives its corpus from `git ls-files` and reads the publication surface — root README/CHANGELOG plus `docs/**` **outside** `docs/design`, with `docs/design` as its positive control. Its real siblings are `check_retired_composition_vocab` / `check_retired_image_keys` / `check_failure_corpus_residue` / `check_runtime_subsystem_grading`: same self-test-then-live pair, same Python-only needs, **no extra runner**. Same workflow the bead ruled, honest neighbours.

**The wiring does not defeat the gate's unusual design.** It fires on a per-write byte *figure* rather than the word "allocation" (a word-scan gets reworded around); it *passes* a figure whose paragraph carries the refusal; it uses the design record as a positive control and reds if the pattern matches nothing there; and it **fails on its own premise**, so it retires rather than outliving its reason. That last one is a *retirement signal wearing a red*, so both steps run unswallowed — a "non-blocking" wiring would hide precisely the message the gate exists to raise.

**Armed on its own source.** Added to both the `push: paths:` filter and the `detect` classifier, so a change that loosens the claim pattern until it matches nothing cannot ship without the gate running. Verified by replaying the classifier's `case` over sample paths: the checker's own source, the premise rows, README, CHANGELOG and `docs/core/**` all light `docs_surface`; an `implementation/**` file does not.

**One line beyond wiring:** the checker's docstring said "Four fixtures" over five. Per rf2-93u6 (recorded in `lint.yml`) the durable fix is to stop writing the count down, so it is removed rather than corrected — the cases already name themselves as they run. I removed a count from my own new comment for the same reason. Drop this hunk if you would rather keep the diff pure wiring.

## Jobs that newly fire, on what trigger, at what cost

| Job | Workflow | Trigger | Cost | Can it red? |
|---|---|---|---|---|
| `provenance-pins-corpus` — "Provenance pins (full corpus)" | `lint.yml` | `schedule` (03:30 UTC), `push` to main (lint.yml's existing path filter), `workflow_dispatch`. **Never on a PR.** | **~50s measured** + checkout at `fetch-depth: 0` | Yes — unswallowed, exit 1 on findings / exit 2 if it cannot run. Reds the workflow run. Not in `Lint required` (see above). |
| 2 steps in the existing `build` job | `docs.yml` | Unchanged: PR + push, gated on `docs_surface` | **~0.4s measured**, no new runner | Yes — `build` is in `docs-required`'s `needs:`, so a red blocks the merge. |

No job's trigger was widened; no existing job changed cost.

## Quality gates

**Passed: 14. Failed: 1 (environmental, diagnosed below). Sabotage proofs: 3/3 fired.**

All exit codes below are the ones I captured with `echo $?` on the runner's own command line — never a harness report about the same run — and all were re-run on the **final post-rebase base** (`b18a95d10e`).

| Gate | Exit |
|---|---|
| `check_provenance_pins.py` (full corpus) | **0** — 110 pages, 509 cited pins, 0 findings |
| `check_provenance_pins.py --changed-since origin/main` | **0** — 0 pages inspected (this branch touches no corpus page; the checker says so rather than implying a verdict) |
| `check_provenance_pins.py --self-test --verbose` | **0** — all 68 self-tests passed |
| `check_allocation_non_claim.py` (live) | **0** — 235 publication files scanned, 147 design-record excluded, positive control fires in 6 files |
| `check_allocation_non_claim.py --self-test` | **0** |
| `check_ci_reproduce_commands.py --self-test --verbose` / `--check --verbose` | **0** / **0** |
| `check_fast_pr_gap.py --self-test --verbose` / `--check` / `--list` | **0** / **0** / **0** |
| `check_gate_scheduling.py --self-test --verbose` / `--verbose` | **0** / **0** — 51 gate commands, 43 scheduled, 8 declared |
| `check_jvm_lane_rosters.py --self-test` / `--verbose` | **0** / **0** — no roster entry needed (this PR adds no JVM lane) |
| YAML parse, both edited workflows | **0** |
| `scripts/test-fast-pr.sh` | **1** — see below |

### The one red, and why it is not this diff

The spine ran to the **CLJS node integration** lane and died there: `compile-node-test: could not resolve shadow-cljs: Cannot find module 'shadow-cljs/cli/runner.js'`. This is a fresh worktree with no `implementation/node_modules`. A diff of workflow comments and one Python docstring paragraph cannot create or remove a `node_modules` directory, and nothing in it is loaded by any build. I did **not** junction `node_modules` from the mayor checkout to re-run: that junction has twice been followed by a later `git worktree remove` and silently emptied the mayor's real `node_modules`, and the lane it would unblock cannot be affected by this change. Everything upstream of that lane in the spine passed. The gates that *can* see this diff are the eleven above, all run directly, all green.

### Sabotage proofs — each gate was seen to fail

A wiring change whose gate was never seen to fail proves nothing. Each plant is anchored to a single line, exists **only in this worktree** (so a run that had wandered into a sibling checkout would have come back green — that red *is* the discrimination), and each restore is verified by `git hash-object` bytes, not by reading a diff.

1. **Full-corpus provenance run.** Planted an unlanded SHA in `docs/design/hicasso/architecture.md`. Hash changed `9bdc83ce…` → `cad9059f…` (proving the patch applied, not silently no-opped). Run: **exit 1**, `architecture.md:254 deadbeefcafe… [UNRESOLVABLE]`, 1 finding. Restored: hash back to `9bdc83ce…`, byte-identical.
2. **Allocation scan, the claim row.** Planted `2,031 B/boundary/write` unqualified into `docs/quiet-tests.md`. Hash `283d6642…` → `6da980d4…`. Run: **exit 1**, `UNQUALIFIED ALLOCATION CLAIM: docs/quiet-tests.md:112`. Restored byte-identical.
3. **Allocation scan, the premise — the property the wiring must not defeat.** Rewrote `budgets.md`'s live S7 row to read a cleared floor. Hash `2d7a095d…` → `da6277ee…`. Run: **exit 1**, `PREMISE MOVED … THIS GATE SHOULD BE RETIRED, not repaired`. Restored byte-identical. This is the real tree, not a fixture: the gate's self-retirement path fires through the wiring as landed.

### Fast-spine-versus-required-CI gap

Per TESTING.md:121 the one path is `scripts/check_fast_pr_gap.py --list`, exit **0**: *89 required jobs across 3 workflows; 32 fully covered by the spine, 5 partly, 52 not at all (103 required checks unrun locally).* That is a fact about the spine, not a census of what I ran — what I ran is the table above. The newly-wired `check_allocation_non_claim` appears there as an unrun local lane, which is the correct direction (a new required checker is reported until a spine lane is taught); the nightly `provenance-pins-corpus` correctly does **not** appear, because it is not in an aggregator's `needs:`.

### Fence

Derived at start-up from `gh pr list --state open --json number,headRefName` plus each PR's changed **files**, not branch names. One open PR at the time: **#8259**, touching only `docs/design/hicasso/product/dispositions.md`. No open PR touched `.github/workflows/**`. Post-rebase, trunk had moved three commits; `git diff <merge-base>..origin/main` shows it changed only `.beads/issues.jsonl` and two hicasso product pages — **zero overlap** with my three files, so this push reverts nothing. `.beads/issues.jsonl` and `.beads/metadata.json` are not in this diff.
