### PR TITLE
hicasso: HS-21's attribution boundary and the presence seam's product path, both measured (rf2-s52w, rf2-doadc); rf2-t32wg refused to spec

### DIFF
--- a/implementation/hicasso/src/re_frame/hicasso/impl/presence_react.cljs
+++ b/implementation/hicasso/src/re_frame/hicasso/impl/presence_react.cljs
@@ -133,16 +133,21 @@
         ;; DOM the server already delivered, which is the flash this
         ;; branch exists to avoid.
         ;;
-        ;; THE SERVER HALF DOES NOT EXIST YET (rf2-kpig). Nothing in
-        ;; this tier opens a window around a server render, so
-        ;; `adopting-here?` reads `nil` there and the tray emits
-        ;; `:mounting` children that the hydrating client then renders
-        ;; `:present` — the divergence measured in
-        ;; `re-frame.hicasso.presence-ssr-seam-dom-cljs-test`.
-        ;; rf2-hic-046 has RULED the Render arm: a request-scoped
-        ;; server door will mint one window per request and make the
-        ;; two halves agree by construction. Until it lands, this line
-        ;; is client-only.
+        ;; THE SERVER HALF EXISTS NOW, ON ONE PATH (rf2-kpig, corrected
+        ;; by rf2-doadc). `re-frame.hicasso.server/render` opens a
+        ;; window per request and renders through `impl.mount/tree`, so
+        ;; `adopting-here?` reads a real open window on the server, this
+        ;; line settles, and the tray's children are `present` in the
+        ;; bytes — the phase the hydrating client's first pass also
+        ;; computes. That is the Render arm rf2-hic-046 ruled, landed.
+        ;;
+        ;; A server render taken by hand — `renderToString` over the app
+        ;; element, with no door — scopes no window, so `adopting-here?`
+        ;; reads `nil` there and the tray still emits `:mounting`
+        ;; children that the hydrating client renders `:present`. Both
+        ;; paths are measured in
+        ;; `re-frame.hicasso.presence-ssr-seam-dom-cljs-test`: §1 the
+        ;; windowless one, §5 the product door.
         next       (if (roots/adopting-here?) (presence/settle stepped) stepped)]
     ;; Adjusting state while rendering — React's own answer to "a value
     ;; derived from props that must persist". `step` is idempotent, so the

--- a/implementation/hicasso/src/re_frame/hicasso/impl/roots.cljs
+++ b/implementation/hicasso/src/re_frame/hicasso/impl/roots.cljs
@@ -51,18 +51,22 @@
 (defn open-adoption-window!
   "Open a window and answer it — the ONLY handle on it there is.
 
-  Minted per `hydrate-root!` call — TODAY'S ONLY MINTER. Its one
-  product consumer is `impl.mount/tree`, which scopes it over that
-  root's subtree with [[with-adoption]] when the handle carries an
-  `:adoption`. **No server-render entry exists in this tier**, so a
-  server render finds no provider above it, reads the adoption
-  context's `nil` default, and [[adopting?]] calls that closed —
-  measured in `re-frame.hicasso.presence-ssr-seam-dom-cljs-test`.
+  TWO MINTERS, and each hands the window to the same consumer —
+  `impl.mount/tree`, which scopes it over the subtree with
+  [[with-adoption]] when the handle carries an `:adoption`:
 
-  rf2-hic-046 has RULED the Render arm for motion and presence, which
-  adds a second minter: one window per server render/request, scoped
-  over that request's tree (rf2-6tmu's repair shape, item 5). That
-  door is named here because it is DECIDED, not because it is built.
+  - `impl.mount/hydrate-root!`, once per hydrating client root; and
+  - `re-frame.hicasso.server/render`, once per REQUEST, closed in that
+    door's `finally` (rf2-b6jkj — the Render arm rf2-hic-046 ruled and
+    rf2-6tmu shaped as item 5 of its repair). Because both call `tree`,
+    the fork is decided once for both sides of the wire.
+
+  A render that neither door took — a hand-rolled `renderToString` over
+  the app element — still finds no provider above it, reads the adoption
+  context's `nil` default, and [[adopting?]] calls that closed. Both
+  paths are measured in
+  `re-frame.hicasso.presence-ssr-seam-dom-cljs-test`: §1 the windowless
+  one, §5 the product door.
 
   Born open: the renders that follow it are adopting server-rendered
   DOM until something calls [[close-adoption-window!]] on this very

