### PR TITLE
bench(hicasso): the direct-return clock's control goes per-round and strict (rf2-gsn62)

### DIFF
--- a/docs/design/hicasso/product/budgets.md
+++ b/docs/design/hicasso/product/budgets.md
@@ -388,7 +388,7 @@ and the allocation row has no publishable claim to re-pin.
 | S5 | Teardown, retained **bytes** | indistinguishable from zero — all ten candidate rungs' bands straddle 0 | as S1 | **package figure** |
 | S6 | Cold mount vs direct UIx-on-subs | `1.1718x` [1.1263–1.2190] n=8; `1.1976x` [1.1504–1.2468] n=6 | final K1 estimator | **bench-tree figure** — registered `1.10x` gate missed; `1.25x` is the *accepted price* for that miss (ratified 2026-08-13), never a line this row is judged on |
 | S7 | Warm allocation | no publishable claim | allocation instrument | **bench-tree** — no fitted series clears the quality floor |
-| S8 | Direct-return escape (Rung 3): mount time against the same page written as hiccup | `0.7418x`, per-round escapes [0.6458–0.8409] over run 1's five rounds — **25.8% of mount time recovered** [15.9–35.4%]. Run 2 is excluded: its positive control refuses under the strict rule | P0 lane direct-return clock arm | **package figure** — an observed range, not a confidence interval; it excludes 1.0 and it CROSSES C8's 20% line |
+| S8 | Direct-return escape (Rung 3): mount time against the same page written as hiccup | `0.7418x`, per-round escapes [0.6458–0.8409] over run 1's five rounds — **25.8% of mount time recovered** [15.9–35.4%]. Run 2 is excluded: its positive control missed an every-round reading of its band | P0 lane direct-return clock arm | **package figure** — an observed range, not a confidence interval; it excludes 1.0 and it CROSSES C8's 20% line |
 
 The run's evidence, its controls and its full provenance are
 [on the ladder's studio page](../studio/reads-per-boundary-heap-ladder.md#the-package-itself-priced-on-this-rung-at-last-rf2-fe0l);
@@ -476,6 +476,31 @@ refuses cannot contribute to a published figure. On run 1 the arm-order guard
 returned `reportable`, the positive control predicted `4.500` and measured
 `4.300` `[3.950–4.950]` — every round inside `[3.375–5.625]` — and all 225 of
 its measured mounts were read back out of the document at their own far end.
+
+**Both those control adjudications were taken against an ACROSS-ROUND
+denominator, and that is not the rule the instrument now applies
+(`rf2-gsn62`).** The prediction each run was judged on is `2.0 ×` the
+across-round median of the `:hiccup` arm — `4.500` and `4.000` above — rather
+than each round's own `:hiccup`, so a round whose judged leg ran fast was
+measured against every other round's. That is the one comparison a positive
+control exists to make, and a cross-round prediction does not have it to make:
+a control range can sit wholly inside its band while a round misses by half
+again on its own denominator. The instrument now calls
+`lane/control-verdict-strict` on the per-round `:ctl-2x`/`:hiccup` ratio
+instead — these legs read ~2.25 ms judged against ~4.3 ms control, twenty to
+forty-three of Chrome's 100 µs quanta clear, so the coarse-leg exemption the
+2026-07-31 ruling grants does not reach them.
+
+**Neither run can be re-adjudicated under that rule, and no strict verdict is
+claimed here for either.** Only `n`/`min`/`max`/`p50` across rounds was
+retained per arm, so the per-round `:ctl-2x`/`:hiccup` ratios are gone; the
+containment statement above stands only as stated, against the aggregate
+denominator, and run 2's exclusion rests on the same aggregate — it is the
+conservative direction, and the published figure is run 1 alone either way.
+The instrument now records `:per-round` for the control alongside the escape,
+so the **next** run's verdict is readable from what it keeps. Taking that run
+is its own window and its own bead (`rf2-zcgps`); nothing here re-adjudicates
+`0.7418x`, which is an escape figure and not a control one.
 
 ### The §6 user-visible budgets
 

--- a/implementation/hicasso/test/re_frame/bench/hicasso/direct_return_clock_app.cljs
+++ b/implementation/hicasso/test/re_frame/bench/hicasso/direct_return_clock_app.cljs
@@ -68,6 +68,30 @@
   and one builds two pages, both on purpose, and folding either into the
   equality would make the fairness gate a permanent failure.
 
+  ## The control is adjudicated STRICTLY, and per round (rf2-gsn62)
+
+  `lane/control-verdict-strict` decides it: every round's `:ctl-2x` /
+  `:hiccup` ratio must sit inside ±25% of 2.00x, and one bad round
+  refuses the run however good the others were. This instrument is
+  entitled to that rule and the coarse-leg rows are not — the 2026-07-31
+  ruling keeps the weaker OVERLAP rule for legs sitting on Chrome's
+  100 µs clamp and names a batched window clear of the quantum as its own
+  revisit trigger. This one reads ~2.25 ms judged and ~4.3 ms control (the
+  figures S8 publishes), twenty to forty-three quanta clear, so a round
+  outside the band here is not the clock. The floor's own leg is coarse
+  and does not enter: the control divides one floor-normalised ratio by
+  another taken in the SAME round, so the floor cancels exactly.
+
+  The adjudication is also PER ROUND rather than aggregate. The two runs
+  taken for S8 compared `2.0 x` the ACROSS-ROUND median of `:hiccup`
+  against the ACROSS-ROUND range of `:ctl-2x`, which never puts a round
+  beside its own denominator — a round whose judged leg ran fast was
+  measured against everybody else's. That shape also recorded only the
+  aggregate, so neither run's strict verdict is recoverable and none is
+  claimed; this file now records `:per-round` for the control as well as
+  for the escape, so the next run can be re-adjudicated under either rule
+  WITHOUT re-running the window.
+
   ## The published figure
 
   `lane/ratio-between :direct :hiccup` over the per-round floor-normalised
@@ -289,7 +313,12 @@
        "BEFORE the clock starts; the :ctl-2x arm's sample is the SAME operation "
        "performed TWICE inside one window, so its per-sample constants double "
        "with its work and its prediction is 2.00x by construction rather than by "
-       "model. Arms interleaved at the SAMPLE level under the lane's rotating AND "
+       "model — adjudicated by lane/control-verdict-strict, which requires EVERY "
+       "round's ctl-2x/hiccup ratio to sit inside ±"
+       (.toFixed (* 100.0 control-slack) 0)
+       "% of it rather than merely the range, and records the per-round values so "
+       "the run can be re-adjudicated without being re-run. Arms interleaved at "
+       "the SAMPLE level under the lane's rotating AND "
        "REFLECTING schedule, so no arm always follows the same neighbour; "
        rounds " rounds of " (:warmup sampling) " warm-up + " (:samples sampling)
        " samples per arm per round; every measured mount read back out of the DOM "
@@ -352,11 +381,14 @@
                                arms)
                 escape   (lane/ratio-between ratios :direct :hiccup)
                 gv       (lane/guard! samples "direct-return clock arms (in-page ms)")
