### PR TITLE
fix(hicasso): R10 covers every emit site, and the parity table gets its delay row (rf2-5zmul, rf2-tsdik, rf2-0ftho)

### DIFF
--- a/implementation/hicasso/scripts/check_complaint_catalogue.py
+++ b/implementation/hicasso/scripts/check_complaint_catalogue.py
@@ -70,9 +70,10 @@ THE TEN RULES
                      for which directions that is, and which it is not.
   R10 THE RUNTIME IS THE ANCHOR.  Every `:recovery` keyword the package
                      RAISES for an id Spec 009 rows in its Hicasso
-                     section appears in that row's recovery cell — and
-                     every such id has at least one emit site this gate
-                     can read.  R1–R9 reconcile documents with documents;
+                     section appears in that row's recovery cell — read at
+                     EVERY emit site, so an id needs both a site the gate
+                     can read and no site it cannot.  R1–R9 reconcile
+                     documents with documents;
                      this is the only rule that opens the source and
                      reads what the runtime actually passes.  See R10 IS
                      THE RUNTIME ANCHOR below, which is careful about
@@ -178,22 +179,39 @@ WHAT R10 CANNOT SEE:
 
   * A recovery that is CORRECT against Spec 009 and wrong about the API.
     That is the paragraph above, and it is the whole of rf2-15bqc.
-  * A recovery computed from something the reader cannot fold to a
-    keyword — a lookup, a function call.  Nothing in the package does
-    this today; a conditional (`impl/codec` writes one) is read as the
-    SET of both arms, which is what the id can answer.
+  * WHAT a recovery MEANS.  The reader folds an argument expression to
+    keywords; it does not evaluate anything, and a site that computes its
+    recovery from a lookup or a function call is not read — it is FAILED,
+    per the paragraph below.  Two expression shapes are admitted and
+    `_resolve` is the whole grammar: a keyword literal, and a two-branch
+    `if`/`if-not` over keyword literals, which reads as the SET of arms
+    because both are answers the id can give (`impl/codec` writes one).
   * The three corpus-owned spellings, deliberately, per the subject rule
     above.  `:rf.error/no-frame-context` is rowed `:supply-frame` for
     `re-frame.frame`'s emitter while Hicasso's boundary passes
     `:mount-under-a-frame`; both are right where they stand, and no rule
     here has an opinion.
 