--- a/implementation/hicasso/test/re_frame/hicasso/native_abi_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/native_abi_cljs_test.cljs
@@ -34,7 +34,18 @@
   `re-frame.hicasso.native-abi-dom-cljs-test`. What is here is what a
   server render and a pure function can settle, and the server renderer
   runs bodies for real, so the props-arrival row is a measurement rather
-  than an assertion about a data structure."
+  than an assertion about a data structure.
+
+  HS-21's OTHER half is over there for the same reason (rf2-s52w). The
+  bytes half is here — `renderToStaticMarkup` through the outward bridge,
+  below — but *mismatch attribution* is a claim about an adoption, so the
+  sibling's
+  [[re-frame.hicasso.native-abi-dom-cljs-test/a-consumer-built-root-hydrates-a-bridged-subtree-with-no-framework-reporter]]
+  measures it, and that file's header states the scope: the framework's
+  Spec 011 reporter is a ROOT option, a bridged subtree lives under a root
+  the CONSUMER opened, and Spec 011 already says a direct `hydrateRoot`
+  takes React's silent default. A boundary, not a gap — and measured with
+  the package's own door beside it so the zero means something."
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
             [re-frame.adapter.uix :as uix-adapter]
             [re-frame.core :as rf]

--- a/implementation/hicasso/test/re_frame/hicasso/native_abi_dom_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/native_abi_dom_cljs_test.cljs
@@ -25,7 +25,34 @@
   | [[a-ref-reaches-a-real-dom-node-through-the-memo-helper]] | why there is no third helper | a `forward-ref` helper — the row is green with and without it, and the point is that it is green WITHOUT |
   | [[a-lazy-head-suspends-and-then-names-its-own-component]] | the marker is filled by arrival, in the object minted at declaration | a second marker minted on resolve |
   | [[teardown-across-the-bridge-releases-exactly-what-mount-acquired]] | the bridge adds no ownership of its own | a wrapper holding a cell reference past unmount |
+  | [[a-consumer-built-root-hydrates-a-bridged-subtree-with-no-framework-reporter]] | HS-21's mismatch-attribution half, measured as a BOUNDARY with its control beside it | a claim that attribution is missing when in truth the harness never diverged |
   | [[the-declared-population-was-actually-exercised]] | the roster, asserted rather than described | a row that started returning early |
+
+  ## HS-21's mismatch attribution, and why it stops at the consumer's root
+
+  Checkpoint 3 recorded row 5's *mismatch attribution* clause as unmet for
+  the outward bridge, and it is worth writing down that this is a SCOPE
+  rather than a gap (rf2-s52w).
+
+  A bridged subtree is a child of a root the CONSUMER built with their own
+  `createElement` and adopts with their own `hydrateRoot`. Spec 011's
+  Hydration-mismatch detection carries the consequence already, in its
+  native-adoption section and in as many words: the framework reporter
+  rides the package's own hydrate path, and *\"hydrating via the
+  substrate-native renderer directly (`uix.dom/hydrate-root`, react-dom
+  `hydrateRoot`) bypasses the reporter and falls back to React's default
+  (silent) handling\"*. `onRecoverableError` is a ROOT option, and a root
+  the package did not open takes none of ours.
+
+  So attribution is scoped to roots the package adopts, and the boundary is
+  a consequence of who owns the root rather than an omission in the bridge.
+  Nothing here argues that: the row below MEASURES it, and does so with the
+  package's own door as the control, so a zero can never be read as a
+  harness that failed to diverge.
+
+  What this file does NOT settle is HS-21's disposition row and row 5's
+  required-result sentence — `docs/design/hicasso/product/dispositions.md`
+  is the ledger keeper's, and a witness may not amend the row it witnesses.
 
   ## Browser lane
 
@@ -45,7 +72,9 @@
             [re-frame.hicasso.roots-frames-support :as support]
             [re-frame.test-support :as test-support]
             [uix.core :as uix :refer-macros [defui]]
-            ["react" :as react]))
+            ["react" :as react]
+            ["react-dom/client" :as react-dom-client]
+            ["react-dom/server" :as react-dom-server]))
 
 (def ^:private alpha ::alpha)
 (def ^:private beta  ::beta)
@@ -70,7 +99,8 @@
     :bridge/strict-mode
     :helper/ref-to-a-node
     :helper/lazy-arrival
-    :bridge/teardown})
+    :bridge/teardown
+    :bridge/no-reporter})
 
 (defonce ^:private !exercised (atom #{}))
 
@@ -854,6 +884,142 @@
             ;; roots go down first, and the single `done` is the last act,
             ;; with nothing after it.
             (.then (fn [_] (release-minted!) (done))))))))
