### PR TITLE
fix(story): route the single-pane render through the substrate registry (rf2-3afns)

### DIFF
--- a/tools/story/spec/003-Render-Shell.md
+++ b/tools/story/spec/003-Render-Shell.md
@@ -262,6 +262,30 @@ each substrate **inline** in its own pane.
 The rationale for inline-rendering substrate failures is documented in
 [`DESIGN-RATIONALE.md`](DESIGN-RATIONALE.md) §inline-substrate-failures.
 
+### One declared substrate — the single pane
+
+The size of the declared set decides side-by-side panes versus a single
+pane, and **nothing else**. It does not decide the renderer. A variant
+declaring `:substrates #{:uix}` renders through the render fn registered
+under `:uix`, exactly as the `:uix` pane of a two-substrate variant would;
+Reagent is the default only because it is the default *declaration*, never
+because a set happens to hold one element.
+
+That matters for the substrate a story never names as much as for the one
+it does. Both render paths — the live canvas and the `render-variant` verb —
+resolve the renderer by looking the declared substrate up in the registry
+`register-substrate!` writes to. A single-tree render reduces the declared
+set to one substrate under a rule worth stating outright: **it never paints
+under a substrate the variant did not declare.** One declared substrate wins
+outright; a multi-substrate variant keeps the host default when it declared
+it, and otherwise gets a name-sorted pick from what it did declare.
+
+A declared substrate with no registered render fn is a **failure that says
+so**. The single pane renders the same inline diagnostic naming the missing
+substrate that the grid's error cell carries — it does not quietly fall back
+to Reagent, because a silent fallback tells the author their UIx component
+works when what they watched render was Reagent.
+
 ### Substrate-portable post-render hook
 
 DOM-mutating chrome that runs against the rendered output of a variant

