### PR TITLE
fix(hicasso): the census gate compared bare def names, so a new owner inherited a stranger's row (rf2-hic-087)

### DIFF
--- a/docs/design/hicasso/product/architecture-census.md
+++ b/docs/design/hicasso/product/architecture-census.md
@@ -215,13 +215,15 @@ This matters more than one row, and `globals.md`'s own opening says why: *"a ros
 |---|---|
 | `mechanism` | a seventh `defmacro`; a render call on an alias that is not a `react-dom` require; a `:require` of an emitter namespace |
 | `retained-tooling` | a checker, a `hicasso` npm script or a tool namespace with no row above, or a row whose Consumer cell is empty |
-| `mutable-globals` | a module-level owner the seven arms find that has no row in [`globals.md`](globals.md) |
+| `mutable-globals` | a module-level owner the seven arms find whose `impl.<ns>/name` identity has no row in [`globals.md`](globals.md) |
 
 Each arm is shown to bite by `--self-test`, which plants the smallest edit that would land the mechanism the arm refuses and asserts the arm reports it.
 
 **Its own consumer, by the standard this page holds everything else to, is [`rf2-hic-064`](correction-ledger.md)** — the final audit, which re-derives rather than trusts. It is deliberately not wired into a workflow, and the precedent is its sibling: [`release-scans.md`](release-scans.md)'s `scripts/check_allocation_non_claim.py` is a census gate on the same footing and is scheduled nowhere either. A census re-run belongs to the audit that needs it rather than to every PR, and `.github/**` was fenced from this bead in any case. It is named here so the row is not missing.
 
 **The mutable-globals arm enforces one direction only**, and the reason is on the page rather than in the script's silence: the reverse check — every rostered row is found by some arm — is what produced this census's own correction, and it cannot be automated honestly, because six identities-roster rows are plain `def`s of React classes and components that no textual arm distinguishes from any other `def`. Enforcing it would mean either a sixth of the roster permanently red or an allowlist that fails open. The direction that *is* enforced is the one the kill rules need: a new owner arrives with no row, and reds.
+
+**And it compares fully qualified identities**, `impl.<ns>/name` on both sides, with the declaring namespace read off the source's path — in ClojureScript the path *is* the declaration, so no parser is involved. The gate shipped comparing bare `def` names, and the merged-PR audit of #8258 showed what that costs: a planted `impl.planted/!cells` inherited `impl.collector/!cells`'s row and returned no finding at all. This tree has two `evidence` namespaces and two `overlay` namespaces, so the collision is not hypothetical. The `--self-test` agreed with the broken gate, because its control only ever planted a name nothing else owned — a control that cannot tell *the arm bit* from *the arm matched the wrong row*. It now discriminates in both directions: the duplicate reds while the rostered `impl.collector/!cells` stays accepted in the same run. Re-running the sweep under qualified identities surfaced no owner the bare matcher had been accepting, so every count above stands as published.
 
 ## What was filed
 

--- a/scripts/check_architecture_census.py
+++ b/scripts/check_architecture_census.py
@@ -178,6 +178,31 @@ def sources() -> list[tuple[str, str, str]]:
     return rows
 
 
+def declaring_ns(short: str) -> str:
+    """The declaring namespace of a source, spelled as `globals.md` spells it.
+
+    In ClojureScript a namespace IS its path, so the path is the declaration:
+    no parser is required, and there is no way for the spelling in an `ns`
+    form to drift from the file the compiler loaded it out of.  `sources()`
+    hands out paths relative to `re_frame/` and the rosters abbreviate away
+    the shared `re-frame.hicasso.` prefix, so `hicasso/impl/collector.cljs` is
+    `impl.collector` and the facade `hicasso.cljc` is `hicasso`.  Underscores
+    become hyphens, which is the compiler's own munging read backwards
+    (`presence_react.cljs` declares `impl.presence-react`).
+
+    This is what makes an owner *identity* comparable, and a bare `def` name
+    is not one.  Both `evidence.cljs` and `impl/evidence.cljs` exist in this
+    tree, as do `overlay.cljs` and `impl/overlay.cljs`; a name is an address
+    only once its namespace is in front of it.  Matching bare names let a new
+    owner inherit an unrelated roster row and exit green — the fail-open the
+    merged-PR audit of #8258 reproduced against this gate.
+    """
+    parts = re.sub(r"\.clj[sc]$", "", short).split("/")
+    if parts[0] == "hicasso":
+        parts = parts[1:] or ["hicasso"]
+    return ".".join(parts).replace("_", "-")
+
+
 # ---------------------------------------------------------------------------
 # The page's own tables
 # ---------------------------------------------------------------------------
