### PR TITLE
docs(hicasso): the mechanism prose names the carrier the door ships (rf2-0ftho)

### DIFF
--- a/docs/design/hicasso/product/callback-identity-verdict.md
+++ b/docs/design/hicasso/product/callback-identity-verdict.md
@@ -18,9 +18,9 @@ The rule is a conjunction, and its two halves need different instruments.
 
 ## The mechanism, read from source before anything was measured
 
-`impl.intent`'s `intent-handler`, `key-map-handler` and `event-callback` each allocate a fresh closure at LOWERING time, and lowering happens per render. Every event-position carrier therefore churns identity per render — the intent vector and the key-map exactly as much as `h/fn`. The churn is the lowering's, not the author's.
+`impl.intent`'s `intent-handler`, `key-map-handler` and `event-callback` each allocate a fresh closure at LOWERING time, and lowering happens per render. Every event-position carrier therefore churns identity per render — the intent vector and the key-map exactly as much as `h/event`. The churn is the lowering's, not the author's.
 
-Two paths already preserve identity, and both say so in their own docstrings: `lower-declared-prop` hands an unmarked function through untouched at every contract and hands a marked `h/fn` through by identity at `:handler`; and `codec/host-prop-value` crosses functions by identity *"so `React.memo` and every downstream bail-out that compares handler identity keep working"*.
+Two paths already preserve identity, and both say so in their own docstrings: `lower-declared-prop` hands an unmarked function through untouched at every contract and hands a marked `h/event` through by identity at `:handler`; and `codec/host-prop-value` crosses functions by identity *"so `React.memo` and every downstream bail-out that compares handler identity keep working"*.
 
 **Hicasso's own boundaries never had this problem.** `codec/boundary-props=` compares with CLJS `=`, and an intent vector or key-map is data, so a boundary child bails on value equality. The question exists only at a foreign `React.memo` edge.
 


### PR DESCRIPTION
Closes rf2-0ftho.

## What this is

Two words on two lines in `docs/design/hicasso/product/callback-identity-verdict.md`.

`:21` and `:23` are **live mechanism prose, not historical quotation**, and both still named `h/fn` — a carrier that does not exist:

- `:21` "... the intent vector and the key-map exactly as much as `h/fn`" → `h/event`
- `:23` "hands a marked `h/fn` through by identity at `:handler`" → `h/event`

Verified at source rather than taken on trust: the shipped door carries `(defmacro event` and **no `fn` macro at all** (`implementation/hicasso/src/re_frame/hicasso.cljc` — `defview`, `event`, `defhost` are the three), and `impl/intent.cljs` says `h/event` throughout. So the two sentences disagreed with the table twelve lines below them, whose `:handler` row already reads `h/event`.

The three lowering fns `:21` names (`intent-handler`, `key-map-handler`, `event-callback`) all still exist in `impl/intent.cljs`, and `:handler` is still a live declared contract in `lower-declared-prop`'s docstring — so `h/fn` was the only stale token on either line.

## What is deliberately NOT touched

**Line 45 stays.** It records that the two `:event-*` arms were *measured* under `:hfn-inline` and `:hfn-hoisted` and renamed with their witness — a genuine historical label note, which the audit explicitly says to keep.

**No reading was recomputed and no arm keyword moved.** PR #8317 already landed the witness and the verdict together; `grep -n hfn implementation/hicasso/test/re_frame/hicasso/retaining_host_callbacks_dom_cljs_test.cljs` returns nothing (exit 1). The original bead description's test-file half was already discharged — this PR is only the remainder the reopening audit named.

## The publication fence, checked before editing

`docs/design/hicasso/product/README.md` §Refresh contract names the published copies **exhaustively**: "The copies here are `decision-brief.md`, `specification.md`, and everything under `lanes/` — one for each source named in the manifest above." `callback-identity-verdict.md` is none of those, has no source in the digest manifest (which lists only `synth.md`, `synth-codex.md`, `codex/*`), and carries three in-tree commits of its own — including `da648001e7`, the #8317 change this bead owns. It is tracked-native, so this edit does not silently revert and `rf2-rbme3`'s hold does not reach it.

## Gates

Docs-only change under `docs/design/`, which `mkdocs build --strict` deliberately excludes — so it is **not** nominated here. `scripts/check_doc_slugs.py` is the gate that does cover this tree; it was proven live (fault planted, seen red naming this file, restored, verified by hash). Exit codes in the worker report.