-  The first arm of R10 is what keeps the other two honest.  A gate that
-  reads emit sites can always read FEWER of them than it claims to — a
-  new constructor shape, and the rule quietly covers less while still
-  reporting OK.  So every id in the subject must yield a recovery the
-  reader understood, and an id it cannot account for is a FAILURE rather
-  than a silence.
+  THE COVERAGE ARM IS PER EMIT SITE, AND HAD TO BE CORRECTED TO SAY SO
+  (rf2-5zmul, audit of #8315).  A gate that reads emit sites can always
+  read FEWER of them than it claims to — a new constructor shape, and the
+  rule quietly covers less while still reporting OK.  The first version
+  of this arm asked only whether an id had ANY recovery the reader
+  understood, and that is not the same question: `recoveries_in` is keyed
+  by id, so one site passing a literal made the id look accounted for and
+  a SIBLING site passing `(recovery-for x)` was dropped in silence.
+  Measured: a fixture with one call, and the same file plus a second call
+  for the SAME id through an unreadable expression, produced byte-for-byte
+  identical output — and R1's emitted-id input was identical too, because
+  the sibling names the same id.  So the second site could raise a keyword
+  no row carries with every arm green.  The scan now KEEPS such a site and
+  R10 fails on it, which is why both halves of the fixture are pinned in
+  `--self-test`.  MEASURED COST ON THIS TREE: 105 constructor call sites.
+  One is a constructor's own body forwarding its `id` parameter, which has
+  no id to attribute and is read where its CALLERS stand.  Of the other
+  104: 103 pass a keyword literal, 1 passes the `impl/codec` conditional,
+  and 0 are unreadable.  The rule tightens and nothing needed an
+  exemption — which is the evidence that it is worth its keep.
 
 WHAT COUNTS AS AN EMIT
 ----------------------
@@ -285,7 +303,9 @@ def mask(text, strings_as_atoms=False):
 
     Character literals (`\\;`, `\\"`) are consumed as two characters so a
     quote or semicolon written as a value cannot open a phantom string or
-    comment.  Newlines survive so a caller can still report line numbers.
+    comment.  Newlines survive UNDER BOTH MODES so a caller can still
+    report line numbers — R10 names the emit site it refuses to read, and
+    a gate that names the wrong line is worse than one that names none.
 
     `strings_as_atoms` collapses each string literal to the single
     character `#` instead of a same-width run of spaces.  R10 needs it and
@@ -310,6 +330,12 @@ def mask(text, strings_as_atoms=False):
                 continue
             if not strings_as_atoms:
                 out.append("\n" if c == "\n" else " ")
+            elif c == "\n":
+                # The atom is already written; a newline AFTER it separates
+                # arguments exactly as it did before, so keeping it costs the
+                # reader nothing and buys back the line number.  Dropping it
+                # made R10 name a line 1850 short of the site it had found.
+                out.append("\n")
             if c == '"':
                 in_string = False
             i += 1
@@ -368,7 +394,6 @@ _SYMBOL = r"[A-Za-z0-9*+!_'?<>=.-]+"
 _DEFN_RE = re.compile(r"\(defn-?\s+(" + _SYMBOL + r")(?=[\s\n])")
 _PARAM_VEC_RE = re.compile(r"\[([^]\[]*)\]")
 _KEYWORD_RE = re.compile(r"^:[a-zA-Z][a-zA-Z0-9*+!_'?<>=./-]*$")
-_ANY_KEYWORD_RE = re.compile(r":[a-zA-Z][a-zA-Z0-9*+!_'?<>=./-]*")
 
 
 def _forms(code, head_pattern):
@@ -414,6 +439,37 @@ def _call_args(body):
     if start is not None:
         found.append(body[start:])
     return found
+
+
+def _resolve(argument):
+    """The keyword answers one ARGUMENT EXPRESSION can yield, or None.
+
+    A deliberately small grammar, and small is the point.  Two shapes are
+    admitted, because two shapes are what the package writes:
+
+      * a literal keyword — 103 of the 104 attributable call sites;
+      * a two-branch `if`/`if-not` over literal keywords — the one other,
+        `impl/codec`'s `(if (fn? head) :call-it-or-make-it-a-view
+        :supply-a-valid-hiccup-head)`, which reads as the SET of arms
+        because both are answers the id can give.
+
+    ANYTHING ELSE IS None, meaning UNREADABLE, and the caller must keep
+    the site rather than drop it.  The predecessor of this function
+    scavenged every keyword out of the expression with a bare regex, which
+    is worse than not reading it: `(get advice :fallback)` would have been
+    reported as raising `:fallback`, and R10 would then have gone on to
+    reconcile an invention against Spec 009.  A reader that cannot fold an
+    expression must say so; guessing puts a false keyword into the one
+    rule that opens the source (rf2-5zmul, audit of #8315).
+    """
+    if _KEYWORD_RE.match(argument):
+        return [argument]
+    if argument.startswith("(") and argument.endswith(")"):
+        cells = _call_args(argument[1:-1])
+        if len(cells) == 4 and cells[0] in ("if", "if-not") \
+                and all(_KEYWORD_RE.match(cell) for cell in cells[2:]):
+            return cells[2:]
+    return None
 
 
 def _literal_pairs(body):
@@ -523,12 +579,17 @@ def _forwarded(body, params, known):
 
 
 def read_runtime_recoveries(roots):
-    """`{id: set(recovery keyword, …)}` as the PACKAGE'S OWN CODE passes them.
+    """`({id: {recovery, …}}, [unreadable site, …])` as the PACKAGE passes them.
 
     A set rather than one keyword because a site may compute the recovery —
     `(if (fn? head) :call-it-or-make-it-a-view :supply-a-valid-hiccup-head)`
     is written in `impl/codec` today — and both arms are then answers the
     id can give.
+
+    The second half is the sites the reader could NOT fold, one per call,
+    and it is a LIST rather than a set of ids on purpose: the claim R10
+    makes is per emit site, so an id with three readable sites and one
+    unreadable one is not covered, and only a per-site record can say so.
     """
     sources = []
     for path in _source_files(roots):
@@ -543,9 +604,24 @@ def recoveries_in(sources):
 
     Split out so the readers can be run over source this checkout does not
     have — a historical tree, a fixture — without a tree to walk.
+
+    A CALL WHOSE ID RESOLVES AND WHOSE RECOVERY DOES NOT IS KEPT, as
+    `(id, where, constructor, argument-text)`.  Dropping it was the hole
+    the #8315 audit found: the aggregate is keyed by id, so a sibling call
+    passing a literal made the id look accounted for and R10 asked no
+    further question.  Two fixtures — one call for an id, and the same
+    file plus a second call for the SAME id through `(recovery-for x)` —
+    produced byte-for-byte identical output, and the second call could
+    therefore raise an unrowed recovery with every arm green.
+
+    A call whose ID does not resolve is still dropped, and that is not the
+    same case: with no id there is no Spec 009 row to reconcile against,
+    and the shape occurs in the package already — a constructor's own body
+    forwarding its `id` parameter, which the call-site scan reads where
+    its CALLERS stand instead.
     """
     constructors = read_constructors(sources)
-    found = {}
+    found, unreadable = {}, []
 
     def record(error_id, keywords):
         found.setdefault(error_id, set()).update(keywords)
@@ -553,12 +629,12 @@ def recoveries_in(sources):
     for name, (id_source, recovery_source) in constructors.items():
         if id_source[0] == "fixed" and recovery_source[0] == "fixed":
             record(id_source[1], [recovery_source[1]])
-    for _rel, code in sources:
+    for rel, code in sources:
         for error_id, recovery in _literal_pairs(code):
             record(error_id, [recovery])
         for name, (id_source, recovery_source) in constructors.items():
             head = r"\((?:%s/)?%s(?=[\s)])" % (_SYMBOL, re.escape(name))
-            for _match, inner in _forms(code, head):
+            for match, inner in _forms(code, head):
                 arguments = _call_args(inner)
 
                 def read(source):
@@ -567,18 +643,25 @@ def recoveries_in(sources):
                         return [value]
                     if value >= len(arguments):
                         return None
-                    argument = arguments[value]
-                    if _KEYWORD_RE.match(argument):
-                        return [argument]
-                    return _ANY_KEYWORD_RE.findall(argument) or None
+                    return _resolve(arguments[value])
 
-                ids, recoveries = read(id_source), read(recovery_source)
-                if not ids or not recoveries:
+                ids = [error_id for error_id in (read(id_source) or [])
+                       if _ERROR_ID_RE.match(error_id)]
+                if not ids:
                     continue
-                for error_id in ids:
-                    if _ERROR_ID_RE.match(error_id):
+                recoveries = read(recovery_source)
+                if recoveries:
+                    for error_id in ids:
                         record(error_id, recoveries)
-    return found
+                    continue
+                _kind, position = recovery_source
+                argument = (arguments[position]
+                            if position < len(arguments) else "<no such argument>")
+                where = "%s:%d" % (rel, code[:match.start()].count("\n") + 1)
+                for error_id in ids:
+                    unreadable.append(
+                        (error_id, where, name, " ".join(argument.split())))
+    return found, unreadable
 
 
 # ---------------------------------------------------------------------------
@@ -736,7 +819,8 @@ def guide_chapter(number):
 
 def check(register, emitted, package_ids, spec_active, spec_retired, chapter_text,
           index_entries=None, index_recoveries=None, index_mismatched=None,
-          spec_recoveries=None, runtime_recoveries=None, spec_hicasso_ids=None):
+          spec_recoveries=None, runtime_recoveries=None, unreadable_sites=None,
+          spec_hicasso_ids=None):
     """Every rule, against already-read inputs.
 
     Pure so `--self-test` can drive each red by doctoring one input rather
@@ -754,6 +838,7 @@ def check(register, emitted, package_ids, spec_active, spec_retired, chapter_tex
     index_mismatched = [] if index_mismatched is None else index_mismatched
     spec_recoveries = {} if spec_recoveries is None else spec_recoveries
     runtime_recoveries = {} if runtime_recoveries is None else runtime_recoveries
+    unreadable_sites = [] if unreadable_sites is None else unreadable_sites
     spec_hicasso_ids = set() if spec_hicasso_ids is None else spec_hicasso_ids
 
     # R1 — no gap.
@@ -907,6 +992,17 @@ def check(register, emitted, package_ids, spec_active, spec_retired, chapter_tex
                 "pass — runtime, Spec 009, then the guide R9 checks"
                 % (error_id, keyword,
                    ", ".join(sorted(rowed)) or "no recovery keyword at all"))
+    for error_id, where, minter, argument in sorted(unreadable_sites):
+        if error_id not in live or error_id not in spec_hicasso_ids:
+            continue
+        failures.append(
+            "R10 %s is raised at %s through `%s` with a `:recovery` this gate "
+            "cannot read: %s. A SIBLING call passing a literal is not cover — "
+            "the claim is per emit site, and this one can raise a keyword no "
+            "row carries. Pass a keyword literal, or an `if`/`if-not` over two "
+            "of them; if the recovery genuinely has to be computed, the reader "
+            "in this script is what needs the edit"
+            % (error_id, where, minter, argument))
     return failures
 
 
@@ -941,13 +1037,15 @@ def read_all():
         with open(path, encoding="utf-8") as fh:
             chapter_text[number] = fh.read()
     index_entries, index_recoveries, index_mismatched = read_index(TROUBLESHOOTING)
+    runtime_recoveries, unreadable_sites = read_runtime_recoveries(EMIT_ROOTS)
     return dict(register=register, emitted=emitted, package_ids=package_ids,
                 spec_active=spec_active, spec_retired=spec_retired,
                 chapter_text=chapter_text, index_entries=index_entries,
                 index_recoveries=index_recoveries,
                 index_mismatched=index_mismatched,
                 spec_recoveries=read_spec_recoveries(SPEC_009),
-                runtime_recoveries=read_runtime_recoveries(EMIT_ROOTS),
+                runtime_recoveries=runtime_recoveries,
+                unreadable_sites=unreadable_sites,
                 spec_hicasso_ids=read_spec_hicasso_ids(SPEC_009))
 
 
@@ -1091,15 +1189,27 @@ def self_test():
         "a plain-string reason must survive as ONE argument, not vanish"
     assert mask('(fail! :rf.error/a "r")').count(":rf.error/") == 1, \
         "and the default masking is unchanged, because R1-R9 read it"
+    assert mask('(str "a\nb") :fix', strings_as_atoms=True) == '(str #\n) :fix', \
+        "a newline inside a collapsed string SURVIVES, or every line number " \
+        "R10 prints is short by the length of the reasons above the site"
     assert _call_args(" :rf.error/a 'w (str # #) :fix {}") \
         == [":rf.error/a", "'w", "(str # #)", ":fix", "{}"], \
         "arguments split at the TOP level, a multi-line (str …) counting once"
-    assert _ANY_KEYWORD_RE.findall("(if (fn? head) :call-it :supply-a-head)") \
+    assert _resolve("(if (fn? head) :call-it :supply-a-head)") \
         == [":call-it", ":supply-a-head"], \
-        "a computed recovery reads as the SET of arms the id can answer"
+        "a conditional recovery reads as the SET of arms the id can answer"
+    assert _resolve(":supply-a-head") == [":supply-a-head"], "and a literal is one"
+    assert _resolve("(get advice :fallback)") is None, \
+        "a lookup is UNREADABLE, not a site that raises :fallback — scavenging " \
+        "keywords out of an expression invents a recovery to reconcile"
+    assert _resolve("(if (fn? head) :call-it (advise head))") is None, \
+        "and a conditional is admitted only when BOTH arms are literals"
 
     def constructors_of(text):
         return read_constructors([("fixture.cljc", mask(text, strings_as_atoms=True))])
+
+    def read_fixture(text):
+        return recoveries_in([("fixture.cljs", mask(text, strings_as_atoms=True))])
 
     minter = ("(defn fail! [id where reason recovery extra]"
               "  (throw (ex-info reason {:rf.error/id id :where where"
@@ -1118,6 +1228,28 @@ def self_test():
         "a helper that fixes the recovery and takes the id from its caller " \
         "is itself a constructor, and its call sites are emit sites"
 
+    # THE KNOWN-PLUS-UNREADABLE-SIBLING FIXTURE, pinned exactly (rf2-5zmul,
+    # audit of #8315).  Before the per-site correction these two texts read
+    # byte-for-byte identically, and that identity IS the defect: the second
+    # site can raise anything at all and the id still looks accounted for.
+    one_site = minter + ('(defn a [] (fail! :rf.error/example (quote w) "r"'
+                         '                  :known-recovery {}))')
+    sibling = one_site + ('(defn b [x] (fail! :rf.error/example (quote w) "r"'
+                          '                   (recovery-for x) {}))')
+    known, quiet_sites = read_fixture(one_site)
+    also_known, kept = read_fixture(sibling)
+    assert known == {":rf.error/example": {":known-recovery"}} and not quiet_sites, \
+        "a readable site is read, and reports nothing unreadable"
+    assert also_known == known, \
+        "the AGGREGATE is blind to the sibling — this is why it cannot be the " \
+        "whole of the rule, and asserting it keeps the reason on the record"
+    assert [(error_id, minter_name) for error_id, _where, minter_name, _argument
+            in kept] == [(":rf.error/example", "fail!")], \
+        "so the unreadable sibling is KEPT as a site, which is the fix"
+    assert kept[0][3] == "(recovery-for x)" and kept[0][1].startswith("fixture.cljs:"), \
+        "and it names the expression and the place, because the reader's " \
+        "own limit is what the author has to act on"
+
     # R10 — the rule, both arms, plus the subject boundary that is the whole
     # reason it needs no exemption list.
     runtime = inputs["runtime_recoveries"]
@@ -1129,6 +1261,12 @@ def self_test():
     unaccounted = dict(runtime)
     unaccounted.pop(an_anchored, None)
     red("R10", runtime_recoveries=unaccounted)      # covering less than it claims
+    # And the arm the audit of #8315 added: an id with a perfectly good
+    # readable site is STILL uncovered while one of its siblings is unreadable.
+    # `runtime_recoveries` is left untouched here on purpose — that input is
+    # exactly what the aggregate could not distinguish.
+    red("R10", unreadable_sites=[(an_anchored, "impl/codec.cljs:1", "fail!",
+                                  "(recovery-for x)")])
 
     corpus_owned = sorted(set(register["live"]) - set(inputs["spec_hicasso_ids"]))
     assert corpus_owned, \
@@ -1138,6 +1276,11 @@ def self_test():
     assert not [failure for failure in quiet if failure.startswith("R10")], \
         "R10 must hold NO opinion on a spelling Hicasso reuses from the " \
         "corpus: that row's recovery answers for a different emitter"
+    quiet = check(**dict(inputs, unreadable_sites=[
+        (corpus_owned[0], "impl/x.cljs:1", "fail!", "(recovery-for x)")]))
+    assert not [failure for failure in quiet if failure.startswith("R10")], \
+        "and the per-site arm stops at the SAME boundary, or the subject rule " \
+        "would hold for two arms and not the third"
 
     print("OK: check_complaint_catalogue self-test passed")
     return 0
@@ -1172,9 +1315,10 @@ def main(argv=None):
           "unbuilt, every anchor resolves, and the troubleshooting index "
           "carries all %d live ids exactly once with Spec 009's recoveries.\n"
           "    R10: %d of those are rowed in Spec 009's Hicasso section, and "
-          "every `:recovery` the package raises for them is in its row. The "
-          "other %d are corpus-owned spellings rowed in the main catalogue, "
-          "whose recovery answers for a different emitter."
+          "every `:recovery` the package raises for them is in its row — at "
+          "every emit site, with none the reader had to skip. The other %d are "
+          "corpus-owned spellings rowed in the main catalogue, whose recovery "
+          "answers for a different emitter."
           % (len(register["live"]), len(register["reserved"]),
              len(register["pending-retirement"]), len(register["retired"]),
              len(register["live"]), len(anchored),

--- a/implementation/hicasso/test/re_frame/hicasso/test_kit_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/test_kit_cljs_test.cljs
@@ -527,10 +527,19 @@
 
   (testing "and an unforced `delay` is refused rather than forced — forcing
             an author's explicit deferral would change what their program
-            means, which is the runtime's own ruling at a crossing"
-    (is (= :rf.error/hicasso-deferred-read-at-boundary
-           (:rf.error/id
-            (:refused (outcome #(ht/tree [(fn [_] [:div (delay [:p])]) {}]))))))))
+            means, which is the runtime's own ruling at a crossing.
+
+            THE WHOLE IDENTITY, not the id alone (rf2-tsdik). This assertion
+            read only `:rf.error/id` for a release, so the kit could and did
+            answer the runtime's id with its OWN opacity recovery,
+            `:assert-it-at-l3` — a pointer to a tier where the identical
+            refusal waits — and stayed green throughout (rf2-llps1). A
+            borrowed id brings the advice with it or it is not a borrowing."
+    (is (= {:rf.error/id :rf.error/hicasso-deferred-read-at-boundary
+            :where       're-frame.hicasso.test
+            :recovery    :hand-a-function-or-deref-it-in-this-body}
+           (refusal (outcome #(ht/tree [(fn [_] [:div (delay [:p])]) {}]))
+                    [])))))
 
 (deftest a-plain-function-in-head-position-refuses-as-the-runtime-does
   (testing "HD-016 makes it a loud error in Hicasso, so the kit refuses it

--- a/implementation/hicasso/test/re_frame/hicasso/test_kit_runtime_parity_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/test_kit_runtime_parity_cljs_test.cljs
@@ -95,7 +95,14 @@
       [:element tag]  is a native element
       [:fragment]     is a fragment
       [:opaque]       is an element only React can interpret
+      [:deferred]     is an unforced `delay`, handed onward untouched
       [:refused id r] is a loud error, with its id and its recovery
+
+  `[:deferred]` is a token rather than `[:foreign (pr-str v)]` because
+  the print of a `Delay` carries its `:status` and `:val` — a pin on
+  ClojureScript's internals that would red on a print change and say
+  nothing about Hicasso. What the row is about is that the value crosses
+  UNFORCED, and the token says exactly that.
 
   The refusal token carries the RECOVERY as well as the id, because the
   advice is half of what a refusal is: the audit that reopened this bead
@@ -112,6 +119,7 @@
           (nil? v)    [:nothing]
           (string? v) [:text v]
           (number? v) [:text (str v)]
+          (delay? v)  [:deferred]
           (react/isValidElement v)
           (let [t (.-type v)]
             (cond
@@ -288,6 +296,28 @@
                   "distinct. `:where` is the KIT here, deliberately: L2's own "
                   "opacity is the kit's claim to make, and the rows above show "
                   "what it looks like when a refusal is the runtime's instead.")}
+
+   {:case    "an unforced `delay` child carries the runtime's id AND its recovery"
+    :form    [:div (delay [:p])]
+    :subject (delay [:p])
+    :runtime [:deferred]
+    :refuses {:rf.error/id :rf.error/hicasso-deferred-read-at-boundary
+              :where       're-frame.hicasso.test
+              :recovery    :hand-a-function-or-deref-it-in-this-body}
+    :why     (str "THE ROW THE RECOVERY COLUMN EXISTS FOR (rf2-tsdik, after "
+                  "rf2-llps1). The kit borrows the RUNTIME's id here, and the "
+                  "runtime's recovery has to come with it: opacity is honest "
+                  "only where the runtime CAN read a form, and the `:runtime` "
+                  "column says it cannot read this one — an unforced `delay` "
+                  "crosses a native child position untouched, so the refusal "
+                  "waiting for the author is the crossing's, not React's. The "
+                  "kit answered this id with `:assert-it-at-l3` for a release, "
+                  "which pointed at a tier where the identical refusal waits, "
+                  "and a document gate (R10) had to be the thing that noticed "
+                  "— because the only test over the path asserted the id "
+                  "ALONE. `:where` is the KIT, on the `defhost` row's "
+                  "precedent: what is borrowed is the id and the advice, never "
+                  "the raising site.")}
 
    {:case    "an SVG subtree carries `:ns`, and `:foreignObject` reverts"
     :form    [:svg {:view-box "0 0 1 1"}


### PR DESCRIPTION
Three beads from `implementation/hicasso/`, each read **bottom-up, newest note first**. Two produced code; one produced a reading and a reported remainder.

## Which note each bead was worked from

| Bead | Note acted on | Outcome |
|---|---|---|
| rf2-5zmul | the **merged-PR audit of #8315**, not the description (#8315 already satisfied that) | fixed |
| rf2-tsdik | the **description** — the bead has no notes; it was filed by #8318's author as an out-of-fence residual | fixed, with the bead's proposed row **corrected** |
| rf2-0ftho | the **merged-PR audit of #8317** | code half already on `main`; the remainder is doc-only and outside this fence — reported, bead left open |

---

## rf2-5zmul — what the audit actually found

R10 works: `check_complaint_catalogue.py` exits 0 on `main` with 77 live / 77 anchors, 74 subject ids, 0 coverage holes. The audit found something about how it was built.

**The coverage arm asked a per-ID question about a per-SITE claim.** `recoveries_in` is keyed by id, and a constructor call whose recovery the reader could not fold was `continue`d — silently dropped. So one call passing a literal made the id look accounted for, and a *sibling* call for the same id could raise a keyword no Spec 009 row carries with every arm green.

**Reproduced at source before touching anything**, on the audit's own fixture:

```
one-site : {':rf.error/example': {':known-recovery'}}
two-site : {':rf.error/example': {':known-recovery'}}
IDENTICAL: True
```

The second source adds `(fail! :rf.error/example 'w "r" (recovery-for x) {})`. Byte-for-byte identical, and R1's emitted-id input is identical too because the sibling names the same id.

**A second thing the audit named, and it is the worse half.** The fallback was `_ANY_KEYWORD_RE.findall(argument)` — every keyword scavenged out of the expression. `(get advice :fallback)` would have been reported as *raising* `:fallback`, putting an invention into the one rule that opens the source. The header meanwhile described a grammar the code did not have ("a conditional … is read as the SET of both arms").

### The repair — the audit's own prescription, kept narrow

- `_resolve` replaces the regex scavenger with a deliberately small grammar: a keyword literal, or a two-branch `if`/`if-not` over keyword literals. Anything else is **unreadable**.
- the scan **keeps** a call whose id resolves and whose recovery does not, with its file, line, minter and the expression. A call whose *id* does not resolve is still dropped, deliberately: with no id there is no row to reconcile, and that shape occurs already — a constructor body forwarding its own `id` parameter, read where its callers stand.
- R10 fails on every such site, on the **same section boundary** as its other two arms.
- `--self-test` pins the known-plus-unreadable-sibling fixture in **both** halves, including the assertion that the aggregate cannot tell them apart.

### One defect I found that the audit had not named

The line number the new failure prints was **wrong by 1855 lines** — `mask(strings_as_atoms=True)` collapsed each string literal to `#` and dropped the newlines inside it, so every line counted on the masked text was short by the length of the reasons above the site (it printed **1792** for a site at **3647**). `mask` now keeps those newlines; the atom is already written, so a newline after it separates arguments exactly as before. A gate that names the wrong line is worse than one that names none.

### Measured cost — the rule tightens and needs no exemption

105 constructor call sites. 1 is a constructor body forwarding its `id`. Of the other 104: **103** keyword literals, **1** conditional (`impl/codec`'s), **0** unreadable.

---

## rf2-tsdik — the test-level carrier, and why the bead's row was wrong

The bead proposed `:form [:div (delay [:p])]` with `:runtime [:refused :rf.error/hicasso-deferred-read-at-boundary …]`, and hedged that it might need a boundary. **Both halves are wrong**, and I measured all three spellings through the parity file's own two probes before writing anything:

| form | runtime | kit |
|---|---|---|
| `[:div (delay [:p])]` | `[:foreign #object[Delay …]]` — **no refusal** | refuses, id **and** recovery both right |
| `[a-boundary {:x (delay 1)}]` | refuses `deferred-read-at-boundary` | refuses **`:rf.error/ui-tree-malformed`** |
| `[:div {:data-x (delay 1)}]` | `[:element "div"]` | refuses `:rf.error/ui-tree-malformed` |

`realize-deep` runs at a **boundary crossing**, so a delay in a native child position is handed onward untouched — the runtime does not refuse the bead's form. And the boundary form, which the runtime *does* refuse, gets a different id from the kit (filed separately, below).

**So the carrier is the child spelling**, and its `:runtime` column is the fact that makes the kit's borrowing necessary rather than decorative: the runtime cannot read this one, so `:assert-it-at-l3` pointed at a tier where the identical refusal waits.

- `runtime-kind` gains a `[:deferred]` token. `[:foreign (pr-str v)]` would pin `Delay`'s `:status` and `:val` — a ClojureScript internal that says nothing about Hicasso.
- `:where` is asserted as the **kit**, on the `defhost` row's precedent: a borrowed refusal borrows the id and the advice, never the raising site.
- the weak assertion the bead named is strengthened in the same pass — `test_kit_cljs_test`'s delay arm read `:rf.error/id` **alone**, which is exactly why it was green through the whole defect.

### The red

Restored the rf2-llps1 defect (the kit's `:foreign` delay arm answering `:assert-it-at-l3`) and ran the hicasso node lane:

```
Ran 1218 tests containing 4953 assertions.
2 failures, 0 errors.                                   exit 1
```

Both failures are the new carriers — the parity row and the strengthened assertion:

```
actual: (not (= {… :recovery :hand-a-function-or-deref-it-in-this-body}
                {… :recovery :assert-it-at-l3}))
```

Reverted; `git hash-object` reads `0cf646afff3ba9d06b9611aeb82445e87d0def1d` before and after.

---

## rf2-0ftho — nothing remained in this fence

**Count: zero.** `grep -n hfn implementation/hicasso/test/re_frame/hicasso/retaining_host_callbacks_dom_cljs_test.cljs` returns nothing — #8317 landed the witness and the verdict together, as its author intended.

The audit's remaining miss is real and I verified its premise at source: `callback-identity-verdict.md:21` and `:23` are live mechanism prose still saying `h/fn`, and the shipped door carries `(defmacro event` with no `fn` macro at all (`impl/intent.cljs` says `h/event` throughout, zero `h/fn`).

**That file is `docs/design/hicasso/**`, which is not this worker's fence** — a peer may hold it. Reported rather than edited; the bead stays open with its audit note intact.

---

## Quality gates

Every number below was captured from the runner's own line into a named `.exit` file in this worktree's scratch, never read off the harness.

| Gate | Runner | Exit | Reading |
|---|---|---:|---|
| `check_complaint_catalogue.py` (baseline, before any edit) | python | **0** | 77 live / 77 anchors, 74 subject ids, 0 coverage holes |
| `check_complaint_catalogue.py` (final base) | python | **0** | **unchanged** — 77 live / 77 anchors, 74 subject ids, 0 holes |
| `check_complaint_catalogue.py --self-test` | python | **0** | all R1–R10 arms, **no stub needed** |
| `check_guide_samples.py --self-test` | python | **0** | all rules fire |
| `check_guide_samples.py` | python | **0** | 217 fenced blocks pinned across 29 pages (206 Clojure), 104 hicasso verb use-sites resolved, 62 blocks self-contained against 23 guide aliases, 1 declared divergence + 0 absent namespaces |
| `check_naming_census.py --self-test` | python | **0** | |
| `check_naming_census.py <root>` | python | **0** | **104 public names** across 10 shipped namespaces, 0 unrostered |
| `npm run test:hicasso-invariants` | node/python | **0** | all checkers end-to-end |
| `node-test-hicasso` (compile + run) | shadow-cljs → node | **0** | **1218 tests / 4953 assertions, 0 failures** |
| `scripts/test-fast-pr.sh` | sh | **0** | 66 gate steps; the CLJS lane inside it ran **13944 tests / 70241 assertions, 0 failures, 0 errors**; JVM implementation 2243/11691 and `implementation/hicasso` 3/92, both 0 failures |
| `scripts/check_fast_pr_gap.py --list` | python | **0** | **106** required checks this spine does not run |

`node-test-hicasso` is the lane that sees `.cljs` — `clojure -M:test` cannot load a `.cljs` file, so it was never used for the two test files here. The python checkers were run with `python`, direct, never piped.

Heavy gates were run **one at a time**; no second shadow-cljs build shared `.shadow-cljs` or `out/` with a running one. Every run produced a test summary, so none was a cache-contention death.

The spine's log holds **35 `FAIL` matches while exiting 0** — they are self-test control lines. The verdict quoted above is the exit code from the runner's own line, captured into `gate-spine-hicaudit-5zmul-1.exit`. Nothing was piped through a filter.

`node_modules` in this worktree is a real `npm ci --prefix implementation`, not a junction. The mayor's count reads **102** before and after.

### Plant proof — R10's new arm, on live source

Added an unreadable sibling `(fail! :rf.error/hicasso-true-child … (recovery-for x) {})` to `impl/codec.cljs`, beside the existing literal `:use-nil-or-false` site for the same id — the audit's fixture, on real source:

| gate | exit | |
|---|---:|---|
| **HEAD's** `check_complaint_catalogue.py` | **0** | GREEN — silently blind, which is the defect |
| **this branch's** | **1** | RED, naming file, **line 3647**, `fail!` and `(recovery-for x)` |

Plant reverted; `git hash-object` on `impl/codec.cljs` reads `4fd031f0665c485f5e4c8c4f9a88802a3bb1cf9e` before and after.

### Sabotage of the self-test

Neutered the new per-site arm (`if True: continue`) and ran `--self-test`: **exit 1**, `AssertionError: R10 did not red: []`. Restored; hash `66e9c47e2a5e60deb08e1418382466baea77f847` before and after.

The first attempt at this sabotage **did not apply** — the file is CRLF and my `\n` pattern did not match, so the run that followed was an unsabotaged green. Caught by hashing the file rather than trusting the "OK" line.

---

## Confirmations the brief asked for

- **Row 18's `hframe` occurrences are untouched.** Identical on this branch and `origin/main`: **300** occurrences, **198** lines, **44** files. rf2-t32wg's instruction is respected.
- **No prefix rule was reintroduced into R10.** The only `hicasso-` prefix mentions in the file are the header's warning against one (`:rf.error/no-frame-prop` is Hicasso's own and carries no prefix). `read_spec_hicasso_ids` — the structural heading-stack scope — is untouched.
- **Nothing from #8311/#8315/#8317/#8318/#8321 is reverted.** Read `git diff origin/main...HEAD` deletion-side line by line: every deletion is either prose replaced with corrected prose or the exact machinery the audit asked to be replaced. The rf2-15bqc docstring correction survives verbatim ("**R10 would have been green for the whole life of that defect**").
- **Fence derived on both signals**, at dispatch and again after the rebase: **zero open PRs**; four peer branches (`receipts-hic081`, `retire-delete`, `retire-final`, `samplegate-vz6dg`), **none touching my three files**.

### Fence correction

The brief's premise that **`implementation/hicasso/**` is FREE is false.** `origin/worker/receipts-hic081` is live inside it, holding `impl/collector.cljs` (M), `impl/receipt.cljs` (A) and `test/…/receipt_spike_cljs_test.cljs` (A). No overlap with this PR, but the tree is not free.

### Filed out of fence

- **rf2-dr0ad** (new, `discovered-from:rf2-tsdik`) — for the one form the runtime actually refuses, a delay reachable from a **boundary's props**, the kit answers its own generic `:rf.error/ui-tree-malformed` / `:hoist-it-to-its-own-site` instead of the runtime's `:rf.error/hicasso-deferred-read-at-boundary` / `:hand-a-function-or-deref-it-in-this-body`. Same class as rf2-llps1 with the cases the other way round, and **R10 cannot see it** — a right recovery for the wrong id is invisible to a rule that reconciles recovery against row. Not fixed here: it is a ruling about which id L2 owes, and freezing today's answer into the parity table would read as an endorsement.
- **rf2-0ftho's remainder** — `callback-identity-verdict.md:21` and `:23`, outside this fence. Left on the existing bead rather than duplicated.

## Beads

`.beads/issues.jsonl` and `.beads/metadata.json` are **not** in this PR.
