### PR TITLE
test(hicasso): the two bench SSR suites re-expressed on the package entry, one whole and one to its subject (rf2-wehh0)

### DIFF
--- a/docs/design/hicasso/product/prototype-suite-triage.md
+++ b/docs/design/hicasso/product/prototype-suite-triage.md
@@ -491,6 +491,41 @@ package behaviour and would be worth re-expressing **if** the package ever gets 
 `spike_cljs_test`'s own docstring settles the rest: *"No verdict is published here and none is
 implied."*
 
+**[The condition FIRED, and here is what happened — rf2-wehh0, 2026-08-15.]**
+`re-frame.hicasso.server` landed with rf2-b6jkj, so the conditional came due. Both named suites
+**re-expressed**, and all five **still stay**: they reach `ssr.fixtures`, which is the corpus
+`driver.cjs` bakes and `bake_bytes.test.cjs` pins, and their subject is the PROTOTYPE entry the
+bake is taken from. Re-expression added a package witness beside them; it moved nothing.
+
+- `ssr/hframe_ssr_cljs_test.cljs` → `test/re_frame/hicasso/hframe_ssr_cljs_test.cljs`, whole.
+  All four claims — the per-request id a body reads, determinism when it is kept out of markup,
+  the authorable hazard that breaks determinism, and the ambient carry's refusal inside a server
+  render — are about the RUNTIME under `renderToString` rather than about the tree's shape, so
+  each moved across unchanged. The third is the one the package could not previously make:
+  `server_render_ssr_dom_cljs_test`'s `two-renders-of-one-request-are-the-same-bytes` had never
+  been watched failing, and a determinism check nobody has seen red is a claim about a check.
+- `ssr/instance_key_payload_dom_cljs_test.cljs` → `test/re_frame/hicasso/instance_key_payload_ssr_dom_cljs_test.cljs`,
+  **its subject only**. The obligation and its enforcement — `:ui` named, zero mismatch; `:ui`
+  omitted, the structured `:rf.ssr/hydration-mismatch` fires and the client's default wins — had
+  no package owner. Its other rows do: determinism and the round trip through the real doors are
+  `server_render_ssr_dom_cljs_test`'s (§2 and §5, the latter rf2-lb1xi's repair), and the
+  constant-hash measurement is a fact about `re-frame.ssr.hash` rather than about either entry, so
+  it stays in the bench tree. The half that IS about the entry — an adoption-tier root ships no
+  `:rf/render-hash` — crossed as one assertion.
+
+**No coverage was lost, and the check for that was the tree shape.** The prototype renders
+`(provider frame (codec/root-element frame hiccup))`; `server/render` renders `impl.mount/tree`
+with a hydrating handle. The two disagree inside a `useId` — that is obstruction 2, and
+`identifier_prefix_ssr_dom_cljs_test` measured it — and the prototype lane avoided it by having no
+`useId` anywhere in it. Retargeting is therefore a strict improvement on that axis and neutral on
+every other. Two further differences exist and neither is a thing either suite asserts: the
+prototype's adoption window is a MODULE-LEVEL flag where the package's is a per-request handle,
+and `:identifier-prefix` is the package entry's alone. **The two entries are otherwise nearly the
+same file** — `fresh-frame-id`, `setup-events`, `payload-script`, `document`, the whole payload
+path and `render-twice` are token-for-token identical, and of the seventeen string literals in
+`server.cljs`'s code positions, sixteen appear verbatim in `ssr/entry.cljs`. The seventeenth is
+`"identifierPrefix"`, which is exactly the difference above.
+
 ### (iv) The package already asserts it — 13 suites, 4,269 lines
 
 | bench suite | lines | the Phase-1 witness that covers it |

