### PR TITLE
fix(story): settle a step's async preconditions, not a wall clock (rf2-n0sz4)

### DIFF
--- a/tools/story/spec/017-Testing-Story.md
+++ b/tools/story/spec/017-Testing-Story.md
@@ -942,6 +942,41 @@ the existing framework drain and a flush-hook seam over it.
   same set the assert executor routes on. Steps below `:cljs-reactive` are
   untouched, and on a host whose hooks register no richer flush the whole
   mechanism is inert.
+
+  **A boundary commits what is SCHEDULED; it cannot commit what has not
+  happened yet.** Two things a script depends on are in flight at the
+  instant a step wants them, and no flush can conjure either: the ASYNC
+  DISPATCH behind a synthetic DOM event (`exec-click!` / `exec-type!` /
+  `exec-focus!` fire the event and the handler's `dispatch` schedules its
+  drain through `interop/next-tick`, a macrotask, never inline), and the
+  MOUNT the auto-run outruns (leading sync-class steps run inside the
+  canvas's post-commit hook, while the canvas has committed its loading
+  skeleton and the variant's own markup is not yet in the document).
+  Note the dispatch case is not "nothing drains the queue": `dispatch-sync*`
+  pushes its seed at the FRONT of the queue and drains, so an assertion
+  dispatched at the next step jumps AHEAD of the still-queued event and
+  reads app-db before it lands. Draining harder cannot fix an ordering
+  inversion.
+
+  So on CLJS a step ALSO does not run until its **preconditions** hold:
+  the frame's event queue has drained, and the node the step names is
+  present when it names one. While one is outstanding the runner yields,
+  asks the substrate to commit whatever is pending, and re-checks —
+  without advancing the cursor. This is a settle, not a sleep: it
+  proceeds on the first tick the OBSERVED condition holds rather than
+  after a fixed duration, and it is **bounded** — exhausting the budget
+  FAILS the step readably, naming what never settled, never a silent
+  proceed onto a stale read. `:rf.assert/dom-hidden` is deliberately
+  exempt from the node precondition, an absent node being its pass
+  condition. The mechanism is CLJS-only by construction: the JVM runner
+  has no event loop to yield to, `dispatch-sync*` has already drained by
+  the time any step observes the queue, and no DOM is available — so
+  every precondition reads as met and the headless path is unchanged.
+
+  This is what lets an interaction script be **deterministic** end to end
+  with no `[:wait ms]` (§Determinism gate) — the settle-on-condition
+  discipline `[:wait-until pred]` names, applied automatically at the one
+  place a step's own precondition is knowable.
 - `dispatch-and-settle!` — the entry point `[:dispatch event-vector]`
   lowers to: dispatch through the supplied `:dispatch!`, then run each
   registered flush whose level is `<= required` in ladder order. It

--- a/tools/story/src/re_frame/story/play/runner_events.cljc
+++ b/tools/story/src/re_frame/story/play/runner_events.cljc
@@ -45,6 +45,7 @@
   (:require [re-frame.core              :as rf]
             [re-frame.router            :as router]
             [re-frame.frame             :as frame]
+            [re-frame.interop           :as interop]
             #?(:cljs [reagent.core      :as r])
             [re-frame.story.assertions  :as assertions]
             [re-frame.story.config      :as config]
@@ -1462,6 +1463,129 @@
     (or (nil? state)
         (and token (some? (:run-token state)) (not= token (:run-token state))))))
 
