### PR TITLE
fix(hicasso): the naming census could not see a name its own defining macro minted (rf2-wyazi)

### DIFF
--- a/implementation/hicasso/scripts/check_naming_census.py
+++ b/implementation/hicasso/scripts/check_naming_census.py
@@ -32,7 +32,22 @@ docstrings are dense with worked examples -- `(defhost modal Modal …)`,
 [props] …)`. Every one of those is PROSE, and a grep-derived roster counts
 all three as public names. So the source is read as CODE: [[code_only]]
 blanks strings, comments, character literals and reader-discarded forms,
-and what survives is walked for `(def…)` heads.
+and what survives is walked for `(def…)` heads -- QUALIFIED or not.
+
+
+## A DEFINING MACRO MAY BE QUALIFIED (rf2-wyazi)
+
+`(h/defview buffered-field …)`. A module mints its public surface with the
+package's OWN macro, so the head is `h/defview` rather than `defview`, and
+a pattern matching only bare `def*` heads does not see the name at all.
+That was this gate's state when it was armed: it reported 103 public names
+and 0 unrostered while `forms/buffered-field` shipped, was rostered and was
+taught, and it exited 0 the whole time. **It failed GREEN**, which is the
+direction an absence check has no defence against, and it is why the
+qualifier is in [[DEF_HEAD_RE]] rather than being left for the day a second
+one lands. `check_guide_samples.py`'s `_DEF_RE` already carried the same
+optional `alias/`, for the same reason, written down in its own comment;
+this is that character class ported, not a second pattern invented.
 
 
 ## A DEFINITION OPENS A LINE
@@ -58,6 +73,13 @@ definition. No such call exists in the ten namespaces -- both of
 -- and the failure it would produce is a phantom name reported UNROSTERED,
 which is a false RED. That is the safe direction, and it is why a bracket
 depth tracker is not being built for it.
+
+The qualified arm inherits that limit unchanged and widens nothing else: a
+line-opening `(alias/defaults …)` call would mint `defaults` the same way a
+line-opening `(defaults …)` already would. Measured on the ten namespaces
+the day the arm landed, the only line-opening qualified `def*` head in the
+tree is `forms.cljs`'s `(h/defview buffered-field …)`, and the CALLS note
+was unchanged -- still `evidence.cljs`'s two, still mid-line.
 
 
 ## The root is an ABSOLUTE argument, and it is printed
@@ -302,7 +324,9 @@ def code_only(text):
 # ---------------------------------------------------------------------------
 
 SYMBOL_TAIL = r"[A-Za-z0-9_.*+!?<>=$%&/'-]"
-DEF_HEAD_RE = re.compile(r"\((def" + SYMBOL_TAIL + r"*)")
+# The optional `alias/` is `check_guide_samples.py`'s `_DEF_RE` character class,
+# ported unchanged and for that gate's own stated reason (rf2-wyazi).
+DEF_HEAD_RE = re.compile(r"\((?:[a-zA-Z0-9.*+!?<>=_-]+/)?(def" + SYMBOL_TAIL + r"*)")
 NAME_RE = re.compile(r"[A-Za-z*+!?<>=$%&_-]" + SYMBOL_TAIL + r"*")
 
 
@@ -573,6 +597,25 @@ def self_test():
     checks += 1
     print("  ok  an unknown `def*` head is public; a computed name is reported")
 
+    # A NAMESPACE-QUALIFIED defining macro is still a definition (rf2-wyazi).
+    # `forms.cljs` mints its one public view with the package's OWN macro --
+    # `(h/defview buffered-field …)` -- and a pattern reading only bare `def*`
+    # heads was blind to it.  Blind in the ABSENCE direction, so the run stayed
+    # green: 103 names, 0 unrostered, exit 0, with a rostered name it never saw.
+    # The other two rules must survive the qualifier rather than be bypassed by
+    # it, so a qualified `defn-` and a qualified mid-line CALL are asserted here
+    # too.
+    minted, _, qualified_mid = roster(
+        "(h/defview qualified [props] 1)\n"
+        "(h/defn- quiet-qualified [] 2)\n"
+        "  (when x (n/defcomponent called-not-defined y))\n"
+    )
+    assert minted == ["qualified"], minted
+    assert qualified_mid == ["defcomponent"], qualified_mid
+    checks += 1
+    print("  ok  a QUALIFIED `def*` head is a definition -- and is still "
+          "subject to the private and open-the-line rules")
+
     # ---- the green baseline ----------------------------------------------
     rows, _, notes, _ = case("a fully rostered tree is GREEN", [])
     assert len(rows) == 3, rows
@@ -598,6 +641,16 @@ def self_test():
         [],
         two=seeded,
         ledger=_LEDGER + "| 4 | `g/seeded-export` |\n",
+    )
+
+    # ...and the same control minted the way `forms/buffered-field` is.  This
+    # one is the regression that stops the blind spot regrowing: it is a whole
+    # SYNTHETIC CORPUS rather than a roster case, so it fails the way the live
+    # gate failed -- a public name simply absent from a green run.
+    case(
+        "a SEEDED export minted by a QUALIFIED macro is caught",
+        ["g/qualified-export"],
+        two=_TWO + "(h/defview qualified-export [props] :escaped)\n",
     )
 
     # A private export is not a public name and owes no row.


### PR DESCRIPTION
Closes rf2-wyazi.

`implementation/hicasso/scripts/check_naming_census.py` is an armed CI job, pinned into
`all-required-passed`'s `needs:` (`.github/workflows/test.yml:1278`, `:6911`), whose whole
subject is *a public name that nobody wrote down*. It could not see a public name minted by
a namespace-qualified defining macro — and because that is the ABSENCE direction, it did not
go red about it. **It failed green**, reporting `103 public names … 0 NOT rostered` and
exiting 0 while the shipped surface was 104.

The change is one line: `check_guide_samples.py`'s `_DEF_RE` qualifier character class,
ported unchanged.

```diff
-DEF_HEAD_RE = re.compile(r"\((def" + SYMBOL_TAIL + r"*)")
+DEF_HEAD_RE = re.compile(r"\((?:[a-zA-Z0-9.*+!?<>=_-]+/)?(def" + SYMBOL_TAIL + r"*)")
```

## The count, before and after

Both runs are the live gate over this branch's worktree root, captured to a log with the
runner's own exit code echoed on the same command line.

| | census line | exit |
|---|---|---|
| before | `CENSUS: 103 public names across 10 shipped namespaces; 0 NOT rostered in naming-ledger.md` | 0 |
| after | `CENSUS: 104 public names across 10 shipped namespaces; 0 NOT rostered in naming-ledger.md` | 0 |

## Every name the blind spot was hiding

The bead named one. The instruction was to run the fixed pattern and report the *full* delta
rather than trusting that number. Diffing the two rosters row-for-row:

```
30a31
> OK   re-frame.hicasso.forms           forms/buffered-field
```

**Exactly one, and it is the one the bead named.** The surface is tidier than feared. The
independent sweep agrees: grepping all ten sources for a line-opening qualified `def*` head
returns eleven hits, ten of which are worked examples inside docstrings that `code_only()`
blanks before the roster ever sees them, leaving `forms.cljs:324` as the only one in code.

Two things did **not** move, which is the other half of the measurement:

- The name arrives **rostered** — `naming-ledger.md` row 32 already carries
  `` `forms/buffered-field` `` in a code span, so `0 NOT rostered` is unchanged and **no ledger
  edit was needed**. Confirmed by running it, not assumed.
- The CALLS note is unchanged — still `evidence.cljs`'s `defects` and `defects-message`, still
  mid-line. The qualifier minted no new phantom.

`re-frame.hicasso` still derives **16 door names**, so the docstring's standing claim that this
gate and `check_facade_inventory.py` agree on that door survives the change.

## The self-test did not cover the case

Asked directly: **no.** The proof is that the *unfixed* script's `--self-test` passes — captured
exit **0**. A gate whose self-test cannot see its own blind spot regrows it, so two arms were
added (10 checks → 12):

1. **Roster-level** — a qualified head is a definition, and the qualifier does not let a form
   slip the other two rules: `(h/defn- quiet-qualified …)` stays private, and
   `(n/defcomponent …)` mid-line is still reported as a CALL.
2. **Whole synthetic corpus** — a seeded `(h/defview qualified-export …)` with no ledger row,
   the mirror of the existing bare-`defn` positive control. This one fails the way the live
   gate failed: a public name simply absent from a green run.

Both redden when the qualifier alone is reverted:

| sabotage | exit | first failure |
|---|---|---|
| regex reverted | 1 | `AssertionError: []` at `assert minted == ["qualified"]` |
| regex reverted, roster assert neutralised so the corpus case is reached | 1 | `AssertionError: ('a SEEDED export minted by a QUALIFIED macro is caught', [])` |

## The planted qualified name

Run against a scratch mirror of the tree (a copy of `implementation/hicasso/**` plus the
ledger) so nothing inside the fence was written to. A qualified public view was planted at
line start in `motion.cljs`, both scripts were run over the same root, and the plant was then
removed and the restore verified by **hashing the file** — `sha256 ea615a2b612ddc98`, 5440
bytes, identical before and after, `match count 0`.

| | census line | exit |
|---|---|---|
| **unfixed** | `103 public names … 0 NOT rostered` → `OK: every public name … is rostered.` | **0** |
| **fixed** | `105 public names … 1 NOT rostered` → `UNROSTERED  re-frame.hicasso.motion  motion/qualified-escape-wyazi` | **1** |

The unfixed gate did not merely fail to flag the plant — it never counted it. That is the
blind spot, demonstrated by the red it now produces.

## The sibling's reasoning applied

Yes, and to the letter. `check_guide_samples.py:372-380` carries the optional `alias/` with a
comment naming *this exact name* as the reason: "`(h/defview buffered-field …)` mints
`forms/buffered-field`, and reading only bare `def*` heads would miss it". The two gates ask
different questions — is the verb the guide teaches resolvable, versus is the name written
down — but both answer theirs by asking a file *what names does it define*, and that
sub-question is identical. So the character class was ported unchanged rather than a second
pattern invented. It is read-only here: PR #8307 holds that file, and its 14 lines are digest
pins, not the regex, so this branch does not touch it.

One departure worth stating, because it is a departure: the sibling's `_DEF_RE` also narrows
the def-head tail to `[a-z-]*` and requires trailing `\s+`. Neither was ported. The census
deliberately takes a wider tail so an unknown `defsomething` counts as public — its own
self-test asserts that — and it consumes whitespace and metadata in a loop rather than in the
pattern. Porting those would have changed behaviour the bead did not ask about.

## Scope

One line, its comment, its self-test arms, and a docstring passage. Nothing under
`implementation/hicasso/src/**` was edited — the gate was corrected to see the source, not the
source bent to suit the gate. No second checker, no lint rule, no nag diagnostic (`rf2-sc1dt`),
and the census still reads its three inputs.

The docstring now states what the gate can and cannot see, since a gate's inputs are part of its
contract: a new `## A DEFINING MACRO MAY BE QUALIFIED` section, and the qualified arm's limit
recorded beside the existing one — a line-opening `(alias/defaults …)` call would mint
`defaults` exactly as a line-opening `(defaults …)` already would, which is the same false-RED
direction the file already argues is the safe one.

Nothing was found that is larger than this, so nothing was filed.

## Quality gates

**6 pass, 0 fail, 2 skipped** — plus 3 deliberate REDs above, which are proofs rather than
failures. Every exit code below is the one captured from the runner on the same command line,
never one reported about the run.

| gate | exit | result |
|---|---|---|
| `check_naming_census.py --self-test` | 0 | `self-test OK (12 checks)` — was 10 |
| `check_naming_census.py <root>` (live) | 0 | 104 names, 0 unrostered |
| `check_facade_inventory.py --self-test` + live | 0 | **16 names on `re-frame.hicasso`, 43 inventory rows** — unmoved |
| `scripts/check_fast_pr_gap.py --list` | 0 | no spine/CI gap |
| `scripts/check_gate_scheduling.py` | 0 | pass |
| `scripts/check_ci_reproduce_commands.py` | 0 | pass |

**Skipped, with reasons:**

- **`scripts/test-fast-pr.sh` in full** — its CLJS tier reds in a fresh worktree with no
  `node_modules`, and none was installed. Not a bare red: `check_fast_pr_gap.py --list` (the one
  path for the spine-versus-required-CI gap, TESTING.md:121) shows the `hicasso-naming-census`
  lane's spine coverage is exactly `check_naming_census.py --self-test` and
  `check_naming_census.py "$PWD"`, **both modes** — and both were run directly and are in the
  table above. This branch changes one Python gate script and nothing a CLJS build compiles.
- **`scripts/check_doc_slugs.py`** — no markdown changed. `naming-ledger.md` needed no edit,
  which the live run proves rather than assumes.
