### PR TITLE
fix(hicasso): the test kit owes the runtime's id at a boundary's props (rf2-dr0ad)

### DIFF
--- a/implementation/hicasso/test/re_frame/hicasso/test_kit_runtime_parity_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/test_kit_runtime_parity_cljs_test.cljs
@@ -148,6 +148,8 @@
 
 (h/defhost a-host js/Object {:server :client-only})
 
+(h/defview a-boundary [props] [:i (str (:x props))])
+
 (defn- raw-component [] nil)
 
 (def ^:private v ht/tree-version)
@@ -318,6 +320,45 @@
                   "ALONE. `:where` is the KIT, on the `defhost` row's "
                   "precedent: what is borrowed is the id and the advice, never "
                   "the raising site.")}
+
+   {:case    "an unforced `delay` in a BOUNDARY's PROPS — the row both sides refuse"
+    :form    [a-boundary {:x (delay 1)}]
+    :runtime [:refused :rf.error/hicasso-deferred-read-at-boundary
+              :hand-a-function-or-deref-it-in-this-body]
+    :refuses {:rf.error/id :rf.error/hicasso-deferred-read-at-boundary
+              :where       're-frame.hicasso.test
+              :recovery    :hand-a-function-or-deref-it-in-this-body}
+    :why     (str "THE POSITION THE ID IS NAMED FOR (rf2-dr0ad). The row above "
+                  "is a delay the runtime hands ONWARD; this is the one form "
+                  "it genuinely REFUSES — `codec/realize-deep` runs at the "
+                  "crossing and will not force an author's explicit deferral, "
+                  "so the props map is where the walk raises. Spec 009's row "
+                  "for this id states that trigger in those words. The kit "
+                  "answered its own generic `:rf.error/ui-tree-malformed` with "
+                  "`:hoist-it-to-its-own-site` here for a release — strictly "
+                  "vaguer than the runtime at exactly the crossing the refusal "
+                  "exists for, and advice with no exit, because the delay was "
+                  "already at its own site. Same class as rf2-llps1, cases "
+                  "reversed. `:where` is the KIT, on the row above's "
+                  "precedent.")}
+
+   {:case    "a REALIZED `delay` in a boundary's props CROSSES — the row above's control"
+    :form    [a-boundary {:x (doto (delay 1) deref)}]
+    :runtime [:opaque]
+    :refuses {:rf.error/id :rf.error/ui-tree-malformed}
+    :why     (str "`realize-deep` refuses only an UNFORCED delay: one the "
+                  "author already deref'd in their own body carries a computed "
+                  "value, derefs to it without calling anything, and is "
+                  "harmless wherever it goes — so the runtime builds the "
+                  "element and the `:runtime` column is opaque like any "
+                  "boundary's. Without this row the narrowing above is a "
+                  "predicate no test has ever seen false, and 'the kit refuses "
+                  "every delay in props' would read identically. The kit still "
+                  "refuses — a `Delay` is outside 004B's value grammar however "
+                  "forced — but with its OWN id, which is the honest one: "
+                  "nothing is waiting for this author at the crossing. The id "
+                  "ALONE is asserted; the generic arm's recovery wording is "
+                  "not this table's to endorse.")}
 
    {:case    "an SVG subtree carries `:ns`, and `:foreignObject` reverts"
     :form    [:svg {:view-box "0 0 1 1"}

--- a/implementation/hicasso/test_kit/src/re_frame/hicasso/test.cljs
+++ b/implementation/hicasso/test_kit/src/re_frame/hicasso/test.cljs
@@ -181,6 +181,16 @@
     it carries the runtime's id and the runtime's own recovery,
     `:hand-a-function-or-deref-it-in-this-body`, rather than a pointer
     to a tier where the identical refusal is waiting (rf2-llps1).
+  - The same id at the position it is NAMED for: **an unforced `delay`
+    reachable from a BOUNDARY's props**, which is the one form
+    `codec/realize-deep` genuinely refuses rather than repairs and the
+    trigger Spec 009's row states in those words. This walk answered its
+    own generic `:rf.error/ui-tree-malformed` with
+    `:hoist-it-to-its-own-site` there for a release — vaguer than the
+    runtime at exactly the crossing the refusal exists for, and advice
+    with no exit, since a delay written at a prop site is already at its
+    own site (rf2-dr0ad). At a NATIVE attribute the runtime refuses
+    nothing, so the generic id stays: see [[opaque-prop]].
 
   ### Subs
 
@@ -759,20 +769,57 @@
 
   Rejected rather than marked because below the key the grammar names no
   site, and a marker written there would claim one that does not exist
-  and silently replace a value the author will go looking for."
-  [k v]
+  and silently replace a value the author will go looking for.
+
+  `site` is `:crossing` for a BOUNDARY's props map and `:attr` for a
+  native element's attributes and handlers, and the two differ over
+  exactly one non-data value. A boundary's props are the one position
+  `codec/realize-deep` walks, and it **refuses** an unforced `delay`
+  reachable from them (`:rf.error/hicasso-deferred-read-at-boundary`,
+  Spec 009) rather than forcing an author's explicit deferral. A native
+  attribute is not walked and the runtime refuses nothing there. So the
+  crossing borrows the runtime's id and the runtime's recovery, and the
+  attribute keeps this namespace's own — the rule §Children already
+  states for a child, applied at the position the id is NAMED for
+  (rf2-dr0ad).
+
+  Only an **unforced** delay, because that is the runtime's own
+  narrowing: one the author already deref'd carries a computed value and
+  crosses freely, so nothing is waiting for that author at the crossing
+  and the generic refusal is the honest one. Without `realized?` here the
+  kit would refuse in the runtime's name a form the runtime accepts —
+  which is the fault this parity costs a branch to avoid, inverted."
+  [site k v]
   (if (fn? v)
     {:rf.ui/opaque :fn}
     (do (when-some [[path bad] (non-data v)]
-          (refuse! :rf.error/ui-tree-malformed
-                   (str "the value at " (pr-str k)
-                        (when (seq path) (str ", at " (pr-str path) " within it,"))
-                        " is " (offender-name bad) ", which this tree cannot "
-                        "record: 004B pins it as plain data an EDN reader takes "
-                        "back, and the opaque marker occupies a SITE rather than "
-                        "a value inside one.")
-                   :hoist-it-to-its-own-site
-                   {:key k :path (into [k] path) :value bad}))
+          (if (and (= :crossing site) (delay? bad) (not (realized? bad)))
+            (refuse! :rf.error/hicasso-deferred-read-at-boundary
+                     (str "an unforced `delay` is at the boundary prop "
+                          (pr-str k)
+                          (when (seq path)
+                            (str ", at " (pr-str path) " within it"))
+                          ". Hicasso refuses it at the crossing rather than "
+                          "forcing it, because forcing an author's explicit "
+                          "deferral would change what their program means: it "
+                          "would be forced inside the CHILD's render, so any "
+                          "subscription it reads becomes the child's edge, is "
+                          "cached by the delay, and is dropped the next time "
+                          "the child renders. Hand a FUNCTION instead — the "
+                          "child calls it on every render, so its reads are "
+                          "the child's edges and are kept — or deref the delay "
+                          "in the body that wrote it.")
+                     :hand-a-function-or-deref-it-in-this-body
+                     {:key k :path (into [k] path) :value bad})
+            (refuse! :rf.error/ui-tree-malformed
+                     (str "the value at " (pr-str k)
+                          (when (seq path) (str ", at " (pr-str path) " within it,"))
+                          " is " (offender-name bad) ", which this tree cannot "
+                          "record: 004B pins it as plain data an EDN reader takes "
+                          "back, and the opaque marker occupies a SITE rather than "
+                          "a value inside one.")
+                     :hoist-it-to-its-own-site
+                     {:key k :path (into [k] path) :value bad})))
         v)))
 
 (defn- refuse-opaque!
@@ -788,7 +835,7 @@
     (reduce-kv (fn [m k v]
                  (if (or (= :key k) (= :children k))
                    m
-                   (assoc! m k (opaque-prop k v))))
+                   (assoc! m k (opaque-prop :crossing k v))))
                (transient {})
                props)))
 