+;; ---- step preconditions: the settle rung for asynchrony (rf2-n0sz4) ------
+;;
+;; rf2-ek9qb gave a step's required BOUNDARY a producer: before a step that
+;; reads or drives the DOM, `settle-substrate-for-step!` asks the live
+;; adapter to COMMIT. That closed the render race, and it closed only that
+;; one, because a synchronous commit can only commit what the host has
+;; already SCHEDULED. Two things a play waits on are scheduled but not yet
+;; landed at the instant the step wants them, and no flush can conjure
+;; either (both MEASURED on the browser lane, rf2-n0sz4):
+;;
+;;   1. THE ASYNC DISPATCH. `exec-click!` / `exec-type!` / `exec-focus!` fire
+;;      a synthetic DOM event; React runs the handler; the handler
+;;      dispatches; the router schedules its drain through
+;;      `interop/next-tick` — `goog.async.nextTick`, a genuine macrotask,
+;;      never inline. The next step then read app-db before the handler's
+;;      event had run: `expected 42 at [:count] but got 0`. Note that this
+;;      is NOT "nothing drains the queue" — `dispatch-sync!` pushes its seed
+;;      at the FRONT of the queue and drains, so an assertion dispatched at
+;;      the next step JUMPS AHEAD of the click's still-queued event and
+;;      reads app-db before it lands. Draining harder cannot fix an ordering
+;;      inversion; only waiting for the queue can.
+;;
+;;   2. THE MOUNT. The auto-run resumes from the canvas's
+;;      `component-did-mount`, and sync-class steps `recur` rather than
+;;      yielding, so a script's leading steps run INSIDE that hook — while
+;;      the canvas has committed its loading SKELETON and the variant's own
+;;      markup is not in the document at all. A first `[:assert-dom …]`
+;;      reported `selector matched no node`.
+;;
+;; ## Why a bounded poll, and why that is not `[:wait ms]` with extra steps
+;;
+;; The choice was between growing the flush-hooks contract a new
+;; drain-only rung verb and settling here, in the runner. This is the
+;; runner's own concern and not the host's: every host's router schedules
+;; the same way, so a verb per host would ask each of them to re-describe
+;; one framework-wide fact. It would also be PUBLIC surface added for a
+;; test harness's convenience, which the project's stance rejects. Nothing
+;; below is reachable by an author.
+;;
+;; A poll is not a sleep, and the difference is the whole point of the
+;; bead. `[:wait 300]` proceeds after 300ms whether or not anything
+;; settled — it is a GUESS, it is spec/017's explicit determinism OPT-OUT,
+;; and `assert-deterministic` refuses a script containing one. This
+;; proceeds on an OBSERVED condition, on the first tick the condition
+;; holds (so it costs a tick, not 300ms, on a fast machine), and when the
+;; condition never holds it FAILS LOUDLY naming what never settled rather
+;; than proceeding on a stale read. spec/017 already anticipated exactly
+;; this and assigned it to exactly this layer: `exec-wait-until!` is
+;; one-shot by contract, and its docstring hands the bounded re-check to
+;; "a richer DOM/browser runner … that poll is the adapter caller's
+;; concern".
+;;
+;; CLJS ONLY, by construction. The JVM runner has no event loop to yield
+;; to, `dispatch-sync!` has already drained the queue by the time any step
+;; observes it, and no DOM is available — so every precondition below
+;; reads as met there and the JVM path is byte-for-byte unchanged.
+
+(def settle-poll-timeout-ms
+  "Wall-clock budget for one step's preconditions to settle before the
+  step is FAILED as un-settleable. Generous next to the tick a settle
+  actually costs, and far short of a lane timeout, so a genuine hang
+  reports as this step's readable failure rather than as a dead run."
+  2000)
+
+(def ^:private presence-required-selector-atoms
+  "The DOM assertion atoms whose selector must RESOLVE before the
+  assertion can be evaluated. `:rf.assert/dom-hidden` is deliberately
+  absent — an absent node is its PASS condition, so waiting for one to
+  appear would invert the assertion and burn the whole budget doing it."
+  #{assertions/id-dom-text
+    assertions/id-dom-visible})
+
+(defn- step-required-selector
+  "The DOM selector `step` must be able to resolve before it can run, or
+  nil when the step needs no node present.
+
+  Covers the interaction steps, which cannot fire an event at a node that
+  is not there, and the presence-asserting half of the DOM assertion
+  family — reading the selector out of the FOLDED atom
+  (`[:rf.assert/dom-* selector & args]`, `exec-assert-dom-atom!`'s own
+  shape) as well as off a raw shipping step that bypassed folding."
+  [step]
+  (case (runner/step-type step)
+    (:click :type :focus) (runner/step-selector step)
+    :assert               (let [atom-v (runner/step-assertion step)]
+                            (when (and (vector? atom-v)
+                                       (contains? presence-required-selector-atoms
+                                                  (first atom-v)))
+                              (nth atom-v 1 nil)))
+    :assert-dom           (runner/step-selector step)
+    nil))
+
+(defn- step-precondition-unmet
+  "nil when every precondition `step` needs is already true — the common
+  case, and a pure read costing nothing. Otherwise a readable phrase
+  naming the one that is not, which becomes the timeout message.
+
+  Two preconditions, in the order a step depends on them:
+
+  - the frame's event queue has DRAINED, so the step observes the
+    consequences of every step before it rather than racing them
+    (`queue-empty?` is a real read of the router's `:queue` +
+    `:scheduled?`, not a stub);
+  - the node the step names is PRESENT, when the step names one.
+
+  Both are tolerant of the headless case: `queue-empty?` reads an
+  unregistered frame as drained, and with no DOM available the selector
+  precondition is moot — the executor's own `{:skipped? true}` no-DOM
+  branch is the right answer there and must not be pre-empted by a
+  timeout."
+  [frame-id step]
+  (let [selector (step-required-selector step)]
+    (cond
+      (not (queue-empty? frame-id))
+      "the frame's event queue has not drained"
+
+      (and selector
+           (dom/dom-available?)
+           (nil? (dom/query selector)))
+      (str "no node matches " (pr-str selector))
+
+      :else nil)))
+
 (defn- run-loop!
   "Iterate over the script, running each step. `:wait` steps yield
   to the scheduler and resume from the wait time onwards.
@@ -1481,8 +1605,18 @@
   `:type`, `:wait`) yield one tick so the queued effects drain before
   the next step runs. A blanket setTimeout-0 between every step would
   reintroduce the re-mount race the async-class split avoids — see
