### PR TITLE
docs(xray,template): Hicasso rides :rf.adapter/uix — fix two substrate rosters' reasoning (rf2-wtznc, rf2-48rk3)

### DIFF
--- a/tools/template/spec/001-Substrate-Variants.md
+++ b/tools/template/spec/001-Substrate-Variants.md
@@ -150,6 +150,27 @@ Reserved space — not implemented:
   `tools/story/spec/DESIGN-RATIONALE.md` §inline-substrate-failures);
   nothing in this repo has published yet. Once fired the template can
   ship reagent-slim as a third substrate choice.
+- **Hicasso.** Gated on the same trigger as reagent-slim — a published
+  `day8/re-frame2-hicasso` artefact. `release.yml` publishes twelve
+  coords and hicasso is not among them; `:hicasso-release` in
+  `test.yml` is an `:advanced` COMPILE gate, not a publish. An emitted
+  `deps.edn` names `{:mvn/version "{{rf2-version}}"}`, so scaffolding
+  this variant today would hand a new user a project whose very first
+  command fails to resolve its dependencies (rf2-48rk3).
+
+  **Hicasso is also not a substrate peer of `:reagent` and `:uix`, and
+  that ordering matters.** It mints no adapter — there is no
+  `:rf.adapter/hicasso` — and a Hicasso app installs the *UIx* adapter,
+  then mounts boundaries through it (`(rf/init! uix-adapter/adapter)`
+  then `(h/mount! …)`). What differs from the `:uix` variant is the
+  AUTHORING model, not the substrate. So the open design question is
+  whether this is a third value of `:substrate` at all, rather than a
+  flag on the UIx variant; it is not a mechanical fourth row in the
+  checklist above. Note also that the two `(not= substrate :reagent)`
+  guards in `hooks.clj` are a two-value idiom whose Story/SSR refusal
+  messages name UIx explicitly, and that Xray wiring keys off a `uix?`
+  boolean that a Hicasso host would need to join — Hicasso rides UIx,
+  so Xray cannot mount there either.
 - **TypeScript port.** Per Spec 000 — re-frame2 is a pattern, not a
   CLJS library. A `create-re-frame2-app` style npm template is
   reserved for a future iteration.

--- a/tools/xray/spec/008-Embedding-Contract.md
+++ b/tools/xray/spec/008-Embedding-Contract.md
@@ -447,8 +447,8 @@ namespace docstring (see `tools/xray/src/day8/re_frame2_xray/registry.cljs`).
 
 Xray renders pure hiccup, so it can mount only through a host adapter
 whose `:render` slot accepts hiccup render-trees — the **ratom family**
-(stock Reagent, Reagent-slim). The React-hook substrates (UIx and
-the first-party Freehand) share an **element-shaped** `render`
+(stock Reagent, Reagent-slim). The React-hook substrates (UIx, and the
+first-party Freehand and re-frame.ui) share an **element-shaped** `render`
 that hands the tree to React untouched; a hiccup shell mounted there
 reaches React children as raw CLJS data (fn-as-child console.error
 plus an uncaught MapEntry pageerror — rf2-qgfo4). On those hosts the
@@ -459,6 +459,17 @@ preload auto-open) MUST refuse cleanly: publish the
 nothing. Rendering Xray on the React-element substrates is future
 work (tracked from rf2-qgfo4); until then the supported render hosts
 are the ratom family.
