### PR TITLE
bench(hicasso): the commit-half re-take runs and declines to publish (rf2-07rnj)

### DIFF
--- a/docs/design/hicasso/studio/the-cold-read-mount-term.md
+++ b/docs/design/hicasso/studio/the-cold-read-mount-term.md
@@ -175,6 +175,110 @@ and settled between samples behind a residue equality gate that never fired):
 > `rf2-gttif` gave: every term that has left or joined `c-local` left or joined
 > the seam it is divided by.
 
+> **THE WHOLE RE-TAKE RAN ON THE WIDENED WINDOW, AND IT DOES NOT PUBLISH**
+> (`rf2-07rnj`, 2026-08-16, commit `a43aa8609f`, instrument blob
+> `6d2b67b5b0`, `:advanced`, HeadlessChrome 147.0.7727.15, node v24.13.0).
+> Three runs, `exit 0` on each, **both arm-order guards reportable on every
+> run**, the phase-A positive control passing on every run, the phase-B
+> residue gate never firing.
+>
+> **The window shape, chosen once before the first run and held for every arm
+> of every run: 32 frames per window, 8 × (2 + 8) = 64 kept samples per arm,
+> grid 0.0015625 ms/commit.** That is `rf2-3l6hf`'s widened shape exactly as
+> it landed; no gate, tolerance or knob was touched, and nothing was adjusted
+> between runs. Every arm of a run was taken in ONE process, interleaved under
+> the lane's reflecting schedule. **The shape is stated because the shares are
+> not invariant to it** — the reaction build reads 56% of `c-local` at 4
+> frames and 67–68% at 32 — and **no share is computed below**, for the reason
+> the next paragraph but one gives.
+>
+> | arm | run 1 p50 [min–max] | run 2 p50 [min–max] | run 3 p50 [min–max] |
+> |---|---|---|---|
+> | `commit` (shipping seam) | 0.6953 [0.5281–0.8844] | 0.7516 [0.5313–1.0875] | 0.7203 [0.5812–0.8969] |
+> | `c-local` (the copy) | 0.6594 [0.4750–1.0281] | 0.6969 [0.5469–0.9188] | 0.6875 [0.5062–0.9219] |
+> | `c-noactivate` | 0.6172 [0.4750–0.8906] | 0.6484 [0.4875–0.8469] | 0.6313 [0.4813–0.8625] |
+> | `c-nowatch` | 0.5875 [0.4313–0.7531] | 0.6313 [0.4625–0.8281] | 0.6094 [0.4562–0.8875] |
+> | `c-nosub` | 0.2156 [0.1594–0.4188] | 0.2250 [0.1625–0.4500] | 0.2188 [0.1688–0.2969] |
+> | `c-noreaders` | 0.6547 [0.5250–0.8250] | 0.7109 [0.4875–1.0125] | 0.6750 [0.5344–0.8188] |
+> | `c-nomap` | 0.6156 [0.4375–0.7875] | 0.6703 [0.4875–0.9125] | 0.6375 [0.4750–0.9063] |
+> | `b-build` | 0.4938 [0.3937–0.9906] | 0.5688 [0.3937–0.8656] | 0.5406 [0.4531–0.7750] |
+> | copy fidelity `c-local`/`commit` | 0.9483 | 0.9272 | 0.9544 |
+>
+> **Four of the five ablation terms resolve at this shape with one sign on
+> every run. The fifth does not, and that is why nothing above is
+> republished.**
+>
+> | term (`c-local −` the arm) | run 1 | run 2 | run 3 |
+> |---|---|---|---|
+> | reaction build + cache insert (`c-nosub`) | 0.4437 | 0.4719 | 0.4688 |
+> | watch wiring (`c-nowatch`) | 0.0719 | 0.0656 | 0.0781 |
+> | activation capture (`c-noactivate`) | 0.0422 | 0.0484 | 0.0562 |
+> | cell-map insert (`c-nomap`) | 0.0437 | 0.0266 | 0.0500 |
+> | **reader membership (`c-noreaders`)** | **+0.0047** | **−0.0141** | **+0.0125** |
+>
+> **Reader membership straddles zero across three runs of one binary in one
+> session.** A negative delta is arithmetically impossible here — `c-noreaders`
+> does strictly less work than `c-local` — so the term the `rf2-dabt3` fusion
+> left in place of the retired index write is **UNRESOLVED at this window**. A
+> decomposition that cannot see one of its terms is not a decomposition; that
+> is this page's own standard, and it applies to its own re-take.
+>
+> **The `< 0.006 ms/commit` bound floated for that term is withdrawn, and this
+> window did not chase it.** The reasoning was that a most-negative reading of
+> −0.0062 measures a symmetric instrument floor. It does not. If an observed
+> delta is an unknown positive cost plus estimator error, a reading of −0.0062
+> establishes only that one negative excursion exceeded 0.0062 *plus that
+> cost*: it neither calibrates a symmetric floor nor bounds the cost from
+> above, and comparing most-negative readings taken at two window widths
+> cannot demonstrate that a floor scaled with the window. The arithmetic is
+> beside the point on this box in any case — **run 2 read −0.0141, more than
+> twice the figure that was to have been published as the bound.** (Merged-PR
+> audit of #8328; `rf2-3l6hf` reopened on it.) Widening the window further was
+> deliberately not attempted: whether 128–256 frames would bring the term clear
+> is a prediction from floor readings, not a measurement, and a rung added
+> between runs makes the series two instruments.
+>
+> **`c-noactivate` is a term and not the noise floor** the instrument's own
+> namespace docstring calls it (`rf2-tcffa`; `rf2-19usn` carries the shipping
+> cost behind it), and this window corroborates that independently: it reads
+> 0.0422 / 0.0484 / 0.0562 with one sign on every run, **larger than the
+> cell-map insert in two runs of three.** It therefore cannot serve as the
+> arbiter of whether a window is wide enough, which is the job the widening
+> commit gave it.
+>
+> **Nothing in §1's table or in §4 is restated by this window, and the
+> obligations that ride the republication stay open on `rf2-07rnj`.** The
+> `index write` row still prices the structure `rf2-dabt3` deleted; 0.8625 is
+> still not the `c-local` measured above; and the conclusions built on both —
+> §1's "Reading it" 4, and `the-in-page-mount-term-decomposed.md`'s §6(b)
+> comparison and §9.2 "batching the index write" — still read as current.
+> Retiring or qualifying them was to ride the republished decomposition, and
+> there is no republished decomposition.
+>
+> **The box, sampled with real counters and reported whole.** Processor Queue
+> Length (`\System\Processor Queue Length`) was sampled **235 times** across
+> the window, back-to-back at 1 s during every run, and read **0 on 211 of
+> them**. Of the 24 non-zero readings: **10 are build-phase** — `run.cjs`
+> rebuilds the `:advanced` bundle unconditionally on every run and that
+> compile saturates this box — and they are the only large ones (2, 34, 57, 1,
+> 26 in run 2; 1, 1, 1, **93**, 1 in run 3), every one of them before the
+> bundle's own mtime. **10 are measurement-phase** and none exceeds 2 (five
+> 1s in run 2; 2, 1, 1, 1, 1 in run 3). Three more (all 1) fall inside run 1,
+> which was sampled without timestamps and whose readings therefore **cannot
+> be proven to sit in either phase**; the remaining one is a 1 on the idle box
+> before certification. The non-zero count is higher than the predecessor
+> windows' because the sampling here is continuous rather than spaced, not
+> because the box was busier.
+>
+> Raw driver output for all three runs, unedited, is committed beside the
+> instrument at
+> `implementation/hicasso/test/re_frame/bench/hicasso/data/readprofile-07rnj/`
+> (`run1.txt`, `run2.txt`, `run3.txt` — `.txt` because the repo ignores
+> `*.log`).
+> Reproduction: `HICASSO_INIT_FN=re-frame.bench.hicasso.read-profile-app/-main
+> HICASSO_OUT_DIR=out/hicasso-readprof node
+> implementation/hicasso/test/re_frame/bench/hicasso/run.cjs`.
+
 Micro table, over the page's own roster (ns/op): `subscribe-once` 5,284;
 `compute-sub` 1,170; the raw handler invoke 227; `registrar/lookup` 67;
 `frame-state-value` 266; the `call-with-frame-resolution` wrap 206; the

--- a/docs/design/hicasso/studio/the-cold-read-mount-term.md
+++ b/docs/design/hicasso/studio/the-cold-read-mount-term.md
@@ -271,11 +271,15 @@ and settled between samples behind a residue equality gate that never fired):
 > because the sampling here is continuous rather than spaced, not because the
 > box was busier.
 >
-> Raw driver output for all three runs, unedited, is committed beside the
-> instrument at
+> Raw driver output for all three runs is committed beside the instrument at
 > `implementation/hicasso/test/re_frame/bench/hicasso/data/readprofile-07rnj/`
 > (`run1.txt`, `run2.txt`, `run3.txt` — `.txt` because the repo ignores
-> `*.log`).
+> `*.log`). Verbatim **except for one line per file**: the `shadow-cljs -
+> config:` banner, whose absolute path is replaced by `<worktree>` and marked
+> inline as redacted, because the portability gate refuses a tracked personal
+> home path and is right to. No figure, guard verdict or exit line was touched;
+> the directory's `README.md` states the redaction, and re-running the
+> reproduction above prints the banner with the reader's own checkout in it.
 > Reproduction: `HICASSO_INIT_FN=re-frame.bench.hicasso.read-profile-app/-main
 > HICASSO_OUT_DIR=out/hicasso-readprof node
 > implementation/hicasso/test/re_frame/bench/hicasso/run.cjs`.

--- a/docs/design/hicasso/studio/the-cold-read-mount-term.md
+++ b/docs/design/hicasso/studio/the-cold-read-mount-term.md
@@ -256,19 +256,20 @@ and settled between samples behind a residue equality gate that never fired):
 > there is no republished decomposition.
 >
 > **The box, sampled with real counters and reported whole.** Processor Queue
-> Length (`\System\Processor Queue Length`) was sampled **235 times** across
-> the window, back-to-back at 1 s during every run, and read **0 on 211 of
-> them**. Of the 24 non-zero readings: **10 are build-phase** — `run.cjs`
+> Length (`\System\Processor Queue Length`) was sampled **243 times** across
+> the window, back-to-back at 1 s during every run, and read **0 on 218 of
+> them**. Of the 25 non-zero readings: **10 are build-phase** — `run.cjs`
 > rebuilds the `:advanced` bundle unconditionally on every run and that
 > compile saturates this box — and they are the only large ones (2, 34, 57, 1,
 > 26 in run 2; 1, 1, 1, **93**, 1 in run 3), every one of them before the
 > bundle's own mtime. **10 are measurement-phase** and none exceeds 2 (five
 > 1s in run 2; 2, 1, 1, 1, 1 in run 3). Three more (all 1) fall inside run 1,
 > which was sampled without timestamps and whose readings therefore **cannot