+
+;; ---------------------------------------------------------------------------
+;; 5. HS-21's mismatch attribution — the boundary, with the door as its control
+;; ---------------------------------------------------------------------------
+
+(defn- consumer-element
+  "The tree a CONSUMER writes for a bridged view: their own
+  `createElement` over the minted [[card]], under the frame provider the
+  bridge needs — and nothing else.
+
+  `impl.mount/tree` is deliberately not reached for. That function is what
+  wraps a hydrating root in its adoption-window closer and is called only
+  from doors that also pass root options; a consumer who has bridged a view
+  into a tree of their own calls neither. So this element is the exact
+  shape the package cannot install an `onRecoverableError` on, and building
+  it by hand is what keeps the row about the consumer's root rather than
+  about a door with its options removed."
+  [frame-kw article-id]
+  (mount/provider
+    frame-kw
+    (react/createElement "section" #js {:className "consumer"}
+                         (react/createElement card #js {:articleId article-id}))))
+
+(defn- relabel!
+  "Move `frame-kw`'s label after its server bytes were taken, so the
+  client tree disagrees with the DOM it is about to adopt. A TEXT
+  divergence specifically: React recovers from those and reports them,
+  where an attribute-only divergence is outside `onRecoverableError` by
+  React's own contract (Spec 011 §Hydration-mismatch detection), and a row
+  built on one would read zero on BOTH arms and prove nothing."
+  [frame-kw label]
+  (rf/with-frame frame-kw (rf/dispatch-sync [::relabel label]))
+  nil)
+
+(deftest a-consumer-built-root-hydrates-a-bridged-subtree-with-no-framework-reporter
+  (async done
+    (if-not (mount/browser?)
+      (do (support/skip! ":node-test has no React DOM, so nothing hydrates") (done))
+      (do
+        (seat! alpha "server")
+        (seat! beta "server")
+        (let [;; CONTROL FIRST, and the order is load-bearing: the arm that
+              ;; must see a diagnostic runs before the arm that must see
+              ;; none, so a zero below can never be a harness that stopped
+              ;; diverging.
+              control-html      (support/server-html! alpha [article-card {:article-id 7}])
+              control-container (support/server-dom! control-html)
+              control-watch     (support/watch-mismatches!)
+              _                 (relabel! alpha "client")
+              ;; MANUFACTURED fault, asserted on — the one call site
+              ;; `:swallow-uncaught?` belongs at (rf2-mwx08).
+              control-console   (support/open-console-capture! {:swallow-uncaught? true})
+              control-handle    (mount/hydrate-root! control-container alpha
+                                                     [article-card {:article-id 7}])]
+          (-> (support/adopted! control-handle)
+              (.then
+                (fn [ok]
+                  ((:close! control-console))
+                  ((:stop! control-watch))
+                  (testing "CONTROL — the package's OWN door, the same
+                            divergence. `impl.mount/hydrate-root!` opens the
+                            root, so the root's options are the package's to
+                            set and Spec 011's diagnostic fires with this
+                            door's site on it. Without this arm the row below
+                            is an absence with no meaning"
+                    (is (true? ok) "the adoption completed")
+                    (is (= 1 (count @(:seen control-watch)))
+                        (str "the door emitted exactly one "
+                             ":rf.ssr/hydration-mismatch. Saw: "
+                             (pr-str @(:seen control-watch))))
+                    (when-let [mm (first @(:seen control-watch))]
+                      (is (= 're-frame.hicasso.impl.mount/hydrate-root!
+                             (:where (support/tags-of mm)))
+                          "tier-discriminated by :where — this door's site"))
+                    (is (seq @(:captured control-console))
+                        (str "and React itself complained, which is what says
+                              the divergence was real: "
+                             (pr-str @(:captured control-console)))))
+                  (mount/unmount! control-handle)
+                  nil))
+              (.then
+                (fn [_]
+                  ;; THE MEASUREMENT. Same view, same divergence, same
+                  ;; renderer — a root the consumer opened.
+                  (let [html      (react-dom-server/renderToString
+                                    (consumer-element beta 7))
+                        container (support/server-dom! html)
+                        watch     (support/watch-mismatches!)
+                        _         (relabel! beta "client")
+                        console   (support/open-console-capture! {:swallow-uncaught? true})
+                        root      (react-dom-client/hydrateRoot
+                                    container (consumer-element beta 7))]
+                    (-> (support/wait-until!
+                          #(= "#7 client" (some-> (.querySelector container ".card")
+                                                  .-textContent)))
+                        (.then
+                          (fn [recovered?]
+                            ((:close! console))
+                            ((:stop! watch))
+                            (testing "the server's bytes really did say
+                                      `server` and the consumer's root really
+                                      did adopt them — the premise, so the
+                                      zero below is about attribution and not
+                                      about a render that never happened"
+                              (is (re-find #"#7 server" html)
+                                  (str "the bridged view rendered under the
+                                        consumer's own createElement — " html))
+                              (is (true? recovered?)
+                                  "React recovered the text divergence by
+                                   replacing it with the client's model")
+                              (is (seq @(:captured console))
+                                  (str "and complained while doing it: "
+                                       (pr-str @(:captured console)))))
+                            (testing "**HS-21, measured.** A mismatch inside a
+                                      bridged subtree is attributed to NOTHING
+                                      the instrumentation stream can see. The
+                                      reporter is a ROOT option and this root
+                                      is the consumer's, so no Spec 011
+                                      diagnostic is emitted — the scope Spec
+                                      011 states for direct `hydrateRoot`
+                                      hydration, here as a reading rather than
+                                      as a sentence.
+
+                                      This row inverts the day the package
+                                      grows a door for a consumer-built root;
+                                      it is not to be re-pinned by loosening
+                                      the assertion"
+                              (is (= [] @(:seen watch))
+                                  (str "a consumer-built root installs no "
+                                       ":rf.ssr/hydration-mismatch reporter. "
+                                       "Saw: " (pr-str @(:seen watch)))))
+                            (.unmount root)
+                            (exercised! :bridge/no-reporter)
+                            nil))))))
+              (.catch (report-failure! "no-reporter"))
+              (.then (fn [_] (release-minted!) (done)))))))))
 
 (deftest the-declared-population-was-actually-exercised
   (if-not (mount/browser?)

--- a/implementation/hicasso/test/re_frame/hicasso/presence_ssr_seam_dom_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/presence_ssr_seam_dom_cljs_test.cljs
@@ -6,11 +6,19 @@
   ## What this file is, said plainly
 
   It is a **RECORD OF A MISSING REFUSAL, not a proof of parity.**
-  Presence has a server/client seam and the seam is currently OPEN: the
-  client half exists and the server half does not. Every row below drives
-  `react-dom/server` for real and hydrates those actual bytes, and what
-  they establish is the divergence, its cause, and the exact shape of the
-  repair that closes it. Nothing here claims presence round-trips.
+  Presence has a server/client seam, and §1–§4 measure it on the path
+  where it is open: a server render with no adoption window scoped over
+  it. Every one of those rows drives `react-dom/server` for real and
+  hydrates those actual bytes, and what they establish is the divergence,
+  its cause, and the exact shape of the repair that closes it.
+
+  **The repair has since landed as a product door**, and §5 is the
+  measurement of it: `re-frame.hicasso.server/render` opens a window per
+  request, and through it the tray's bytes say `present` (rf2-doadc). So
+  the verdict this file returns is now a SPLIT one — closed through the
+  package's server entry, open through a hand-rolled `renderToString` —
+  and neither half is claimed for the other. Nothing here claims presence
+  round-trips on a path §5 did not drive.
 
   ## The surface is dispositioned, and it does not do what its
   disposition says
@@ -40,20 +48,34 @@
   ## The census that says so
 
   `re-frame.hicasso.impl.roots/with-adoption` is the ONLY door onto the
-  adoption window's React context. Over the whole tree it has exactly one
-  product-source caller:
+  adoption window's React context. It is reached from exactly one place —
+  `impl.mount/tree`, and only for a handle carrying an `:adoption` window
+  — so the census is really a census of that window's MINTERS. When this
+  file was written there was one, `impl.mount/hydrate-root!`, and no
+  server entry, request scope or render helper anywhere.
 
-      implementation/hicasso/src/re_frame/hicasso/impl/mount.cljs:107
-        — inside `impl.mount/tree`, and only for a handle carrying an
-          `:adoption` window, which only `hydrate-root!` mints.
+  **THERE ARE TWO NOW, AND THE SECOND IS A SERVER DOOR** (rf2-doadc, the
+  door landed by rf2-b6jkj). `re-frame.hicasso.server/render` opens a
+  window PER REQUEST, hands `impl.mount/tree` a
+  `{:frame … :adoption <window>}` handle — the hydrating shape, so the
+  same fork on both sides of the wire — and closes it in a `finally`.
+  §5 drives that door and measures what it does to this seam, which is
+  the honest answer to the paragraph below: the seam is CLOSED on the
+  product path and stays open on the bare one.
 
-  There is no second caller anywhere: no server entry, no request scope,
-  no render helper. So on **every** server render `roots/adopting-here?`
-  reads the context default `nil`, `roots/adopting?` calls that closed,
-  and `impl.presence-react/presence-body` takes its ordinary
-  `:mounting` branch. The client's hydrating root reads a real open
-  window one line later and takes `:present`. Two different phases for
-  the same tree, decided on opposite sides of a wire.
+  So on a server render **that no window is scoped over**
+  `roots/adopting-here?` reads the context default `nil`,
+  `roots/adopting?` calls that closed, and
+  `impl.presence-react/presence-body` takes its ordinary `:mounting`
+  branch. The client's hydrating root reads a real open window one line
+  later and takes `:present`. Two different phases for the same tree,
+  decided on opposite sides of a wire.
+
+  That windowless render is still a path a consumer can spell — a
+  hand-rolled `renderToString`, which is exactly what [[server-bytes!]]
+  performs — so no row below is wrong and none is deleted here. What was
+  stale was the RECORD: this page read as though the seam had no product
+  answer, and one had landed.
 
   §1 measures that as a property rather than restating it, and its
   control shows the divergence is caused by the missing provider and by
@@ -77,9 +99,11 @@
                                    `:mounting` children
 
   Both now cite rf2-hic-046's RULED Render arm as DECIDED rather than
-  built, and both cite this file. §1 and §3 remain the
-  counter-measurement standing behind them: the two halves do not
-  agree, and nothing opens a window around a request.
+  built, and both cite this file. Both have since gone stale the other
+  way and are corrected again by rf2-doadc, because a window IS opened
+  around a request now. §1 and §3 remain the counter-measurement for the
+  path they name — the windowless render — and §5 is the measurement for
+  the path that has one.
 
   ## Why the existing presence witness did not catch this
 
@@ -111,9 +135,18 @@
 
   **RENDER.** A product server-render door that mints one window per
   request and scopes it over that request's tree — the fifth item of
-  rf2-6tmu's adopted repair shape, explicitly deferred there to
-  rf2-hic-046. §1's control is that door in one line, so the cost is
-  already measured. When it lands:
+  rf2-6tmu's adopted repair shape, deferred there to rf2-hic-046. §1's
+  control is that door in one line, so the cost was measured before it
+  existed.
+
+  **IT EXISTS** — `re-frame.hicasso.server/render` (rf2-b6jkj), driven by
+  §5. What that does NOT do is close this file, and the distinction is
+  the whole of rf2-doadc's triage: the rows below are about a render with
+  no window, which remains spellable by hand, so they keep measuring
+  what they always measured. What closing the file needs is a decision
+  that the windowless spelling is out of scope — and HS-33's disposition
+  is `docs/design/hicasso/product/dispositions.md`'s, not a witness's.
+  The transitions below stay written down for whoever takes it:
 
     §1  the `\"mounting\"` expectation becomes `\"present\"`, and the
         hand-installed control is deleted because the product does it.
@@ -185,6 +218,7 @@
             [re-frame.hicasso.impl.roots :as roots]
             [re-frame.hicasso.motion :as motion]
             [re-frame.hicasso.roots-frames-support :as sup]
+            [re-frame.hicasso.server :as server]
             [re-frame.test-support :as test-support]
             ["react-dom/server" :as react-dom-server]))
 
@@ -319,7 +353,8 @@
   (some-> (.querySelector container sel) .-textContent))
 
 ;; ---------------------------------------------------------------------------
-;; §1 — the real server render installs no adoption window
+;; §1 — a server render with NO window scoped over it installs no adoption
+;;      context, so presence enters
 ;; ---------------------------------------------------------------------------
 
 ;; The census, turned into a measurement. `renderToString` runs the tray's
@@ -332,7 +367,7 @@
 ;; [[server-bytes-under-a-hand-held-window!]] — and this row reds three ways
 ;; at once: `"present"` in the bytes, `:present` off the machine, and the
 ;; control no longer differing from the measurement it controls.
-(deftest the-real-server-render-installs-no-adoption-window-so-presence-enters
+(deftest a-windowless-server-render-installs-no-adoption-context-so-presence-enters
   (fresh!)
   (reset! !phases {})
   (let [real (server-bytes! [tray-screen {:tag :server}])]
@@ -603,3 +638,65 @@
                         (is (sup/every-server-node? ca ".screen, .value")))
 
                       (finally (mount/release! ha) (done))))))))))))