@@ -319,11 +344,15 @@ def arm_tooling(page: str) -> list[str]:
 
 
 def globals_roster() -> set[str]:
-    """Every owner name `globals.md` publishes, from both of its rosters.
+    """Every owner IDENTITY `globals.md` publishes, from both of its rosters.
 
     Both, and not just the mutable one, because the arms cannot tell them
     apart: `adoption-context` is a `defonce` of a React context and sits on
     the *identities* roster, and C1 and C7 both find it.
+
+    The identity is `impl.<ns>/<name>`, exactly as the page spells it in its
+    first column, and the namespace half is kept rather than discarded — see
+    `declaring_ns`.  A roster of bare names is a roster of the wrong thing.
     """
     text = GLOBALS_PAGE.read_text(encoding="utf-8")
     names = set()
@@ -334,7 +363,7 @@ def globals_roster() -> set[str]:
         first = s.strip("|").split("|")[0].strip()
         m = re.fullmatch(r"`(impl\.[a-z-]+)/([^`]+)`", first)
         if m:
-            names.add(m.group(2))
+            names.add(f"{m.group(1)}/{m.group(2)}")
     return names
 
 
@@ -354,12 +383,16 @@ def open_corrections(page: str) -> set[str]:
     expires by construction: when the corrective PR adds the roster row, this
     row is removed with it and the arm goes back to enforcing the plain rule.
     A new owner nobody has filed anything about still reds.
+
+    Identities here are `impl.<ns>/<name>` for the same reason they are on the
+    roster: a filed finding about one namespace's owner excuses that owner and
+    not a same-named one somewhere else.
     """
     names = set()
     for row in table_after("<!-- census:open-corrections -->", page):
         for cell in row:
-            for m in re.finditer(r"`impl\.[a-z-]+/([^`]+)`", cell):
-                names.add(m.group(1))
+            for m in re.finditer(r"`(impl\.[a-z-]+)/([^`]+)`", cell):
+                names.add(f"{m.group(1)}/{m.group(2)}")
     return names
 
 
@@ -374,22 +407,33 @@ def arm_globals(srcs, page: str = "") -> list[str]:
     roster permanently red or an allowlist that fails open.  The direction
     that IS enforced is the one that matters for *"later work introduced no
     unjustified global"*: a new owner arrives with no row, and reds.
