### PR TITLE
fix(story): settle a play step on the substrate's own commit, and route the workspace cell through the registry (rf2-ek9qb, rf2-r4coe)

### DIFF
--- a/tools/story/spec/017-Testing-Story.md
+++ b/tools/story/spec/017-Testing-Story.md
@@ -902,6 +902,46 @@ the existing framework drain and a flush-hook seam over it.
   `:provides`; the runner resolves them through the
   `:settled-boundary-hooks` late-bind slot and never reaches for
   `dispatch-sync` directly.
+
+  **Story SHIPS the producer for that slot** —
+  `re-frame.story.play.substrate-boundary`, installed from the canonical
+  installer chain. It names no substrate: it reads the optional
+  `:flush-render!` contract fn off the LIVE adapter
+  (`rf/current-adapter-spec`, Spec 006 §Adapter introspection) and, when it
+  finds one, declares `:provides :dom` with that synchronous commit
+  registered at the `:cljs-reactive` and `:dom` rungs. `flush-render!` is
+  the framework's substrate-neutral settle signal (Spec 006
+  §`flush-render!`) and the same primitive the pair MCP's own
+  dispatch-and-settle op builds on; reaching it through the installed
+  adapter rather than a named substrate API is required by
+  [Tool-Pair §Driving the render](../../../spec/Tool-Pair.md) — "a tool that
+  names `reagent.core/flush!` is non-conforming and breaks under UIx". An
+  adapter with no live commit (plain-atom, SSR) and a bare JVM run with no
+  adapter both fall back to `headless-flush-hooks`, so the headless floor
+  is unchanged. A host with a genuinely richer boundary — a browser runner
+  that settles layout and paint — re-registers the slot and wins it.
+
+- `settle-to!` — the flush phase on its own: run the registered flushes
+  `<= required` in ladder order, with the same `:timeout-ms` deadline
+  discipline, and settle **without dispatching**. `dispatch-and-settle!`
+  is `:dispatch!` followed by `settle-to!`, so there is one flush loop
+  rather than two. It does NOT refuse: the fail-closed `:cannot-run` check
+  belongs to `dispatch-and-settle!`, where refusing means an event is not
+  dispatched at all. A rung the hooks do not register is a no-op for that
+  rung.
+
+  **A step that reads or drives the DOM has its required boundary
+  established BEFORE it runs** (`runner-events/exec-step!`). `[:click …]`
+  must match its selector against the DOM as it currently stands, and a
+  folded `[:assert [:rf.assert/dom-* …]]` checkpoint must read the DOM the
+  preceding steps produced; both are preconditions, not afterthoughts.
+  Because the folded checkpoint carries the `:assert` tag — whose declared
+  boundary is deliberately `:headless`, its capability tokens rather than
+  its boundary gating the DOM requirement — the runner recovers the `:dom`
+  requirement from the assertion's own family (`dom-assertion-ids`), the
+  same set the assert executor routes on. Steps below `:cljs-reactive` are
+  untouched, and on a host whose hooks register no richer flush the whole
+  mechanism is inert.
 - `dispatch-and-settle!` — the entry point `[:dispatch event-vector]`
   lowers to: dispatch through the supplied `:dispatch!`, then run each
   registered flush whose level is `<= required` in ladder order. It

--- a/tools/story/src/re_frame/story/canonical.cljc
+++ b/tools/story/src/re_frame/story/canonical.cljc
@@ -27,6 +27,7 @@
             [re-frame.story.loaders      :as loaders]
             [re-frame.story.play         :as play]
             [re-frame.story.play.runner-events :as runner-events]
+            [re-frame.story.play.substrate-boundary :as substrate-boundary]
             [re-frame.story.registrar    :as registrar]
             [re-frame.story.render       :as render]
             [re-frame.story.runtime      :as runtime]
@@ -179,6 +180,13 @@
    install-late-bind-shims!
    layout-debug/install-canonical-layout-debug!
    ui-cofx/install-canonical-cofx!
+   ;; The `:settled-boundary-hooks` producer (rf2-ek9qb). Unconditional
+   ;; rather than CLJS-gated: it names no substrate — it reads
+   ;; `:flush-render!` off whatever adapter is seated — so it adds nothing
+   ;; to the JVM classpath, and on the JVM (no adapter) it resolves to the
+   ;; headless hooks the runner already defaulted to. Installing it in both
+   ;; readers keeps ONE settle story rather than a CLJS-only one.
+   substrate-boundary/install!
    #?@(:cljs [ui-multi-substrate/install-reagent-substrate!
               install-render-host!
               ui-open-in-editor/install!

--- a/tools/story/src/re_frame/story/late_bind.cljc
+++ b/tools/story/src/re_frame/story/late_bind.cljc
@@ -146,7 +146,28 @@
                                      can walk the rendered tree. The bare
                                      headless floor leaves it nil, so the
                                      executor refuses `:cannot-run` (never a
-                                     vacuous pass over a nil tree)."
+                                     vacuous pass over a nil tree).
+
+  - `:settled-boundary-hooks`       — an adapter-aware caller → the play
+                                     runner (`re-frame.story.play.runner-events/
+                                     current-flush-hooks`). Supplies the
+                                     flush-hooks map that decides how far a
+                                     step settles: `{:provides … :dispatch! …
+                                     :flush! {…} :timeout-ms …}` per
+                                     `re-frame.story.play.settled-boundary`.
+                                     Signature: `(f frame-id) → hooks-map`.
+                                     Story SHIPS the producer
+                                     (`play/substrate-boundary`, installed from
+                                     `canonical`), which reads `:flush-render!`
+                                     off the live adapter and declares
+                                     `:provides :dom` when it finds one. A host
+                                     with a richer boundary — a real browser
+                                     runner settling layout and paint —
+                                     re-registers and wins the slot. An absent
+                                     producer is a no-op: the runner falls back
+                                     to `headless-flush-hooks`, which is what
+                                     every host silently ran on before rf2-ek9qb
+                                     wired this one."
   )
 
 (defonce

--- a/tools/story/src/re_frame/story/play/runner_events.cljc
+++ b/tools/story/src/re_frame/story/play/runner_events.cljc
@@ -1135,6 +1135,63 @@
     (k result))
   nil)
 
