### PR TITLE
ci: the two remaining repo-wide walks join the unconditional lane (rf2-6ng7)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3240,6 +3240,25 @@ jobs:
   #   warn-once-clear-governance-test          file-seq over implementation/
   #   prod-gate-naming-drift-test              every artefact's test/ tree
   #                                            under implementation/ (rf2-n4a2b)
+  #   late-bind-drift-test                     every implementation/**/src file,
+  #                                            anchored to a classpath resource
+  #                                            (rf2-6ng7)
+  #   observation-render-law-drift-test        every TRACKED prose-bearing file
+  #                                            in the repo, from `git ls-files`
+  #                                            (rf2-6ng7)
+  #
+  # SIX AND SEVEN CAME FROM rf2-6ng7's OWN BOUNDED AUDIT, which is this lane's
+  # standing rule paying for itself: neither namespace was selected by any
+  # workflow or script, so both ran only inside `jvm-core`. `late-bind-drift`
+  # walks `implementation/**/src` — the same corpus as the four above, so the
+  # hicasso / ssr-node false arms already measured below are exactly its hole:
+  # a `late-bind/set-fn!` published from either tree, or a directory entry
+  # orphaned by an edit there, merged green. `observation-render-law-drift` is
+  # WIDER than any of them: its census is `git ls-files`, so its domain is the
+  # whole tracked corpus, and rf2-61ar armed `implementation_jvm` for only the
+  # pinned slice of that prose (nearly all `spec/*`, `docs/machines/*`, three
+  # named pages). The rest of `docs/` — `docs/design/hicasso/**` measured —
+  # reads FALSE, so retired render-law prose could land there unread.
   #
   # THE FIFTH ARRIVED THE SAME DAY (rf2-n4a2b). rf2-sk5hf widened
   # prod-gate-naming-drift-test from a depth-1 `.listFiles` over one artefact's
@@ -3271,8 +3290,17 @@ jobs:
   # depth-independent, so tomorrow's artefact is walked by construction while
   # any arming list would have to be re-widened by hand. Arming to completion
   # costs ~59 more PRs and puts 92% of all PRs through that tier. This lane
-  # costs ONE runner of ~30s. An unconditional lane has no read-set model to
+  # costs ONE runner. An unconditional lane has no read-set model to
   # be wrong about, which is the whole point: there is nothing to drift.
+  #
+  # WHAT THE LANE COSTS, measured (rf2-6ng7) on a clean worktree off main with
+  # a warm `~/.m2`, each step its own JVM exactly as CI runs it: 5 / 7 / 13 /
+  # 7 / 5 / 61 / 8 seconds for the seven steps in order, ~106s of test time
+  # against this job's 10-minute ceiling. `late-bind-drift-test` is 61s of
+  # that, and it is the price of the repair rather than a defect to fix here:
+  # its producer spot-check re-reads the source corpus per directory entry.
+  # Slow, bounded, and still an order of magnitude under the ~21-minute JVM
+  # tier that arming these roots would have cost instead.
   #
   # A new classifier output was the third option and is rejected for the
   # reason jvm-hicasso gives at length — the defect being repaired IS a
@@ -3286,7 +3314,7 @@ jobs:
   # SILENT: measured on this tree, `-n <valid> -n <does-not-exist>` exits 0
   # having run only the valid one, with no warning. One combined step therefore
   # rests entirely on the quiet runner's TOTAL test-count floor, and these
-  # namespaces are lopsided — 1 / 3 / 27 / 1 / 2 tests. A total floor cannot tell
+  # namespaces are lopsided — 1 / 3 / 27 / 1 / 2 / 8 / 5 tests. A total floor cannot tell
   # "the 1-test floor lint stopped selecting" from "the 27-test catalogue
   # gained a test", so the guard would silently stop guarding the moment the
   # big suite grew. Run per namespace and each takes the runner's DEFAULT