+
+    FULLY QUALIFIED END TO END.  What is found, what is rostered and what is
+    reported are all `impl.<ns>/<name>`.  Keying by the bare `def` name — which
+    is what this arm did until the merged-PR audit of #8258 caught it — let a
+    new owner in ANY namespace inherit the row of a same-named owner in another
+    one and exit green; a planted `impl.planted/!cells` was absolved by
+    `impl.collector/!cells` and returned no finding at all.  The self-test's
+    own positive control missed it because it only ever planted a name nothing
+    else owned, which is a control that cannot tell "the gate works" from "the
+    gate matched the wrong row".
     """
     found: dict[str, str] = {}
     for short, _raw, code in srcs:
+        ns = declaring_ns(short)
         for name, form in top_level_defs(code):
             for arm, rx in CENSUS_ARMS.items():
                 if any(rx.search(ln) for ln in form.splitlines()):
-                    found.setdefault(name, f"{short} ({arm})")
+                    found.setdefault(f"{ns}/{name}", f"{short} ({arm})")
                     break
     known = globals_roster() | open_corrections(page)
     return [
-        f"mutable-global sweep: `{name}` in {site} is a module-level owner with no row "
+        f"mutable-global sweep: `{owner}` in {site} is a module-level owner with no row "
         f"in `globals.md`. Scope it, justify it in place — or, if it is a retained "
         f"per-read or per-read-and-boundary structure, it is the VIEWCELL-CLASS GRAPH "
         f"and the PER-BOUNDARY CALLBACK-CELL TABLE the kill rules refuse"
-        for name, site in sorted(found.items())
-        if name not in known
+        for owner, site in sorted(found.items())
+        if owner not in known
     ]
 
 
@@ -428,6 +472,16 @@ def self_test() -> int:
     A census whose arms are never made to fail is an assertion with a
     script-shaped decoration on it.  Each case below is the smallest edit that
     would land the mechanism the arm refuses.
+
+    A CONTROL HAS TO DISCRIMINATE.  Every planted source below is spelled the
+    way `sources()` spells a real one, because `declaring_ns` now reads the
+    path and a seed on a path shape that cannot occur tests nothing.  And the
+    duplicate-owner pair at the end is here because this suite passed a gate
+    that was matching the wrong roster row: it planted only names nothing else
+    owned, so a green told it the arm bit when the arm had merely failed to
+    find anything.  That pair asserts in BOTH directions — the duplicate reds,
+    and the legitimately rostered original stays accepted in the same run.  A
+    control that reds on both would be a different bug wearing this one's face.
     """
     ok = True
 
@@ -438,26 +492,37 @@ def self_test() -> int:
 
     real = sources()
 
-    seeded = list(real) + [("impl/planted.cljs", "", '(defmacro deftemplate [& body])\n')]
+    PLANTED = "hicasso/impl/planted.cljs"
+
+    seeded = list(real) + [(PLANTED, "", '(defmacro deftemplate [& body])\n')]
     check("a seventh macro is a compiled-hiccup tripwire",
           any("macro roster" in f for f in arm_mechanism(seeded)))
 
     seeded = list(real) + [
-        ("impl/planted.cljs", "", '(ns x (:require [own-renderer :as r]))\n(r/renderToString e)\n')]
+        (PLANTED, "", '(ns x (:require [own-renderer :as r]))\n(r/renderToString e)\n')]
     check("a render call on a non-react-dom alias is a second emitter",
           any("SECOND EMITTER" in f for f in arm_mechanism(seeded)))
 