+(defn- step-settle-boundary
+  "The boundary the substrate must already be AT for `step` to observe or
+  drive an honest DOM. Pure data → data.
+
+  Mostly this is the step's own `step-required-boundary`. The one place it
+  is not is the folded in-script checkpoint: a shipping
+  `[:assert-dom selector …]` has been rewritten to
+  `[:assert [:rf.assert/dom-* …]]` by the time it reaches the executor, and
+  `default-step-boundaries` maps the `:assert` tag to `:headless` on
+  purpose — 'the wrapped atom may need more (e.g. DOM); its capability
+  tokens, not its boundary, gate that'. So the boundary ladder alone
+  cannot see that this particular checkpoint reads the DOM. We recover it
+  from the atom's family, using the SAME `dom-assertion-ids` set
+  `exec-assert!` routes on, rather than re-deriving a second notion of
+  'this one is a DOM assertion'.
+
+  Tolerant: a malformed / non-vector assertion atom reads as its declared
+  boundary rather than throwing on the way to the executor that will
+  report it properly."
+  [step]
+  (let [declared (boundary/step-required-boundary step)]
+    (if (and (= :assert (runner/step-type step))
+             (let [atom-v (runner/step-assertion step)]
+               (and (vector? atom-v)
+                    (contains? assertions/dom-assertion-ids (first atom-v)))))
+      (boundary/max-boundary declared :dom)
+      declared)))
+
+(defn- settle-substrate-for-step!
+  "Establish `step`'s required settled-boundary BEFORE the step runs, via
+  the active flush-hooks. Returns a step-result when the settle refused /
+  errored (projected through the same `boundary-result->step` the dispatch
+  path uses, so a refusal reads identically wherever it arose), else nil.
+
+  Why BEFORE. A step that requires `:dom` requires it as a PRECONDITION:
+  `[:click …]` must match its selector against the DOM as it currently
+  stands, and `[:assert [:rf.assert/dom-text …]]` must read the DOM the
+  preceding steps produced. Establishing the boundary up front is also
+  what `dispatch-and-settle!` already does with its fail-closed refusal —
+  it decides before it acts, not after.
+
+  This is what retired the `setTimeout` 0 as Story's settle signal
+  (rf2-ek9qb). The run-loop's macrotask yield stays where it is: it drains
+  the MICROTASK queue after a synthetic DOM event, which is a different
+  job and still a real one. What it never did was ask the substrate to
+  COMMIT, and on a rAF-scheduled substrate no amount of yielding makes it.
+
+  Cheap and inert below `:cljs-reactive` — the overwhelming majority of
+  steps — and inert on any host whose hooks register no richer flush,
+  which is every headless host. So the JVM path is unchanged."
+  [frame-id idx step]
+  (let [required (step-settle-boundary step)]
+    (when (boundary/boundary>= required :cljs-reactive)
+      (boundary-result->step
+        idx step
+        (boundary/settle-to! frame-id (current-flush-hooks frame-id) required step)))))
+
 (defn exec-step!
   "Execute ONE step against `frame-id`. Returns a step-result record
   (per `runner/step-pass` / `step-fail` / `step-skip` / `step-exception`).
@@ -1151,24 +1208,30 @@
   (a hand-built step that bypassed resolution) is folded inline as a
   belt-and-braces guard so there is ONE in-script assertion executor and
   ONE assertion-record vocabulary — never a synthetic `:rf.assert/db` /
-  `:rf.assert/dom` rail."
+  `:rf.assert/dom` rail.
+
+  A step that requires a boundary richer than `:headless` has that
+  boundary ESTABLISHED first (`settle-substrate-for-step!`), so it runs
+  against a substrate that has committed rather than one that is about to."
   [frame-id idx step]
-  (let [stype (runner/step-type step)]
-    (case stype
-      :dispatch       (exec-dispatch!      frame-id idx step)
-      :dispatch-sync  (exec-dispatch-sync! frame-id idx step)
-      :assert         (exec-assert!        frame-id idx step)
-      ;; A raw shipping assertion step that escaped folding — fold it inline
-      ;; to the canonical checkpoint and run the ONE assert executor.
-      (:assert-db
-       :assert-dom)   (exec-assert! frame-id idx (assertions/fold-assert-step step))
-      :wait-until     (exec-wait-until!    frame-id idx step)
-      :flush-presence (exec-flush-presence! frame-id idx step)
-      :click          (exec-click!         frame-id idx step)
-      :type           (exec-type!          frame-id idx step)
-      :focus          (exec-focus!         frame-id idx step)
-      :wait           (runner/step-skip idx step)   ; driver handles the actual sleep
-      (runner/unknown-step idx step))))
+  (or
+    (settle-substrate-for-step! frame-id idx step)
+    (let [stype (runner/step-type step)]
+      (case stype
+        :dispatch       (exec-dispatch!      frame-id idx step)
+        :dispatch-sync  (exec-dispatch-sync! frame-id idx step)
+        :assert         (exec-assert!        frame-id idx step)
+        ;; A raw shipping assertion step that escaped folding — fold it inline
+        ;; to the canonical checkpoint and run the ONE assert executor.
+        (:assert-db
+         :assert-dom)   (exec-assert! frame-id idx (assertions/fold-assert-step step))
+        :wait-until     (exec-wait-until!    frame-id idx step)
+        :flush-presence (exec-flush-presence! frame-id idx step)
+        :click          (exec-click!         frame-id idx step)
+        :type           (exec-type!          frame-id idx step)
+        :focus          (exec-focus!         frame-id idx step)
+        :wait           (runner/step-skip idx step)   ; driver handles the actual sleep
+        (runner/unknown-step idx step)))))
 
 ;; ---- terminal assertions ------------------------------------------------
 ;;
@@ -1224,7 +1287,18 @@
   [frame-id atoms]
   (when (and config/enabled? (seq atoms))
     (doseq [[idx atom-v] (map-indexed vector atoms)]
-      (exec-assert! frame-id idx [:assert atom-v])))
+      (let [step [:assert atom-v]]
+        ;; Terminal assertions are the OTHER place a DOM atom is evaluated,
+        ;; so they get the same pre-read settle the in-script checkpoint
+        ;; gets (rf2-ek9qb). Without it the rule would be half-applied: a
+        ;; terminal `:rf.assert/dom-*` would read whatever the DOM happened
+        ;; to be when the script phase ended, which is settled only if the
+        ;; script's LAST step happened to be a DOM step. The result is
+        ;; discarded here exactly as the executor's own is — terminal
+        ;; assertions are not a runner step stream — and the commit is
+        ;; no-op-safe, so an already-settled substrate costs nothing.
+        (settle-substrate-for-step! frame-id idx step)
+        (exec-assert! frame-id idx step))))
   nil)
 
 ;; ---- single-step driver -------------------------------------------------

--- a/tools/story/src/re_frame/story/play/settled_boundary.cljc
+++ b/tools/story/src/re_frame/story/play/settled_boundary.cljc
@@ -246,6 +246,74 @@
      ;; default :cannot-run
      (cannot-run-refusal required provided step :flush-timeout))))
 