-                ctl      (lane/control-verdict
-                           (* 2.0 (:p50 (get abs :hiccup)))
-                           (let [s (get abs :ctl-2x)]
-                             {:min (:min s) :max (:max s) :mean (:p50 s)})
-                           control-slack)
+                ;; THE POSITIVE CONTROL, per round and strictly (rf2-gsn62).
+                ;; `:ctl-2x` is `:hiccup`'s own operation performed twice in
+                ;; one window, so 2.00x is arithmetic rather than a model,
+                ;; and dividing each round by ITS OWN `:hiccup` leaves the
+                ;; floor and the round's drift out of it.
+                ctl-ratio (lane/ratio-between ratios :ctl-2x :hiccup)
+                ctl      (lane/control-verdict-strict
+                           2.0 (:per-round ctl-ratio) control-slack)
                 tv       (lane/tally-value tally)]
             (lane/assert-teardown-clean! "the measured rounds")
             (lane/record! :direct-return-clock
@@ -392,7 +424,9 @@
                      "  <- STRADDLES 1.0: INDISTINGUISHABLE"
                      "  <- range excludes 1.0")))
             (js/console.log (str ";;   per-round: " (pr-str (:per-round escape))))
-            (js/console.log (str ";;   control: " (:why ctl)))
+            (js/console.log (str ";;   control (" (name (:rule ctl)) ", ctl-2x/hiccup): "
+                                 (:why ctl)))
+            (js/console.log (str ";;   control per-round: " (pr-str (:per-round ctl))))
             (js/console.log (str ";;   writes: " (:unverified tv) " unverified of "
                                  (:writes tv)))
             (when (pos? (:unverified tv))

--- a/implementation/hicasso/test/re_frame/bench/hicasso/lane_control_strict_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/bench/hicasso/lane_control_strict_cljs_test.cljs
@@ -13,9 +13,22 @@
   the two into one, in either direction. So the assertion that carries the
   design is [[one-dataset-two-rules-opposite-verdicts]]: the SAME readings
   are driven through both rules and the two must disagree. A `simplify`
-  pass that routes `amp_merge_clock_app` back to the overlap rule goes red
-  here, in the always-on `cljs-test$` gate, rather than in a bench run
-  months later that quietly stopped having teeth.
+  pass that routes `amp_merge_clock_app` or `direct_return_clock_app` back
+  to the overlap rule goes red here, in the always-on `cljs-test$` gate,
+  rather than in a bench run months later that quietly stopped having
+  teeth. Both instruments read milliseconds against a 0.1 ms quantum —
+  ~4 ms judged and ~8 ms control on one, ~2.25 ms and ~4.3 ms on the other
+  — so both are the case the 2026-07-31 ruling named as its own revisit
+  trigger, and neither is entitled to the coarse-leg exemption.
+
+  [[the-aggregate-rule-cannot-even-ask-the-question]] pins the OTHER half
+  of what both callers were doing, which the overlap-versus-containment
+  contrast above does not reach: a prediction built from an ACROSS-ROUND
+  median of the judged arm, compared against the ACROSS-ROUND range of the
+  control. That shape passes a dataset the per-round rule refuses even
+  when the control's whole range sits INSIDE the band, because the round
+  that misses misses on ITS OWN denominator and the aggregate never looks
+  at one.
 
   The rest pin the modes a browser run cannot reach. A control adjudicated
   on an AGGREGATE cannot be re-adjudicated afterwards — that is the
@@ -74,6 +87,73 @@
       (is (= :every-round (:rule s))
           "and each answer says which rule decided it, so a published record
            cannot be read under the other one"))))
+
+;; ---------------------------------------------------------------------------
+;; The shape BOTH callers handed the rule before rf2-egdaq and rf2-gsn62
+;; ---------------------------------------------------------------------------
+;;
+;; Five rounds of raw millisecond `p50`s. Round 4's judged leg ran fast
+;; while its control leg did not, so that round's control is 3.00x its OWN
+;; denominator — and no other round is disturbed. It is the one excursion
+;; a positive control exists to catch.
+
+(def ^:private rounds-ms
+  [{:hiccup 2.25 :ctl 4.50}
+   {:hiccup 2.20 :ctl 4.40}
+   {:hiccup 2.30 :ctl 4.60}
+   {:hiccup 1.50 :ctl 4.50}      ;; <- 3.00x, half again past the band's roof
+   {:hiccup 2.25 :ctl 4.50}])
+
+(def ^:private floor-ms
+  "The floor arm's own leg. It divides out of both terms in the SAME round,
+  which is why a coarse floor cannot reach the control's verdict."
+  0.05)
+
+(defn- floor-normalised
+  "The per-round `{id ratio-to-floor}` maps `lane/normalise` produces, which
+  is what an instrument hands `lane/ratio-between`."
+  []
+  (mapv (fn [{:keys [hiccup ctl]}]
+          {:floor 1.0 :hiccup (/ hiccup floor-ms) :ctl-2x (/ ctl floor-ms)})
+        rounds-ms))
+
+(deftest the-aggregate-rule-cannot-even-ask-the-question
+  (testing "the OLD caller arithmetic — 2.0x the across-round median of the
+            judged arm, against the across-round range of the control —
+            passes a dataset the per-round rule refuses, and passes it with
+            the control's ENTIRE range inside the band, so overlap versus
+            containment is not what saved it. The aggregate is simply
+            blind: round 4's miss is a miss against round 4's own
+            denominator, and a cross-round prediction never has one"
+    (let [hiccups   (mapv :hiccup rounds-ms)
+          ctls      (mapv :ctl rounds-ms)
+          predicted (* 2.0 (:p50 (lane/summarise hiccups)))
+          s-ctl     (lane/summarise ctls)
+          aggregate (lane/control-verdict predicted
+                                          {:min  (:min s-ctl)
+                                           :max  (:max s-ctl)
+                                           :mean (:p50 s-ctl)}
+                                          slack)
+          per-round (:per-round (lane/ratio-between (floor-normalised)
+                                                    :ctl-2x :hiccup))
+          strict'   (strict per-round)]
+      (is (= 4.5 predicted)
+          "the across-round median judged leg is 2.25 ms, so the band is
+           [3.375 – 5.625] in milliseconds")
+      (is (= {:n 5 :min 4.4 :max 4.6 :p50 4.5} s-ctl)
+          "and the control's whole measured range is 4.40 – 4.60 ms")
+      (is (true? (:ok? aggregate))
+          "the aggregate rule PASSES — not by overlap but by containment,
+           which is the stronger of the two readings it could have taken")
+      (is (= [2.0 2.0 2.0 3.0 2.0] per-round)
+          "while round 4 read 3.00x its own denominator")
+      (is (false? (:ok? strict'))
+          "and the per-round rule REFUSES it. This is the disagreement
+           rf2-gsn62 turns on: an aggregate adjudication is not a weaker
+           answer to the same question, it is an answer to a different one")
+      (is (= [{:round 4 :measured 3.0 :off-by 0.25}] (:outside strict'))
+          "named, with its distance past the roof as a fraction of the
+           prediction, so an operator knows which round to go looking at"))))
 
 ;; ---------------------------------------------------------------------------
 ;; The rule itself


### PR DESCRIPTION
Closes rf2-gsn62.

`direct_return_clock_app` adjudicated its positive control exactly the way
`amp_merge_clock_app` did before rf2-egdaq (PR #8333): `lane/control-verdict`
on OVERLAP, against a prediction built from the ACROSS-ROUND median of the
judged arm and the ACROSS-ROUND range of the control.

## The bead's own precondition, checked at source first

The bead made the fix conditional: *"check at source whether this instrument's
legs clear the quantum. If they do not, the overlap rule is correct for it and
the right deliverable is a REFUSAL saying so."*

They clear it. The published S8 run (`docs/design/hicasso/product/budgets.md`
§4) records the control's prediction as `4.500`, which is `2.0 x` the judged
arm's `p50`, so the judged leg is **~2.25 ms** and the control leg measured
**4.300 ms** `[3.950–4.950]`. Against Chrome's 100 µs `performance.now()`
clamp that is **twenty to forty-three quanta clear** — the batched window the
2026-07-31 ruling named as its own revisit trigger, not the "handful of quanta"
class the ruling protects. `amp_merge` reads forty to eighty; this one is the
same class with less margin, and one quantum is 2.3% of the control leg against
a ±25% band.

The floor arm's leg *is* coarse and does not reach the verdict: the control
divides one floor-normalised ratio by another taken in the **same round**, so
the floor cancels exactly.

## What changed

- `direct_return_clock_app` now calls `lane/control-verdict-strict` on
  `(:per-round (lane/ratio-between ratios :ctl-2x :hiccup))` against a `2.00x`
  prediction, pairing each round with **its own** denominator. `lane.cljs` is
  untouched — the rule rf2-egdaq landed is the one being called.
- The record carries `:per-round` for the control now, as it already did for
  the escape, so the next run is re-adjudicable under either rule without
  being re-run.
- `measurement-method` and the console line name the rule that decided it.

## The RED proof

`the-aggregate-rule-cannot-even-ask-the-question` in
`lane_control_strict_cljs_test` drives **one** five-round dataset through both
shapes and asserts they part:

| round | `:hiccup` | `:ctl-2x` | ratio |
|---|---|---|---|
| 1 | 2.25 ms | 4.50 ms | 2.00x |
| 2 | 2.20 ms | 4.40 ms | 2.00x |
| 3 | 2.30 ms | 4.60 ms | 2.00x |
| **4** | **1.50 ms** | **4.50 ms** | **3.00x** |
| 5 | 2.25 ms | 4.50 ms | 2.00x |

The old shape predicts `2.0 x 2.25 = 4.500` and measures `[4.400 – 4.600]` —
which passes **by containment**, not merely by overlap, so this is not the
overlap-versus-containment difference the existing
`one-dataset-two-rules-opposite-verdicts` already pins. The aggregate is simply
blind: round 4 misses against **its own** denominator, and a cross-round
prediction never has one. The per-round rule names it,
`[{:round 4 :measured 3.0 :off-by 0.25}]`, and refuses.

A `simplify` back to either the overlap rule or the aggregate shape now goes
red in the always-on `cljs-test$` gate.

## No retrospective pass is claimed

`lane/record!` parks whatever the caller hands it, and the caller handed it
`lane/summarise`'s `n`/`min`/`max`/`p50` across rounds per arm. `run.cjs`
persists nothing to disk, and there is no dataset under
`implementation/hicasso/test/re_frame/bench/hicasso/data/` for this
instrument. **The per-round `:ctl-2x`/`:hiccup` ratios of both S8 runs are
gone**, so no strict verdict is recoverable for either.

`budgets.md` §4 previously read run 1's control as passing *"the strict
every-round-inside rule"*. That claim is every-round **containment against an
across-round denominator**, which is not what `control-verdict-strict` asks;
the page now says so, states that neither run can be re-adjudicated, and notes
that run 2's exclusion rests on the same aggregate (the conservative
direction — the published figure is run 1 alone either way). `0.7418x` is
untouched: it is an escape figure, not a control one.

Re-running the window is **rf2-zcgps**, filed rather than run — a measurement
window is not this bead, and the box is loud with concurrent workers. It notes
the sibling rf2-20uei wants the same box.

## Gates

- `npm run test:cljs` — the runner matched to the `.cljs` extension; `clojure -M:test` cannot load these namespaces.
- Sabotage/restore proof of the strict predicate, and a hash check on restore.
- `sh scripts/check-no-hardcoded-paths.sh`.
- `python scripts/check_doc_slugs.py` for the `docs/design/hicasso/` edit — `mkdocs build --strict` excludes that tree. The `budgets.md` change adds prose plus one table-cell edit inside an existing 5-column row; column counts hand-verified unchanged.

Exit codes are quoted in the thread.
