### PR TITLE
fix(story): the play runner stops discarding settle failures (rf2-ek9qb, rf2-n0sz4)

### DIFF
--- a/tools/story/src/re_frame/story/play/runner_events.cljc
+++ b/tools/story/src/re_frame/story/play/runner_events.cljc
@@ -1263,6 +1263,45 @@
 ;;     `tape-evaluated-assertion?` branch is the single source of truth for
 ;;     that split).
 
+(defn- terminal-settle-refusal-record
+  "The assertion record for a terminal atom whose PRE-READ SETTLE refused or
+  threw — the record that carries a non-settled substrate into the unified
+  verdict. Pure data → data.
+
+  A terminal assertion is not a runner step stream, so the step-result
+  `settle-substrate-for-step!` hands back has nowhere to be recorded; the
+  ONE accumulator a terminal verdict is folded from is
+  `:rf.story/assertions`. This projects the refusal onto that accumulator
+  in the SAME shape every other refusal on the run path uses
+  (`exec-assert-browser-atom!`'s `:cannot-run` record, whose `:status` is
+  what `requirements/aggregate-status` reads), so a settle that never
+  happened reads as the distinct THIRD status rather than vanishing.
+
+  Two verdicts, matching the two ways `settle-to!` can decline (it never
+  refuses on `:provides` — `dispatch-and-settle!` owns that check):
+
+  - a flush that exceeded the hooks' `:timeout-ms` budget arrives as
+    `:cannot-run?` and records `:cannot-run` — the runner could not
+    establish the boundary it needed, and proved nothing;
+  - a flush that THREW arrives as a step-exception and records `:error` —
+    `:error` outranks everything in the aggregation rule, which is right:
+    a substrate that blew up mid-commit is not a refusal, it is a fault.
+
+  `atom-v` is a vector by construction — the settle only produces a
+  non-nil result for a boundary above `:headless`, and the only terminal
+  atoms that reach one are the DOM family, which `step-settle-boundary`
+  identifies by `(contains? dom-assertion-ids (first atom-v))`."
+  [atom-v settle-result]
+  (let [cannot-run? (boolean (:cannot-run? settle-result))]
+    (cond-> {:assertion (assertions/assertion-atom-id atom-v)
+             :payload   (vec (rest atom-v))
+             :passed?   false
+             :status    (if cannot-run? :cannot-run :error)
+             :reason    (or (:message settle-result)
+                            (str "the substrate did not settle before "
+                                 (pr-str atom-v)))}
+      cannot-run? (assoc :cannot-run? true))))
+
 (defn run-terminal-assertions!
   "Evaluate `frame-id`'s terminal handler-backed `:assertions` against the
   FINAL settled state, AFTER the script phase. `atoms` is the
@@ -1283,6 +1322,10 @@
   and never dispatches — the result boundary already evaluates them against
   the epoch tape from the plan, so they are NOT double-processed here.
 
+  A pre-read settle that REFUSED or THREW PREVENTS the assertion from
+  being evaluated at all, and lands as a `:cannot-run` / `:error` record
+  instead (`terminal-settle-refusal-record`). See the call site.
+
   Idempotent w.r.t. an empty / nil `atoms` (no-op). Production callers
   (Story disabled) no-op."
   [frame-id atoms]
@@ -1294,12 +1337,31 @@
         ;; gets (rf2-ek9qb). Without it the rule would be half-applied: a
         ;; terminal `:rf.assert/dom-*` would read whatever the DOM happened
         ;; to be when the script phase ended, which is settled only if the
-        ;; script's LAST step happened to be a DOM step. The result is
-        ;; discarded here exactly as the executor's own is — terminal
-        ;; assertions are not a runner step stream — and the commit is
-        ;; no-op-safe, so an already-settled substrate costs nothing.
-        (settle-substrate-for-step! frame-id idx step)
-        (exec-assert! frame-id idx step))))
+        ;; script's LAST step happened to be a DOM step.
+        ;;
+        ;; And the settle GATES the read. `exec-step!` has always short-
+        ;; circuited on a non-settled pre-step result — `(or (settle… ) …)`
+        ;; — but this path discarded the same result and evaluated anyway,
+        ;; so a terminal DOM assertion could still read, and record a PASS,
+        ;; over a substrate whose commit had just thrown or timed out. The
+        ;; settle failure then disappeared from the terminal verdict
+        ;; entirely: the step-result is dropped here by design (terminal
+        ;; assertions are not a runner step stream), and the executor's own
+        ;; record said only what the stale DOM happened to show. A pass
+        ;; earned against a substrate that never committed is exactly the
+        ;; false-GREEN class this bead exists to close, so the refusal now
+        ;; REPLACES the evaluation rather than preceding it.
+        ;;
+        ;; Inert on a settled substrate: the commit is no-op-safe and
+        ;; `settle-substrate-for-step!` returns nil below `:cljs-reactive`,
+        ;; so every headless run (JVM included) takes the `exec-assert!`
+        ;; arm unchanged.
+        (if-let [refused (settle-substrate-for-step! frame-id idx step)]
+          (assertions/record!
+            frame-id
+            (assoc (terminal-settle-refusal-record atom-v refused)
+                   :source-coord (:source (registrar/handler-meta :variant frame-id))))
+          (exec-assert! frame-id idx step)))))
   nil)
 
 ;; ---- single-step driver -------------------------------------------------