-  `runner/async-yield?`."
-  [frame-id play-key token done-cb]
+  `runner/async-yield?`.
+
+  On CLJS a step does not run until its PRECONDITIONS hold
+  (`step-precondition-unmet` — the queue drained, and the node present
+  when the step names one). While one is outstanding the loop yields,
+  commits whatever the substrate has pending, and re-checks, WITHOUT
+  advancing the cursor; `settle-deadline` carries the wall-clock bound
+  across those re-entries and is nil whenever the loop is not mid-poll.
+  Exhausting the bound FAILS the step readably (rf2-n0sz4) — it is never
+  a silent proceed, and never a silent pass."
+  ([frame-id play-key token done-cb] (run-loop! frame-id play-key token done-cb nil))
+  ([frame-id play-key token done-cb settle-deadline]
   (let [state (current-state-for-play frame-id play-key)]
     (cond
       ;; The slot is no longer ours — the frame was torn down mid-run, or a
@@ -1502,7 +1636,12 @@
       :else
       (let [idx  (:step-idx state)
             step (runner/current-step state)
-            nm   (:name state)]
+            nm   (:name state)
+            ;; Read once per pass. CLJS-only: the JVM runner has no event
+            ;; loop to yield to and no DOM, so it never polls and never
+            ;; needs the answer.
+            unmet #?(:cljs (step-precondition-unmet frame-id step)
+                     :clj  nil)]
         (cond
           (= :wait (runner/step-type step))
           (let [ms (or (runner/step-wait-ms step) 0)]
@@ -1515,8 +1654,46 @@
             ;; flat. CLJS keeps async `setTimeout` scheduling so the event loop
             ;; drains between steps (rf2-epqsvh).
             #?(:clj  (do (when (pos? ms) (Thread/sleep ^long ms))
-                         (recur frame-id play-key token done-cb))
-               :cljs (schedule! ms #(run-loop! frame-id play-key token done-cb))))
+                         (recur frame-id play-key token done-cb nil))
+               :cljs (schedule! ms #(run-loop! frame-id play-key token done-cb nil))))
+
+          ;; The step's preconditions are not met YET (CLJS only — see
+          ;; `step-precondition-unmet`). Something is in flight that the
+          ;; step depends on: the router's `next-tick` drain after a
+          ;; synthetic DOM event, or the render that puts the variant's
+          ;; markup in the document. Give the host a turn, ask the
+          ;; substrate to commit whatever is pending, and re-check —
+          ;; WITHOUT advancing the cursor, so this step still runs.
+          #?@(:cljs
+              [(and (some? unmet)
+                    (or (nil? settle-deadline)
+                        (< (interop/now-ms) settle-deadline)))
+               (let [deadline (or settle-deadline
+                                  (+ (interop/now-ms) settle-poll-timeout-ms))]
+                 ;; Commit anything the substrate has already scheduled. This
+                 ;; is rf2-ek9qb's own rung, reused: on a rAF-scheduled
+                 ;; substrate in a throttled tab the pending render would
+                 ;; otherwise never land no matter how long we yielded. Its
+                 ;; refusal result is deliberately discarded — `exec-step!`
+                 ;; establishes the same boundary and reports a refusal
+                 ;; properly when the step actually runs.
+                 (settle-substrate-for-step! frame-id idx step)
+                 (js/setTimeout
+                   #(run-loop! frame-id play-key token done-cb deadline) 0))
+
+               ;; Budget exhausted. FAIL LOUDLY, naming what never settled —
+               ;; never a silent proceed onto a stale read (which is what a
+               ;; wall-clock `[:wait ms]` does by construction).
+               (some? unmet)
+               (do
+                 (record-result!
+                   frame-id play-key nm idx step
+                   (runner/step-fail
+                     idx step
+                     {:message (str "step preconditions never settled within "
+                                    settle-poll-timeout-ms "ms — " unmet)}))
+                 (js/setTimeout
+                   #(run-loop! frame-id play-key token done-cb nil) 0))])
 
           :else
           (let [_      (record-settle-boundary! frame-id play-key step)
@@ -1575,7 +1752,7 @@
                            ;; continuation, which the play-promise and the
                            ;; outer `run-variant` promise resolve through.
                            (js/setTimeout
-                             #(run-loop! frame-id play-key token done-cb) 0)))
+                             #(run-loop! frame-id play-key token done-cb nil) 0)))
                  :clj  nil)
               (do
                 (record-result! frame-id play-key nm idx step result)
@@ -1587,9 +1764,10 @@
                 ;; queued router work / synthetic DOM event handlers drain
                 ;; before the next step runs.
                 #?(:cljs (if yield?
-                           (js/setTimeout #(run-loop! frame-id play-key token done-cb) 0)
-                           (recur frame-id play-key token done-cb))
-                   :clj  (recur frame-id play-key token done-cb))))))))))
+                           (js/setTimeout
+                             #(run-loop! frame-id play-key token done-cb nil) 0)
+                           (recur frame-id play-key token done-cb nil))
+                   :clj  (recur frame-id play-key token done-cb nil)))))))))))
 
 ;; ---- public driver -------------------------------------------------------
 

