### PR TITLE
bench(hicasso): phase B's window gets the resolution it never had (rf2-3l6hf)

### DIFF
--- a/implementation/hicasso/test/re_frame/bench/hicasso/read_profile_app.cljs
+++ b/implementation/hicasso/test/re_frame/bench/hicasso/read_profile_app.cljs
@@ -75,21 +75,30 @@
   `record-reads!` into it; the readers now live on the cell, so the
   commit pushes one slot per key and the copy prices that instead.
   Phase B prices that half through the runtime's own
-  [[rt/commit-boundary!]] seam on four
-  identically-seeded frames per window (window ~= 4 x 141 acquisitions,
-  clear of the 100 us clock clamp), released and settled between samples
-  with a residue equality gate.
+  [[rt/commit-boundary!]] seam on [[frames-per-window]] identically-seeded
+  frames per window, released and settled between samples with a residue
+  equality gate.
+
+  **That frame count is the window's resolution and it was raised from 4
+  to 32 by rf2-3l6hf**, which found that at 4 the deltas below could not
+  decompose anything: three of the four terms straddled zero across runs
+  of one binary, and a negative delta is arithmetically impossible when
+  the ablation arm does strictly less work. 4 frames was sized to clear
+  the 100 µs clock clamp and nothing more, and clearing the clamp is a
+  much weaker condition than resolving a term. [[frames-per-window]]
+  carries the arithmetic, including why the sample count could not have
+  fixed it.
 
   | arm         | one window is                                     | what it prices |
   |-------------|---------------------------------------------------|----------------|
-  | `commit`    | 4 frames x `rt/commit-boundary!` on the harvested entry | the shipping commit half |
+  | `commit`    | [[frames-per-window]] frames x `rt/commit-boundary!` on the harvested entry | the shipping commit half |
   | `c-local`   | faithful copy: cell mint + subscribe + activation + baseline deref + watch + dispose hook + map insert + reader membership | the ablation baseline, validated against `commit` |
   | `c-noactivate` | `c-local` minus `interop/activate-derived-value!` | the substrate's capture run (rf2-lzpfj) |
   | `c-nowatch` | `c-local` minus add-watch + the disposal hook     | the watch wiring |
   | `c-nosub`   | `c-local` with `compute-sub` in place of subscribe + deref | the reaction build + cache insert (the compute is kept, priced by the swap) |
   | `c-noreaders` | `c-local` minus the cell's reader array and the membership push | the fused reverse edge (rf2-dabt3) |
   | `c-nomap`   | `c-local` minus the per-key cells-map insert      | the cell-map insert |
-  | `b-build`   | 4 frames x 141 bare `subscribe` + deref (torn down sync, outside the window) | build + compute WITHOUT in-window dispose — beside `no-shell` it floors the render read's dispose/evict share |
+  | `b-build`   | [[frames-per-window]] frames x 141 bare `subscribe` + deref (torn down sync, outside the window) | build + compute WITHOUT in-window dispose — beside `no-shell` it floors the render read's dispose/evict share |
 
   Every phase-B delta is quoted as `c-local - variant`, a floor on the
   phase (the stubs are not free). Teardown runs outside every window;
@@ -139,7 +148,47 @@
 
 (def cold-frame ::cold)
 (def warm-frame ::warm)
