### PR TITLE
feat(hicasso): defview publishes its authoring-time name to the :view registrar (rf2-5qaf4)

### DIFF
--- a/implementation/hicasso/src/re_frame/hicasso.cljc
+++ b/implementation/hicasso/src/re_frame/hicasso.cljc
@@ -217,24 +217,81 @@
   its own name ambient for whatever runs next. A declaration refusal is
   routinely caught — by a module loader, or by an HMR runtime whose
   mounted page carries on rendering — and the slot then named a `def`
-  that never completed."
+  that never completed.
+
+  ## The name is also REGISTERED — an AUTHORING-TIME ALIAS FOR FORWARD
+  RESOLUTION ONLY (rf2-5qaf4)
+
+  The declaration publishes one entry in re-frame's `:view` registrar,
+  under `(keyword \"<ns>\" \"<sym>\")` — the id `rf/reg-view` derives
+  from its own symbol, one convention for both substrates — carrying the
+  coordinate above and the minted head at `:hicasso/component`. It
+  carries NO `:handler-fn`: a boundary is a React component rather than
+  a hiccup-returning render fn, so `rf/view` answers nil for this entry
+  and its *returns the registered render fn* contract stays honest.
+
+  **Forward resolution is the whole of it.** The entry exists so that a
+  tool holding a keyword the author WROTE — a story naming its subject,
+  an editor jumping to source — reaches the view they meant. It mints no
+  runtime identity: a MOUNTED boundary is still keyed by its read set
+  and still unnamed, and the tool tier
+  ([[re-frame.hicasso.tool]]) is unchanged. The refusals that say so —
+  rf2-jkdy, rf2-l86mm, rf2-2og6s — are NOT overturned by this, because
+  they answer the BACKWARD question *which view is this runtime
+  boundary?* and this answers the forward one, where the author already
+  knows and is naming it in source.
+
+  The name itself is not new. It is the `displayName` React DevTools
+  shows, the `rf:render:<name>` User-Timing id Spec 009 keys off, and
+  the string a refusal is attributed with; only lookup was missing.
+  Registration adds RESOLVABILITY, not identity.
+
+  It rides the SAME `debug-enabled?` gate as the coordinate, so under
+  `:advanced` + `goog.DEBUG=false` nothing registers and a production
+  Hicasso app still holds no registry at runtime — the entry serves
+  tools. Re-evaluating a declaration replaces the entry behind the same
+  id, which is the registrar's own behaviour and needed nothing added.
+  [[re-frame.hicasso.impl.collector/publish-view-alias!]] carries the
+  slot's shape and why it is written there rather than through
+  `rf/reg-view*`."
      [sym & more]
      (let [doc       (when (string? (first more)) (first more))
            [argv & body] (if doc (rest more) more)
            view-name (str (ns-name *ns*) "/" sym)
-           coord     (source-coords/coords-form (meta &form) *file* (ns-name *ns*))]
+           ;; rf2-5qaf4 — the registrar id, derived by `reg-view`'s own
+           ;; rule (`core-reg-view-macro/expand-reg-view`) so the two
+           ;; substrates spell one convention. No `^{:rf/id …}` override
+           ;; here: a `defview` has exactly one name and this is it.
+           view-id   (keyword (str (ns-name *ns*)) (str sym))
+           coord     (source-coords/coords-form (meta &form) *file* (ns-name *ns*))
+           ;; The registration slot IS the coordinate map — `reg-view`
+           ;; merges its coords into the slot's top level and tools read
+           ;; them back from there — plus the author's `:doc`, without
+           ;; which the registrar would dev-warn `:rf.warning/missing-doc`
+           ;; against a view that IS documented.
+           slot      (cond-> coord doc (assoc :doc doc))]
        `(def ~(if doc (vary-meta sym assoc :doc doc) sym)
           (do
             (when re-frame.interop/debug-enabled?
               (re-frame.hicasso.impl.error/declaring! ~view-name ~coord))
             (try
-              (re-frame.hicasso.impl.collector/mint-view!
-                ~view-name
-                ;; ANONYMOUS — see the docstring's rf2-jan2 section. A
-                ;; named `fn` binds its own name for its own body, so any
-                ;; name derived from `sym` shadows the author's helper of
-                ;; that name.
-                (fn ~argv ~@body))
+              (let [head# (re-frame.hicasso.impl.collector/mint-view!
+                            ~view-name
+                            ;; ANONYMOUS — see the docstring's rf2-jan2
+                            ;; section. A named `fn` binds its own name
+                            ;; for its own body, so any name derived from
+                            ;; `sym` shadows the author's helper of that
+                            ;; name.
+                            (fn ~argv ~@body))]
+                ;; rf2-5qaf4 — inside the extent, so a refusal the
+                ;; registration raised would name this declaration; after
+                ;; the mint, because the head is what the entry carries.
+                ;; The head is still what the `def` binds: registration is
+                ;; a side effect and returns nothing to it.
+                (when re-frame.interop/debug-enabled?
+                  (re-frame.hicasso.impl.collector/publish-view-alias!
+                    ~view-id ~slot head#))
+                head#)
               (finally
                 (when re-frame.interop/debug-enabled?
                   (re-frame.hicasso.impl.error/declared!)))))))))

--- a/implementation/hicasso/src/re_frame/hicasso/impl/collector.cljs
+++ b/implementation/hicasso/src/re_frame/hicasso/impl/collector.cljs
@@ -2022,6 +2022,89 @@
       (codec/mark-frame-prop! (codec/mark-boundary! component)))))
 
 ;; ---------------------------------------------------------------------------
+;; The authoring-time alias — one registrar entry per declaration, dev only
+;; ---------------------------------------------------------------------------
+
+(defn publish-view-alias!
+  "Publish the name `defview` already computed to core's `:view`
+  registrar, so a keyword an author WROTE resolves forward to the
+  boundary they meant (rf2-5qaf4; ruled on rf2-1gy4e).
+
+  Three arguments, each already in the macro's hand at the declaration:
+
+  - `view-id` is `(keyword \"<ns>\" \"<sym>\")` — byte-identical to the
+    id `rf/reg-view` derives from its own symbol
+    (`core-reg-view-macro/expand-reg-view`), so ONE convention answers
+    for both substrates and a tool needs no per-substrate spelling.
+  - `slot` is the coordinate map the macro captured, plus the author's
+    `:doc` when they wrote one. It is stored the way `reg-view` stores
+    it — `:ns` / `:file` / `:line` / `:column` at the TOP LEVEL of the
+    registration metadata, which is where `(rf/handler-meta :view id)`
+    already reads them, so a consumer needs no second seam. `:doc`
+    rides along for the same reason it does on a `reg-view`: the
+    registrar dev-warns `:rf.warning/missing-doc` for a macro-path
+    registration with no usable `:doc`, and withholding a docstring the
+    author DID write would make that warning fire on a documented view.
+  - `head` is the value the `def` binds — the minted boundary — under
+    `:hicasso/component`.
+
+  ## The entry is an ALIAS, and carries NO `:handler-fn`
+
+  `rf/view` answers *the registered render fn*, and this entry has none:
+  a Hicasso boundary is a React component minted by [[mint-view!]], not
+  a hiccup-returning render fn, and pretending otherwise would make that
+  contract lie. So `(rf/view id)` answers nil here, deliberately, and a
+  substrate handed a Hicasso id keeps whatever diagnostic it already
+  has. The head is reachable at `:hicasso/component` by a consumer that
+  knows what to do with a React component.
+
+  This publishes RESOLVABILITY and not identity. The name is not new —
+  `defview` already stamps it as DevTools `displayName`, keys Spec 009's
+  `rf:render:<name>` measure off it, and attributes refusals with it;
+  the only thing missing was lookup. Mounted boundary identity is still
+  keyed by the read set and still unnamed, which is what
+  `re-frame.hicasso.tool` answers the BACKWARD question with (rf2-jkdy /
+  rf2-l86mm / rf2-2og6s stand untouched — they refuse *which view is
+  this runtime boundary?*; this answers *where is the view the author
+  named in source?*).
+
+  ## Why `registrar/register!` rather than `rf/reg-view*`
+
+  Two reasons, and either alone is decisive. `rf/reg-view*` on CLJS
+  delegates to `re-frame.views/reg-view*`, which ALWAYS builds a
+  frame-aware render wrapper and stores it under `:handler-fn` — so it
+  cannot mint the metadata-only entry above at all. And its first step
+  is `apply-adapter-wrap-view`, which consults the `:adapter/wrap-view`
+  late-bind hook AT REGISTRATION TIME; a `defview` is declared at
+  namespace load, which routinely precedes `rf/init!`, so a registration
+  that went through that path would ask an adapter question before there
+  is an adapter to answer it. Writing the slot here — a plain
+  registration under a kind the registrar already knows — is
+  adapter-NEUTRAL by construction: no hook is consulted, nothing wraps
+  the head, and `:hicasso/component` is `identical?` to the value the
+  `def` binds whether an adapter is installed or not.
+
+  ## Hot reload needs nothing added
+
+  Re-evaluating a `defview` re-registers the SAME id, and the registrar
+  replaces the slot atomically — one entry, never two, with the fresh
+  head. The provenance is unchanged across a save, so the registrar's
+  collision warning stays correctly silent; a genuine cross-source clash
+  on one id still surfaces, because it surfaces for every kind.
+
+  Called ONLY from inside the `defview` expansion's
+  `(when re-frame.interop/debug-enabled? …)` gate — the same gate the
+  declaration extent rides — so under `:advanced` + `goog.DEBUG=false`
+  the call, this fn and the slot map all leave the bundle and a
+  production Hicasso app has no registry at runtime. Witnessed in
+  `re-frame.hicasso.error-source-coord-elision-prod-test`.
+
+  Answers `view-id`, per Conventions §`reg-*` return-value."
+  [view-id slot head]
+  (registrar/register! :view view-id (assoc slot :hicasso/component head))
+  view-id)
+
+;; ---------------------------------------------------------------------------
 ;; Teardown — the one door that empties every module
 ;; ---------------------------------------------------------------------------
 