--- a/tools/story/test/re_frame/story/play/step_settle_cljs_test.cljc
+++ b/tools/story/test/re_frame/story/play/step_settle_cljs_test.cljc
@@ -1,0 +1,174 @@
+(ns re-frame.story.play.step-settle-cljs-test
+  "rf2-n0sz4 — the settle rung for a step's ASYNCHRONOUS preconditions.
+
+  rf2-ek9qb gave a step's required BOUNDARY a producer, so a DOM-touching
+  step now asks the live adapter to COMMIT before it runs. That closed the
+  render race and only that one: a synchronous commit can commit only what
+  the host has already SCHEDULED. Two things a play depends on are
+  scheduled-but-not-landed at the instant the step wants them, and the
+  browser lane measured both —
+
+    - the async DISPATCH behind a synthetic DOM event
+      (`expected 42 at [:count] but got 0`), and
+    - the MOUNT the auto-run outruns (`selector matched no node`).
+
+  ## Why these witnesses are reads and counts, never timings
+
+  A timing measurement proves nothing in either direction: a fast machine
+  passes a broken runner and a loaded one fails a correct one. So the
+  witnesses below assert on STATE the runner is supposed to consult —
+  `step-precondition-unmet`, the one decision the poll is built on. Before
+  this bead nothing consulted it: the run-loop executed every step the
+  moment it reached it, and the only thing standing between a `:click` and
+  the next step's read of app-db was one blind `setTimeout` 0.
+
+  The load-bearing subtlety, and the reason the queue is the predicate:
+  `router/dispatch-sync!` pushes its seed at the FRONT of the queue and
+  drains, so an assertion dispatched at the next step JUMPS AHEAD of the
+  click's still-queued event and reads app-db before it lands. Draining
+  harder cannot fix an ordering inversion — only waiting for the queue
+  can, which is what `queue-not-drained-is-an-unmet-precondition` pins.
+
+  ## Which lane proves what
+
+  `.cljc` so the JVM lane (`clojure -M:test` from `tools/story`) loads it,
+  and `*_cljs_test` so the `:node-test` build's `cljs-test$` ns-regexp
+  discovers it too — the same dual-lane trick
+  `substrate_boundary_cljs_test.cljc` uses, and for the same reason: the
+  production change is `.cljc` and a reader-conditional mistake in the
+  `:cljs` branch would be invisible to a JVM-only run.
+
+  ONE test is deliberately CLJS-only, and it is flagged in its own name.
+  Observing a queued-but-undrained router demands that the drain provably
+  has NOT run yet, and only CLJS guarantees that: `interop/next-tick` is
+  `goog.async.nextTick`, a macrotask that cannot run inside the current
+  synchronous turn. The JVM's `next-tick` hands the drain to a thread
+  executor which explicitly does NOT promise return-before-start, so the
+  same assertion would be a race there. Nothing about the read is async in
+  either case — it happens on the statement after the dispatch, which is
+  precisely what makes it deterministic."
+  (:require #?(:clj  [clojure.test :refer [deftest is testing use-fixtures]]
+               :cljs [cljs.test    :refer [deftest is testing use-fixtures]])
+            [re-frame.core   :as rf]
+            [re-frame.router :as router]
+            [re-frame.frame  :as frame]
+            [re-frame.registrar :as registrar]
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.story  :as story]
+            [re-frame.story.play.runner-events :as re]))
+
+;; The two private decisions under witness, reached by var-quote — the
+;; established Story-test seam for a runner internal.
+(def ^:private step-required-selector   @#'re/step-required-selector)
+(def ^:private step-precondition-unmet  @#'re/step-precondition-unmet)
+
+(def ^:private settle-frame :story.step-settle/frame)
+
+(defn- reset-rf! [test-fn]
+  (story/clear-all!)
+  (registrar/clear-all!)
+  (reset! frame/frames {})
+  (try (rf/init! plain-atom/adapter)
+       (catch #?(:clj clojure.lang.ExceptionInfo :cljs :default) _ nil))
+  (reset! re/run-state {})
+  (story/install-canonical-vocabulary!)
+  (frame/ensure-default-frame!)
+  (rf/make-frame {:id settle-frame :doc "step-settle witness frame"})
+  (rf/reg-event :settle/inc (fn [{:keys [db]} _] {:db (update db :n (fnil inc 0))}))
+  (test-fn))
+
+(use-fixtures :each reset-rf!)
+
+;; ===========================================================================
+;; PURE: which steps must wait for a node, and — the trap — which must not
+;; ===========================================================================
+
+(deftest interaction-steps-require-their-node
+  (testing "a step that fires an event at a node cannot run before the node
+            exists — it has nothing to fire at"
+    (is (= "[data-test=go]" (step-required-selector [:click "[data-test=go]"])))
+    (is (= "[data-test=in]" (step-required-selector [:type "[data-test=in]" "42"])))
+    (is (= "[data-test=in]" (step-required-selector [:focus "[data-test=in]"])))))
+
+(deftest presence-asserting-dom-atoms-require-their-node
+  (testing "the FOLDED atom shape [:rf.assert/dom-* selector & args] is what
+            reaches the run-loop, so the selector is read out of the atom"
+    (is (= "[data-test=out]"
+           (step-required-selector
+             [:assert [:rf.assert/dom-text "[data-test=out]" "42"]])))
+    (is (= "[data-test=out]"
+           (step-required-selector
+             [:assert [:rf.assert/dom-visible "[data-test=out]"]]))))
+  (testing "a raw shipping :assert-dom step that bypassed folding is covered too"
+    (is (= "[data-test=out]"
+           (step-required-selector [:assert-dom "[data-test=out]" :text "42"])))))
+
+(deftest dom-hidden-must-not-wait-for-the-node
+  (testing "THE TRAP. An ABSENT node is :rf.assert/dom-hidden's PASS
+            condition. Waiting for one to appear would invert the assertion
+            and burn the whole budget doing it, so it is excluded"
+    (is (nil? (step-required-selector
+                [:assert [:rf.assert/dom-hidden "[data-test=gone]"]])))))
+
+(deftest non-dom-steps-require-no-node
+  (testing "a step naming no node waits for no node"
+    (is (nil? (step-required-selector [:dispatch [:settle/inc]])))
+    (is (nil? (step-required-selector [:dispatch-sync [:settle/inc]])))
+    (is (nil? (step-required-selector [:wait-until [:queue-empty]])))
+    (is (nil? (step-required-selector
+                [:assert [:rf.assert/path-equals [:n] 1]])))))
+
+;; ===========================================================================
+;; The precondition decision itself
+;; ===========================================================================
+
+(deftest a-settled-frame-has-no-unmet-precondition
+  (testing "the common case is a pure read that costs nothing and blocks
+            nothing — no queue outstanding, no node demanded"
+    (is (nil? (step-precondition-unmet settle-frame
+                                       [:dispatch-sync [:settle/inc]])))
+    (is (nil? (step-precondition-unmet settle-frame
+                                       [:assert [:rf.assert/path-equals [:n] 0]])))))
+
+(deftest headless-never-waits-for-a-node
+  (testing "with no DOM available the selector precondition is MOOT — the
+            executor's own no-DOM {:skipped? true} branch is the right
+            answer and must not be pre-empted by a timeout. This is what
+            keeps the JVM / node-runtime headless path unchanged"
+    (is (nil? (step-precondition-unmet settle-frame [:click "[data-test=go]"])))
+    (is (nil? (step-precondition-unmet
+                settle-frame
+                [:assert [:rf.assert/dom-text "[data-test=out]" "42"]])))))
+
+(deftest an-unknown-frame-reads-as-drained
+  (testing "tolerant — a destroyed / never-registered frame has nothing left
+            to wait for, so it never parks the loop"
+    (is (nil? (step-precondition-unmet :story.step-settle/no-such-frame
+                                       [:dispatch-sync [:settle/inc]])))))
+
+;; ===========================================================================
+;; CLJS ONLY: the queue is genuinely outstanding after an async dispatch
+;; ===========================================================================
+
+#?(:cljs
+   (deftest queue-not-drained-is-an-unmet-precondition
+     (testing "THE HOLE rf2-n0sz4 measured. `router/dispatch!` enqueues and
+               schedules the drain through `interop/next-tick` — a
+               MACROTASK, so it provably has not run on the statement after
+               the dispatch. That is the state a step lands in right after a
+               synthetic DOM event fires a handler that dispatches, and it
+               is exactly the state the runner used to execute the next step
+               in, reading app-db before the event landed"
+       (router/dispatch! [:settle/inc] {:frame settle-frame})
+       (let [unmet (step-precondition-unmet settle-frame
+                                            [:assert [:rf.assert/path-equals [:n] 1]])]
+         (is (some? unmet)
+             "the runner must NOT run the step while the queue is outstanding")
+         (is (re-find #"queue" unmet)
+             "and the timeout message must name what never settled"))
+       (testing "and it clears once the queue really has drained — the poll
+                 proceeds on the OBSERVED condition, not on a timer"
+         (router/dispatch-sync! [:settle/inc] {:frame settle-frame})
+         (is (nil? (step-precondition-unmet
+                     settle-frame
+                     [:assert [:rf.assert/path-equals [:n] 1]])))))))

--- a/tools/story/testbeds/counter_with_stories/stories.cljs
+++ b/tools/story/testbeds/counter_with_stories/stories.cljs
@@ -788,19 +788,20 @@
      :script
      {:name      "type-click-and-assert-dom"
       :auto-run? true
-      ;; A leading `:wait 300` gives React's first commit a chance to
-      ;; render the component before the first DOM assertion. The
-      ;; auto-run fires as soon as the lifecycle machine reaches
-      ;; `:ready`, which can race ahead of React's render flush.
+      ;; NO `[:wait ms]` — this script is DETERMINISTIC end to end
+      ;; (rf2-n0sz4). It used to open with a 300ms sleep for the mount and
+      ;; carry another after the `:click` for the dispatch, because neither
+      ;; the mount nor a synthetic event's async dispatch had a settle
+      ;; rung. Both now do: the runner holds a step until its
+      ;; preconditions hold — the frame's event queue drained, and the
+      ;; node the step names present — yielding and committing the
+      ;; substrate until they do, bounded, failing readably if they never
+      ;; settle. `[:wait ms]` is spec/017's determinism OPT-OUT that
+      ;; `assert-deterministic` refuses, so its absence here is the point.
       :script    [[:dispatch-sync [:counter/initialise 0]]
-                  [:wait        300]
                   [:assert-dom  "[data-test=count-display]" :text "0"]
                   [:type        "[data-test=count-input]" "42"]
                   [:click       "[data-test=set-button]"]
-                  ;; The click dispatches :counter/set synchronously
-                  ;; on Reagent; the wait ensures the next render cycle
-                  ;; has flushed before we read the DOM.
-                  [:wait        300]
                   [:assert-db   [:count] 42]
                   [:assert-dom  "[data-test=count-display]" :text "42"]
                   [:assert-dom  "[data-test=set-button]"    :visible]]}
@@ -819,11 +820,13 @@
      :script
      {:name      "type-click-and-assert-dom-wrong"
       :auto-run? true
+      ;; Sleep-free for the same reason as its twin (rf2-n0sz4). The row
+      ;; must still reach `:fail`, and it does so on the ASSERTION it was
+      ;; written to fail — "99" against a settled "42" — rather than on a
+      ;; race that happened to read an unsettled DOM.
       :script    [[:dispatch-sync [:counter/initialise 0]]
-                  [:wait          50]
                   [:type          "[data-test=count-input]" "42"]
                   [:click         "[data-test=set-button]"]
-                  [:wait          100]
                   [:assert-dom    "[data-test=count-display]" :text "99"]]}
      :tags       #{:dev :test :internal}
      :substrates #{:reagent}})


### PR DESCRIPTION
Closes rf2-n0sz4.

## Both original failures, reproduced first

Before designing anything I reproduced both captures on the browser lane. They match the bead verbatim, at captured exit 1.

**Failure 1 — post-click sleep deleted** (`gate-play-settle-n0sz4-2`, exit 1):

```
MISS story.counter-play-script/dom[type-click-and-assert-dom]  expected=pass actual=fail  steps=8
     step 5 assert — expected 42 at [:count] but got 0 expected=42 actual=0
```

**Failure 2 — both sleeps deleted** (`gate-play-settle-n0sz4-3`, exit 1):

```
     step 1 assert — expected "[data-test=count-display]" text-content = "0", but selector matched no node
     step 2 type — type failed — no node matched "[data-test=count-input]"
```

Control before either: 30 rows, 0 unexpected, exit 0.

I acted on the bead's **description**. It has no notes — `comment_count: 0` — so the two captured failures are FINDING 1 and FINDING 2 in the description body.

## What the mechanism actually is — one correction to the bead

Finding 1 is **not** "nothing drains the event queue". `router/dispatch-sync!` documents that it *"pushes the seed event at the FRONT of the queue and then the drain loop runs"*. The next step's `:assert-db` folds to a handler-backed atom that is **dispatched** through `settled-boundary`, so it jumps **ahead** of the click's still-queued `:counter/set` and reads app-db before it lands. Draining harder cannot fix an ordering inversion — only waiting for the queue can. That is why the predicate is the queue, not a drain verb.

Finding 2 is the mount: a script's leading sync-class steps `recur` **inside** the canvas's `component-did-mount`, while the canvas has committed its loading **skeleton** and the variant's own markup is not in the document at all.

## The remedy, and why, in the stance's terms

**The bounded poll. I tested the lean rather than assuming it, and I also refuted one candidate by measurement.**

A **new hooks rung verb** was rejected: it is PUBLIC contract surface added for one test's convenience, and it would ask every host to re-describe a single framework-wide fact about its own router. Nothing added here is reachable by an author.

**A bounded poll is not `[:wait ms]` with extra steps** — the refusal test the brief set. `[:wait 300]` proceeds after 300ms whether or not anything settled; it is spec/017's explicit determinism **opt-out** that `assert-deterministic` refuses. This proceeds on the first tick an **observed** condition holds (a tick, not 300ms, on a fast machine) and **fails loudly** naming what never settled when it does not. spec/017 had already assigned exactly this to exactly this layer: `exec-wait-until!` is one-shot by contract and hands the bounded re-check to *"the adapter caller"*.

**One remedy closes both gaps**, with two predicates on one mechanism: the frame's event queue has drained, and the node the step names is present. While one is outstanding the loop yields, commits whatever the substrate has pending (rf2-ek9qb's own rung, reused — no new verb), and re-checks **without advancing the cursor**.

**A refuted candidate, reported because it was measured.** I first tried fixing finding 2 at the source, per the bead's own suggestion — retiring the loading skeleton before the run resumes, so the mount becomes *scheduled* work `flush-render!` could commit. The lane still failed `selector matched no node` (`gate-play-settle-n0sz4-4`, exit 1), so I **reverted it** rather than ship a change that fixes nothing.

`:rf.assert/dom-hidden` is deliberately **exempt** from the node precondition — an absent node is its pass condition, so waiting would invert the assertion. That trap has its own witness.

## Are the sleeps gone?

**All four, and the lane is green.** Not just the two the bead named: the expected-fail twin's `[:wait 50]` / `[:wait 100]` are gone too, and it still reaches `:fail` on the assertion it was written to fail. A grep for wait steps under `tools/story/testbeds/` now returns only prose. The DOM row runs 7 steps (was 9); the twin runs 4 (was 6).

## Hooks contract

**Untouched.** No new rung verb, no new late-bind key, no new `:flush!` entry, nothing added to `settled_boundary.cljc`'s map shape. The two new fns are `defn-` private in `runner_events.cljc`.

## Bounded, and loud on timeout

Bounded at `settle-poll-timeout-ms` = 2000ms wall-clock, carried across re-entries as a deadline. On exhaustion the step is **failed** with `step preconditions never settled within 2000ms — <what>`, recorded as a normal step-fail, and the run continues to its verdict. It is never a silent proceed onto a stale read. CLJS-only by construction: the JVM has no event loop to yield to, has already drained via `dispatch-sync!`, and has no DOM — so every precondition reads as met and it never polls there.

## Spec

`tools/story/spec/017-Testing-Story.md` updated in this PR, same rule as #8313 — shipped behaviour changed. Added to the `settle-to!` section: a boundary commits what is SCHEDULED and cannot commit what has not happened yet; the two gaps; the front-of-queue ordering inversion; the precondition rule, its bound, its loud failure, the `dom-hidden` exemption and the CLJS-only construction; and that this is what lets an interaction script be deterministic with no `[:wait ms]`.

## Plant proof — hashed, not measured

File hash before: `08582cca9e828a3b22edae66928dace76ad496b801dcc992192bc05b1faef8a9`.

**Plant A** (add `id-dom-hidden` to the presence set) → hash `e45c3898…`, JVM lane **exit 1**, `1855 tests / 6791 assertions, 1 failures`, the single failure in `dom-hidden-must-not-wait-for-the-node`. Identical counts to the control.

**Plant B** (disable the queue precondition) → hash `6c3ad026…`, `npm run test:cljs` **exit 1**, `13944 / 70239, 1 failures, 1 errors` — both in `queue-not-drained-is-an-unmet-precondition` (lines 165 and 167; the error is the knock-on `re-find` on nil). No collateral.

Restored after each; hash back to `08582cca…` **exactly**.

Both lanes are proven to exercise the changed file, which matters because the production change is `.cljc`: Plant A bites the JVM runner, Plant B bites the CLJS branch that a JVM-only run cannot see.

## Witnesses — reads, not timings

`tools/story/test/re_frame/story/play/step_settle_cljs_test.cljc`, `.cljc` + `*_cljs_test` so **both** lanes execute it (the dual-lane trick `substrate_boundary_cljs_test.cljc` uses, and for the same reason). +7 tests / +16 assertions. Per #8313's shape these assert on **state the runner must consult**, never elapsed time. The queue witness reads **synchronously on the statement after** `router/dispatch!` — deterministic on CLJS because `goog.async.nextTick` is a macrotask that cannot run in the current turn, and marked CLJS-only because the JVM's `next-tick` executor explicitly does not promise return-before-start.

## Quality gates

| Gate | Result | Exit |
|---|---|---|
| `npm run test:story-play-scripts` (decisive) | **30 rows, 0 unexpected** | **0** |
| `clojure -M:test` in `tools/story` | **1855 tests / 6791 assertions, 0 failures, 0 errors** | **0** |
| `npm run test:cljs` | **13944 tests / 70239 assertions, 0 failures, 0 errors** | **0** |
| `scripts/check_doc_slugs.py` | clean | **0** |

All re-run on the final rebased base (`2ab9a428`). Every number above was captured from the runner's own output with the exit code echoed on the same command line, never piped through a filter.

Fast-spine-versus-required-CI gap read through the one path, `scripts/check_fast_pr_gap.py --list` (TESTING.md:121): **`106 required checks unrun locally`**. It names both lanes for this surface — `story-xray-browser` → `npm run test:story-play-scripts`, and `jvm-tools-story` → `cd tools/story && clojure -M:test`. Both run above.

No gate skipped.

## Fence

Derived at start-up on both signals and verified: `gh pr list --state all` (only #8314 open — release wiring, no `tools/story`), `git diff origin/main...<branch>` across **every** local worker branch (only `worker/storysettle-ek9qb` touches `tools/story`, and it is #8313, **merged**), and `git status --porcelain` inside each named live worktree (no uncommitted `tools/story`). All four files here are under `tools/story/**`. No `.beads` file is committed.