-(def commit-frames [::c1 ::c2 ::c3 ::c4])
+
+(def ^:private frames-per-window
+  "How many identically-seeded frames ONE phase-B window commits
+  (rf2-3l6hf). It was 4, and 4 could not decompose the commit half.
+
+  **A window's resolution is set here and nowhere else, because the
+  reported statistic is a p50.** `lane/now-ms` is `performance.now`,
+  which Chrome clamps to 100 µs, so every raw window reading is a
+  multiple of 0.1 ms; [[lane/summarise]] takes the mean of the two middle
+  order statistics on an even sample count, which halves that to 0.05 ms;
+  and the row divides by the frame count. The grid a phase-B delta can
+  land on is therefore exactly `0.05 / frames-per-window` ms/commit — at
+  4 frames, 0.0125, which is precisely the spacing every delta rf2-d360z
+  published turned out to be a multiple of.
+
+  **More SAMPLES cannot move that grid.** A median of quantised readings
+  is itself a grid value whatever the sample count; more samples make the
+  p50 land on the right step more often, they do not create a step
+  between two others. So the sample count is a stability knob and the
+  frame count is the resolution knob, and only one of them was ever going
+  to make three sub-quantum terms visible. That is the reasoning
+  rf2-3l6hf's window was opened to act on, and it is why the frame count
+  moved by 8x rather than the sampling alone.
+
+  32 puts the grid at 0.0015625 ms/commit. The terms that need to be seen
+  are the watch wiring, the reader membership and the cell-map insert,
+  which the micro table's anchors price at roughly 0.004-0.02 ms/commit —
+  so the smallest of them is a few grid steps rather than a fraction of
+  one. The window is ~20 ms of wall clock at the absolutes this arm
+  reads, still 200x the clock's own quantum, and the run stays under a
+  minute of sampling.
+
+  **The arbiter that this was enough is not this docstring — it is
+  `c-noactivate`**, which on this UIx host ablates a routed no-op and so
+  reads the instrument's own floor. A term is trustworthy when it stands
+  clear of that arm, and no wider."
+  32)
+
+(def commit-frames
+  (mapv (fn [i] (keyword "rf-readprof.commit" (str "c" i)))
+        (range 1 (inc frames-per-window))))
 
 (defn- seed-frame! [id]
   (lt/make-frame! id)
@@ -513,8 +562,17 @@
      {:id :b-build
       :run (fn [] (mapv (fn [f] (build-only! f roster)) commit-frames))}]))
 