+
+;; ---------------------------------------------------------------------------
+;; §5 — the PRODUCT server door, which does scope a window, and what that
+;;      does to the seam §1 records
+;; ---------------------------------------------------------------------------
+
+;; THE ROW rf2-doadc ASKS FOR. §1 measures a `renderToString` with no window
+;; over it; this measures `re-frame.hicasso.server/render`, which opens one
+;; per request and hands `impl.mount/tree` the hydrating handle shape. The
+;; two rows differ in exactly one thing, so what separates their bytes is
+;; the window and nothing else — which is §1's control, now taken through a
+;; product door instead of by hand.
+;;
+;; It answers the triage question at source: the presence seam is CLOSED
+;; through this entry. `adopting-here?` reads a real open window on the
+;; server, `impl.presence-react/presence-body` settles, and the tray's
+;; children are `present` in the bytes a consumer ships — the phase that
+;; hydrates against a client whose first pass is also `present`.
+;;
+;; WHAT IT DOES NOT DO is retire §1. A hand-rolled `renderToString` is still
+;; a path a consumer can spell, and §1 is what that path costs. Which of the
+;; two spellings HS-33 is dispositioned against is `dispositions.md`'s, and
+;; a witness does not amend the row it witnesses.
+;;
+;; Node-safe for the same reason §1 is: `server/render` is a `renderToString`
+;; call and reads no `document`.
+(deftest the-product-server-door-scopes-a-window-so-presence-is-present-in-its-bytes
+  (fresh!)
+  (reset! !phases {})
+  (let [{:keys [html]} (server/render {:hiccup   [tray-screen {:tag :product}]
+                                       :snapshot {:label "alpha"}
+                                       :payload  [:label]})]
+
+    (testing "premise: the door rendered this tree, and the frame it minted
+              per request resolved the subscription"
+      (is (re-find #"class=\"screen\"" html) (str "got " html))
+      (is (re-find #"alpha" html)
+          (str "the per-request frame's subscription resolved — " html)))
+
+    (testing "**the seam is closed on this path.** The tray's child is
+              `present` in the bytes `re-frame.hicasso.server/render`
+              delivers, where §1's windowless render emits `mounting`.
+              `roots/adopting-here?` reads the window this door opened, so
+              `presence-body` settles on the server and the page ships the
+              phase a hydrating client's first pass also computes"
+      (is (= "present" (probe-text html))
+          (str "got " (pr-str (probe-text html)) " from " html))
+      (is (= :present (first (get @!phases :product)))
+          (str "and the machine computed it that way on the server's first
+                render; saw " (pr-str (get @!phases :product)))))
+
+    (testing "and the two producers really do differ, which is what makes
+              this a measurement of the WINDOW rather than of the door's
+              name. §1's bare `renderToString` over the same tree still
+              emits the enter phase"
+      (reset! !phases {})
+      (let [bare (server-bytes! [tray-screen {:tag :bare}])]
+        (is (= "mounting" (probe-text bare))
+            (str "got " (pr-str (probe-text bare)) " from " bare))
+        (is (not= (probe-text html) (probe-text bare))
+            "the product door and the hand-rolled path must differ, or this
+             row is measuring nothing")))))


### PR DESCRIPTION
Three beads on `implementation/hicasso`, taken in the order dispatched, one commit each.
**Two landed as code; one is a source-located REFUSAL** — its seam is a `spec/*` change,
which this fence forbids.

---

## rf2-t32wg — the row-18 seam: **REFUSED, and the refusal is the deliverable**

**No commit. This bead reaches `spec/*`, so it is sequencing rather than implementation.**

**Premise re-derived at source, and it HOLDS.** Zero-arity `rf/capture-frame` inside a
Hicasso body still refuses today: `impl/intent.cljs:367` binds
`frame/*ambient-frame-refusal*` for the body's extent, `frame/resolve-current-frame`
(`core/src/re_frame/frame.cljc:758`) collapses to the carried tier while that var is
non-nil, and `require-current-frame!` turns the resulting nil into
`:rf.error/ambient-frame-refused`. `core.cljc:1494` passes `:capture-frame` and
`core.cljc:1249` passes `:current-frame-id` into exactly that primitive.
`bench/hicasso/arm1/ambient_refusal_cljs_test.cljs:331-356` asserts it.

**Why admitting the two ops cannot be done inside my fence.** The refusal is enforced in
the READER, which takes no operation argument; the operation keyword reaches only
`require-current-frame!`. So admitting exactly `:current-frame-id` and `:capture-frame`
requires core to read a NEW key off the substrate's refusal map and branch on the
operation — the same shape of change rf2-nqj22 made when it added `:extent-frame`.
That is `implementation/core/src/re_frame/frame.cljc`, and it contradicts two normative
sentences:

- **`spec/002-Frames.md` §The refusal tier** — *"**The condition is what this contracts,
  not a list of operations.** Any operation that resolves its frame ambiently and requires
  one meets the refusal"*, and *"This is the **only** documented exception to a carried
  stamp winning"*. Admitting two named ops converts a condition into a per-operation list
  and mints a second exception.
- **`spec/009-Instrumentation.md:2018`** — *"The CARRY is the same extent's third door and
  refuses identically: `capture-frame`'s 0-arity … refuses inside a body"*. Admitting it
  makes that sentence false.

**And the Spec 009 half is a live collision**: `worker/overlay-1ppe0` holds
`spec/009-Instrumentation.md` right now. This is exactly the STOP condition the dispatch
brief names, and the same one that keeps `rf2-15bqc` undispatched.

**What the mayor needs to decide** is whether the ruled `hframe` retirement is worth
amending the refusal tier's contract from a CONDITION to a condition-plus-admission-set.
That is a spec ruling, not a worker's. The bead stays OPEN with this recorded.

---

## rf2-s52w — outward-bridge mismatch attribution: **premise HOLDS, and it is a SCOPE**

**Read the landed `impl/mount.cljs` first**, as instructed — PR #8291's `h/mount!` config
map and `ensure-frame!` are in it, and nothing there changes this bead's finding.

**Found at source.** `onRecoverableError` is a ROOT option. `impl/mount.cljs:427-447`
builds it and `hydrate-root!:560` installs it, so a root the package opens gets Spec 011's
reporter. An outward-bridged subtree is a child of a root the CONSUMER opened with their
own `createElement` and adopts with their own `hydrateRoot`, and the package sets no option
on a root it did not open.

**The scoping sentence the bead asks for ALREADY EXISTS normatively**, which is the finding
that decides the route. `spec/011-SSR.md:810` says it in as many words: *"hydrating via the
substrate-native renderer directly (`uix.dom/hydrate-root`, react-dom `hydrateRoot`)
bypasses the reporter and falls back to React's default (silent) handling."* So this is a
documented boundary, not an unmet clause — acceptance option B, whose spec half is already
carried.

**What was missing was a source-located statement and a READING, and both are here.** The
DOM suite's header states the boundary with its citation; the new row measures it with the
package's own door as the CONTROL, so the zero can never be read as a harness that failed
to diverge.

**NOT DONE, and out of fence:** `dispositions.md`'s HS-21 row and row 5's required-result
sentence are the ledger keeper's — and `docs/design/hicasso/product/dispositions.md` is
open in PR #8297 right now, so touching it would have conflicted.

---

## rf2-doadc — presence_ssr_seam's stale record: **REPAIRED, not moot**

**Re-read `re-frame.hicasso.server` after PR #8289** as instructed: `fresh-frame-id` and
`setup-events` are private, and `document` / `payload-script` / `render` / `render-twice`
are the public four. That privatisation does not touch this finding.

**The premise HOLDS, and the falsifier is exact.** The suite's census says
`impl.mount/hydrate-root!` is the adoption window's only minter and that there is *"no
second caller anywhere: no server entry, no request scope, no render helper."*
`server.cljs:384` opens a window per request, hands `impl.mount/tree` the hydrating
`{:frame … :adoption <window>}` handle, and closes it in a `finally`. The census sentence
was false, and so were the two source comments the suite quotes verbatim.

**Triage outcome (a), MEASURED rather than argued.** New §5 drives `server/render` and
reads `present` out of its bytes, where §1's windowless `renderToString` over the same tree
reads `mounting`. The window is the only difference between the two producers.

**REPAIRED, not MOOT, and the reading that decides it:** a hand-rolled `renderToString` is
still a path a consumer can spell — it is what the suite's own `server-bytes!` helper
performs — so §1–§4 keep measuring exactly what they always measured and none is deleted.
The verdict is a SPLIT one and the file now says so. Deciding the windowless spelling out
of scope is HS-33's disposition, which is `dispositions.md`'s and open in PR #8297.

§1's deftest is renamed: `the-real-server-render-installs-no-adoption-window` was a claim,
and it stopped being true the day a real server render installed one.

---

## Quality gates

Run from `C:/Users/miket/code/re-frame2-worktrees/seam-t32wg`. Every number below is the
**captured** exit code from the runner's own `$?`, written to a per-worktree `.exit` file
on the same command line — never a harness report. The browser plant run is the case that
matters: the harness reported it as exit 0 and the captured file read **1**.

| gate | captured exit | result |
|---|---|---|
| `scripts/test-fast-pr.sh` (the pre-checkin spine) | **0** | PASS |
| `npm run test:cljs` (node lane, final tree) | **0** | 13927 tests / 70339 assertions, **0 failures, 0 errors** |
| `npm run test:browser` (final tree) | **0** | 1558 tests / 9891 assertions, **0 failures, 0 errors** |
| `npm run test:browser` (**PLANTED**, deliberately red) | **1** | 1558 tests / 9887 assertions, **18 failures, 0 errors** |
| `check_naming_census.py --self-test` | **0** | PASS |
| `check_naming_census.py <root>` | **0** | **103 public names / 0 unrostered** |
| `npm run test:hicasso-invariants` (incl. `check_facade_inventory.py` + self-tests) | **0** | facade inventory **16 door names / 43 rows** |

**The census read MY tree, and it says so on its own line:**
`CENSUS_REPO_ROOT=C:/Users/miket/code/re-frame2-worktrees/seam-t32wg`. The script refuses to
derive its root precisely so a sibling worktree cannot be reported as the census.

### Plant proof — two faults, one run, each red naming what it broke

A green compile proves nothing here (and the warnings-fatal compile does not police
cross-namespace private access at all), so both new rows were falsified by planting.

1. `impl/presence_react.cljs` — `(if (roots/adopting-here?) (presence/settle stepped) stepped)`
   became `stepped`. **§5 went red naming the phase**:
   `expected: (= "present" (probe-text html)) / actual: (not (= "present" "mounting"))`.
   So §5 measures the WINDOW, not the door's name.
2. `native_abi_dom_cljs_test.cljs` — gave the hand-rolled `hydrateRoot` the package's own
   `mount/hydration-reporter`. **The `(= [] @(:seen watch))` assertion went red** at
   `native_abi_dom_cljs_test.cljs:1018`. So the zero is a live reading, not a dead listener.

15 further reds fell in the other presence suites, which is the plant being real rather
than cosmetic. **Test count was 1558 on both runs**, so no namespace was stopped by the
plant and the log is comparable to its control.

Both files restored and verified **by hashing the bytes, not by reading a diff**:
`presence_react.cljs` back to `5ba70bc44ebf1352294e74a23a1262ab8b196fa7` (11323 bytes),
`native_abi_dom_cljs_test.cljs` back to `f53a0d00a2fcf6d9346962d30e637ac65670edc0`
(55185 bytes); `git status --porcelain` clean afterwards.

### Skipped, each with its reason

- **`check_bundle_isolation.cjs` (full)** — needs the `:advanced` hicasso release build; the
  diff adds no `:require` to any `implementation/hicasso/src` namespace (the two src edits
  are a docstring and a comment), so no bundle edge changed. CI's `build:hicasso-release`
  step runs it.
- **`check_doc_slugs.py`** — no `.md` in the diff.

**The fast-spine-versus-required-CI gap is `scripts/check_fast_pr_gap.py --list`, and it is
the one path**: it reports **105 required checks this spine does not run** (TESTING.md:121).
Green here is not green in CI.

### Base

Branched from `origin/main` at `9a541371e0`. `git diff --name-only 9a541371e0..origin/main --
implementation/hicasso implementation/core` is **empty**, so nothing this branch touches has
moved on main and no rebase is owed. Diffed against the merge base (`origin/main...HEAD`) and
read for reverts: `impl/mount.cljs` (#8291) and `server.cljs` (#8289) are **not in the diff
at all** — both were read, neither was edited, so neither the door contract nor the
privatisation can be reverted by this branch.

### Anchors and tables

No `.md` touched. The one markdown table edited is **inside a CLJS docstring**
(`native_abi_dom_cljs_test.cljs`'s row table gains one row); column count verified by hand at
3 columns, matching the header and every existing row.
