### PR TITLE
bench(hicasso): a strict per-round control rule, and the estimator named (rf2-egdaq, rf2-pqyxz)

### DIFF
--- a/docs/design/hicasso/decisions.md
+++ b/docs/design/hicasso/decisions.md
@@ -1581,8 +1581,14 @@ mounted through `run.cjs` on `:hicasso-bench` under `:advanced` with
 judged arms build one 1,001-element page and is proven able to answer false before
 any clock is read.
 
-Three run-medians, each five rounds of three warm-up plus six samples, taken back
-to back on a quiet box, positive control passing in all three:
+Three runs, each five rounds of three warm-up plus six samples, taken back to
+back on a quiet box. **Each run's figure is the ARITHMETIC MEAN of that run's
+five per-round ratios**, each of which is a ratio of the two arms' *within-round
+median* mount times — a mean over medians, and not a median of anything at the
+run level. That is what `lane/ratio-between` computes and hands the table; an
+earlier draft of this paragraph called the three values "run-medians" and their
+spans "effect medians", which named an estimator the instrument never used
+(`rf2-pqyxz`).
 
 | run | `:merged`/`:expanded` | per-round range | NULL `:expanded-b`/`:expanded` | per `:&` site |
 |---|---|---|---|---|
@@ -1592,10 +1598,31 @@ to back on a quiet box, positive control passing in all three:
 
 So on a page where every input carries one, the `:&` spelling costs about **25% of
 mount**, and about **2.4 µs per site**. It is outside instrument resolution: the
-three effect medians span 1.217 – 1.270 while the three null medians span
-1.001 – 1.013, and those two intervals do not touch. The per-round ranges are
-weaker evidence than that and are printed rather than leaned on — run 2's includes
-1.0, which is why the separation is claimed between runs and not within one.
+three effect run-means span 1.217 – 1.270 while the three null run-means span
+1.001 – 1.013, and those two intervals do not touch. **Naming the estimator
+correctly moves none of those numbers and the conclusion stands**: both columns
+always were the same statistic computed the same way, so the effect-versus-null
+comparison that carries the claim is untouched by the correction. What the
+correction does do is make the hedge below read as it should — a mean over five
+rounds is more moveable by one round than a median would be, which is precisely
+why the separation is claimed between runs and not within one. The per-round
+ranges are weaker evidence than that and are printed rather than leaned on —
+run 2's includes 1.0.
+
+**The positive control, and the rule it passed under (`rf2-egdaq`).** `:ctl-2x`
+predicts 2.00x by construction and passed in all three runs: measured 8.250 ms
+against a predicted 8.100, 8.350 against 8.500, and 8.500 against 8.600 — every
+one within 2% of its own prediction. That verdict was `lane/control-verdict`'s
+**overlap** rule applied to *cross-round aggregates*, which is the weaker of the
+lane's two readings and is not the same claim as *every round sat inside the
+band*. The instrument now adjudicates this control per round under
+`lane/control-verdict-strict` — the ruling that keeps overlap for legs sitting on
+Chrome's 100 µs clamp names a batched window clear of the quantum as its own
+revisit trigger, and these legs read ~4 ms judged against ~8 ms control, forty to
+eighty quanta clear — and records the per-round values so a later reader can
+re-adjudicate without re-running the window. **These three runs recorded only the
+aggregate, so their strict verdict is not recoverable from what was kept, and
+none is claimed here.**
 
 **What that figure is, and what it is not.** It prices the AUTHORING CHANGE whole:
 the caller map each call site builds, the `dissoc` the helper performs on it, and

--- a/implementation/hicasso/test/re_frame/bench/hicasso/amp_merge_clock_app.cljs
+++ b/implementation/hicasso/test/re_frame/bench/hicasso/amp_merge_clock_app.cljs
@@ -59,6 +59,26 @@
                  prediction is a clean 2.00x rather than a modelled one.
                  rf2-5yn9 records the same construction and its reason.
 