--- a/implementation/hicasso/test/re_frame/hicasso/hframe_ssr_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/hframe_ssr_cljs_test.cljs
@@ -1,0 +1,217 @@
+(ns re-frame.hicasso.hframe-ssr-cljs-test
+  "`h/hframe` ON THE SERVER (rf2-wehh0 — the design's W8 and W11,
+  re-expressed on the package's own entry).
+
+  ## Why this file exists, and what it is a copy of
+
+  `docs/design/hicasso/product/prototype-suite-triage.md` §(iii) disposed
+  of five bench SSR suites as STAYS, with one conditional: two of them
+  *\"assert real package behaviour and would be worth re-expressing IF the
+  package ever gets its own SSR entry\"*. [[re-frame.hicasso.server]]
+  landed (rf2-b6jkj), so the condition fired, and this file is the first
+  half of the answer — `ssr/hframe_ssr_cljs_test` pointed at
+  `server/render` instead of at the bench prototype's
+  `re-frame.bench.hicasso.ssr.entry/render`.
+
+  **The re-expression is not a downgrade, and that is worth one sentence
+  because the reverse would be easy to ship by accident.** The prototype
+  renders `(provider frame (codec/root-element frame hiccup))` — *the
+  tree a consumer can spell today* — while `server/render` renders
+  [[re-frame.hicasso.impl.mount/tree]] with a hydrating handle, which is
+  the Fragment-plus-closer shape `hydrate-root!` adopts. The two disagree
+  inside a `useId` (`identifier_prefix_ssr_dom_cljs_test`, and
+  `server_render_ssr_dom_cljs_test` §1 pins which one the entry picked),
+  and the prototype's lane avoided the disagreement by having no `useId`
+  in it at all. Every claim below is about the RUNTIME under a server
+  render rather than about the tree's shape, so all four move across
+  unchanged and each of them now describes shipped code.
+
+  ## W8 — the id is process-local identity, and must never reach markup
+
+  Two same-process renders take two different gensyms, so a body that
+  RENDERS the value makes the document nondeterministic. That is an
+  authorable hazard rather than a framework one, and it is already
+  instrumented: [[re-frame.hicasso.server/render-twice]]'s byte
+  comparison is the standing determinism check. Both halves are asserted
+  here — a body that reads the id and keeps it out of markup renders
+  byte-identical documents, and a body that deliberately prints it does
+  not.
+
+  **The second row is the reason the first is worth having**, and it is
+  the one thing the package could not say before. `server_render_ssr_dom`
+  has `two-renders-of-one-request-are-the-same-bytes`, and nothing
+  anywhere has watched that comparison FAIL — a check that has never been
+  seen red is a claim about a check.
+
+  ## W11 — the ambient chain refuses on BOTH sides, for ONE reason
+
+  As designed the row contrasted `h/hframe` answering against the ambient
+  chain throwing *server-side for a renderer-specific reason*: the raw
+  React-context read the adapters publish is client-renderer-only. That
+  stopped being true at rf2-2rtt6.122 — the ambient chain now refuses on
+  both sides for ONE reason, the arm's own refusal, established by
+  `impl.intent/with-frame` over every render extent. The contrast
+  survives and its explanation changed.
+
+  `hframe_cljs_test` already witnesses the carry refusing inside a
+  boundary body, but it drives `collector/render-body` directly. This row
+  is the same refusal observed through `react-dom/server`, which is what
+  makes it a statement about the SERVER rather than about a synthetic
+  extent: same operation, same substrate, same extent id.
+
+  Runtime: `-cljs-test`, i.e. the `:node-test-hicasso` build (and the
+  always-on `:node-test`), which is where `react-dom/server` resolves and
+  where the rest of the entry's string-only rows run."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [clojure.string :as str]
+            [re-frame.adapter.uix :as uix-adapter]
+            [re-frame.core :as rf]
+            [re-frame.hicasso :as h]
+            [re-frame.hicasso.impl.collector :as collector]
+            [re-frame.hicasso.server :as server]
+            [re-frame.test-support :as test-support]))
+
+;; Registered ABOVE `use-fixtures`, for the sibling suites' reason: the
+;; reset fixture captures its source-store baseline when the
+;; `use-fixtures` form is EVALUATED, so a registration written below it is
+;; erased before the first row runs.
+
+(rf/reg-sub ::remaining (fn [db _] (:remaining db)))
+
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture
+    {:adapter uix-adapter/adapter
+     ;; `:ambient-frame nil`, where `server_render_ssr_dom` takes the same
+     ;; and the DOM suites take the fixture's default — and here it is
+     ;; load-bearing rather than tidiness. The default root-binds
+     ;; `frame/*current-frame*` to `:rf/default`, which is a CARRIED tier-1
+     ;; stamp; the refusal withdraws the ambient FIND and never the
+     ;; carrying, so an ambient carry inside a body would resolve
+     ;; `:rf/default` and succeed. That is core behaving exactly as
+     ;; specified, and it is not the configuration a server request has:
+     ;; `server/render` establishes no scope and a host calls it at top of
+     ;; stack. Measuring the refusal against the fixture's own stamp would
+     ;; be measuring the fixture. (The MISMATCHED-scope case is interesting
+     ;; in its own right and is pinned deliberately, in `hframe_cljs_test`'s
+     ;; `a-carried-outer-scope-refuses-rather-than-answering-the-wrong-frame`.)
+     :ambient-frame nil
+     :init-fn       (fn [] (collector/reset-runtime!))}))
+
+(def ^:private !seen
+  "Every frame id a server body read, newest last."
+  (atom []))
+
+(def ^:private !ambient
+  "What the ambient carry answered inside a server body — the ex-data of
+  its refusal, or `::no-throw` with the value it produced."
+  (atom ::unset))
+
+(h/defview discreet
+  "Reads the request's frame and keeps it OUT of the markup — the
+  documented correct shape. What it renders is a subscription value, so
+  the boundary is an ordinary one."
+  [_]
+  (swap! !seen conj (h/hframe))
+  [:span.row (str (h/sub [::remaining]))])
+
+(h/defview indiscreet
+  "Renders the per-request id INTO the markup. This is the authorable
+  hazard the module's docstring warns about, written on purpose so the
+  determinism check can be watched failing."
+  [_]
+  [:span.row {:data-frame (str (h/hframe))}])
+
+(h/defview carrying
+  "Tries the AMBIENT carry — `(rf/capture-frame)`, 0-arity — inside a
+  server body, and records what it got. It catches its own throw so the
+  render completes and the row can read the markup rather than a
+  `renderToString` failure."
+  [_]
+  (reset! !ambient
+          (try [::no-throw (rf/capture-frame)]
+               (catch :default e (ex-data e))))
+  [:span.row (str (h/hframe))])
+
+(defn- request [hiccup]
+  {:hiccup   hiccup
+   :snapshot {:remaining 3}
+   :payload  [:remaining]})
+
+;; ---------------------------------------------------------------------------
+;; W8 — the per-request id, and the one authorable hazard
+;; ---------------------------------------------------------------------------
+
+(deftest a-server-body-reads-the-requests-own-frame
+  (testing "the frame `h/hframe` answers on the server IS the request's
+           per-request gensym, and two requests answer two different ones —
+           which is what per-request isolation means when the id is the
+           thing being read"
+    (reset! !seen [])
+    (let [a (server/render (request [discreet {}]))
+          b (server/render (request [discreet {}]))]
+      (is (= 2 (count @!seen)) "one read per request")
+      (is (= [(:frame-id a) (:frame-id b)] @!seen)
+          "each body read its OWN request's id, in order")
+      (is (not= (:frame-id a) (:frame-id b))
+          "precondition: the two requests really did take different frames,
+           so the row above is not comparing a constant to itself"))))
+
+(deftest a-body-that-reads-the-id-and-keeps-it-out-of-markup-is-deterministic
+  (testing "the correct shape. Two renders take two gensyms, and the
+           documents are byte-identical anyway — because the value went
+           into a read and not into the page"
+    (let [{:keys [identical? differs-at] a :first b :second}
+          (server/render-twice (request [discreet {}]))]
+      (is identical? (str "the two documents differ at index " differs-at))
+      (is (not= (:frame-id a) (:frame-id b))
+          "and they were different requests — this is the whole point")
+      (is (not (str/includes? (:document a) (name (:frame-id a))))
+          "the id is nowhere in the markup"))))
+
+(deftest a-body-that-renders-the-id-breaks-determinism-and-the-check-says-so
+  (testing "THE ROW THAT MAKES THE ONE ABOVE MEAN SOMETHING, and the one
+           claim in this family the package could not previously make.
+           Rendering the per-request id is an authorable hazard, and the
+           claim is that `server/render-twice`'s byte comparison catches
+           it. A claim about a check that has never been watched failing is
+           not a check, so here it is failing"
+    (let [{:keys [identical? differs-at] a :first} (server/render-twice (request [indiscreet {}]))]
+      (is (not identical?)
+          "a document carrying the per-request gensym cannot be
+           deterministic, and the determinism witness must say so")
+      (is (some? differs-at) "with a diagnosable diff position")
+      (is (str/includes? (:document a) (name (:frame-id a)))
+          "and the id is visibly in the markup, which is the mistake"))))
+
+;; ---------------------------------------------------------------------------
+;; W11 — the ambient chain refuses on BOTH sides, for ONE reason
+;; ---------------------------------------------------------------------------
+
+(deftest the-ambient-carry-refuses-server-side-for-the-substrates-own-reason
+  (testing "the designed row contrasted `h/hframe` answering against a
+           renderer-specific server-side throw; the arm's refusal now covers
+           the server render extent exactly as it covers the client's, so
+           what the server reports is the SUBSTRATE's refusal — same
+           operation, same substrate, same extent — and not a fact about
+           `react-dom/server`"
+    (reset! !ambient ::unset)
+    (let [{:keys [document]} (server/render (request [carrying {}]))
+          data               @!ambient]
+      (is (= :rf.error/ambient-frame-refused (:rf.error/id data))
+          (str "expected the ambient refusal for the carry; got " (pr-str data)))
+      (is (= :capture-frame (:operation data))
+          "named as the CARRY, which is the third of the ambient door's three
+           consumers and the one with its own recovery sentence (rf2-hnrww)")
+      (is (= :hicasso (:substrate data))
+          "the substrate refused, not the renderer — which is what makes
+           this the same answer the browser gives")
+      (is (= 'hicasso/boundary-render (:extent data)))
+      (is (str/includes? document "class=\"row\"")
+          "and the render completed: the refusal is the carry's, not the
+           page's")))
+
+  (testing "while `h/hframe` answers in the same body — the contrast the
+           design's W11 exists for, with its explanation updated"
+    (reset! !seen [])
+    (let [{:keys [frame-id]} (server/render (request [discreet {}]))]
+      (is (= [frame-id] @!seen)))))

--- a/implementation/hicasso/test/re_frame/hicasso/instance_key_payload_ssr_dom_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/instance_key_payload_ssr_dom_cljs_test.cljs
@@ -1,0 +1,454 @@
+(ns re-frame.hicasso.instance-key-payload-ssr-dom-cljs-test
+  "THE INSTANCE-KEY PAYLOAD OBLIGATION, WITNESSED BOTH WAYS (rf2-wehh0,
+  re-expressing the prototype's `ssr/instance_key_payload_dom_cljs_test`
+  on [[re-frame.hicasso.server]]).
+
+  [[re-frame.hicasso/reg-state]] puts a widget's own state at
+  `[:ui ::concern ikey]`, which is APP-SPACE data — so whether it reaches
+  the client is decided by the hydration payload policy and by nothing
+  else. The 2026-08-04 ruling states the obligation that follows:
+
+  > an allowlist MUST name `:ui` whenever server-side events write
+  > render-affecting instance state; strip it only if the server never
+  > writes it. Whole-app-db carries it automatically.
+
+  ## Why prose was not enough, stated precisely
+
+  The payload policy is fail-closed and stays fail-closed: an ABSENT
+  `:payload` throws `:rf.error/ssr-missing-payload-policy` at the
+  framework's own validator, and nothing here softens that (it is pinned
+  by `server_render_ssr_dom_cljs_test`'s
+  `the-payload-is-fail-closed-and-allowlisted`). But `[:panels]` is a
+  perfectly well-formed allowlist. There is no shape for the validator to
+  refuse, no default to fall back on, and no way for the framework to know
+  that `:ui` mattered on THIS page — so a policy that is fail-closed
+  against absence is silent about omission, and the obligation is a rule
+  the author keeps or does not.
+
+  What catches the author who does not is React. The divergence between
+  the server's open panel and the client's shut one is a hydration
+  mismatch, and `impl.mount/hydration-reporter` surfaces one as Spec 011's
+  `:rf.ssr/hydration-mismatch`. **That is the enforcement**, and
+  [[omitting-ui-from-the-allowlist-fires-the-structured-mismatch]] asserts
+  it POSITIVELY — the row is red-by-design and the error is the row's
+  subject, not an accident it survives.
+
+  ## What this file DOES NOT re-express, and why
+
+  The prototype suite is 493 lines and this one is not, because three of
+  its rows now have package owners and re-stating them here would be
+  duplicate coverage wearing the shape of thoroughness:
+
+  - **determinism** — `server_render_ssr_dom_cljs_test`'s
+    `two-renders-of-one-request-are-the-same-bytes` makes the byte-identity
+    claim on the package entry, and `hframe_ssr_cljs_test` supplies the
+    red control the prototype's own determinism row never had;
+  - **the round trip through the real doors** — that suite's §5 drives
+    `server/render`'s own `__rf_payload` script through `re-frame.ssr`'s
+    `hydrate!` and then `h/hydrate!` (rf2-lb1xi). This file therefore
+    seeds the client frame from the payload map directly, exactly as the
+    prototype did and for a sharper reason: what is under test is the
+    CONTENT of the payload, so the seeding door is deliberately the least
+    interesting part of the row;
+  - **the render-hash measurement** — the prototype kept
+    `ssr-hash/render-tree-hash`'s constant value live to explain WHY the
+    hash was dropped. That is a fact about `re-frame.ssr.hash` rather than
+    about this entry, and it stays in the bench tree. The half that is a
+    fact about the entry — the wire carries no `:rf/render-hash` for an
+    adoption-tier root — is one assertion in [[the-two-requests-differ-by-exactly-the-ui-key]]
+    and had no package owner before this file.
+
+  What is left is the obligation and its enforcement, which is what the
+  prototype suite exists for and what nothing in the package asserted.
+
+  ## The two hydration rows are each other's control
+
+  A witness that only manufactured a fault could be reading a diagnostic
+  that fires on every adoption; a witness that only took a clean adoption
+  could be reading a capture that never fires at all. So the green row
+  asserts zero emits, zero console complaints and the server's own nodes
+  adopted — which is what stops the red row's diagnostic being a constant
+  — and the red row asserts the diagnostic firing, tagged with the door's
+  own site, which is what makes the green row's silence a reading.
+
+  ## Where the structured error is read from, and why not `thrown?`
+
+  From the live trace stream — `roots-frames-support/watch-mismatches!`,
+  which filters `re-frame.trace.tooling`'s listener on
+  `:rf.ssr/hydration-mismatch`. It is the only place this diagnostic can
+  be read: it fires from a React root-error callback, outside any dispatch
+  scope, so it is frameless and never reaches a per-frame ring.
+
+  `(is (thrown? …))` would be wrong here twice over. React routes a
+  recoverable hydration error to `reportError`, so nothing throws on any
+  stack `cljs.test` is watching — a `thrown?` row would be RED over a
+  working door. And the recoverable error is exactly the thing the door is
+  supposed to have RECOVERED from, so there is no exception left to catch
+  even in principle. The `window` `error` and `console.error` channels are
+  watched as well because a row asserting \"nothing complained\" that
+  watched neither would be green over a live failure — and in the red row
+  they carry the other half of the claim: the door COMPOSES over React's
+  default, so the uncaught report is still there beside the diagnostic and
+  `rf2-mwx08` is not softened.
+
+  Runtime: `-dom-cljs-test`, so `:browser-test` runs it against a real
+  React DOM. The payload-shape row needs no DOM and runs under
+  `:node-test` too; every DOM claim degrades to a stated skip there."
+  (:require [cljs.test :refer-macros [async deftest is testing use-fixtures]]
+            [re-frame.adapter.uix :as uix-adapter]
+            [re-frame.core :as rf]
+            [re-frame.hicasso :as h]
+            [re-frame.hicasso.impl.collector :as collector]
+            [re-frame.hicasso.impl.mount :as mount]
+            [re-frame.hicasso.impl.state :as impl-state]
+            [re-frame.hicasso.roots-frames-support :as sup]
+            [re-frame.hicasso.server :as server]
+            [re-frame.test-support :as test-support]))
+
+(def ^:private wire-frame ::instance-key-payload)
+
+;; ---------------------------------------------------------------------------
+;; The page the obligation is witnessed on
+;; ---------------------------------------------------------------------------
+;;
+;; One screen, two disclosure panels, one `reg-state` concern. The server's
+;; boot event opens the first panel through the ordinary setter `reg-state`
+;; mints, so this is a page whose APPEARANCE depends on instance state a
+;; server-side event wrote — which is the only kind of page the obligation
+;; is about.
+;;
+;; Registered ABOVE `use-fixtures` for the sibling suites' reason: the reset
+;; fixture captures its source-store baseline when the `use-fixtures` form is
+;; EVALUATED, so a registration written below it is erased before the first
+;; row runs.
+
+(def ^:private open?
+  "The concern. Its `:default` is `false`, which is what makes the
+  omission row's client render a CLOSED panel: an absent
+  `[:ui ::open? ikey]` entry reads the default, and the default is the
+  shut one."
+  ::open?)
+
+(def ^:private panels
+  "The roster, as authored data. Instance keys are the `:id` values —
+  domain ids, per `impl.state`'s first taught rule, and stable across a
+  server render and its client hydration because both read them from this
+  same seeded value. Never a render-order index, never a counter, never
+  `random-uuid`, never `useId`."
+  [{:id "billing" :title "Billing"}
+   {:id "shipping" :title "Shipping"}])
+
+(def ^:private open-key
+  "The panel the SERVER's boot event opens. The other stays shut in both
+  rows, so \"the payload did not arrive\" is distinguishable from \"the
+  page rendered nothing\"."
+  "billing")
+
+(def ^:private state-path
+  "Where the opened panel's flag sits — `[:ui ::open? \"billing\"]`, the
+  documented tier. Spelled through `impl-state/ui-root` so the witness
+  asserts on the same vector the sugar writes rather than on a
+  hand-spelled copy of it."
+  [impl-state/ui-root open? open-key])
+
+(rf/reg-sub ::panel-ids (fn [db _] (mapv :id (:panels db))))
+
+(rf/reg-sub ::panel-title
+  (fn [db [_ id]] (some (fn [p] (when (= id (:id p)) (:title p))) (:panels db))))
+
+(h/reg-state open? {:default false})
+
+(h/defview panel
+  "A disclosure. It holds its own open flag under the instance key it was
+  handed and knows nothing else about where it sits.
+
+  The body is a CONDITIONAL ELEMENT rather than a changed attribute or a
+  changed string: an element the server rendered and the client does not
+  is an unambiguous structural divergence, where a text difference would
+  be measuring React's SSR text-separator behaviour alongside the thing
+  under test."
+  [{:keys [ikey title]}]
+  (let [shown? (h/sub [open? ikey])]
+    [:section.panel {:data-ikey ikey}
+     [:button.panel-toggle {:on-click [open? ikey (not shown?)]} title]
+     (when shown?
+       [:div.panel-body "the details"])]))
+
+(h/defview screen
+  "The page. A heading, then one [[panel]] per roster entry, keyed by the
+  same authored id it is instance-keyed by."
+  [_]
+  [:div.instance-key-page
+   [:h1.title "instance state across the wire"]
+   [:div.panels
+    (for [id (h/sub [::panel-ids])]
+      [panel {:key id :ikey id :title (h/sub [::panel-title id])}])]])
+
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture
+    {:adapter       uix-adapter/adapter
+     :ambient-frame nil
+     :async?        true
+     :init-fn       (fn [] (collector/reset-runtime!))}))
+
+;; ---------------------------------------------------------------------------
+;; The two requests, differing by ONE allowlist entry
+;; ---------------------------------------------------------------------------
+
+(def ^:private names-ui
+  "The allowlist that MEETS the obligation." [:panels :ui])
+
+(def ^:private omits-ui
+  "The allowlist that breaks it — and is perfectly well formed, which is
+  the entire problem." [:panels])
+
+(defn- request
+  "One request. The two rows render the same hiccup from the same boot
+  events; `payload` is the only thing that moves, and it moves exactly one
+  key."
+  [payload]
+  {:hiccup          [screen {}]
+   :snapshot        {:panels panels}
+   ;; The whole obligation in one line: a render-affecting write into
+   ;; `[:ui …]` performed by a SERVER-side event.
+   :initial-events  [[open? open-key true]]
+   :payload         payload
+   :client-frame-id wire-frame})
+
+(defn- client-frame!
+  "Boot a CLIENT frame out of the payload the server shipped, and NOTHING
+  else.
+
+  `[:rf/set-db (:rf/app-db payload)]` is the reserved framework seeding
+  event carrying exactly the slice `re-frame.ssr.hydrate`'s own
+  `:rf/hydrate` handler installs. It is spelled this way rather than by
+  driving `ssr/hydrate!` off the emitted script because THAT round trip
+  already has a package owner — `server_render_ssr_dom_cljs_test` §5,
+  rf2-lb1xi — and what is under test here is the CONTENT of the payload,
+  so the seeding door is deliberately the least interesting part of the
+  row."
+  [payload]
+  (sup/leave-act-environment!)
+  (rf/make-frame {:id             wire-frame
+                  :platform       :client
+                  :initial-events [[:rf/set-db (:rf/app-db payload)]]})
+  wire-frame)
+
+(defn- open-panel-in [container] (.querySelector container ".panel-body"))
+(defn- panel-count [container] (.-length (.querySelectorAll container ".panel")))
+
+(defn- adopt!
+  "Put `html` on the page, stamp every node, hydrate it through the PUBLIC
+  door on `wire-frame`, and answer a promise of what happened across the
+  WHOLE adoption.
+
+  `capture-opts` reaches `sup/open-console-capture!`; the only caller that
+  sets `:swallow-uncaught?` is the row that manufactures the fault and
+  asserts on it."
+  [html capture-opts]
+  (let [container                 (sup/stamp-server-nodes! (sup/server-dom! html))
+        {:keys [seen stop!]}      (sup/watch-mismatches!)
+        {:keys [captured close!]} (sup/open-console-capture! capture-opts)
+        before                    (some? (open-panel-in container))
+        handle                    (h/hydrate! container {:frame wire-frame} [screen {}])]
+    (-> (sup/adopted! handle)
+        (.then (fn [shut?]
+                 (close!)
+                 (stop!)
+                 {:handle       handle
+                  :container    container
+                  :adopted?     shut?
+                  :open-before? before
+                  :mismatches   @seen
+                  :warnings     @captured})))))
+
+;; ===========================================================================
+;; The payload itself — the omission is a fact about the WIRE
+;; ===========================================================================
+
+(deftest the-two-requests-differ-by-exactly-the-ui-key
+  (testing "**the variable, isolated.** The two requests render the same
+           hiccup from the same boot events, so the SERVER BYTES are
+           identical; the allowlist is the only thing that moves. Without
+           this row the two hydration rows below could be measuring any
+           difference at all between two pages"
+    (let [green (server/render (request names-ui))
+          red   (server/render (request omits-ui))
+          gdb   (:rf/app-db (:payload green))
+          rdb   (:rf/app-db (:payload red))]
+      (is (= (:html green) (:html red))
+          "the server rendered the same markup for both — the payload
+           policy is a decision about what CROSSES, never about what is
+           drawn")
+      (is (re-find #"class=\"panel-body\"" (:html green))
+          (str "and that markup carries the OPEN panel the boot event
+                wrote, so there is something for the payload to be obliged
+                about: " (:html green)))
+
+      (testing "the green request ships the instance state at the documented tier"
+        (is (= true (get-in gdb state-path))
+            (str "[:ui ::open? \"billing\"] crossed the wire as written. Saw: "
+                 (pr-str gdb))))
+
+      (testing "the red request ships a WELL-FORMED allowlist that strands it"
+        (is (not (contains? rdb :ui))
+            (str "no :ui partition at all — not an empty one, not a
+                  defaulted one; absent: " (pr-str rdb)))
+        (is (nil? (get-in rdb state-path))))
+
+      (testing "and everything else is identical, so `:ui` is the whole
+               difference"
+        (is (= (:panels gdb) (:panels rdb) panels))
+        (is (= #{:panels :ui} (set (keys gdb))))
+        (is (= #{:panels} (set (keys rdb)))))
+
+      (testing "read off the EDN the client bootstrap actually parses,
+               because a claim about a payload map is a claim about the
+               wire only if the bytes agree with it"
+        (is (re-find #":ui\b" (:payload-edn green)))
+        (is (nil? (re-find #":ui\b" (:payload-edn red)))))
+
+      (testing "and neither carries a render hash — an adoption-tier root
+               ships none, which is Spec 011's own answer for this tier
+               rather than a gap, and is what stops any claim in this file
+               resting on one"
+        (is (not (contains? (:payload green) :rf/render-hash)))
+        (is (not (contains? (:payload red) :rf/render-hash)))))))
+
+;; ===========================================================================
+;; ROW 1 — GREEN. The obligation met.
+;; ===========================================================================
+
+(deftest naming-ui-on-the-allowlist-hydrates-with-zero-mismatch
+  (testing "**the obligation met.** `:ui` is on the allowlist, so the panel
+           the server's boot event opened crosses the wire, the client's
+           first render draws the same open panel, and React finds nothing
+           to reconcile — asserted on the framework's own diagnostic AND on
+           both channels React complains through"
+    (if-not (mount/browser?)
+      (sup/skip! "a payload-obligation hydration claim needs a real React DOM")
+      (async done
+        (let [{:keys [html payload]} (server/render (request names-ui))]
+          (client-frame! payload)
+          (is (= true (get-in (rf/app-db-value wire-frame) state-path))
+              "the client frame booted holding the instance state the server
+               wrote — which is the whole of what the allowlist bought")
+          (-> (adopt! html nil)
+              (.then
+                (fn [{:keys [handle container adopted? open-before? mismatches warnings]}]
+                  (try
+                    (is (true? adopted?) "the adoption completed")
+                    (is (true? open-before?)
+                        "the panel was open in the bytes the client was handed,
+                         BEFORE any JavaScript adopted them")
+
+                    (is (= [] mismatches)
+                        (str "**zero `:rf.ssr/hydration-mismatch`.** The
+                              framework's own instrument stayed silent across
+                              the whole adoption. Saw: " (pr-str mismatches)))
+                    (is (= [] warnings)
+                        (str "and React reported nothing on either channel —
+                              `window` `error` or `console.error`: "
+                             (pr-str warnings)))
+
+                    (is (some? (open-panel-in container))
+                        "the panel is STILL open after adoption — open before,
+                         open after, which is what \"hydrated\" means for a
+                         page whose appearance is instance state")
+                    (is (sup/server-node? (open-panel-in container))
+                        "and it is the SERVER'S own node. The stamp is an
+                         expando and cannot survive re-serialisation, so React
+                         reused the markup rather than building a replacement
+                         that happens to look alike")
+                    (is (sup/every-server-node? container "*")
+                        "as is every element on the page — no partial adoption,
+                         which is what a mismatch on one subtree would look
+                         like")
+                    (is (= 2 (panel-count container))
+                        "both panels are there, so the row above is a claim
+                         about a page and not about an empty container")
+                    (finally (h/unmount! handle)))))
+              ;; Reports and UNMOUNTS; it never finishes. `done` runs the whole
+              ;; remainder of the run synchronously, so a `.catch` downstream of
+              ;; it would claim a later namespace's throw as this row's and fire
+              ;; `done` a second time. The unmount stays in the `finally`: it is
+              ;; the success arm's, and only that arm was ever handed a handle.
+              (.catch (fn [e] (is false (str "row 1 threw: " e)) nil))
+              (.then (fn [_] (done)))))))))
+
+;; ===========================================================================
+;; ROW 2 — RED BY DESIGN. The obligation broken, and caught.
+;; ===========================================================================
+
+(deftest omitting-ui-from-the-allowlist-fires-the-structured-mismatch
+  (testing "**the teaching witness, and it EXPECTS the error.** The same page
+           with `:ui` omitted: the client boots without the instance state,
+           its first render reads `reg-state`'s default and draws a SHUT
+           panel where the server's bytes say open, and the structured
+           `:rf.ssr/hydration-mismatch` fires. Asserted positively — a row
+           that merely documented the obligation, or that passed because
+           nothing happened, would be worth nothing.
+
+           **This row MANUFACTURES the fault and is the assertion about
+           it**, which is the one case `open-console-capture!`'s
+           `:swallow-uncaught?` exists for. `rf2-mwx08` is not softened: the
+           error is not unasserted here, it is the subject, and the row goes
+           on to assert that the door reported it as well as emitting it"
+    (if-not (mount/browser?)
+      (sup/skip! "a payload-obligation hydration claim needs a real React DOM")
+      (async done
+        (let [{:keys [html payload]} (server/render (request omits-ui))]
+          (client-frame! payload)
+          (is (nil? (get-in (rf/app-db-value wire-frame) state-path))
+              "the client frame booted WITHOUT the instance state — the entry
+               is absent, so `reg-state`'s sub will read its `:default`,
+               which is `false`")
+          ;; MANUFACTURED fault, asserted on — see the testing string.
+          (-> (adopt! html {:swallow-uncaught? true})
+              (.then
+                (fn [{:keys [handle container adopted? open-before? mismatches warnings]}]
+                  (try
+                    (is (true? adopted?) "the adoption completed")
+                    (is (true? open-before?)
+                        "the server's bytes DID carry the open panel — the
+                         divergence is the payload's, not the render's")
+
+                    (is (pos? (count mismatches))
+                        (str "**the structured hydration-mismatch FIRED.** The
+                              taught obligation is enforced by the mismatch
+                              machinery, and this is that machinery answering.
+                              Saw " (count mismatches) ": " (pr-str mismatches)))
+                    (doseq [mm mismatches]
+                      (let [tags (sup/tags-of mm)]
+                        (is (= :rf.ssr/hydration-mismatch (:operation mm)))
+                        (is (= 're-frame.hicasso.impl.mount/hydrate-root! (:where tags))
+                            "tier-discriminated by :where — this arm's hydrate
+                             door, so this is React's own reconciliation report
+                             and not a hash comparison")
+                        (is (= :warned-and-replaced (:recovery tags))
+                            "React had already patched the DOM when the callback
+                             ran")
+                        (is (string? (:error tags))
+                            "and the recoverable error's own message rides
+                             along")))
+
+                    (is (seq warnings)
+                        (str "and the complaint ALSO reached a console channel —
+                              the door composes over React's default rather than
+                              replacing it, so composing a diagnostic in did not
+                              make the mismatch quieter than React left it: "
+                             (pr-str warnings)))
+
+                    (is (nil? (open-panel-in container))
+                        "**and the client's model won, which is the cost.** The
+                         panel the server rendered open is SHUT on the adopted
+                         page: the server's work was thrown away and the user
+                         sees the default. That is what omitting `:ui` buys,
+                         stated as a DOM reading")
+                    (is (= 2 (panel-count container))
+                        "the rest of the page adopted normally — a stranded
+                         partition is a wrong screen, not a blank one")
+                    (finally (h/unmount! handle)))))
+              ;; Reports and UNMOUNTS, as above.
+              (.catch (fn [e] (is false (str "row 2 threw: " e)) nil))
+              (.then (fn [_] (done)))))))))


### PR DESCRIPTION
`prototype-suite-triage.md` §(iii) disposed of five bench SSR suites as STAYS with one
conditional: two of them *"assert real package behaviour and would be worth re-expressing **if**
the package ever gets its own SSR entry"*. `re-frame.hicasso.server` landed (rf2-b6jkj, #8236), so
the condition fired. Nothing had looked, which is what rf2-wehh0 says may not stand.

**Triage first.** I acted on the bead's DESCRIPTION; it carries no notes. Its sequencing
instruction — *"Sequence AFTER rf2-lb1xi, whose repair decides how much is left to re-express"* —
is satisfied: rf2-lb1xi is CLOSED (#8260), and its repair is exactly what subtracts one of the two
suites down to its subject.

## Per suite: re-expressed, or left, and why

| bench suite | verdict | package witness |
|---|---|---|
| `ssr/hframe_ssr_cljs_test.cljs` (175) | **re-expressed, whole** | `test/re_frame/hicasso/hframe_ssr_cljs_test.cljs` |
| `ssr/instance_key_payload_dom_cljs_test.cljs` (493) | **re-expressed, its SUBJECT only** | `test/re_frame/hicasso/instance_key_payload_ssr_dom_cljs_test.cljs` |
| `ssr/entry_cljs_test.cljs`, `ssr/spike_cljs_test.cljs`, `ssr/spike_dom_cljs_test.cljs` | **left** | none — §(iii) never conditioned them, and `spike_cljs_test`'s own docstring settles it: *"No verdict is published here and none is implied."* |

**All five bench suites STAY where they are.** They reach `ssr.fixtures`, which is the corpus
`ssr/driver.cjs` bakes and `bake_bytes.test.cjs` pins, and their subject is the PROTOTYPE entry the
bake is taken from. Re-expression put a package witness beside them; it moved nothing and deleted
nothing. The bench tree is untouched by this PR.

### `hframe_ssr` — whole

All four claims are about the RUNTIME under `renderToString` rather than about the tree's shape, so
each crossed unchanged: the per-request id a body reads through `h/hframe`; determinism when that
id is kept out of markup; the authorable hazard that breaks determinism; and the ambient
`rf/capture-frame` carry refusing inside a real server render with the substrate's own ex-data
(`:operation :capture-frame`, `:substrate :hicasso`, `:extent 'hicasso/boundary-render`).

The third is the one the package could not previously make. `server_render_ssr_dom_cljs_test`'s
`two-renders-of-one-request-are-the-same-bytes` asserts determinism and **had never been watched
failing** — a check nobody has seen red is a claim about a check. The fourth is distinct from
`hframe_cljs_test`'s existing carry row, which drives `collector/render-body` directly: this one is
the same refusal observed through `react-dom/server`, which is what makes it a statement about the
server rather than about a synthetic extent.

### `instance_key_payload` — its subject only, and the subtraction is stated at source

Carried across: the payload obligation and its **enforcement** — `:ui` named on the allowlist, zero
`:rf.ssr/hydration-mismatch` and the server's own nodes adopted; `:ui` omitted, the structured
mismatch FIRES tagged `re-frame.hicasso.impl.mount/hydrate-root!`, the complaint also reaches a
console channel, and the client's default wins so the panel the server rendered open is shut. The
two rows are each other's control. Nothing in the package asserted any of it.

Deliberately NOT carried, because these now have package owners and restating them would be
duplicate coverage wearing the shape of thoroughness:

- **determinism** — `server_render_ssr_dom_cljs_test` §2, plus the red control this PR adds in the
  sibling file;
- **the round trip through the real doors** — that suite's §5 (rf2-lb1xi) drives `server/render`'s
  own `__rf_payload` script through real `ssr/hydrate!` then public `h/hydrate!`. This file
  therefore seeds the client frame from the payload map directly, exactly as the prototype did and
  for a sharper reason: what is under test is the CONTENT of the payload;
- **the constant-hash measurement** — a fact about `re-frame.ssr.hash`, not about either entry, so
  it stays in the bench tree. The half that IS about the entry — an adoption-tier root ships no
  `:rf/render-hash` — crossed as one assertion, and had no package owner before.

### No coverage was lost, and the check for that was the tree shape

The prototype renders `(provider frame (codec/root-element frame hiccup))` — *the tree a consumer
can spell today*. `server/render` renders `impl.mount/tree` with a hydrating handle. The two
disagree inside a `useId` (obstruction 2, measured by `identifier_prefix_ssr_dom_cljs_test`), and
the prototype lane avoided the disagreement by having no `useId` in it at all. Retargeting is
therefore a strict improvement on that axis and neutral on every other. Two further differences
exist and neither is a thing either suite asserts: the prototype's adoption window is a
MODULE-LEVEL flag where the package's is a per-request handle, and `:identifier-prefix` is the
package entry's alone.

**On the duplicated-literals finding, corrected.** `release-scans.md`'s claim as written in the
tree — *"the bench prototype mints the same string"* — is TRUE: `ssr/entry.cljs:227` and
`server.cljs:177` are the identical `(keyword "hicasso.ssr" (str (gensym "request-")))`. The
stronger form, *every* literal in `server.cljs` being duplicated there, is **false by exactly one**:
of the seventeen string literals in `server.cljs`'s code positions, sixteen appear verbatim in
`ssr/entry.cljs` and the seventeenth is `"identifierPrefix"` — which is the `render-options`
difference above. Recorded in the triage page.

## Follow-up filed, not filled

**rf2-doadc** — `presence_ssr_seam_dom_cljs_test`'s §1 explains its finding with *"No product door
installs the adoption context on this path"*. One now does: `server/render` opens a per-request
adoption window around `renderToString` and names presence's ENTER-appearance divergence as the
reason. The suite does not require the server module at all. Triage-first bead; not actioned here
because rf2-wehh0's fence is the two named suites and that is a third suite's premise.

## Quality gates

Every number below is the exit code **captured in the same shell as the runner** (`> log 2>&1;
echo $? > exitfile`), never a harness-reported one. All run against the final rebased base
`2e093f6f04`.

| gate | captured exit | result |
|---|---|---|
| `node-test-hicasso` (compile + run) | **0** | 1212 tests / 4927 assertions, **0 failures, 0 errors**, 0 compile warnings |
| `npm run test:browser` | **0** | 1554 tests / 9865 assertions, **0 failures, 0 errors** |
| `clojure -M:test` in `implementation/hicasso` | **0** | 3 tests / 92 assertions, **0 failures, 0 errors** |
| `npm run test:hicasso-invariants` | **0** | all six checks + self-tests pass |
| `npm run test:hicasso-lint` | **0** | 6 checks fire on fixtures, correct code silent |
| `python scripts/check_doc_slugs.py` | **0** | pass |
| `python scripts/check_provenance_pins.py` | **0** | 110 pages, 529 pins, **0 findings** |

Browser count moved **1551 → 1554** against rf2-lb1xi's reported baseline: exactly the three DOM
rows this PR adds. `hframe_ssr_cljs_test` is `-cljs-test`, so it rides node and not browser, which
is where the prototype original ran too.

### Sabotage — both suites proved to bite, in the fenced file

Two single-line faults planted in `implementation/hicasso/src/re_frame/hicasso/server.cljs` (my
worktree only, **never committed**):

1. `render-twice`'s `:identical? (= x y)` → `:identical? true`;
2. `setup-events`'s `(seq initial-events) (into initial-events)` → the clause disabled.

Result, captured exit **1**: **5 failures, 0 errors**, and every one is mine —
`a-body-that-renders-the-id-breaks-determinism-and-the-check-says-so` (plant 1) and four assertions
in `the-two-requests-differ-by-exactly-the-ui-key` (plant 2). **No collateral**: the run executed
the same 1212 tests / 4927 assertions as the control, so no namespace was stopped, and no sibling
suite reddened.

`server.cljs` restored and verified **by hashing the bytes, not by reading a diff**:

```
baseline  git hash-object …/server.cljs = 692922e913ac7db247515df0178a5146ea2841e8
planted                                 = 348042dd17982893190d10dc992a9eea7f867ae6
restored                                = 692922e913ac7db247515df0178a5146ea2841e8   ← equal
```

`git diff --name-only origin/main...HEAD` is three files and **`server.cljs` is absent** from it.

### Gates NOT run, each with a reason

- **`scripts/test-fast-pr.sh` — the pre-checkin spine did NOT run.** It needs ~25 minutes against a
  ten-minute harness ceiling, and the browser gate above (its most expensive member, and the only
  one that can execute this PR's DOM rows) was run directly and twice — once before the final
  rebase and once after. The targeted gates above cover the diff's whole surface.
- **The fast-spine-versus-required-CI gap is `python scripts/check_fast_pr_gap.py --list`**, which
  reports **103 required checks the spine does not run** (TESTING.md:121). That is a fact about the
  SPINE and not a census of what I ran; the table above is the census of what I ran.
- **`npm run test:hicasso-compile`** (the bench compile gate) not run: the bench tree is untouched
  by this PR.
- **`mkdocs build --strict`** not run: `mkdocs.yml`'s `exclude_docs` keeps `design/hicasso/` out of
  the site, so it is not the gate for this edit. `check_doc_slugs.py` and
  `check_provenance_pins.py` are, and both ran. **Verified by hand**, as that tree requires: the
  edit adds no markdown links and no tables, changes no heading, and touches no anchor — it is
  prose and one bullet list appended inside §(iii).
- **`rf2-r5iy7`'s known hole does not apply**: the diff is under `implementation/hicasso/**`, so CI
  arms the invariants regardless — and they were run locally anyway.

### Base

Gated at `2e093f6f04`. Trunk has since moved to `f1438e3130`; that delta is `.beads/issues.jsonl`,
`docs/design/hicasso/product/architecture-census.md` and `scripts/check_architecture_census.py` —
none of which this PR touches and none of which is an input to any gate above, so it is named here
rather than chased.

Closes rf2-wehh0.