@@ -3343,6 +3371,12 @@ jobs:
 
       - name: Production-gate naming drift (every artefact's test/ tree)
         run: clojure -M:test -n re-frame.prod-gate-naming-drift-test
+
+      - name: Late-bind directory drift (every implementation/ src root)
+        run: clojure -M:test -n re-frame.late-bind-drift-test
+
+      - name: Observation render-law drift (every tracked prose file, git ls-files)
+        run: clojure -M:test -n re-frame.observation-render-law-drift-test
 
   cljs:
     name: CLJS (shadow-cljs :node-test)

--- a/implementation/scripts/_changed-surfaces.test.cjs
+++ b/implementation/scripts/_changed-surfaces.test.cjs
@@ -388,9 +388,11 @@ test('Xray CLJS src change runs cljs (node-test compiles tools/xray) (rf2-f79t8)
 // made the corpus depth-independent by construction, so a future artefact is
 // walked with nobody maintaining a list, while an arming predicate would have
 // to be re-widened by hand every time. Instead `test.yml`'s UNCONDITIONAL
-// `jvm-repo-source-walks` job runs the four namespaces on every PR, one step
-// each so that a namespace which stops selecting reds on the runner's own
-// test-count floor rather than hiding inside a combined total.
+// `jvm-repo-source-walks` job runs those namespaces on every PR — seven of
+// them now, the roster being `REPO_SOURCE_WALK_NAMESPACES` below rather than
+// this paragraph — one step each so that a namespace which stops selecting
+// reds on the runner's own test-count floor rather than hiding inside a
+// combined total.
 //
 // So do NOT "fix" these to true: that re-incurs the tax and re-opens the
 // maintenance hole. If the unconditional job is ever deleted, THIS is the
@@ -435,12 +437,27 @@ test('implementation/core/src still arms implementation_jvm (rf2-cujx control)',
 // assertion up there goes on passing, asserting a coverage that has gone. This
 // is the rf2-6ng7 codicil applied to a repair whose "arming" is a workflow step
 // rather than a classifier output.
+//
+// rf2-6ng7 — THE SIXTH AND SEVENTH, found by this bead's bounded audit rather
+// than by tripping over them. Neither namespace was selected by any workflow or
+// script (measured: `git grep` over `.github/**` and `scripts/**` returns the
+// source file and nothing else), so both ran only inside `jvm-core`.
+//
+// `late-bind-drift-test` walks `implementation/**/src` — the SAME corpus as the
+// four src-walkers above, so the hicasso / ssr-node rows already asserted here
+// are its hole verbatim. `observation-render-law-drift-test` is wider than any
+// of them and needs its own probe: its census is `git ls-files`, so its domain
+// is the whole tracked prose corpus, and rf2-61ar armed `implementation_jvm`
+// for only the pinned SLICE of that prose. `docs/design/hicasso/**` is outside
+// the slice, which the row below measures.
 const REPO_SOURCE_WALK_NAMESPACES = Object.freeze([
   're-frame.no-rf-default-floor-lint-test',
   're-frame.egress-chokepoint-conformance-test',
   're-frame.error-catalogue-channel-conformance-test',
   're-frame.warn-once-clear-governance-test',
   're-frame.prod-gate-naming-drift-test',
+  're-frame.late-bind-drift-test',
+  're-frame.observation-render-law-drift-test',
 ]);
 
 test('hicasso + ssr-node TEST trees read implementation_jvm false — the naming-drift walk reads them anyway (rf2-n4a2b)', () => {
@@ -457,6 +474,24 @@ test('hicasso + ssr-node TEST trees read implementation_jvm false — the naming
     classify('implementation/epoch/test/re_frame/foo_prod_gate_test.clj').implementation_jvm,
     'true',
   );
+});
+
+test('unpinned PROSE reads implementation_jvm false — the render-law census reads it anyway (rf2-6ng7)', () => {
+  // The seventh walk's domain is `git ls-files`, not a directory: every tracked
+  // `.md` / `.clj` / `.cljc` / `.cljs` in the repo. rf2-61ar armed
+  // `implementation_jvm` for the prose a test.yml suite PINS — nearly all of
+  // `spec/*`, `docs/machines/*`, three named pages — and deliberately left the
+  // rest of `docs/` arming nothing. So the census outruns the arm, and a
+  // retired render-law claim landing on an unpinned page merged green.
+  for (const p of [
+    'docs/design/hicasso/product/foo.md',
+    'docs/core/hicasso/foo.md',
+  ]) {
+    assert.equal(classify(p).implementation_jvm, 'false', p);
+  }
+  // The control: prose that rf2-61ar DOES arm. Without it a classifier
+  // returning false for every `.md` would read as this census passing.
+  assert.equal(classify('docs/machines/concepts.md').implementation_jvm, 'true');
 });
 
 test('the unconditional walk lane runs every namespace whose false arm it excuses (rf2-n4a2b)', () => {


### PR DESCRIPTION
rf2-6ng7's bounded audit of the gate-arming class, re-run at the post-#8256 tip. The bead has been re-scoped twice; I acted on its **newest note** (2026-08-14 14:03, "MERGED-PR AUDIT #8242"), not the description's catalogue, which #8256 discharged.

## What I re-derived at source

The note's finding **still holds** on current main. Both namespaces exist, both are genuinely unselected, and the classifier reading is confirmed:

| namespace | input root | scheduled job | classifier probe |
|---|---|---|---|
| `re-frame.late-bind-drift-test` | `file-seq` from the implementation root, selecting every `implementation/**/src` Clojure/CLJS file | `jvm-core` only, `if: implementation_jvm == 'true'` | `implementation/hicasso/src` **false**, `implementation/ssr-node/src` **false** |
| `re-frame.observation-render-law-drift-test` | `git ls-files` census of every tracked prose-bearing file (>500) | `jvm-core` only, same condition | `docs/design/hicasso/**` **false**, `docs/core/hicasso/**` **false** |

- `jvm-repo-source-walks` runs **five** explicit per-namespace steps on main; neither namespace is among them.
- `clojure -M:test -n` appears 51 times across `.github/workflows/*.yml` and names neither. A repo-wide `git grep` for either namespace returns its own source file plus prose references only, no selector.
- I classified **every** artefact `src` root that publishes a late-bind hook (11 of them, via `set-fn!` / `set-fns!` / `chain-fn!` / `route-hook!`). Eleven arm `implementation_jvm` true; exactly two read false, `hicasso` and `ssr-node`, the same pair rf2-cujx's census already names. So the late-bind walk's hole is that census verbatim.
- The render-law walk's hole is **wider and needed its own probe**: its domain is the whole tracked prose corpus, while rf2-61ar armed `implementation_jvm` for only the pinned slice (nearly all `spec/*`, `docs/machines/*`, three named pages). The rest of `docs/` reads false.

## The cost measurement, and the repair it chose

Measured on **this worktree**, a clean checkout cut from `origin/main` and never warmed, with a warm `~/.m2`, each step its own JVM exactly as CI runs it. **~25 peer java/node processes were on the box** (54 worker worktrees live); a CI runner will not see that contention.

| step | elapsed | tests / assertions |
|---|---|---|
| `no-rf-default-floor-lint-test` | 5s | 1 / 1 |
| `egress-chokepoint-conformance-test` | 7s | 3 / 9 |
| `error-catalogue-channel-conformance-test` | 13s | 27 / 130 |
| `warn-once-clear-governance-test` | 5s | 1 / 1 |
| `prod-gate-naming-drift-test` | 7s | 2 / 5 |
| **`late-bind-drift-test` (new)** | **61s** | 8 / 674 |
| **`observation-render-law-drift-test` (new)** | **8s** | 5 / 21 |

The lane goes from ~37s to **~106s** of test time, against the job's `timeout-minutes: 10`. The bead recorded that the focused late-bind run "did not finish inside this audit's 120-second local command ceiling"; it finishes in 61s, so it was hitting the *harness* ceiling rather than an unbounded cost.

**So: a step on the existing unconditional lane, not a declared hole.** 69 extra seconds on one already-required runner is small, and it is the standing answer #8242 wrote into the job's own comment. The alternative measured in that comment, arming `implementation_jvm` for the two false roots, costs ~10 more PRs through the 22-job / ~21-minute JVM tier and still leaves the class open as walks widen. `late-bind-drift` is 61s of the total because its producer spot-check re-reads the source corpus per directory entry; that is the price of the repair, not a defect to fix inside this fence.

## The lane-content pin, and the proof it bites

Both namespaces join `REPO_SOURCE_WALK_NAMESPACES` in `implementation/scripts/_changed-surfaces.test.cjs`, so the pin now requires **seven** steps and seven single-`-n` selectors. A new census row measures the render-law walk's own domain (unpinned prose reads false) with an armed `docs/machines/` control, since the existing `src` rows say nothing about it either way.

**Sabotage proof** (both that the pin bites and that the gate read *this* worktree): renamed the new step's namespace to `re-frame.SABOTAGE-late-bind-drift-test`.

```
CAPTURED_EXIT=1
FAIL the unconditional walk lane runs every namespace whose false arm it excuses (rf2-n4a2b)
AssertionError: re-frame.late-bind-drift-test is a repo-wide source walk parked in
implementation/core/test/, and this lane is the only scheduling it has that does not
depend on a read-set model. It must be a step here.
changed-surfaces tests: 1 failed.
```

Restore verified by hashing bytes rather than by reading a diff: `git hash-object .github/workflows/test.yml` is `5bf67d6ef7065922c571b5056616cd35b380ad13` both before the plant and after the restore, byte-identical.

The lane's two measured properties are preserved: **one step per namespace** (a missing namespace inside a multi-`-n` selector is silent, exit 0, no warning) and **no `RF2_MIN_TESTS`** (no calibrated number to go stale).

## Which jobs newly fire

**None.** `jvm-repo-source-walks` is already unconditional, already required (present in `all-required-passed`'s `needs:`), and already fires on every `pull_request` and `push`. This adds two steps inside it. Nothing that was skipping now runs; one existing required job gets ~69s longer, well inside its 10-minute ceiling. No classifier output changed, so no PR changes tier.

## Quality gates

Every exit code below is the one **I captured** with `echo $?` on the same command line as the redirect, never a harness-reported number. All re-run **after** the rebase onto the current `origin/main`.

| gate | captured exit | result |
|---|---|---|
| `node implementation/scripts/_changed-surfaces.test.cjs` | **0** | 377 passed (376 on main plus the new census row) |
| `python scripts/check_gate_scheduling.py` | **0** | 51 gate commands, 43 scheduled, 8 declared, 0 unbeaded holes |
| `python scripts/check_jvm_lane_rosters.py` | **0** | 34 rostered artefacts, 0 baselined, bijection clean |
| `python scripts/check_ci_reproduce_commands.py` | **0** | 43 checker steps in sync |
| `python scripts/check_fast_pr_gap.py` | **0** | gap map clean |
| `node implementation/scripts/_reagent-slim-smoke-policy.test.cjs` | **0** | pass |
| `python scripts/check_donor_inventory.py` | **0** | 224 rows against 224 pinned |
| sabotage control (above) | **1** | red, naming the deleted namespace |
| YAML parse of `test.yml` plus step enumeration | **0** | job unconditional, 7 `clojure -M:test -n` steps, one namespace each |
| the 7 lane namespaces run directly, `clojure -M:test -n <ns>` | **0** x7 | 47 tests / 841 assertions, 0 failures 0 errors |

**Pass 10, fail 0** (the sabotage red is a control, counted as a pass of the guard).

Skipped, with reasons:

- **`scripts/test-fast-pr.sh`** was not run. It needs ~25 minutes against a 10-minute harness ceiling, and its coverage of this diff is `_changed-surfaces.test.cjs` plus the workflow checkers, all of which I ran directly and post-rebase. Per `TESTING.md:121`, `python scripts/check_fast_pr_gap.py --list` is the one path for the spine-versus-required-CI gap; it reports 89 required jobs across 3 workflows, 32 fully covered by the spine, 5 partly, 52 not at all. That is a fact about the spine, not a census of what I ran; what I ran is the table above.
- **`node implementation/scripts/check-ui-facade-isolation.cjs`**: its static half passed ("roster complete, every library view is exercised by the mounted suite"); its shadow-cljs half died with `Cannot find module 'shadow-cljs/cli/runner.js'`, i.e. no `node_modules` in this worktree. Environmental, not caused by this diff: the script reads `test.yml` only for build ids and this change touches none.
- **`npm run test:cljs` and the browser gates**: no CLJS, no runtime and no library surface in the diff.

## Hygiene

No `node_modules` junction was created (this worktree has none, which is why the two gates above were skipped rather than run). The mayor checkout's `implementation/node_modules` canary reads **101 before and 101 after**. No `.beads/` path is in this commit. No `git stash` at any point. Diffed `origin/main...HEAD` before pushing: this branch reverts nothing. Main moved four commits while I worked (#8259, #8261, rf2-52xpx, rf2-fn62g) and touched neither of my two files.
