### PR TITLE
test(epoch): triage the prod-gate exclusion roster; witness the lane's absence assertions (rf2-t7qh8)

### DIFF
--- a/implementation/epoch/test/re_frame/epoch_jvm_prod_gate_test.clj
+++ b/implementation/epoch/test/re_frame/epoch_jvm_prod_gate_test.clj
@@ -81,7 +81,24 @@
   The companion core gate vocabulary suite is
   `re-frame.interop-debug-gate-test`; the core integration suite is
   `re-frame.jvm-prod-gate-integration-test`. This file is the epoch
-  artefact's contribution."
+  artefact's contribution.
+
+  ## Why every negative assertion below is paired with a WITNESS (rf2-t7qh8)
+
+  Almost everything this suite claims is an ABSENCE — an empty ring, a silent
+  listener, an uninvoked `:redact-fn`, a warning that never fired. An absence is
+  satisfied by two different worlds: the gate elided the recording (the claim),
+  or the dispatch never happened at all (a defect). rf2-9c2jf was the second
+  world — `dispatch-sync` running its handler ZERO times under the documented
+  gate — and a bare `(is (empty? …))` cannot tell them apart. It reports green
+  for both, which is what let rf2-9c2jf live.
+
+  So each of these deftests asserts, beside the absence, that the dispatch it is
+  reasoning about actually landed: the handler's app-db write is read back
+  through `app-db-of`. That converts \"nothing was recorded\" from an
+  unfalsifiable statement into a conditional one — the run did the work AND
+  epoch kept none of it. Do not delete a witness to \"simplify\" a test; the
+  witness is the half that makes the other half mean something."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
             [re-frame.epoch :as epoch]
@@ -115,6 +132,11 @@
     {:adapter plain-atom/adapter
      :init-fn (fn [] (rf/configure! {:epoch-history {:trace-events-keep 5}}))}))
 
+;; rf2-t7qh8 — the witness read. See the docstring section above: it is what
+;; separates "epoch recorded nothing" from "nothing happened".
+(defn- app-db-of [frame-id]
+  (:rf.db/app (rf/frame-state-value frame-id)))
+
 (deftest epoch-history-inert-when-debug-disabled
   (testing "Per rf2-0la4f: when the JVM debug gate reads false, the
             per-frame epoch ring stays empty regardless of how many
@@ -128,6 +150,9 @@
       (rf/dispatch-sync [:prod-gate.epoch/inc])
       (rf/dispatch-sync [:prod-gate.epoch/inc])
       (rf/dispatch-sync [:prod-gate.epoch/inc])
+      (is (= 3 (:n (app-db-of :rf/default)))
+          "WITNESS: all three dispatches ran their handler and committed —
+           so the empty ring below is elision, not a dead dispatch loop")
       (is (empty? (epoch/epoch-history :rf/default))
           "epoch ring is empty under disabled debug gate"))))
 
@@ -144,6 +169,9 @@
         (rf/reg-event :prod-gate.epoch/silent
                          (fn [{:keys [db]} _] {:db (update db :n (fnil inc 0))}))
         (rf/dispatch-sync [:prod-gate.epoch/silent])
+        (is (= 1 (:n (app-db-of :rf/default)))
+            "WITNESS: the dispatch ran — the silent listener below had a real
+             cascade to miss")
         (is (empty? @seen)
             "epoch listener silent under disabled debug gate")))))
 
@@ -201,6 +229,9 @@
       (rf/reg-event :prod-gate.priv/silent
                        (fn [{:keys [db]} _] {:db (update db :n (fnil inc 0))}))
       (rf/dispatch-sync [:prod-gate.priv/silent])
+      (is (= 1 (:n (app-db-of :rf/default)))
+          "WITNESS: the dispatch ran — nothing reached the ring for the
+           projection to read")
       (is (= [] (epoch/projected-history :rf/default))
           "empty projected-history under the disabled gate"))))
 
@@ -215,6 +246,9 @@
                        {:sensitive? true}
                        (fn [{:keys [db]} _] {:db (assoc db :token "shh")}))
       (rf/dispatch-sync [:prod-gate.priv/sensitive])
+      (is (= "shh" (:token (app-db-of :rf/default)))
+          "WITNESS: the `:sensitive?`-flagged handler ran and wrote the token —
+           so the absent rollup below is elision, not an absent event")
       (is (empty? (epoch/epoch-history :rf/default))
           "no record assembled — rollup never reached"))))
 