@@ -884,7 +931,7 @@
         events  (persistent!
                   (reduce-kv (fn [m k v]
                                (if (intent/event-prop? k)
-                                 (assoc! m k (opaque-prop k v))
+                                 (assoc! m k (opaque-prop :attr k v))
                                  m))
                              (transient {})
                              props))
@@ -896,7 +943,7 @@
                                  (= :class k)           m
                                  (= :id k)              m
                                  (nil? v)               m
-                                 :else (assoc! m k (opaque-prop k v))))
+                                 :else (assoc! m k (opaque-prop :attr k v))))
                              (transient {})
                              props))
         attrs   (cond-> attrs


### PR DESCRIPTION
Closes rf2-dr0ad.

## The bead asked for a ruling first, so here it is

rf2-dr0ad was filed and deliberately NOT fixed, because its author read the
gap as a ruling about which id L2 owes rather than a defect: *"pinning
today's answer into the parity table would read as endorsement."* Two things
found at source say the answer is not in doubt, and both of them predate the
bead.

**Spec 009 has already ruled.** The row for
`:rf.error/hicasso-deferred-read-at-boundary` states its trigger as *"An
UNFORCED `delay` was reachable from a boundary's props"* — the position, in
those words — and its recovery cell as
`:hand-a-function-or-deref-it-in-this-body`. The same document's kit-surface
section already records the kit as raising this id "for the condition rather
than a kit-private twin, per rf2-hic-020". The kit raising something else at
precisely the props position is a gap against a written contract, not an open
question.

**And the advice it gave had no exit.** `:hoist-it-to-its-own-site` tells an
author to move the offending value to a prop site of its own. In the measured
form `[a-boundary {:x (delay 1)}]` the delay is already at its own site, so
the recovery pointed back at what had just been written, and the runtime's
refusal stayed exactly where it was. That is the rf2-llps1 fault verbatim —
"not merely a different id but the wrong instruction" — and it is what makes
this a repair.

The bead's option (a), *"L2's tree grammar legitimately owns a props-position
non-data value"*, cannot be the answer here, because L2 does not own it: the
kit refuses too. Both sides refuse the same form, so there is no divergence
for a `:why` to justify — only a choice of words, and one side's words are
wrong. The bead's own note says the alternative "would make the middle row a
SHARED row of the parity table — both sides refusing with one id, one
recovery, which is the strongest shape that table has." It does.

## The change

`opaque-prop` now takes the SITE it is applied at.

- `:crossing` — a boundary's props map. `codec/realize-deep` walks it and
  refuses an unforced `delay` reachable from it, so the kit borrows the
  runtime's id AND the runtime's recovery, and names the offending key and
  path, which the runtime's own payload cannot.
- `:attr` — a native element's attributes and handlers. `realize-deep` never
  walks them and the runtime refuses nothing there, so the generic
  `:rf.error/ui-tree-malformed` stays. Measured, not assumed: the runtime
  answers `[:element "div"]` for `[:div {:data-x (delay 1)}]`.

`realized?` is carried across from the runtime's guard: a delay the author
already deref'd carries a computed value, crosses freely, and has nothing
waiting for it at the crossing — so refusing it in the runtime's name would
be the same fault inverted.

No spec or catalogue change: the id/recovery pair is already rowed, and the
kit already raises it on the child arm.

## Why no gate saw it

R10 of `check_complaint_catalogue.py` reconciles a raised recovery against
its Spec 009 row, and `:hoist-it-to-its-own-site` is correctly rowed for
`:rf.error/ui-tree-malformed`. A right recovery under the wrong id is
invisible to it — the limit R10's own header states. The parity table is the
instrument that can see it, and now does.

## Quality gates

Every gate run foreground to completion, exit code captured on the same
command line, log redirected to a file rather than piped.

| gate | runner | exit |
|---|---|---|
| `node-test-hicasso` compile + run (focused, pre-fix) | node | **1** — the new row red, as intended |
| `node-test-hicasso` compile + run (post-fix) | node | **0** — 1218 tests, 4957 assertions |
| `npm run test:cljs` (the `.cljs` runner for this surface) | node | **0** |
| `npm run test:hicasso-invariants` (incl. R10 catalogue + freeze) | python | **0** |
| `sh scripts/check-no-hardcoded-paths.sh` | sh | **0** |

`clojure -M:test` is NOT the runner for this surface — both changed files are
`.cljs`.

## Proof the new rows can go red

A parity row that has only ever seen the correct answer has not been tested,
so both new rows were sabotaged and each was checked to red the row it is
about, one plant at a time. Restoration verified by SHA-256, not by eye.

1. **The refused row.** `walk-props` reverted to `:attr` — the pre-fix
   behaviour exactly. Red on *"an unforced `delay` in a BOUNDARY's PROPS"*:
   `(not (= {:rf.error/id :rf.error/hicasso-deferred-read-at-boundary …}
   {:rf.error/id :rf.error/ui-tree-malformed, :recovery
   :hoist-it-to-its-own-site}))`. Exit 1, one failure.
2. **The control row.** `(not (realized? bad))` deleted. Red on *"a REALIZED
   `delay` in a boundary's props CROSSES"*: `(not (= {:rf.error/id
   :rf.error/ui-tree-malformed} {:rf.error/id
   :rf.error/hicasso-deferred-read-at-boundary}))`. Exit 1, one failure —
   which is what makes the `realized?` narrowing a tested branch rather than
   decoration.

Restored file hashes
`0fa2ff1b22ce808104a4bf48cdb1cd1558724939a428a171dfbb5ea4c1fe874a` after each
plant, identical to the pre-plant hash. Both plants changing the gate's
colour is also the evidence that the gate read this worktree.

## Not done, deliberately

`:hoist-it-to-its-own-site` is odd advice for ANY non-data value that is
already at its own top-level prop site — the pre-existing `#js {"a" 1}` row
has the same shape. That is a separate finding about the generic arm's
wording, outside this bead, and the control row asserts the id ALONE rather
than pinning a recovery this table has no business endorsing.