--- a/tools/story/src/re_frame/story/canonical.cljc
+++ b/tools/story/src/re_frame/story/canonical.cljc
@@ -120,26 +120,41 @@
      descendant subscribe reads the override at deref time via the
      `:subs/resolve-sub-override` core hook (consulted dev-only inside
      `subscribe`'s `interop/debug-enabled?` gate). See
-     `re-frame.story.sub-overrides` ns docstring §STATUS."
-     [{:keys [view frame effective-args sub-overrides decorators]}]
+     `re-frame.story.sub-overrides` ns docstring §STATUS.
+
+     The substrate is READ off the variant, not assumed. rf2-3afns: this hook
+     passed a LITERAL `:reagent` into the seam, so `render-variant` painted a
+     `:substrates #{:uix}` variant under Reagent — the same defect the canvas
+     single-pane branch carried, which is why the two agreed with each other.
+     The declared set rides the compiled plan at `[:world :substrates]` (folded
+     there by `plan/variant-plan`, so it arrives already `:extends`-merged) and
+     `ui-multi-substrate/single-render-substrate` reduces it to the one
+     substrate a single-tree render can paint under. Multi-substrate variants
+     that declare `:reagent` are unaffected."
+     [{:keys [view frame effective-args sub-overrides decorators plan]}]
      (sub-overrides/override-provider sub-overrides
        (ui-multi-substrate/render-decorated-view
-         :reagent frame view effective-args decorators))))
+         (ui-multi-substrate/single-render-substrate
+           (get-in plan [:world :substrates]) :reagent)
+         frame view effective-args decorators))))
 
 #?(:cljs
    (defn- install-render-host!
      "Wire the `render-variant` host-render hook. The
      render-prep core (`re-frame.story.render/prepare-render`) is host-free
      + JVM-testable; the actual painting of the active view is this CLJS
-     hook. It renders the active `:view` under the host substrate's render
-     fn, wrapped in the variant's `:hiccup` decorators via the SHARED
+     hook. It renders the active `:view` under the render fn registered for
+     the variant's DECLARED substrate, wrapped in the variant's `:hiccup`
+     decorators via the SHARED
      `re-frame.story.ui.multi-substrate/render-decorated-view` seam the
      canvas single-pane path also uses, inside the
      `render-host-scope` component so the resolved `:sub-overrides` surface
      at React render time via the override-context carriage
-     (spec/017 §View-state subscription overrides). The
-     result is a hiccup tree (the Reagent default) — the SAME decorated
-     render the canvas paints, so render-variant and the live shell agree.
+     (spec/017 §View-state subscription overrides). The result is whatever
+     that substrate's render fn returns — a hiccup tree for the `:reagent`
+     default — and it is the SAME decorated render the canvas paints, so
+     render-variant and the live shell agree. They agree on the SUBSTRATE too
+     (rf2-3afns): both read the declared set rather than assuming Reagent.
 
      The bare JVM installs NO render host, so `render-variant` returns
      `:cannot-run` there rather than a silent empty render."

--- a/tools/story/src/re_frame/story/ui/canvas.cljs
+++ b/tools/story/src/re_frame/story/ui/canvas.cljs
@@ -18,11 +18,20 @@
   - Surfaces variant-level errors inline (per `002-Runtime.md` §Substrate hooks +
     `:assertions`).
 
-  The canvas reads the registered `:component` keyword and renders via
-  `(re-frame.core/view <id>)` — this is the late-bind view lookup that
-  spec/004 exposes. The view must be registered against the
-  variant's frame; the runtime allocates the frame, so any
-  frame-scoped subscriptions resolve through it correctly."
+  The canvas reads the registered `:component` keyword and renders it
+  through the SUBSTRATE REGISTRY — `multi-substrate/render-view` looks the
+  variant's declared substrate up in `substrate->render-fn` and calls its
+  render fn. Both render branches resolve the renderer that way: the
+  side-by-side grid for a variant declaring two or more substrates, and the
+  single pane for a variant declaring one. The built-in `:reagent` render fn
+  is what performs the `(re-frame.core/view <id>)` late-bind lookup spec/004
+  exposes; a variant declaring `:substrates #{:uix}` reaches the UIx render
+  fn its host registered instead (rf2-3afns — before which the single-pane
+  branch called `rf/view` itself and painted Reagent regardless).
+
+  The view must be registered against the variant's frame; the runtime
+  allocates the frame, so any frame-scoped subscriptions resolve through it
+  correctly."
   (:require [clojure.string :as str]
             [reagent.core :as r]
             [re-frame.core :as rf]
@@ -607,41 +616,65 @@
         [multi-substrate/multi-substrate-grid variant-id]]
 
        :else
-       (let [resolved-view (rf/view view-id)]
-         (if resolved-view
-           ;; The variant's frame is already allocated; scope the
-           ;; rendered view's subscribe / dispatch to it (scope-only)
-           ;; via the merged `rf/frame-provider {:frame …}` shape, which
-           ;; routes through Reagent's `:r>` interop head so the namespace
-           ;; of a `:story.x/y`-shaped variant id survives the
-           ;; React-context round trip (a plain `[:> Provider …]` mount
-           ;; calls `(name kw)` on prop values and drops the namespace
-           ;; before React sees it).
-           ;;
-           ;; Stamp `data-rf-story-variant-root` on the
-           ;; immediate wrapper around the user-authored decorated view
-           ;; so the a11y panel (ui/a11y.cljs) can scope axe-core's
-           ;; scan to ONLY the variant's rendered tree — excluding the
-           ;; surrounding Story chrome (title bar, share button, open-
-           ;; in-editor chip, panels, sidebar, toolbar). Without this
-           ;; marker axe-core's `run()` against `document.body` flags
-           ;; Story's own UI as the source of violations, which is
-           ;; wrong: Story chrome a11y is Story's concern, not the
-           ;; variant author's.
-           ^{:key (str "single-" variant-id)}
-           [rf/frame-provider {:frame variant-id}
-            [:div {:key (str "variant-root:" (pr-str variant-id))
-                   :data-rf-story-variant-root (pr-str variant-id)}
-             ;; Bind the variant's resolved view-state
-             ;; subscription overrides for the view-render extent (a no-op
-             ;; wrapper when the variant authors none).
-             [sub-overrides-scope sub-ovr
-              (safe-decorated-view
-                [resolved-view eff-args]
-                (:hiccup decorator-pack)
-                eff-args)]]]
-           [:div {:style (:empty styles)}
-            (str ":component " (pr-str view-id) " is not registered as a view")])))
+       ;; SINGLE-PANE render. The renderer is resolved through the SAME
+       ;; substrate registry the grid branch above consults —
+       ;; `multi-substrate/render-view` → `substrate->render-fn` — keyed on
+       ;; the variant's ONE declared substrate.
+       ;;
+       ;; rf2-3afns: this branch used to call `(rf/view view-id)` itself and
+       ;; embed the result as a Reagent hiccup vector, so a variant declaring
+       ;; `:substrates #{:uix}` — a set of size one, which is exactly what a
+       ;; single-substrate UIx story looks like — rendered under REAGENT, with
+       ;; nothing said. The registry was real, public and simply not on the
+       ;; path almost every story takes. The `multi?` count above decides GRID
+       ;; vs SINGLE PANE and nothing else; it never decided the renderer, and
+       ;; the two arms now resolve one the same way.
+       ;;
+       ;; `render-view` also owns the two misses this branch used to hand-roll
+       ;; or swallow. A `:component` naming an unregistered view degrades to
+       ;; the same message via `reagent-render`; an unregistered substrate now
+       ;; degrades LOUDLY to `substrate :<id> is not registered` instead of
+       ;; silently painting Reagent — which is the user-visible half of this
+       ;; fix. Both are FRAGMENT-level; the grid keeps its own CELL-level pair,
+       ;; and `render-view`'s docstring says why the two are not folded.
+       ;;
+       ;; Decoration stays HERE, exactly once. `render-decorated-view` bundles
+       ;; render + decorate, but resolves the decorator refs itself, WITHOUT
+       ;; the mode / cell-override `run-opts` threaded into `resolve-decorators`
+       ;; above (see that binding's comment — an `[:arg …]` resolvable only
+       ;; through a mode layer throws without them). Calling it here would
+       ;; either decorate twice or lose those opts, so the canvas consumes the
+       ;; render half and keeps its own `safe-decorated-view` wrap.
+       ;;
+       ;; The variant's frame is already allocated; scope the rendered view's
+       ;; subscribe / dispatch to it (scope-only) via the merged
+       ;; `rf/frame-provider {:frame …}` shape, which routes through Reagent's
+       ;; `:r>` interop head so the namespace of a `:story.x/y`-shaped variant
+       ;; id survives the React-context round trip (a plain `[:> Provider …]`
+       ;; mount calls `(name kw)` on prop values and drops the namespace before
+       ;; React sees it).
+       ;;
+       ;; Stamp `data-rf-story-variant-root` on the immediate wrapper around
+       ;; the user-authored decorated view so the a11y panel (ui/a11y.cljs) can
+       ;; scope axe-core's scan to ONLY the variant's rendered tree — excluding
+       ;; the surrounding Story chrome (title bar, share button, open-in-editor
+       ;; chip, panels, sidebar, toolbar). Without this marker axe-core's
+       ;; `run()` against `document.body` flags Story's own UI as the source of
+       ;; violations, which is wrong: Story chrome a11y is Story's concern, not
+       ;; the variant author's.
+       ^{:key (str "single-" variant-id)}
+       [rf/frame-provider {:frame variant-id}
+        [:div {:key (str "variant-root:" (pr-str variant-id))
+               :data-rf-story-variant-root (pr-str variant-id)}
+         ;; Bind the variant's resolved view-state
+         ;; subscription overrides for the view-render extent (a no-op
+         ;; wrapper when the variant authors none).
+         [sub-overrides-scope sub-ovr
+          (safe-decorated-view
+            (multi-substrate/render-view
+              (first substrates) variant-id view-id eff-args)
+            (:hiccup decorator-pack)
+            eff-args)]]])
      (render-errors (:errors decorator-pack))
      (render-assertions assertions)]))
 