@@ -243,6 +277,9 @@
         (rf/dispatch-sync [:prod-gate.redact/inc])
         (rf/dispatch-sync [:prod-gate.redact/inc])
         (rf/dispatch-sync [:prod-gate.redact/inc])
+        (is (= 3 (:n (app-db-of :rf/default)))
+            "WITNESS: all three dispatches ran — the zero invocation count
+             below is a hook that was never on the path, not a path never taken")
         (is (zero? @invocations)
             ":redact-fn was never called along the storage path — it is a
              projection-side hook, and record assembly is elided anyway")
@@ -309,6 +346,10 @@
                        (fn [{:keys [db]} _] {:db (update db :n (fnil inc 0))}))
       (rf/dispatch-sync [:prod-gate.redact/throw] {:frame :prod-gate.throw/frame})
       (rf/dispatch-sync [:prod-gate.redact/throw] {:frame :prod-gate.throw/frame})
+      (is (= 2 (:n (app-db-of :prod-gate.throw/frame)))
+          "WITNESS: both dispatches ran with a THROWING :redact-fn installed —
+           the absent warning below is a hook never reached at settle, not a
+           dispatch that never happened")
       (let [redact-warns (filter (fn [ev]
                                    (= :rf.warning/epoch-redact-fn-exception
                                       (:operation ev)))

--- a/scripts/test-epoch-prod-gate.sh
+++ b/scripts/test-epoch-prod-gate.sh
@@ -84,8 +84,15 @@
 # namespace added to `implementation/epoch/test/` joins this lane BY DEFAULT and
 # has to be excluded deliberately, so a new suite that quietly starts retaining
 # state under the production gate reddens this job the day it lands.  An
-# allowlist would have the opposite failure mode.  The triage bead is rf2-t7qh8
-# — read the note above before treating any line below as debt.
+# allowlist would have the opposite failure mode.
+#
+# TRIAGED (rf2-t7qh8, 2026-08-15) AND LEFT AT 22.  Every entry was classified,
+# and the classes are recorded beside the entries below: 15 subject-elided, 6
+# publication-elided, 1 non-terminating.  None was incidental, so the roster did
+# not shrink and is not expected to.  The count is not the health metric here —
+# a shrinking roster would mean epoch had acquired production behaviour, which
+# is the opposite of its design.  What triage DID change is in the runnable
+# half, not this list: see the note above `known_red`.
 #
 # BEFORE YOU ADD A LINE: a namespace that is red here is asserting epoch's DEV
 # behaviour, or it is a genuine production defect (rf2-9c2jf was the latter).
@@ -113,13 +120,32 @@ test_root="$artefact/test"
 # below), so a rename cannot leave a stale exclusion quietly suppressing
 # coverage.
 # ---------------------------------------------------------------------------
+# rf2-t7qh8 TRIAGED THIS ROSTER AND CHANGED NO ENTRY.  All 22 fall into three
+# classes, below; NONE is the "could run, nobody tried" class, so the roster has
+# no incidental members and nothing to shrink.  The discriminator that decides
+# every case is one question — DOES THE GATE ERASE WHAT THE SUITE IS ABOUT? — and
+# the two green projection suites are what make it sharp rather than rhetorical.
+# `epoch-egress-resource-scope-test` and the projection suites in class A test
+# the SAME transform; the green one SYNTHESISES its record as a literal, the red
+# ones dispatch and read theirs back out of the ring.  Projection is ungated
+# (tool_pair.cljc — the gate elides record ASSEMBLY, not record PROJECTION), so
+# what fails is never the subject, it is the suite's ability to obtain one.
+#
+# THE ONE THING TRIAGE FOUND WORTH DOING was not on this list at all.  It was in
+# the lane's RUNNABLE half: six of `epoch-jvm-prod-gate-test`'s ten lane-running
+# deftests asserted an absence with no witness that the dispatch they reason
+# about had happened — rf2-9c2jf's exact shape, inside a required job.  Each now
+# reads its handler's app-db write back before asserting the absence.  That is
+# the VACUOUS-PASS class rf2-o5dbf kept finding in routing, and for this artefact
+# it lives among the greens, not among the reds.
 known_red=(
-  # ── EPOCH IS OFF UNDER THIS GATE, BY DESIGN.  Every namespace in this group
-  #    exercises epoch's recording, restore, projection, redaction, silencing
-  #    or attribution behaviour, and under the production gate the artefact
-  #    performs none of it — see the header, and rf2-vnjfg / rf2-0la4f for why
-  #    that is the intended posture.  These are legitimate dev-posture suites,
-  #    not defects and not triage debt; see rf2-t7qh8 before moving any of them.
+  # ── CLASS A · SUBJECT ELIDED (15).  These suites obtain their subject by
+  #    dispatching and reading the ring back — recording, restore, replay,
+  #    capture-buffer and projection-of-a-recorded-record.  Under the gate the
+  #    ring never fills, so there is no subject to assert about; see the header
+  #    and rf2-vnjfg / rf2-0la4f for why that is the intended posture.  NOT debt:
+  #    re-including one would require inventing behaviour the artefact is
+  #    designed not to have in production.  DISPOSITION: correct as-is.
   re-frame.actor-revertibility-restore-test              #  21 /   44
   re-frame.epoch-attribution-test                        # 107 /  208
   re-frame.epoch-drain-serialization-test                #  13 /   26
@@ -132,24 +158,51 @@ known_red=(
   re-frame.epoch-redact-fn-projection-test               #  23 /   45
   re-frame.epoch-redact-fn-test                          #  42 /   66
   re-frame.epoch-run-cause-test                          #  20 /   27
+  re-frame.epoch-test                                    # 428 /  752
+  re-frame.join-strict-mint-epoch-replay-test            #  17 /   29
+  re-frame.machine-minted-cofx-replay-token-test         #   6 /    9
+
+  # ── CLASS B · PUBLICATION ELIDED (6).  Different mechanism, same verdict, and
+  #    worth separating because the failure ratios invite the wrong conclusion —
+  #    `lineage-285` fails 68 of 3608 assertions, which reads like a suite that
+  #    almost runs.  It nearly does: the LEDGER these suites drive
+  #    (`re-frame.epoch.state`) carries no `debug-enabled?` gate at all, so its
+  #    arithmetic is posture-INDEPENDENT and its thousands of assertions pass
+  #    here for the same reason they pass in dev.  What the gate erases is the
+  #    PUBLICATION — `listeners.cljc`'s `on-frame-destroyed!` and the fan-out
+  #    around it are gated — and the emitted silencing trace is the observable
+  #    every one of these suites is actually about.
+  #
+  #    So splitting them would buy assertions, not coverage: a posture-
+  #    independent path re-run in a second posture reports what the dev lane
+  #    already reported, at the cost of permanent per-deftest tagging and, for
+  #    `lineage-285` and `lineage-aba`, concurrency latches in a required job.
+  #    The lane already carries two ungated-ledger suites under the real gate
+  #    (`silence-decision-atomicity`, `silencing-emit-deadlock`), which is what
+  #    covers the load-time risk; four more of the same shape add cost, not
+  #    information.  DISPOSITION: correct as-is.
   re-frame.epoch-silence-contract-test                   #   6 /   21
   re-frame.epoch-silence-receiver-public-api-test        #   7 /   12
   re-frame.epoch-silencing-generation-emission-test      #   4 /   13
   re-frame.epoch-silencing-lineage-285-test              #  68 / 3608
   re-frame.epoch-silencing-lineage-aba-test              #   7 /   19
   re-frame.epoch-silencing-same-generation-rearm-test    #  17 /   34
-  re-frame.epoch-test                                    # 428 /  752
-  re-frame.join-strict-mint-epoch-replay-test            #  17 /   29
-  re-frame.machine-minted-cofx-replay-token-test         #   6 /    9
 
-  # ── DOES NOT TERMINATE under the gate, which is a different fact from "red"
-  #    and is recorded as such.  Its stress loops wait on epoch ids the no-op
-  #    floor never mints, so each iteration burns its full budget: the whole
-  #    namespace runs inside a 53s dev-posture suite and exceeded a 150s ceiling
-  #    ALONE under the gate.  It stays excluded on cost grounds regardless of
-  #    how rf2-t7qh8 triages the group above — a lane that WEDGES is worse than
-  #    one that reds, because it consumes the job's whole timeout and reports
-  #    nothing.
+  # ── CLASS C · HAZARDOUS: DOES NOT TERMINATE (1).  A different fact from "red"
+  #    and recorded as such.  Its stress loops wait on epoch ids the no-op floor
+  #    never mints, so each iteration burns its full budget.  RE-MEASURED under
+  #    rf2-t7qh8, this namespace ALONE, on the same box minutes apart:
+  #
+  #        dev posture   7 tests / 929 assertions, 0 failures, exit 0 —   21s
+  #        under gate    no summary line, no verdict, killed at a 200s bound
+  #
+  #    The shape is worse than the ratio suggests.  It emits a ~267KB burst of
+  #    failures in its first half-minute and then produces NOTHING for the rest
+  #    of the bound — from outside, indistinguishable from a healthy long run.
+  #    A lane that WEDGES is worse than one that reds: it consumes the job's
+  #    whole timeout and reports no verdict at all.  DISPOSITION: stays excluded
+  #    on cost grounds, permanently, independent of how A and B are read.  This
+  #    is the highest-risk line in the file to re-include — do not.
   re-frame.epoch-concurrency-stress-test
 )
 


### PR DESCRIPTION
Triages the 22-namespace exclusion roster that #8292 (rf2-bo8lq) landed with the
`jvm-epoch-prod-gate` lane. I acted on the bead's **description** — it has no
notes (`comment_count` 0).

## The roster did not change, and that is the answer

All 22 entries classified. **None is the "could run, nobody tried" class**, so
there is nothing to shrink. Membership is byte-identical to `origin/main`
(diffed as a set: 22 vs 22, `diff` exit 0). What changed in
`scripts/test-epoch-prod-gate.sh` is the reasoning recorded beside the entries.

| Class | Count | Why excluded | Disposition |
|---|---|---|---|
| **A · subject elided** | 15 | The suite obtains its subject by dispatching and reading the ring back — recording, restore, replay, capture-buffer, projection-of-a-recorded-record. Under the gate the ring never fills. | correct as-is |
| **B · publication elided** | 6 | The silencing ledger (`epoch.state`) carries **no** `debug-enabled?` gate, so it is posture-independent; what the gate erases is the gated **publication** (`listeners.cljc`), which is the observable these suites are about. | correct as-is |
| **C · hazardous, non-terminating** | 1 | Wedges. See below. | excluded permanently |

**Class A (15):** `actor-revertibility-restore`, `epoch-attribution`,
`epoch-drain-serialization`, `epoch-egress-redaction-cljs`,
`epoch-egress-resource-trace`, `epoch-egress-trace-events`,
`epoch-mcp-egress-conformance`, `epoch-override-capture`, `epoch-privacy`,
`epoch-redact-fn-projection`, `epoch-redact-fn`, `epoch-run-cause`, `epoch-test`,
`join-strict-mint-epoch-replay`, `machine-minted-cofx-replay-token`.

**Class B (6):** `epoch-silence-contract`, `epoch-silence-receiver-public-api`,
`epoch-silencing-generation-emission`, `epoch-silencing-lineage-285`,
`epoch-silencing-lineage-aba`, `epoch-silencing-same-generation-rearm`.

**Class C (1):** `re-frame.epoch-concurrency-stress-test`.

The discriminator that decides every case is one question — *does the gate erase
what the suite is about?* — and the greens make it sharp rather than rhetorical.
`epoch-egress-resource-scope-test` (green) and the Class A projection suites
(red) test the **same** transform; the green one synthesises its record as a
literal, the red ones dispatch and read theirs back. Projection is ungated, so
what fails is never the subject — it is the suite's ability to obtain one.

Class B invites the wrong conclusion via its ratios: `lineage-285` fails 68 of
3608 assertions, which reads like a suite that almost runs. It nearly does — but
the 3540 that pass are posture-**independent** ledger arithmetic passing for the
same reason they pass in dev. Splitting it buys assertions, not coverage, at the
cost of permanent per-deftest tagging and concurrency latches in a required job.
The lane already carries two ungated-ledger suites under the real gate
(`silence-decision-atomicity`, `silencing-emit-deadlock`), which is what covers
the load-time risk.

### The non-terminating namespace: `re-frame.epoch-concurrency-stress-test`

**Recommendation: stays excluded permanently, on cost grounds, independent of
how A and B are read.** Re-measured this namespace alone, same box, minutes
apart:

| posture | result |
|---|---|
| dev (`clojure -M:test`) | 7 tests / 929 assertions, 0 failures, captured exit **0** — **21s** |
| under the gate | **no summary line, no verdict**, killed at a 200s bound, captured exit **124** |

The shape is worse than the ratio. It emits a ~267KB burst of failures in its
first half-minute then produces **nothing** for the remaining ~170s — from
outside, indistinguishable from a healthy long run. This is the highest-risk
line in the file to re-include; I did not.

## What triage actually found — and it was not on the roster

It was in the lane's **runnable** half. Six of `epoch-jvm-prod-gate-test`'s ten
lane-running deftests asserted an absence — empty ring, silent listener,
uninvoked `:redact-fn`, unemitted warning — with **no witness that the dispatch
they reason about ever happened**. An absence is satisfied by two worlds: the
gate elided the recording (the claim), or the dispatch never ran (rf2-9c2jf's
exact defect, green for as long as it existed). A bare `(is (empty? …))` reports
green for both. That is the vacuous-pass class rf2-o5dbf kept finding in
routing — for this artefact it lives among the **greens**, not the reds.

Each now reads its handler's app-db write back through `app-db-of` before
asserting the absence. All six hold under the real load-time gate, so there is
no live recurrence — they are now pinned against one.

### Plant proof — an A/B, not an assertion

Identical fault (the three `dispatch-sync` calls removed — rf2-9c2jf's shape),
run through the same lane script:

| test file | verdict | captured exit | counts |
|---|---|---|---|
| `origin/main` (no witness) | **PASS** | **0** | 24 tests / 66 assertions, 0 failures |
| this branch (witnessed) | **FAIL** | **1** | 24 tests / 72 assertions, **1 failure** — the witness |

The false green is demonstrated, not hypothesised. Test/assertion counts are
**identical to the control run**, so the plant stopped no other namespace. The
lane prints `gate root:` and it read this worktree on every run. Planted file
restored and verified byte-identical by `git hash-object`
(`97e7ca58627c75d87923264e1473438e7a044c4b`).

## Job key or steps?

**Neither — `.github/workflows/` is untouched.** No job key added or removed, so
this is **not a band event**; the band stays at **100** (set by `6e158ebd6d` for
#8292).

```
$ git diff origin/main...HEAD -- .github/workflows/ | grep -cE '^\+  [a-z][a-z0-9_-]*:[[:space:]]*$'
0
$ git diff --name-only origin/main...HEAD
implementation/epoch/test/re_frame/epoch_jvm_prod_gate_test.clj
scripts/test-epoch-prod-gate.sh
```

## Quality gates

All exit codes below are **captured** from the runner (`echo $?` to a `.exit`
file), never read off the harness — which disagreed twice in this session,
reporting 0 for the 124-timeout probe and for the exit-1 plant run.

Re-run on the final rebased base (`c725277f06`) after a mid-session rebase.

| gate | result | captured exit |
|---|---|---|
| `scripts/test-epoch-prod-gate.sh` (the lane) | 24 tests / **72** assertions, **0 failures** | **0** |
| `clojure -M:test` in `implementation/epoch` (dev control) | 539 tests / **7139** assertions, **0 failures** | **0** |
| `scripts/test-epoch-prod-gate.sh --plan` | 5 runnable / 22 excluded of 27 | **0** |
| `scripts/check_jvm_lane_rosters.py` | pass | **0** |
| `scripts/check_gate_scheduling.py` | pass | **0** |
| `scripts/check_ci_reproduce_commands.py` | pass | **0** |
| `bash -n scripts/test-epoch-prod-gate.sh` | pass | **0** |
| `scripts/test-fast-pr.sh` (spine) | pass, 29m47s | **0** |

**Totals: 8 gates pass, 0 fail.** The two red runs above are the deliberate
plants, restored.

Assertion deltas are exactly the six witnesses: lane 66 → 72, dev control
7133 → 7139. Test counts unchanged (24, 539) — no test added or removed.

**Spine base note:** the spine ran green on `f0fc31996e`; `origin/main` then
advanced to `c725277f06` while it ran. The intervening commits touch only
`.beads/`, `skills/`, `docs/design/` and `.claude/` — no overlap with my diff or
with any gate that grades it — so I re-ran the epoch dev control, the lane and
all three `check_*` scripts on the final base rather than the full 30-minute
spine. No gate was skipped for any other reason.

Per `scripts/check_fast_pr_gap.py --list` (TESTING.md:121), the spine leaves 106
required checks undecided; CI owns those. Not enumerated by hand.

**YAML:** no workflow file was edited, so there was nothing to parse.

## Beads

- **Filed rf2-s0y22** (P2) — the same witness-free shape, **verified at source**,
  in `implementation/core/test/re_frame/jvm_prod_gate_integration_test.clj`,
  which feeds the equally-required `jvm-core-prod-gate` lane.
  `trace-buffer-inert-when-debug-disabled` is the sharper instance: its failure
  message reads *"no event landed despite dispatch firing"* — asserting exactly
  the fact the assertion cannot establish. Not fixed here: different artefact,
  and it would widen this PR's surface.
- **Closed as correct-as-is:** all 22 roster entries. Classes A and B need no
  work — re-including any would require inventing behaviour epoch is designed
  not to have in production. Class C needs no work either: making the stress
  suite terminate under a gate it has no subject under would be gold-plating.
- **No bead filed for "shrink the roster."** The count is not the health metric
  here; a shrinking list would mean epoch had acquired production behaviour.