--- a/implementation/hicasso/test/re_frame/hicasso/coord_sentinel_source.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/coord_sentinel_source.cljs
@@ -21,8 +21,11 @@
 
   This file is compiled into the `:browser-test-prod-elision` build by the
   elision suite's `:require`, the same way `checkpoint_support` and
-  `roots_frames_support` reach their suites. It registers nothing, mounts
-  nothing and holds no state."
+  `roots_frames_support` reach their suites. It mounts nothing and holds no
+  state, and **in the build it is compiled into it registers nothing** —
+  `defview`'s authoring-time alias (rf2-5qaf4) rides the same
+  `debug-enabled?` gate as the coordinate, so the registrar entry is one
+  more thing this build is asserted not to have."
   (:require [re-frame.hicasso :as h]))
 
 (h/defview sentinel-row
@@ -49,3 +52,14 @@
 (def host-name
   "The ledger key for [[sentinel-host]]."
   "re-frame.hicasso.coord-sentinel-source/sentinel-host")
+
+(def view-id
+  "The `:view` registrar id [[sentinel-row]] would be published under in a
+  DEV build (rf2-5qaf4) — `(keyword \"<ns>\" \"<sym>\")`, the same
+  derivation `rf/reg-view` uses. Written here beside [[view-name]] rather
+  than rebuilt in the suite, so the two spellings of one declaration's
+  identity cannot drift.
+
+  A keyword, so what reaches the bundle is `\"re-frame.hicasso.coord-sentinel-source\"`
+  — dots, not the `coord_sentinel_source.cljs` PATH the scan looks for."
+  ::sentinel-row)

--- a/implementation/hicasso/test/re_frame/hicasso/error_source_coord_elision_prod_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/error_source_coord_elision_prod_test.cljs
@@ -9,6 +9,16 @@
   Closure compiler removes the call AND the map literal it would have
   been given, absolute file path included.
 
+  **`defview`'s authoring-time alias rides that same gate** (rf2-5qaf4):
+  the declaration also publishes a `:view` registrar entry carrying the
+  coordinate and the minted head, and it is emitted inside the identical
+  `when`. So the same constant-fold that erases the coordinate erases the
+  registration, which is what makes Hicasso's *no registry at runtime*
+  stance a production fact rather than a claim about the dev build. The
+  dev-side shape is
+  `re-frame.hicasso.view-alias-registry-cljs-test`'s; only the ABSENCE is
+  assertable here.
+
   This file compiles under `:browser-test-prod-elision`, the dedicated
   build with `goog.DEBUG=false` + `:advanced`, so what is asserted below
   is a genuine constant-fold rather than a `with-redefs`. Every assertion
@@ -42,7 +52,8 @@
   (:require [cljs.test :refer-macros [deftest is testing]]
             [re-frame.hicasso.coord-sentinel-source :as sentinel]
             [re-frame.hicasso.impl.codec :as codec]
-            [re-frame.hicasso.impl.error :as error]))
+            [re-frame.hicasso.impl.error :as error]
+            [re-frame.registrar :as registrar]))
 
 ;; ---------------------------------------------------------------------------
 ;; The ledger was never written