--- a/tools/story/src/re_frame/story/ui/multi_substrate.cljs
+++ b/tools/story/src/re_frame/story/ui/multi_substrate.cljs
@@ -318,6 +318,35 @@
       (when (seq (:substrates story-body))   (:substrates story-body))
       #{host-substrate}))
 
+(defn single-render-substrate
+  "Pick the ONE substrate a single-tree render paints under, given the
+  variant's declared substrate set and the host default. Pure data → data.
+
+  The side-by-side grid renders every declared substrate; a single-tree
+  render — the `render-variant` host hook — has to choose one, and the
+  choice is constrained by a rule this ns had no way to state before
+  rf2-3afns: **never paint under a substrate the variant did not declare.**
+
+  - Exactly one declared → that one. This is the whole point: a variant
+    declaring `#{:uix}` paints under `:uix`.
+  - More than one declared → `host-default` when the variant actually
+    declared it (the overwhelmingly common `#{:reagent :uix}` case, whose
+    behaviour is therefore unchanged), otherwise the name-sorted first of
+    the declared set. Sorted rather than `first`, because `first` over a
+    set of two is not a decision, it is whatever the hash order was.
+  - Nothing declared → `host-default`.
+
+  Choosing a single tree for a MULTI-substrate variant is a policy this
+  fn pins, not a feature: `render-variant` returns one render result and
+  always did. The grid remains the surface that shows all of them."
+  [substrates host-default]
+  (let [declared (set substrates)]
+    (cond
+      (empty? declared)                  host-default
+      (= 1 (count declared))             (first declared)
+      (contains? declared host-default)  host-default
+      :else                              (first (sort-by name declared)))))
+
 ;; ---- the multi-substrate grid component ---------------------------------
 
 (defn multi-substrate-grid

--- a/tools/story/test/re_frame/story/ui/canvas_substrate_routing_cljs_test.cljs
+++ b/tools/story/test/re_frame/story/ui/canvas_substrate_routing_cljs_test.cljs
@@ -1,0 +1,264 @@
+(ns re-frame.story.ui.canvas-substrate-routing-cljs-test
+  "rf2-3afns — the canvas SINGLE-PANE branch and the `render-variant` host
+  hook must resolve the renderer through the substrate registry, keyed on the
+  variant's DECLARED substrate.
+
+  ## The defect this namespace is the witness for
+
+  Story's substrate abstraction is an open runtime registry with a public
+  `register-substrate!` — and the default render path did not use it.
+  `canvas/canvas-inner` used the declared substrate set only as a COUNT: a set
+  of size one fell to the `:else` branch, which called `(rf/view view-id)`
+  itself and embedded the result as a Reagent hiccup vector.
+  `canonical/render-host-scope` passed a LITERAL `:reagent` into the shared
+  seam. So a variant declaring `:substrates #{:uix}` — a set of size one,
+  which is exactly what a single-substrate UIx story looks like — rendered
+  under REAGENT, and the user was not told.
+
+  ## Why a green compile proved nothing, and what these tests do instead
+
+  The bug was a working code path rendering the WRONG thing, which compiles
+  perfectly. Every test here therefore DISTINGUISHES WHICH SUBSTRATE ACTUALLY
+  RENDERED: the variant's `:component` resolves to a Reagent view emitting
+  `reagent-view-render`, while the stub registered under `:uix` emits
+  `uix-stub-render`. Asserting the uix marker is present AND the reagent
+  marker is absent is the whole point — either assertion alone would pass on
+  a path that rendered both, or neither.
+
+  The existing coverage could not catch this. `render_shell_cljs_test`'s
+  `:uix` arms drive `multi-substrate-grid` DIRECTLY, and
+  `story_multi_substrate_cljs_test` covers `render-view` on its own terms —
+  neither goes anywhere near `canvas-inner`, which is the path almost every
+  story takes.
+
+  ## Registry hygiene
+
+  `substrate->render-fn` is a `defonce` atom that `story/clear-all!` does not
+  touch, so a `:uix` stub registered here would leak into every namespace that
+  runs after this one — including `render_shell_cljs_test`'s
+  `unregistered-substrate-renders-inline-error-cell`, whose precondition is
+  that `:uix` is ABSENT. The `:after` fixture dissocs it.
+
+  Sub-millisecond per case; no DOM mount, no React, no Playwright."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.frame :as frame]
+            [re-frame.machines :as machines]
+            [re-frame.registrar :as registrar]
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.story :as story]
+            [re-frame.story.loaders :as loaders]
+            [re-frame.story.render :as render]
+            [re-frame.story.ui.canvas :as canvas]
+            [re-frame.story.ui.multi-substrate :as multi-substrate]
+            [re-frame.story.ui.state :as state]
+            [re-frame.story.test-helpers.e2e-multi-frame :as e2e]
+            [re-frame.subs :as subs]))
+
+;; ---- fixtures ------------------------------------------------------------
+
+(declare register-probe-views!)
+
+(defn- reset-all! []
+  (story/clear-all!)
+  (registrar/clear-all!)
+  (reset! frame/frames {})
+  (try (rf/init! plain-atom/adapter) (catch :default _ nil))
+  ;; EP-0001 (rf2-vzld77 / rf2-ixb0bq): machine snapshots are durable
+  ;; RUNTIME-DB state at [:rf.runtime/machines :snapshots <id>] — the framework
+  ;; `:rf/machine` sub reads the runtime-db partition, NOT the retired app-db
+  ;; `:rf/runtime` path. Mirror `re-frame.machines`. Without it the lifecycle
+  ;; machine cannot resolve and the canvas reads `:pre-mount` indefinitely.
+  (subs/reg-runtime-sub :rf/machine
+    (fn [runtime-db [_ machine-id]]
+      (get-in runtime-db [:rf.runtime/machines :snapshots machine-id])))
+  (machines/reset-timers!)
+  (loaders/clear-watchers!)
+  (canvas/reset-first-rendered!)
+  (state/reset-shell-state!)
+  (story/install-canonical-vocabulary!)
+  (frame/ensure-default-frame!)
+  ;; Start every case from a KNOWN-EMPTY :uix slot. Individual tests register
+  ;; the stub when they want the registered path; the unregistered-substrate
+  ;; test wants it absent.
+  (multi-substrate/unregister-substrate! :uix)
+  (register-probe-views!))
+
+(defn- restore-registry! []
+  (multi-substrate/unregister-substrate! :uix))
+
+(use-fixtures :each {:before reset-all! :after restore-registry!})
+
+;; ---- probe views + variants ----------------------------------------------
+
+;; The two markers that make "which substrate rendered?" answerable. If the
+;; canvas resolves through `rf/view` (the pre-rf2-3afns Reagent-pinned path)
+;; the tree carries `reagent-view-render`; if it resolves through the registry
+;; it carries `uix-stub-render`. They are mutually exclusive by construction.
+
+(defn- reagent-probe-view [_args]
+  [:div {:data-test "reagent-view-render"} "rendered under reagent"])
+
+(defn- uix-stub-render
+  "Stand-in for a host-registered UIx render fn. The real one would build a
+  React element; this returns hiccup so the test can walk it without a React
+  render cycle. What matters is WHICH fn the canvas reached, not what it built."
+  [_variant-id view-id _eff-args]
+  [:div {:data-test "uix-stub-render"} (str "rendered under uix: " (pr-str view-id))])
+
+(defn- register-probe-views! []
+  (rf/reg-view* :views/probe reagent-probe-view)
+  (story/reg-story* :story.substrate-routing {:doc "rf2-3afns witness story"})
+  ;; `:loaders` is declared so `events-only-variant?` returns false — the only
+  ;; condition that matters for the `loading-phase?` skeleton gate. The test
+  ;; drives the lifecycle machine directly, so the slot needs no real event.
+  (story/reg-variant* :story.substrate-routing/uix-only
+    {:doc        "Declares ONE substrate, and it is not Reagent."
+     :component  :views/probe
+     :substrates #{:uix}
+     :loaders    [[:noop/loader]]})
+  (story/reg-variant* :story.substrate-routing/reagent-only
+    {:doc        "Declares ONE substrate, Reagent — the unchanged baseline."
+     :component  :views/probe
+     :substrates #{:reagent}
+     :loaders    [[:noop/loader]]}))
+
+;; ---- helpers -------------------------------------------------------------
+
+(def ^:private canvas-inner @#'canvas/canvas-inner)
+
+(defn- ready-tree
+  "Drive `variant-id`'s lifecycle to `:ready`, then render the canvas's inner
+  tree and expand it to plain hiccup. `:ready` + the first-rendered sentinel
+  is what elides the skeleton so the render reaches the substrate branch at
+  all — a skeleton tree carries NEITHER marker and would make both assertions
+  fail for the wrong reason."
+  [variant-id]
+  (rf/make-frame {:id variant-id})
+  (loaders/mount! variant-id)
+  (loaders/start-loaders! variant-id)
+  (loaders/finish-loaders! variant-id)
+  (loaders/finish-events! variant-id)
+  (canvas/mark-variant-rendered! variant-id)
+  (e2e/expand-tree (canvas-inner variant-id)))
+
+(defn- rendered-under-uix? [tree]
+  (some? (e2e/find-by-test-id tree "uix-stub-render")))
+
+(defn- rendered-under-reagent? [tree]
+  (some? (e2e/find-by-test-id tree "reagent-view-render")))
+
+;; ===========================================================================
+;; THE WITNESS — the canvas single-pane path honours the declared substrate
+;; ===========================================================================
+
+(deftest single-pane-renders-through-the-declared-substrate
+  (testing "rf2-3afns — a variant declaring `:substrates #{:uix}` renders
+            through the render fn REGISTERED FOR :uix, not through Reagent.
+            This is the bead's defect stated as an assertion: before the fix
+            the canvas `:else` branch called `(rf/view view-id)` itself, so
+            this tree carried `reagent-view-render` and no uix marker at all."
+    (story/register-substrate! :uix uix-stub-render)
+    (let [variant-id :story.substrate-routing/uix-only
+          tree       (ready-tree variant-id)]
+      (is (rendered-under-uix? tree)
+          "the canvas reached the :uix render fn — the registry is ON the
+           default path, not merely present in it")
+      (is (not (rendered-under-reagent? tree))
+          "and it did NOT also paint Reagent — a UIx user gets a UIx render,
+           which is the whole defect (a silent Reagent render is what they
+           got before)")
+      (story/destroy-variant! variant-id))))
+
+(deftest single-pane-substrate-is-resolved-not-counted
+  (testing "rf2-3afns — the substrate SET SIZE decides grid-vs-single-pane and
+            nothing else. A one-element set is not a licence to assume
+            Reagent: swap the sole declared substrate and the renderer swaps
+            with it, with the count held constant at one."
+    (story/register-substrate! :uix uix-stub-render)
+    (let [uix-tree     (ready-tree :story.substrate-routing/uix-only)
+          reagent-tree (ready-tree :story.substrate-routing/reagent-only)]
+      (is (and (rendered-under-uix? uix-tree)
+               (not (rendered-under-reagent? uix-tree)))
+          "#{:uix} → the uix render fn")
+      (is (and (rendered-under-reagent? reagent-tree)
+               (not (rendered-under-uix? reagent-tree)))
+          "#{:reagent} → the built-in reagent render fn (the baseline this
+           fix must not disturb — the same count, the other renderer)")
+      (story/destroy-variant! :story.substrate-routing/uix-only)
+      (story/destroy-variant! :story.substrate-routing/reagent-only))))
+
+(deftest single-pane-says-so-when-the-substrate-is-unregistered
+  (testing "rf2-3afns — the user-visible half of the fix. With :uix declared
+            but NOT registered, the single pane must say so rather than
+            silently painting Reagent. Silence was the defect's real cost: a
+            UIx user got a Reagent render and no signal that anything was
+            wrong."
+    (is (not (contains? @multi-substrate/substrate->render-fn :uix))
+        "precondition: :uix absent from the registry")
+    (let [variant-id :story.substrate-routing/uix-only
+          tree       (ready-tree variant-id)
+          text       (e2e/text-nodes tree)]
+      (is (re-find #"is not registered" text)
+          "the miss is named — `render-view`'s FRAGMENT-level diagnostic,
+           the counterpart to the grid's cell-level error cell")
+      (is (re-find #"uix" text)
+          "and it names WHICH substrate, so the author knows what to
+           register")
+      (is (not (rendered-under-reagent? tree))
+          "it did NOT fall back to Reagent — falling back silently is the
+           bug, not the remedy")
+      (story/destroy-variant! variant-id))))
+
+;; ===========================================================================
+;; render-variant's host hook — the second pinned site
+;; ===========================================================================
+
+(deftest render-variant-host-honours-the-declared-substrate
+  (testing "rf2-3afns — `canonical/render-host-scope` passed a LITERAL
+            :reagent into the shared seam, so `render-variant` painted a
+            #{:uix} variant under Reagent too. The canvas and the host agreed
+            with each other only because both were wrong the same way; they
+            must now agree by both being right."
+    (story/register-substrate! :uix uix-stub-render)
+    (let [result (render/render-variant :story.substrate-routing/uix-only)
+          tree   (e2e/expand-tree (:rendered result))]
+      (is (= :rendered (:status result))
+          "the CLJS canonical vocabulary installs the host → :rendered")
+      (is (rendered-under-uix? tree)
+          "render-variant painted through the :uix render fn")
+      (is (not (rendered-under-reagent? tree))
+          "and not through Reagent")
+      (story/destroy-variant! :story.substrate-routing/uix-only))))
+
+;; ===========================================================================
+;; single-render-substrate — the policy, on its own terms
+;; ===========================================================================
+;;
+;; A single-tree render has to reduce a declared SET to one substrate. The
+;; rule the canvas and the host both depend on: never paint under a substrate
+;; the variant did not declare.
+
+(deftest single-render-substrate-policy
+  (testing "one declared substrate wins outright — the case the whole bead is
+            about"
+    (is (= :uix (multi-substrate/single-render-substrate #{:uix} :reagent)))
+    (is (= :reagent (multi-substrate/single-render-substrate #{:reagent} :reagent))))
+
+  (testing "nothing declared falls back to the host default"
+    (is (= :reagent (multi-substrate/single-render-substrate nil :reagent)))
+    (is (= :reagent (multi-substrate/single-render-substrate #{} :reagent))))
+
+  (testing "a multi-substrate variant that DECLARED the host default keeps it
+            — the common #{:reagent :uix} case is behaviour-unchanged"
+    (is (= :reagent (multi-substrate/single-render-substrate #{:reagent :uix} :reagent))))
+
+  (testing "a multi-substrate variant that did NOT declare the host default
+            gets a declared one, chosen deterministically by name rather than
+            by hash order — never the undeclared default"
+    (let [picked (multi-substrate/single-render-substrate #{:uix :custom} :reagent)]
+      (is (contains? #{:uix :custom} picked)
+          "the pick is one the variant actually declared")
+      (is (= :custom picked)
+          "and it is name-sorted, so the choice is a decision rather than
+           whatever the set's hash order happened to be"))))


### PR DESCRIPTION
Fixes **rf2-3afns** — a live defect with a UIx user today, not a hicasso feature.

## What I found at the two cited sites

I located both by content, not line number, then read the surrounding branch. Both claims held exactly as the bead stated them.

**1. `tools/story/src/re_frame/story/ui/canvas.cljs:498`** — the declared substrate set used only as a count:

```clojure
multi?         (and variant-id (> (count substrates) 1))
```

Located with `grep -n "count substrates\|multi?"`, which returned `:498` (the binding), `:560` (the title-bar substrate list) and `:599` (the `cond` arm). A set of size one falls through to `:else` at `:609-644`, which read:

```clojure
:else
(let [resolved-view (rf/view view-id)]
  (if resolved-view
    ... (safe-decorated-view [resolved-view eff-args] ...)
```

Straight to the framework view registry, embedded as a Reagent hiccup vector. `substrate->render-fn` was never consulted, so the `:reagent` registry entry was dead code on this path.

**2. `tools/story/src/re_frame/story/canonical.cljc:126-127`** — the `render-variant` host hook:

```clojure
(ui-multi-substrate/render-decorated-view
  :reagent frame view effective-args decorators)
```

Located with `grep -n "render-decorated-view\|:reagent"`, which returned `:110` and `:136` (docstring references to the shared seam) and `:126-127` (the call). Registry-based but pinned by a literal.

So a story declaring `:substrates #{:uix}` rendered under Reagent, and the canvas and `render-variant` agreed with each other only because both were wrong the same way.

## The fix

Both sites now resolve the renderer through `substrate->render-fn` — the same lookup the side-by-side grid already used. The count decides grid vs single pane and **nothing else**.

- **`canvas.cljs`** — the `:else` branch calls `multi-substrate/render-view` with `(first substrates)`. The `data-rf-story-variant-root` a11y anchor, the `frame-provider` scope and the `sub-overrides-scope` binding are all preserved unchanged.
- **`canonical.cljc`** — reads the declared set off the compiled plan's `[:world :substrates]`, which already rides `render-inputs`' `:plan`, so `render.cljc` needed no change.
- **`multi_substrate.cljs`** — adds `single-render-substrate`, the pure reduction from a declared set to the one substrate a single-tree render can paint, under one rule: **never paint under a substrate the variant did not declare.** Multi-substrate variants declaring `:reagent` are behaviour-unchanged.

**Decoration happens exactly once.** The bead flagged the double-decorate trap. `render-decorated-view` bundles render + decorate but resolves decorator refs *itself*, without the mode / cell-override `run-opts` the canvas threads into `resolve-decorators` (see that binding's own comment — an `[:arg …]` resolvable only through a mode layer throws without them). So the canvas consumes the render half (`render-view`) and keeps its own `safe-decorated-view` wrap, rather than calling `render-decorated-view` and losing those opts.

**The two-level miss behaviour is kept, not folded.** `render-view`'s fragment-level diagnostic and `safe-render-cell`'s cell-level error cell remain separate, as that docstring defends. The canvas's own hand-rolled missing-view branch is gone because it hard-coded the *Reagent* resolution — `reagent-render` returns the same message, and each substrate's render fn now owns its own miss.

**The user-visible half:** a declared-but-unregistered substrate now degrades loudly to `substrate :uix is not registered` instead of silently painting Reagent. The silence was the defect's real cost.

## The witness, and its failing-without-the-fix proof

A green compile proves nothing here — the bug is a working path rendering the *wrong* thing. So every test in `canvas_substrate_routing_cljs_test.cljs` **distinguishes which substrate actually rendered**: the variant's `:component` resolves to a Reagent view emitting `reagent-view-render`, while the stub registered under `:uix` emits `uix-stub-render`. Asserting the uix marker present **and** the reagent marker absent is the point.

Existing coverage could not have caught this: `render_shell_cljs_test`'s `:uix` arms drive `multi-substrate-grid` directly and `story_multi_substrate_cljs_test` covers `render-view` on its own terms — neither reaches `canvas-inner`.

**Proof it fails without the change.** I committed the fix, then reverted `canvas.cljs` and `canonical.cljc` to `origin/main` (keeping the helper and the test so the failure is behavioural, not a compile abort) and re-ran the full CLJS suite.

Revert verified by match count, not byte delta: the `(multi-substrate/render-view` call count went `1 -> 0`, `resolved-view (rf/view view-id)` came back at count 1, and the literal `:reagent frame view effective-args decorators` came back at count 1.

Captured exit code **`EXIT=1`**, `Ran 13930 tests containing 70352 assertions. 7 failures, 2 errors.` All 9 are in the witness namespace, across exactly the 4 behavioural tests; `single-render-substrate-policy` still passed, and no other namespace failed. The test count held at **13930**, identical to the green run — the revert was scoped.

The failure text quotes the defect verbatim. For a variant declaring `:substrates #{:uix}` with `:uix` unregistered, the canvas text read:

```
expected: (re-find #"is not registered" text)
  actual: (not (re-find #"is not registered"
                ":story.substrate-routing/uix-only-> :views/proberendered under reagent"))
```

`rendered under reagent` — for a variant that declared UIx. And:

```
expected: (not (rendered-under-reagent? tree))
  actual: (not (not true))
```

## Quality gates

Run from `C:/Users/miket/code/re-frame2-worktrees/storyreg-3afns`, on the final rebased base (`origin/main` = `fce250e0fb`). Every exit code below is the one **I captured** via `echo "EXIT=$?"` on the same command line, never one the harness reported — they disagreed twice in this session (the harness called two of these runs 0 when the captured value was 1).

| Gate | Captured exit | Result |
|---|---|---|
| `scripts/test-fast-pr.sh` (pre-checkin spine, absolute path) | **`EXIT=0`** | pass; its CLJS lane ran 13930 tests / 70350 assertions, 0 failures, 0 errors |
| `npm run test:cljs` (standalone, pre-rebase) | **`EXIT=0`** | 13930 tests, 70350 assertions, **0 failures, 0 errors** |
| `clojure -M:test` in `tools/story` (CI job `jvm-tools-story`) | **`EXIT=0`** | 1835 tests, 6747 assertions, **0 failures, 0 errors** |
| `python scripts/check_doc_slugs.py` (for the `.md` edit) | **`EXIT=0`** | pass |
| `npm run test:cljs` with the fix REVERTED (witness proof) | **`EXIT=1`** | 7 failures, 2 errors — all in the witness namespace |
| `clojure -M:test` with a PLANTED fault (tree proof) | **`EXIT=1`** | 1 failure — see below |

No gate was skipped. The fast-PR-spine-versus-required-CI gap is `python scripts/check_fast_pr_gap.py --list` (TESTING.md:121), which reports 106 required checks the spine does not decide; `jvm-tools-story` is among them, which is why I ran it directly.

**Which tree each gate read.** The CLJS gate prints its root, and it printed mine: `shadow-cljs - config: C:\Users\miket\code\re-frame2-worktrees\storyreg-3afns\implementation\shadow-cljs.edn`. The JVM story gate prints nothing, so the proof is red from a planted fault.

**Plant proof.** These files are CRLF, so I verified the write by hashing the line rather than measuring bytes. Target: `plan.cljc`'s `(assoc :substrates (:substrates ctx))` — the very slot the `canonical.cljc` fix reads, so the plant also confirms that slot is real and JVM-covered.

- Before: match count **1**, line hash `68c513a045c0ce4f…`
- After planting `:substrates-PLANT-3afns`: original-line match count **0**, planted line present, hash `5baa10b6a34b51d7…`
- Restored: match count back to **1**, hash back to `68c513a045c0ce4f…`, plant count 0

Planted run: captured **`EXIT=1`**, `Ran 1835 tests containing 6747 assertions. 1 failures, 0 errors.` — failing at `render_test.cljc:80`, `expected: (= #{:uix :reagent} (:substrates w))`. The test and assertion counts are **identical to the green control (1835 / 6747)**, so the plant was scoped to one assertion and stopped no namespace.

## Scope

- **I did not widen the substrate enum.** `schemas.cljc:288` is still `[:set [:enum :reagent :uix]]` and `schemas.cljc` is not in this diff.
- **I added no hicasso support.** `git diff origin/main...HEAD | grep -ci hicasso` returns **0**. That work is rf2-2dbpd, sequenced behind this bead and behind an operator ruling.
- **Story's own chrome is out of scope.** Of the 39 src files that `:require` reagent, 37 are under `story/ui/` — Story's own interface, not the subject's substrate. Untouched, and correctly so.

## Spec

`tools/story/spec/003-Render-Shell.md` gains a `### One declared substrate — the single pane` subsection under §Multi-substrate side-by-side rendering. The shipped behaviour did change, so per the bead this is updated rather than waived: the spec previously described only the >=2 case and was silent on what one declared substrate does. Per rf2-5gka Story carries no same-PR spec-sync *obligation*; this is the weaker `tools/README.md` convention, met.

**Verified by hand, since `mkdocs build --strict` does not cover this tree:** the new subsection adds one `###` heading, introduces no new links, and adds no tables — so there are no column counts to check. `scripts/check_doc_slugs.py` (which does validate `tools/*/spec`) passed with captured `EXIT=0`.

## Follow-up filed, deliberately not fixed here

**rf2-r4coe** (P2, discovered-from rf2-3afns) — `workspace.cljc`'s `variant-cell-inner` has the same `(let [resolved-view (rf/view view-id)] …)` shape. I left it out because it is a different question, not a bigger version of this one: the canvas already *resolved* the declared substrate set and then ignored it, so the fix was to stop ignoring a value in hand. The workspace cell has no substrate axis at all — it never reads `:substrates`, and its docstring pins it as "single substrate". Making it substrate-aware is new behaviour needing a ruling, and inventing one here would be the re-architecture this bead's brief rejects.