+  ## The control is adjudicated STRICTLY, and per round (rf2-egdaq)
+
+  `lane/control-verdict-strict` decides it: every round's `:ctl-2x` /
+  `:expanded` ratio must sit inside ±25% of 2.00x, and one bad round
+  refuses the run however good the others were. This instrument is
+  entitled to that rule and the coarse-leg rows are not — the 2026-07-31
+  ruling keeps the weaker OVERLAP rule for legs sitting on Chrome's
+  100 µs clamp and names a batched window clear of the quantum as its own
+  revisit trigger. This one reads ~4 ms judged and ~8 ms control, forty to
+  eighty quanta clear, so a round outside the band here is not the clock.
+
+  The adjudication is also PER ROUND rather than aggregate. The three runs
+  published on 2026-08-15 compared a cross-round prediction against a
+  cross-round range, which never puts a round beside its own denominator,
+  and recorded only that aggregate — so their strict verdict is not
+  recoverable and this file now records `:per-round` for the control as
+  well as for the effect and the null. A run that cannot be
+  re-adjudicated without re-running the window is a run that has to be
+  re-run to answer a question it already had the data for.
+
   `:floor` and `:ctl-2x` are `:parity-exempt?`: one builds an empty page
   and one builds two pages, both on purpose, and folding either into the
   equality would make the fairness gate a permanent failure.
@@ -375,7 +395,12 @@
        "BEFORE the clock starts; the :ctl-2x arm's sample is the SAME operation "
        "performed TWICE inside one window, so its per-sample constants double "
        "with its work and its prediction is 2.00x by construction rather than by "
-       "model. :expanded-b is the NULL arm — a second boundary head over the same "
+       "model — adjudicated by lane/control-verdict-strict, which requires EVERY "
+       "round's ctl-2x/expanded ratio to sit inside ±"
+       (.toFixed (* 100.0 control-slack) 0)
+       "% of it rather than merely the range, and records the per-round values so "
+       "the run can be re-adjudicated without being re-run. :expanded-b is the "
+       "NULL arm — a second boundary head over the same "
        "body, carrying no effect by construction, so its reading against "
        ":expanded is this instrument's resolution rather than a result. Arms "
        "interleaved at the SAMPLE level under the lane's rotating AND REFLECTING "
@@ -445,11 +470,14 @@
                 eff-ns   (per-element-ns p50s :merged :expanded)
                 null-ns  (per-element-ns p50s :expanded-b :expanded)
                 gv       (lane/guard! samples "amp-merge clock arms (in-page ms)")