-> be proven to sit in either phase**; the remaining one is a 1 on the idle box
-> before certification. The non-zero count is higher than the predecessor
-> windows' because the sampling here is continuous rather than spaced, not
-> because the box was busier.
+> be proven to sit in either phase**; the remaining two are a 1 on the idle box
+> before certification and a 1 on the idle box at close, with no run in flight
+> for either. The non-zero count is higher than the predecessor windows'
+> because the sampling here is continuous rather than spaced, not because the
+> box was busier.
 >
 > Raw driver output for all three runs, unedited, is committed beside the
 > instrument at

--- a/implementation/hicasso/test/re_frame/bench/hicasso/data/readprofile-07rnj/README.md
+++ b/implementation/hicasso/test/re_frame/bench/hicasso/data/readprofile-07rnj/README.md
@@ -1,0 +1,49 @@
+# `read_profile` phase-A/B transcripts — rf2-07rnj's measurement window
+
+Raw driver output from the three runs of `rf2-07rnj`'s measurement window
+(2026-08-16), one file per run, in run order. The window is written up in
+`docs/design/hicasso/studio/the-cold-read-mount-term.md`; these are the
+transcripts that page's refusal is read off.
+
+**The window declined to publish a decomposition.** Four of the five phase-B
+ablation terms resolve with one sign on every run; reader membership reads
+`+0.0047 / −0.0141 / +0.0125` and straddles zero, and a negative delta is
+arithmetically impossible when `c-noreaders` does strictly less work than
+`c-local`. Nothing here restates a published figure, and no share is computed
+from these numbers.
+
+## What produced them
+
+| | |
+|---|---|
+| **Commit** | `a43aa8609f` |
+| **Instrument blob** | `6d2b67b5b033d57c20a993732fd7f5664c3188ac` (`read_profile_app.cljs`, identical before and after the window) |
+| **Window shape** | 32 frames/window, 8 × (2 + 8) = 64 kept samples per arm, grid 0.0015625 ms/commit — chosen once and held for every arm of every run |
+| **Build** | `:advanced`, `goog.DEBUG false`, lane cache cleared per run |
+| **Runtime** | HeadlessChrome 147.0.7727.15 (Playwright), node v24.13.0 |
+| **Outcome** | `exit 0` on all three; both arm-order guards reportable; phase-A positive control passing; phase-B residue gate never fired |
+
+## Reproduction
+
+```bash
+HICASSO_INIT_FN=re-frame.bench.hicasso.read-profile-app/-main \
+HICASSO_OUT_DIR=out/hicasso-readprof \
+  node implementation/hicasso/test/re_frame/bench/hicasso/run.cjs
+```
+
+## The one redaction, stated so nobody reads these as doctored
+
+Each file is the driver's output verbatim **except for exactly one line**, the
+`shadow-cljs - config:` banner, whose absolute path is replaced by
+`<worktree>` and marked inline as redacted. Nothing else was touched — no
+figure, no guard verdict, no exit line.
+
+The path was the window's proof that every build and every gate read the
+worker's own worktree rather than the mayor checkout, which is why the line is
+kept rather than deleted. It cannot be committed as it stood: the portability
+gate (`scripts/check-no-hardcoded-paths.sh`, run by
+`.github/workflows/portability.yml`) refuses any tracked file carrying a
+personal home path, correctly and with no escape hatch. Re-running the command
+above prints the same banner with the reader's own checkout in it, which is the
+better proof anyway — a path in a transcript proves only where somebody else
+once stood.

