### PR TITLE
Two gate scripts: qualification binds to its row, and the public-surface census becomes standing (rf2-b9707, rf2-hxbhe)

### DIFF
--- a/docs/design/hicasso/product/naming-packet.md
+++ b/docs/design/hicasso/product/naming-packet.md
@@ -312,121 +312,49 @@ and the sitting need not clear the inventory before deciding.
 
 ## 7. Re-running the census — for `rf2-hic-064`
 
-`rf2-hic-064` re-runs both the census and its positive control. The script is reproduced
-here in full rather than committed, because its natural home —
-`implementation/hicasso/scripts/` — was held by another worker for the whole of this bead.
-**Promoting it to a standing gate is `rf2-hxbhe`**, and until that lands the census is a
-one-shot measurement rather than a guarantee that stays true.
+`rf2-hic-064` re-runs both the census and its positive control. Both are now a **committed
+gate** — `implementation/hicasso/scripts/check_naming_census.py` — rather than a script
+reproduced in this section, which is what `rf2-hxbhe` promoted. Until that landed the census
+was a one-shot measurement; it is now re-runnable by anyone, with its controls attached.
 
-Run it as `python <script> <ABSOLUTE repo root>`; it exits 1 when any public name is
-unrostered and prints the root it read.
-
-```python
-#!/usr/bin/env python3
-"""rf2-hic-065 completeness census: every public name in implementation/hicasso,
-diffed against docs/design/hicasso/product/naming-ledger.md."""
-import importlib.util, os, re, sys
-
-REPO = os.path.abspath(sys.argv[1])
-print(f"CENSUS_REPO_ROOT={REPO}")
-
-spec = importlib.util.spec_from_file_location(
-    "cfi", os.path.join(REPO, "implementation", "hicasso", "scripts",
-                        "check_facade_inventory.py"))
-cfi = importlib.util.module_from_spec(spec); spec.loader.exec_module(cfi)
-
-HIC = os.path.join(REPO, "implementation", "hicasso")
-
-PUBLIC = [
-    ("re-frame.hicasso",          "src/re_frame/hicasso.cljc",                 "h"),
-    ("re-frame.hicasso.native",   "src/re_frame/hicasso/native.cljc",          "n"),
-    ("re-frame.hicasso.forms",    "src/re_frame/hicasso/forms.cljs",           "forms"),
-    ("re-frame.hicasso.overlay",  "src/re_frame/hicasso/overlay.cljs",         "overlay"),
-    ("re-frame.hicasso.motion",   "src/re_frame/hicasso/motion.cljs",          "motion"),
-    ("re-frame.hicasso.server",   "src/re_frame/hicasso/server.cljs",          "server"),
-    ("re-frame.hicasso.tool",     "src/re_frame/hicasso/tool.cljs",            "tool"),
-    ("re-frame.hicasso.evidence", "src/re_frame/hicasso/evidence.cljs",        "evidence"),
-    ("re-frame.hicasso.test",     "test_kit/src/re_frame/hicasso/test.cljs",   "ht"),
-    ("re-frame.hicasso.test.mounted",
-                                  "test_kit/src/re_frame/hicasso/test/mounted.cljs", "hm"),
-]
-
-
-def roster(text):
-    """(public, computed, midline). A DEFINITION OPENS A LINE -- a `def`-headed
-    form mid-line is a CALL, and reading those as definitions minted the phantom
-    names `p` and `ds` out of evidence.cljs."""
-    source = cfi.code_only(text)
-    public, computed, midline = [], [], []
-    for match in cfi.DEF_HEAD_RE.finditer(source):
-        head = match.group(1)
-        start = match.start()
-        line_start = source.rfind("\n", 0, start) + 1
-        if source[line_start:start].strip():
-            midline.append(head)
-            continue
-        i = match.end()
-        private = head.endswith("-")
-        while True:
-            while i < len(source) and source[i].isspace():
-                i += 1
-            if i < len(source) and source[i] == "^":
-                end = cfi.form_end(source, i + 1)
-                if ":private" in source[i:end]:
-                    private = True
-                i = end
-                continue
-            break
-        name_match = cfi.NAME_RE.match(source, i)
-        if not name_match:
-            computed.append(head)
-            continue
-        if not private:
-            public.append(name_match.group(0))
-    return sorted(set(public)), computed, sorted(set(midline))
-
-
-ledger = open(os.path.join(REPO, "docs", "design", "hicasso", "product",
-                           "naming-ledger.md"), encoding="utf-8").read()
-SPANS = set(re.findall(r"`([^`]+)`", ledger))
-
-rows, missing, total = [], [], 0
-for ns, rel, alias in PUBLIC:
-    path = os.path.join(HIC, rel)
-    if not os.path.exists(path):
-        print(f"FAIL: declared public namespace has no source: {path}"); sys.exit(2)
-    names, computed, midline = roster(open(path, encoding="utf-8").read())
-    if not names:
-        print(f"FAIL: {ns} produced an EMPTY roster -- read nothing"); sys.exit(2)
-    total += len(names)
-    for nm in names:
-        spelled = f"{alias}/{nm}"
-        covered = spelled in SPANS or nm in SPANS
-        rows.append((ns, spelled, covered))
-        if not covered:
-            missing.append((ns, spelled))
-    if computed:
-        print(f"  note {ns}: {len(computed)} computed def name(s) skipped: {computed}")
-    if midline:
-        print(f"  note {ns}: mid-line def-headed forms read as CALLS: {midline}")
-
-for ns, spelled, covered in rows:
-    print(f"{'OK  ' if covered else 'MISS'} {ns:32s} {spelled}")
-
-print(f"\nCENSUS: {total} public names across {len(PUBLIC)} shipped namespaces; "
-      f"{len(missing)} NOT rostered in naming-ledger.md")
-for ns, spelled in missing:
-    print(f"  UNROSTERED  {ns}  {spelled}")
-sys.exit(1 if missing else 0)
+```
+python3 implementation/hicasso/scripts/check_naming_census.py <ABSOLUTE repo root>
+python3 implementation/hicasso/scripts/check_naming_census.py --self-test
 ```
 
-**Re-running the positive control**: append a public `(defn …)` to any file in the `PUBLIC`
-list, confirm the census total rises by one and names it under `UNROSTERED`, then revert
-and verify the restore with `git hash-object` — a diff misreads a restore two ways, and a
-plant that silently no-ops makes the control pass having proved nothing.
+It exits 0 when every public name is rostered, 1 naming each name that is not, and 2 when it
+REFUSES — a namespace source that has moved, a roster that came back empty, a missing
+ledger, or a ledger it could not read a single code span from. A refusal is distinct from a
+red on purpose: an absence check that inspected nothing otherwise reports the same green as
+one that inspected everything.
 
-**Measured at publication, with rows 47–54 in the ledger**: *"CENSUS: 105 public names
-across 10 shipped namespaces; 0 NOT rostered in naming-ledger.md"*, exit **0**. That is the
-bead's acceptance condition met mechanically rather than by inspection. A non-zero count
-from here is a public name minted since publication with no ledger row — precisely what
-section 3 of [`dispositions.md`](dispositions.md) forbids.
+**Two properties the gate keeps, both of which were found the hard way.** *A definition
+opens a line*: `check_facade_inventory.py` accepts a `def`-headed form anywhere, which is
+safe on the one door it reads, and here it minted the phantom public names `p` and `ds` out
+of the two calls in `evidence.cljs` — `(let [ds (defects p)]` and `(defects-message ds)`.
+*The root is an absolute argument and is printed*, because a script deriving its root from
+its own invocation path can walk a sibling worktree and report that as the census; a
+relative path is refused rather than resolved against the working directory.
+
+**The positive control now ships.** It used to be a manual dance recorded here — plant a
+public `(defn …)`, confirm the count rises by one, revert, verify the restore with `git
+hash-object`. It is now a fixture inside `--self-test`: a seeded export with no ledger row,
+which the census must catch and name, run on every invocation rather than when somebody
+remembers. The live form still works and was re-run at promotion — a public `defn` planted
+in `motion.cljs` moved the census 105 → 106 and named it under `UNROSTERED`, reverted, the
+restore verified at `ce1cf16681b879913f0342d0c14e8966718b4704` either side.
+
+**Measured at publication, with rows 47–54 in the ledger**, and re-measured identically by
+the committed gate: *"CENSUS: 105 public names across 10 shipped namespaces; 0 NOT rostered
+in naming-ledger.md"*, exit **0**. That is the bead's acceptance condition met mechanically
+rather than by inspection. A non-zero count from here is a public name minted since
+publication with no ledger row — precisely what section 3 of
+[`dispositions.md`](dispositions.md) forbids.
+
+**Not yet wired into CI.** `.github/workflows/*` is hot zone and arming the gate is filed
+separately (`rf2-st1x5`), and it has three parts rather than one: the
+`test:hicasso-invariants` chain, an unconditional job for the ledger side — which arms no
+classifier output, so a deleted row would otherwise next redden on somebody else's source
+PR — and the `all-required-passed` `needs:` entry that pins the second, without which the
+lane exists and gates nothing. Until that lands, the census is runnable and proven but not
+standing, and nothing re-runs it on your behalf.

--- a/implementation/hicasso/scripts/check_naming_census.py
+++ b/implementation/hicasso/scripts/check_naming_census.py
@@ -1,0 +1,669 @@
+#!/usr/bin/env python3
+"""Every public name in `implementation/hicasso` owes a naming-ledger row (rf2-hxbhe).
+
+`dispositions.md` section 3 states the constraint unconditionally -- *adding
+a public surface adds an id* -- and `check_facade_inventory.py` enforces it
+over exactly ONE door, `re-frame.hicasso`, by design and says so in its own
+module docstring:
+
+>   Adding a second door here is a data change; deciding what its public
+>   roster IS is not, and is filed rather than guessed.
+
+That was the right call for an inventory gate whose rule is *every name owes
+a DISPOSITION*, because the native tier's `el`, `props*`, `component` and
+`marker` are compiler targets rather than authoring surface and only that
+tier's owner can say which is which. It is the wrong scope for the weaker
+question this gate asks -- *is the name WRITTEN DOWN anywhere in the naming
+ledger* -- which needs no such judgement and reaches all ten shipped
+namespaces. `rf2-hic-065`'s census measured what the gap costs: 105 public
+names, of which 60 carried no ledger row, and 58 of those sat outside every
+existing gate's reach.
+
+The ledger is now complete (rows 47-54, PR #8252) and this gate is what
+keeps it complete. It is the standing form of a census that was, until now,
+a one-shot measurement reproduced in `naming-packet.md` section 7.
+
+
+## Why this is not a grep
+
+`re-frame.hicasso`'s doors document themselves at length and their
+docstrings are dense with worked examples -- `(defhost modal Modal …)`,
+`(def article-card* (h/as-component article-card))`, `(defn todo-row-body
+[props] …)`. Every one of those is PROSE, and a grep-derived roster counts
+all three as public names. So the source is read as CODE: [[code_only]]
+blanks strings, comments, character literals and reader-discarded forms,
+and what survives is walked for `(def…)` heads.
+
+
+## A DEFINITION OPENS A LINE
+
+`check_facade_inventory.py` accepts a `def`-headed form anywhere on a line,
+which is safe on the one door it reads because nothing there CALLS a
+`def*`-named function. It is not safe here. `evidence.cljs` calls two --
+
+    (let [ds (defects p)]
+      … (defects-message ds) …)
+
+-- and reading those two calls as definitions mints the phantom public
+names `p` and `ds`, which no ledger will ever roster and no author can
+ever write. So a definition must OPEN its line (leading whitespace aside),
+and a `def`-headed form found mid-line is reported as a CALL rather than
+silently dropped. A skip nobody prints reads exactly like a name nobody
+has, which is this gate's own subject.
+
+The rule's limit, stated rather than left to be discovered: a `def`-headed
+CALL that happens to begin its own line would still be read as a
+definition. No such call exists in the ten namespaces -- both of
+`evidence.cljs`'s are mid-line, which is why this rule is sufficient today
+-- and the failure it would produce is a phantom name reported UNROSTERED,
+which is a false RED. That is the safe direction, and it is why a bracket
+depth tracker is not being built for it.
+
+
+## The root is an ABSOLUTE argument, and it is printed
+
+    python3 check_naming_census.py <ABSOLUTE repo root>
+
+A script that derives its repository root from its own invocation path can
+walk a SIBLING WORKTREE and report that as the census -- a complete,
+internally consistent run about somebody else's tree, which is far harder
+to catch than a broken one. So the root is supplied, a relative path is
+REFUSED rather than resolved against the working directory (the same hazard
+wearing a different hat), and the root actually read is printed on every
+run, green or red, as the first line of output.
+
+That has one consequence worth stating, because it is a real cost and not
+an oversight: `--self-test` runs over SYNTHETIC trees only and asserts
+nothing about the live one. `check_facade_inventory.py`'s self-test can
+re-assert its live premises because it derives its own root; this gate
+declines to derive a root at all, so it cannot. The live premise is the
+live run, which is a separate invocation and says which tree it read.
+
+
+## Duplicated, not imported
+
+[[form_end]], [[strip_inert]] and [[code_only]] are copied from
+`check_facade_inventory.py` rather than imported from it, per rf2-t9t0:
+these checkers are self-contained single files with no cross-imports, and
+that file's own docstring records the same decision about the same three
+functions when IT copied them from `check_optional_module_reachability.py`.
+The one-shot census in `naming-packet.md` section 7 loaded the sibling by
+path with `importlib`, which is fine for a script quoted in a document and
+would have been the first cross-import among the checkers had it been
+committed that way.
+
+The copies were measured to agree: both this gate and
+`check_facade_inventory.py` derive the same 16 names for `re-frame.hicasso`,
+an agreement neither was arranged to produce.
+
+
+## Failing closed
+
+An absence check that inspected nothing reports the same green as one that
+inspected everything. Each of these is a REFUSAL (exit 2) naming the input
+it could not read, rather than an empty result: a declared namespace whose
+source is missing, a namespace whose roster came back empty, a missing
+ledger, and a ledger from which no code span could be read at all.
+
+
+## Self-test, and the positive control that ships
+
+`--self-test` builds throwaway trees and runs the real [[census]] over
+them, which is `check_allocation_non_claim.py`'s model rather than
+`check_provenance_pins.py`'s -- both of those carry self-tests, and the
+allocation scan is the closer one twice over: it is the other absence check
+in the tree, and its fixtures are whole synthetic corpora rather than
+in-memory rule cases, which is what a gate that WALKS A TREE needs.
+
+The positive control is the fixture that matters. `naming-packet.md`
+section 7 described it as a manual dance -- plant a public `(defn …)`,
+confirm the count rises by one, revert, verify the restore with `git
+hash-object`. Here it is a fixture: a seeded export the census must catch,
+run on every invocation of `--self-test`, so the control proves itself
+rather than waiting for a worker to remember it.
+
+
+## Where it should run -- and it is NOT wired yet
+
+Two input families that do not arm the same lane, exactly as
+`check_facade_inventory.py` documents for exactly this reason:
+
+    implementation/hicasso/src/**, test_kit/src/**   the ten namespaces
+    docs/design/hicasso/product/naming-ledger.md     the ledger
+
+A name escapes when the SOURCE grows, and a source change arms the `cljs`
+job under `cljs_node_test`. The document side arms nothing (`docs/**`
+measures false at every classifier output), so the doc-side direction --
+a ledger row deleted out from under a name -- needs an unconditional lane
+or it next reddens on somebody else's source PR.
+
+`.github/workflows/*` is hot zone and arming this gate is filed separately
+rather than done here. Until that lands this gate is runnable and proven
+but not standing, and `naming-packet.md` section 7 says so.
+"""
+
+import os
+import re
+import sys
+
+# The ten shipped namespaces, their sources relative to `implementation/hicasso`,
+# and the alias each one's names are spelled under in the ledger.
+PUBLIC = [
+    ("re-frame.hicasso", "src/re_frame/hicasso.cljc", "h"),
+    ("re-frame.hicasso.native", "src/re_frame/hicasso/native.cljc", "n"),
+    ("re-frame.hicasso.forms", "src/re_frame/hicasso/forms.cljs", "forms"),
+    ("re-frame.hicasso.overlay", "src/re_frame/hicasso/overlay.cljs", "overlay"),
+    ("re-frame.hicasso.motion", "src/re_frame/hicasso/motion.cljs", "motion"),
+    ("re-frame.hicasso.server", "src/re_frame/hicasso/server.cljs", "server"),
+    ("re-frame.hicasso.tool", "src/re_frame/hicasso/tool.cljs", "tool"),
+    ("re-frame.hicasso.evidence", "src/re_frame/hicasso/evidence.cljs", "evidence"),
+    ("re-frame.hicasso.test", "test_kit/src/re_frame/hicasso/test.cljs", "ht"),
+    ("re-frame.hicasso.test.mounted",
+     "test_kit/src/re_frame/hicasso/test/mounted.cljs", "hm"),
+]
+
+PACKAGE_REL = ("implementation", "hicasso")
+LEDGER_REL = ("docs", "design", "hicasso", "product", "naming-ledger.md")
+
+EXIT_OK = 0
+EXIT_UNROSTERED = 1
+EXIT_REFUSED = 2
+
+
+# ---------------------------------------------------------------------------
+# Reading Clojure: strings, comments and inert forms are not code
+# ---------------------------------------------------------------------------
+#
+# Copied from `check_facade_inventory.py`, which copied them from
+# `check_optional_module_reachability.py` -- see the module docstring and
+# rf2-t9t0.  No cross-imports between these checkers.
+
+OPENERS = "([{"
+CLOSERS = ")]}"
+
+
+def form_end(text, i):
+    """Index just past the ONE form beginning at or after `text[i]`.
+
+    `text` has already been through [[code_only]]'s string, comment and
+    character-literal passes, so every remaining bracket is structural.
+    """
+    n = len(text)
+    while i < n and text[i].isspace():
+        i += 1
+    if i >= n:
+        return n
+    if text[i] not in OPENERS:  # a bare symbol, keyword or number
+        while i < n and not text[i].isspace() and text[i] not in OPENERS + CLOSERS:
+            i += 1
+        return i
+    depth = 0
+    while i < n:
+        ch = text[i]
+        if ch in OPENERS:
+            depth += 1
+        elif ch in CLOSERS:
+            depth -= 1
+            if depth == 0:
+                return i + 1
+        i += 1
+    return n
+
+
+COMMENT_FORM_RE = re.compile(r"\(\s*comment(?![\w.*+!?<>=$%&|:'/-])")
+
+
+def strip_inert(text):
+    """`text` with the INERT form shapes blanked out.
+
+    A form the reader discards is not a definition:
+
+        #_(def gone 1)          reader discard
+        (comment (def gone 1))  comment macro
+        `(def ~name ~value)     syntax-quoted -- a macro's EXPANSION, not a def
+
+    Quoting is recognised only where a form may START, because `'` is a legal
+    symbol character in Clojure (`next'`).
+    """
+    chars = list(text)
+    i, n = 0, len(text)
+    while i < n:
+        ch = text[i]
+        if text.startswith("#_", i):
+            start, body = i, i + 2
+        elif ch in "'`" and (i == 0 or text[i - 1].isspace() or text[i - 1] in OPENERS):
+            start, body = i, i + 1
+        elif COMMENT_FORM_RE.match(text, i):
+            start, body = i, i  # the `(comment …)` form is inert entire
+        else:
+            i += 1
+            continue
+        end = form_end(text, body)
+        for j in range(start, end):
+            if chars[j] != "\n":
+                chars[j] = " "
+        i = end
+    return "".join(chars)
+
+
+def code_only(text):
+    """`text` reduced to the forms the reader would actually EVALUATE.
+
+    `\\"` is a character literal in Clojure, not a string, so a backslash
+    outside a string consumes the character after it; inside a string it is
+    the escape it looks like.  [[strip_inert]] runs last, over text whose
+    brackets are all structural by then.
+    """
+    out = []
+    i, n = 0, len(text)
+    in_string = False
+    while i < n:
+        ch = text[i]
+        if in_string:
+            if ch == "\\":
+                i += 2
+                continue
+            if ch == '"':
+                in_string = False
+            i += 1
+            continue
+        if ch == "\\":  # character literal: \" \newline \a
+            out.append(" ")
+            i += 2
+            continue
+        if ch == ";":
+            while i < n and text[i] != "\n":
+                i += 1
+            continue
+        if ch == '"':
+            in_string = True
+            out.append(" ")
+            i += 1
+            continue
+        out.append(ch)
+        i += 1
+    return strip_inert("".join(out))
+
+
+# ---------------------------------------------------------------------------
+# The roster: every public name a namespace defines
+# ---------------------------------------------------------------------------
+
+SYMBOL_TAIL = r"[A-Za-z0-9_.*+!?<>=$%&/'-]"
+DEF_HEAD_RE = re.compile(r"\((def" + SYMBOL_TAIL + r"*)")
+NAME_RE = re.compile(r"[A-Za-z*+!?<>=$%&_-]" + SYMBOL_TAIL + r"*")
+
+
+def roster(text):
+    """`(public, computed, midline)` for one namespace's source.
+
+    `public` is the sorted list of names an author can write.  `computed` is
+    the def-forms whose name is not a literal symbol.  `midline` is the
+    def-headed forms that did NOT open their line -- those are CALLS, and
+    reading them as definitions is what minted `p` and `ds` out of
+    `evidence.cljs`.  Both skips are returned so a run can print them.
+    """
+    source = code_only(text)
+    public, computed, midline = [], [], []
+    for match in DEF_HEAD_RE.finditer(source):
+        head = match.group(1)
+        line_start = source.rfind("\n", 0, match.start()) + 1
+        if source[line_start:match.start()].strip():
+            midline.append(head)
+            continue
+        i = match.end()
+        private = head.endswith("-")  # defn-
+        # Skip any number of metadata forms: `^{:private true}`, `^:private`,
+        # `^Symbol`.  These namespaces write their docstrings this way, so
+        # this is the ordinary case rather than an edge one.
+        while True:
+            while i < len(source) and source[i].isspace():
+                i += 1
+            if i < len(source) and source[i] == "^":
+                end = form_end(source, i + 1)
+                if ":private" in source[i:end]:
+                    private = True
+                i = end
+                continue
+            break
+        name_match = NAME_RE.match(source, i)
+        if not name_match:
+            computed.append(head)
+            continue
+        if private:
+            continue
+        public.append(name_match.group(0))
+    return sorted(set(public)), computed, sorted(set(midline))
+
+
+# ---------------------------------------------------------------------------
+# The ledger
+# ---------------------------------------------------------------------------
+
+CODE_SPAN_RE = re.compile(r"`([^`]+)`")
+
+
+def ledger_spans(text):
+    """Every code span written anywhere in the naming ledger.
+
+    Deliberately the whole document rather than one column: the question is
+    *is this name written down*, not *which row owns it*.  Attribution to a
+    particular row is `check_facade_inventory.py`'s stricter job, over the
+    one door where the answer is decidable.
+    """
+    return set(CODE_SPAN_RE.findall(text))
+
+
+# ---------------------------------------------------------------------------
+# The census
+# ---------------------------------------------------------------------------
+
+def read(path):
+    with open(path, encoding="utf-8") as handle:
+        return handle.read()
+
+
+def census(root, public=None):
+    """`(rows, missing, notes, problems)` for the tree at `root`.
+
+    `rows` is `[(namespace, spelled_name, covered)]` over every public name
+    found; `missing` is the unrostered subset; `notes` records what was
+    skipped and why; `problems` is non-empty only for a REFUSAL -- an input
+    the gate could not read, which is not the same as an input with nothing
+    in it.
+
+    `public` is an argument so the self-test drives the real rules over
+    synthetic namespaces, rather than over a manifest that moves whenever a
+    namespace ships.
+    """
+    public = PUBLIC if public is None else public
+    rows, missing, notes, problems = [], [], [], []
+
+    ledger_path = os.path.join(root, *LEDGER_REL)
+    if not os.path.isfile(ledger_path):
+        problems.append(
+            "the naming ledger is not at {}. Every name is measured against "
+            "that document, so a census without it would report all of them "
+            "unrostered.".format(os.path.join(*LEDGER_REL))
+        )
+        return rows, missing, notes, problems
+
+    spans = ledger_spans(read(ledger_path))
+    if not spans:
+        problems.append(
+            "{} yielded no code spans at all. A ledger this gate could not "
+            "read is not a ledger with nothing in it, and the difference is "
+            "the whole reason an absence check has to say so.".format(
+                os.path.join(*LEDGER_REL)
+            )
+        )
+        return rows, missing, notes, problems
+
+    package = os.path.join(root, *PACKAGE_REL)
+    for ns, rel, alias in public:
+        path = os.path.join(package, *rel.split("/"))
+        if not os.path.isfile(path):
+            problems.append(
+                "{} is declared a shipped public namespace and its source is "
+                "not at {}. Either the namespace moved -- update this gate's "
+                "PUBLIC list in the same commit -- or it was deleted and the "
+                "entry is stale.".format(ns, rel)
+            )
+            continue
+        names, computed, midline = roster(read(path))
+        if not names:
+            problems.append(
+                "{} produced an EMPTY roster. A namespace the reader came "
+                "back empty on would report a complete census over "
+                "nothing.".format(ns)
+            )
+            continue
+        for name in names:
+            spelled = "{}/{}".format(alias, name)
+            covered = spelled in spans or name in spans
+            rows.append((ns, spelled, covered))
+            if not covered:
+                missing.append((ns, spelled))
+        if computed:
+            notes.append(
+                "{}: {} def-form(s) with a computed name skipped -- not a "
+                "public spelling anyone can write: {}".format(
+                    ns, len(computed), ", ".join(sorted(set(computed)))
+                )
+            )
+        if midline:
+            notes.append(
+                "{}: {} def-headed form(s) read as CALLS because they do not "
+                "open a line: {}".format(ns, len(midline), ", ".join(midline))
+            )
+
+    return rows, missing, notes, problems
+
+
+# ---------------------------------------------------------------------------
+# self-test
+# ---------------------------------------------------------------------------
+#
+# Throwaway trees, run through the real [[census]] -- the model is
+# `scripts/check_allocation_non_claim.py`, the tree's other absence check,
+# whose fixtures are whole synthetic corpora for the same reason: a gate
+# that walks a tree is not exercised by an in-memory rule case.
+
+_FIXTURE_NS = [
+    ("fixture.one", "src/fixture/one.cljs", "f"),
+    ("fixture.two", "src/fixture/two.cljs", "g"),
+]
+
+# `one.cljs` exercises every way a name can fail to be public, all at once:
+# a docstring carrying worked `(def …)` examples, a `defn-`, a `^:private`,
+# a reader discard, a line comment, and two def-headed CALLS mid-line.
+_ONE = (
+    '(ns fixture.one)\n'
+    '(def ^{:doc "Worked examples, all PROSE:\n'
+    '  (def article-card* (h/as-component article-card))\n'
+    '  (defn todo-row-body [props] …)"} alpha impl/alpha)\n'
+    '(defn- hidden [] 1)\n'
+    '(defn ^:private also-hidden [] 2)\n'
+    ';; (def commented-out impl/x)\n'
+    '#_(def discarded impl/y)\n'
+    '(defn beta []\n'
+    '  (let [ds (defects p)]\n'
+    '    (when (seq ds)\n'
+    '      (throw (ex-info (defects-message ds) {})))))\n'
+)
+
+_TWO = '(ns fixture.two)\n(def gamma impl/gamma)\n'
+
+# Every name in `_ONE` and `_TWO`, rostered.  This is the green baseline the
+# positive control moves.
+_LEDGER = (
+    "# Naming ledger\n\n"
+    "| # | Name |\n|---|---|\n"
+    "| 1 | `f/alpha` |\n"
+    "| 2 | `f/beta` |\n"
+    "| 3 | `g/gamma` |\n"
+)
+
+
+def _write_tree(root, one=_ONE, two=_TWO, ledger=_LEDGER, omit=()):
+    package = os.path.join(root, *PACKAGE_REL)
+    for rel, text in (("src/fixture/one.cljs", one), ("src/fixture/two.cljs", two)):
+        if rel in omit:
+            continue
+        path = os.path.join(package, *rel.split("/"))
+        os.makedirs(os.path.dirname(path), exist_ok=True)
+        with open(path, "w", encoding="utf-8") as handle:
+            handle.write(text)
+    if ledger is not None:
+        path = os.path.join(root, *LEDGER_REL)
+        os.makedirs(os.path.dirname(path), exist_ok=True)
+        with open(path, "w", encoding="utf-8") as handle:
+            handle.write(ledger)
+    return root
+
+
+def self_test():
+    # THIS SELF-TEST'S OWN CLAIMS MUST NOT BE DELETABLE (rf2-uyhh). `python -O`
+    # -- and `PYTHONOPTIMIZE` in the environment, which needs no flag at the
+    # call site -- strips every `assert` below, leaving a function that runs to
+    # its success line having verified nothing.  Empirical rather than a read
+    # of `__debug__`, so it catches a `.pyc` compiled under `-O` too.
+    try:
+        assert False
+    except AssertionError:
+        pass
+    else:
+        raise SystemExit(
+            "assertions are disabled (python -O / PYTHONOPTIMIZE), so this "
+            "self-test would prove nothing. Re-run without -O."
+        )
+
+    import tempfile
+
+    checks = 0
+
+    def case(label, expect_missing, expect_refusal=False, **kwargs):
+        nonlocal checks
+        with tempfile.TemporaryDirectory() as tmp:
+            root = _write_tree(os.path.join(tmp, "tree"), **kwargs)
+            rows, missing, notes, problems = census(root, _FIXTURE_NS)
+        checks += 1
+        if expect_refusal:
+            assert problems, (label, rows, missing, problems)
+            assert any(expect_refusal in p for p in problems), (label, problems)
+        else:
+            assert not problems, (label, problems)
+            assert [s for _, s in missing] == expect_missing, (label, missing)
+        print("  ok  {}".format(label))
+        return rows, missing, notes, problems
+
+    # ---- the roster, read as CODE rather than grepped ---------------------
+    names, computed, midline = roster(_ONE)
+    # `alpha` and `beta` are the only public names.  Everything else in that
+    # file is a docstring example, a private, an inert form or a CALL.
+    assert names == ["alpha", "beta"], names
+    assert computed == [], computed
+    # THE PHANTOM NAMES.  A def-headed form mid-line is a call: reading
+    # `(defects p)` and `(defects-message ds)` as definitions is what minted
+    # `p` and `ds` out of `evidence.cljs`.
+    assert midline == ["defects", "defects-message"], midline
+    assert "p" not in names and "ds" not in names, names
+    checks += 1
+    print("  ok  a definition OPENS a line -- mid-line def-headed forms are CALLS")
+
+    # A `defsomething` nobody has written yet counts as public: the direction
+    # that fails loudly is the one this gate wants.
+    later, _, _ = roster("(defwidget gadget [] 1)")
+    assert later == ["gadget"], later
+    # ...and a computed name is REPORTED, not silently dropped.
+    _, computed, _ = roster("(def ~(symbol s) 1)\n(def real 2)")
+    assert computed == ["def"], computed
+    checks += 1
+    print("  ok  an unknown `def*` head is public; a computed name is reported")
+
+    # ---- the green baseline ----------------------------------------------
+    rows, _, notes, _ = case("a fully rostered tree is GREEN", [])
+    assert len(rows) == 3, rows
+    assert any("read as CALLS" in n for n in notes), notes
+
+    # ---- THE SEEDED POSITIVE CONTROL -------------------------------------
+    # A public export the ledger does not roster.  This is the control that
+    # `naming-packet.md` section 7 described as a manual plant-and-revert; as
+    # a fixture it runs on every invocation instead of when somebody
+    # remembers.  It must move the count by exactly one and NAME the export.
+    seeded = _TWO + "(defn seeded-export [] :escaped)\n"
+    after, missing, _, _ = case(
+        "a SEEDED public export with no ledger row is caught",
+        ["g/seeded-export"],
+        two=seeded,
+    )
+    assert len(after) == len(rows) + 1, (len(after), len(rows))
+
+    # The control's other half: the same export, once rostered, goes green --
+    # so the gate is checking the ledger rather than banning new names.
+    case(
+        "the same export, once rostered, is GREEN",
+        [],
+        two=seeded,
+        ledger=_LEDGER + "| 4 | `g/seeded-export` |\n",
+    )
+
+    # A private export is not a public name and owes no row.
+    case("a PRIVATE export owes no row", [], two=_TWO + "(defn- quiet [] 1)\n")
+
+    # ---- failing closed ---------------------------------------------------
+    # Each of these would otherwise be a green -- or a red for the wrong
+    # reason -- over an input the gate never read.
+    case("a missing namespace source is REFUSED", None,
+         "its source is not at", omit=("src/fixture/two.cljs",))
+    case("an empty roster is REFUSED", None,
+         "produced an EMPTY roster", two="(ns fixture.two)\n;; nothing\n")
+    case("a missing ledger is REFUSED", None,
+         "the naming ledger is not at", ledger=None)
+    case("a ledger with no code spans is REFUSED", None,
+         "yielded no code spans", ledger="# Naming ledger\n\nNo spans here.\n")
+
+    print("\nhicasso naming census: self-test OK ({} checks).".format(checks))
+    return EXIT_OK
+
+
+# ---------------------------------------------------------------------------
+
+def main(argv):
+    if "--self-test" in argv:
+        return self_test()
+
+    if len(argv) != 1:
+        sys.stderr.write(
+            "usage: check_naming_census.py <ABSOLUTE repo root>\n"
+            "       check_naming_census.py --self-test\n\n"
+            "The root is supplied rather than derived, because a script that\n"
+            "derives its root from its own invocation path can walk a sibling\n"
+            "worktree and report that as the census.\n"
+        )
+        return EXIT_REFUSED
+
+    root = argv[0]
+    if not os.path.isabs(root):
+        sys.stderr.write(
+            "REFUSED: {!r} is not an absolute path. A relative root resolves\n"
+            "against the working directory, which is the same hazard the\n"
+            "argument exists to close -- pass the absolute repository root.\n".format(root)
+        )
+        return EXIT_REFUSED
+
+    print("CENSUS_REPO_ROOT={}".format(root))
+    rows, missing, notes, problems = census(root)
+
+    for note in notes:
+        print("  note {}".format(note))
+
+    if problems:
+        sys.stderr.write("hicasso naming census: REFUSED\n")
+        for problem in problems:
+            sys.stderr.write("  - " + problem + "\n")
+        return EXIT_REFUSED
+
+    for ns, spelled, covered in rows:
+        print("{} {:32s} {}".format("OK  " if covered else "MISS", ns, spelled))
+
+    print("\nCENSUS: {} public names across {} shipped namespaces; {} NOT "
+          "rostered in naming-ledger.md".format(len(rows), len(PUBLIC), len(missing)))
+
+    if missing:
+        for ns, spelled in missing:
+            print("  UNROSTERED  {}  {}".format(ns, spelled))
+        sys.stderr.write(
+            "\nhicasso naming census: FAIL -- {} public name(s) with no naming-ledger "
+            "row.\ndispositions.md section 3: adding a public surface adds an id. Add a "
+            "row to\ndocs/design/hicasso/product/naming-ledger.md, or make the name "
+            "private.\n".format(len(missing))
+        )
+        return EXIT_UNROSTERED
+
+    print("OK: every public name in implementation/hicasso is rostered.")
+    return EXIT_OK
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/scripts/check_allocation_non_claim.py
+++ b/scripts/check_allocation_non_claim.py
@@ -61,12 +61,38 @@ non-claim in the name of enforcing the non-claim. So:
     scanned row.
 
 Qualification is honoured rather than assumed away: a publication-surface
-figure passes if its own paragraph also carries the non-claim in words.
+figure passes if its own CLAIM UNIT also carries the non-claim in words.
 The rule is *no claim WITHOUT its qualification*, not *no figure*, because
 a page that states the number and then says the instrument does not
 certify it has published no claim — it has published the refusal, which is
-the truthful thing to publish. Today no such paragraph exists and the row
-is empty, which is a stronger state and not the one being enforced.
+the truthful thing to publish. Today no such unit exists and the row is
+empty, which is a stronger state and not the one being enforced.
+
+
+## The claim unit, which is NOT the blank-line block
+
+Qualification attaches to the row that carries the figure, and the first
+cut of this gate got that wrong (rf2-b9707). It scoped qualification to
+the blank-line block — and in Markdown a whole table and a whole tight
+list are ONE such block, so an unqualified figure in one row went green
+because a DIFFERENT row happened to say `quality floor unmet`. That is a
+fail-open, and it fails open exactly where the figures are: a table is how
+a publication surface presents numbers.
+
+So a block is subdivided into claim units, minimally, by three line
+shapes:
+
+  * a table row is its own unit, and so is whatever follows it;
+  * a tight list item is its own unit, its wrapped continuation lines
+    included;
+  * everything else is prose and keeps the whole blank-line block,
+    because an English sentence routinely carries its qualification onto
+    the next line, and splitting prose per line would turn this gate into
+    the false-positive machine authors reword their way around.
+
+Three line shapes is not a Markdown parser, and it does not need to be.
+The gate never has to know what a table MEANS — only that two rows are
+two claims.
 
 
 ## The positive control, and why an absence check needs one
@@ -110,7 +136,7 @@ CLAIM = re.compile(
     re.IGNORECASE,
 )
 
-# Words that say, in the same paragraph, that the figure is not certified.
+# Words that say, in the same CLAIM UNIT, that the figure is not certified.
 # Deliberately generous: the gate's job is to catch an UNQUALIFIED claim,
 # and a false red on a paragraph that qualifies honestly in wording this
 # list did not anticipate would teach authors to fight the gate.
@@ -166,23 +192,49 @@ def design_corpus(paths: list[str]) -> list[str]:
     return sorted(p for p in paths if p.startswith(DESIGN_PREFIX))
 
 
-def paragraphs(text: str) -> list[tuple[int, str]]:
-    """(1-based start line, paragraph text) for each blank-line-separated block."""
-    blocks: list[tuple[int, str]] = []
-    line_no = 1
-    for block in re.split(r"\n[ \t]*\n", text):
-        if block.strip():
-            blocks.append((line_no, block))
-        line_no += block.count("\n") + 2
-    return blocks
+# The two line shapes that carry a claim of their own.  A tight list item
+# and a table row each state one thing, and the next one states another.
+TABLE_ROW = re.compile(r"^[ \t]*\|")
+LIST_ITEM = re.compile(r"^[ \t]*(?:[-*+]|[0-9]+[.)])[ \t]")
+
+
+def claim_units(text: str) -> list[tuple[int, str]]:
+    """(1-based start line, unit text) for each independent claim unit.
+
+    The unit is what qualification attaches to, so getting it wrong fails
+    OPEN — see the module docstring.  A blank line ends a unit; a table row
+    or a tight list item begins one; a table row ends at the very next line,
+    because a table row has no continuation.  Anything else is prose and
+    accumulates, so a sentence that wraps keeps its qualification.
+    """
+    units: list[tuple[int, str]] = []
+    buffer: list[str] = []
+    start = 0
+    row = False  # the buffered unit is a table row, which nothing continues
+
+    for line_no, line in enumerate(text.splitlines(), start=1):
+        blank = not line.strip()
+        is_row = bool(TABLE_ROW.match(line))
+        is_item = bool(LIST_ITEM.match(line))
+        if (blank or is_row or is_item or row) and buffer:
+            units.append((start, "\n".join(buffer)))
+            buffer, row = [], False
+        if blank:
+            continue
+        if not buffer:
+            start, row = line_no, is_row
+        buffer.append(line)
+    if buffer:
+        units.append((start, "\n".join(buffer)))
+    return units
 
 
 def unqualified_claims(text: str) -> list[tuple[int, str]]:
-    """Paragraphs carrying a per-write figure and no qualification of it."""
+    """Claim units carrying a per-write figure and no qualification of it."""
     found = []
-    for start, block in paragraphs(text):
-        m = CLAIM.search(block)
-        if m and not QUALIFIERS.search(block):
+    for start, unit in claim_units(text):
+        m = CLAIM.search(unit)
+        if m and not QUALIFIERS.search(unit):
             found.append((start, m.group(0).strip()))
     return found
 
@@ -328,6 +380,85 @@ def _run_self_tests() -> int:
                 publication=(
                     "An early window read about 2,031 B/boundary/write, but no fitted series\n"
                     "clears the quality floor, so this is not a claim.\n"
+                ),
+            ),
+            None,
+        )
+    )
+
+    # 3a. THE CROSS-SIBLING FAIL-OPEN (rf2-b9707). A whole Markdown table is
+    #     one blank-line block, so scoping qualification to the block let a
+    #     DIFFERENT row's honest `quality floor unmet` certify this figure.
+    #     Both halves of the rule are fixtured, in both shapes, because a
+    #     repair that simply stopped honouring qualification would pass the
+    #     red pair and quietly delete case 3.
+    cases.append(
+        (
+            "a figure whose QUALIFIER IS IN ANOTHER TABLE ROW is RED",
+            dict(
+                budgets=_GOOD_BUDGETS,
+                baseline=_GOOD_BASELINE,
+                design="The floor arm reads 24,108 B per write.\n",
+                publication=(
+                    "| Product cost | 2,031 B/boundary/write |\n"
+                    "| Separate instrument | quality floor unmet |\n"
+                ),
+            ),
+            "UNQUALIFIED ALLOCATION CLAIM",
+        )
+    )
+
+    # 3b. The same leak in a tight list, which shares the blank-line block for
+    #     the same reason.
+    cases.append(
+        (
+            "a figure whose QUALIFIER IS IN ANOTHER LIST ITEM is RED",
+            dict(
+                budgets=_GOOD_BUDGETS,
+                baseline=_GOOD_BASELINE,
+                design="The floor arm reads 24,108 B per write.\n",
+                publication=(
+                    "- Product cost: 2,031 B/boundary/write\n"
+                    "- Separate instrument: quality floor unmet\n"
+                ),
+            ),
+            "UNQUALIFIED ALLOCATION CLAIM",
+        )
+    )
+
+    # 3c. A row that qualifies ITSELF still passes: the unit is the row, not
+    #     the digits.
+    cases.append(
+        (
+            "a table row qualified IN ITS OWN CELLS is GREEN",
+            dict(
+                budgets=_GOOD_BUDGETS,
+                baseline=_GOOD_BASELINE,
+                design="The floor arm reads 24,108 B per write.\n",
+                publication=(
+                    "| Product cost | 2,031 B/boundary/write, off a window the "
+                    "instrument refused |\n"
+                    "| Separate instrument | measured |\n"
+                ),
+            ),
+            None,
+        )
+    )
+
+    # 3d. ...and a list item's qualification may be on its WRAPPED line, which
+    #     is the case that stops the repair from becoming a per-line scan.
+    cases.append(
+        (
+            "a list item qualified on its own WRAPPED line is GREEN",
+            dict(
+                budgets=_GOOD_BUDGETS,
+                baseline=_GOOD_BASELINE,
+                design="The floor arm reads 24,108 B per write.\n",
+                publication=(
+                    "- Product cost: an early window read 2,031 B/boundary/write,\n"
+                    "  but no fitted series clears the quality floor, so it is not\n"
+                    "  a claim.\n"
+                    "- Separate instrument: measured.\n"
                 ),
             ),
             None,


### PR DESCRIPTION
Two gate-script beads. Both descriptions were acted on; **neither bead carries notes of its own** — the long notes visible under `bd show` belong to their dependency beads (`rf2-hic-072`, `rf2-hic-065`). Bead 1 also has acceptance criteria, and they are what the fixture set is shaped to.

---

## 1. `rf2-b9707` — qualification leaked across sibling rows

### The scope rule, established at source

The gate already **stated** the right rule in three places, and only the implementation was wrong:

| Where | What it says |
|---|---|
| module docstring | "a publication-surface figure passes if **its own paragraph** also carries the non-claim in words" |
| `QUALIFIERS` comment | "Words that say, **in the same paragraph**, that the figure is not certified" |
| `paragraphs()` | "each **blank-line-separated block**" |

So the stated scope is the paragraph and the implemented scope is the blank-line block. In Markdown those coincide for prose and diverge exactly where the figures live: **a whole table and a whole tight list are one blank-line block**. Reproduced on the landed tree before touching anything:

```
TABLE  -> []      | Product cost | 2,031 B/boundary/write |
                  | Separate instrument | quality floor unmet |
LIST   -> []      - Product cost: 2,031 B/boundary/write
                  - Separate instrument: quality floor unmet
PLAIN  -> [(1, '2,031 B/boundary/write')]
```

The plain sentence is caught, so this is association scope rather than the claim regex — as filed.

### How qualification is now bound to the row

`claim_units()` replaces `paragraphs()` and subdivides a block by **three line shapes**: a table row is its own unit and nothing continues it; a tight list item is its own unit **including its wrapped continuation lines**; everything else stays prose at block scope. Prose keeps block scope deliberately — an English sentence routinely carries its qualification onto the next line, and a per-line scan would be the false-positive machine authors reword their way around. Three line shapes, not a Markdown parser.

### The new fixtures, and the evidence they go red

Four added (two RED, two GREEN). The acceptance criterion names both directions — *"fails when a different table row or tight-list item contains a qualifier; the same figure passes when its own row/item is honestly qualified"* — and the GREEN pair is load-bearing, not decoration: a repair that simply stopped honouring qualification would pass the red pair while silently deleting the gate's third property.

Run against the **pre-fix module from HEAD** and the new one, same inputs:

| Fixture | OLD | NEW |
|---|---|---|
| 3a table cross-sibling (want RED) | **GREEN** | **RED** |
| 3b list cross-sibling (want RED) | **GREEN** | **RED** |
| 3c row self-qualified (want GREEN) | GREEN | GREEN |
| 3d item wrapped-qualified (want GREEN) | GREEN | GREEN |
| existing (3) prose wrapped-qualified | GREEN | GREEN |
| existing (2) plain unqualified | RED | RED |

The two `GREEN -> RED` flips are the fail-open closing. Nothing else moves, so the repair did not over-tighten.

Self-test **9 fixtures, exit 0**. Live scan **235 publication-surface files, 0 claims, exit 0** — unchanged, as the acceptance criterion requires.

---

## 2. `rf2-hxbhe` — the public-surface census is now a standing gate

Lives at **`implementation/hicasso/scripts/check_naming_census.py`**, which is the home the bead names and the right one: it is where the other eleven hicasso checkers live, and `naming-packet.md` section 7 said that tree was held by a live worker as the only reason it was not there already. Section 7 is now **repointed at the committed script** rather than reproducing it.

**Live run: `CENSUS: 105 public names across 10 shipped namespaces; 0 NOT rostered in naming-ledger.md`, exit 0** — identical to the packet's published figure. Two agreements were measured rather than assumed:

- the committed gate returns the **identical 105 names** as the section-7 one-shot (set equality, zero on either side of the difference);
- it agrees with `check_facade_inventory.py` on **all 16** `re-frame.hicasso` door names.

### Both must-keeps preserved

**A definition opens a line.** `evidence.cljs` lines 410-412 call two `def*`-named functions — `(let [ds (defects p)]` and `(defects-message ds)` — and reading those as definitions mints the phantom public names `p` and `ds`. Both are reported as CALLS on every run rather than dropped. The rule's **limit is now stated in the docstring** instead of left to be rediscovered: a def-headed call that began its own line would still read as a definition, no such call exists in the ten namespaces, and the failure it would produce is a phantom reported UNROSTERED — a **false RED**, the safe direction. That is why no bracket-depth tracker is being built for it. (My first fixture accidentally wrote such a call and minted `ds`; the fixture was wrong, not the rule, and it now mirrors `evidence.cljs`'s real shape.)

**The root is an absolute argument and is printed.** First line of every run is `CENSUS_REPO_ROOT=<root>`. A relative path is now **REFUSED (exit 2)** rather than `abspath`-ed against the working directory — the section-7 original silently resolved it, which is the same sibling-worktree hazard wearing a different hat.

### Not a grep, and not an import

Sources are read as **code** (`code_only` blanks strings, comments, character literals and reader-discarded forms), because these docstrings carry worked `(def ...)` examples a grep counts. The three reader helpers are **duplicated rather than imported**, per `rf2-t9t0`: these checkers are self-contained files with no cross-imports, and `check_facade_inventory.py`'s own docstring records that same decision about those same three functions when it copied them from `check_optional_module_reachability.py`. The section-7 one-shot loaded the sibling by path with `importlib`, which would have been the first cross-import among them had it been committed that way. Verified no checker in that directory imports another.

### The self-test, and the positive control that ships

Model is **`check_allocation_non_claim.py`**, not `check_provenance_pins.py`, and it is the closer one twice over: it is the tree's other absence check, and its fixtures are whole synthetic corpora rather than in-memory rule cases — which is what a gate that *walks a tree* needs. (`check_provenance_pins.py` was read first; its self-test is a 2,300-line rule-by-rule sweep over in-memory documents.)

**10 checks, exit 0**, including the positive control the packet described as a manual dance:

```
  ok  a definition OPENS a line -- mid-line def-headed forms are CALLS
  ok  an unknown `def*` head is public; a computed name is reported
  ok  a fully rostered tree is GREEN
  ok  a SEEDED public export with no ledger row is caught
  ok  the same export, once rostered, is GREEN
  ok  a PRIVATE export owes no row
  ok  a missing namespace source is REFUSED
  ok  an empty roster is REFUSED
  ok  a missing ledger is REFUSED
  ok  a ledger with no code spans is REFUSED
```

The seeded export must both **move the count by exactly one** and **name the escapee**; the fixture asserts both. Its converse — the same export, once rostered, going green — is what stops the gate degenerating into a ban on new names. Four REFUSALS (exit 2, distinct from a red) because an absence check that inspected nothing reports the same green as one that inspected everything.

**The live control was also re-run**, since the packet's acceptance names it: a public `defn` planted in `motion.cljs` moved the census **105 -> 106**, exit 1, naming `motion/seeded-census-control` under `UNROSTERED`. Reverted; restore verified by `git hash-object` at `ce1cf16681b879913f0342d0c14e8966718b4704` either side — which is the same hash `rf2-hic-065` recorded, so `motion.cljs` is untouched since publication.

### CI arming is needed — filed, not wired

`.github/workflows/*` is hot zone. Filed **`rf2-st1x5`**, and it needs **three** edits rather than one:

1. the `test:hicasso-invariants` chain in `implementation/package.json` (noting the root argument: that chain runs with cwd `implementation/`, and this gate refuses to derive its own root);
2. an **unconditional job** for the ledger side — `docs/**` measures false at every classifier output, so a deleted ledger row would run this gate nowhere and next redden on somebody else's source PR;
3. the **`all-required-passed` `needs:` entry** pinning that job. Per `rf2-6ng7`: an arming excuse that *names* an unconditional lane needs that lane's contents pinned, or the excuse outlives the coverage. A job not listed there runs and gates nothing.

`check_ci_reproduce_commands.py` was read as instructed and **does not constrain this gate as placed** — it audits the aggregated `verify-skill-mcp-drift` job, where a checker is a `python scripts/check_*.py` step or one carrying a `check_*` id. This gate lives in `implementation/hicasso/scripts/` with its own job, exactly like `hicasso-facade-inventory`, so it sits outside that audit. The constraint is recorded on `rf2-st1x5` anyway, for the case where someone later moves it into the aggregated job: id `check_naming_census` for the live step, `check_naming_census_selftest` for the `--self-test` step.

---

## Quality gates

**12 captured exits, 12 pass, 0 fail** — every one re-run on the final rebased base (`2e093f6f04`), and every number below is the one I captured with the redirect and the `echo` on one command line, not one the harness reported.

| Gate | Exit | Result |
|---|---|---|
| `scripts/check_allocation_non_claim.py --self-test` | 0 | 9 fixtures |
| `scripts/check_allocation_non_claim.py` | 0 | 235 publication files, 0 claims |
| `implementation/hicasso/scripts/check_naming_census.py --self-test` | 0 | 10 checks |
| `implementation/hicasso/scripts/check_naming_census.py <abs root>` | 0 | 105 names, 0 unrostered |
| `implementation/hicasso/scripts/check_facade_inventory.py` | 0 | 16 names, 43 rows |
| `scripts/check_doc_slugs.py` | 0 | clean |
| `scripts/check_provenance_pins.py` | 0 | 110 pages, 513 pins, 0 findings |
| `scripts/check_provenance_pins.py --self-test` | 0 | clean |
| `scripts/check_ci_reproduce_commands.py` | 0 | 43 checker steps in sync |
| `scripts/check_gate_scheduling.py` | 0 | 51 commands, 43 scheduled |
| `scripts/check_fast_pr_gap.py --list` | 0 | see below |
| `python -m py_compile` both scripts | 0 | CI pins 3.12; local 3.14 |

**`check_facade_inventory.py` still measures exit 0, 16 names, 43 rows** — the figure the dispatch cited an hour earlier still holds, before and after my change.

### Sabotage controls — three planted, all red by name, all restored and hash-verified

Each gate was checked for *which tree it read*, by the route that gate affords:

- **`check_naming_census.py` prints its root**, and it printed my worktree. It also went red on a fault that exists only here (`105 -> 106`).
- **`check_allocation_non_claim.py` prints nothing discriminating**, so the proof is the red: a cross-sibling table planted in `README.md` gave `UNQUALIFIED ALLOCATION CLAIM: README.md:298 publishes '4,242 B/boundary/write'`, **exit 1**. That plant is doubly discriminating — it exists only in my tree *and* it is the exact shape the pre-fix code passed green, so it proves both the tree and that my fix was live in the run. Restored, `git hash-object` `2a5f9ac1534bd7eeac1e5c8345ee75f74bc60cf2` either side.
- **`check_doc_slugs.py`**: broken anchor planted in the packet gave `BROKEN ANCHOR: ...naming-packet.md:358`, **exit 1**. Restored, `c07bb8defe4e5e6fac1b2df029e5d92bd5270e80` either side.

No green sabotage run.

### The fast spine did NOT run — reason

`scripts/test-fast-pr.sh` was **skipped**. The one path for the spine-versus-required-CI gap is `scripts/check_fast_pr_gap.py --list` (TESTING.md:121), and it names this diff's principal gate as having **no local lane at all**:

> `- 2 python scripts/check_*.py invocation(s) with no local lane:`
> `    check_allocation_non_claim, check_allocation_non_claim --self-test`

So the spine could not have decided bead 1 — I ran that gate directly instead, both modes, plus a sabotage control. That gap is a fact about the spine, not a census of what I ran; the table above is what I ran. The rest of the reason: this diff contains no Clojure, no build config and no mkdocs-included page (`mkdocs.yml`'s `exclude_docs` keeps `docs/design/hicasso/` out of the site), so the spine's CLJS/JVM/mkdocs phases are inert against it; its Python doc-checker phase is `check_doc_slugs.py`, run directly and green with a planted-fault proof; and 26 concurrent `node` processes were live from other workers, which is the documented wedge shape for a 25-minute heavyweight run.

**CI arms bead 1's gate on this very PR**: `docs.yml` lists `scripts/check_allocation_non_claim.py` in its docs-surface path set and runs both `--self-test` and the live scan, so the change is self-arming rather than relying on my local run.

### Doc-surface checks done by hand

`mkdocs build --strict` is **not** the gate for `docs/design/hicasso/` (excluded from the site). Nothing validates that tree's tables, rendering or nav, so by hand: **no table rows changed** (zero `|`-leading lines in the diff), **no heading changed** (the only `#`-leading diff line is the deleted `#!/usr/bin/env python3` inside the removed code block), section 7's heading is byte-identical at line 313, and **no page anywhere links to a `naming-packet.md#` anchor**. The one link in the new text, `[dispositions.md](dispositions.md)`, is pre-existing and `check_doc_slugs.py` resolves it.

---

## Fence

Derived at start-up with the corrected three-dot form, and **liveness tested separately from the diff** — nine branches listed my neighbourhood, and six of them were rebase-merge ghosts. Testing was by locating each tip's commit subject in `origin/main`:

- `dispcells-lvelh` (`check_facade_inventory.py`) — **LANDED** `aa1385130d`, so that file is free, as the dispatch said.
- `hicchecks-df9b`, `fencecheck-t9kd`, `inertarm-7v5vx`, `presence-hic053`, `rung3-hic033` — all **LANDED**.
- Genuinely live: `#8266` `srvapi-52xpx` and `#8267` `focus-cervn` (PR state `OPEN`); `frameops-uejlj` and `records-lbn9o` sit at their base with no commits.

**No live branch touches any of my three files**, and no incoming commit on `origin/main` touched them either (checked per-file before rebasing, for what a push would REVERT rather than for conflicts). Diff is 3 files — deliberately tight, since `rf2-hic-066`'s rename sweep is waiting for `implementation/hicasso` to go quiet. `.beads/issues.jsonl` and `.beads/metadata.json` are not committed; both commits staged explicit paths.

Worktree: `C:/Users/miket/code/re-frame2-worktrees/gatescripts-b9707`. No `node_modules` junction was created — these are pure-Python gates.
