### PR TITLE
docs(hicasso): the ratio spread does not bracket 0.9718, nor is the box proven (rf2-d360z)

### DIFF
--- a/docs/design/hicasso/studio/the-cold-read-mount-term.md
+++ b/docs/design/hicasso/studio/the-cold-read-mount-term.md
@@ -126,14 +126,21 @@ and settled between samples behind a residue equality gate that never fired):
 >
 > **The two absolutes are not restated, and the reason is stronger than the
 > "it came back inside the quantum" result the bead anticipated.** The `commit`
-> arm's spread across three runs of one binary on a certified-quiet box is
-> 0.100 ms — **four grid steps, in one session, with nothing changing between
-> runs.** The effect commissioned for sight is 141 keyword mints, which this
+> arm's spread across three runs of one binary — one source file, one build,
+> one session, no deliberate change between them — is 0.100 ms, **four grid
+> steps.** The effect commissioned for sight is 141 keyword mints, which this
 > window's own micro readings price at 14–32 ns each (the micro table below is
 > the published run's and is not restated): **0.002–0.005 ms/commit, an eighth
-> of one grid step and about a thirtieth of the dispersion just quoted.** The
-> term is not merely under the instrument's resolution — it is far under the
-> instrument's own run-to-run noise, and more runs would not change that.
+> of one grid step and about a thirtieth of the dispersion just quoted.** What
+> produced that dispersion this window does not establish. The instrument's own
+> run-to-run variation is the leading candidate and the box was quiet on 82 of
+> 85 samples — but two of the three non-zero readings cannot be placed outside
+> run 3's measurement phase, and that is enough to keep residual load in the
+> frame. **The refusal does not turn on which it is.** Under either cause the
+> term is not merely below the window's resolution but far below its scatter,
+> and more runs of this shape would only measure the scatter again. Separating
+> the two causes would take a window built to do it, and would not bring this
+> term into view.
 >
 > **A restatement of two cells could no longer be honest in any case, because
 > two further changes have landed under this table, neither of them the mint,
@@ -171,9 +178,15 @@ and settled between samples behind a residue equality gate that never fired):
 >
 > **The fidelity ratio is not restated either, and does not need to be.** It
 > read 0.8864 / 0.9444 / 0.9189 against the published 0.9718 — a spread of