+
+**Hicasso is not a fourth kind in this test — it rides UIx (rf2-wtznc).**
+Hicasso ships no adapter and mints no `:kind`; `:rf.adapter/hicasso` does
+not exist. A Hicasso application installs the UIx adapter and then mounts
+its boundaries through it, so
+`re-frame.substrate.adapter/current-adapter` answers `:rf.adapter/uix` on
+a Hicasso page and the refusal above already covers it — on the correct
+structural ground, since the element-shaped `:render` in play is UIx's.
+Any roster of the refused kinds should therefore read the absence of a
+hicasso member as load-bearing rather than as a gap to fill; naming one
+would invent a keyword the runtime never produces.
 
 Where Xray needs an
 imperative escape hatch (canvas refs, mount-lifecycle hooks for large

--- a/tools/xray/spec/011-Launch-Modes.md
+++ b/tools/xray/spec/011-Launch-Modes.md
@@ -467,12 +467,16 @@ load. It MAY schedule a bounded adapter-ready retry. Once the adapter
 is ready, it MUST find the configured layout host and mount the shell
 there. If the host is missing, it MUST emit the diagnostic described in
 §Layout host contract and leave the app running. If the installed
-adapter is a React-element substrate (UIx / Helix / Freehand —
-hosts whose `:render` cannot take the hiccup shell, per
+adapter is a React-element substrate (UIx / Helix / Freehand /
+re-frame.ui — hosts whose `:render` cannot take the hiccup shell, per
 [`008-Embedding-Contract.md`](./008-Embedding-Contract.md) §Adapter
 resolution), it MUST refuse the mount with the
 `:unsupported-substrate` diagnostic (status API + one `console.warn`)
-and leave the app running (rf2-qgfo4).
+and leave the app running (rf2-qgfo4). **A Hicasso host is one of these
+and needs no entry of its own**: Hicasso mints no adapter kind — there
+is no `:rf.adapter/hicasso` — so a Hicasso app installs the UIx adapter
+and mounts its boundaries through it, and the refusal fires on
+`:rf.adapter/uix` (rf2-wtznc).
 
 **The foundation side-effects fire on the preload path only (rf2-5w06uu).**
 The two-phase boot above runs at the load of

--- a/tools/xray/src/day8/re_frame2_xray/mount.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/mount.cljs
@@ -216,7 +216,20 @@
   (rf2-0yp7w) and Xray no longer reads a Freehand host at all (rf2-l86mm),
   but a stale co-loaded build could still present the kind, and refusing it
   costs nothing. The refusal is what makes the difference a diagnostic
-  instead of an uncaught React child error."
+  instead of an uncaught React child error.
+
+  HICASSO IS COVERED BY THE `:rf.adapter/uix` ENTRY, AND HAS NO ENTRY OF ITS
+  OWN BECAUSE IT MINTS NO KIND (rf2-wtznc). There is no `:rf.adapter/hicasso`
+  — Hicasso ships no adapter at all. A Hicasso host installs the UIx adapter
+  and then mounts Hicasso boundaries through it (`(rf/init!
+  uix-adapter/adapter)` then `(h/mount! …)`, both Hicasso testbeds), so
+  `re-frame.substrate.adapter/current-adapter` returns `:rf.adapter/uix` on a
+  Hicasso page and this set refuses it on the entry above — for the right
+  structural reason, since the `:render` doing the work IS the UIx adapter's
+  element-shaped one. The absence of a hicasso member is therefore correct
+  and load-bearing, not an oversight: adding one would name a kind the
+  runtime never produces, and reading it as a gap is the mistake this
+  paragraph exists to prevent."
   #{:rf.adapter/ui :rf.adapter/uix :rf.adapter/helix :rf.adapter/freehand})
 
 (defn- unsupported-substrate-diagnostic [kind]


### PR DESCRIPTION
Two beads, one commit each. Both turned out to be **reasoning** defects, not behaviour defects — the runtime is already correct in both places, and what was wrong was what a reader learns.

## The fact that decides both: `:rf.adapter/hicasso` does not exist

Confirmed at source on this base:

```
git grep -n 'rf\.adapter/hicasso' -- . ':(exclude).beads/*'
docs/design/retirement/freehand-and-ui.md:303:  ... `:rf.adapter/hicasso` does not exist anywhere in the tree.
```

Exactly **one** hit in the whole tracked tree, and it is prose asserting the keyword's non-existence. Enumerating every `:rf.adapter/*` value in the tree returns 17 keywords; the only `hicasso` one is that same prose line. Hicasso mints no adapter kind.

What it does instead, in both Hicasso testbeds (`hicasso_testbed/core.cljs:880`, `hicasso_hmr_testbed/core.cljs:456`):

```clojure
(rf/init! uix-adapter/adapter)
(rf/make-frame {:id frame-id :initial-events [[:tb/seed]]})
(h/mount! (js/document.getElementById "app") {:frame frame-id} [app {}])
```

So `current-adapter` — which returns `(:kind a :custom)` — answers `:rf.adapter/uix` on a Hicasso page.

**Neither roster invents a keyword.** Both express Hicasso as *a substrate whose React adapter is UIx*, and say explicitly that adding a `:rf.adapter/hicasso` member would name a kind the runtime never produces.

## rf2-wtznc — REASONING (behaviour was already correct)

`react-element-render-kinds` in `mount.cljs` refuses the inline Xray mount on element-shaped `:render` kinds. Because `:rf.adapter/uix` is already a member, **a Hicasso host already refuses correctly today** — and for the right structural reason, since the `:render` in play really is UIx's. No behaviour changed.

What was wrong is that a reader of that set could not learn this. Fixed in three places:

- `mount.cljs` — a docstring paragraph recording the provenance, in the same "defensive footing" register the file already uses for helix/freehand.
- `tools/xray/spec/011-Launch-Modes.md:470` — the roster prose.
- `tools/xray/spec/008-Embedding-Contract.md` §Adapter resolution — the section 011 *cites as the authority*. Fixing 011 while leaving its cited authority stale would have been half a repair.

`:rf.adapter/freehand` is **left alone** — it travels with rf2-0yp7w, as the bead directs.

**One adjacent drift found and fixed:** both spec rosters read "UIx / Helix / Freehand", omitting `:rf.adapter/ui`, which *is* in the live four-member set. Verified it belongs there — `re-frame.ui`'s adapter is built by `spine/make-react-adapter` (`implementation/ui/src/re_frame/ui/substrate.cljs:105`), element-shaped for the same reason Freehand is.

## rf2-48rk3 — my judgement: **genuine feature work, correctly deferred. Filed, not half-done.**

Not a roster fix. Two source facts, either one sufficient:

1. **The artefact is not published.** An emitted `deps.edn` names real Maven coords (`{:mvn/version "{{rf2-version}}"}`). `release.yml` publishes twelve coords; `day8/re-frame2-hicasso` is not among them, there is no `release-hicasso.yml`, and `:hicasso-release` in `test.yml` is an `:advanced` **compile** gate, not a publish. A `:hicasso` scaffold would hand a new user a project whose first `shadow-cljs watch app` cannot resolve its dependencies.

2. **Hicasso is not a substrate peer of `:reagent`/`:uix`.** It rides the UIx adapter; what differs is the *authoring* model, not the substrate. So "is this a third `:substrate` value at all, or a flag on the UIx variant?" is an open design question, not a mechanical fourth row in the spec's own "Adding a substrate" checklist.

Decisively, **the template's spec already has the rule for case 1**: its "Future variants" section defers `reagent-slim` on exactly this trigger — *"Gated on reagent-slim GA / first published artefact … nothing in this repo has published yet."* I recorded Hicasso in that same place on those same terms, with its trigger named, rather than writing code.

The note also flags the two traps the bead correctly predicted, both confirmed at source: the `(not= substrate :reagent)` guards at `hooks.clj:269,283` are a two-value idiom whose refusal messages name UIx explicitly, and Xray wiring keys off a `uix?` boolean (`hooks.clj:312`) a Hicasso host must join — it rides UIx, so Xray cannot mount there either.

**rf2-48rk3 stays OPEN** as the implementation bead. No code change.

## `tools/xray/spec/*` — UPDATED

Per the standing rule, in the same PR: `011-Launch-Modes.md` and `008-Embedding-Contract.md`. `tools/template/spec/001-Substrate-Variants.md` likewise carries the template bead's whole deliverable.

## Quality gates

Every number below is the exit code **I captured to a file**, never one the harness reported about the same run — the two disagreed twice here (see the two findings).

| Gate | Captured exit | Result |
|---|---|---|
| `npm run test:cljs` (`implementation`, `:node-test`) — **clean, fresh cache** | **0** | **13927 tests / 70339 assertions, 0 failures, 0 errors** (full recompile: 2392 files, 2391 compiled, 0 warnings) |
| `npm run test:cljs` — **sabotage run** | **1** | **1 error, correctly scoped** (see plant proof) |
| `clojure -M:test` in `tools/xray` (JVM) | 0 | 1320 tests / 6246 assertions, 0 failures, 0 errors — **but see finding 1: this gate does not reach `mount.cljs`** |
| `scripts/check_doc_slugs.py` (after each spec edit) | 0, 0 | Verified it scans `tools/xray/spec` (31 files) + `tools/template/spec` — its roots are `DEFAULT_ROOTS` **plus `tools/*/spec`** |
| `clj-kondo --fail-level error` on `mount.cljs` | 0 | 0 errors, 0 warnings. *Caveat:* local v2025.10.23 vs CI's pinned v2026.04.15 |

**Skipped, with reasons:**

- `implementation/hicasso/scripts/check_bundle_isolation.cjs` — requires a prebuilt `out/hicasso-release/main.js` (`npm run build:hicasso-release`). It reports `MISSING RELEASE BUNDLE`, a missing prerequisite rather than a violation. The contract it enforces is *nothing in `implementation/` may `:require` from `tools/`*; this diff adds no `:require` anywhere and touches **no file under `implementation/`**, so it cannot move that verdict.
- `scripts/test-fast-pr.sh` — **the full spine was not run.** The diff is one CLJS docstring plus three markdown files. I ran the lane that actually compiles `tools/xray/src` (`test:cljs`, sabotage-proven below) plus the doc and lint gates directly. Per `TESTING.md:121`, the one path for the fast-spine-versus-required-CI gap is `scripts/check_fast_pr_gap.py --list` (106 required checks the spine does not decide) — not a hand-written enumeration.

### Plant proof — hashed, not measured

Plant: removed `:rf.adapter/uix` from `react-element-render-kinds` — deliberately the exact entry this PR documents as covering Hicasso.

| | intact-line match count | file sha256 |
|---|---|---|
| before | **1** | `03390f31dd744f5b34bfcafc5aaa200c7d58f49001a95a4f57b733a3b45e1563` |
| planted | **0** | `57886b613d6234c7b9eb2e4d4a32d1c576bf04812df8b40598cd8bd85d34f1d6` |
| reverted | **1** | `03390f31dd744f5b34bfcafc5aaa200c7d58f49001a95a4f57b733a3b45e1563` |

Match count moved 1 → 0 → 1 and the hash returned to its exact original. The files are CRLF, so this was verified by hashing rather than by byte-delta.

**Scoped:** planted, the suite failed at `day8.re-frame2-xray.mount-cljs-test` / `open!-on-react-element-substrate-refuses-cleanly` — the test that pins this very set — and nowhere else. So `:rf.adapter/uix` covering Hicasso is **test-pinned, not merely asserted in prose**.

### Finding 1 — the nominated xray gate does not reach `mount.cljs` (a GREEN sabotage)

`clojure -M:test` in `tools/xray` returned **1320 tests / 6246 assertions, 0 failures** *with the plant in place* — byte-identical counts to the control. It is a JVM runner and cannot load a `.cljs` file, so it never sees `mount.cljs`. A worker nominating it as this file's gate would have shipped on a verdict about other code. The lane that does reach it is `npm run test:cljs` (`implementation/shadow-cljs.edn` puts `../tools/xray/src` + `../tools/xray/test` on the `:node-test` build), and that is the one proven red above.

### Finding 2 — a killed background run reported success, and its cache poisoned the next run

The first `test:cljs` attempt was killed mid-compile; the harness reported it "completed exit code 0" while **my `.exit` file was never written** and the log stopped at `dependencies updated`. The captured artefact is what caught it.

That kill left a corrupt shadow cache (`Failed reading cache … JsonEOFException`). The next *clean* run then failed with **7 errors** — all `ReferenceError: values__1982__auto___… is not defined`, i.e. gensym'd `clojure.test` macro locals, in `re-frame.resources-revision-substrate-cljs-test` and `re-frame.testbed.config-cljs-test`: namespaces this diff cannot reach, after an incremental 232-file compile. Deleting `implementation/.shadow-cljs` and recompiling all 2391 files returned **0 failures, 0 errors**. Recorded because that failure wears the costume of a real regression in unrelated code.

## Fence

Derived at start-up on **both** signals, not taken on trust:

- **Committed:** `git diff --name-only origin/main...<branch> -- tools/xray tools/template` across all **85** local branches and all **6** remote refs → **0 hits**.
- **Uncommitted:** `git status --porcelain -- tools/xray tools/template` inside **every** worktree in `git worktree list` → **0 hits**.

`tools/xray/**` and `tools/template/**` are free. Open PRs #8304 (`TESTING.md`, `spec/**`) and #8305 (`docs/design/hicasso/`) do not intersect. `storyreg-3afns` was read before touching any substrate-roster reasoning: it is Story canvas substrate routing and introduces no `hicasso`/`rf.adapter` vocabulary, so there was none to match. Nothing under `implementation/`, top-level `spec/`, `.github/workflows/`, `docs/` or `tools/story/` is touched.

## Corrections to the dispatch framing

- **This was briefed as a three-bead cluster; it is two.** `rf2-f0ajt` was already **CLOSED** before I started, as the later duplicate of `rf2-wtznc` (merged-PR audit #8301, 103 seconds apart). Its source evidence and two-file scope were already folded into `rf2-wtznc`. I acted on `rf2-wtznc`'s **description as amended by that audit note**, which is the current scope, and did not re-do f0ajt's work.
- **`rf2-wtznc` is P3/task, not P2/bug**, and has been retitled to *"document that Hicasso hosts ride `:rf.adapter/uix`; retire stale roster prose with Freehand"* — i.e. already re-scoped to documentation, which is what this PR does.
- **xray's hicasso-aware file count was 9, not 8** (`grep -rli hicasso tools/xray/src`). It is **10** after this PR, because `mount.cljs` joins the set — which is precisely the gap the bead asked to close.
