### PR TITLE
docs(hicasso): the blessed recipe teaches a symbol the door does not carry (rf2-hic-047)

### DIFF
--- a/docs/design/hicasso/product/virtualizer-recipe.md
+++ b/docs/design/hicasso/product/virtualizer-recipe.md
@@ -22,7 +22,7 @@ The repo-root `examples/` tree was the other candidate and is the wrong home: ex
 
 That is the entire interop surface. Two declared positions carrying two different contracts, neither inferred from the prop's spelling; every other prop — `:count`, `:row-height`, `:viewport-height`, `:overscan`, `:pinned-index` — is ordinary data and needs no declaration at all.
 
-Both callbacks are written with `h/fn` rather than as intent vectors, and for one reason: the vendor invokes them **value-first** — `renderRow(index, offset)`, `onWindow(from, to)` — so there is no DOM event at argument one and nothing for a vector's markers to read. That is HD-024's motivating shape, and the one callback form receives the library's own arguments, in order.
+Both callbacks are written with `h/event` rather than as intent vectors, and for one reason: the vendor invokes them **value-first** — `renderRow(index, offset)`, `onWindow(from, to)` — so there is no DOM event at argument one and nothing for a vector's markers to read. That is HD-024's motivating shape, and the one callback form receives the library's own arguments, in order. The spelling is `h/event` at the `:render` position too, and that is not a slip: it is the single callback form, and which of its contracts applies comes from the position the declaration above named, never from the name.
 
 The application's foreign-dependency roster is **four** namespaces: `re-frame.core`, `re-frame.hicasso`, `re-frame.adapter.uix`, and the vendor. Three of those four are what the 100-cell grid names. Read as a table, that is the headline: **a serious third-party component costs one line on the roster and one declaration in the view.** No wrapper library, no adapter namespace, no interop shim.
 
@@ -31,7 +31,7 @@ The application's foreign-dependency roster is **four** namespaces: `re-frame.co
 ### Rule 1 — the key is the row's place in the MODEL
 
 ```clojure
-:render-row (h/fn [i offset]
+:render-row (h/event [i offset]
               (h/as-element
                 [ledger-row {:key (row-key i) :index i :offset offset}]))
 ```
@@ -76,7 +76,7 @@ The spec's adjective is doing work. Three properties, all of them real library f
 
 ### Which packages have them, audited by version
 
-A claim about a third-party API is not a fact until a version is attached to it, and these two packages have both changed their answer at least once. Each cell below names the API that answers the property and the release it was read from. The reading is off each package's own published declarations and source rather than its prose — `react-window@2.3.0/dist/react-window.d.ts` and its source map, `react-window@1.8.11/src/createListComponent.js`, and `@tanstack/virtual-core@3.17.7/dist/esm/index.d.ts`, the core that `@tanstack/react-virtual@3.14.9` depends on — taken 2026-08-13.
+A claim about a third-party API is not a fact until a version is attached to it, and these two packages have both changed their answer at least once. Each cell below names the API that answers the property and the release it was read from. The reading is off each package's own published declarations and source rather than its prose — `react-window@2.3.0/dist/react-window.d.ts` and its source map, `react-window@1.8.11/src/createListComponent.js`, and `@tanstack/virtual-core@3.17.7/dist/esm/index.d.ts`, the core that `@tanstack/react-virtual@3.14.9` depends on — taken 2026-08-13, and re-read off the same published declarations on 2026-08-16, when every cell below still held and each package's `latest` tag still resolved to the version named in its column heading.
 
 | property | `@tanstack/react-virtual` 3.14.9 | `react-window` 2.3.0 | `react-window` 1.8.11 |
 |---|---|---|---|


### PR DESCRIPTION
## What this is

`rf2-hic-047`'s newest note. `docs/design/hicasso/product/virtualizer-recipe.md` is the blessed recipe a consumer copies, written on shipped public doors — not a historical naming record. Two places still spelled the callback form `h/fn`: the prose at the crossing (line 25) and the fenced Rule 1 form (line 34). `h/fn` does not exist. Naming-ledger row 1 swept it to `h/event` under `rf2-hic-066`, because a bare `fn` shadows `cljs.core/fn` for anyone who `:refer`s it, and `re-frame.hicasso/event` is what the door carries. The live witnesses this page reports already use `h/event` — `implementation/hicasso/test/re_frame/hicasso/examples/ledger/views.cljs:225,230` and `.../virtualized_dom_cljs_test.cljs:99,115` — so the page was the only thing left teaching an unreadable symbol.

The value-first explanation is preserved verbatim. One clause is added exactly where the rename opens a new question, since `:render-row` is a `:render` position and the form is now spelled `event`: it is the single callback form, and which contract applies comes from the declared position, never from the name. That is the shipped docstring's own statement.

No runtime, witness, gate or measurement change. No new surface.

## The versioned re-audit

The bead's earlier comment asked for the react-window / TanStack comparison to be versioned and re-audited property by property against vendor APIs. That correction landed in #8317; this PR **re-verifies it at source rather than taking it on trust**, since a comparison with no fresh reading behind it is what produced the bead. Every reading below is off the vendor's own published declarations, fetched directly — never a search snippet.