+;; ---- the flush phase -----------------------------------------------------
+
+(defn settle-to!
+  "Run `hooks`' registered flushes up to and including `required`, in
+  ladder order, WITHOUT dispatching anything. The flush half of
+  `dispatch-and-settle!`, factored out so there is ONE flush loop in the
+  codebase rather than a second copy of the ladder walk and its deadline
+  arithmetic.
+
+  Two callers, and the split between them is the point:
+
+  - `dispatch-and-settle!` calls it AFTER its `:dispatch!` hook, so
+    `[:dispatch …]` means dispatch-then-settle.
+  - the play runner calls it BEFORE a step that reads or drives the DOM
+    (`runner-events/exec-step!`), so such a step runs against a substrate
+    that has already committed — the guarantee its required boundary
+    names, established before the step rather than hoped for after it.
+
+  This fn does NOT refuse. `dispatch-and-settle!` owns the fail-closed
+  `:cannot-run` check because refusing there means the event is not
+  dispatched at all, which is a decision about a side effect; settling is
+  not. A rung the hooks do not register is simply a no-op for that rung
+  (the cheaper rungs still ran), so a headless host settles to `:headless`
+  and changes nothing — which is what makes calling this on every host
+  safe.
+
+  Returns `{:status :settled :boundary required}`, a `flush-timeout-result`
+  when the hooks' `:timeout-ms` budget is exceeded (re-checked after each
+  flush fn returns, terminal flush included), or `{:status :error …}` when
+  a flush fn throws. NEVER a silent pass."
+  ([frame-id hooks required] (settle-to! frame-id hooks required nil))
+  ([frame-id hooks required step]
+   (let [required (if (boundary? required) required :headless)
+         provided (hooks-provided-boundary hooks)]
+     (try
+       (let [flushes    (:flush! hooks)
+             timeout-ms (:timeout-ms hooks)
+             deadline   (when (number? timeout-ms)
+                          (+ (interop/now-ms) timeout-ms))
+             ;; Every registered level up to and including `required`, in
+             ;; ladder order. The headless flush is folded into `:dispatch!`
+             ;; (`drain-sync!`), so its hook is a no-op; the richer flushes
+             ;; carry the adapter's reactive / DOM work.
+             levels     (take-while #(boundary>= required %) boundary-levels)]
+         (loop [[level & more] levels]
+           (cond
+             ;; The deadline is re-checked BEFORE this branch returns so it
+             ;; also covers the TERMINAL flush: the last (richest) flush can
+             ;; run within budget on entry yet blow the wall-clock budget as
+             ;; it returns. Checking here — not only at the top of the next
+             ;; iteration — means an over-budget terminal flush refuses with
+             ;; a fail-closed `:flush-timeout` instead of a settled pass it
+             ;; did not earn.
+             (and deadline (> (interop/now-ms) deadline))
+             (flush-timeout-result required provided step)
+
+             (nil? level)
+             {:status :settled :boundary required}
+
+             :else
+             (do (when-let [f (get flushes level)]
+                   (f frame-id))
+                 (recur more)))))
+       (catch #?(:clj Throwable :cljs :default) e
+         {:status :error
+          :error  #?(:clj (.getMessage ^Throwable e) :cljs (str e))
+          :step   step})))))
+
 ;; ---- the dispatch-and-settle entry point ---------------------------------
 
 (defn dispatch-and-settle!
@@ -302,51 +370,20 @@
        ;; needs a richer boundary than the runner provides is refused.
        (cannot-run-refusal required provided step)
        (try
-         (let [dispatch!  (or (:dispatch! hooks) drain-sync!)
-               flushes    (:flush! hooks)
-               timeout-ms (:timeout-ms hooks)
-               deadline   (when (number? timeout-ms)
-                            (+ (interop/now-ms) timeout-ms))
-               ;; The flush levels to run: every registered level up to and
-               ;; including `required`, in ladder order. The headless flush
-               ;; is folded into `:dispatch!` (`drain-sync!`), so its hook is
-               ;; a no-op; the richer flushes carry the adapter's reactive /
-               ;; DOM work.
-               levels     (take-while #(boundary>= required %) boundary-levels)
-               ;; A replayed `[:dispatch evec {:rf.cofx …}]` step carries a
-               ;; captured recordable-coeffect envelope. The caller
-               ;; (`exec-dispatch!`) extracts it off the step and passes it as
-               ;; `dispatch-opts`; thread it into the dispatch opts (via the
-               ;; hook's optional 3-arity) so the handler's declared recordable
-               ;; coeffects replay from the recorded value rather than being
-               ;; restamped. Absent cofx uses the bare 2-arity call.
-               ]
+         (let [dispatch! (or (:dispatch! hooks) drain-sync!)]
+           ;; A replayed `[:dispatch evec {:rf.cofx …}]` step carries a
+           ;; captured recordable-coeffect envelope. The caller
+           ;; (`exec-dispatch!`) extracts it off the step and passes it as
+           ;; `dispatch-opts`; thread it into the dispatch opts (via the
+           ;; hook's optional 3-arity) so the handler's declared recordable
+           ;; coeffects replay from the recorded value rather than being
+           ;; restamped. Absent cofx uses the bare 2-arity call.
            (if (and (map? dispatch-opts) (seq dispatch-opts))
              (dispatch! frame-id event-vector dispatch-opts)
              (dispatch! frame-id event-vector))
-           ;; Run each flush, re-checking the `:timeout-ms` deadline after
-           ;; each returns. An over-budget flush phase stops the ladder and
-           ;; refuses with a fail-closed `:flush-timeout` (`flush-timeout-result`)
-           ;; rather than reporting a settled pass it did not earn.
-           (loop [[level & more] levels]
-             (cond
-               ;; The deadline is re-checked BEFORE this branch returns so it
-               ;; also covers the TERMINAL flush: the last (richest) flush can
-               ;; run within budget on entry yet blow the wall-clock budget as
-               ;; it returns. Checking here — not only at the top of the next
-               ;; iteration — means an over-budget terminal flush refuses with
-               ;; a fail-closed `:flush-timeout` instead of a settled pass it
-               ;; did not earn.
-               (and deadline (> (interop/now-ms) deadline))
-               (flush-timeout-result required provided step)
-
-               (nil? level)
-               {:status :settled :boundary required}
-
-               :else
-               (do (when-let [f (get flushes level)]
-                     (f frame-id))
-                   (recur more)))))
+           ;; The flush phase — one shared ladder walk (`settle-to!`),
+           ;; deadline arithmetic and all.
+           (settle-to! frame-id hooks required step))
          (catch #?(:clj Throwable :cljs :default) e
            {:status :error
             :error  #?(:clj (.getMessage ^Throwable e) :cljs (str e))

--- a/tools/story/src/re_frame/story/play/substrate_boundary.cljc
+++ b/tools/story/src/re_frame/story/play/substrate_boundary.cljc
@@ -1,0 +1,124 @@
+(ns re-frame.story.play.substrate-boundary
+  "The `:settled-boundary-hooks` PRODUCER — the adapter-aware caller the
+  `settled-boundary` contract has always been written against
+  (`re-frame.story.play.settled-boundary` §The flush-hook seam).
+
+  ## What was missing
+
+  `settled-boundary` names a ladder (`:headless` → `:cljs-reactive` →
+  `:dom` → `:browser`) and takes its richer flushes from a hooks map the
+  host registers under the `:settled-boundary-hooks` late-bind slot. The
+  CONSUMER shipped (`runner-events/current-flush-hooks`); no producer
+  ever did. Every host therefore ran at `:provides :headless`, whose only
+  flush is a no-op — so the live browser shell had no way to ask the
+  substrate to commit a render, and a play's real settle after an
+  interaction was the run-loop's `setTimeout` 0 yield (rf2-ek9qb).
+
+  A macrotask yield drains the MICROTASK queue, which is the right
+  instrument for a host that commits inside `flushSync` or on a promise.
+  It is the wrong one for the reference substrates, which schedule
+  re-renders on a `requestAnimationFrame`-style tick — `setTimeout` 0
+  fires BEFORE the next frame, and in a backgrounded or headless tab that
+  frame is throttled to ~never (`re-frame.substrate.adapter/flush-render!`
+  §Why it exists). So the yield raced the render, and raced it hardest
+  exactly where the machine was busiest.
+
+  ## The settle signal, and why it is not `reagent.core/flush`
+
+  The framework already owns the substrate-neutral answer:
+  **`flush-render!`**, the optional adapter-contract fn that commits
+  pending renders through the substrate's SYNCHRONOUS-commit path
+  (`flushSync` for the React-hook substrates, `reagent.core/flush` for the
+  ratom family) rather than the rAF-scheduled tick — Spec 006
+  §`flush-render!`, and the primitive `spec/Tool-Pair.md` §Driving the
+  render builds its own `dispatch-and-settle` op on.
+
+  Tool-Pair is explicit that a tool MUST reach it through the LIVE
+  adapter, \"never a hardcoded substrate API (the framework knows its own
+  registered adapter; a tool that names `reagent.core/flush!` is
+  non-conforming and breaks under UIx)\". This ns therefore names no
+  substrate at all: it reads `:flush-render!` off
+  `re-frame.core/current-adapter-spec` — the introspection surface Spec
+  006 documents for exactly this purpose (\"give me the adapter fns to
+  call — tools\"). Story consequently settles correctly under Reagent,
+  reagent-slim and UIx today, and under any adapter added later, with no
+  entry here per substrate and no substrate on Story's classpath.
+
+  ## What it declares
+
+  `:provides :dom` when — and only when — an adapter is seated AND ships
+  `:flush-render!`. That is an honest reading of the ladder: `flush-render!`
+  commits the pending renders to the DOM before it returns, which is the
+  `:dom` rung's guarantee. An adapter with no live commit (plain-atom,
+  SSR) ships no `:flush-render!`, and a bare JVM run seats no adapter at
+  all; both fall back to `headless-flush-hooks`, so nothing about the
+  headless floor changes and the fail-closed ladder still refuses a step
+  it cannot honour.
+
+  `:dispatch!` stays `drain-sync!` — the framework's run-to-fixed-point
+  drain is the same at every rung, and the richer rungs add the render
+  commit on top of it rather than replacing it."
+  (:require [re-frame.core :as rf]
+            [re-frame.story.late-bind :as late-bind]
+            [re-frame.story.play.settled-boundary :as boundary]))
+
+(defn adapter-flush-render
+  "The installed adapter's optional `:flush-render!` contract fn, or nil.
+
+  Nil covers all three of \"no adapter seated\" (a bare JVM run, or before
+  `rf/init!`), \"adapter seated but shipping no live commit\" (plain-atom,
+  SSR) and \"the adapter is mid-dispose\" — `current-adapter-spec` already
+  returns nil for the last. Tolerant: a throwing host reads as nil rather
+  than taking the play down, which matches every other Story probe of
+  framework state.
+
+  The returned fn takes a THUNK (`(fn [f] …)`, per the Spec 006 contract
+  shape): it runs `f` and then commits, so the 0-arity \"flush what is
+  already pending\" form is `(flush-render (fn [] nil))`."
+  []
+  (try
+    (:flush-render! (rf/current-adapter-spec))
+    (catch #?(:clj Throwable :cljs :default) _ nil)))
+
+(defn substrate-flush-hooks
+  "Build the flush-hooks map for `frame-id` off the LIVE adapter.
+
+  This is the fn registered under `:settled-boundary-hooks`; the runner
+  calls it per step (`runner-events/current-flush-hooks`), so an adapter
+  installed, swapped or disposed mid-session is picked up on the next
+  step rather than frozen at boot.
+
+  With a `:flush-render!` in hand the hooks declare `:provides :dom` and
+  register the SAME synchronous commit at both richer rungs. That is not
+  a doubled flush in any meaningful sense: `flush-render!` is documented
+  no-op-safe, so the second call over already-committed work returns
+  having done nothing. Registering it at both is the honest reading —
+  each rung genuinely re-establishes its own guarantee, and a step
+  requiring only `:cljs-reactive` gets the reaction flush without being
+  told it got a DOM commit it did not ask for.
+
+  Without one, the headless default — unchanged behaviour, and the
+  reason installing this producer is safe on every host."
+  [_frame-id]
+  (if-let [flush-render (adapter-flush-render)]
+    (let [commit! (fn substrate-commit [_frame-id]
+                    (flush-render (fn [] nil))
+                    nil)]
+      {:provides  :dom
+       :dispatch! boundary/drain-sync!
+       :flush!    {:headless      (fn headless-flush [_frame-id] nil)
+                   :cljs-reactive commit!
+                   :dom           commit!}})
+    boundary/headless-flush-hooks))
+
+(defn install!
+  "Register `substrate-flush-hooks` under the `:settled-boundary-hooks`
+  late-bind slot. Idempotent (`set-fn!` replaces the slot).
+
+  Called from `re-frame.story.canonical`'s installer chain. A host with a
+  richer boundary than this one can offer — a real browser runner that
+  settles layout and paint, say — registers its own hooks after boot and
+  wins the slot, which is what the late-bind seam is for."
+  []
+  (late-bind/set-fn! :settled-boundary-hooks substrate-flush-hooks)
+  nil)

--- a/tools/story/src/re_frame/story/ui/canvas.cljs
+++ b/tools/story/src/re_frame/story/ui/canvas.cljs
@@ -460,11 +460,18 @@
             ;; this exactly-once even though the shell also schedules a resume.
             (runtime/resume-run! variant-id)))))))
 
-(defn- variant-substrate-set
+(defn variant-substrate-set
   "Resolve the variant's effective substrate set. Per `001-Authoring.md` §Registration macros
   the variant body's `:substrates` wins, otherwise the parent story's
   `:substrates`, otherwise the shell's host substrate. The canvas uses
-  this to decide single-substrate vs side-by-side rendering."
+  this to decide single-substrate vs side-by-side rendering.
+
+  Public for the same reason `run-key`, `render-view`'s caller and
+  `safe-decorated-view` are: the workspace cell (`ui/workspace.cljc`)
+  renders a variant too, and must resolve its substrate by the SAME policy
+  rather than a second copy of it (rf2-r4coe). The resolution order is
+  itself the answer to \"declared set or host substrate?\" — it is both,
+  in that precedence, with the shell's substrate as the fallback."
   [variant-id]
   (let [vb (registrar/handler-meta :variant variant-id)
         sid (args/parent-story-id variant-id)

--- a/tools/story/src/re_frame/story/ui/workspace.cljc
+++ b/tools/story/src/re_frame/story/ui/workspace.cljc
@@ -89,6 +89,7 @@
                        ;; subtree to `:y` — a frame that does not exist.
                        [re-frame.story.ui.assertion-strip :as assertion-strip]
                        [re-frame.story.ui.canvas :as canvas]
+                       [re-frame.story.ui.multi-substrate :as multi-substrate]
                        [re-frame.story.ui.state :as state]])
             #?(:cljs [re-frame.story.ui.markdown :as md])
             [re-frame.story.theme.typography :as typography :refer [mono-stack]]
@@ -332,8 +333,16 @@
    (defn- variant-cell-inner
      "Read the variant's resolved view + decorator pack + effective
      args and render the variant body inside the cell. Mirrors
-     `canvas/canvas-inner` at a smaller scale — single substrate, no
+     `canvas/canvas-inner` at a smaller scale — a SINGLE-TREE render, no
      share affordance, errors render inline.
+
+     'Single substrate' describes the render's SHAPE, not an assumption
+     about which one: since rf2-r4coe the cell resolves the substrate
+     through `canvas/variant-substrate-set` and reduces it with
+     `multi-substrate/single-render-substrate`, rather than painting
+     Reagent whatever the variant declared. A workspace never grids a
+     single variant across substrates the way the canvas can — that is
+     what stays smaller here.
 
      Per /spec/007-Stories.md §Relationship with frames + tools/story
      feature-set §4.2: each variant cell wraps the rendered view in a
@@ -383,38 +392,67 @@
            "variant has no :component registered — register one on the story or variant body"]
 
           :else
-          (let [resolved-view (rf/view view-id)]
-            (if resolved-view
-              ;; Scope the rendered view's subscribe / dispatch to the
-              ;; variant's allocated frame via the namespace-preserving
-              ;; provider exported by canvas. The cells in a workspace
-              ;; share a parent React tree, so per-cell wraps are the
-              ;; load-bearing isolation — without them every cell
-              ;; subscribes against whichever frame happened to be the
-              ;; React-context default at the workspace's mount site,
-              ;; and the variant body's :counter/initialise dispatches
-              ;; (which DID route to the variant's frame) become
-              ;; invisible to the view. The merged `rf/frame-provider
-              ;; {:frame …}` shape (scope-only — the frame is already
-              ;; allocated) routes through Reagent's `:r>` interop head, so
-              ;; the namespace of a `:story.x/y`-shaped variant id survives
-              ;; the React-context round trip (a plain `[:> Provider …]`
-              ;; mount calls `(name kw)` on prop values and drops the
-              ;; namespace before React sees it).
-              ;; Per rf2-qgms1: stamp `data-rf-story-variant-root` on
-              ;; the immediate wrapper around the decorated view (same
-              ;; reason as canvas.cljs) so the a11y panel can scope
-              ;; axe-core to ONLY the variant's rendered tree.
-              [rf/frame-provider {:frame variant-id}
-               [:div {:data-rf-story-variant-root (pr-str variant-id)}
-                (canvas/safe-decorated-view
-                  [resolved-view eff-args]
-                  (:hiccup decorator-pack)
-                  eff-args)]]
-              [:div {:style {:color (:text-secondary colors/tokens) :font-style "italic"
-                             :padding "8px 0"}}
-               (str ":component " (pr-str view-id)
-                    " is not registered as a view")])))
+          ;; Resolve the renderer through the SUBSTRATE REGISTRY, by the same
+          ;; policy the canvas uses (`canvas/variant-substrate-set` →
+          ;; declared set, else the shell's host substrate) reduced to the one
+          ;; substrate a single-tree render can paint under
+          ;; (`multi-substrate/single-render-substrate`).
+          ;;
+          ;; rf2-r4coe: this branch used to call `(rf/view view-id)` itself and
+          ;; embed the result as a Reagent hiccup vector — the identical bypass
+          ;; rf2-3afns removed from the canvas single-pane path, down to the
+          ;; missing-view diagnostic string. The bead that filed it read the
+          ;; cell as having NO substrate axis, so that giving it one would be
+          ;; new behaviour needing a ruling. At source it already had one, and
+          ;; used it everywhere except here: `run-variant-with-shell-opts!`
+          ;; threads `:substrate (:substrate shell)` into every run, and
+          ;; `canvas/run-key` — which `variant-cell` keys its re-runs on —
+          ;; carries `:substrate` precisely so the cell re-renders when the
+          ;; user flips it. Painting Reagent regardless made that re-run a lie.
+          ;; So this is a bypass removal, not a feature: the cell now honours
+          ;; the substrate it was already reacting to.
+          ;;
+          ;; `render-view` also owns the two misses this branch hand-rolled: an
+          ;; unregistered VIEW degrades to the same italic diagnostic (via
+          ;; `reagent-render`), and an unregistered SUBSTRATE now degrades
+          ;; LOUDLY to `substrate :<id> is not registered` instead of silently
+          ;; painting Reagent — the user-visible half, exactly as on the canvas.
+          ;;
+          ;; Decoration stays HERE, exactly once. `render-decorated-view`
+          ;; bundles render + decorate but resolves decorator refs WITHOUT the
+          ;; mode / cell-override `run-opts` threaded into `resolve-decorators`
+          ;; above, so the cell consumes the render half and keeps its own
+          ;; `safe-decorated-view` wrap — the same trap rf2-3afns navigated.
+          (let [substrate (multi-substrate/single-render-substrate
+                            (canvas/variant-substrate-set variant-id)
+                            :reagent)]
+            ;; Scope the rendered view's subscribe / dispatch to the
+            ;; variant's allocated frame via the namespace-preserving
+            ;; provider exported by canvas. The cells in a workspace
+            ;; share a parent React tree, so per-cell wraps are the
+            ;; load-bearing isolation — without them every cell
+            ;; subscribes against whichever frame happened to be the
+            ;; React-context default at the workspace's mount site,
+            ;; and the variant body's :counter/initialise dispatches
+            ;; (which DID route to the variant's frame) become
+            ;; invisible to the view. The merged `rf/frame-provider
+            ;; {:frame …}` shape (scope-only — the frame is already
+            ;; allocated) routes through Reagent's `:r>` interop head, so
+            ;; the namespace of a `:story.x/y`-shaped variant id survives
+            ;; the React-context round trip (a plain `[:> Provider …]`
+            ;; mount calls `(name kw)` on prop values and drops the
+            ;; namespace before React sees it).
+            ;; Per rf2-qgms1: stamp `data-rf-story-variant-root` on
+            ;; the immediate wrapper around the decorated view (same
+            ;; reason as canvas.cljs) so the a11y panel can scope
+            ;; axe-core to ONLY the variant's rendered tree.
+            [rf/frame-provider {:frame variant-id}
+             [:div {:data-rf-story-variant-root (pr-str variant-id)}
+              (canvas/safe-decorated-view
+                (multi-substrate/render-view
+                  substrate variant-id view-id eff-args)
+                (:hiccup decorator-pack)
+                eff-args)]]))
         (when (seq errors)
           [:div {:style {:background (:danger-bg colors/tokens)
                          :border "1px solid #be4040"

--- a/tools/story/test/re_frame/story/play/substrate_boundary_cljs_test.cljc
+++ b/tools/story/test/re_frame/story/play/substrate_boundary_cljs_test.cljc
@@ -1,0 +1,226 @@
+(ns re-frame.story.play.substrate-boundary-cljs-test
+  "rf2-ek9qb — the `:settled-boundary-hooks` PRODUCER, and the settle it
+  put in place of a timer.
+
+  The defect these tests witness was not that the settle was slow. It was
+  that Story had NO settle signal from the substrate at all: the
+  `:settled-boundary-hooks` slot had a consumer and no producer, so every
+  host ran at `:provides :headless`, whose only flush is a no-op, and the
+  real settle after an interaction was the run-loop's `setTimeout` 0 —
+  which drains the microtask queue but never asks a rAF-scheduled
+  substrate to commit.
+
+  So the witness cannot be a timing measurement (a fast machine proves
+  nothing, and a slow one proves nothing either). It is a COUNT: with a
+  substrate whose commit is observable, does the runner call it? Before
+  this bead it did not, once, ever — `substrate-commits-before-a-dom-step`
+  and `settle-is-synchronous-not-scheduled` both read 0.
+
+  Runner note, and it is why this file is named and extensioned the way
+  it is: `.cljc` so the JVM lane (`clojure -M:test` from `tools/story`)
+  loads it, and `*_cljs_test` so the `:node-test` build's `cljs-test$`
+  ns-regexp DISCOVERS it too. Both lanes therefore execute every assertion
+  here — which matters because the production change is entirely `.cljc`
+  and a reader-conditional mistake in the `:cljs` branch would be
+  invisible to a JVM-only run. Nothing in this file needs a DOM: the
+  settle under test happens BEFORE the DOM executor runs, which is exactly
+  why the JVM can witness it."
+  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.story.assertions :as assertions]
+            [re-frame.story.late-bind :as late-bind]
+            [re-frame.story.play.runner-events :as runner-events]
+            [re-frame.story.play.settled-boundary :as boundary]
+            [re-frame.story.play.substrate-boundary :as substrate-boundary]
+            [re-frame.substrate.plain-atom :as plain-atom]))
+
+;; ---- harness -------------------------------------------------------------
+
+(def ^:private commits
+  "Count of substrate commits the fake adapter's `:flush-render!` has been
+  asked for. The whole witness reduces to whether this moves."
+  (atom 0))
+
+(defn- committing-adapter
+  "`plain-atom` plus the ONE optional contract fn this bead is about. The
+  real Reagent adapter's is `(fn [f] (f) (r/flush))`; this one keeps the
+  same shape and counts instead of flushing, so a JVM run can observe the
+  call the browser would make."
+  []
+  (assoc plain-atom/adapter
+         :flush-render! (fn [f] (f) (swap! commits inc) nil)))
+
+;; NOT `late-bind/clear!` — that wipes the canonical shims every sibling
+;; test ns registers at load time (`:run-play-step`, `:clear-step-boundaries`,
+;; `:ensure-canonical-installed`), and the wipe outlives this ns in a shared
+;; JVM. Snapshot the whole map and restore it, so exactly the one slot this
+;; bead is about is under test and nothing else moves.
+
+(use-fixtures :each
+  (fn [t]
+    (let [saved @late-bind/hooks]
+      (reset! commits 0)
+      (swap! late-bind/hooks dissoc :settled-boundary-hooks)
+      (try (t)
+           (finally
+             (reset! commits 0)
+             (reset! late-bind/hooks saved)
+             (try (rf/destroy-adapter!)
+                  (catch #?(:clj Throwable :cljs :default) _ nil)))))))
+
+(defn- dom-assert-step
+  "A folded in-script DOM checkpoint — the shape a shipping
+  `[:assert-dom sel :text \"x\"]` has by the time the executor sees it."
+  []
+  [:assert [assertions/id-dom-text "[data-test=x]" "42"]])
+
+;; ---- the producer --------------------------------------------------------
+
+(deftest headless-when-no-adapter-is-seated
+  (testing "with no adapter installed the producer yields the headless
+            default — the JVM floor is unchanged, which is what makes
+            installing it unconditionally safe"
+    (is (nil? (substrate-boundary/adapter-flush-render)))
+    (let [hooks (substrate-boundary/substrate-flush-hooks :any-frame)]
+      (is (identical? boundary/headless-flush-hooks hooks))
+      (is (= :headless (boundary/hooks-provided-boundary hooks))))))
+
+(deftest headless-when-adapter-ships-no-flush-render
+  (testing "an adapter with no live commit (plain-atom, SSR) ships no
+            :flush-render!, so the producer stays at the headless floor
+            rather than claiming a :dom boundary it cannot honour"
+    (rf/init! plain-atom/adapter)
+    (is (nil? (:flush-render! (rf/current-adapter-spec)))
+        "precondition: plain-atom ships no :flush-render!")
+    (is (nil? (substrate-boundary/adapter-flush-render)))
+    (is (= :headless
+           (boundary/hooks-provided-boundary
+             (substrate-boundary/substrate-flush-hooks :any-frame))))))
+
+(deftest provides-dom-when-the-live-adapter-can-commit
+  (testing "an adapter shipping :flush-render! lifts the declared boundary
+            to :dom and registers the commit at both richer rungs"
+    (rf/init! (committing-adapter))
+    (let [hooks (substrate-boundary/substrate-flush-hooks :f)]
+      (is (= :dom (boundary/hooks-provided-boundary hooks)))
+      (is (fn? (get-in hooks [:flush! :cljs-reactive])))
+      (is (fn? (get-in hooks [:flush! :dom])))
+      (is (zero? @commits) "building the hooks must not commit anything")
+      ((get-in hooks [:flush! :dom]) :f)
+      (is (= 1 @commits)))))
+
+(deftest producer-names-no-substrate
+  (testing "the hooks are built from the LIVE adapter, so swapping the
+            adapter swaps the settle with no Story-side entry per
+            substrate (spec/Tool-Pair.md §Driving the render: a tool that
+            names reagent.core/flush! is non-conforming)"
+    (rf/init! plain-atom/adapter)
+    (is (= :headless (boundary/hooks-provided-boundary
+                       (substrate-boundary/substrate-flush-hooks :f))))
+    (rf/destroy-adapter!)
+    (rf/init! (committing-adapter))
+    (is (= :dom (boundary/hooks-provided-boundary
+                  (substrate-boundary/substrate-flush-hooks :f))))))
+
+;; ---- the slot ------------------------------------------------------------
+
+(deftest install-registers-the-late-bind-slot
+  (testing "before install! the slot is empty and the runner falls back to
+            headless — the state every host shipped in before rf2-ek9qb"
+    (is (nil? (late-bind/get-fn :settled-boundary-hooks)))
+    (rf/init! (committing-adapter))
+    (is (= :headless
+           (boundary/hooks-provided-boundary
+             (runner-events/current-flush-hooks :f)))
+        "WITNESS: with no producer the live shell plays at :provides :headless"))
+  (testing "after install! the runner resolves the substrate hooks"
+    (substrate-boundary/install!)
+    (is (some? (late-bind/get-fn :settled-boundary-hooks)))
+    (is (= :dom
+           (boundary/hooks-provided-boundary
+             (runner-events/current-flush-hooks :f))))))
+
+;; ---- the settle, which is the point --------------------------------------
+
+(deftest substrate-commits-before-a-dom-step
+  (testing "WITNESS (rf2-ek9qb): a step that reads the DOM now runs against
+            a COMMITTED substrate. Without the producer + the pre-step
+            settle this count stays 0 — the runner never asked the
+            substrate to commit, and the only thing between an event and a
+            DOM read was a setTimeout 0"
+    (rf/init! (committing-adapter))
+    (substrate-boundary/install!)
+    (is (zero? @commits))
+    (runner-events/exec-step! :f 0 (dom-assert-step))
+    (is (pos? @commits)
+        "a DOM-family checkpoint must settle the substrate before reading")))
+
+(deftest settle-is-synchronous-not-scheduled
+  (testing "the commit lands INSIDE the exec-step! call — no tick, no
+            timer, nothing to race. This is the property a longer
+            setTimeout could never buy"
+    (rf/init! (committing-adapter))
+    (substrate-boundary/install!)
+    (let [before @commits
+          _      (runner-events/exec-step! :f 0 (dom-assert-step))
+          after  @commits]
+      (is (> after before)
+          "already committed by the time exec-step! returned"))))
+
+(deftest headless-steps-do-not-commit
+  (testing "a step that requires only :headless does not drag the
+            substrate through a commit — the ladder still means what it
+            says, and the cheap path stays cheap"
+    (rf/init! (committing-adapter))
+    (substrate-boundary/install!)
+    (runner-events/exec-step! :f 0 [:wait-until [:queue-empty]])
+    (is (zero? @commits))))
+
+(deftest no-producer-means-no-commit
+  (testing "the fix is the PRODUCER, not the pre-step settle alone: with
+            the slot empty, the same DOM step commits nothing even though
+            the adapter could have"
+    (rf/init! (committing-adapter))
+    (runner-events/exec-step! :f 0 (dom-assert-step))
+    (is (zero? @commits))))
+
+;; ---- the shared flush loop ----------------------------------------------
+
+(deftest settle-to-runs-registered-rungs-in-ladder-order
+  (testing "settle-to! walks the registered flushes up to `required`, in
+            order, and settles without dispatching anything"
+    (let [seen  (atom [])
+          hooks {:provides :dom
+                 :flush!   {:headless      (fn [_] (swap! seen conj :headless))
+                            :cljs-reactive (fn [_] (swap! seen conj :cljs-reactive))
+                            :dom           (fn [_] (swap! seen conj :dom))}}]
+      (is (= {:status :settled :boundary :dom}
+             (boundary/settle-to! :f hooks :dom)))
+      (is (= [:headless :cljs-reactive :dom] @seen)))))
+
+(deftest settle-to-is-inert-below-its-rung
+  (testing "a cheaper `required` stops the ladder where it should"
+    (let [seen  (atom [])
+          hooks {:provides :dom
+                 :flush!   {:cljs-reactive (fn [_] (swap! seen conj :cljs-reactive))
+                            :dom           (fn [_] (swap! seen conj :dom))}}]
+      (boundary/settle-to! :f hooks :headless)
+      (is (= [] @seen)))))
+
+(deftest settle-to-reports-a-throwing-flush
+  (testing "a flush that throws is reported as :error — never swallowed,
+            never a silent pass"
+    (let [hooks {:provides :dom
+                 :flush!   {:dom (fn [_] (throw (ex-info "boom" {})))}}
+          res   (boundary/settle-to! :f hooks :dom)]
+      (is (= :error (:status res))))))
+
+(deftest settle-to-honours-the-timeout-budget
+  (testing "an over-budget flush phase refuses fail-closed with
+            :flush-timeout rather than reporting a settle it did not earn"
+    (let [hooks {:provides   :dom
+                 :timeout-ms -1
+                 :flush!     {:dom (fn [_] nil)}}
+          res   (boundary/settle-to! :f hooks :dom)]
+      (is (= :cannot-run (:status res)))
+      (is (= :flush-timeout (:reason res))))))

--- a/tools/story/test/re_frame/story/ui/workspace_substrate_routing_cljs_test.cljs
+++ b/tools/story/test/re_frame/story/ui/workspace_substrate_routing_cljs_test.cljs
@@ -1,0 +1,191 @@
+(ns re-frame.story.ui.workspace-substrate-routing-cljs-test
+  "rf2-r4coe — the WORKSPACE cell must resolve its renderer through the
+  substrate registry, exactly as the canvas single-pane path now does
+  (rf2-3afns / #8306).
+
+  ## What the bead asked, and what the source answered
+
+  The bead filed this as a decision, not a reroute: it read
+  `variant-cell-inner` as having NO substrate axis at all, so that honouring
+  a variant's declared `:substrates` would be NEW BEHAVIOUR needing a ruling.
+
+  At source the cell already had a substrate axis and was already reacting to
+  it — it simply did not consult it at the one line that paints:
+
+  - `run-variant-with-shell-opts!` threads `:substrate (:substrate shell)`
+    into every `runtime/run-variant` call;
+  - `variant-cell` keys its re-runs on `canvas/run-key`, which CARRIES
+    `:substrate` for the stated purpose of covering \"substrate flips\".
+
+  So the cell re-ran on a substrate change and then painted Reagent
+  regardless, which made that re-run a lie. That is a bypass, in the same
+  shape as the canvas's, down to the shared missing-view diagnostic string —
+  not a feature. And the policy question the bead wanted ruled on is already
+  settled inside `canvas/variant-substrate-set`, whose resolution order IS
+  the answer: the variant's declared `:substrates`, else the parent story's,
+  else the shell's host substrate. Option (a) and option (b) are not rivals
+  there; (b) is (a)'s fallback.
+
+  ## Why a green compile proves nothing here
+
+  Same reason as the canvas witness: the bug is a working path rendering the
+  WRONG thing. Every test below DISTINGUISHES WHICH SUBSTRATE RENDERED — the
+  variant's `:component` resolves to a Reagent view emitting
+  `reagent-view-render`, the stub registered under `:uix` emits
+  `uix-stub-render`, and the assertions require the uix marker PRESENT and
+  the reagent marker ABSENT. Either alone would pass on a path that rendered
+  both, or neither.
+
+  Runner note: `.cljs`, and `workspace.cljc`'s body is entirely inside
+  `#?(:cljs …)` — so `clojure -M:test` from `tools/story` loads the file and
+  sees NONE of the code under test. This namespace is witnessed by
+  `npm run test:cljs` and only by it.
+
+  ## Registry hygiene
+
+  `substrate->render-fn` is a `defonce` atom `story/clear-all!` does not
+  touch, so a leaked `:uix` entry would break
+  `render_shell_cljs_test`'s `unregistered-substrate-renders-inline-error-cell`,
+  whose precondition is that `:uix` is ABSENT. The `:after` fixture dissocs it."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.frame :as frame]
+            [re-frame.registrar :as registrar]
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.story :as story]
+            [re-frame.story.loaders :as loaders]
+            [re-frame.story.test-helpers.e2e-multi-frame :as e2e]
+            [re-frame.story.ui.multi-substrate :as multi-substrate]
+            [re-frame.story.ui.state :as state]
+            [re-frame.story.ui.workspace :as workspace]))
+
+;; ---- fixtures ------------------------------------------------------------
+
+(declare register-probe-views!)
+
+(defn- reset-all! []
+  (story/clear-all!)
+  (registrar/clear-all!)
+  (reset! frame/frames {})
+  (try (rf/init! plain-atom/adapter) (catch :default _ nil))
+  (loaders/clear-watchers!)
+  (state/reset-shell-state!)
+  (story/install-canonical-vocabulary!)
+  (frame/ensure-default-frame!)
+  (multi-substrate/unregister-substrate! :uix)
+  (register-probe-views!))
+
+(defn- restore-registry! []
+  (multi-substrate/unregister-substrate! :uix))
+
+(use-fixtures :each {:before reset-all! :after restore-registry!})
+
+;; ---- probe views + variants ----------------------------------------------
+
+(defn- reagent-probe-view [_args]
+  [:div {:data-test "reagent-view-render"} "rendered under reagent"])
+
+(defn- uix-stub-render
+  "Stand-in for a host-registered UIx render fn — returns hiccup so the test
+  can walk it without a React cycle. What matters is WHICH fn the cell
+  reached, not what it built."
+  [_variant-id view-id _eff-args]
+  [:div {:data-test "uix-stub-render"} (str "rendered under uix: " (pr-str view-id))])
+
+(defn- register-probe-views! []
+  (rf/reg-view* :views/probe reagent-probe-view)
+  (story/reg-story* :story.workspace-routing {:doc "rf2-r4coe witness story"})
+  (story/reg-variant* :story.workspace-routing/uix-only
+    {:doc        "Declares ONE substrate, and it is not Reagent."
+     :component  :views/probe
+     :substrates #{:uix}})
+  (story/reg-variant* :story.workspace-routing/reagent-only
+    {:doc        "Declares ONE substrate, Reagent — the unchanged baseline."
+     :component  :views/probe
+     :substrates #{:reagent}})
+  (story/reg-variant* :story.workspace-routing/undeclared
+    {:doc        "Declares NO substrates — the shell's host substrate decides."
+     :component  :views/probe}))
+
+;; ---- helpers -------------------------------------------------------------
+
+(def ^:private variant-cell-inner @#'workspace/variant-cell-inner)
+
+(defn- cell-tree
+  "Render the workspace cell's inner tree for `variant-id` and expand it to
+  plain hiccup. Unlike the canvas, the cell has no skeleton/lifecycle gate to
+  drive — it renders its variant body directly."
+  [variant-id]
+  (rf/make-frame {:id variant-id})
+  (e2e/expand-tree (variant-cell-inner variant-id)))
+
+(defn- rendered-under-uix? [tree]
+  (some? (e2e/find-by-test-id tree "uix-stub-render")))
+
+(defn- rendered-under-reagent? [tree]
+  (some? (e2e/find-by-test-id tree "reagent-view-render")))
+
+;; ===========================================================================
+;; THE WITNESS
+;; ===========================================================================
+
+(deftest workspace-cell-renders-through-the-declared-substrate
+  (testing "rf2-r4coe — a workspace cell whose variant declares
+            `:substrates #{:uix}` renders through the render fn REGISTERED
+            FOR :uix. Before the fix this branch called `(rf/view view-id)`
+            itself, so the tree carried `reagent-view-render` and no uix
+            marker at all — the identical bypass rf2-3afns removed from the
+            canvas"
+    (story/register-substrate! :uix uix-stub-render)
+    (let [tree (cell-tree :story.workspace-routing/uix-only)]
+      (is (rendered-under-uix? tree)
+          "the cell reached the :uix render fn — the registry is ON the
+           workspace's path, not merely present in it")
+      (is (not (rendered-under-reagent? tree))
+          "and it did NOT also paint Reagent — the silent Reagent render is
+           what a UIx author got before"))))
+
+(deftest reagent-variants-are-behaviour-unchanged
+  (testing "the overwhelmingly common case — a variant declaring
+            `:substrates #{:reagent}` — paints exactly as it always did"
+    (story/register-substrate! :uix uix-stub-render)
+    (let [tree (cell-tree :story.workspace-routing/reagent-only)]
+      (is (rendered-under-reagent? tree))
+      (is (not (rendered-under-uix? tree))))))
+
+(deftest undeclared-substrate-falls-back-to-the-shell-host
+  (testing "a variant declaring NO :substrates keeps the host-substrate
+            behaviour — which is the bead's option (b), already present as
+            the FALLBACK inside `canvas/variant-substrate-set`'s resolution
+            order rather than as a rival to option (a)"
+    (story/register-substrate! :uix uix-stub-render)
+    (let [tree (cell-tree :story.workspace-routing/undeclared)]
+      (is (rendered-under-reagent? tree))
+      (is (not (rendered-under-uix? tree))))))
+
+;; Read diagnostics with `e2e/text-nodes`, never `pr-str` on the tree. The
+;; cell's expanded tree carries nodes whose printed form recurses without
+;; bound (`pr-str` on it raises `RangeError: Maximum call stack size
+;; exceeded`), while the structural walk `text-nodes` and `find-by-test-id`
+;; share handles it fine. Walking the tree is safe; printing it is not.
+
+(deftest unregistered-substrate-degrades-loudly
+  (testing "a declared substrate with NO registered render fn now says so
+            instead of silently painting Reagent — the user-visible half of
+            the fix, and the same degradation the canvas gives"
+    ;; :uix deliberately NOT registered here.
+    (let [tree (cell-tree :story.workspace-routing/uix-only)
+          txt  (e2e/text-nodes tree)]
+      (is (not (rendered-under-reagent? tree))
+          "silence was the defect's real cost — Reagent must NOT be painted")
+      (is (re-find #"substrate :uix is not registered" txt)))))
+
+(deftest missing-view-diagnostic-survives-the-reroute
+  (testing "routing through the registry must not lose the cell's
+            missing-view message — `render-view` owns it now, via
+            `reagent-render`, and it reads the same"
+    (story/reg-variant* :story.workspace-routing/no-such-view
+      {:doc       "Names a :component nobody registered."
+       :component :views/does-not-exist})
+    (let [txt (e2e/text-nodes (cell-tree :story.workspace-routing/no-such-view))]
+      (is (re-find #"is not registered as a view" txt)))))


### PR DESCRIPTION
Two Story beads, one PR, one commit each. Both are in `tools/story`, which cannot take two workers.

## rf2-ek9qb — what `:settled-boundary-hooks` turned out to be

**Declared-but-unwired, and the wiring fix was available.** Not absent, so this is not the larger bead.

Declared in three places: the consumer `runner-events/current-flush-hooks` (:476-487) reads the slot; `settled-boundary`'s ns docstring specifies the hooks map in full (§The flush-hook seam); and `spec/017-Testing-Story.md:903` names it normatively. Producers in `src`: zero. In `test`: zero. The bead's count of four `rg` hits reproduced exactly.

Consequence, confirmed at source: every host — including the live browser shell — resolved to `boundary/headless-flush-hooks`, whose only registered flush is `(fn [_frame-id] nil)`. Story had no way to ask a substrate to commit a render.

**One correction to the bead.** It reports the `setTimeout 0` as the settle "after an interaction", and that is right — but `:dispatch` is *not* in `runner/async-yield-step-types` (`#{:click :type :focus :wait :flush-presence}`), so a `[:dispatch …]` step already recurred synchronously. The timer governed the interaction steps, and its own docstring justifies it as a microtask drain — correct for a `flushSync`/promise host, and precisely wrong for a rAF-scheduled one. `setTimeout 0` fires *before* the next frame, and in a backgrounded/headless tab that frame is throttled to ~never (`substrate/adapter.cljc:637-644`).

**The bead's proposed remedy would have been non-conforming.** It suggests `reagent.core/flush`. `spec/Tool-Pair.md` §Driving the render forbids exactly that: a tool must call "the **installed adapter's** `flush-render!` — resolved from the live adapter, never a hardcoded substrate API (… a tool that names `reagent.core/flush!` is non-conforming and breaks under UIx)". So the producer reads `:flush-render!` off `rf/current-adapter-spec` and names no substrate. Reagent, reagent-slim and UIx all work today; a later adapter needs no entry here.

**The cost has a user today, in this repo.** `:story.counter-play-script/dom` (`tools/story/testbeds/counter_with_stories/stories.cljs:795-806`) pays 650ms of wall-clock `[:wait]` to wait out renders, with comments saying so ("the wait ensures the next render cycle has flushed"). `[:wait ms]` is, per spec/017 §Determinism gate, the explicit determinism **opt-out** that `assert-deterministic` refuses. Story's own DOM fixture could only be authored by opting out of Story's determinism gate, because the runner had no settle to offer.

### The witness

Timing proves nothing on either a fast or a slow machine, so the witness is a **count**: with a substrate whose commit is observable, does the runner ever call it?

- `substrate-commits-before-a-dom-step`
- `settle-is-synchronous-not-scheduled`

Both read **0** before the change — the runner never once asked.

**Sabotage proof** (plant verified by hashing, not byte-delta — these files are CRLF):

| | value |
|---|---|
| target line | `runner_events.cljc:1190` |
| match count before → after plant | **1 → 0** |
| file sha256 before | `88d3eedd04e9db2e98af966e13abeff50b7e002c795662b738dd08eeeddb67f3` |
| file sha256 after plant | `291a24ee0039b94ff0aee19fd77d90b15cdec47ee44e8dfc5c9dbd87e9a74745` |
| file sha256 after restore | `88d3eedd04e9db2e98af966e13abeff50b7e002c795662b738dd08eeeddb67f3` (exact match) |
| sabotaged run | **1848 tests / 6775 assertions, 2 failures**, captured exit **1** |
| failures | exactly the two witness tests, both `(not (> 0 0))` |

Namespace and assertion counts are **identical** to the control run, so the plant changed behaviour rather than discovery.

### What changed

- **`play/substrate_boundary.cljc`** (new) — the producer. `:provides :dom` only when an adapter is seated *and* ships `:flush-render!`; otherwise `headless-flush-hooks`. Installed unconditionally from `canonical`, because it names no substrate and adds nothing to the JVM classpath.
- **`settled_boundary.cljc`** — `settle-to!` factors the flush phase out of `dispatch-and-settle!`, so one ladder walk and one deadline discipline serve both callers. It deliberately does **not** refuse; the fail-closed `:cannot-run` check stays with `dispatch-and-settle!`, where refusing means an event is not dispatched.
- **`runner_events.cljc`** — `exec-step!` *establishes* a step's required boundary before the step runs. Because the folded `[:assert …]` checkpoint declares `:headless` on purpose (its capability tokens gate the DOM requirement, not its boundary), the `:dom` requirement is recovered from the assertion's own family via the same `dom-assertion-ids` set the assert executor routes on. Terminal assertions get the same pre-read settle — otherwise the rule would be half-applied.
- **`late_bind.cljc`** — documents the tenth hook key the bead flagged as undocumented.

Headless hosts are unchanged: no adapter, or an adapter with no live commit (plain-atom, SSR), falls back to `headless-flush-hooks`. `headless-steps-do-not-commit` asserts the cheap path stays cheap.

## rf2-r4coe — verdict: **(c) on the premise, resolving to (a) on the remedy**

The bead's *observation* is correct and reproduced: `workspace/variant-cell-inner` carried the same `(rf/view view-id)` shape #8306 removed from the canvas, down to the shared missing-view diagnostic string.

Its *gating premise* does not hold at source. The bead says the cell "has NO substrate axis whatsoever". It has one, and was already reacting to it:

- `run-variant-with-shell-opts!` (`workspace.cljc:326`) threads `:substrate (:substrate shell)` into every `runtime/run-variant` call for the cell;
- `variant-cell` (`:481-484`) keys its re-runs on `canvas/run-key`, which carries `:substrate` — its docstring (`canvas.cljs:383`, `workspace.cljc:473`) says this exists to cover "substrate flips".

So the cell re-ran on a substrate change and then painted Reagent regardless, which made that re-run a lie. That is the same bypass, not new behaviour.

**The ruling the bead asked for is already written into the fn the fix uses.** `canvas/variant-substrate-set`'s resolution order *is* the answer: the variant's declared `:substrates`, else the parent story's, else the shell's host substrate. The bead's option (b) — "keep the workspace host-substrate-only" — is not a rival to (a); it is (a)'s fallback, and `undeclared-substrate-falls-back-to-the-shell-host` asserts it.

**`rf2-1gy4e` does not gate this.** That ruling is about how a story *names* a hicasso view. This registers no substrate, widens no enum, and adds no hicasso support — like #8306, it fixes UIx today.

`variant-substrate-set` becomes public rather than copied, so one resolution policy serves both surfaces — the same sharing `run-key` and `safe-decorated-view` already have. Decoration stays on the cell exactly once (`render-decorated-view` resolves decorator refs without the mode / cell-override run-opts), which is the trap #8306 navigated.

Witness distinguishes **which** substrate rendered, since the bug is a working path painting the wrong thing: the probe view emits `reagent-view-render`, the `:uix` stub emits `uix-stub-render`, and each case asserts one present and the other absent.

## Which runner for which file, and why

`clojure -M:test` in a `tools/*` artefact cannot load a `.cljs` file, and `workspace.cljc`'s body is entirely inside `#?(:cljs …)` — so each runner sees a different half. Matched deliberately:

| file | ext | runner that decides it |
|---|---|---|
| `play/substrate_boundary.cljc` | `.cljc` | **both** — JVM + `test:cljs` |
| `play/settled_boundary.cljc` | `.cljc` | **both** |
| `play/runner_events.cljc` | `.cljc` | **both** |
| `canonical.cljc`, `late_bind.cljc` | `.cljc` | **both** |
| `ui/workspace.cljc` (body all `#?(:cljs …)`) | `.cljc` | **`npm run test:cljs` only** — the JVM loads the file and sees none of the code |
| `ui/canvas.cljs` | `.cljs` | **`npm run test:cljs` only** |
| `spec/017-Testing-Story.md` | `.md` | `scripts/check_doc_slugs.py` |

The bead-1 witness is `.cljc` **and** named `*_cljs_test`, so the `:node-test` build's `cljs-test$` ns-regexp discovers it too — both lanes run every assertion, which matters because the production change is all `.cljc` and a `:cljs`-branch reader mistake would be invisible to a JVM-only run. The bead-2 witness is `.cljs` because the code it tests does not exist on the JVM.

## Quality gates

| gate | result | captured exit |
|---|---|---|
| `clojure -M:test` in `tools/story` (final tree) | **1848 tests / 6775 assertions — 0 failures, 0 errors** | **0** |
| `clojure -M:test` in `tools/story` — **sabotaged control** | 1848 / 6775 — **2 failures** (the two witnesses) | **1** |
| `npm run test:cljs` | **13950 tests / 70394 assertions — 0 failures, 0 errors** | **0** |
| `npm run test:story-play-scripts` (Playwright) | **30 `:play-script` rows — 0 unexpected outcomes** | **0** |
| `python scripts/check_doc_slugs.py` | pass | **0** |
| `python scripts/check_fast_pr_gap.py --list` | consulted — 106 required checks the spine does not run | — |

`#8306` measured 1835 / 6747; this adds 13 tests / 28 assertions.

Every number above was captured from the runner's own exit-code file, never read off the harness's report. An earlier `test:cljs` run was **killed** (it predated the final commit); it wrote exit `127`, which is the kill and not a verdict — it is discarded, and `.shadow-cljs` was cleared before the run quoted here.

### The play-script lane WAS run, and it found the fix's boundary

`npm run test:story-play-scripts` — the Playwright lane that actually drives a play step, CI job `story-xray-browser`, surfaced by `check_fast_pr_gap.py --list`. Run locally, green: **30 rows, 0 unexpected, exit 0**, including `story.counter-play-script/dom[type-click-and-assert-dom]` at 9 steps, which is `:type` + `:click` + `:assert-dom` end-to-end through the changed `exec-step!`.

Because I could run it, I tried to cash in the payoff — deleting the fixture's 650ms of sleeps — and **measured two things that a guess would have got wrong**. Both attempts are recorded because the negative result is the useful part.

**Attempt 1 — delete both sleeps.** Fails at step 1: `selector matched no node`. The component has not **mounted**, not rendered stale. `flush-render!` commits work the substrate has already scheduled; it cannot conjure a mount nobody has requested. The leading `[:wait 300]` covers a **mount-ordering** gap — the auto-run fires when the lifecycle machine hits `:ready`, which can precede the canvas mounting the variant — and no settle can close that.

**Attempt 2 — keep the mount wait, delete only the post-click sleep** (the one whose own comment says "the wait ensures the next render cycle has flushed"). Fails one step later, at `[:assert-db [:count] 42] → got 0`. The click's synthetic DOM event runs its handler, which dispatches; the router schedules an **async** drain via `interop/next-tick`. This PR settles the **render**; nothing settles the **event queue** after a synthetic DOM event. That is a distinct rung, and closing it is a design question, not a wiring one — so it is reported, not invented.

**So the fixture is reverted byte-for-byte and its sleeps stay**, and the follow-up is filed rather than half-done. The unit witnesses prove the render settle is real and synchronous; this lane proves the change breaks nothing, and tells us precisely what the *next* bead is.

### Deliberately not done

- **The testbed's `[:wait]` sleeps stay** — measured, not assumed; see above. Removing them needs a mount-ordering fix and an event-queue settle, neither of which is this bead.
- **`:render-hiccup`** — the bead's second neighbouring finding (a shipped assertion with no producer outside tests) is fail-closed and untouched. Out of scope for a settle bead.

## Spec

`tools/story/spec/017-Testing-Story.md` updated in the same PR, per the standing rule that a dispatch changing taught behaviour updates the tool's own spec — the same reason #8306 updated `003-Render-Shell.md`. §Concrete contract surface now records the shipped producer, the `flush-render!` seam and its Tool-Pair constraint, `settle-to!`, and the pre-step boundary establishment (including why the folded `:assert` checkpoint needs the assertion-family recovery). Anchors and the one added cross-tree link (`../../../spec/Tool-Pair.md`, matching the convention in `000-Vision.md`) verified by hand; `check_doc_slugs.py` passes. **`003-Render-Shell.md` is unchanged because** rf2-r4coe changes no rendering *contract* — it makes the workspace cell obey the routing rule #8306 already wrote there.
