### PR TITLE
fix(hicasso): the kit answers the runtime's recovery for a deferred read (rf2-llps1)

### DIFF
--- a/implementation/hicasso/test_kit/src/re_frame/hicasso/test.cljs
+++ b/implementation/hicasso/test_kit/src/re_frame/hicasso/test.cljs
@@ -175,9 +175,12 @@
     assert its contents.
   - A **`defhost` crossing**, a **well-formed raw escape `[:> …]`**, a
     **raw React element** and anything else the codec hands to React
-    untouched are **opaque** and refuse with a pointer to L3. So does an
-    unforced `delay`, which Hicasso itself refuses at a boundary
-    crossing. A MALFORMED escape is not opaque — see above.
+    untouched are **opaque** and refuse with a pointer to L3. An
+    unforced `delay` is NOT among them, for the reason a MALFORMED
+    escape is not: Hicasso itself refuses it at a boundary crossing, so
+    it carries the runtime's id and the runtime's own recovery,
+    `:hand-a-function-or-deref-it-in-this-body`, rather than a pointer
+    to a tier where the identical refusal is waiting (rf2-llps1).
 
   ### Subs
 
@@ -1054,12 +1057,21 @@
 
     :foreign
     (if (delay? x)
-      (refuse-opaque! :rf.error/hicasso-deferred-read-at-boundary
-                      (str "an unforced `delay` reached a boundary crossing. "
-                           "Hicasso refuses it there rather than forcing it, "
-                           "because forcing an author's explicit deferral would "
-                           "change what their program means.")
-                      {:value x})
+      ;; The RUNTIME refuses this one, so it is refused here with the
+      ;; runtime's id AND the runtime's recovery — not with this
+      ;; namespace's opacity. Opacity is honest only where the runtime CAN
+      ;; read the form; `:assert-it-at-l3` would send the programmer to
+      ;; mount, in a browser, a crossing where the same refusal is waiting.
+      (refuse! :rf.error/hicasso-deferred-read-at-boundary
+               (str "an unforced `delay` reached a boundary crossing. "
+                    "Hicasso refuses it there rather than forcing it, "
+                    "because forcing an author's explicit deferral would "
+                    "change what their program means. Hand a FUNCTION "
+                    "instead — the child calls it on every render, so its "
+                    "reads are the child's edges and are kept — or deref "
+                    "the delay in the body that wrote it.")
+               :hand-a-function-or-deref-it-in-this-body
+               {:value x})
       (refuse! :rf.error/ui-tree-malformed
                (str "a child outside the tree's value grammar. The runtime "
                     "hands this to React as it stands, which has no semantic "


### PR DESCRIPTION
Fixes rf2-llps1. **This unblocks #8315**, which is deliberately red on exactly this
finding and must not be greened by weakening R10.

## The rule the file already states

The kit's own namespace docstring is the specification here, and it states the rule
twice — once as the general law, once as the test that decides this case:

> **A form the runtime REFUSES is refused here with the runtime's own id.**
> `codec/vector-kind` is the preflight and not merely the head discrimination, so an
> empty vector raises `:rf.error/hicasso-empty-vector` and a malformed escape — `[:>]`,
> `[:> nil]`, `[:> :div]` — raises `:rf.error/hicasso-raw-no-component` or
> `:rf.error/hicasso-raw-not-a-component`, each carrying **the runtime's recovery rather
> than one of this namespace's**. **Opacity is a claim about a form L2 cannot read, and
> it is honest only where the runtime CAN read it**: a second audit found `[:> :div]`
> answered `:assert-it-at-l3`, which tells the programmer to mount, in a browser, a form
> that will not mount anywhere.

`walk`'s own docstring says the same in one line: *"Every arm is the runtime's own
answer for that kind, or an honest refusal where L2 cannot give one."*

An unforced `delay` at a boundary crossing **is refused by the runtime** —
`re-frame.hicasso.impl.codec/boundary-element` raises
`:rf.error/hicasso-deferred-read-at-boundary` with the recovery
`:hand-a-function-or-deref-it-in-this-body`, and Spec 009 rows it that way. So the
runtime cannot read the form either, opacity is not honest for it, and `:assert-it-at-l3`
sent the programmer to L3 where the identical refusal is waiting. **The fixed call obeys
the rule by carrying the runtime's id *and* the runtime's recovery**, exactly as its
sibling arms already did: `:true-child` uses `refuse!` with the runtime's
`:use-nil-or-false`, and the non-delay `:foreign` arm uses `refuse!` with
`:fix-the-child`. Only the delay arm forwarded to `refuse-opaque!`.

Spec 009 had already pinned this, in the kit's own surface section: *"the kit raises the
runtime's own id for the condition rather than a kit-private twin"* — one row, one
recovery.

## Was it one call?

**Yes — one call**, `refuse-opaque!` → `refuse!` with
`:hand-a-function-or-deref-it-in-this-body`, plus the reason text picking up the
runtime's own advice.

The commit also corrects **one docstring sentence in the same file**, because the fix
falsified it: the opaque-set bullet read *"So does an unforced `delay`, which Hicasso
itself refuses at a boundary crossing"* — a sentence that states its own disqualifying
fact in its own clause. It is the defect's prose twin, not a second rule, and leaving it
would have left the file contradicting itself. Nothing else changed; `refuse-opaque!`
keeps its four other call sites.

No behaviour other callers depend on moved. The one existing test over this path
(`test_kit_cljs_test.cljs`) asserts the **id** only, and the runtime-parity table has no
delay row at all — see the follow-up below.

## R10 before and after

R10 lives on #8315's branch, not on `main`. I fetched `origin/worker/catgate-5zmul`,
extracted its `check_complaint_catalogue.py` with `git show`, and ran it **read-only**
against this tree as a temporary probe copy inside `implementation/hicasso/scripts/`
(the script resolves its roots from `__file__`, so it must sit there to read this
worktree). The probe copy was **deleted before the commit** — `git status` clean.

**Before** (exit `1`) — the only failure in the run:

```
R10 :rf.error/hicasso-deferred-read-at-boundary is RAISED with the recovery
:assert-it-at-l3, which its Spec 009 row does not carry (the row has
:hand-a-function-or-deref-it-in-this-body).
```

**After** (exit `0`):

```
OK: 77 live, 5 reserved, 1 pending retirement, 1 retired; ...
    R10: 74 of those are rowed in Spec 009's Hicasso section, and every `:recovery`
    the package raises for them is in its row. The other 3 are corpus-owned spellings
    rowed in the main catalogue, whose recovery answers for a different emitter.
```

**The rule is not blunted.** With the fix in place I planted a one-sided drift —
`:hand-a-function-or-deref-it-in-this-body` → `:deref-it-in-the-body-that-wrote-it`,
a plausible rename — and R10 still went red (exit `1`), naming the planted keyword:

```
R10 :rf.error/hicasso-deferred-read-at-boundary is RAISED with the recovery
:deref-it-in-the-body-that-wrote-it, which its Spec 009 row does not carry
```

The plant was verified by **hashing the file**, not by measuring bytes (this file is
CRLF): `699f9231e8ae1ba4` → `a56f3ecb6f7152e8` → restored to `699f9231e8ae1ba4`, with
R10 green again on the restored tree. The gate's own `--self-test` also passes (exit `0`),
including its arm proving R10 stays silent on the corpus-owned `:rf.error/no-frame-context`.

**I did not touch `check_complaint_catalogue.py`**, did not adjust R10, and added no
exemption. The fix is entirely inside the emit fence.

## Quality gates

Runner note: the changed file is **`.cljs`**, so `clojure -M:test` cannot load it. The
lane that sees this change is the CLJS one. Every exit code below was captured from the
runner on the same command line, redirected to a log, never piped through a filter.

| Gate | Runner | Exit | Result |
|---|---|---|---|
| `check_complaint_catalogue.py` **with R10** (from #8315) | `python` | `0` | **green** (was `1` on base) |
| same, planted one-sided drift | `python` | `1` | **red as intended** — rule not blunted |
| same, `--self-test` | `python` | `0` | pass |
| `check_complaint_catalogue.py` (main's version) | `python` | `0` | pass |
| `npm run test:cljs` | node/shadow-cljs | `0` | **13936 tests, 70220 assertions, 0 failures, 0 errors** |
| `npm run test:hicasso-invariants` | `python` | `0` | pass (6 OK sections; 217 fenced blocks pinned across 29 pages) |
| `check_naming_census.py` | `python` | `0` | **104 public names across 10 shipped namespaces**, 0 unrostered — unmoved by this change, as expected for a private-fn edit |
| `scripts/test-fast-pr.sh` (pre-checkin spine) | `sh` | `0` | pass — 6602 log lines ending in a real summary, not a silent death |

**Re-run on the final base.** The branch was rebased onto `f35ba5d` (5 commits arrived
while the gates ran: the `rf2-gra70` release commit plus four beads checkpoints; none
touch this file, Spec 009 or the complaint register). After the rebase the decisive gate
and the CLJS lane were both **re-run to completion**: R10 exit `0`, its `--self-test`
exit `0`, `npm run test:cljs` exit `0` with **13936 tests / 70220 assertions / 0
failures, 0 errors**.

`git diff origin/main...HEAD` is one file, 21 insertions and 9 deletions — read for what
it would revert, it reverts nothing: `refuse-opaque!` keeps its four other call sites and
no other arm moves.

Heavy gates were run **one at a time** — no two shadow-cljs builds shared `.shadow-cljs`
or `out/`. `npm ci --prefix implementation` was a **real install** (exit `0`), not a
junction; the mayor checkout's `node_modules` read **101** before and **101** after.

Fast-spine-versus-required-CI gap: `scripts/check_fast_pr_gap.py --list` reads **106**
required checks this spine does not run (TESTING.md:121). Nothing was skipped silently.

## Docs

No documentation change is needed and none is made. The guide already documents the
**runtime's** recovery for this id (`docs/core/hicasso/16-diagnostics.md`,
`15-testing.md`, `troubleshooting.md`), so the kit moving onto that recovery removes a
contradiction rather than creating one. The only two `:assert-it-at-l3` rows in
`troubleshooting.md` are the genuinely-opaque kit ids
(`:rf.error/hicasso-test-host-is-opaque`, `:rf.error/hicasso-test-react-is-opaque`),
which are untouched.

## Follow-up filed — rf2-tsdik

`re-frame.hicasso.test-kit-runtime-parity-cljs-test` has a row for every other member of
this class — `[:>]`, `[:> nil]`, `[:> :div]`, the empty vector, the `true` child — and
**no row for the unforced `delay`**. That missing row is why the defect survived to be
caught by a document gate instead of a test. It belongs in
`implementation/hicasso/test/**`, which is fenced to a live agent on this pass, so it is
filed rather than written here.