-(def ^:private b-sampling {:warmup 2 :samples 6})
-(def ^:private b-rounds 4)
+(def ^:private b-sampling
+  "The stability half of the rf2-3l6hf widening — see
+  [[frames-per-window]] for the resolution half and for why the two are
+  different knobs. 8 rounds x 8 kept samples is 64 against the old 24:
+  the arm's own distribution has a long right tail (a `max` around twice
+  the `p50`, GC landing inside a window), and a 24-sample median of that
+  moves a grid step or two between runs on its own. This does not buy a
+  finer grid and is not asked to."
+  {:warmup 2 :samples 8})
+
+(def ^:private b-rounds 8)
 
 (defn residue-settle!
   "**The one point behind which every phase-B residue reading is taken** —
@@ -736,7 +794,7 @@
                               (.then
                                 (fn [{:keys [readings samples]}]
                                   (let [ids  [:commit :c-local :c-noactivate :c-nowatch :c-nosub :c-noreaders :c-nomap :b-build]
-                                        rows (arm-rows ids readings 4)
+                                        rows (arm-rows ids readings frames-per-window)
                                         gv-b (lane/guard! samples "read-profile phase B (in-page ms, diagnostic)")]
                                     (lane/record! :read-profile-commit
                                                   (into {} (map (fn [[k v]] [k (-> v (update :min lane/round4)
@@ -744,7 +802,8 @@
                                                                                    (update :p50 lane/round4))])) rows))
                                     (js/console.log ";; ==== READ PROFILE, PHASE B — THE COMMIT HALF (ms per 141-key boundary commit) ====")
                                     (js/console.log (str ";;   design " b-rounds "x(" (:warmup b-sampling) "+" (:samples b-sampling)
-                                                         ")  window = 4 frames/commit each"))
+                                                         ")  window = " frames-per-window " frames/commit each"
+                                                         "  grid = " (fmt (/ 0.05 frames-per-window) 6) " ms/commit"))
                                     (doseq [id ids]
                                       (js/console.log (arm-line id (get rows id))))
                                     (js/console.log ";; ==== PHASE B DELTAS (c-local minus ablation; floors) ====")


### PR DESCRIPTION
Closes rf2-3l6hf. A **measurement window** under Shape 6: the deliverable is whether a trustworthy number can be produced at all, not a number.

**Result in one line: the window now resolves three of the four terms that were straddling zero — in fact four of five, because rf2-d360z's own logs show `c-noactivate` was straddling too and was never tabled — and the fourth is now bounded rather than unknown.** Full figures, every Processor Queue Length sample and the gate exits are in the comment below.

## The premise, checked at source before acting on it

All three of the bead's structural claims verify:

- **4 frames/window** — `commit-frames` was `[::c1 ::c2 ::c3 ::c4]`, and `arm-rows ids readings 4` divided by a literal 4.
- **0.1 ms clock** — `lane/now-ms` is `performance.now`; its own docstring states Chrome's 100 µs clamp.
- **b-sampling 4x(2+6) = 24** — `b-sampling {:warmup 2 :samples 6}`, `b-rounds 4`.

One thing the bead did **not** say, and it is the crux: `lane/summarise` takes the **mean of the two middle order statistics** on an even sample count. That halves the 0.1 ms clock quantum to 0.05 ms, and the row then divides by the frame count — so a phase-B delta can only ever land on a `0.05/frames` grid, i.e. **0.0125 ms/commit at 4 frames**. Every delta the bead quotes is an exact multiple of 0.0125. The instrument was reporting its own grid.

## Why the sample count could not have fixed it

The bead names its candidates as "more frames per window, and/or more samples per arm". They are **not interchangeable, and only one of them could have worked**: a median of quantised readings is itself a grid value whatever the sample count. More samples make the p50 land on the right step more often; they cannot create a step between two others. **Frames are the resolution knob; samples are the stability knob.** Both moved, and the code now says which does which.

## The window shape, chosen once and held for the whole series

| | before | after |
|---|---|---|
| frames/window | 4 | **32** |
| grid | 0.0125 ms/commit | **0.0015625 ms/commit** |
| sampling | 4x(2+6) = 24 | **8x(2+8) = 64** |

The per-window divisor is now derived from the frame count so the two cannot drift, and the design line prints the grid it is working on.

**No gate and no tolerance was moved.** The bead's own instruction ("DO NOT widen a gate or a tolerance to make the terms come out positive") is the crux of the job and is respected: the negative readings were the instrument being honest, and the repair is the window, not the threshold.

## The arbiter — and the finding that it was the wrong one

The intended arbiter was `c-noactivate`, which the instrument documents as ablating a routed no-op and therefore reading its noise floor. **It is not a noise floor.** `late-bind/get-fn-cached` documents that "Nil resolutions are NOT cached", and `:adapter/activate-derived-value!` is deliberately never published on the React-hook spine — so the lookup is precisely the one that can never be cached, and it runs in full 141 times per commit, measuring ~0.04 ms/commit of real work. Filed as **rf2-19usn** (the shipping cost, paid by every UIx / Helix / re-frame.ui / Freehand app on every boundary commit) and **rf2-tcffa** (the docstring that hides it).

The floor was therefore taken from **arithmetic impossibility** instead: `c-noreaders` must be positive and reads −0.0000 / −0.0062 / −0.0000, putting the instrument's floor at about ±0.006 ms/commit.

## Scope held

`the-cold-read-mount-term.md` was **not touched** — PR #8327 is still open on it, and this bead does not own that page. The rig was not otherwise improved mid-window: the `c-noactivate` docstring is provably wrong and was still left alone, so that the three published runs correspond byte-for-byte to the blob they were taken on. It is filed instead.

## Quality gates

| gate | runner | captured exit |
|---|---|---|
| `npm run test:cljs` (node-test bundle; carries `read_profile_baseline_cljs_test`, which drives `app/residue-settle!`) | node/shadow-cljs — the `.cljs` runner, **not** `clojure -M:test`, which cannot load a `.cljs` file | **0** — 13944 tests, 70241 assertions, 0 failures, 0 errors |
| `read_profile_app` end-to-end, `:advanced`, x4 (R0 + S1–S3) | `run.cjs`; `lane_build.cjs` fails the build on warnings | **0, 0, 0, 0** |

Both were confirmed to have read **this worktree**: `test:cljs` printed its config root as `...\re-frame2-worktrees\measure-3l6hf\implementation\shadow-cljs.edn` and its compiled `read_profile_app.js` contains `rf-readprof.commit`, a keyword namespace existing only on this branch; the measurement runs printed `grid = 0.001563 ms/commit`, a line the mayor's copy cannot produce.

Nothing under `docs/` changed, so `check_doc_slugs.py` and `mkdocs build --strict` are not implicated. No table was added — two rows of the instrument docstring's existing arms table were edited in column 2 only, and **both were hand-checked and still carry 3 cells**, matching the header and separator.