--- a/tools/story/src/re_frame/story/play/runner_events.cljc
+++ b/tools/story/src/re_frame/story/play/runner_events.cljc
@@ -1597,6 +1597,16 @@
   #{assertions/id-dom-text
     assertions/id-dom-visible})
 
+(defn- atom-required-selector
+  "The DOM selector an assertion ATOM must be able to resolve before it can
+  be evaluated, or nil when absence is acceptable — or, for
+  `:rf.assert/dom-hidden`, is the whole point. Pure data → data; tolerant
+  of a malformed / non-vector atom."
+  [atom-v]
+  (when (and (vector? atom-v)
+             (contains? presence-required-selector-atoms (first atom-v)))
+    (nth atom-v 1 nil)))
+
 (defn- step-required-selector
   "The DOM selector `step` must be able to resolve before it can run, or
   nil when the step needs no node present.
@@ -1605,16 +1615,33 @@
   is not there, and the presence-asserting half of the DOM assertion
   family — reading the selector out of the FOLDED atom
   (`[:rf.assert/dom-* selector & args]`, `exec-assert-dom-atom!`'s own
-  shape) as well as off a raw shipping step that bypassed folding."
+  shape) as well as off a raw shipping step that bypassed folding.
+
+  ONE STEP, ONE MEANING, whichever entry path supplied it. The runtime
+  normally consumes a folded plan, but `run!` documents and accepts a
+  hand-built `spec` and does NOT fold it, so a raw
+  `[:assert-dom selector :hidden]` can reach the run-loop verbatim. Read
+  as a bare selector that step demands a node be PRESENT — inverting the
+  one assertion whose pass condition is absence, and burning the entire
+  `settle-poll-timeout-ms` budget waiting for a node the author declared
+  should not be there, where the identical assertion in folded form passes
+  immediately (rf2-n0sz4, audit #8319). So the raw step is folded here
+  through the SAME `fold-assert-step` `exec-step!` will apply to it, and
+  the presence requirement is read off the canonical atom — rather than a
+  second, mode-blind notion of 'this one needs a node'.
+
+  Tolerant: a malformed `:assert-dom` (missing or unknown mode) folds by
+  throwing, which must not become this fn's problem — it reads as 'no
+  node required' so the step reaches the executor that reports it
+  properly, instead of timing out on a precondition first."
   [step]
   (case (runner/step-type step)
     (:click :type :focus) (runner/step-selector step)
-    :assert               (let [atom-v (runner/step-assertion step)]
-                            (when (and (vector? atom-v)
-                                       (contains? presence-required-selector-atoms
-                                                  (first atom-v)))
-                              (nth atom-v 1 nil)))
-    :assert-dom           (runner/step-selector step)
+    :assert               (atom-required-selector (runner/step-assertion step))
+    :assert-dom           (atom-required-selector
+                            (try (runner/step-assertion
+                                   (assertions/fold-assert-step step))
+                                 (catch #?(:clj Throwable :cljs :default) _ nil)))
     nil))
 
 (defn- step-precondition-unmet
@@ -1676,7 +1703,10 @@
   advancing the cursor; `settle-deadline` carries the wall-clock bound
   across those re-entries and is nil whenever the loop is not mid-poll.
   Exhausting the bound FAILS the step readably (rf2-n0sz4) — it is never
-  a silent proceed, and never a silent pass."
+  a silent proceed, and never a silent pass. A poll whose own COMMIT
+  fails reports that failure verbatim and advances, rather than
+  re-running a broken flush until the budget expires and then reporting
+  the timeout in its place."
   ([frame-id play-key token done-cb] (run-loop! frame-id play-key token done-cb nil))
   ([frame-id play-key token done-cb settle-deadline]
   (let [state (current-state-for-play frame-id play-key)]
@@ -1731,17 +1761,40 @@
                     (or (nil? settle-deadline)
                         (< (interop/now-ms) settle-deadline)))
                (let [deadline (or settle-deadline
-                                  (+ (interop/now-ms) settle-poll-timeout-ms))]
-                 ;; Commit anything the substrate has already scheduled. This
-                 ;; is rf2-ek9qb's own rung, reused: on a rAF-scheduled
-                 ;; substrate in a throttled tab the pending render would
-                 ;; otherwise never land no matter how long we yielded. Its
-                 ;; refusal result is deliberately discarded — `exec-step!`
-                 ;; establishes the same boundary and reports a refusal
-                 ;; properly when the step actually runs.
-                 (settle-substrate-for-step! frame-id idx step)
-                 (js/setTimeout
-                   #(run-loop! frame-id play-key token done-cb deadline) 0))
+                                  (+ (interop/now-ms) settle-poll-timeout-ms))
+                     ;; Commit anything the substrate has already scheduled.
+                     ;; This is rf2-ek9qb's own rung, reused: on a
+                     ;; rAF-scheduled substrate in a throttled tab the
+                     ;; pending render would otherwise never land no matter
+                     ;; how long we yielded.
+                     refused  (settle-substrate-for-step! frame-id idx step)]
+                 (if refused
+                   ;; THE COMMIT ITSELF FAILED — a flush threw, or blew its
+                   ;; boundary budget. Record that exact result and advance.
+                   ;;
+                   ;; This used to be discarded, on the reasoning that
+                   ;; `exec-step!` establishes the same boundary and would
+                   ;; report the refusal properly when the step ran. It is
+                   ;; the precondition that makes that false: a step parks
+                   ;; here precisely because it is NOT running yet, and a
+                   ;; selector that stays absent never reaches `exec-step!`
+                   ;; at all. So the loop re-ran the same broken flush every
+                   ;; tick for the whole budget and then replaced a named,
+                   ;; actionable settle error with the generic "preconditions
+                   ;; never settled" timeout — the true cause discarded and
+                   ;; the symptom reported in its place (rf2-n0sz4, audit
+                   ;; #8319).
+                   ;;
+                   ;; Advancing is right, not merely convenient: polling
+                   ;; exists to wait out work that is IN FLIGHT, and a commit
+                   ;; that threw is not in flight. Waiting out the budget
+                   ;; could only re-throw.
+                   (do
+                     (record-result! frame-id play-key nm idx step refused)
+                     (js/setTimeout
+                       #(run-loop! frame-id play-key token done-cb nil) 0))
+                   (js/setTimeout
+                     #(run-loop! frame-id play-key token done-cb deadline) 0)))
 
                ;; Budget exhausted. FAIL LOUDLY, naming what never settled —
                ;; never a silent proceed onto a stale read (which is what a

--- a/tools/story/test/re_frame/story/play/run_loop_settle_cljs_test.cljs
+++ b/tools/story/test/re_frame/story/play/run_loop_settle_cljs_test.cljs
@@ -1,0 +1,240 @@
+(ns re-frame.story.play.run-loop-settle-cljs-test
+  "rf2-n0sz4 (merged-PR audit #8319) — the run-loop's precondition POLL,
+  driven end to end.
+
+  The sibling `step-settle-cljs-test` witnesses the poll's DECISION
+  (`step-precondition-unmet` / `step-required-selector`) as pure reads, on
+  both runtimes. That is the right shape for a decision, and it is not
+  enough for the two defects the audit named: both are about what the LOOP
+  does with an answer, and neither is reachable without actually running a
+  script. So these witnesses drive `run!` and read the recorded results.
+
+  ## Why this file is `.cljs` and needs a `document`
+
+  The whole precondition mechanism is reader-gated to CLJS — the JVM
+  runner has no event loop to yield to and no DOM, so every precondition
+  reads as met there and the loop never polls. The JVM lane therefore
+  cannot witness any of this, and a `.cljc` would only pretend otherwise.
+
+  A DOM is needed for a sharper reason than 'these are DOM steps'. The
+  node runtime's only reachable unmet precondition is the event queue,
+  which is global to every step in the script and clears itself within a
+  tick — it cannot express 'this selector is absent, and stays absent',
+  which is the exact state both defects live in. So the fixture installs a
+  `document` whose every query MISSES: `dom-available?` reads true, and
+  the selector precondition is then genuinely, permanently unmet. Nothing
+  is faked about the code under test — only the environment it reads.
+
+  ## No timings
+
+  A budget-exhausted poll is 2 seconds of wall clock, so a red run here is
+  slow. That is a property of the defect, not of the assertions: nothing
+  below asserts on elapsed time. The witnesses read the RECORDED RESULTS —
+  how many, in what order, carrying which message — which is the same
+  discipline the sibling file states and for the same reason."
+  (:require [cljs.test :refer [async deftest is testing use-fixtures]]
+            [goog.object :as gobj]
+            [re-frame.core :as rf]
+            [re-frame.frame :as frame]
+            [re-frame.registrar :as registrar]
+            [re-frame.story :as story]
+            [re-frame.story.late-bind :as late-bind]
+            [re-frame.story.play.runner-events :as re]
+            [re-frame.substrate.plain-atom :as plain-atom]))
+
+(def ^:private run-frame :story.run-loop-settle/frame)
+
+(def ^:private absent-selector
+  "A selector that will never resolve — the fixture's `document` misses on
+  everything, so a step demanding this node waits forever."
+  "[data-test=gone]")
+
+(defn- missing-everything-document
+  "A `document` that answers every query with a miss. Enough for
+  `dom/dom-available?` (which probes for `.querySelector`) and for
+  `dom/query` / `dom/query-all`, which is the whole surface the
+  precondition and the DOM executor touch."
+  []
+  #js {:querySelector    (fn [_] nil)
+       :querySelectorAll (fn [_] #js [])})
+
+(defn- setup! []
+  (story/clear-all!)
+  (registrar/clear-all!)
+  (reset! frame/frames {})
+  (try (rf/init! plain-atom/adapter) (catch :default _ nil))
+  (reset! re/run-state {})
+  (re/clear-all-runs!)
+  (reset! re/step-boundaries {})
+  (story/install-canonical-vocabulary!)
+  (frame/ensure-default-frame!)
+  (rf/make-frame {:id run-frame :doc "run-loop settle witness frame"})
+  (rf/reg-event :run-loop-settle/inc
+                (fn [{:keys [db]} _] {:db (update db :n (fnil inc 0))})))
+
+;; Snapshot the whole late-bind map rather than `clear!`-ing it: the wipe
+;; would take the canonical shims every sibling ns registers at load time
+;; with it, and outlive this ns in a shared runtime.
+(def ^:private saved-hooks (atom nil))
+
+(use-fixtures :each
+  {:before (fn []
+             (reset! saved-hooks @late-bind/hooks)
+             ;; The `document` goes in AFTER the Story runtime is seated.
+             ;; Xray rides Story's package graph and probes for its inline
+             ;; layout host as the runtime installs; finding a document
+             ;; that misses on every selector, it reports an actionable
+             ;; `console.error`. Correct behaviour, irrelevant here, and
+             ;; noise on an otherwise-silent green run — so the fixture
+             ;; simply does not present a document until the probe is past.
+             (setup!)
+             (gobj/set js/globalThis "document" (missing-everything-document)))
+   :after  (fn []
+             (js-delete js/globalThis "document")
+             (reset! late-bind/hooks @saved-hooks)
+             (re/clear-all-runs!)
+             (try (rf/destroy-adapter!) (catch :default _ nil)))})
+
+(defn- install-hooks!
+  "Seat `hooks` as the active flush-hooks for every frame — the producer
+  seam a live adapter fills."
+  [hooks]
+  (late-bind/set-fn! :settled-boundary-hooks (fn [_frame-id] hooks)))
+
+(defn- run-script!
+  "Drive `script` as a HAND-BUILT spec through the explicit-spec arity of
+  `run!` — deliberately, since that is the entry path that does not fold,
+  and the one the raw-`:assert-dom` defect lives behind."
+  [script done-cb]
+  (re/run! run-frame "witness" {:name "witness" :script script} done-cb))
+
+(defn- message-of [result]
+  (str (:message result)))
+
+;; ===========================================================================
+;; 1. THE RAW HIDDEN ARM — one step must not mean two things
+;; ===========================================================================
+
+(deftest raw-assert-dom-hidden-passes-on-absence
+  (testing "WITNESS (rf2-n0sz4, audit #8319): `[:assert-dom sel :hidden]`
+            handed to `run!` as an explicit spec is never folded, so the
+            run-loop sees it raw. Read as a bare selector it demanded the
+            node be PRESENT — so the runner waited out the entire settle
+            budget for a node the author had just declared should not be
+            there, and then failed the step. The identical assertion
+            through the folded entry path passes immediately. Behaviour
+            must not depend on which supported entry path supplied the
+            same step"
+    (async done
+      (run-script!
+        [[:assert-dom absent-selector :hidden]]
+        (fn [final]
+          (is (= 1 (count (:results final))))
+          (let [r (first (:results final))]
+            (is (true? (:passed? r))
+                (str "an absent node is this assertion's PASS condition; got "
+                     (message-of r)))
+            (is (not (re-find #"never settled" (message-of r)))
+                "and it must not have waited on a presence precondition"))
+          (is (= :pass (:status final)))
+          (done))))))
+
+(deftest raw-assert-dom-text-still-waits-for-its-node
+  (testing "the repair is mode-aware, not blanket. The presence-asserting
+            half of the family still demands its node through the raw
+            entry path — otherwise `:text` / `:visible` would read a DOM
+            that had not rendered yet, which is the race the poll exists
+            to close"
+    (async done
+      (run-script!
+        [[:assert-dom absent-selector :text "42"]]
+        (fn [final]
+          (let [r (first (:results final))]
+            (is (false? (:passed? r)))
+            (is (re-find #"never settled" (message-of r))
+                "the presence precondition was enforced and timed out"))
+          (done))))))
+
+;; ===========================================================================
+;; 2. A FAILING COMMIT UNDER AN UNMET PRECONDITION
+;; ===========================================================================
+
+(deftest a-failing-commit-while-the-selector-is-absent-is-recorded-verbatim
+  (testing "WITNESS (rf2-n0sz4, audit #8319): while a precondition is unmet
+            the poll commits the substrate and used to DISCARD the result,
+            on the reasoning that `exec-step!` establishes the same
+            boundary and would report the refusal when the step ran. The
+            precondition is what makes that false — a step parks here
+            precisely because it is not running, and a selector that stays
+            absent never reaches `exec-step!` at all. So the loop re-ran
+            the same broken flush every tick for the whole budget and then
+            reported the generic precondition timeout in place of the real
+            settle error: the true cause discarded, the symptom recorded"
+    (async done
+      (install-hooks!
+        {:provides :dom
+         :flush!   {:dom (fn [_] (throw (ex-info "commit blew up" {})))}})
+      (run-script!
+        [[:assert-dom absent-selector :text "42"]]
+        (fn [final]
+          (is (= 1 (count (:results final)))
+              "the failing commit was recorded ONCE, then the loop advanced")
+          (let [r (first (:results final))]
+            (is (true? (:exception r))
+                "the settle's own exception — the exact result, not a projection")
+            (is (re-find #"commit blew up" (message-of r))
+                (str "the run must name what actually failed; got " (message-of r)))
+            (is (not (re-find #"never settled" (message-of r)))
+                "and must NOT have replaced it with the generic timeout"))
+          (done))))))
+
+(deftest a-refusing-commit-while-the-selector-is-absent-is-recorded-verbatim
+  (testing "the other way a commit declines — an over-budget flush phase.
+            `settle-to!` returns the fail-closed `:flush-timeout` refusal,
+            which is a `:cannot-run`, so the step reads as the distinct
+            THIRD status naming the boundary it could not reach rather
+            than as an un-settleable precondition"
+    (async done
+      (install-hooks!
+        {:provides :dom :timeout-ms -1 :flush! {:dom (fn [_] nil)}})
+      (run-script!
+        [[:assert-dom absent-selector :text "42"]]
+        (fn [final]
+          (is (= 1 (count (:results final))))
+          (let [r (first (:results final))]
+            (is (true? (:cannot-run? r)))
+            (is (= :flush-timeout (:reason r)))
+            (is (not (re-find #"never settled" (message-of r)))))
+          (done))))))
+
+;; ===========================================================================
+;; 3. THE GENUINE TIMEOUT STILL ADVANCES — EXACTLY ONCE
+;; ===========================================================================
+
+(deftest a-genuine-precondition-timeout-advances-exactly-once
+  (testing "the useful bounded poll is kept, and its failure path is pinned
+            from both sides. With a commit that SUCCEEDS, an absent
+            selector is a real un-settleable precondition: the step fails
+            readably naming what never settled, contributes exactly ONE
+            record (not one per poll tick), and the loop advances so the
+            FOLLOWING step still runs — a failed precondition fails its own
+            step, never the rest of the script"
+    (async done
+      (install-hooks! {:provides :dom :flush! {:dom (fn [_] nil)}})
+      (run-script!
+        [[:assert-dom absent-selector :text "42"]
+         [:dispatch-sync [:run-loop-settle/inc]]]
+        (fn [final]
+          (is (= 2 (count (:results final)))
+              "one record for the timed-out step, one for the step after it")
+          (is (= 2 (:step-idx final))
+              "the cursor advanced past both — no step was walked twice")
+          (let [r (first (:results final))]
+            (is (false? (:passed? r)))
+            (is (re-find #"never settled" (message-of r)))
+            (is (re-find (re-pattern absent-selector) (message-of r))
+                "and the message names the precondition that never held"))
+          (is (= 1 (:n (rf/app-db-value run-frame)))
+              "the FOLLOWING step really ran — the timeout failed its own
+               step, not the script")
+          (done))))))

--- a/tools/story/test/re_frame/story/play/step_settle_cljs_test.cljc
+++ b/tools/story/test/re_frame/story/play/step_settle_cljs_test.cljc
@@ -101,14 +101,32 @@
              [:assert [:rf.assert/dom-visible "[data-test=out]"]]))))
   (testing "a raw shipping :assert-dom step that bypassed folding is covered too"
     (is (= "[data-test=out]"
-           (step-required-selector [:assert-dom "[data-test=out]" :text "42"])))))
+           (step-required-selector [:assert-dom "[data-test=out]" :text "42"])))
+    (is (= "[data-test=out]"
+           (step-required-selector [:assert-dom "[data-test=out]" :visible])))))
 
 (deftest dom-hidden-must-not-wait-for-the-node
   (testing "THE TRAP. An ABSENT node is :rf.assert/dom-hidden's PASS
             condition. Waiting for one to appear would invert the assertion
             and burn the whole budget doing it, so it is excluded"
     (is (nil? (step-required-selector
-                [:assert [:rf.assert/dom-hidden "[data-test=gone]"]])))))
+                [:assert [:rf.assert/dom-hidden "[data-test=gone]"]]))))
+  (testing "AND IN RAW FORM, which is the half audit #8319 caught. `run!`
+            documents and accepts a hand-built spec and does not fold it, so
+            this shape reaches the run-loop verbatim. Read as a bare
+            selector it demanded the node be PRESENT — inverting the
+            assertion, burning the whole budget, and failing a script that
+            passes character-for-character through the folded entry path.
+            One step must not mean two things"
+    (is (nil? (step-required-selector [:assert-dom "[data-test=gone]" :hidden])))))
+
+(deftest a-malformed-assert-dom-waits-for-nothing
+  (testing "tolerant: an :assert-dom the fold cannot parse (missing mode,
+            unknown mode) reads as needing no node, so it reaches the
+            executor that reports it properly rather than timing out on a
+            precondition first"
+    (is (nil? (step-required-selector [:assert-dom "[data-test=x]"])))
+    (is (nil? (step-required-selector [:assert-dom "[data-test=x]" :sideways])))))
 
 (deftest non-dom-steps-require-no-node
   (testing "a step naming no node waits for no node"

--- a/tools/story/test/re_frame/story/play/substrate_boundary_cljs_test.cljc
+++ b/tools/story/test/re_frame/story/play/substrate_boundary_cljs_test.cljc
@@ -27,11 +27,14 @@
   why the JVM can witness it."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
+            [re-frame.frame :as frame]
+            [re-frame.story :as story]
             [re-frame.story.assertions :as assertions]
             [re-frame.story.late-bind :as late-bind]
             [re-frame.story.play.runner-events :as runner-events]
             [re-frame.story.play.settled-boundary :as boundary]
             [re-frame.story.play.substrate-boundary :as substrate-boundary]
+            [re-frame.story.requirements :as requirements]
             [re-frame.substrate.plain-atom :as plain-atom]))
 
 ;; ---- harness -------------------------------------------------------------
@@ -224,3 +227,159 @@
           res   (boundary/settle-to! :f hooks :dom)]
       (is (= :cannot-run (:status res)))
       (is (= :flush-timeout (:reason res))))))
+
+;; ===========================================================================
+;; THE TERMINAL PATH — where the settle used to be asked and then ignored
+;; ===========================================================================
+;;
+;; Merged-PR audit #8313 reopened this bead on one missed path.
+;; `exec-step!` short-circuits correctly — `(or (settle-substrate-for-step!
+;; …) (case stype …))`, so an in-script DOM checkpoint cannot run against a
+;; substrate that failed to commit. `run-terminal-assertions!` called the
+;; SAME settle, DISCARDED its result, and then called `exec-assert!`
+;; unconditionally. The audit's control redefined the settle to error and
+;; the executor to record its invocation, and got `[:settle-error
+;; :assert-ran]` back: both ran.
+;;
+;; Two consequences, and the second is the one that bites. The assertion
+;; READ a substrate whose commit had just thrown or timed out — so it could
+;; record a PASS it had not earned. And the settle failure itself
+;; disappeared: terminal assertions are not a runner step stream, so the
+;; discarded step-result had nowhere to land, and the ONE accumulator the
+;; terminal verdict is folded from (`:rf.story/assertions`) never heard
+;; about it. A DOM-family atom records NOTHING under a headless runner (the
+;; executor's own `{:skipped? true}` branch declines to mint a vacuous
+;; record), which is precisely why the witnesses below can count: before
+;; the repair the accumulator held ZERO records for a failed settle, after
+;; it holds exactly one carrying the refusal.
+
+(def ^:private terminal-frame
+  "A real registered frame — `assertions/record!` lands its record by
+  dispatching into the frame's app-db, and swallows the dispatch when the
+  frame is gone. `:f` (which every test above uses) is never registered:
+  fine for the settle-count witnesses, useless for a record witness."
+  :story.substrate-boundary/terminal)
+
+(defn- terminal-frame!
+  "Seat the adapter, (re-)register `terminal-frame`, and install the
+  canonical assertion vocabulary so `::append` has a handler. Called per
+  test rather than from the fixture: the fixture is shared with the
+  settle-count witnesses above, which deliberately run with no frame."
+  []
+  (rf/init! (committing-adapter))
+  (story/install-canonical-vocabulary!)
+  (frame/ensure-default-frame!)
+  (swap! frame/frames dissoc terminal-frame)
+  (rf/make-frame {:id terminal-frame :doc "terminal-assertion settle witness"}))
+
+(defn- install-hooks!
+  "Register `hooks` as the active flush-hooks for every frame."
+  [hooks]
+  (late-bind/set-fn! :settled-boundary-hooks (fn [_frame-id] hooks)))
+
+(defn- terminal-records []
+  (vec (:rf.story/assertions (rf/app-db-value terminal-frame))))
+
+(def ^:private terminal-dom-atom
+  "The terminal counterpart of `dom-assert-step` — a bare DOM-family atom,
+  the shape `[:expect :assertions]` carries."
+  [assertions/id-dom-text "[data-test=x]" "42"])
+
+(deftest terminal-assertion-refuses-when-the-commit-throws
+  (testing "WITNESS (rf2-ek9qb, audit #8313): a terminal DOM assertion whose
+            pre-read settle THREW must not be evaluated, and the failure
+            must reach the unified verdict. Before the repair the throw was
+            discarded and the accumulator held nothing at all — the run
+            reported on a substrate that had blown up mid-commit as though
+            nothing had happened"
+    (terminal-frame!)
+    (install-hooks! {:provides :dom
+                     :flush!   {:dom (fn [_] (throw (ex-info "commit blew up" {})))}})
+    (runner-events/run-terminal-assertions! terminal-frame [terminal-dom-atom])
+    (let [recs (terminal-records)]
+      (is (= 1 (count recs))
+          "the settle failure reached the ONE terminal accumulator")
+      (is (= assertions/id-dom-text (:assertion (first recs)))
+          "recorded against the atom it refused, not a synthetic id")
+      (is (= :error (:status (first recs))))
+      (is (false? (:passed? (first recs))))
+      (is (= :error (requirements/aggregate-status recs nil))
+          "and folds to :error through the ONE aggregation rule — a
+           substrate that threw mid-commit is a fault, not a refusal"))))
+
+(deftest terminal-assertion-refuses-when-the-commit-times-out
+  (testing "WITNESS (rf2-ek9qb, audit #8313): the same for the other way a
+            settle declines — an over-budget flush phase. `settle-to!`
+            returns the fail-closed :flush-timeout refusal, so the terminal
+            verdict must read :cannot-run: the runner could not establish
+            the boundary the assertion needed, and therefore proved nothing"
+    (terminal-frame!)
+    (install-hooks! {:provides   :dom
+                     :timeout-ms -1
+                     :flush!     {:dom (fn [_] nil)}})
+    (runner-events/run-terminal-assertions! terminal-frame [terminal-dom-atom])
+    (let [recs (terminal-records)]
+      (is (= 1 (count recs)))
+      (is (= :cannot-run (:status (first recs))))
+      (is (true? (:cannot-run? (first recs))))
+      (is (= :cannot-run (requirements/aggregate-status recs nil))
+          "the distinct THIRD status — never a silent pass"))))
+
+(deftest a-settled-terminal-assertion-still-evaluates
+  (testing "the repair must not over-fire. With a commit that SUCCEEDS the
+            terminal path is exactly what it was: the substrate is asked to
+            commit, and the executor — not a refusal record — owns the
+            verdict. Under a headless runner that DOM executor declines to
+            mint a record at all, so an empty accumulator here is the proof
+            that nothing was refused"
+    (terminal-frame!)
+    (install-hooks! {:provides :dom :flush! {:dom (fn [_] nil)}})
+    (reset! commits 0)
+    (runner-events/run-terminal-assertions! terminal-frame [terminal-dom-atom])
+    (is (empty? (terminal-records))
+        "no refusal record was minted for a settle that succeeded")))
+
+(deftest a-headless-terminal-assertion-is-untouched
+  (testing "the JVM / node-runtime path is unchanged: below :cljs-reactive
+            `settle-substrate-for-step!` returns nil without consulting a
+            hook, so a handler-backed terminal atom takes the same
+            `exec-assert!` arm it always did — even under hooks whose :dom
+            flush would throw if it were ever reached"
+    (terminal-frame!)
+    (install-hooks! {:provides :dom
+                     :flush!   {:dom (fn [_] (throw (ex-info "must not run" {})))}})
+    (rf/reg-event ::seed (fn [{:keys [db]} [_ m]] {:db (merge db m)}))
+    (rf/dispatch-sync [::seed {:status :loaded}] {:frame terminal-frame})
+    (runner-events/run-terminal-assertions!
+      terminal-frame [[:rf.assert/path-equals [:status] :loaded]])
+    (let [recs (filterv #(= :rf.assert/path-equals (:assertion %)) (terminal-records))]
+      (is (= 1 (count recs)) "the handler-backed atom recorded exactly once")
+      (is (true? (:passed? (first recs)))
+          "and it PASSED — the :dom flush was never consulted"))))
+
+#?(:clj
+   (deftest jvm-only-a-refused-terminal-settle-never-reaches-the-executor
+     ;; JVM-ONLY, and the name says so. The audit's control is the only
+     ;; direct read of "did `exec-assert!` run?": a DOM-family atom records
+     ;; nothing under a headless runner either way, so the count witnesses
+     ;; above prove the failure ARRIVES without proving the evaluation was
+     ;; PREVENTED. Var redefinition answers that — and only on the JVM.
+     ;; `with-redefs` in CLJS mutates a var whose call sites the compiler
+     ;; may already have inlined (`:static-fns`), so a spy that never fires
+     ;; would read as a PASS there: a false green, which is worse than no
+     ;; witness at all.
+     (testing "WITNESS (rf2-ek9qb, audit #8313): the refusal REPLACES the
+               evaluation. The audit's control got [:settle-error
+               :assert-ran] from the landed fn — both ran"
+       (terminal-frame!)
+       (install-hooks! {:provides :dom
+                        :flush!   {:dom (fn [_] (throw (ex-info "commit blew up" {})))}})
+       (let [ran (atom [])]
+         (with-redefs-fn {#'runner-events/exec-assert!
+                          (fn [_frame-id _idx _step] (swap! ran conj :assert-ran) nil)}
+           (fn []
+             (runner-events/run-terminal-assertions! terminal-frame [terminal-dom-atom])))
+         (is (= [] @ran)
+             "the assertion executor was NOT invoked behind a failed settle")
+         (is (= [:error] (mapv :status (terminal-records)))
+             "and the refusal is what the terminal verdict folds")))))


### PR DESCRIPTION
Two P2 bugs in the Story play runner, both reopened by a merged-PR audit, both
living in `tools/story/src/re_frame/story/play/runner_events.cljc`. They share
one shape — a failure result computed and then dropped — so they are held
together to keep them off each other's toes, and split into one commit each to
keep their scopes apart.

## rf2-ek9qb — a refused terminal settle blocks the assertion, not just precedes it

Reopened by merged-PR audit #8313 on one missed path. `exec-step!` has always
short-circuited on a non-settled pre-step result. `run-terminal-assertions!`
called the same settle, DISCARDED its result, and called `exec-assert!`
unconditionally — so a terminal `:rf.assert/dom-*` still read the DOM, and could
record a PASS, after `flush-render!` threw or `settle-to!` returned
`:cannot-run` / `:flush-timeout`. The settle failure then vanished from the
verdict entirely: terminal assertions are not a runner step stream, so the
dropped step-result had nowhere to land, and `:rf.story/assertions` — the one
accumulator the terminal verdict folds — never heard about it.

A refused or thrown pre-read now REPLACES the evaluation with a record carrying
the refusal: `:cannot-run` for a flush that blew its budget, `:error` for one
that threw. Both ride the `:status` field `requirements/aggregate-status`
already reads.

Inert on the settled path — `settle-substrate-for-step!` returns nil below
`:cljs-reactive`, so the whole JVM lane takes the `exec-assert!` arm unchanged.

## rf2-n0sz4 — a step means one thing, and a failed commit is not a timeout

Reopened by merged-PR audit #8319 on two concrete gaps.

**One step, one meaning.** `run!` documents and accepts a hand-built spec and
does not fold it, so a raw `[:assert-dom sel :hidden]` reaches the run-loop
verbatim. `step-required-selector` read every raw `:assert-dom` as
presence-requiring — inverting the one assertion whose pass condition is
ABSENCE, burning the full 2s budget on a node the author declared should not be
there, and failing a script that passes character-for-character through the
folded path. The raw arm now folds through the same `fold-assert-step`
`exec-step!` applies and reads the requirement off the canonical atom.

**A failed commit is not a timeout.** While a precondition was unmet the poll
committed the substrate and discarded the result, on the reasoning that
`exec-step!` would report the refusal when the step ran. The precondition is
what makes that false: a step parks there precisely because it is not running,
and a selector that stays absent never reaches `exec-step!` at all. The loop
re-ran the same broken flush every tick, then reported the generic
"preconditions never settled" message in place of the real settle error. It now
records that exact result and advances.

No new public rung verb, timer API or generalized scheduler — the bead is
explicit about that, and the bounded observed-condition poll is otherwise
untouched.

## Witnesses, and that each can go RED

Every witness below was proved red by planting its defect back and re-running.

| Witness | Lane | Red when |
|---|---|---|
| `terminal-assertion-refuses-when-the-commit-throws` | JVM + CLJS (`.cljc`) | settle result discarded → 0 records, not 1 |
| `terminal-assertion-refuses-when-the-commit-times-out` | JVM + CLJS (`.cljc`) | same |
| `a-settled-terminal-assertion-still-evaluates` | JVM + CLJS (`.cljc`) | guard against the repair over-firing |
| `a-headless-terminal-assertion-is-untouched` | JVM + CLJS (`.cljc`) | guard on the unchanged headless arm |
| `jvm-only-a-refused-terminal-settle-never-reaches-the-executor` | JVM only | executor spy records `[:assert-ran]` |
| `dom-hidden-must-not-wait-for-the-node` (raw arm) | JVM + CLJS (`.cljc`) | raw arm mode-blind |
| `a-malformed-assert-dom-waits-for-nothing` | JVM + CLJS (`.cljc`) | fold throws out of the poll |
| `raw-assert-dom-hidden-passes-on-absence` | CLJS only | raw arm mode-blind → 2s timeout, `:fail` |
| `raw-assert-dom-text-still-waits-for-its-node` | CLJS only | control — the repair must stay mode-aware |
| `a-failing-commit-…-recorded-verbatim` (throw) | CLJS only | poll discards → generic timeout message |
| `a-refusing-commit-…-recorded-verbatim` (timeout) | CLJS only | same |
| `a-genuine-precondition-timeout-advances-exactly-once` | CLJS only | double-record mutation → 3 results, following step never runs |

The prevention half of rf2-ek9qb is JVM-only and the name says so: a DOM-family
atom records nothing under a headless runner either way, so the counting
witnesses prove the failure ARRIVES without proving the evaluation was
PREVENTED. Var redefinition answers that, and only on the JVM — `with-redefs` in
CLJS mutates a var whose call sites the compiler may have inlined, so a spy that
never fired would read as a false PASS.

The new CLJS file installs a `document` that misses on every query. The node
runtime's only otherwise-reachable unmet precondition is the event queue, which
is global to every step and clears itself within a tick; it cannot express "this
selector is absent and stays absent", which is the state both defects live in.
Only the environment is faked, never the code under test.
## Quality gates

All run in the foreground to completion from this worktree
(`C:/Users/miket/code/re-frame2-worktrees/w-story-settle`), each redirected to
its own file with `$?` captured on the same command line.

| Gate | Runner arm | Captured exit |
|---|---|---|
| `clojure -M:test` (from `tools/story`) | JVM — loads `.clj` + `.cljc` | **0** — 1861 tests, 6809 assertions |
| `npm run test:cljs` (from `implementation`) | CLJS `:node-test` — loads `.cljs` + `.cljc` | **0** — 13954 tests, 70277 assertions |
| `npm run test:story-play-scripts` | Playwright browser lane | **0** — 30 `:play-script` rows, 0 unexpected |
| `sh scripts/check-no-hardcoded-paths.sh` | — | **0** |

Which arm ran what, since `runner_events.cljc` is `.cljc` and `clojure -M:test`
cannot load a `.cljs` file:

- `substrate_boundary_cljs_test.cljc` and `step_settle_cljs_test.cljc` run under
  BOTH arms — `.cljc` for the JVM lane, `*_cljs_test` so the `:node-test`
  build's `cljs-test$` ns-regexp discovers them too.
- `run_loop_settle_cljs_test.cljs` runs under the CLJS arm ONLY, and must: the
  whole precondition mechanism is reader-gated to CLJS, so a `.cljc` would only
  pretend the JVM was witnessing it. Confirmed running there — the focused
  `node out/node-test.js --test=re-frame.story.play.run-loop-settle-cljs-test`
  reports `Ran 5 tests containing 20 assertions`.
- The one JVM-only witness carries `jvm-only-` in its name and the reason in a
  comment.

The browser lane is included because it is the gate rf2-n0sz4's description
names, and it is where the fixture that motivated the bead lives:
`story.counter-play-script/dom[type-click-and-assert-dom]` passes at 7 steps
with no `[:wait ms]`.

The `npm ci --prefix implementation` in this worktree is a real install, never a
junction into the mayor checkout; the mayor's `implementation/node_modules`
reads 101 before and after.

No `*.spec.cjs` added — new Story tests are CLJS unit tests per the standing
ruling.
