### PR TITLE
docs(hicasso): the mislabelled estimator was published, not drafted (rf2-pqyxz)

### DIFF
--- a/docs/design/hicasso/decisions.md
+++ b/docs/design/hicasso/decisions.md
@@ -1585,10 +1585,10 @@ Three runs, each five rounds of three warm-up plus six samples, taken back to
 back on a quiet box. **Each run's figure is the ARITHMETIC MEAN of that run's
 five per-round ratios**, each of which is a ratio of the two arms' *within-round
 median* mount times — a mean over medians, and not a median of anything at the
-run level. That is what `lane/ratio-between` computes and hands the table; an
-earlier draft of this paragraph called the three values "run-medians" and their
-spans "effect medians", which named an estimator the instrument never used
-(`rf2-pqyxz`).
+run level. That is what `lane/ratio-between` computes and hands the table. As
+first published this paragraph called the three values "run-medians" and their
+spans "effect medians" and "null medians", naming an estimator the instrument
+never computed; the numbers were always these ones (`rf2-pqyxz`).
 
 | run | `:merged`/`:expanded` | per-round range | NULL `:expanded-b`/`:expanded` | per `:&` site |
 |---|---|---|---|---|


### PR DESCRIPTION
Follow-up to **#8333**, which merged while its gates were still running. One wording correction the merge did not carry, plus the captured exit codes for both PRs' gates.

## The change

HD-023's corrected estimator paragraph said the mislabel was in "an earlier draft of this paragraph". It was not a draft — it was the version published on 2026-08-15 and merged in #8326. The sentence now says so, and adds the "null medians" span the first correction omitted from the list. Four lines, no number touched.

## Quality gates (this PR)

| gate | captured exit |
|---|---|
| `python scripts/check_doc_slugs.py` | `0` |
| `python scripts/check_provenance_pins.py` | `0` |

Both run on this branch after the cherry-pick onto `origin/main` (which had moved under #8333's merge — `rf2-d360z` landed on the same page and the pick applied clean).

## Quality gates (#8333, captured after that PR merged)

Every one foreground, redirected to a file with `$?` captured on the same command line, never through a pipe.

| gate | captured exit | proof it read this worktree |
|---|---|---|
| `npm run test:cljs` | `0` | 13,953 tests / 70,270 assertions, 0 failures 0 errors |
| ↳ focused `node out/node-test.js --test=re-frame.bench.hicasso.lane-control-strict-cljs-test` | `0` | 9 tests / 29 assertions — the new namespace is in the bundle and green |
| ↳ **sabotage proof** | `1` | `control-verdict-strict`'s per-round test weakened from `and` to `or` (i.e. back to overlap semantics) → **7 failures**, naming `one-dataset-two-rules-opposite-verdicts`, `one-bad-round-refuses-and-names-it` and `a-high-excursion-refuses-too`. Source restored and re-verified by sha256; recompiled and re-run green |
| `npm run test:hicasso-compile` | `0` | printed `C:\…\re-frame2-worktrees\w-lane-est\implementation\hicasso\test\re_frame\bench\hicasso` as the directory it walked; **141** namespaces (140 before this branch — the new one is mine), zero warnings |
| `python scripts/check_doc_slugs.py` | `0` | **proven able to answer red**: a broken anchor planted in `decisions.md` → exit `1` naming `decisions.md:2424`; removed and restored identical by sha256 |
| `python scripts/check_provenance_pins.py` | `0` | 112 pages, 522 pins, 0 findings |
| `sh scripts/check-no-hardcoded-paths.sh` | `0` | plus a direct `grep -F 'C:\Users\miket'` over the four changed files — no match |

`mkdocs build --strict` is not the gate for `docs/design/**` (`exclude_docs`); `check_doc_slugs.py` is, and it runs unconditionally in `test.yml`. Markdown table column counts hand-verified: HD-023's table is unchanged at **5** columns in header, separator and all three rows; no table was added.

## One consequence worth stating rather than discovering

The strict rule may **refuse** a future amp-merge run. `rf2-y0pkh` priced exactly that on the census-clock rows (18.2% and 39.8% per-run false refusal) and retained the strict rule anyway. If it refuses here, that is the control arbitrating — the band is not to be widened to admit a run, and the per-round values are now recorded so the refusal can be read rather than guessed at.