-    seeded = list(real) + [("impl/planted.cljs", "", '(ns x (:require [re-frame.ssr.emit :as e]))\n')]
+    seeded = list(real) + [(PLANTED, "", '(ns x (:require [re-frame.ssr.emit :as e]))\n')]
     check("requiring a foreign emitter namespace is a finding",
           any("view tree" in f for f in arm_mechanism(seeded)))
 
     seeded = list(real) + [
-        ("impl/planted.cljs", "", '(defonce !callback-cells (atom {}))\n')]
+        (PLANTED, "", '(defonce !callback-cells (atom {}))\n')]
     check("a new module-level owner is a ViewCell/callback-cell tripwire",
-          any("!callback-cells" in f for f in arm_globals(seeded)))
+          any("`impl.planted/!callback-cells`" in f for f in arm_globals(seeded)))
     check("an open correction is not an allowlist for anything else",
-          any("!callback-cells" in f
+          any("`impl.planted/!callback-cells`" in f
               for f in arm_globals(seeded, PAGE.read_text(encoding="utf-8"))))
+
+    # The duplicate-owner pair.  `impl.collector/!cells` is rostered; a second
+    # `!cells` in another namespace is a different owner and has no row.
+    seeded = list(real) + [(PLANTED, "", '(defonce !cells (atom {}))\n')]
+    findings = arm_globals(seeded, PAGE.read_text(encoding="utf-8"))
+    check("a same-named owner in another namespace does not inherit the rostered row",
+          any("`impl.planted/!cells`" in f for f in findings))
+    check("...and the rostered `impl.collector/!cells` is still accepted in that run",
+          not any("`impl.collector/!cells`" in f for f in findings))
 
     check("a docstring is not code",
           strip_docstrings('(def x "a (defonce !y (atom 0)) example")').count("defonce") == 0)


### PR DESCRIPTION
Closes the residual the merged-PR audit of #8258 reopened `rf2-hic-087` for.

## The fail-open

`scripts/check_architecture_census.py` published a fully qualified mutable-owner inventory and then compared it by bare name. `globals_roster()` and `open_corrections()` kept only `m.group(2)`; `arm_globals()` keyed what it found by the bare `def` name. A new module-level owner in *any* namespace therefore matched a same-named owner in another one, and the gate exited green.

**I reproduced it myself against the landed script and unmodified `origin/main`**, by importing the module and seeding a synthetic source rather than writing one into the tree (no `planted.cljs` exists in either checkout, and none is in this diff):

| plant | landed script |
|---|---|
| `impl/planted.cljs` — `(defonce !cells (atom {}))` | `[]` — absolved by `impl.collector/!cells` |
| `impl/planted.cljs` — `(defonce !audit-unique-owner (atom {}))` | the expected finding |

The collision is not hypothetical in this tree: `sources()` walks both `evidence.cljs` and `impl/evidence.cljs`, and both `overlay.cljs` and `impl/overlay.cljs`.

And the `--self-test` stayed green through all of it, because its positive control only ever planted a name nothing else owned — a control that cannot tell *the arm bit* from *the arm matched the wrong row*.

## The repair

Owner identity is `impl.<ns>/name` end to end — found, rostered, and reported.

- `declaring_ns()` derives the declaring namespace from the source's path. In ClojureScript the path *is* the declaration, so **no Clojure parser arrives**; underscores fold to hyphens, which is the compiler's own munging read backwards (`presence_react.cljs` → `impl.presence-react`).
- `globals_roster()` and `open_corrections()` keep both capture groups.
- `arm_globals()` keys `found` by that identity and names it in the finding.

The textual recognisers, the seven census arms and the one-direction policy are untouched, per `rf2-6ng7`'s standing (c)-narrow ruling. Net +82/−15 in one script plus two lines of page.

## The two-direction proof

The new self-test pair runs `arm_globals` **once** with a second `!cells` planted in `impl.planted`, and asserts both halves of that single run:

```
ok    a same-named owner in another namespace does not inherit the rostered row
ok    ...and the rostered `impl.collector/!cells` is still accepted in that run
```

Sabotage — reverting the two qualifying lines to the landed bare-name behaviour (`git hash-object` before `7e43bd90ed0f…`, sabotaged `8c44c2ac0ac5…`, restored `7e43bd90ed0f…`, byte-identical):

```
FAIL  a new module-level owner is a ViewCell/callback-cell tripwire
FAIL  an open correction is not an allowlist for anything else
FAIL  a same-named owner in another namespace does not inherit the rostered row
ok    ...and the rostered `impl.collector/!cells` is still accepted in that run
self-test: AN ARM DID NOT BITE.          exit 1
```

**The pair discriminates rather than co-firing**: under the bug the duplicate arm FAILs while the "original still accepted" arm stays `ok`. A control that reds on both would be a different bug wearing this one's face.

Separately, to prove the gate read **this** worktree and not a sibling's (the runner prints no root), a single-line fault was planted in this tree's `globals.md` — renaming the `impl.collector/!cells` roster row. The census went **exit 1 with exactly one finding**, naming the fully qualified identity and its site, with the other 28 owners still accepted:

```
architecture-census [mutable-globals]: mutable-global sweep: `impl.collector/!cells` in
hicasso/impl/collector.cljs (C1) is a module-level owner with no row in `globals.md`. …
```

Restored and hash-verified: `1eba3c820ab5…` → `295b1e64c6da…` → `1eba3c820ab5…`.

**Self-test arms: 8 before, 10 after.**

## Does the published conclusion still hold? Yes.

Re-run under fully qualified identities: **23 owners found, every one rostered, 0 findings.** Nothing the bare matcher had been silently accepting was surfaced, and no bare-name collision exists anywhere in the tree today (29 roster rows → 29 distinct bare names; 23 found → 23 distinct bare names). `architecture-census.md`'s counts and its third conclusion stand exactly as published, so no correction is filed against the page and `correction-ledger.md` is untouched — this is a corrective PR, and per that page's protocol a corrective PR never edits it.

The conclusion was right. The gate certifying it could not have told the difference, which is what this PR fixes. The page now records the matching method alongside the one-direction policy, since "the search method recorded" is this bead's own acceptance criterion.

## Quality gates

**9 pass, 0 fail** (plus 2 deliberate sabotage runs that went red as designed).

| gate | captured exit |
|---|---|
| `python scripts/check_architecture_census.py` | **0** — 27 sources, 6 rostered macros, 29 rostered globals, three arms, 0 findings |
| `python scripts/check_architecture_census.py --self-test` | **0** — 10/10 arms bite |
| `python scripts/check_doc_slugs.py` | **0** |
| `python scripts/check_provenance_pins.py --changed-since origin/main` | **0** — 1 page inspected, 0 findings |
| `python scripts/check_ci_reproduce_commands.py` | **0** — 43 checker steps in sync |
| `python scripts/check_fast_pr_gap.py --list` | **0** |
| `bash scripts/test-fast-pr.sh` | **0** — `PASS fast PR spine` |
| *sabotage:* `--self-test` with the two qualifying lines reverted | **1** (expected red) |
| *sabotage:* census with a planted `globals.md` fault | **1** (expected red) |

Every number above is the one captured by `echo $?` into a `.exit` file on the same command line as the redirect — never a harness-reported status, and nothing piped through a filter.

**The spine ran** — `bash scripts/test-fast-pr.sh` from the repo root, by absolute path, detached and polled to completion within the turn. The diff *does* arm its documentation tier (`is_doc_surface_path` matches `*.md`), and the log shows that tier executing: the docs corpus anchor validator, provenance pins on changed pages, and `mkdocs --strict`. `scripts/check_architecture_census.py` is on no spine surface — it is not runtime source and not on the documentation list — and it has no workflow lane either; `git grep check_architecture_census` finds only the script and the page.

**Rebased onto `deefcc532d` and all targeted gates re-run on that final base** (census, `--self-test`, `check_doc_slugs.py`, `check_provenance_pins.py`) — all still 0. The spine itself ran on `7fb3175840`, one merge earlier; `main` moves faster than a 25-minute spine can chase, and nothing between the two bases touches this diff's surface.

**The fast-spine-versus-required-CI gap is `scripts/check_fast_pr_gap.py --list`** (TESTING.md:121) — 103 required checks this spine does not run. That is a fact about the spine, not a census of what this PR ran; the table above is the latter.

`mkdocs build --strict` is **not** nominated: `mkdocs.yml`'s `exclude_docs` keeps `design/hicasso/` out of the site. Per the doc-surface protocol, **anchors and table column counts were verified by hand**: the edited `## The gate` table is 2 columns across header, delimiter and all three rows; the new paragraph introduces no links; the existing `[gate](#the-gate)` anchor and the `[`globals.md`](globals.md)` target are unchanged. `check_doc_slugs.py` and `check_provenance_pins.py` agree.

No skipped gate.

## Fence

Derived at start-up, not taken from the brief — one of the brief's premises was already wrong (it placed the script at `implementation/hicasso/scripts/`; it is at `scripts/`). `gh pr list --state open --json number,headRefName,files` plus `git diff --name-only origin/main...<branch>` (three-dot) over every `origin/worker/*` branch returned **no open PR and no worker branch touching `scripts/check_architecture_census.py`, `docs/design/hicasso/product/architecture-census.md` or `globals.md`**. Liveness was tested separately from the diff by re-checking PR state after `git fetch --prune`. Re-verified before push. No hot-zone file is touched: no `spec/*`, no `.github/workflows/*`, no `implementation/deps.edn`, no `implementation/shadow-cljs.edn`, and no `.beads/` path.