| property | claim as the page states it | audited against | verdict |
|---|---|---|---|
| consumer supplies the key | `getItemKey?: (index: number) => Key` | `@tanstack/virtual-core@3.17.7/dist/esm/index.d.ts`; [tanstack.com/virtual/latest/docs/api/virtualizer](https://tanstack.com/virtual/latest/docs/api/virtualizer) | CONFIRMED, signature exact |
| consumer supplies the key | `rowKey?: (index, data) => React.Key` | `react-window@2.3.0/dist/react-window.d.ts`; [github.com/bvaughn/react-window](https://github.com/bvaughn/react-window) | CONFIRMED — `rowKey?: (index: number, data: RowProps) => React.Key` |
| consumer supplies the key | `itemKey?: (index, data) => any` | `react-window@1.8.11/src/createListComponent.js` | CONFIRMED, verbatim |
| wrappers are the consumer's | TanStack ships hooks, no components | `@tanstack/react-virtual@3.14.9/dist/esm/index.d.ts` | CONFIRMED — exports are `useVirtualizer`, `useWindowVirtualizer`, two types, and a re-export of core; no component |
| wrappers are the consumer's | 2.3.0: one root whose `tagName` picks, default `role="list"` overridable by rest props, plus one `aria-hidden` sizing div | `react-window@2.3.0/dist/react-window.{d.ts,js}` | CONFIRMED — `tagName?: TagName`; root built as `{ role: "list", ...rest }` so rest wins; the extra element is `{"aria-hidden": true, style:{...zIndex:-1}}` |
| wrappers are the consumer's | 1.8.11: `outerElementType` / `innerElementType` replace both wrappers | `react-window@1.8.11/src/createListComponent.js`; CHANGELOG | CONFIRMED — both typed `string \| React$AbstractComponent<…>`; `innerTagName`/`outerTagName` retained `// deprecated` with the migration warning |
| can be told to keep a row mounted | TanStack: yes, `rangeExtractor?: (range: Range) => Array<number>` | `@tanstack/virtual-core@3.17.7` d.ts + API page | CONFIRMED, signature exact |
| can be told to keep a row mounted | react-window 2.3.0: **no** | `react-window@2.3.0` d.ts and dist | CONFIRMED — no `rangeExtractor`, no `stickyIndices`, no pinned index anywhere; the loop is contiguous `for (w = startIndexOverscan; w <= stopIndexOverscan; w++)` |
| can be told to keep a row mounted | react-window 1.8.11: **no** | `react-window@1.8.11/src/createListComponent.js` | CONFIRMED — `for (let index = startIndex; index <= stopIndex; index++)`; no `rangeExtractor`, no `stickyIndices` |
| dates in the historical paragraph | 1.0.0 Jul 2018 · 1.4.0 Dec 2018 · 1.8.11 Dec 2024 · 2.0.0 Aug 2025 | tag commit dates, `api.github.com/repos/bvaughn/react-window` | CONFIRMED — 2018-07-22, 2018-12-21, 2024-12-17, 2025-08-28 |
| 1.4.0 introduced the element-type props | rename from `innerTagName`/`outerTagName` | react-window `CHANGELOG.md` | CONFIRMED — "Renamed List and Grid `innerTagName` and `outerTagName` props to `innerElementType` and `outerElementType`" |
| the versions are still current | 2.3.0 · 3.14.9 · 3.17.7 | `registry.npmjs.org/react-window/latest`, `…/@tanstack/react-virtual/latest` | CONFIRMED — `latest` still resolves to each; nothing has shipped past the audited columns |

**Nothing was overturned, and the recommendation is unchanged.** TanStack Virtual remains the recommendation, on `rangeExtractor` alone, exactly as the page already argues. No integration was started, and none is warranted.

The only diff this produced in the comparison section is a second date on the provenance line, recording that the reading was re-taken 2026-08-16 and held. `requirements-mine.md` was checked too: its two virtualizer rows link to this page and restate no vendor property, so nothing there needed correcting.

## Publication fence

`virtualizer-recipe.md` is **not** one of the published copies. `docs/design/hicasso/product/README.md:71` names those as `decision-brief.md`, `specification.md` and everything under `lanes/` — the set `rf2-rbme3` holds. This page is in-tree work product and editing it here is safe.

## Gates

Run foreground to completion, exit codes captured on the same command line.

| gate | exit |
|---|---|
| `python scripts/check_doc_slugs.py` | **0** |
| `python scripts/check_provenance_pins.py` | **0** — 112 pages, 523 pins, 0 findings |
| `sh scripts/check-no-hardcoded-paths.sh` | **0** |

`check_doc_slugs.py` prints nothing on success, so it was proved live rather than assumed: a broken anchor was planted in this file, the gate exited **1** naming `docs\design\hicasso\product\virtualizer-recipe.md:121`, the file was restored, and the restoration was verified by `sha256sum -c` against the pre-fault digest before the green run. That also proves the gate read this worktree and not another.

`mkdocs build --strict` is **not** nominated — `exclude_docs` drops `docs/design/**`, so it cannot see this file.

**Table columns hand-verified**, since nothing in this tree validates them: the three tables in the page are 3/3/3/3, 4/4/4/4 and 3/3/3/3/3 cells (header, separator, data rows) — all consistent. The table in this PR body is 4 columns throughout.