--- a/implementation/hicasso/test/re_frame/bench/hicasso/data/readprofile-07rnj/run1.txt
+++ b/implementation/hicasso/test/re_frame/bench/hicasso/data/readprofile-07rnj/run1.txt
@@ -1,0 +1,205 @@
+[hicasso] building :advanced bundle — re-frame.bench.hicasso.read-profile-app/-main -> out/hicasso-readprof
+shadow-cljs - updating dependencies
+shadow-cljs - dependencies updated
+[:hicasso-bench] Compiling ...
+[:hicasso-bench] Build completed. (187 files, 132 compiled, 0 warnings, 18.73s)
+shadow-cljs - config: C:\Users\miket\code\re-frame2-worktrees\measure-07rnj\implementation\shadow-cljs.edn
+;; order-guard ok   the recorded 2.01x is REFUSED  — ratio 2.0125
+;; order-guard ok   the same study's uncontaminated slope passes  — forward 2830.7 / reversed 2842.8
+;; order-guard ok   a single-order result is refused as UNCHECKED  — only 1 stratum — the question was never asked
+;; order-guard ok   overlapping ranges are indistinguishable even 20% apart in median  — medians 1.2000x apart but the ranges OVERLAP — indistinguishable
+;; order-guard ok   the measured warm-up step is caught by PHASE, which no reversal would show  — phase: FIRST-THIRD reads 1.2633x LAST-THIRD, ranges disjoint
+;; order-guard ok   an arm that reads exactly zero in both strata is indistinguishable, not infinite  — within 10%
+;; order-guard ok   cyclic rotation gives every arm exactly ONE within-round predecessor  — rotation over 6 rounds: distinct predecessors per arm 1,1,1,1 (only the round seam ever differs, and that is one sample in R)
+;; order-guard ok   the reflecting schedule gives every arm TWO, in balance  — reflected: 2,2,2,2 predecessors per arm, largest modal share 50%
+;; order-guard ok   at k=2 an ALWAYS-reflecting schedule runs one order for ever and is UNCHECKED  — always-reflect over 6 rounds of 2 arms: 1 distinct order(s), predecessors per arm 2,1 — rotating a pair by one IS reversing it, so the two cancel
+;; order-guard ok   at k=2 slot-order alternates, and every arm gets TWO predecessors in balance  — slot-order: 2 distinct orders, predecessors per arm 3,2, largest modal share 50%
+;; order-guard ok   samples whose :position went NON-FINITE refuse instead of narrowing the question  — 18 of 24 samples have NO USABLE :position (nil, absent or non-finite) in a run that records them — the harness lost them, so this contrast is over the rest and the sample count above is not it
+;; order-guard ok   a present-but-NIL :position is the same loss, and recording NONE is still excused  — 18 of 24 samples have NO USABLE :position (nil, absent or non-finite) in a run that records them — the harness lost them, so this contrast is over the rest and the sample count above is not it — and a run offering no position at all is excused, not refused
+;; harvest OK — 1202 elements, 141 reads (141 distinct), from the real page's own entry
+;; ==== ARM-ORDER GUARD — read-profile phase A (in-page ms, diagnostic) ====
+;;   every arm partitioned by WHAT RAN BEFORE IT and by WHERE IN THE RUN it was measured; tolerance 10%, overlapping ranges are indistinguishable
+;;   ctl2  (60 samples)
+;;     [ok  ] by predecessor  within 10%
+;;              warm                     n=30  p50       8.7000  [7.3000–12.7000]
+;;              ship                     n=30  p50       8.8500  [7.3000–11.3000]
+;;     [ok  ] by phase        within 10%
+;;              LAST-THIRD               n=20  p50       8.6500  [7.3000–12.7000]
+;;              FIRST-THIRD              n=20  p50       8.8000  [7.6000–11.3000]
+;;   floor  (60 samples)
+;;     [ok  ] by predecessor  within 10%
+;;              probe-fresh              n=30  p50       0.2000  [0.1000–0.3000]
+;;              warm                     n=30  p50       0.2000  [0.1000–0.8000]
+;;     [ok  ] by phase        within 10%
+;;              LAST-THIRD               n=20  p50       0.2000  [0.1000–0.8000]
+;;              FIRST-THIRD              n=20  p50       0.2000  [0.1000–0.4000]
+;;   local  (60 samples)
+;;     [ok  ] by predecessor  within 10%
+;;              ship                     n=30  p50       4.5000  [3.5000–5.2000]
+;;              no-shell                 n=30  p50       4.7000  [4.0000–5.9000]
+;;     [ok  ] by phase        within 10%
+;;              LAST-THIRD               n=20  p50       4.5000  [3.5000–5.0000]
+;;              FIRST-THIRD              n=20  p50       4.7000  [4.0000–5.9000]
+;;   no-shell  (60 samples)
+;;     [ok  ] by predecessor  within 10%
+;;              local                    n=36  p50       4.3000  [3.3000–7.7000]
+;;              probe                    n=24  p50       4.4000  [3.6000–4.9000]
+;;     [ok  ] by phase        within 10%
+;;              LAST-THIRD               n=20  p50       4.3000  [3.3000–7.7000]
+;;              FIRST-THIRD              n=20  p50       4.4000  [3.9000–5.5000]
+;;   probe  (60 samples)
+;;     [ok  ] by predecessor  within 10%
+;;              no-shell                 n=30  p50       2.1000  [1.8000–3.4000]
+;;              probe-fresh              n=30  p50       2.1000  [1.7000–2.4000]
+;;     [ok  ] by phase        within 10%
+;;              LAST-THIRD               n=20  p50       2.0000  [1.7000–2.5000]
+;;              FIRST-THIRD              n=20  p50       2.1000  [1.8000–3.4000]
+;;   probe-fresh  (60 samples)
+;;     [ok  ] by predecessor  within 10%
+;;              probe                    n=36  p50       1.0000  [0.8000–1.6000]
+;;              floor                    n=23  p50       1.0000  [0.8000–1.4000]
+;;              <none>                   n= 1  p50       1.3000  [1.3000–1.3000]
+;;     [ok  ] by phase        within 10%
+;;              LAST-THIRD               n=20  p50       1.0000  [0.8000–1.4000]
+;;              FIRST-THIRD              n=20  p50       1.0500  [0.8000–1.6000]
+;;   ship  (60 samples)
+;;     [ok  ] by predecessor  within 10%
+;;              local                    n=24  p50       2.3000  [2.0000–4.1000]
+;;              ctl2                     n=36  p50       2.4000  [1.9000–3.7000]
+;;     [ok  ] by phase        within 10%
+;;              LAST-THIRD               n=20  p50       2.3000  [1.9000–2.8000]
+;;              FIRST-THIRD              n=20  p50       2.4000  [2.0000–4.1000]
+;;   warm  (60 samples)
+;;     [ok  ] by predecessor  within 10%
+;;              floor                    n=36  p50       0.4000  [0.3000–1.2000]
+;;              ctl2                     n=24  p50       0.4000  [0.3000–1.3000]
+;;     [ok  ] by phase        within 10%
+;;              FIRST-THIRD              n=20  p50       0.4000  [0.3000–0.7000]
+;;              LAST-THIRD               n=20  p50       0.4000  [0.3000–1.3000]
+;;   VERDICT: reportable — no arm reads differently for its position in the plan
+;; HICASSO read-profile-census
+{:reads 141, :distinct 141, :by-sub-id {:conduit/your-feed? 1, :conduit/slugs 1, :conduit/tags 1, :conduit/article 69, :conduit/favorite-pending? 69}, :input-kinds {:db 141}}
+;; HICASSO read-profile-arms
+{:ship {:n 60, :min 0.2375, :max 0.5125, :p50 0.2875}, :local {:n 60, :min 0.4375, :max 0.7375, :p50 0.575}, :no-shell {:n 60, :min 0.4125, :max 0.9625, :p50 0.5375}, :probe {:n 60, :min 0.2125, :max 0.425, :p50 0.2625}, :probe-fresh {:n 60, :min 0.1, :max 0.2, :p50 0.125}, :floor {:n 60, :min 0.0125, :max 0.1, :p50 0.025}, :warm {:n 60, :min 0.0375, :max 0.1625, :p50 0.05}, :ctl2 {:n 60, :min 0.9125, :max 1.5875, :p50 1.1}}
+;; ==== READ PROFILE, PHASE A (ms per 141-read pass; diagnostic in-page clock) ====
+;;   reads/pass 141  passes/sample 8  design 6x(4+10)
+;;   ship: p50 0.2875 [0.2375 - 0.5125] ms/pass  (2.04 us/read)
+;;   local: p50 0.5750 [0.4375 - 0.7375] ms/pass  (4.08 us/read)
+;;   no-shell: p50 0.5375 [0.4125 - 0.9625] ms/pass  (3.81 us/read)
+;;   probe: p50 0.2625 [0.2125 - 0.4250] ms/pass  (1.86 us/read)
+;;   probe-fresh: p50 0.1250 [0.1000 - 0.2000] ms/pass  (0.89 us/read)
+;;   floor: p50 0.0250 [0.0125 - 0.1000] ms/pass  (0.18 us/read)
+;;   warm: p50 0.0500 [0.0375 - 0.1625] ms/pass  (0.35 us/read)
+;;   ctl2: p50 1.1000 [0.9125 - 1.5875] ms/pass  (7.80 us/read)
+;; ==== PHASE A DELTAS (floors; stubs stated in the ns docstring) ====
+;;   copy fidelity: local/ship = 2.0000  (local is the FROZEN subscribe-once path)
+;;   the-hicasso-shell (local - no-shell): delta 0.0375 ms/pass (0.27 us/read, 6.5% of the baseline)
+;;   churn-vs-probe (local - probe, the candidate's saving): delta 0.3125 ms/pass (2.22 us/read, 54.3% of the baseline)
+;;   memo-economy (probe-fresh - probe): delta -0.1375 ms/pass (-0.98 us/read, -110.0% of the baseline)
+;;   probe-overhead (probe - floor): delta 0.2375 ms/pass (1.68 us/read, 90.5% of the baseline)
+;;   warm steady-state: 0.0500 ms/pass (0.35 us/read)
+;;   control: predicted 1.075x, measured 1.100x [0.913–1.587] — the range meets the prediction within ±25%
+;; ==== ARM-ORDER GUARD — read-profile phase B (in-page ms, diagnostic) ====
+;;   every arm partitioned by WHAT RAN BEFORE IT and by WHERE IN THE RUN it was measured; tolerance 10%, overlapping ranges are indistinguishable
+;;   b-build  (64 samples)
+;;     [ok  ] by predecessor  within 10%
+;;              c-nomap                  n=32  p50      15.5500  [12.6000–20.2000]
+;;              commit                   n=32  p50      15.9500  [12.6000–31.7000]
+;;     [ok  ] by phase        within 10%
+;;              FIRST-THIRD              n=21  p50      15.9000  [12.6000–20.9000]
+;;              LAST-THIRD               n=21  p50      16.5000  [12.7000–20.2000]
+;;   c-local  (64 samples)
+;;     [ok  ] by predecessor  within 10%
+;;              c-noactivate             n=32  p50      21.0000  [15.2000–26.3000]
+;;              commit                   n=32  p50      21.1000  [18.5000–32.9000]
+;;     [ok  ] by phase        within 10%
+;;              LAST-THIRD               n=21  p50      20.9000  [16.2000–32.9000]
+;;              FIRST-THIRD              n=21  p50      21.2000  [16.4000–26.3000]
+;;   c-noactivate  (64 samples)
+;;     [ok  ] by predecessor  within 10%
+;;              c-nowatch                n=24  p50      19.6500  [18.7000–23.1000]
+;;              c-local                  n=39  p50      19.8000  [15.2000–28.5000]
+;;              <none>                   n= 1  p50      19.9000  [19.9000–19.9000]
+;;     [ok  ] by phase        within 10%
+;;              LAST-THIRD               n=21  p50      19.6000  [16.1000–23.6000]
+;;              FIRST-THIRD              n=21  p50      19.8000  [17.8000–28.5000]
+;;   c-nomap  (64 samples)
+;;     [ok  ] by predecessor  within 10%
+;;              b-build                  n=24  p50      19.6000  [16.8000–25.2000]
+;;              c-noreaders              n=40  p50      19.7000  [14.0000–24.2000]
+;;     [ok  ] by phase        within 10%
+;;              LAST-THIRD               n=21  p50      18.8000  [14.0000–21.7000]
+;;              FIRST-THIRD              n=21  p50      20.1000  [15.9000–25.2000]
+;;   c-noreaders  (64 samples)
+;;     [ok  ] by predecessor  within 10%
+;;              c-nosub                  n=32  p50      20.4000  [17.0000–26.4000]
+;;              c-nomap                  n=32  p50      21.2000  [16.8000–25.4000]
+;;     [ok  ] by phase        within 10%
+;;              LAST-THIRD               n=21  p50      20.0000  [17.0000–25.2000]
+;;              FIRST-THIRD              n=21  p50      21.0000  [17.9000–26.4000]
+;;   c-nosub  (64 samples)
+;;     [ok  ] by predecessor  within 10%
+;;              c-nowatch                n=40  p50       6.9000  [5.1000–13.4000]
+;;              c-noreaders              n=24  p50       7.1000  [6.0000–10.2000]
+;;     [ok  ] by phase        within 10%
+;;              LAST-THIRD               n=21  p50       6.8000  [5.6000–9.9000]
+;;              FIRST-THIRD              n=21  p50       7.0000  [6.0000–13.4000]
+;;   c-nowatch  (64 samples)
+;;     [ok  ] by predecessor  within 10%
+;;              c-nosub                  n=32  p50      18.6500  [14.9000–24.1000]
+;;              c-noactivate             n=32  p50      18.8000  [13.8000–23.3000]
+;;     [ok  ] by phase        within 10%
+;;              LAST-THIRD               n=21  p50      18.7000  [14.9000–21.3000]
+;;              FIRST-THIRD              n=21  p50      19.0000  [15.7000–24.1000]
+;;   commit  (64 samples)
+;;     [ok  ] by predecessor  within 10%
+;;              c-local                  n=24  p50      21.0000  [16.9000–25.4000]
+;;              b-build                  n=40  p50      22.7000  [18.8000–28.3000]
+;;     [ok  ] by phase        within 10%
+;;              LAST-THIRD               n=21  p50      21.6000  [17.4000–24.7000]
+;;              FIRST-THIRD              n=21  p50      22.6000  [19.4000–28.3000]
+;;   VERDICT: reportable — no arm reads differently for its position in the plan
+;; HICASSO read-profile-commit
+{:commit {:n 64, :min 0.5281, :max 0.8844, :p50 0.6953}, :c-local {:n 64, :min 0.475, :max 1.0281, :p50 0.6594}, :c-noactivate {:n 64, :min 0.475, :max 0.8906, :p50 0.6172}, :c-nowatch {:n 64, :min 0.4313, :max 0.7531, :p50 0.5875}, :c-nosub {:n 64, :min 0.1594, :max 0.4188, :p50 0.2156}, :c-noreaders {:n 64, :min 0.525, :max 0.825, :p50 0.6547}, :c-nomap {:n 64, :min 0.4375, :max 0.7875, :p50 0.6156}, :b-build {:n 64, :min 0.3937, :max 0.9906, :p50 0.4938}}
+;; ==== READ PROFILE, PHASE B — THE COMMIT HALF (ms per 141-key boundary commit) ====
+;;   design 8x(2+8)  window = 32 frames/commit each  grid = 0.001563 ms/commit
+;;   commit: p50 0.6953 [0.5281 - 0.8844] ms/pass  (4.93 us/read)
+;;   c-local: p50 0.6594 [0.4750 - 1.0281] ms/pass  (4.68 us/read)
+;;   c-noactivate: p50 0.6172 [0.4750 - 0.8906] ms/pass  (4.38 us/read)
+;;   c-nowatch: p50 0.5875 [0.4313 - 0.7531] ms/pass  (4.17 us/read)
+;;   c-nosub: p50 0.2156 [0.1594 - 0.4188] ms/pass  (1.53 us/read)
+;;   c-noreaders: p50 0.6547 [0.5250 - 0.8250] ms/pass  (4.64 us/read)
+;;   c-nomap: p50 0.6156 [0.4375 - 0.7875] ms/pass  (4.37 us/read)
+;;   b-build: p50 0.4938 [0.3937 - 0.9906] ms/pass  (3.50 us/read)
+;; ==== PHASE B DELTAS (c-local minus ablation; floors) ====
+;;   copy fidelity: c-local/commit = 0.9483
+;;   activation-capture (c-local - c-noactivate): delta 0.0422 ms/pass (0.30 us/read, 6.4% of the baseline)
+;;     ^ routed no-op on this UIx host — expect the noise floor; real only under the ratom family (rf2-lzpfj)
+;;   watch-wiring (c-local - c-nowatch): delta 0.0719 ms/pass (0.51 us/read, 10.9% of the baseline)
+;;   reaction-build+cache-insert (c-local - c-nosub): delta 0.4437 ms/pass (3.15 us/read, 67.3% of the baseline)
+;;   reader-membership (c-local - c-noreaders): delta 0.0047 ms/pass (0.03 us/read, 0.7% of the baseline)
+;;   cell-map-insert (c-local - c-nomap): delta 0.0437 ms/pass (0.31 us/read, 6.6% of the baseline)
+;;   b-build (build+compute, no in-window dispose): 0.4938 ms/pass (3.50 us/read)
+;; HICASSO read-profile-micro
+{:subscribe-once 4964.539, :compute-sub 921.9858, :handler-invoke 226.9504, :registrar-lookup 70.922, :frame-state-value 265.9574, :resolution-wrap 223.4043, :cache-peek-miss 28.3688, :sub-key-mint 21.2766}
+;; ==== MICRO (ns/op over the page's own roster) ====
+;;   subscribe-once: 4964.5 ns
+;;   compute-sub: 922.0 ns
+;;   handler-invoke: 227.0 ns
+;;   registrar-lookup: 70.9 ns
+;;   frame-state-value: 266.0 ns
+;;   resolution-wrap: 223.4 ns
+;;   cache-peek-miss: 28.4 ns
+;;   sub-key-mint: 21.3 ns
+;; HICASSO DONE
+;; ==== HICASSO RUNTIME ====
+;; chromium 147.0.7727.15 (playwright), :advanced, goog.DEBUG false
+;; ==== HICASSO read-profile-census ====
+{:reads 141, :distinct 141, :by-sub-id {:conduit/your-feed? 1, :conduit/slugs 1, :conduit/tags 1, :conduit/article 69, :conduit/favorite-pending? 69}, :input-kinds {:db 141}}
+;; ==== HICASSO read-profile-arms ====
+{:ship {:n 60, :min 0.2375, :max 0.5125, :p50 0.2875}, :local {:n 60, :min 0.4375, :max 0.7375, :p50 0.575}, :no-shell {:n 60, :min 0.4125, :max 0.9625, :p50 0.5375}, :probe {:n 60, :min 0.2125, :max 0.425, :p50 0.2625}, :probe-fresh {:n 60, :min 0.1, :max 0.2, :p50 0.125}, :floor {:n 60, :min 0.0125, :max 0.1, :p50 0.025}, :warm {:n 60, :min 0.0375, :max 0.1625, :p50 0.05}, :ctl2 {:n 60, :min 0.9125, :max 1.5875, :p50 1.1}}
+;; ==== HICASSO read-profile-commit ====
+{:commit {:n 64, :min 0.5281, :max 0.8844, :p50 0.6953}, :c-local {:n 64, :min 0.475, :max 1.0281, :p50 0.6594}, :c-noactivate {:n 64, :min 0.475, :max 0.8906, :p50 0.6172}, :c-nowatch {:n 64, :min 0.4313, :max 0.7531, :p50 0.5875}, :c-nosub {:n 64, :min 0.1594, :max 0.4188, :p50 0.2156}, :c-noreaders {:n 64, :min 0.525, :max 0.825, :p50 0.6547}, :c-nomap {:n 64, :min 0.4375, :max 0.7875, :p50 0.6156}, :b-build {:n 64, :min 0.3937, :max 0.9906, :p50 0.4938}}
+;; ==== HICASSO read-profile-micro ====
+{:subscribe-once 4964.539, :compute-sub 921.9858, :handler-invoke 226.9504, :registrar-lookup 70.922, :frame-state-value 265.9574, :resolution-wrap 223.4043, :cache-peek-miss 28.3688, :sub-key-mint 21.2766}
+[hicasso] ok

--- a/implementation/hicasso/test/re_frame/bench/hicasso/data/readprofile-07rnj/run1.txt
+++ b/implementation/hicasso/test/re_frame/bench/hicasso/data/readprofile-07rnj/run1.txt
@@ -3,7 +3,7 @@ shadow-cljs - updating dependencies
 shadow-cljs - dependencies updated
 [:hicasso-bench] Compiling ...
 [:hicasso-bench] Build completed. (187 files, 132 compiled, 0 warnings, 18.73s)
-shadow-cljs - config: C:\Users\miket\code\re-frame2-worktrees\measure-07rnj\implementation\shadow-cljs.edn
+shadow-cljs - config: <worktree>\implementation\shadow-cljs.edn   ;; ABSOLUTE PATH REDACTED — see README.md
 ;; order-guard ok   the recorded 2.01x is REFUSED  — ratio 2.0125
 ;; order-guard ok   the same study's uncontaminated slope passes  — forward 2830.7 / reversed 2842.8
 ;; order-guard ok   a single-order result is refused as UNCHECKED  — only 1 stratum — the question was never asked

--- a/implementation/hicasso/test/re_frame/bench/hicasso/data/readprofile-07rnj/run2.txt
+++ b/implementation/hicasso/test/re_frame/bench/hicasso/data/readprofile-07rnj/run2.txt
@@ -2,7 +2,7 @@
 [hicasso] building :advanced bundle — re-frame.bench.hicasso.read-profile-app/-main -> out/hicasso-readprof
 [:hicasso-bench] Compiling ...
 [:hicasso-bench] Build completed. (187 files, 132 compiled, 0 warnings, 21.63s)
-shadow-cljs - config: C:\Users\miket\code\re-frame2-worktrees\measure-07rnj\implementation\shadow-cljs.edn
+shadow-cljs - config: <worktree>\implementation\shadow-cljs.edn   ;; ABSOLUTE PATH REDACTED — see README.md
 ;; order-guard ok   the recorded 2.01x is REFUSED  — ratio 2.0125
 ;; order-guard ok   the same study's uncontaminated slope passes  — forward 2830.7 / reversed 2842.8
 ;; order-guard ok   a single-order result is refused as UNCHECKED  — only 1 stratum — the question was never asked

--- a/implementation/hicasso/test/re_frame/bench/hicasso/data/readprofile-07rnj/run2.txt
+++ b/implementation/hicasso/test/re_frame/bench/hicasso/data/readprofile-07rnj/run2.txt
@@ -1,0 +1,204 @@
+[hicasso] cleared .shadow-cljs/builds/hicasso-bench — one build id, N arms (rf2-2rtt6.20)
+[hicasso] building :advanced bundle — re-frame.bench.hicasso.read-profile-app/-main -> out/hicasso-readprof
+[:hicasso-bench] Compiling ...
+[:hicasso-bench] Build completed. (187 files, 132 compiled, 0 warnings, 21.63s)
+shadow-cljs - config: C:\Users\miket\code\re-frame2-worktrees\measure-07rnj\implementation\shadow-cljs.edn
+;; order-guard ok   the recorded 2.01x is REFUSED  — ratio 2.0125
+;; order-guard ok   the same study's uncontaminated slope passes  — forward 2830.7 / reversed 2842.8
+;; order-guard ok   a single-order result is refused as UNCHECKED  — only 1 stratum — the question was never asked
+;; order-guard ok   overlapping ranges are indistinguishable even 20% apart in median  — medians 1.2000x apart but the ranges OVERLAP — indistinguishable
+;; order-guard ok   the measured warm-up step is caught by PHASE, which no reversal would show  — phase: FIRST-THIRD reads 1.2633x LAST-THIRD, ranges disjoint
+;; order-guard ok   an arm that reads exactly zero in both strata is indistinguishable, not infinite  — within 10%
+;; order-guard ok   cyclic rotation gives every arm exactly ONE within-round predecessor  — rotation over 6 rounds: distinct predecessors per arm 1,1,1,1 (only the round seam ever differs, and that is one sample in R)
+;; order-guard ok   the reflecting schedule gives every arm TWO, in balance  — reflected: 2,2,2,2 predecessors per arm, largest modal share 50%
+;; order-guard ok   at k=2 an ALWAYS-reflecting schedule runs one order for ever and is UNCHECKED  — always-reflect over 6 rounds of 2 arms: 1 distinct order(s), predecessors per arm 2,1 — rotating a pair by one IS reversing it, so the two cancel
+;; order-guard ok   at k=2 slot-order alternates, and every arm gets TWO predecessors in balance  — slot-order: 2 distinct orders, predecessors per arm 3,2, largest modal share 50%
+;; order-guard ok   samples whose :position went NON-FINITE refuse instead of narrowing the question  — 18 of 24 samples have NO USABLE :position (nil, absent or non-finite) in a run that records them — the harness lost them, so this contrast is over the rest and the sample count above is not it
+;; order-guard ok   a present-but-NIL :position is the same loss, and recording NONE is still excused  — 18 of 24 samples have NO USABLE :position (nil, absent or non-finite) in a run that records them — the harness lost them, so this contrast is over the rest and the sample count above is not it — and a run offering no position at all is excused, not refused
+;; harvest OK — 1202 elements, 141 reads (141 distinct), from the real page's own entry
+;; ==== ARM-ORDER GUARD — read-profile phase A (in-page ms, diagnostic) ====
+;;   every arm partitioned by WHAT RAN BEFORE IT and by WHERE IN THE RUN it was measured; tolerance 10%, overlapping ranges are indistinguishable
+;;   ctl2  (60 samples)
+;;     [ok  ] by predecessor  within 10%
+;;              ship                     n=30  p50       8.3500  [7.5000–9.6000]
+;;              warm                     n=30  p50       8.5000  [8.0000–12.2000]
+;;     [ok  ] by phase        within 10%
+;;              LAST-THIRD               n=20  p50       8.2500  [7.8000–12.2000]
+;;              FIRST-THIRD              n=20  p50       8.5500  [7.8000–9.2000]
+;;   floor  (60 samples)
+;;     [ok  ] by predecessor  within 10%
+;;              warm                     n=30  p50       0.2000  [0.1000–0.5000]
+;;              probe-fresh              n=30  p50       0.2000  [0.1000–0.4000]
+;;     [ok  ] by phase        within 10%
+;;              FIRST-THIRD              n=20  p50       0.2000  [0.1000–0.4000]
+;;              LAST-THIRD               n=20  p50       0.2000  [0.1000–0.5000]
+;;   local  (60 samples)
+;;     [ok  ] by predecessor  within 10%
+;;              ship                     n=30  p50       4.4000  [3.7000–6.6000]
+;;              no-shell                 n=30  p50       4.5000  [3.7000–5.6000]
+;;     [ok  ] by phase        within 10%
+;;              LAST-THIRD               n=20  p50       4.3000  [3.7000–5.5000]
+;;              FIRST-THIRD              n=20  p50       4.5500  [4.0000–6.6000]
+;;   no-shell  (60 samples)
+;;     [ok  ] by predecessor  within 10%
+;;              probe                    n=24  p50       4.1500  [3.6000–5.9000]
+;;              local                    n=36  p50       4.4000  [4.0000–8.0000]
+;;     [ok  ] by phase        within 10%
+;;              LAST-THIRD               n=20  p50       4.2000  [3.6000–5.9000]
+;;              FIRST-THIRD              n=20  p50       4.4000  [3.7000–8.0000]
+;;   probe  (60 samples)
+;;     [ok  ] by predecessor  within 10%
+;;              no-shell                 n=30  p50       1.9000  [1.7000–2.6000]
+;;              probe-fresh              n=30  p50       1.9500  [1.6000–2.7000]
+;;     [ok  ] by phase        medians 1.1944x apart but the ranges OVERLAP — indistinguishable
+;;              LAST-THIRD               n=20  p50       1.8000  [1.6000–2.7000]
+;;              FIRST-THIRD              n=20  p50       2.1500  [1.8000–2.6000]
+;;   probe-fresh  (60 samples)
+;;     [ok  ] by predecessor  within 10%
+;;              probe                    n=36  p50       1.0000  [0.8000–1.7000]
+;;              floor                    n=23  p50       1.0000  [0.8000–1.9000]
+;;              <none>                   n= 1  p50       1.1000  [1.1000–1.1000]
+;;     [ok  ] by phase        medians 1.1667x apart but the ranges OVERLAP — indistinguishable
+;;              LAST-THIRD               n=20  p50       0.9000  [0.8000–1.9000]
+;;              FIRST-THIRD              n=20  p50       1.0500  [0.9000–1.7000]
+;;   ship  (60 samples)
+;;     [ok  ] by predecessor  within 10%
+;;              local                    n=24  p50       2.1000  [1.9000–2.6000]
+;;              ctl2                     n=36  p50       2.3000  [1.9000–3.9000]
+;;     [ok  ] by phase        within 10%
+;;              LAST-THIRD               n=20  p50       2.2000  [1.9000–2.6000]
+;;              FIRST-THIRD              n=20  p50       2.4000  [2.0000–3.9000]
+;;   warm  (60 samples)
+;;     [ok  ] by predecessor  medians 1.1250x apart but the ranges OVERLAP — indistinguishable
+;;              floor                    n=36  p50       0.4000  [0.3000–0.6000]
+;;              ctl2                     n=24  p50       0.4500  [0.3000–0.5000]
+;;     [ok  ] by phase        within 10%
+;;              FIRST-THIRD              n=20  p50       0.4000  [0.4000–0.5000]
+;;              LAST-THIRD               n=20  p50       0.4000  [0.3000–0.5000]
+;;   VERDICT: reportable — no arm reads differently for its position in the plan
+;; HICASSO read-profile-census
+{:reads 141, :distinct 141, :by-sub-id {:conduit/your-feed? 1, :conduit/slugs 1, :conduit/tags 1, :conduit/article 69, :conduit/favorite-pending? 69}, :input-kinds {:db 141}}
+;; HICASSO read-profile-arms
+{:ship {:n 60, :min 0.2375, :max 0.4875, :p50 0.2875}, :local {:n 60, :min 0.4625, :max 0.825, :p50 0.5563}, :no-shell {:n 60, :min 0.45, :max 1, :p50 0.5375}, :probe {:n 60, :min 0.2, :max 0.3375, :p50 0.2375}, :probe-fresh {:n 60, :min 0.1, :max 0.2375, :p50 0.125}, :floor {:n 60, :min 0.0125, :max 0.0625, :p50 0.025}, :warm {:n 60, :min 0.0375, :max 0.075, :p50 0.05}, :ctl2 {:n 60, :min 0.9375, :max 1.525, :p50 1.0625}}
+;; ==== READ PROFILE, PHASE A (ms per 141-read pass; diagnostic in-page clock) ====
+;;   reads/pass 141  passes/sample 8  design 6x(4+10)
+;;   ship: p50 0.2875 [0.2375 - 0.4875] ms/pass  (2.04 us/read)
+;;   local: p50 0.5563 [0.4625 - 0.8250] ms/pass  (3.95 us/read)
+;;   no-shell: p50 0.5375 [0.4500 - 1.0000] ms/pass  (3.81 us/read)
+;;   probe: p50 0.2375 [0.2000 - 0.3375] ms/pass  (1.68 us/read)
+;;   probe-fresh: p50 0.1250 [0.1000 - 0.2375] ms/pass  (0.89 us/read)
+;;   floor: p50 0.0250 [0.0125 - 0.0625] ms/pass  (0.18 us/read)
+;;   warm: p50 0.0500 [0.0375 - 0.0750] ms/pass  (0.35 us/read)
+;;   ctl2: p50 1.0625 [0.9375 - 1.5250] ms/pass  (7.54 us/read)
+;; ==== PHASE A DELTAS (floors; stubs stated in the ns docstring) ====
+;;   copy fidelity: local/ship = 1.9348  (local is the FROZEN subscribe-once path)
+;;   the-hicasso-shell (local - no-shell): delta 0.0187 ms/pass (0.13 us/read, 3.4% of the baseline)
+;;   churn-vs-probe (local - probe, the candidate's saving): delta 0.3187 ms/pass (2.26 us/read, 57.3% of the baseline)
+;;   memo-economy (probe-fresh - probe): delta -0.1125 ms/pass (-0.80 us/read, -90.0% of the baseline)
+;;   probe-overhead (probe - floor): delta 0.2125 ms/pass (1.51 us/read, 89.5% of the baseline)
+;;   warm steady-state: 0.0500 ms/pass (0.35 us/read)
+;;   control: predicted 1.075x, measured 1.063x [0.938–1.525] — the range meets the prediction within ±25%
+;; ==== ARM-ORDER GUARD — read-profile phase B (in-page ms, diagnostic) ====
+;;   every arm partitioned by WHAT RAN BEFORE IT and by WHERE IN THE RUN it was measured; tolerance 10%, overlapping ranges are indistinguishable
+;;   b-build  (64 samples)
+;;     [ok  ] by predecessor  within 10%
+;;              commit                   n=32  p50      18.1000  [12.6000–27.7000]
+;;              c-nomap                  n=32  p50      18.2000  [15.7000–22.8000]
+;;     [ok  ] by phase        within 10%
+;;              FIRST-THIRD              n=21  p50      18.5000  [13.4000–27.7000]
+;;              LAST-THIRD               n=21  p50      18.5000  [16.6000–23.0000]
+;;   c-local  (64 samples)
+;;     [ok  ] by predecessor  within 10%
+;;              c-noactivate             n=32  p50      21.8000  [18.0000–28.4000]
+;;              commit                   n=32  p50      22.4500  [17.5000–29.4000]
+;;     [ok  ] by phase        within 10%
+;;              FIRST-THIRD              n=21  p50      22.9000  [17.5000–29.4000]
+;;              LAST-THIRD               n=21  p50      23.0000  [20.7000–28.2000]
+;;   c-noactivate  (64 samples)
+;;     [ok  ] by predecessor  within 10%
+;;              <none>                   n= 1  p50      20.4000  [20.4000–20.4000]
+;;              c-nowatch                n=24  p50      20.6000  [16.2000–25.6000]
+;;              c-local                  n=39  p50      20.9000  [15.6000–27.1000]
+;;     [ok  ] by phase        within 10%
+;;              LAST-THIRD               n=21  p50      20.7000  [16.2000–27.1000]
+;;              FIRST-THIRD              n=21  p50      20.7000  [16.2000–25.6000]
+;;   c-nomap  (64 samples)
+;;     [ok  ] by predecessor  within 10%
+;;              c-noreaders              n=40  p50      21.3500  [15.6000–29.2000]
+;;              b-build                  n=24  p50      21.6500  [15.6000–27.9000]
+;;     [ok  ] by phase        within 10%
+;;              LAST-THIRD               n=21  p50      21.4000  [19.1000–28.3000]
+;;              FIRST-THIRD              n=21  p50      21.6000  [15.6000–29.2000]
+;;   c-noreaders  (64 samples)
+;;     [ok  ] by predecessor  within 10%
+;;              c-nomap                  n=32  p50      22.7500  [17.8000–26.9000]
+;;              c-nosub                  n=32  p50      22.8000  [15.6000–32.4000]
+;;     [ok  ] by phase        within 10%
+;;              LAST-THIRD               n=21  p50      22.6000  [18.2000–27.9000]
+;;              FIRST-THIRD              n=21  p50      23.7000  [15.6000–32.4000]
+;;   c-nosub  (64 samples)
+;;     [ok  ] by predecessor  within 10%
+;;              c-noreaders              n=24  p50       7.1500  [5.3000–12.1000]
+;;              c-nowatch                n=40  p50       7.2000  [5.2000–14.4000]
+;;     [ok  ] by phase        within 10%
+;;              LAST-THIRD               n=21  p50       6.9000  [5.2000–14.4000]
+;;              FIRST-THIRD              n=21  p50       7.4000  [6.0000–12.1000]
+;;   c-nowatch  (64 samples)
+;;     [ok  ] by predecessor  within 10%
+;;              c-nosub                  n=32  p50      19.9000  [14.8000–25.2000]
+;;              c-noactivate             n=32  p50      20.3500  [14.9000–26.5000]
+;;     [ok  ] by phase        within 10%
+;;              FIRST-THIRD              n=21  p50      20.0000  [15.3000–25.2000]
+;;              LAST-THIRD               n=21  p50      20.0000  [15.1000–24.5000]
+;;   commit  (64 samples)
+;;     [ok  ] by predecessor  within 10%
+;;              c-local                  n=24  p50      23.5500  [17.0000–34.8000]
+;;              b-build                  n=40  p50      24.4000  [18.8000–29.4000]
+;;     [ok  ] by phase        within 10%
+;;              LAST-THIRD               n=21  p50      24.1000  [22.0000–27.1000]
+;;              FIRST-THIRD              n=21  p50      24.6000  [18.8000–34.8000]
+;;   VERDICT: reportable — no arm reads differently for its position in the plan
+;; HICASSO read-profile-commit
+{:commit {:n 64, :min 0.5313, :max 1.0875, :p50 0.7516}, :c-local {:n 64, :min 0.5469, :max 0.9188, :p50 0.6969}, :c-noactivate {:n 64, :min 0.4875, :max 0.8469, :p50 0.6484}, :c-nowatch {:n 64, :min 0.4625, :max 0.8281, :p50 0.6313}, :c-nosub {:n 64, :min 0.1625, :max 0.45, :p50 0.225}, :c-noreaders {:n 64, :min 0.4875, :max 1.0125, :p50 0.7109}, :c-nomap {:n 64, :min 0.4875, :max 0.9125, :p50 0.6703}, :b-build {:n 64, :min 0.3937, :max 0.8656, :p50 0.5688}}
+;; ==== READ PROFILE, PHASE B — THE COMMIT HALF (ms per 141-key boundary commit) ====
+;;   design 8x(2+8)  window = 32 frames/commit each  grid = 0.001563 ms/commit
+;;   commit: p50 0.7516 [0.5313 - 1.0875] ms/pass  (5.33 us/read)
+;;   c-local: p50 0.6969 [0.5469 - 0.9188] ms/pass  (4.94 us/read)
+;;   c-noactivate: p50 0.6484 [0.4875 - 0.8469] ms/pass  (4.60 us/read)
+;;   c-nowatch: p50 0.6313 [0.4625 - 0.8281] ms/pass  (4.48 us/read)
+;;   c-nosub: p50 0.2250 [0.1625 - 0.4500] ms/pass  (1.60 us/read)
+;;   c-noreaders: p50 0.7109 [0.4875 - 1.0125] ms/pass  (5.04 us/read)
+;;   c-nomap: p50 0.6703 [0.4875 - 0.9125] ms/pass  (4.75 us/read)
+;;   b-build: p50 0.5688 [0.3937 - 0.8656] ms/pass  (4.03 us/read)
+;; ==== PHASE B DELTAS (c-local minus ablation; floors) ====
+;;   copy fidelity: c-local/commit = 0.9272
+;;   activation-capture (c-local - c-noactivate): delta 0.0484 ms/pass (0.34 us/read, 7.0% of the baseline)
+;;     ^ routed no-op on this UIx host — expect the noise floor; real only under the ratom family (rf2-lzpfj)
+;;   watch-wiring (c-local - c-nowatch): delta 0.0656 ms/pass (0.47 us/read, 9.4% of the baseline)
+;;   reaction-build+cache-insert (c-local - c-nosub): delta 0.4719 ms/pass (3.35 us/read, 67.7% of the baseline)
+;;   reader-membership (c-local - c-noreaders): delta -0.0141 ms/pass (-0.10 us/read, -2.0% of the baseline)
+;;   cell-map-insert (c-local - c-nomap): delta 0.0266 ms/pass (0.19 us/read, 3.8% of the baseline)
+;;   b-build (build+compute, no in-window dispose): 0.5688 ms/pass (4.03 us/read)
+;; HICASSO read-profile-micro
+{:subscribe-once 6347.5177, :compute-sub 1028.3688, :handler-invoke 312.0567, :registrar-lookup 92.1986, :frame-state-value 276.5957, :resolution-wrap 248.227, :cache-peek-miss 28.3688, :sub-key-mint 17.7305}
+;; ==== MICRO (ns/op over the page's own roster) ====
+;;   subscribe-once: 6347.5 ns
+;;   compute-sub: 1028.4 ns
+;;   handler-invoke: 312.1 ns
+;;   registrar-lookup: 92.2 ns
+;;   frame-state-value: 276.6 ns
+;;   resolution-wrap: 248.2 ns
+;;   cache-peek-miss: 28.4 ns
+;;   sub-key-mint: 17.7 ns
+;; HICASSO DONE
+;; ==== HICASSO RUNTIME ====
+;; chromium 147.0.7727.15 (playwright), :advanced, goog.DEBUG false
+;; ==== HICASSO read-profile-census ====
+{:reads 141, :distinct 141, :by-sub-id {:conduit/your-feed? 1, :conduit/slugs 1, :conduit/tags 1, :conduit/article 69, :conduit/favorite-pending? 69}, :input-kinds {:db 141}}
+;; ==== HICASSO read-profile-arms ====
+{:ship {:n 60, :min 0.2375, :max 0.4875, :p50 0.2875}, :local {:n 60, :min 0.4625, :max 0.825, :p50 0.5563}, :no-shell {:n 60, :min 0.45, :max 1, :p50 0.5375}, :probe {:n 60, :min 0.2, :max 0.3375, :p50 0.2375}, :probe-fresh {:n 60, :min 0.1, :max 0.2375, :p50 0.125}, :floor {:n 60, :min 0.0125, :max 0.0625, :p50 0.025}, :warm {:n 60, :min 0.0375, :max 0.075, :p50 0.05}, :ctl2 {:n 60, :min 0.9375, :max 1.525, :p50 1.0625}}
+;; ==== HICASSO read-profile-commit ====
+{:commit {:n 64, :min 0.5313, :max 1.0875, :p50 0.7516}, :c-local {:n 64, :min 0.5469, :max 0.9188, :p50 0.6969}, :c-noactivate {:n 64, :min 0.4875, :max 0.8469, :p50 0.6484}, :c-nowatch {:n 64, :min 0.4625, :max 0.8281, :p50 0.6313}, :c-nosub {:n 64, :min 0.1625, :max 0.45, :p50 0.225}, :c-noreaders {:n 64, :min 0.4875, :max 1.0125, :p50 0.7109}, :c-nomap {:n 64, :min 0.4875, :max 0.9125, :p50 0.6703}, :b-build {:n 64, :min 0.3937, :max 0.8656, :p50 0.5688}}
+;; ==== HICASSO read-profile-micro ====
+{:subscribe-once 6347.5177, :compute-sub 1028.3688, :handler-invoke 312.0567, :registrar-lookup 92.1986, :frame-state-value 276.5957, :resolution-wrap 248.227, :cache-peek-miss 28.3688, :sub-key-mint 17.7305}
+[hicasso] ok

--- a/implementation/hicasso/test/re_frame/bench/hicasso/data/readprofile-07rnj/run3.txt
+++ b/implementation/hicasso/test/re_frame/bench/hicasso/data/readprofile-07rnj/run3.txt
@@ -1,0 +1,204 @@
+[hicasso] cleared .shadow-cljs/builds/hicasso-bench — one build id, N arms (rf2-2rtt6.20)
+[hicasso] building :advanced bundle — re-frame.bench.hicasso.read-profile-app/-main -> out/hicasso-readprof
+[:hicasso-bench] Compiling ...
+[:hicasso-bench] Build completed. (187 files, 132 compiled, 0 warnings, 21.53s)
+shadow-cljs - config: C:\Users\miket\code\re-frame2-worktrees\measure-07rnj\implementation\shadow-cljs.edn
+;; order-guard ok   the recorded 2.01x is REFUSED  — ratio 2.0125
+;; order-guard ok   the same study's uncontaminated slope passes  — forward 2830.7 / reversed 2842.8
+;; order-guard ok   a single-order result is refused as UNCHECKED  — only 1 stratum — the question was never asked
+;; order-guard ok   overlapping ranges are indistinguishable even 20% apart in median  — medians 1.2000x apart but the ranges OVERLAP — indistinguishable
+;; order-guard ok   the measured warm-up step is caught by PHASE, which no reversal would show  — phase: FIRST-THIRD reads 1.2633x LAST-THIRD, ranges disjoint
+;; order-guard ok   an arm that reads exactly zero in both strata is indistinguishable, not infinite  — within 10%
+;; order-guard ok   cyclic rotation gives every arm exactly ONE within-round predecessor  — rotation over 6 rounds: distinct predecessors per arm 1,1,1,1 (only the round seam ever differs, and that is one sample in R)
+;; order-guard ok   the reflecting schedule gives every arm TWO, in balance  — reflected: 2,2,2,2 predecessors per arm, largest modal share 50%
+;; order-guard ok   at k=2 an ALWAYS-reflecting schedule runs one order for ever and is UNCHECKED  — always-reflect over 6 rounds of 2 arms: 1 distinct order(s), predecessors per arm 2,1 — rotating a pair by one IS reversing it, so the two cancel
+;; order-guard ok   at k=2 slot-order alternates, and every arm gets TWO predecessors in balance  — slot-order: 2 distinct orders, predecessors per arm 3,2, largest modal share 50%
+;; order-guard ok   samples whose :position went NON-FINITE refuse instead of narrowing the question  — 18 of 24 samples have NO USABLE :position (nil, absent or non-finite) in a run that records them — the harness lost them, so this contrast is over the rest and the sample count above is not it
+;; order-guard ok   a present-but-NIL :position is the same loss, and recording NONE is still excused  — 18 of 24 samples have NO USABLE :position (nil, absent or non-finite) in a run that records them — the harness lost them, so this contrast is over the rest and the sample count above is not it — and a run offering no position at all is excused, not refused
+;; harvest OK — 1202 elements, 141 reads (141 distinct), from the real page's own entry
+;; ==== ARM-ORDER GUARD — read-profile phase A (in-page ms, diagnostic) ====
+;;   every arm partitioned by WHAT RAN BEFORE IT and by WHERE IN THE RUN it was measured; tolerance 10%, overlapping ranges are indistinguishable
+;;   ctl2  (60 samples)
+;;     [ok  ] by predecessor  within 10%
+;;              warm                     n=30  p50       8.3500  [7.6000–11.5000]
+;;              ship                     n=30  p50       8.3500  [7.7000–12.8000]
+;;     [ok  ] by phase        medians 1.1265x apart but the ranges OVERLAP — indistinguishable
+;;              LAST-THIRD               n=20  p50       8.3000  [7.6000–11.9000]
+;;              FIRST-THIRD              n=20  p50       9.3500  [8.0000–12.8000]
+;;   floor  (60 samples)
+;;     [ok  ] by predecessor  within 10%
+;;              warm                     n=30  p50       0.2000  [0.1000–0.5000]
+;;              probe-fresh              n=30  p50       0.2000  [0.1000–0.7000]
+;;     [ok  ] by phase        within 10%
+;;              FIRST-THIRD              n=20  p50       0.2000  [0.1000–0.5000]
+;;              LAST-THIRD               n=20  p50       0.2000  [0.1000–0.7000]
+;;   local  (60 samples)
+;;     [ok  ] by predecessor  within 10%
+;;              ship                     n=30  p50       4.4000  [3.8000–7.5000]
+;;              no-shell                 n=30  p50       4.4000  [3.9000–8.3000]
+;;     [ok  ] by phase        within 10%
+;;              LAST-THIRD               n=20  p50       4.3500  [3.8000–7.5000]
+;;              FIRST-THIRD              n=20  p50       4.7500  [4.0000–8.3000]
+;;   no-shell  (60 samples)
+;;     [ok  ] by predecessor  within 10%
+;;              local                    n=36  p50       4.1000  [3.6000–8.0000]
+;;              probe                    n=24  p50       4.2000  [3.7000–5.5000]
+;;     [ok  ] by phase        within 10%
+;;              LAST-THIRD               n=20  p50       4.1500  [3.6000–5.1000]
+;;              FIRST-THIRD              n=20  p50       4.4000  [3.7000–8.0000]
+;;   probe  (60 samples)
+;;     [ok  ] by predecessor  within 10%
+;;              probe-fresh              n=30  p50       1.9000  [1.6000–3.8000]
+;;              no-shell                 n=30  p50       2.0000  [1.7000–3.4000]
+;;     [ok  ] by phase        medians 1.1053x apart but the ranges OVERLAP — indistinguishable
+;;              LAST-THIRD               n=20  p50       1.9000  [1.6000–2.7000]
+;;              FIRST-THIRD              n=20  p50       2.1000  [1.8000–3.8000]
+;;   probe-fresh  (60 samples)
+;;     [ok  ] by predecessor  within 10%
+;;              probe                    n=36  p50       1.0000  [0.8000–2.2000]
+;;              floor                    n=23  p50       1.0000  [0.8000–2.0000]
+;;              <none>                   n= 1  p50       1.3000  [1.3000–1.3000]
+;;     [ok  ] by phase        medians 1.2105x apart but the ranges OVERLAP — indistinguishable
+;;              LAST-THIRD               n=20  p50       0.9500  [0.8000–2.2000]
+;;              FIRST-THIRD              n=20  p50       1.1500  [0.8000–2.0000]
+;;   ship  (60 samples)
+;;     [ok  ] by predecessor  within 10%
+;;              local                    n=24  p50       2.1000  [2.0000–3.8000]
+;;              ctl2                     n=36  p50       2.2000  [1.8000–4.0000]
+;;     [ok  ] by phase        medians 1.1905x apart but the ranges OVERLAP — indistinguishable
+;;              LAST-THIRD               n=20  p50       2.1000  [1.8000–4.0000]
+;;              FIRST-THIRD              n=20  p50       2.5000  [1.9000–3.8000]
+;;   warm  (60 samples)
+;;     [ok  ] by predecessor  within 10%
+;;              floor                    n=36  p50       0.4000  [0.2000–1.1000]
+;;              ctl2                     n=24  p50       0.4000  [0.3000–0.9000]
+;;     [ok  ] by phase        medians 1.2500x apart but the ranges OVERLAP — indistinguishable
+;;              LAST-THIRD               n=20  p50       0.4000  [0.2000–1.1000]
+;;              FIRST-THIRD              n=20  p50       0.5000  [0.3000–0.9000]
+;;   VERDICT: reportable — no arm reads differently for its position in the plan
+;; HICASSO read-profile-census
+{:reads 141, :distinct 141, :by-sub-id {:conduit/your-feed? 1, :conduit/slugs 1, :conduit/tags 1, :conduit/article 69, :conduit/favorite-pending? 69}, :input-kinds {:db 141}}
+;; HICASSO read-profile-arms
+{:ship {:n 60, :min 0.225, :max 0.5, :p50 0.275}, :local {:n 60, :min 0.475, :max 1.0375, :p50 0.55}, :no-shell {:n 60, :min 0.45, :max 1, :p50 0.525}, :probe {:n 60, :min 0.2, :max 0.475, :p50 0.25}, :probe-fresh {:n 60, :min 0.1, :max 0.275, :p50 0.125}, :floor {:n 60, :min 0.0125, :max 0.0875, :p50 0.025}, :warm {:n 60, :min 0.025, :max 0.1375, :p50 0.05}, :ctl2 {:n 60, :min 0.95, :max 1.6, :p50 1.0437}}
+;; ==== READ PROFILE, PHASE A (ms per 141-read pass; diagnostic in-page clock) ====
+;;   reads/pass 141  passes/sample 8  design 6x(4+10)
+;;   ship: p50 0.2750 [0.2250 - 0.5000] ms/pass  (1.95 us/read)
+;;   local: p50 0.5500 [0.4750 - 1.0375] ms/pass  (3.90 us/read)
+;;   no-shell: p50 0.5250 [0.4500 - 1.0000] ms/pass  (3.72 us/read)
+;;   probe: p50 0.2500 [0.2000 - 0.4750] ms/pass  (1.77 us/read)
+;;   probe-fresh: p50 0.1250 [0.1000 - 0.2750] ms/pass  (0.89 us/read)
+;;   floor: p50 0.0250 [0.0125 - 0.0875] ms/pass  (0.18 us/read)
+;;   warm: p50 0.0500 [0.0250 - 0.1375] ms/pass  (0.35 us/read)
+;;   ctl2: p50 1.0437 [0.9500 - 1.6000] ms/pass  (7.40 us/read)
+;; ==== PHASE A DELTAS (floors; stubs stated in the ns docstring) ====
+;;   copy fidelity: local/ship = 2.0000  (local is the FROZEN subscribe-once path)
+;;   the-hicasso-shell (local - no-shell): delta 0.0250 ms/pass (0.18 us/read, 4.5% of the baseline)
+;;   churn-vs-probe (local - probe, the candidate's saving): delta 0.3000 ms/pass (2.13 us/read, 54.5% of the baseline)
+;;   memo-economy (probe-fresh - probe): delta -0.1250 ms/pass (-0.89 us/read, -100.0% of the baseline)
+;;   probe-overhead (probe - floor): delta 0.2250 ms/pass (1.60 us/read, 90.0% of the baseline)
+;;   warm steady-state: 0.0500 ms/pass (0.35 us/read)
+;;   control: predicted 1.050x, measured 1.044x [0.950–1.600] — the range meets the prediction within ±25%
+;; ==== ARM-ORDER GUARD — read-profile phase B (in-page ms, diagnostic) ====
+;;   every arm partitioned by WHAT RAN BEFORE IT and by WHERE IN THE RUN it was measured; tolerance 10%, overlapping ranges are indistinguishable
+;;   b-build  (64 samples)
+;;     [ok  ] by predecessor  within 10%
+;;              c-nomap                  n=32  p50      17.2500  [14.5000–20.6000]
+;;              commit                   n=32  p50      17.3500  [14.9000–24.8000]
+;;     [ok  ] by phase        within 10%
+;;              LAST-THIRD               n=21  p50      16.6000  [14.9000–21.0000]
+;;              FIRST-THIRD              n=21  p50      17.5000  [14.5000–21.3000]
+;;   c-local  (64 samples)
+;;     [ok  ] by predecessor  within 10%
+;;              c-noactivate             n=32  p50      21.4500  [17.7000–29.5000]
+;;              commit                   n=32  p50      22.4000  [16.2000–29.0000]
+;;     [ok  ] by phase        within 10%
+;;              LAST-THIRD               n=21  p50      21.3000  [18.9000–25.7000]
+;;              FIRST-THIRD              n=21  p50      22.5000  [18.1000–29.5000]
+;;   c-noactivate  (64 samples)
+;;     [ok  ] by predecessor  within 10%
+;;              c-nowatch                n=24  p50      20.1000  [15.4000–27.6000]
+;;              c-local                  n=39  p50      20.2000  [17.4000–26.7000]
+;;              <none>                   n= 1  p50      25.0000  [25.0000–25.0000]
+;;     [ok  ] by phase        within 10%
+;;              LAST-THIRD               n=21  p50      19.8000  [15.4000–22.4000]
+;;              FIRST-THIRD              n=21  p50      21.4000  [16.0000–27.6000]
+;;   c-nomap  (64 samples)
+;;     [ok  ] by predecessor  within 10%
+;;              b-build                  n=24  p50      20.3000  [18.8000–26.2000]
+;;              c-noreaders              n=40  p50      20.5000  [15.2000–29.0000]
+;;     [ok  ] by phase        within 10%
+;;              LAST-THIRD               n=21  p50      19.8000  [18.3000–23.9000]
+;;              FIRST-THIRD              n=21  p50      20.4000  [15.2000–29.0000]
+;;   c-noreaders  (64 samples)
+;;     [ok  ] by predecessor  within 10%
+;;              c-nosub                  n=32  p50      21.5500  [17.1000–26.2000]
+;;              c-nomap                  n=32  p50      21.6500  [17.2000–25.4000]
+;;     [ok  ] by phase        within 10%
+;;              LAST-THIRD               n=21  p50      21.2000  [17.1000–26.2000]
+;;              FIRST-THIRD              n=21  p50      21.9000  [20.2000–25.4000]
+;;   c-nosub  (64 samples)
+;;     [ok  ] by predecessor  within 10%
+;;              c-nowatch                n=40  p50       7.0000  [5.4000–9.3000]
+;;              c-noreaders              n=24  p50       7.0000  [6.4000–9.5000]
+;;     [ok  ] by phase        within 10%
+;;              LAST-THIRD               n=21  p50       6.8000  [5.4000–9.5000]
+;;              FIRST-THIRD              n=21  p50       7.1000  [6.4000–9.4000]
+;;   c-nowatch  (64 samples)
+;;     [ok  ] by predecessor  within 10%
+;;              c-noactivate             n=32  p50      19.4000  [14.6000–23.7000]
+;;              c-nosub                  n=32  p50      19.6500  [14.8000–28.4000]
+;;     [ok  ] by phase        within 10%
+;;              LAST-THIRD               n=21  p50      19.1000  [15.7000–28.4000]
+;;              FIRST-THIRD              n=21  p50      20.4000  [15.3000–24.0000]
+;;   commit  (64 samples)
+;;     [ok  ] by predecessor  within 10%
+;;              c-local                  n=24  p50      22.6000  [18.6000–27.0000]
+;;              b-build                  n=40  p50      23.3500  [20.3000–28.7000]
+;;     [ok  ] by phase        within 10%
+;;              LAST-THIRD               n=21  p50      22.9000  [19.3000–25.9000]
+;;              FIRST-THIRD              n=21  p50      23.9000  [18.6000–28.7000]
+;;   VERDICT: reportable — no arm reads differently for its position in the plan
+;; HICASSO read-profile-commit
+{:commit {:n 64, :min 0.5812, :max 0.8969, :p50 0.7203}, :c-local {:n 64, :min 0.5062, :max 0.9219, :p50 0.6875}, :c-noactivate {:n 64, :min 0.4813, :max 0.8625, :p50 0.6313}, :c-nowatch {:n 64, :min 0.4562, :max 0.8875, :p50 0.6094}, :c-nosub {:n 64, :min 0.1688, :max 0.2969, :p50 0.2188}, :c-noreaders {:n 64, :min 0.5344, :max 0.8188, :p50 0.675}, :c-nomap {:n 64, :min 0.475, :max 0.9063, :p50 0.6375}, :b-build {:n 64, :min 0.4531, :max 0.775, :p50 0.5406}}
+;; ==== READ PROFILE, PHASE B — THE COMMIT HALF (ms per 141-key boundary commit) ====
+;;   design 8x(2+8)  window = 32 frames/commit each  grid = 0.001563 ms/commit
+;;   commit: p50 0.7203 [0.5812 - 0.8969] ms/pass  (5.11 us/read)
+;;   c-local: p50 0.6875 [0.5062 - 0.9219] ms/pass  (4.88 us/read)
+;;   c-noactivate: p50 0.6313 [0.4813 - 0.8625] ms/pass  (4.48 us/read)
+;;   c-nowatch: p50 0.6094 [0.4562 - 0.8875] ms/pass  (4.32 us/read)
+;;   c-nosub: p50 0.2188 [0.1688 - 0.2969] ms/pass  (1.55 us/read)
+;;   c-noreaders: p50 0.6750 [0.5344 - 0.8188] ms/pass  (4.79 us/read)
+;;   c-nomap: p50 0.6375 [0.4750 - 0.9063] ms/pass  (4.52 us/read)
+;;   b-build: p50 0.5406 [0.4531 - 0.7750] ms/pass  (3.83 us/read)
+;; ==== PHASE B DELTAS (c-local minus ablation; floors) ====
+;;   copy fidelity: c-local/commit = 0.9544
+;;   activation-capture (c-local - c-noactivate): delta 0.0562 ms/pass (0.40 us/read, 8.2% of the baseline)
+;;     ^ routed no-op on this UIx host — expect the noise floor; real only under the ratom family (rf2-lzpfj)
+;;   watch-wiring (c-local - c-nowatch): delta 0.0781 ms/pass (0.55 us/read, 11.4% of the baseline)
+;;   reaction-build+cache-insert (c-local - c-nosub): delta 0.4688 ms/pass (3.32 us/read, 68.2% of the baseline)
+;;   reader-membership (c-local - c-noreaders): delta 0.0125 ms/pass (0.09 us/read, 1.8% of the baseline)
+;;   cell-map-insert (c-local - c-nomap): delta 0.0500 ms/pass (0.35 us/read, 7.3% of the baseline)
+;;   b-build (build+compute, no in-window dispose): 0.5406 ms/pass (3.83 us/read)
+;; HICASSO read-profile-micro
+{:subscribe-once 5070.922, :compute-sub 1028.3688, :handler-invoke 230.4965, :registrar-lookup 74.4681, :frame-state-value 273.0496, :resolution-wrap 241.1348, :cache-peek-miss 24.8227, :sub-key-mint 21.2766}
+;; ==== MICRO (ns/op over the page's own roster) ====
+;;   subscribe-once: 5070.9 ns
+;;   compute-sub: 1028.4 ns
+;;   handler-invoke: 230.5 ns
+;;   registrar-lookup: 74.5 ns
+;;   frame-state-value: 273.0 ns
+;;   resolution-wrap: 241.1 ns
+;;   cache-peek-miss: 24.8 ns
+;;   sub-key-mint: 21.3 ns
+;; HICASSO DONE
+;; ==== HICASSO RUNTIME ====
+;; chromium 147.0.7727.15 (playwright), :advanced, goog.DEBUG false
+;; ==== HICASSO read-profile-census ====
+{:reads 141, :distinct 141, :by-sub-id {:conduit/your-feed? 1, :conduit/slugs 1, :conduit/tags 1, :conduit/article 69, :conduit/favorite-pending? 69}, :input-kinds {:db 141}}
+;; ==== HICASSO read-profile-arms ====
+{:ship {:n 60, :min 0.225, :max 0.5, :p50 0.275}, :local {:n 60, :min 0.475, :max 1.0375, :p50 0.55}, :no-shell {:n 60, :min 0.45, :max 1, :p50 0.525}, :probe {:n 60, :min 0.2, :max 0.475, :p50 0.25}, :probe-fresh {:n 60, :min 0.1, :max 0.275, :p50 0.125}, :floor {:n 60, :min 0.0125, :max 0.0875, :p50 0.025}, :warm {:n 60, :min 0.025, :max 0.1375, :p50 0.05}, :ctl2 {:n 60, :min 0.95, :max 1.6, :p50 1.0437}}
+;; ==== HICASSO read-profile-commit ====
+{:commit {:n 64, :min 0.5812, :max 0.8969, :p50 0.7203}, :c-local {:n 64, :min 0.5062, :max 0.9219, :p50 0.6875}, :c-noactivate {:n 64, :min 0.4813, :max 0.8625, :p50 0.6313}, :c-nowatch {:n 64, :min 0.4562, :max 0.8875, :p50 0.6094}, :c-nosub {:n 64, :min 0.1688, :max 0.2969, :p50 0.2188}, :c-noreaders {:n 64, :min 0.5344, :max 0.8188, :p50 0.675}, :c-nomap {:n 64, :min 0.475, :max 0.9063, :p50 0.6375}, :b-build {:n 64, :min 0.4531, :max 0.775, :p50 0.5406}}
+;; ==== HICASSO read-profile-micro ====
+{:subscribe-once 5070.922, :compute-sub 1028.3688, :handler-invoke 230.4965, :registrar-lookup 74.4681, :frame-state-value 273.0496, :resolution-wrap 241.1348, :cache-peek-miss 24.8227, :sub-key-mint 21.2766}
+[hicasso] ok

--- a/implementation/hicasso/test/re_frame/bench/hicasso/data/readprofile-07rnj/run3.txt
+++ b/implementation/hicasso/test/re_frame/bench/hicasso/data/readprofile-07rnj/run3.txt
@@ -2,7 +2,7 @@
 [hicasso] building :advanced bundle — re-frame.bench.hicasso.read-profile-app/-main -> out/hicasso-readprof
 [:hicasso-bench] Compiling ...
 [:hicasso-bench] Build completed. (187 files, 132 compiled, 0 warnings, 21.53s)
-shadow-cljs - config: C:\Users\miket\code\re-frame2-worktrees\measure-07rnj\implementation\shadow-cljs.edn
+shadow-cljs - config: <worktree>\implementation\shadow-cljs.edn   ;; ABSOLUTE PATH REDACTED — see README.md
 ;; order-guard ok   the recorded 2.01x is REFUSED  — ratio 2.0125
 ;; order-guard ok   the same study's uncontaminated slope passes  — forward 2830.7 / reversed 2842.8
 ;; order-guard ok   a single-order result is refused as UNCHECKED  — only 1 stratum — the question was never asked


### PR DESCRIPTION
## What this is

A **measurement window** (Shape 6) for `rf2-07rnj`. It set out to republish the
whole commit-half decomposition of `the-cold-read-mount-term.md` at one commit,
with `c-noindex` retired and `c-noreaders` in its place. **It ran cleanly and it
does not publish.** The refusal is the deliverable.

## What ran

Three runs of the read-profile instrument, one commit (`a43aa8609f`), instrument
blob `6d2b67b5b0` before and after, `:advanced`, HeadlessChrome 147.0.7727.15,
node v24.13.0.

- `exit 0` on all three runs (captured on the same command line, `.exit` files
  written per attempt).
- Both arm-order guards **reportable** on every run.
- Phase-A positive control **passing** on every run.
- Phase-B residue gate **never fired**.
- No gate, tolerance or knob was moved, and nothing was adjusted between runs.

## The window shape, stated once and held

**32 frames per window, 8 x (2 + 8) = 64 kept samples per arm, grid 0.0015625
ms/commit** — `rf2-3l6hf`'s widened shape exactly as it landed. Every arm of a
run was taken in ONE process, interleaved under the lane's reflecting schedule.
The shape is stated beside the numbers because the shares are **not**
window-size-invariant (reaction build is 56% of `c-local` at 4 frames and 67–68%
at 32), and **no share is computed here at all** — see below.

## Why it does not publish

Four of the five ablation terms resolve with one sign on every run. The fifth
does not:

| term (`c-local −` arm) | run 1 | run 2 | run 3 |
|---|---|---|---|
| reaction build + cache insert | 0.4437 | 0.4719 | 0.4688 |
| watch wiring | 0.0719 | 0.0656 | 0.0781 |
| activation capture | 0.0422 | 0.0484 | 0.0562 |
| cell-map insert | 0.0437 | 0.0266 | 0.0500 |
| **reader membership** | **+0.0047** | **−0.0141** | **+0.0125** |

Reader membership straddles zero across three runs of one binary in one session.
A negative delta is arithmetically impossible — `c-noreaders` does strictly less
work than `c-local`. **A decomposition that cannot see one of its terms is not a
decomposition**, which is `rf2-07rnj`'s own founding argument, now applied to its
own re-take. Nothing in §1's table or §4 is restated.

## The `< 0.006 ms/commit` bound is withdrawn, not published

The brief for this window carried it as guidance. It is wrong on its own terms:
if an observed delta is an unknown positive cost plus estimator error, a reading
of −0.0062 establishes only that one negative excursion exceeded 0.0062 *plus
that cost* — it neither calibrates a symmetric floor nor bounds the cost from
above, and comparing most-negative readings at two window widths cannot show a
floor scaling with the window. **Run 2's −0.0141 refutes the figure on this box
independently, at more than twice its magnitude.** (Merged-PR audit of #8328.)

The window was **not** widened to chase the term. Whether 128–256 frames would
recover it is a prediction, not a measurement, and a rung added between runs
makes the series two instruments.

## `c-noactivate` corroborated as a term, not a floor

`rf2-tcffa`'s finding reproduces here independently: `c-noactivate` reads
0.0422 / 0.0484 / 0.0562 with one sign on every run, **larger than the cell-map
insert in two runs of three**. It cannot arbitrate whether a window is wide
enough, which is the job the widening commit gave it.

## The box — every Processor Queue Length sample

`\System\Processor Queue Length` (never `Win32_Processor.LoadPercentage`),
**243 samples, 218 zero**, taken back-to-back at 1 s through every run.

- **Build-phase non-zeros (10):** 2, 34, 57, 1, 26 (run 2); 1, 1, 1, **93**, 1
  (run 3). All before the bundle's own mtime. `run.cjs` rebuilds the `:advanced`
  bundle unconditionally and that compile saturates this box — known, and not
  this window's to fix.
- **Measurement-phase non-zeros (10), none above 2:** 1, 1, 1, 1, 1 (run 2);
  2, 1, 1, 1, 1 (run 3).
- **Unclassifiable (3, all 1):** run 1 was sampled without timestamps, so its
  non-zeros cannot be proven to sit in either phase. Reported rather than
  assigned.
- **Idle-box non-zeros (2):** a 1 before certification and a 1 at close, with
  no run in flight for either.

The non-zero count is higher than predecessor windows' because the sampling is
continuous rather than spaced, not because the box was busier.

## Gates — foreground, to completion, captured exit codes

| gate | runner | exit |
|---|---|---|
| `python scripts/check_doc_slugs.py` | matched to `.py`; the validator for `docs/design/**` links and anchors | **0** |
| the same, with a broken link planted in the edited page | — | **1**, naming the exact line; restored and re-verified byte-for-byte by `git hash-object` (`85cb6455db…` before and after), then **0** again |
| `python scripts/check_provenance_pins.py` | matched to `.py` | **0** — 112 pages, 523 pins, 0 findings |
| `sh scripts/check-no-hardcoded-paths.sh` | matched to `.sh` | **1** on the first run — a REAL failure, 6 violations, fixed below — then **0** |

`mkdocs build --strict` is **not** run and is not the gate here: `mkdocs.yml`'s
`exclude_docs` drops `docs/design/`, so it cannot see this page.

`npm run test:cljs` is **not** run: no CLJS changed. The instrument blob is
`6d2b67b5b033d57c20a993732fd7f5664c3188ac` before and after this branch, and the
only additions under `implementation/` are three inert `.txt` transcripts.

**Each gate was proven to read this worktree**, not the mayor checkout: the
driver's `shadow-cljs - config:` banner named this worktree's own
`shadow-cljs.edn` on every run, the built bundle landed only in this
worktree, and the slug checker went red on a fault planted in this
worktree's copy of the page. (That banner is the line the portability gate
caught; it is redacted to `<worktree>` in the committed transcripts — see
the section below.)

**Table column counts hand-verified.** Nothing validates tables in
`docs/design/**`, so both new tables were checked mechanically: header,
separator and every row carry exactly 4 columns in each.

## What is NOT concluded, and what stays open

- **Reader membership is unresolved, not bounded.** No figure and no bound is
  published for it.
- **The `index write` row still prices the structure `rf2-dabt3` deleted**, and
  the narrative built on it — §1's "Reading it" 4, and
  `the-in-page-mount-term-decomposed.md`'s §6(b) comparison and §9.2 "batching
  the index write" — still reads as current. Retiring those was to ride the
  republished decomposition; there is none, so **that obligation stays open on
  `rf2-07rnj`**, and `the-in-page-mount-term-decomposed.md` is deliberately
  untouched by this PR.
- `rf2-07rnj` stays **OPEN and BLOCKED**.

## Data

Raw driver output for all three runs at
`implementation/hicasso/test/re_frame/bench/hicasso/data/readprofile-07rnj/`
(`.txt`, because the repo ignores `*.log`), with a `README.md` beside them.

### The portability gate, and the one redaction

The first push was RED on `No hardcoded personal/home paths`
(`scripts/check-no-hardcoded-paths.sh`, exit **1**, 6 violations). A real
failure, not a flake: all three transcripts carried the `shadow-cljs -
config:` banner naming the author's own worktree, and a transcript taken on
one person's box is no licence to pin that box into the tree.

**Redacted rather than deleted**, because that line was doing real work — it
is how the window proved every build and gate read the worker's worktree
rather than the mayor checkout. **Exactly one line per file changed** (the
diff is 1 insertion / 1 deletion per transcript), the absolute path replaced
by `<worktree>` and marked inline as redacted. No figure, guard verdict or
exit line was touched; both arm-order guard verdicts and the driver's own
`ok` line are intact in each file. The new `README.md` states the redaction
and why, so a later reader cannot mistake it for a doctored transcript, and
the studio page's "unedited" wording is corrected in the same commit
because it stopped being true.

Re-running the reproduction prints that banner with the reader's own
checkout in it, which is the better proof anyway — a path in someone else's
transcript only ever proved where someone else once stood.

`sh scripts/check-no-hardcoded-paths.sh` now exits **0** over the whole
tracked tree; `check_doc_slugs.py` and `check_provenance_pins.py` re-run
**0** after the change.