-                ctl      (lane/control-verdict
-                           (* 2.0 (:p50 (get abs :expanded)))
-                           (let [s (get abs :ctl-2x)]
-                             {:min (:min s) :max (:max s) :mean (:p50 s)})
-                           control-slack)
+                ;; THE POSITIVE CONTROL, per round and strictly (rf2-egdaq).
+                ;; `:ctl-2x` is `:expanded`'s own operation performed twice
+                ;; in one window, so 2.00x is arithmetic rather than a
+                ;; model, and dividing each round by ITS OWN `:expanded`
+                ;; leaves the floor and the round's drift out of it.
+                ctl-ratio (lane/ratio-between ratios :ctl-2x :expanded)
+                ctl      (lane/control-verdict-strict
+                           2.0 (:per-round ctl-ratio) control-slack)
                 tv       (lane/tally-value tally)]
             (lane/assert-teardown-clean! "the measured rounds")
             (lane/record! :amp-merge-clock
@@ -502,7 +530,9 @@
             (js/console.log
               (str ";;   PER-ELEMENT null:   " (fmt (:p50 null-ns) 1) " ns/site ["
                    (fmt (:min null-ns) 1) " - " (fmt (:max null-ns) 1) "]"))
-            (js/console.log (str ";;   control: " (:why ctl)))
+            (js/console.log (str ";;   control (" (name (:rule ctl)) ", ctl-2x/expanded): "
+                                 (:why ctl)))
+            (js/console.log (str ";;   control per-round: " (pr-str (:per-round ctl))))
             (js/console.log (str ";;   writes: " (:unverified tv) " unverified of "
                                  (:writes tv)))
             (when (pos? (:unverified tv))

--- a/implementation/hicasso/test/re_frame/bench/hicasso/lane.cljs
+++ b/implementation/hicasso/test/re_frame/bench/hicasso/lane.cljs
@@ -73,7 +73,13 @@
      [[control-verdict]] takes a stated prediction and the measured range
      and answers whether the instrument had the signal its own arithmetic
      says it must. An instrument that cannot see a change it PREDICTS
-     cannot be trusted to see one it does not.
+     cannot be trusted to see one it does not. TWO RULES LIVE HERE and a
+     caller picks by what its legs measure: [[control-verdict]] adjudicates
+     on OVERLAP and stands for legs sitting on Chrome's 100 µs clamp;
+     [[control-verdict-strict]] requires EVERY ROUND inside the band and is
+     for batched windows that clear the quantum. Each answer carries the
+     `:rule` that decided it, so a published record cannot be read under
+     the other one.
   5. **The guard refuses, and the refusal is exit code 2.** [[guard!]]
      runs the shared self-test before anything is measured and the
      verdict after; `run.cjs` turns `:refuse? true` into `exit 2`. Four
@@ -593,7 +599,16 @@
 (defn ratio-between
   "The ratio of arm `a` to arm `b`, per round, as a range. The bar is
   stated against a DENOMINATOR ARM, not against the floor, so this is the
-  arithmetic a bar row quotes."
+  arithmetic a bar row quotes.
+
+  `:mean` IS AN ARITHMETIC MEAN — the average of the per-round ratios in
+  `:per-round`, and not a median of anything. The distinction is worth a
+  line because a median IS in the pipeline one level down (each round's
+  ratio is built from `summarise`'s within-round `:p50`s), which is how
+  PR #8326's publication came to call these values \"run-medians\" and
+  their spans \"effect medians\" — corrected under rf2-pqyxz. A row
+  quoting this key names it a MEAN OF PER-ROUND RATIOS, each of which is
+  a ratio of within-round medians."
   [round-ratios a b]
   (let [vs (mapv (fn [r] (round4 (/ (get r a) (get r b)))) round-ratios)]
     {:numerator a :denominator b
@@ -874,9 +889,9 @@
   `slack` of the prediction means the instrument cannot see a change it
   predicts, and nothing else it measured is worth reading.
 
-  Answers `{:predicted :measured :ok? :why}` — published on every run,
-  passing or not, because a control quoted only when it passes is not a
-  control.
+  Answers `{:rule :predicted :measured :slack :ok? :why}` — published on
+  every run, passing or not, because a control quoted only when it passes
+  is not a control.
 
   ## KNOWN DEFECT: this rule is WEAKER than HD-008's, and the two
   ## disagree on a row that is already published (rf2-egdaq)
@@ -887,31 +902,47 @@
   is wrong has caught something, and letting a good round vouch for a bad
   one is how an instrument stops being one. THE STRICTER RULE IS THE
   RIGHT ONE. This one is the lane's known defect, and a caller must not
-  read `:ok?` as though it were the strict answer.
+  read `:ok?` as though it were the strict answer — which is why the map
+  carries `:rule :overlap`, so a published record says which rule
+  adjudicated it rather than leaving a reader to assume the other.
+  [[control-verdict-strict]] is that other rule, spelled and callable.
 
-  It is not repaired here, and the reason is arithmetic rather than
-  caution. Re-adjudicating the ELEVEN controls this function has already
-  published under the overlap rule flips exactly one:
+  ## Why the defective rule STANDS here anyway (ruling, 2026-07-31)
+
+  Tightening THIS function was adjudicated and refused. rf2-6i0i2's
+  balanced ensemble re-adjudicated 80 controls: 80 of 80 pass under
+  overlap, 64 of 80 under the strict reading — and every miss falls on a
+  row whose control leg is a handful of Chrome's 100 µs
+  `performance.now()` quanta, every miss is LOW, and four of them miss by
+  0.0014 on a two-quantum floor. A rule that refuses a fifth of its
+  controls by landing on the clock quantum is measuring RESOLUTION, not
+  correctness. So the overlap rule stands for clamp-limited legs, no
+  published row was re-adjudicated, and a pass here is a pass UNDER
+  OVERLAP rather than a claim that every round sat inside the band.
+
+  The row this defect was filed over stands on its page under that
+  ruling:
 
       docs/design/hicasso/studio/p0-converged-witness-set.md
       M2 mount, UIx segment — predicted 1.9412, slack 0.25, so the band
       is [1.4559 – 2.4265]. The published range is [1.333 – 2.000]: its
-      worst round sits 8.4% BELOW the band's floor. It carries a ✅, and
-      it holds that ✅ only because a good round vouched for a bad one —
-      which is precisely the failure the stricter rule exists to catch.
+      worst round sits 8.4% BELOW the band's floor and it carries a ✅
+      only because a good round vouched for a bad one. Its legs are
+      coarse — a handful of quanta — which is the whole reason the ruling
+      let it stand rather than re-adjudicating it.
 
-  The other ten pass under either reading. So tightening `:ok?` turns a
-  published pass into a published failure, and that is a finding about a
-  published number rather than a refactor: it needs an operator ruling on
-  rf2-2rtt6.1 (re-adjudicate the row, or apply the strict rule only from
-  the next run), and if the row is re-adjudicated the converged arm needs
-  a re-run to replace it. Whoever takes that must not simply flip the
-  `and` and leave the studio page reading as current."
+  ## And the condition under which this rule does NOT apply
+
+  That ruling named its own revisit trigger: a BATCHED window lifting the
+  legs clear of the quantum. [[control-verdict-strict]] is that rule, and
+  a caller reading milliseconds against a 0.1 ms quantum wants it — there
+  a round outside the band is not the clock."
   [predicted {:keys [min max mean] :as measured} slack]
   (let [lo (* predicted (- 1.0 slack))
         hi (* predicted (+ 1.0 slack))
         ok? (and (<= min hi) (>= max lo))]
-    {:predicted predicted
+    {:rule      :overlap
+     :predicted predicted
      :measured  measured
      :slack     slack
      :ok?       ok?
@@ -926,6 +957,104 @@
                        "% of the prediction; the instrument did not see a change "
                        "its own arithmetic says it must, so no figure in this run "
                        "is reportable"))}))
+
+(defn control-verdict-strict
+  "Adjudicate a positive control the way HD-008 does: EVERY ROUND inside
+  the ±`slack` band around `predicted`, round by round.
+
+  `per-round` is ONE MEASURED VALUE PER ROUND. Where the prediction is a
+  RATIO — `:ctl-2x` performs the judged arm's own operation twice inside
+  one window, so it predicts 2.00x by construction rather than by model —
+  that is `(:per-round (ratio-between ratios :ctl-2x <judged>))`, which
+  pairs each round with its OWN denominator. An aggregate adjudication
+  cannot answer the question this rule asks: a cross-round prediction
+  against a cross-round range never puts a round beside its own
+  denominator, so it cannot tell a control that held every round from one
+  that held on average.
+
+  Answers `{:rule :every-round :predicted :slack :band :per-round
+  :measured :stated? :outside :ok? :why}`. `:outside` NAMES each round
+  that missed and by how much, because an operator told only `FAILED`
+  goes looking at the arms; `:per-round` is carried into the record so a
+  later reader can re-adjudicate the run under either rule WITHOUT
+  re-running the window — which is the durability hole rf2-egdaq's audit
+  of PR #8326 found, and the reason the three runs it audited cannot now
+  be re-adjudicated at all.
+
+  `:stated?` is the other half of a control that can go red. A band built
+  on a prediction of zero or less is cleared by any reading whatever, and
+  the walk profile shipped exactly that failure (`rf2-1huc`, merged-PR
+  audit #8149): a control whose own prediction has gone vacuous reports
+  that it saw what it never predicted. A control with no rounds is the
+  same thing said with no data, so both refuse here.
+
+  ## Which of the two rules a caller wants
+
+  [[control-verdict]] adjudicates on OVERLAP — the measured range need
+  only meet the band — and STANDS for controls whose legs sit within a
+  few of Chrome's 100 µs `performance.now()` quanta. The 2026-07-31
+  ruling on rf2-egdaq keeps it there on evidence: of 80 controls in
+  rf2-6i0i2's balanced ensemble, 80 pass under overlap and 64 under this
+  rule, and every miss is a LOW excursion on a coarse-leg row. On those
+  legs this rule reports the clock clamp as an instrument defect.
+
+  THIS rule is for the case that same ruling named as its own revisit
+  trigger — a batched window whose legs clear the quantum. `amp_merge_
+  clock_app` reads ~4 ms on the judged arm and ~8 ms on the control
+  against a 0.1 ms quantum, forty to eighty quanta clear of it, so a
+  round outside a ±25% band there is not the clock. And a good round must
+  not be allowed to vouch for a bad one."
+  [predicted per-round slack]
+  (let [vs      (vec per-round)
+        lo      (* predicted (- 1.0 slack))
+        hi      (* predicted (+ 1.0 slack))
+        stated? (boolean (and (pos? predicted) (seq vs)))
+        outside (if-not stated?
+                  []
+                  (vec (keep-indexed
+                         (fn [i v]
+                           (when-not (and (>= v lo) (<= v hi))
+                             {:round    (inc i)
+                              :measured (round4 v)
+                              :off-by   (round4 (/ (- v (if (< v lo) lo hi))
+                                                   predicted))}))
+                         vs)))
+        ok?     (and stated? (empty? outside))
+        band    (str "predicted " (.toFixed predicted 3) "x ±"
+                     (.toFixed (* 100.0 slack) 0) "% — band ["
+                     (.toFixed lo 3) "–" (.toFixed hi 3) "]")]
+    {:rule      :every-round
+     :predicted predicted
+     :slack     slack
+     :band      [(round4 lo) (round4 hi)]
+     :per-round vs
+     :measured  (summarise vs)
+     :stated?   stated?
+     :outside   outside
+     :ok?       ok?
+     :why       (cond
+                  (not (pos? predicted))
+                  (str "REFUSED — the control states no prediction ("
+                       (.toFixed (double predicted) 3) "). A band built on it is "
+                       "cleared by any reading whatever, so nothing here is a "
+                       "control and no figure in this run is reportable")
+
+                  (empty? vs)
+                  (str band " — REFUSED: no rounds were adjudicated. A control "
+                       "with no data is not a control that passed")
+
+                  ok?
+                  (str band ", and all " (count vs) " rounds sit inside it — "
+                       "EVERY round, not merely the range")
+
+                  :else
+                  (str band ", and " (count outside) " of " (count vs)
+                       " rounds sit OUTSIDE it ("
+                       (str/join ", " (map (fn [{:keys [round measured]}]
+                                             (str "round " round " " (.toFixed measured 3)))
+                                           outside))
+                       ") — a control whose worst round is wrong has caught "
+                       "something, and no figure in this run is reportable"))}))
 
 ;; ---------------------------------------------------------------------------
 ;; The guard

--- a/implementation/hicasso/test/re_frame/bench/hicasso/lane_control_strict_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/bench/hicasso/lane_control_strict_cljs_test.cljs
@@ -1,0 +1,159 @@
+(ns re-frame.bench.hicasso.lane-control-strict-cljs-test
+  "THE LANE'S TWO CONTROL RULES MUST STAY TWO — pinned (rf2-egdaq).
+
+  `lane/control-verdict` adjudicates a positive control on OVERLAP: the
+  measured range need only meet the ±slack band. `lane/control-verdict-
+  strict` requires EVERY ROUND inside it. Both are correct for their own
+  case — the 2026-07-31 ruling keeps overlap for legs sitting on Chrome's
+  100 µs `performance.now()` clamp, where a low round is the quantum
+  rather than a defect, and names a batched window clear of the quantum
+  as the condition under which the strict rule becomes adoptable.
+
+  The failure this file exists to prevent is a later worker collapsing
+  the two into one, in either direction. So the assertion that carries the
+  design is [[one-dataset-two-rules-opposite-verdicts]]: the SAME readings
+  are driven through both rules and the two must disagree. A `simplify`
+  pass that routes `amp_merge_clock_app` back to the overlap rule goes red
+  here, in the always-on `cljs-test$` gate, rather than in a bench run
+  months later that quietly stopped having teeth.
+
+  The rest pin the modes a browser run cannot reach. A control adjudicated
+  on an AGGREGATE cannot be re-adjudicated afterwards — that is the
+  durability hole rf2-egdaq's audit of PR #8326 found, and it is why the
+  strict answer carries `:per-round`. A control whose own prediction has
+  gone vacuous passes on any reading whatever — the walk profile shipped
+  exactly that (`rf2-1huc`, merged-PR audit #8149), and no mutation of a
+  measured arm can find it.
+
+  Companion to `walk_profile_control_cljs_test`, which pins the same
+  every-round discipline for the walk profile's own bespoke control."
+  (:require [cljs.test :refer-macros [deftest is testing]]
+            [re-frame.bench.hicasso.lane :as lane]))
+
+;; ---------------------------------------------------------------------------
+;; The shape `amp_merge_clock_app` hands the rule
+;; ---------------------------------------------------------------------------
+;;
+;; `:ctl-2x` performs `:expanded`'s own operation twice inside one window,
+;; so the prediction is 2.00x by construction and each round is divided by
+;; its OWN denominator. Five rounds, ±25%, so the band is [1.5 – 2.5].
+
+(def ^:private predicted 2.0)
+(def ^:private slack 0.25)
+
+(defn- strict [per-round] (lane/control-verdict-strict predicted per-round slack))
+
+(def ^:private held
+  "Five rounds a real instrument with signal produces."
+  [2.037 1.965 2.104 1.988 2.012])
+
+(def ^:private one-bad-round
+  "Four good rounds and a fourth-round excursion to 1.40 — 30% below the
+  prediction, outside the band's 1.5 floor."
+  [2.037 1.965 2.104 1.400 2.012])
+
+;; ---------------------------------------------------------------------------
+;; The assertion that carries the design
+;; ---------------------------------------------------------------------------
+
+(deftest one-dataset-two-rules-opposite-verdicts
+  (testing "ONE set of readings, BOTH rules, and they must part — this is
+            the whole of rf2-egdaq and the reason the lane carries two"
+    (let [s (strict one-bad-round)
+          ;; The same five rounds offered to the overlap rule as the
+          ;; `{:min :max :mean}` range it takes.
+          o (lane/control-verdict predicted
+                                  {:min 1.400 :max 2.104 :mean 1.904}
+                                  slack)]
+      (is (true? (:ok? o))
+          "the overlap rule PASSES it — the range meets the band, so a good
+           round vouches for a bad one")
+      (is (false? (:ok? s))
+          "the every-round rule REFUSES it, which is the whole difference")
+      (is (= :overlap (:rule o)))
+      (is (= :every-round (:rule s))
+          "and each answer says which rule decided it, so a published record
+           cannot be read under the other one"))))
+
+;; ---------------------------------------------------------------------------
+;; The rule itself
+;; ---------------------------------------------------------------------------
+
+(deftest every-round-inside-passes
+  (testing "a control with signal in every round"
+    (let [r (strict held)]
+      (is (true? (:ok? r)))
+      (is (= [1.5 2.5] (:band r)))
+      (is (empty? (:outside r)))
+      (is (re-find #"EVERY round" (:why r))))))
+
+(deftest one-bad-round-refuses-and-names-it
+  (testing "an operator told only FAILED goes looking at the arms, where
+            four rounds out of five are healthy"
+    (let [r (strict one-bad-round)]
+      (is (false? (:ok? r)))
+      (is (= [{:round 4 :measured 1.4 :off-by -0.05}] (:outside r))
+          "the round, its value, and how far past the edge it sat as a
+           fraction of the prediction")
+      (is (re-find #"round 4" (:why r))))))
+
+(deftest a-high-excursion-refuses-too
+  (testing "the band is two-sided: a control reading 3.0x against a 2.0x
+            prediction has not confirmed the instrument, it has found
+            something else"
+    (let [r (strict [2.037 3.000 1.988])]
+      (is (false? (:ok? r)))
+      (is (= [2] (mapv :round (:outside r))))
+      (is (= 0.25 (:off-by (first (:outside r))))))))
+
+(deftest the-edges-are-inside
+  (testing "the band is inclusive at both edges — a rule that refused its
+            own stated tolerance would be a different tolerance"
+    (is (true? (:ok? (strict [1.5 2.5 2.0]))))))
+
+;; ---------------------------------------------------------------------------
+;; What the audit of PR #8326 found: the answer must be re-adjudicable
+;; ---------------------------------------------------------------------------
+
+(deftest the-per-round-values-are-carried-into-the-answer
+  (testing "the three runs published on 2026-08-15 recorded only an
+            aggregate, so their strict verdict is unrecoverable and the
+            window would have to be re-run to ask a question its own data
+            had already answered"
+    (let [r (strict held)]
+      (is (= held (:per-round r)))
+      (is (= 5 (:n (:measured r))))
+      (is (= 2.012 (:p50 (:measured r))))
+      (is (= 1.965 (:min (:measured r))))
+      (is (= 2.104 (:max (:measured r)))))))
+
+;; ---------------------------------------------------------------------------
+;; A control that cannot go red is not a control
+;; ---------------------------------------------------------------------------
+
+(deftest no-rounds-refuses
+  (testing "a control with no data has not passed"
+    (let [r (strict [])]
+      (is (false? (:ok? r)))
+      (is (false? (:stated? r)))
+      (is (re-find #"no rounds" (:why r))))))
+
+(deftest a-vacuous-prediction-refuses-however-good-the-rounds-look
+  (testing "the mode merged-PR audit #8149 found on the walk profile: a
+            band around a prediction of zero is cleared by any reading
+            whatever, so passing there is passing on nothing"
+    (let [r (lane/control-verdict-strict 0.0 [0.0 0.0 0.0] slack)]
+      (is (false? (:ok? r)))
+      (is (false? (:stated? r)))
+      (is (re-find #"states no prediction" (:why r)))))
+  (testing "and a NEGATIVE prediction inverts the band rather than
+            narrowing it, which is on its own enough to refuse"
+    (is (false? (:ok? (lane/control-verdict-strict -2.0 [-2.0 -2.0] slack))))))
+
+(deftest the-refusal-is-attributed-to-the-right-half
+  (testing "two refusals, two causes, two repairs — the arms are innocent
+            in one of them"
+    (let [vacuous (lane/control-verdict-strict 0.0 held slack)
+          missed  (strict one-bad-round)]
+      (is (false? (:stated? vacuous)) "the PREDICTION failed")
+      (is (true? (:stated? missed)) "the prediction was real; the ARMS missed it"))))


### PR DESCRIPTION
Two beads, one file — `lane.cljs` — reopened by the same merged-PR audit of #8326. `rf2-egdaq` settled first, because if the strict rule were adopted the re-adjudication of `rf2-pqyxz`'s control data would be part of re-checking its conclusions.

## rf2-egdaq — the control rule

**The premise held.** `lane/control-verdict` adjudicates on OVERLAP (`(and (<= min hi) (>= max lo))`); `hd8-rows/positive-control!` requires every round inside; `amp_merge_clock_app` was deciding fail-closed on the overlap `:ok?`, and on **cross-round aggregates** — prediction `2 x p50(:expanded)` across rounds, measured as the min/max of `:ctl-2x`'s across-round p50s. That never puts a round beside its own denominator.

**What changed.** `lane/control-verdict-strict` — every round inside the ±slack band, adjudicated round by round; `:outside` names each miss and how far past the edge it sat; `:stated?` refuses a prediction of zero or less and a run with no rounds (the vacuous-prediction mode merged-PR audit #8149 found on the walk profile, which no mutation of a measured arm can reach). `amp_merge_clock_app` now decides on `(:per-round (lane/ratio-between ratios :ctl-2x :expanded))` against a 2.00x prediction that is arithmetic rather than a model, and records the per-round values.

**`control-verdict` is NOT tightened.** The 2026-07-31 coarse-leg ruling stands — 80 of 80 controls pass under overlap and 64 of 80 under strict, every miss LOW on a clamp-limited row. Its docstring keeps the KNOWN DEFECT statement and "THE STRICTER RULE IS THE RIGHT ONE" verbatim, because four published pages quote it (`budgets.md` twice, `the-candidates-clock.md`, `the-in-page-mount-term-decomposed.md`); what is added is the ruling that keeps it anyway and the pointer to the new rule. Both answers now carry `:rule` (`:overlap` / `:every-round`) so a published record says which rule decided it.

**The re-adjudication could not be done, and that is the finding.** PR #8326's three runs kept only the aggregate: `lane/record!` stores `:absolute-ms` as `summarise`'s n/min/max/p50 across rounds, and no per-round control value reaches the record, the console, the PR body or the page. The strict verdict for those three runs is **not recoverable from what was kept** and is not claimed. What is durable is the central adjudication — measured 8.250 ms against a predicted 8.100, 8.350 against 8.500, 8.500 against 8.600, each within 2% of prediction — and that is now on the page beside the rule it passed under. No window was re-run: this was not a measurement dispatch.

## rf2-pqyxz — the estimator

**The premise held.** `lane/ratio-between` builds five per-round ratios and stores their **arithmetic mean** in `:mean`; `amp_merge_clock_app` prints that; the publication called the three values "run-medians" and their spans "effect medians" and "null medians".

**Route taken: correct the name.** The median route was checked first and is closed — the per-round values were never recorded (same durability hole as above), so the stated median cannot be computed from retained data, and re-running was out of scope. The publication now says what it is: each run's figure is the arithmetic mean of that run's five per-round ratios, each a ratio of the two arms' *within-round median* mount times. `ratio-between`'s docstring says so too, where the next publisher will read it.

**The conclusions still follow, and the correction sharpens the existing hedge.** Both columns always were the same statistic computed the same way, so the effect-versus-null comparison is untouched: effect run-means span 1.217–1.270, null run-means span 1.001–1.013, disjoint. "~25% of mount" and "~2.4 µs per site" are unmoved. What the correct name does change is the reading of the hedge already on the page — a mean over five rounds is more moveable by one round than a median would be, which is exactly why the separation is claimed between runs and not within one.

## Fences respected

- `rf2-z143r` still owns apportioning the 2.4 µs between caller map, helper `dissoc` and codec. Nothing here touches it.
- `docs/design/hicasso/studio/**` and `bench/hicasso/data/` untouched (PR #8329 holds two of those paths).
- `direct_return_clock_app` (rf2-5yn9) has the identical aggregate/overlap control shape and is left alone — its figure is published and re-adjudicating it is a ruling, not a refactor. Filed as **rf2-gsn62**.

## Quality gates

| gate | captured exit | note |
|---|---|---|
| `npm run test:cljs` | *(see below)* | the runner matched to the extension: `lane.cljs` and the new test are CLJS, and `clojure -M:test` cannot load them |
| `npm run test:hicasso-compile` | *(see below)* | the CI step covering these bench namespaces |
| `python scripts/check_doc_slugs.py` | *(see below)* | the gate that covers `docs/design/**`; `mkdocs build --strict` does not (`exclude_docs`) |
| `python scripts/check_provenance_pins.py` | *(see below)* | changed page under `docs/design/hicasso/` |
| `sh scripts/check-no-hardcoded-paths.sh` | *(see below)* | |

Exit codes and the red-proofs are posted in a follow-up comment as each finishes; a real `npm ci --prefix implementation` (101 packages, no junction) backs the CLJS runs.

New markdown table column counts hand-verified: the HD-023 table is unchanged at 5 columns in header, separator and all three rows. No new table was added. No SHA is cited on the doc page.