-> 0.058 that loosely brackets it — and it stays common-mode for the reason
-> `rf2-gttif` gave: every term that has left or joined `c-local` left or joined
-> the seam it is divided by.
+> 0.058 lying wholly *below* it, so this window neither reproduces the
+> published ratio nor brackets it, and none of it is offered as confirmation.
+> What holds 0.9718 in place is not clock agreement but the reason `rf2-gttif`
+> gave, in the narrow form that reason actually takes: the keyword mint left
+> the copy and the seam alike, so it cancels out of the ratio. `rf2-lzpfj`'s
+> activation is the one term that did not move on both sides — it joined
+> `c-local` alone, restoring parity with work the seam was already performing,
+> and on this UIx host that work is expected at the noise floor. It was never a
+> term that joined both arms together.
 
 > **THE WHOLE RE-TAKE RAN ON THE WIDENED WINDOW, AND IT DOES NOT PUBLISH**
 > (`rf2-07rnj`, 2026-08-16, commit `a43aa8609f`, instrument blob


### PR DESCRIPTION
Repairs the two wording defects the merged-PR audit of #8327 found in the landed window note on `docs/design/hicasso/studio/the-cold-read-mount-term.md`.

**This is a prose and ledger repair, not a measurement window.** No reading was taken, no quiet box was requested or used, and no figure moves. Every number appearing in the diff was already on the page in the same role. One file, two paragraphs, 22 insertions / 9 deletions.

## Defect 1 — an arithmetically false claim

Verified at source before rewriting. The three measured `c-local`/`commit` p50 ratios on the page are **0.8864, 0.9444, 0.9189**; the published **0.9718** sits above their maximum. A spread lying wholly below a value brackets nothing.

Before:

> **The fidelity ratio is not restated either, and does not need to be.** It read 0.8864 / 0.9444 / 0.9189 against the published 0.9718 — a spread of 0.058 that loosely brackets it — and it stays common-mode for the reason `rf2-gttif` gave: every term that has left or joined `c-local` left or joined the seam it is divided by.

After:

> **The fidelity ratio is not restated either, and does not need to be.** It read 0.8864 / 0.9444 / 0.9189 against the published 0.9718 — a spread of 0.058 lying wholly *below* it, so this window neither reproduces the published ratio nor brackets it, and none of it is offered as confirmation. What holds 0.9718 in place is not clock agreement but the reason `rf2-gttif` gave, in the narrow form that reason actually takes: the keyword mint left the copy and the seam alike, so it cancels out of the ratio. `rf2-lzpfj`'s activation is the one term that did not move on both sides — it joined `c-local` alone, restoring parity with work the seam was already performing, and on this UIx host that work is expected at the noise floor. It was never a term that joined both arms together.

The common-mode explanation is narrowed per the audit: the old clause claimed *every* term that left or joined `c-local` did the same to the seam. The mint did; `rf2-lzpfj`'s activation joined the copy alone.

## Defect 2 — an unlicensed attribution

The page attributed the 0.100 ms spread solely to the instrument, on a "certified-quiet box", with "nothing changing between runs", and said more runs would not change that — while the same block records queue readings of 1, 1 and 2 and concedes two cannot be proven outside run 3's measurement phase.

Before:

> The `commit` arm's spread across three runs of one binary on a certified-quiet box is 0.100 ms — **four grid steps, in one session, with nothing changing between runs.** The effect commissioned for sight is 141 keyword mints, which this window's own micro readings price at 14–32 ns each (…): **0.002–0.005 ms/commit, an eighth of one grid step and about a thirtieth of the dispersion just quoted.** The term is not merely under the instrument's resolution — it is far under the instrument's own run-to-run noise, and more runs would not change that.

After:

> The `commit` arm's spread across three runs of one binary — one source file, one build, one session, no deliberate change between them — is 0.100 ms, **four grid steps.** The effect commissioned for sight is 141 keyword mints, which this window's own micro readings price at 14–32 ns each (…): **0.002–0.005 ms/commit, an eighth of one grid step and about a thirtieth of the dispersion just quoted.** What produced that dispersion this window does not establish. The instrument's own run-to-run variation is the leading candidate and the box was quiet on 82 of 85 samples — but two of the three non-zero readings cannot be placed outside run 3's measurement phase, and that is enough to keep residual load in the frame. **The refusal does not turn on which it is.** Under either cause the term is not merely below the window's resolution but far below its scatter, and more runs of this shape would only measure the scatter again. Separating the two causes would take a window built to do it, and would not bring this term into view.

## The refusal survives unweakened

Both paragraphs keep their operative sentence verbatim — "The two absolutes are not restated" and "The fidelity ratio is not restated either". The commissioned 0.002–0.005 ms/commit against the 0.025 ms grid is unchanged, and the changed-basis argument (`rf2-dabt3`'s retired index write, `rf2-lzpfj`'s added activation, the share column that cannot be repaired by re-measuring its denominator) is untouched. The repair strengthens the refusal's evidentiary footing rather than resting it on a false bracket or an unproven quiet box.

## Gates

`mkdocs build --strict` is **not** nominated — `exclude_docs` drops `docs/design/**`, so it does not cover this page.

| gate | exit | note |
|---|---|---|
| `python scripts/check_doc_slugs.py` | **0** | clean before and after; silent on success |
| `python scripts/check_doc_slugs.py` (fault planted) | **1** | proven live |
| `python scripts/check_provenance_pins.py` | **0** | 112 pages, 523 pins, 0 findings |
| `python scripts/check_provenance_pins.py` (fault planted) | **1** | proven live |
| `sh scripts/check-no-hardcoded-paths.sh` | **0** | portability gate OK |

Each exit code captured on the same command line as the gate; no gate piped into a filter.

**Both gates proven live against this worktree.** `check_doc_slugs` was run with a deliberate broken anchor appended to the target file: exit **1**, naming `docs/design/hicasso/studio/the-cold-read-mount-term.md:673 -> #rf2-d360z-no-such-heading-xyzzy`. `check_provenance_pins` was run with a paragraph pinning the stranded head `cb41ee537b` alone: exit **1**, naming the same file at line 673 as `[STRANDED]`. Both faults were restored from backup and the restore **verified by sha256** (`sha256sum -c` → OK, `94526b12…d12e`), then both gates re-run clean.

**Tables hand-verified** (nothing validates them in this tree). Every table block on the page is column-consistent — header, delimiter and body rows agree at 4/4, 3/3, 4/4, 4/4, 4/4, 3/3, 3/3, 7/7, 5/5, 2/2, 2/2, 3/3. This diff touches **no table**; both changed paragraphs are prose inside a blockquote.

## Declined

`§4`'s parallel sentence was checked and left alone — it says the arm's "own same-session dispersion is four grid steps against a prize an eighth of one" and makes neither the bracketing claim nor the sole-attribution claim, so correcting it would be scope expansion.
