### PR TITLE
test(core): witness the dispatch before asserting the gate's absences (rf2-s0y22)

### DIFF
--- a/implementation/core/test/re_frame/jvm_prod_gate_integration_test.clj
+++ b/implementation/core/test/re_frame/jvm_prod_gate_integration_test.clj
@@ -43,7 +43,40 @@
 
   The unit-level vocabulary semantics live in
   `re-frame.interop-debug-gate-test`; this suite is the end-to-end
-  integration story."
+  integration story.
+
+  ## Why every negative assertion below is paired with a WITNESS (rf2-s0y22)
+
+  Two of the claims here are ABSENCES — an empty ring buffer, a silent trace
+  listener. An absence is satisfied by two different worlds: the gate elided
+  the trace (the claim), or the dispatch never happened at all (a defect).
+  rf2-9c2jf was the second world — `dispatch-sync` running its handler ZERO
+  times under the documented gate — and a bare `(is (empty? …))` cannot tell
+  them apart. It reports green for both, which is what let rf2-9c2jf live.
+  `trace-buffer-inert-when-debug-disabled`'s failure message even ASSERTED the
+  distinction (\"no event landed despite dispatch firing\") while the assertion
+  under it could not establish it.
+
+  Measured, not argued: with the two `dispatch-sync` calls below removed, the
+  pre-rf2-s0y22 file passed this artefact's required production-gate lane at
+  exit 0, counts unchanged.
+
+  So each of those deftests now asserts, beside the absence, that the dispatch
+  it is reasoning about actually landed: the handler's app-db write is read
+  back through `app-db-of`. That converts \"nothing was recorded\" from an
+  unfalsifiable statement into a conditional one — the run did the work AND the
+  gate kept none of it. Do not delete a witness to \"simplify\" a test; the
+  witness is the half that makes the other half mean something. This is the
+  same discipline rf2-t7qh8 applied to the epoch sibling
+  (`re-frame.epoch-jvm-prod-gate-test`), spelled the same way on purpose.
+
+  `dispatched-at-retired-cofx-stamped-regardless-of-gate`'s two `(not
+  (contains? … :dispatched-at))` assertions are also absences, and they are
+  deliberately left alone: they read a value returned SYNCHRONOUSLY by
+  `build-envelope` rather than a side effect of a dispatch, and the
+  `:rf/time-ms` assertions in the same deftest already fail if that envelope
+  ever comes back empty or nil, under both gate states. The vacuous world is
+  closed there; adding a witness would be ceremony."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
             [re-frame.interop :as interop]
@@ -58,6 +91,11 @@
   stamping (rf2-s9ss0t) is asserted directly against `build-envelope`'s output."
   #'router/build-envelope)
 
+;; rf2-s0y22 — the witness read. See the docstring section above: it is what
+;; separates "the gate elided the trace" from "nothing happened".
+(defn- app-db-of [frame-id]
+  (:rf.db/app (rf/frame-state-value frame-id)))
+
 (use-fixtures :each
   (test-support/make-reset-runtime-fixture
     {:adapter plain-atom/adapter}))
@@ -71,6 +109,9 @@
       (rf/reg-event :prod-gate/inc
                        (fn [{:keys [db]} _] {:db (update db :n (fnil inc 0))}))
       (rf/dispatch-sync [:prod-gate/inc])
+      (is (= 1 (:n (app-db-of :rf/default)))
+          "WITNESS: the dispatch ran its handler and committed — so the
+           empty buffer below is elision, not a dead dispatch")
       (is (empty? (trace/trace-buffer :rf/default))
           "trace buffer is empty under disabled gate — no event
            landed despite dispatch firing"))))
@@ -89,6 +130,9 @@
                          (fn [{:keys [db]} _] {:db (update db :n (fnil inc 0))}))
         (rf/dispatch-sync [:prod-gate/silent])
         (rf/unregister-listener! :trace :prod-gate/recorder)
+        (is (= 1 (:n (app-db-of :rf/default)))
+            "WITNESS: the dispatch ran — the silent listener below had a real
+             cascade to miss")
         (is (empty? @seen)
             "trace listener saw zero events under disabled gate")))))
 


### PR DESCRIPTION
Makes two absence assertions in `implementation/core`'s
`jvm_prod_gate_integration_test` honest. I acted on the bead's **description** —
it has no notes (`comment_count` 0).

Filed by rf2-t7qh8 after it closed the identical shape in the epoch sibling
(#8303). **The premise held**, and I measured it rather than inheriting it.

## What the sweep found: 8 assertions, 4 absences, 2 witness-free

I counted the whole file rather than trusting the bead's "2", since the epoch
sibling turned out to be 6 of 10.

| deftest | assertions | shape | verdict |
|---|---|---|---|
| `trace-buffer-inert-when-debug-disabled` | 1 | absence, no witness | **FIXED** |
| `trace-listener-silent-when-debug-disabled` | 1 | absence, no witness | **FIXED** |
| `always-on-event-emit-still-fires-when-debug-disabled` | 1 | `(= 1 (count @seen))` — positive | self-witnessing |
| `dispatched-at-retired-cofx-stamped-regardless-of-gate` | 4 | 2 absences + 2 positives | **establishable — left alone** |
| `always-on-error-emit-still-fires-when-debug-disabled` | 1 | `(some? @listener-saw)` — positive | self-witnessing |

**8 assertions found, 2 changed.** The bead's count was right for the
witness-free class; the sweep found two more absences it had not named, and they
did not need the fix.

### Why the third deftest's two absences are left as they are

`(not (contains? (build-envelope [:noop] {}) :dispatched-at))` × 2 are absences,
so they were in scope for the sweep. But the vacuous world is already closed
there, for a reason that does not apply to the other two: they read a value
returned **synchronously** by `build-envelope`, not a side effect of a dispatch,
and the same deftest's `(number? (:rf/time-ms cofx))` assertions — under **both**
gate states — go red the moment that envelope comes back empty or nil. A
witness-free absence needs a witness; an absence whose subject is already
witnessed two forms away does not. Adding one would be ceremony.

## The fix — #8303's shape, deliberately

Followed, not departed from. Each fixed deftest now reads the handler's app-db
write back through a private `app-db-of` helper before asserting the absence,
same helper name and same `WITNESS:` message prefix as
`epoch_jvm_prod_gate_test`. A consistent spelling across sibling gates is worth
more than a locally clever variant.

## Plant proof — an A/B, not an assertion

The identical fault (both `dispatch-sync` calls removed — rf2-9c2jf's shape),
run through the lane script itself, four runs:

| file | verdict | captured exit | counts |
|---|---|---|---|
| pre-change, unplanted (control) | PASS | **0** | 1986 tests / 8704 assertions, 0 failures |
| **pre-change, planted** | **PASS** | **0** | 1986 tests / 8704 assertions, **0 failures** |
| post-change, unplanted | PASS | **0** | 1986 tests / 8706 assertions, 0 failures |
| **post-change, planted** | **FAIL** | **1** | 1986 tests / 8706 assertions, **2 failures** |

**The false green is demonstrated, not hypothesised.** With both dispatches gone,
the pre-change file sails through a required job at exit 0 with counts
byte-identical to its control. The witnessed file cannot: both new assertions
fire, named in the output at lines 112 and 133.

Test counts are **identical across all four runs** (1986), and each planted run's
assertion count matches its own control (8704 / 8706), so the plant stopped no
namespace. The lane prints `gate root:` and it read this worktree on every run.

Planted file restored and verified byte-identical by `git hash-object`
(`242f9bd067f5bb75964de5f02b0abcaeb60774ee`); zero `PLANT` markers remain.

## Quality gates

Every exit code below is **captured** (`echo $?` to a `.exit` file on the same
command line), never read off the harness — which disagreed once here, reporting
"exit code 0" for the exit-**1** plant run.

| gate | result | captured exit |
|---|---|---|
| `scripts/test-core-prod-gate.sh` (the subject lane, final base) | 1986 tests / **8706** assertions, **0 failures**, 178 of 190 namespaces | **0** |
| `clojure -M:test` in `implementation/core` — **after** | 2243 tests / **11691** assertions, 0 failures | **0** |
| `clojure -M:test` in `implementation/core` — **before** | 2243 tests / **11689** assertions, 0 failures | **0** |
| `scripts/check_jvm_lane_rosters.py` | 34 rostered artefacts, bijection holds | **0** |
| `scripts/test-fast-pr.sh` (spine) | `PASS fast PR spine`, 0 `FAIL` lines | **0** |

**Totals: 5 gates pass, 0 fail.** The two red runs above are the deliberate
plants, restored. No gate was skipped.

**Core test counts before → after: 2243 / 11689 → 2243 / 11691.** Both measured
here, not cited. Test count unchanged; +2 assertions is exactly the two
witnesses, and the lane's 8704 → 8706 is the same +2 seen twice.

**Runner matches the extension:** the target is a `.clj`, so the JVM runner
(`clojure -M:test` / the `:prod-gate` alias) is the right one and is what ran.

**The spine does not cover this lane.** `scripts/check_fast_pr_gap.py --list`
(TESTING.md:121) reads **106** required checks the spine does not run, and
`jvm-core-prod-gate` is one of them by name. That is why the lane was run
directly, four times, rather than leaned on through the spine.

**Spine base note:** the spine ran green on `e2c70fe6f9`; `origin/main` then
advanced to `0fb6b1bb42` while it ran. Those 22 files are release/hicasso/docs
work — **none under `implementation/core/`**, so nothing my diff touches or that
grades it moved. Rather than re-run 30 minutes against a moving base, I re-ran
the subject lane on the final rebased base, green above. Same call #8303 made.

**No workflow change.** `.github/` is untouched, so no job key added or removed
and this is not a band event. The fix needed nothing outside the test file.

```
$ git diff --name-only origin/main...HEAD
implementation/core/test/re_frame/jvm_prod_gate_integration_test.clj
```

Closes rf2-s0y22.