@@ -57,6 +68,32 @@
 (deftest no-coordinate-is-registered-for-a-host-declared-under-prod
   (testing "`defhost` opens the same extent under the same gate"
     (is (nil? (error/source-of sentinel/host-name)))))
+
+;; ---------------------------------------------------------------------------
+;; Nor was the authoring-time alias (rf2-5qaf4)
+;; ---------------------------------------------------------------------------
+
+(deftest no-view-registrar-entry-is-published-for-a-view-declared-under-prod
+  (testing "`defview`'s registrar alias rides the SAME `(when
+            debug-enabled? …)` gate as the coordinate above, so a production
+            bundle publishes no entry and Hicasso's *no registry at runtime*
+            stance holds where it is claimed. The entry serves tools; there
+            are none here"
+    (is (nil? (registrar/lookup :view sentinel/view-id))))
+
+  (testing "and NO entry anywhere in the `:view` kind carries the alias's
+            slot — a build-wide absence rather than one id's"
+    (is (empty? (filter :hicasso/component
+                        (vals (registrar/registrations :view)))))))
+
+(deftest the-view-kind-is-populated-under-prod-so-the-absence-above-is-real
+  ;; The positive control the row above needs. This build compiles every
+  ;; `-elision-prod-test` namespace in the repository, and the Reagent
+  ;; adapter's three register views at load — so `registrations :view`
+  ;; answering non-empty is what proves the nil above is the DECLARATION's
+  ;; absence and not a registrar that answers nothing for anyone.
+  (testing "other substrates' views are registered here"
+    (is (seq (registrar/registrations :view)))))
 
 ;; ---------------------------------------------------------------------------
 ;; A refusal carries neither ambient field

--- a/implementation/hicasso/test/re_frame/hicasso/view_alias_registry_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/view_alias_registry_cljs_test.cljs
@@ -1,0 +1,219 @@
+(ns re-frame.hicasso.view-alias-registry-cljs-test
+  "THE AUTHORING-TIME ALIAS — what `h/defview` publishes to core's `:view`
+  registrar, and what it deliberately does not (rf2-5qaf4, ruled on
+  rf2-1gy4e).
+
+  A Story variant names its subject with a KEYWORD and resolves it
+  through the framework registrar. Until this bead `h/defview` computed a
+  name, computed a coordinate, handed both to
+  `impl.collector/mint-view!` and registered nothing — so a Hicasso
+  boundary was the one view in the repository a keyword could not reach.
+  It now publishes one entry, and the shape of that entry is the whole
+  claim:
+
+  | slot | what it is |
+  |---|---|
+  | the id | `(keyword \"<ns>\" \"<sym>\")` — `reg-view`'s own derivation |
+  | `:ns` / `:file` / `:line` / `:column` | the coordinate, at the top level, where `reg-view` puts it |
+  | `:doc` | the author's docstring, when they wrote one |
+  | `:hicasso/component` | the minted head, `identical?` to what the `def` binds |
+  | `:handler-fn` | **absent** |
+
+  ## The peer registration is the point of comparison, not decoration
+
+  `core-peer` below is an ordinary `rf/reg-view` in THIS namespace, and
+  every row that says *the same as `reg-view`* asserts against it rather
+  than against a remembered shape. The id derivation and the coordinate
+  placement are claims about agreement between two macros, and an
+  assertion that names only one of them cannot see the day they diverge.
+
+  ## Why no adapter is installed
+
+  This file's fixture installs none, deliberately, and that makes the
+  whole namespace the adapter-timing witness rf2-1gy4e's constraint 3
+  asks for. Core's view registration consults the `:adapter/wrap-view`
+  hook AT REGISTRATION TIME (`re-frame.views/apply-adapter-wrap-view`),
+  and a `defview` is declared at namespace load — routinely before
+  `rf/init!` has installed anything. The declarations here are made at
+  exactly that moment, with no adapter present, and the rows below assert
+  the entry is intact anyway. Nothing mounts, so nothing needs one.
+
+  ## What this file does NOT assert
+
+  Production absence. `re-frame.hicasso.error-source-coord-elision-prod-test`
+  owns that, because it is the one suite compiled under `:advanced` with
+  `goog.DEBUG=false`, and asserting absence in a dev build would assert
+  nothing at all."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.hicasso :as h]
+            [re-frame.hicasso.impl.collector :as collector]
+            [re-frame.test-support :as test-support]))
+
+;; ---------------------------------------------------------------------------
+;; The declarations — ABOVE `use-fixtures`, and that is load-bearing
+;; ---------------------------------------------------------------------------
+;;
+;; `make-reset-runtime-fixture` pins its stable baseline when the
+;; `use-fixtures` form is EVALUATED, and folds that baseline back over the
+;; live registrar before each test. A sibling namespace's fixture pins a
+;; baseline that predates this file's load and would otherwise strand these
+;; registrations in the shared `:node-test` bundle — which is the run-order
+;; hazard the fixture's own docstring describes. Declared above it, they are
+;; part of this file's baseline and are reinstated before every row.
+
+(h/defview aliased-row
+  "A DOCUMENTED boundary — the `:doc` half of the slot needs one that has a
+  docstring to carry."
+  [{:keys [label]}]
+  [:li label])
+
+(h/defview undocumented-row
+  [_]
+  [:li "no docstring"])
+
+(rf/reg-view core-peer
+  "The comparison. An ordinary core view in this same namespace, so the id
+  derivation and the coordinate placement can be asserted as AGREEMENT
+  rather than as remembered shapes."
+  [_]
+  [:li "core"])
+
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture
+    {:ambient-frame nil}))
+
+;; ---------------------------------------------------------------------------
+;; Helpers
+;; ---------------------------------------------------------------------------
+
+(defn- slot
+  "The registration metadata for `id` under the `:view` kind, read back
+  through the public seam a tool would use."
+  [id]
+  (rf/handler-meta :view id))
+
+(def ^:private coord-keys [:ns :file :line :column])
+
+;; ---------------------------------------------------------------------------
+;; The id — `reg-view`'s derivation, spelled once
+;; ---------------------------------------------------------------------------
+
+(deftest the-entry-appears-under-the-id-reg-view-would-have-derived
+  (testing "`::aliased-row` IS `(keyword \"<ns>\" \"<sym>\")`, so an author
+            who knows how to name a core view already knows how to name a
+            Hicasso one"
+    (is (some? (slot ::aliased-row)))
+    (is (= "re-frame.hicasso.view-alias-registry-cljs-test"
+           (namespace ::aliased-row))))
+
+  (testing "the peer proves it is ONE convention and not two that happen to
+            agree today — both ids are this namespace qualifying the
+            declaration's own symbol"
+    (is (some? (slot ::core-peer)))
+    (is (= (namespace ::aliased-row) (namespace ::core-peer)))))
+
+;; ---------------------------------------------------------------------------
+;; The coordinate — where `reg-view` stores it
+;; ---------------------------------------------------------------------------
+
+(deftest the-coordinate-is-stored-the-way-reg-view-stores-it
+  (let [alias-coords (select-keys (slot ::aliased-row) coord-keys)
+        peer-coords  (select-keys (slot ::core-peer)   coord-keys)]
+
+    (testing "the same coord keys, at the same level of the same map — a
+              consumer needs no second seam for Hicasso"
+      (is (= (set (keys peer-coords)) (set (keys alias-coords)))))
+
+    (testing "and they describe THIS file"
+      (is (= 're-frame.hicasso.view-alias-registry-cljs-test (:ns alias-coords)))
+      (is (re-find #"view_alias_registry_cljs_test\.cljs$" (:file alias-coords)))
+      (is (pos-int? (:line alias-coords)))
+      (is (pos-int? (:column alias-coords))))))
+
+(deftest the-docstring-rides-the-slot-and-its-absence-is-honest
+  (testing "a documented declaration carries its `:doc`, so the registrar's
+            `:rf.warning/missing-doc` nudge cannot fire against a view that
+            IS documented"
+    (is (string? (:doc (slot ::aliased-row))))
+    (is (re-find #"DOCUMENTED boundary" (:doc (slot ::aliased-row)))))
+
+  (testing "an undocumented one carries none — the slot reports what the
+            author wrote rather than manufacturing a value"
+    (is (nil? (:doc (slot ::undocumented-row))))))
+
+;; ---------------------------------------------------------------------------
+;; The head, and the `:handler-fn` that is not there
+;; ---------------------------------------------------------------------------
+
+(deftest the-entry-carries-the-minted-head-itself
+  (testing "`:hicasso/component` is the very value the `def` binds — nothing
+            wrapped it on the way into the registrar"
+    (is (identical? aliased-row (:hicasso/component (slot ::aliased-row))))
+    (is (fn? (:hicasso/component (slot ::aliased-row))))))
+
+(deftest the-entry-has-no-handler-fn-and-rf-view-answers-nil
+  (testing "a Hicasso boundary is a React component, not a hiccup-returning
+            render fn, so the slot has no `:handler-fn` and `rf/view`'s
+            contract stays honest by answering nil"
+    (is (not (contains? (slot ::aliased-row) :handler-fn)))
+    (is (nil? (rf/view ::aliased-row))))
+
+  (testing "the peer is the control: `rf/view` resolves perfectly well in
+            this process, so the nil above is the ENTRY's shape and not a
+            broken lookup"
+    (is (some? (:handler-fn (slot ::core-peer))))
+    (is (some? (rf/view ::core-peer)))))
+
+;; ---------------------------------------------------------------------------
+;; The adapter-timing witness (rf2-1gy4e constraint 3)
+;; ---------------------------------------------------------------------------
+
+(deftest the-slot-is-written-adapter-neutrally
+  (testing "no adapter is installed — the state a `defview` is declared in
+            when its namespace loads before `rf/init!`"
+    (is (nil? (rf/current-adapter))))
+
+  (testing "the absence of `:handler-fn` IS the proof the adapter path was
+            never entered: `re-frame.views/reg-view*` is the only route to
+            `apply-adapter-wrap-view`, and it ALWAYS stores the wrapper it
+            builds under that key. A slot without one was never near it"
+    (is (not (contains? (slot ::aliased-row) :handler-fn))))
+
+  (testing "and a registration made HERE, with no adapter installed, is
+            whole — same id, same coord keys, same untouched head"
+    (let [head #(:hicasso/component (slot ::aliased-row))
+          before (head)]
+      (collector/publish-view-alias!
+        ::aliased-row (select-keys (slot ::aliased-row) coord-keys) before)
+      (is (identical? before (head)))
+      (is (not (contains? (slot ::aliased-row) :handler-fn))))))
+
+;; ---------------------------------------------------------------------------
+;; Hot reload — the registrar's own replacement, and nothing added for it
+;; ---------------------------------------------------------------------------
+
+(deftest re-declaring-replaces-the-entry-rather-than-accumulating
+  ;; ClojureScript cannot re-evaluate a macro at runtime, so a save is
+  ;; driven at the seam the expansion itself calls: the `(when
+  ;; debug-enabled? (publish-view-alias! …))` form is the entire
+  ;; registration half of `defview`, and re-running it with a fresh head is
+  ;; exactly what a reloaded namespace does.
+  (let [reloaded  (fn reloaded-row [_] nil)
+        coords    (select-keys (slot ::aliased-row) coord-keys)
+        before    (count (rf/registrations :view))]
+
+    (collector/publish-view-alias! ::aliased-row coords reloaded)
+
+    (testing "one entry, not two — the registrar replaces the slot behind
+              the id it already holds"
+      (is (= before (count (rf/registrations :view)))))
+
+    (testing "and it is the FRESH head that is reachable, so a story
+              resolving late picks up the reloaded view"
+      (is (identical? reloaded (:hicasso/component (slot ::aliased-row)))))
+
+    (testing "the shape is unchanged across the reload — still no
+              `:handler-fn`, still the coordinate"
+      (is (not (contains? (slot ::aliased-row) :handler-fn)))
+      (is (= coords (select-keys (slot ::aliased-row) coord-keys))))))


### PR DESCRIPTION
Closes rf2-5qaf4. Implementation carrier for the rf2-1gy4e ruling, option (b).

`h/defview` already computed a `"<ns>/<sym>"` name and a source coordinate, handed both to `impl.collector/mint-view!`, and registered nothing — so a Hicasso boundary was the one view in the repository a keyword could not reach. It now also publishes **one** entry in core's `:view` registrar.

## The entry

| slot | value |
|---|---|
| id | `(keyword "<ns>" "<sym>")` — `reg-view`'s own derivation (`core-reg-view-macro/expand-reg-view`) |
| `:ns` / `:file` / `:line` / `:column` | the coordinate, at the **top level** of the registration metadata, where `reg-view` merges it and where `(rf/handler-meta :view id)` already reads it |
| `:doc` | the author's docstring, when they wrote one |
| `:hicasso/component` | the minted head, `identical?` to what the `def` binds |
| `:handler-fn` | **absent** — `(rf/view id)` answers nil |

Story needs no change beyond its own render-fn (rf2-2dbpd): the coordinate arrives through the existing registrar-metadata seam.

## Which route I took for the adapter-timing caveat, and why

**`registrar/register!` directly — the adapter-neutral branch of constraint 3, not `rf/reg-view*`.** Two reasons, either decisive on its own:

1. `rf/reg-view*` on CLJS delegates to `re-frame.views/reg-view*` (`implementation/core/src/re_frame/views.cljs`), which **always** builds a frame-aware render wrapper and stores it under `:handler-fn`. It cannot mint a `:handler-fn`-free entry at all, so the ruled shape is unreachable through it.
2. Its first step is `apply-adapter-wrap-view`, which consults the `:adapter/wrap-view` late-bind hook **at registration time**. A `defview` is declared at namespace load, which routinely precedes `rf/init!` — so that path would ask an adapter question before there is an adapter to answer it.

Writing the slot directly is adapter-neutral *by construction*: no hook is consulted, nothing wraps the head. The witness is in `view_alias_registry_cljs_test.cljs`, whose fixture installs **no adapter at all** (`{:ambient-frame nil}`, no `:adapter`) — the exact state a pre-`init!` declaration is made in. `the-slot-is-written-adapter-neutrally` asserts `(nil? (rf/current-adapter))`, that the head in the slot is `identical?` to the var, and that there is no `:handler-fn` — the last being the proof the adapter path was never entered, since `views/reg-view*` is the only route to `apply-adapter-wrap-view` and it always writes that key.

## The five ruled constraints

1. **Debug-gated.** The registration is emitted inside the *same* `(when re-frame.interop/debug-enabled? …)` form the declaration extent uses — verified at source at `hicasso.cljc`, where `declaring!` / `declared!` already ride it. Asserted the way hicasso's other debug-gated features are: a new deftest in `error_source_coord_elision_prod_test.cljs`, the one suite compiled under `:advanced` + `goog.DEBUG=false`, asserting the sentinel view has no registrar entry and that **no** `:view` entry anywhere in that bundle carries `:hicasso/component` — with a positive control (the Reagent elision suites' views *are* registered there, so the nil is the declaration's absence and not a dead lookup).
2. **Hot reload.** No guards, no aliasing, no parallel naming subsystem — the registrar's own atomic slot replacement. `re-declaring-replaces-the-entry-rather-than-accumulating` re-runs the exact call the expansion makes with a fresh head and asserts the `:view` registration count is unchanged, the fresh head is what is reachable, and the shape is unchanged. Provenance is identical across a save, so the registrar's collision warning stays correctly silent.
3. **Adapter timing** — above.
4. **Wording.** `defview`'s docstring gains a section stating this is an **AUTHORING-TIME ALIAS FOR FORWARD RESOLUTION ONLY**: mounted boundary identity stays read-set-keyed and unnamed, the tool tier is unchanged, and rf2-jkdy / rf2-l86mm / rf2-2og6s are **not** overturned — they answer the backward question *which view is this runtime boundary?* and this answers the forward one. It also records that the name is not new (DevTools `displayName`, the `rf:render:` measure id, error attribution) — registration adds resolvability, not identity.
5. **Nothing ruled out was added.** No props-schema slot on `defview`. No claim of element-click source navigation from the stored coord. No `:rf.adapter/hicasso` anywhere. `tools/story/**`, `implementation/shadow-cljs.edn` and `.github/**` are untouched.

## Facade classification

**No new public name on the door.** `re-frame.hicasso` gains no `def`, `defn` or `defmacro`; `defview` gains behaviour, not surface — so `check_facade_inventory.py` and `check_naming_census.py` have nothing new to roster, and no inventory row is owed. The one new function, `impl.collector/publish-view-alias!`, is `re-frame.hicasso.impl.*` and is not a consumer surface (the naming census reads the ten shipped public namespaces, not `impl/`).

## Two judgement calls, stated

- **The slot spelling is `:hicasso/component`, as the ruling named it.** The in-repo precedent is exact: `:hicasso/on-frame-destroyed!` is already a Hicasso-owned key living in a core-owned structure (`core/src/re_frame/late_bind/directory.cljc`). The `:re-frame.hicasso/*` root is the *authoring marker* vocabulary (`::h/value`, `::h/revision`) — props an author writes — which this is not.
- **`:doc` rides the slot when the author wrote one.** This is the one addition beyond the two the ruling enumerates, and it is there to avoid a false diagnostic rather than to add a feature: `registrar/register!` dev-warns `:rf.warning/missing-doc` for any macro-path registration (keyed on `:ns`, which the coordinate supplies) with no usable `:doc`, so withholding a docstring the author *did* write would fire that warning against a documented view. `reg-view` stores `:doc` in its slot for the same reason.

## Tests

- `implementation/hicasso/test/re_frame/hicasso/view_alias_registry_cljs_test.cljs` (**new**, `.cljs`, Node lane) — the dev-side shape. Every *the same as `reg-view`* row asserts against an ordinary `rf/reg-view` declared in the same namespace, so id derivation and coordinate placement are asserted as **agreement between two macros** rather than against a remembered shape. The declarations sit above `use-fixtures` deliberately: `make-reset-runtime-fixture` pins its baseline when that form is evaluated and folds it back before each test, which is what makes the registrations run-order-independent in the shared `:node-test` bundle.
- `error_source_coord_elision_prod_test.cljs` (`.cljs`, browser `:advanced` lane) — the production absence, plus its positive control.
- `coord_sentinel_source.cljs` — gains `view-id` beside `view-name` so the two spellings of one declaration's identity cannot drift; its "registers nothing" sentence is corrected to say *in the build it is compiled into*.

## Quality gates

Every gate below was run **foreground, to completion**, in this worktree, with the exit code captured on the same command line and read back from a `.exit` file — never from a pipeline.

| gate | how invoked | exit |
|---|---|---|
| `npm run test:cljs` (`:node-test`, carries the hicasso node lane) | `npm run test:cljs` | **0** — Ran 13951 tests / 70267 assertions, 0 failures, 0 errors |
| focused hicasso node lane (`:node-test-hicasso`) | `node scripts/compile-node-test.cjs node-test-hicasso …` | **0** — Ran 1225 tests / 4979 assertions, 0 failures |
| hicasso JVM lane | `clojure -M:test` in `implementation/hicasso` | **0** — Ran 3 tests / 92 assertions, 0 failures |
| `npm run test:browser-prod-elision` (`:advanced` + `goog.DEBUG=false`, real Chromium) | `npm run test:browser-prod-elision` | **0** — Ran 131 tests / 550 assertions, 0 failures |
| `npm run build:hicasso-release` (`:advanced`; production erasure + bundle isolation) | `npm run build:hicasso-release` | **0** — 162 files, **0 warnings**; 5 erasure sentinels absent, 8 isolation sentinels absent, every positive control present |
| `npm run test:hicasso-invariants` (freeze, optional-module reachability, complaint catalogue, budget ledger, example fence, **facade inventory**, guide samples) | `npm run test:hicasso-invariants` | **0** — 16 names on the door, 43 inventory rows read |
| hicasso **naming census** (self-test + run) | `python implementation/hicasso/scripts/check_naming_census.py` | **0** — 104 public names across 10 shipped namespaces, 0 unrostered |
| clj-kondo (pinned 2026.04.15, `--fail-level error`) over `hicasso/{src,test}` | `clojure -M:clj-kondo --fail-level error --lint src test` | **0** — errors: 0; the 27 warnings are all pre-existing and none is in a file this PR touches |
| `sh scripts/check-no-hardcoded-paths.sh` | as written | **0** |
| `python scripts/check_fast_pr_gap.py --list` | as written | **0** — used to pick the two hicasso-relevant required CI checks the fast spine does *not* run (`build:hicasso-release`, `test:browser-prod-elision`); **both are run above** |

### Which arm each test ran under

`hicasso.cljc` is a `.cljc` whose `:clj` branch is the three macros and nothing else. Its macro side was exercised **on the JVM, at expansion**, by every ClojureScript compile above — a macro namespace is loaded as Clojure — and the `build:hicasso-release` line's *0 warnings* is the sharper reading of that, because the `:node-test`-family compile gate reds on any warning and an unresolvable emitted symbol would arrive as `Use of undeclared Var`. Its emitted code was exercised on the **Node** lane by the new `.cljs` suite and on the **browser `:advanced`** lane by the elision suite. `clojure -M:test` in `implementation/hicasso` ran the artefact's 3 JVM tests (the `.cljc` slot-rule pin); it is the runner for neither new suite, both of which are `.cljs`.

### Proof each gate read THIS worktree

- **Planted fault.** One assertion in `view_alias_registry_cljs_test.cljs` was inverted and the focused hicasso node lane re-run: **exit 1**, `FAIL in (the-entry-carries-the-minted-head-itself) (re_frame/hicasso/view_alias_registry_cljs_test.cljs:153:9)`. Reverted, working tree verified clean against the commit, green restored. The lane demonstrably reads this file.
- **Root printed.** The browser-elision and release logs print the `re-frame2-worktrees/w-5qaf4/implementation/…` config, output and served roots.
- **The new elision deftests are in the `:advanced` artefact.** Both names appear in `out/browser-test-prod-elision/js/test.js`, so they compiled into the bundle that then reported 0 failures — the absence assertions *ran*, rather than being quietly absent, which is the failure mode an absence check has no other defence against.

### Left to CI — and now answered by it

`test:hicasso-hmr` and `test:hicasso-controlled` (Chromium + Firefox + WebKit). Neither is disturbed by this change, and the reason is at source rather than by assumption: hicasso's only registrar listener, `impl.collector/sub-registered!`, is narrowed to `(= :sub kind)`, so a `:view` registration costs it one keyword compare and reaches neither `bump-registry-epoch!` nor the cell scan. The `:sub`-side HMR contract is covered by `hmr_registry_cljs_test` in the green node lane above.

**Both have since run on this PR and passed** (`CLJS hicasso HMR contract through a real shadow reload` 2m36s, `CLJS hicasso controlled-input correctness` 1m38s), alongside `CLJS (shadow-cljs :node-test)`, `Hicasso facade inventory` and `Hicasso naming census`. The PR is **53 pass / 47 skipped / 0 failing**, with `All required checks passed` green.

