### PR TITLE
feat(story): register the :hicasso substrate render-fn and widen SubstrateSet (rf2-2dbpd)

### DIFF
--- a/tools/story/src/re_frame/story/schemas.cljc
+++ b/tools/story/src/re_frame/story/schemas.cljc
@@ -279,13 +279,45 @@
   [:map-of :keyword :any])
 
 (def SubstrateSet
-  "Subset of the recognised substrate ids. The framework supplies the
-  closed set; Story validates membership. `:reagent-slim` is reserved
-  for addition at reagent-slim GA / first published artefact — the
-  same trigger that gates Story's own UI-shell migration (see
-  spec/Principles.md §Reagent for the v1 UI shell). Not yet on the
-  canonical substrate enum. See spec/000-Vision."
-  [:set [:enum :reagent :uix]])
+  "The AUTHORING LAYERS a variant may be rendered under — Story's own
+  render-strategy axis, closed here and validated at registration.
+
+  ## It is not a mirror of the framework's adapter enum (rf2-1gy4e)
+
+  This docstring used to say *the framework supplies the closed set*,
+  and that was false in a way worth stating rather than deleting: there
+  is no framework-supplied set for it to mirror. A member here names
+  WHICH REGISTERED RENDER FN embeds the subject in the canvas
+  (`re-frame.story.ui.multi-substrate/substrate->render-fn`) — a
+  different question from which renderer `rf/init!` installed, which is
+  the adapter enum's (spec/006-ReactiveSubstrate.md §CLJS reference
+  scope). The two axes coincided while the members were `:reagent` and
+  `:uix`, and the coincidence read as identity.
+
+  `:hicasso` is the member that separates them, and it is why the claim
+  had to go. Hicasso ships NO adapter — there is no `:rf.adapter/hicasso`
+  anywhere in the repository, deliberately — and a Hicasso application
+  boots on the UIx adapter. It is nonetheless a distinct authoring layer
+  with a distinct render strategy: its views are boundaries minted by
+  `h/defview`, reached through `:hicasso/component` on the view
+  registrar and crossed into with `h/as-element`. So it belongs on THIS
+  axis and is correctly absent from that one.
+
+  ## Who registers what
+
+  Story installs `:reagent` itself (`install-reagent-substrate!`). `:uix`
+  and `:hicasso` are host-registered at boot through the public
+  `register-substrate!` — the `:hicasso` recipe is written out in
+  `re-frame.story.ui.multi-substrate`'s ns docstring. Membership here is
+  an AUTHORING vocabulary check; it says nothing about whether the host
+  actually registered a renderer, and a variant naming a substrate no
+  one registered degrades loudly at render time rather than silently
+  painting Reagent (rf2-3afns).
+
+  `:reagent-slim` is reserved for addition at reagent-slim GA / first
+  published artefact — the same trigger that gates Story's own UI-shell
+  migration (see spec/Principles.md §Reagent for the v1 UI shell)."
+  [:set [:enum :reagent :uix :hicasso]])
 
 (def PlatformSet
   "Subset of `#{:server :client}` per /spec/007-Stories.md `:platforms`."

--- a/tools/story/src/re_frame/story/ui/multi_substrate.cljs
+++ b/tools/story/src/re_frame/story/ui/multi_substrate.cljs
@@ -12,8 +12,73 @@
 
   Story doesn't add a new framework registry — substrate-rendering hooks
   are looked up in `substrate->render-fn` here. Story installs `:reagent`;
-  hosts that load UIx or another adapter register its renderer with
-  `register-substrate!`.
+  hosts that load UIx, Hicasso or another authoring layer register its
+  renderer with `register-substrate!`.
+
+  A substrate here is an AUTHORING LAYER — which registered render fn
+  embeds the subject — and not the adapter `rf/init!` installed. The two
+  are different axes, which `re-frame.story.schemas/SubstrateSet`'s
+  docstring sets out; `:hicasso` is the member that makes the difference
+  visible, since Hicasso ships no adapter and boots on UIx.
+
+  ## The `:hicasso` recipe (rf2-2dbpd)
+
+  Story ships no installer for it, for exactly the reason it ships none
+  for `:uix`: the renderer's one dependency is the HOST's, and Story core
+  stays free of it. Five lines at boot are the whole of it.
+
+      (ns my.app.story-boot
+        (:require [re-frame.core :as rf]
+                  [re-frame.hicasso :as h]
+                  [re-frame.story :as story]))
+
+      (story/register-substrate! :hicasso
+        (fn [_variant-id view-id args]
+          (if-let [head (:hicasso/component (rf/handler-meta :view view-id))]
+            (h/as-element [head args])
+            [:div (str \":component \" (pr-str view-id)
+                       \" is not registered as a hicasso view\")])))
+
+  Four facts about those lines, and each is a reason there are so few.
+
+  **`h/defview` publishes the keyword a story names** (rf2-5qaf4). The
+  declaration registers one `:view` entry under `(keyword \"<ns>\" \"<sym>\")`
+  carrying the minted head at `:hicasso/component`. It is an AUTHORING-TIME
+  ALIAS — debug-gated, and with NO `:handler-fn`, so `rf/view` answers nil
+  for it and this render fn reads the slot instead. A story therefore names
+  a Hicasso view exactly as it names a Reagent one, and `:component` stays
+  a keyword everywhere.
+
+  **Resolution is LATE, per render, and that is not incidental to the
+  shape.** Re-evaluating a `defview` replaces the entry behind the same id
+  with a fresh head, so a hot reload of the view's namespace reaches the
+  story with no story change. A head captured once at boot would paint the
+  stale one after every save.
+
+  **The element is minted fresh and its TYPE is stable, so there is no
+  cache to keep.** `h/defview` already mints ONE `React.memo` wrapper per
+  head at definition time and every element made from that head rides it
+  (`re-frame.hicasso.impl.codec/memoize-boundary!` + `element-type`), so a
+  fresh element per pass re-renders the boundary and never remounts it.
+  `h/as-component` is the wrong door here on both counts: it allocates a
+  component per call — a new element type every render, which React
+  responds to by unmounting the subtree — and it exists to decode
+  camelCase props from a NATIVE parent, work Story does not need, since it
+  already holds the kebab-keyword CLJS args map the boundary body wants.
+
+  **No frame plumbing appears, because none is needed.** The canvas
+  already wraps the subject in `[rf/frame-provider {:frame variant-id} …]`
+  (`re-frame.story.ui.canvas`), whose provider is
+  `re-frame.adapter.context/frame-context` — the single React context
+  every React-shaped adapter reads. A Hicasso boundary spliced into that
+  Reagent tree resolves the VARIANT's frame from it, with no second root,
+  no second state owner and no props ABI. (`h/mount!` is likewise the
+  wrong door: it makes a root, and the canvas is already inside one.)
+
+  Hicasso stories hand-author `:argtypes`. Auto-derivation reads the
+  view's `[:rf/props :schema]` `reg-view` metadata and `defview` carries
+  no props-schema slot — deferred by rf2-1gy4e until someone asks for
+  auto-Controls, rather than invented here.
 
   ## Grid layout
 
@@ -96,8 +161,9 @@
          the named substrate, threading `args` into the component.
 
          Pre-populated with `:reagent` which uses `re-frame.core/view`
-         + plain reagent. UIx entries plug in via
-         `register-substrate!` from the host app."}
+         + plain reagent. `:uix` and `:hicasso` entries plug in via
+         `register-substrate!` from the host app — the `:hicasso`
+         renderer is written out in this namespace's ns docstring."}
   substrate->render-fn
   (atom {}))
 
@@ -108,8 +174,11 @@
   `install-reagent-substrate!` below).
 
   `render-fn` takes `(variant-id view-id args)` and returns a hiccup
-  vector (Reagent) or a `react/createElement`-style React element
-  (UIx). Story's grid renders the result inside a `:div` cell."
+  vector (Reagent) or a `react/createElement`-style React element (UIx,
+  and Hicasso via `h/as-element`). Story's grid renders the result inside
+  a `:div` cell, and the single pane splices it into the canvas tree —
+  Reagent passes a React element in child position through untouched, so
+  the two return shapes are interchangeable at every call site."
   [substrate-id render-fn]
   (swap! substrate->render-fn assoc substrate-id render-fn)
   nil)

--- a/tools/story/src/re_frame/story/ui/multi_substrate.cljs
+++ b/tools/story/src/re_frame/story/ui/multi_substrate.cljs
@@ -80,6 +80,21 @@
   no props-schema slot — deferred by rf2-1gy4e until someone asks for
   auto-Controls, rather than invented here.
 
+  ### One live limit, and it is not this renderer's (rf2-phabt)
+
+  A Hicasso boundary crossed into from a Reagent parent — which is what
+  the canvas is — **paints once and does not re-render on a write into
+  its own frame.** Measured against a live control while this renderer
+  landed: the same boundary under `h/mount!` repaints, and both outward
+  doors (`h/as-element` and a memoized `h/as-component`) are deaf, so it
+  is the crossing rather than the door, the adapter or the drain.
+
+  So a hicasso story renders, takes its args, resolves its variant frame
+  and reads it — and does not yet respond to its own dispatches. Nothing
+  here works around it: a workaround would be a second reactivity path
+  for one substrate. It is fixed in Hicasso, and rf2-kttom's worked
+  testbed waits on it.
+
   ## Grid layout
 
   Each substrate renders into its own bordered cell with a small header

--- a/tools/story/test/re_frame/story/hicasso_substrate_cljs_test.cljc
+++ b/tools/story/test/re_frame/story/hicasso_substrate_cljs_test.cljc
@@ -148,8 +148,8 @@
 ;; `[:world :substrates]` and falls back to the `:reagent` host default.
 ;; That is a narrower residue of the same disagreement rf2-3afns closed,
 ;; it is not about hicasso, and both files are outside this bead's fence;
-;; it is filed rather than fixed here. The rows below pin what the plan
-;; DOES carry.
+;; it is FILED rather than fixed here, as rf2-sc5g0. The rows below pin
+;; what the plan DOES carry.
 
 (deftest the-plan-carries-the-hicasso-declaration
   (testing "rf2-3afns routed `canonical/render-host-scope` at the COMPILED

--- a/tools/story/test/re_frame/story/hicasso_substrate_cljs_test.cljc
+++ b/tools/story/test/re_frame/story/hicasso_substrate_cljs_test.cljc
@@ -1,0 +1,249 @@
+(ns re-frame.story.hicasso-substrate-cljs-test
+  "rf2-2dbpd — `:hicasso` on Story's AUTHORING-LAYER axis, proved on the
+  paths that carry a substrate keyword through data rather than through a
+  render.
+
+  ## What this namespace is the witness for
+
+  `re-frame.story.schemas/SubstrateSet` was `[:set [:enum :reagent :uix]]`
+  — the ONE closed substrate enum in the repository — so a variant
+  declaring `:substrates #{:hicasso}` could not be REGISTERED, let alone
+  rendered: `registrar/validate-shape!` threw `:rf.error/variant-shape`
+  before any renderer was consulted. Widening it is one line; the rows
+  below are what say the widen actually reaches the four places a
+  substrate keyword has to survive to be worth anything.
+
+  1. **Registration** — the closed shape accepts it, on the variant body
+     and on the story body, and STILL refuses an unknown member. A widen
+     that quietly opened the enum would pass every other row here.
+  2. **Plan compilation** — `plan/variant-plan` folds it to
+     `[:world :substrates]`, which is where `canonical/render-host-scope`
+     reads the declared set (rf2-3afns).
+  3. **The EDN / MCP read path** — `story/variant->edn` is what the MCP
+     `list-variants` / read tools relay to an agent, and a keyword that
+     did not round-trip would strand the agent on a story it can see and
+     cannot describe.
+  4. **Snapshot identity** — two hicasso views must be two baselines. The
+     ruling asks for this by name because it is the one that could
+     silently collapse: `fingerprint.cljc` folds every FUNCTION to the
+     `:rf/opaque-fn` sentinel, so had `:component` been widened to accept
+     a component VALUE (rf2-1gy4e's rejected option (a)) two distinct
+     hicasso views would have hashed identically. It stayed a keyword, and
+     these rows are what says so.
+
+  ## Both arms, deliberately
+
+  `.cljc` with a `-cljs-test` ns, so the JVM runner (`clojure -M:test`
+  from `tools/story`) and the shadow `:node-test` build (`npm run
+  test:cljs`, whose `cljs-test$` regex matches) each run every row. Every
+  claim here is about DATA — schema, plan, EDN, hash — so neither arm
+  needs a renderer, and nothing here requires `re-frame.hicasso`: that is
+  what keeps `tools/story/deps.edn` untouched, per rf2-1gy4e's placement
+  ruling. The renderer itself is proved in
+  `re-frame.story.ui.hicasso-substrate-dom-cljs-test`."
+  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            [malli.core :as m]
+            [re-frame.frame :as frame]
+            [re-frame.registrar :as rf-registrar]
+            [re-frame.story :as story]
+            [re-frame.story.identity :as identity]
+            [re-frame.story.plan :as plan]
+            [re-frame.story.registrar :as story-registrar]
+            [re-frame.story.schemas :as schemas]))
+
+;; ---- fixture --------------------------------------------------------------
+
+(defn- reset-all! []
+  (story/clear-all!)
+  (rf-registrar/clear-all!)
+  (reset! frame/frames {})
+  (story/install-canonical-vocabulary!)
+  (frame/ensure-default-frame!))
+
+(use-fixtures :each (fn [t] (reset-all!) (t)))
+
+;; ===========================================================================
+;; 1 · the enum — widened, and still CLOSED
+;; ===========================================================================
+
+(deftest substrate-set-admits-hicasso
+  (testing "rf2-2dbpd — `#{:hicasso}` is a legal substrate set. Before the
+            widen this was the whole blocker: the schema rejected it, so
+            no hicasso variant could be registered at all."
+    (is (m/validate schemas/SubstrateSet #{:hicasso}))
+    (is (m/validate schemas/SubstrateSet #{:reagent :hicasso}))
+    (is (m/validate schemas/SubstrateSet #{:reagent :uix :hicasso})))
+
+  (testing "and the members that were already legal still are — the widen
+            is additive, not a replacement"
+    (is (m/validate schemas/SubstrateSet #{:reagent}))
+    (is (m/validate schemas/SubstrateSet #{:uix}))
+    (is (m/validate schemas/SubstrateSet #{})))
+
+  (testing "the enum is still CLOSED, which is the half a widen can lose
+            with nothing going red to say so. `:reagent-slim` is the
+            reserved member the docstring names as NOT YET admitted, and
+            `:helix` is an authoring layer Story does not carry at all; if
+            either row ever passes, the widen has become an opening and
+            `SubstrateSet` validates nothing."
+    (is (not (m/validate schemas/SubstrateSet #{:reagent-slim})))
+    (is (not (m/validate schemas/SubstrateSet #{:helix})))
+    (is (not (m/validate schemas/SubstrateSet #{:reagent :helix})))
+    (is (not (m/validate schemas/SubstrateSet #{:hicasso :typo})))
+    (is (not (m/validate schemas/SubstrateSet [:hicasso]))
+        "a VECTOR is not a set — the slot's shape is unchanged too")))
+
+;; ===========================================================================
+;; 2 · registration — the closed body shapes take it, on both bodies
+;; ===========================================================================
+
+(deftest a-hicasso-variant-registers
+  (testing "rf2-2dbpd — `reg-variant*` validates the body against
+            `VariantBody` and throws `:rf.error/variant-shape` on a miss
+            (`re-frame.story.registrar/validate-shape!`). Pre-widen THIS
+            call threw; the registration landing is the user-visible half
+            of the enum change."
+    (story/reg-story* :story.hic {:doc "hicasso authoring-layer fixture"})
+    (story/reg-variant* :story.hic/card
+      {:doc        "A variant whose subject is a hicasso boundary."
+       :component  :my.app.views/article-card
+       :substrates #{:hicasso}})
+    (is (= #{:hicasso} (:substrates (story/variant->edn :story.hic/card)))))
+
+  (testing "and the STORY body takes it too — `StoryBody` is closed
+            independently of `VariantBody`, so a whole story can declare
+            the authoring layer once. (Where that story-level declaration
+            is READ is the canvas's `resolve-substrate-set`, not the
+            compiled plan; see the plan row below.)"
+    (story/reg-story* :story.hic-all
+      {:doc        "story-level declaration"
+       :component  :my.app.views/article-card
+       :substrates #{:hicasso}})
+    (story/reg-variant* :story.hic-all/v {:doc "child"})
+    (is (= #{:hicasso}
+           (:substrates (story-registrar/handler-meta :story :story.hic-all))))))
+
+(deftest an-unknown-substrate-is-still-refused-at-registration
+  (testing "the closed enum is enforced where it matters — at
+            registration, with the catalogued error id, so an author's
+            typo is a loud refusal rather than a variant that renders
+            under whatever the shell defaulted to"
+    (story/reg-story* :story.hic-bad {:doc "fixture"})
+    (is (thrown? #?(:clj clojure.lang.ExceptionInfo :cljs js/Error)
+          (story/reg-variant* :story.hic-bad/typo
+            {:doc "declares a substrate nobody defines"
+             :substrates #{:hicaso}})))))
+
+;; ===========================================================================
+;; 3 · plan compilation — `[:world :substrates]` is where the host reads it
+;; ===========================================================================
+;;
+;; MEASURED WHILE WRITING THESE ROWS, and left alone deliberately: the plan
+;; folds `:substrates` from the VARIANT and its `:extends` chain, and NOT
+;; from the parent story. `variant-plan` resolves the parent story for
+;; decorators and tags only (`plan.cljc` `sid` / `story-deco-lk`). So a
+;; substrate declared ONLY at story level reaches the canvas — which reads
+;; it through `multi-substrate/resolve-substrate-set`, story-body included
+;; — and does NOT reach `canonical/render-host-scope`, which reads
+;; `[:world :substrates]` and falls back to the `:reagent` host default.
+;; That is a narrower residue of the same disagreement rf2-3afns closed,
+;; it is not about hicasso, and both files are outside this bead's fence;
+;; it is filed rather than fixed here. The rows below pin what the plan
+;; DOES carry.
+
+(deftest the-plan-carries-the-hicasso-declaration
+  (testing "rf2-3afns routed `canonical/render-host-scope` at the COMPILED
+            PLAN's `[:world :substrates]` instead of a literal `:reagent`,
+            so that slot is the one a hicasso variant has to reach. It is
+            folded by `plan/variant-plan`, already `:extends`-merged."
+    (story/reg-story* :story.hicplan {:doc "fixture"})
+    (story/reg-variant* :story.hicplan/v
+      {:doc        "declares the native authoring layer"
+       :component  :my.app.views/article-card
+       :substrates #{:hicasso}})
+    (let [p (plan/variant-plan :story.hicplan/v)]
+      (is (= #{:hicasso} (get-in p [:world :substrates])))
+      (is (= :my.app.views/article-card (get-in p [:world :component]))
+          "and the subject rides beside it — the two slots the renderer
+           needs are both on the plan")))
+
+  (testing "`:extends` inheritance carries it, so a hicasso base story's
+            children do not each re-declare the layer"
+    (story/reg-story* :story.hicext {:doc "fixture"})
+    (story/reg-variant* :story.hicext/base
+      {:doc "base" :component :my.app.views/article-card
+       :substrates #{:hicasso}})
+    (story/reg-variant* :story.hicext/child
+      {:doc "child" :extends :story.hicext/base})
+    (is (= #{:hicasso}
+           (get-in (plan/variant-plan :story.hicext/child)
+                   [:world :substrates])))))
+
+;; ===========================================================================
+;; 4 · the EDN / MCP read path
+;; ===========================================================================
+
+(deftest the-substrate-keyword-round-trips-through-the-mcp-read-path
+  (testing "`variant->edn` returns the registered body as serialisable EDN
+            — the shape `re-frame.story-mcp`'s read tools relay to an
+            agent. A keyword that did not survive here would leave an
+            agent able to list a hicasso story and unable to say what it
+            renders under."
+    (story/reg-story* :story.hicedn {:doc "fixture"})
+    (let [body {:doc        "a hicasso variant"
+                :component  :my.app.views/article-card
+                :substrates #{:hicasso}
+                :args       {:label "one"}}]
+      (story/reg-variant* :story.hicedn/v body)
+      (let [edn (story/variant->edn :story.hicedn/v)]
+        (is (= #{:hicasso} (:substrates edn)))
+        (is (= :my.app.views/article-card (:component edn))
+            "and `:component` is still a KEYWORD — the whole reason
+             rf2-1gy4e ruled hicasso-side registration rather than
+             widening `:component` to accept a value")
+        (is (= body (select-keys edn (keys body)))
+            "the body round-trips verbatim; `:source` is the registrar's
+             own stamp and is the only addition")))))
+
+;; ===========================================================================
+;; 5 · snapshot identity — two hicasso views are two baselines
+;; ===========================================================================
+
+(deftest two-hicasso-view-ids-are-two-identities
+  (testing "rf2-1gy4e's decisive ground for ruling against a component
+            VALUE in `:component`: `fingerprint.cljc` canonicalises every
+            fn to the `:rf/opaque-fn` sentinel, so two distinct hicasso
+            heads would have been INDISTINGUISHABLE to snapshot identity —
+            one visual-regression baseline for two views. Naming them with
+            keywords is what keeps them apart, and this is the row that
+            would have caught it."
+    (story/reg-story* :story.hicid {:doc "fixture"})
+    (story/reg-variant* :story.hicid/card
+      {:doc "one" :component :my.app.views/article-card :substrates #{:hicasso}})
+    (story/reg-variant* :story.hicid/panel
+      {:doc "one" :component :my.app.views/side-panel :substrates #{:hicasso}})
+    (let [a (:content-hash (identity/snapshot-identity :story.hicid/card))
+          b (:content-hash (identity/snapshot-identity :story.hicid/panel))]
+      (is (string? a))
+      (is (not= a b)
+          "two hicasso view ids, differing in NOTHING but `:component`,
+           get distinct content hashes")))
+
+  (testing "and the authoring layer is identity-bearing in its own right —
+            the same view stories under two layers are two baselines,
+            because the two renderers paint two trees"
+    (story/reg-story* :story.hiclayer {:doc "fixture"})
+    (story/reg-variant* :story.hiclayer/hic
+      {:doc "x" :component :my.app.views/article-card :substrates #{:hicasso}})
+    (story/reg-variant* :story.hiclayer/rea
+      {:doc "x" :component :my.app.views/article-card :substrates #{:reagent}})
+    (is (not= (:content-hash (identity/snapshot-identity :story.hiclayer/hic))
+              (:content-hash (identity/snapshot-identity :story.hiclayer/rea)))))
+
+  (testing "the hash is STABLE for one hicasso variant across calls — the
+            distinctions above are the tuple's, not run-to-run noise"
+    (story/reg-story* :story.hicstable {:doc "fixture"})
+    (story/reg-variant* :story.hicstable/v
+      {:doc "x" :component :my.app.views/article-card :substrates #{:hicasso}})
+    (is (= (:content-hash (identity/snapshot-identity :story.hicstable/v))
+           (:content-hash (identity/snapshot-identity :story.hicstable/v))))))

--- a/tools/story/test/re_frame/story/ui/hicasso_substrate_dom_cljs_test.cljs
+++ b/tools/story/test/re_frame/story/ui/hicasso_substrate_dom_cljs_test.cljs
@@ -1,0 +1,485 @@
+(ns re-frame.story.ui.hicasso-substrate-dom-cljs-test
+  "rf2-2dbpd — THE `:hicasso` SUBSTRATE RENDER FN, and the Reagent-parent
+  crossing it stands on.
+
+  ## The spike this file was written to settle
+
+  rf2-5czki's survey found that Hicasso needs no new plumbing to paint in
+  Story's canvas — `h/as-element` mints a React element from a boundary
+  head, and the canvas already wraps the subject in
+  `[rf/frame-provider {:frame variant-id} …]`, whose provider is the one
+  React context every React-shaped adapter reads. But it also found that
+  NOTHING IN THE REPOSITORY WITNESSED THAT CROSSING: every `h/as-component`
+  / `h/as-element` boundary crossing had a Hicasso, native or UIx parent,
+  and Reagent was not among them. The ruling named it the one material
+  uncertainty and made proving it a precondition of the registration.
+
+  This namespace is that proof, and then the registration's own coverage.
+  `crossing-paints-under-a-reagent-parent` is the spike stated as a row:
+  a `h/defview` boundary, spliced into a REAGENT hiccup tree under
+  `rf/frame-provider`, mounted through `reagent.dom.client` into a real
+  DOM, painting its own markup and reading a subscription from the frame
+  the Reagent provider scoped.
+
+  ## The render fn under test is the SHIPPED RECIPE
+
+  Story ships no `install-hicasso-substrate!` — ruled (rf2-1gy4e
+  placement 1): `:hicasso` is host-registered exactly as `:uix` is, so
+  Story core never names Hicasso and `tools/story/deps.edn` is untouched.
+  [[hicasso-render]] below is therefore the CONSUMER's five lines, and it
+  is byte-for-byte the recipe written out in
+  `re-frame.story.ui.multi-substrate`'s ns docstring. It is registered
+  here through the public `story/register-substrate!` — no private seam,
+  no stub.
+
+  Three decisions ride in those five lines, all ruled on rf2-2dbpd:
+
+  - **resolve LATE, per render**, off `(rf/handler-meta :view id)` — so
+    re-evaluating a `defview` (which replaces the registrar entry behind
+    the same id) reaches the story with no story change;
+  - **read `:hicasso/component`**, because the alias entry deliberately
+    carries no `:handler-fn` and `rf/view` answers nil for it (rf2-5qaf4);
+  - **mint the element directly** with `h/as-element` rather than bridging
+    through `h/as-component`. `element-type-is-stable-across-renders` is
+    the evidence: `defview` already mints ONE `React.memo` wrapper per
+    head at definition time, so a fresh element per pass rides a stable
+    type and the boundary re-renders instead of remounting. A memoized
+    `as-component` would re-implement that machinery one layer up.
+
+  ## Two lanes, one file
+
+  `-dom-cljs-test$` puts this namespace in the `:browser-test` build
+  (real React, real DOM) AND in `:node-test` (whose `cljs-test$` matches
+  the same suffix). The rows that need a fiber self-gate on `(browser?)`
+  and say so in Node rather than passing quietly; the registry, resolution
+  and degradation rows need no DOM and run in both."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            ["react" :as react]
+            ["react-dom" :as react-dom]
+            [reagent.dom.client :as rdc]
+            [re-frame.adapter.reagent :as reagent-adapter]
+            [re-frame.core :as rf]
+            [re-frame.frame :as frame]
+            [re-frame.hicasso :as h]
+            [re-frame.machines :as machines]
+            [re-frame.registrar :as rf-registrar]
+            [re-frame.story :as story]
+            [re-frame.story.loaders :as loaders]
+            [re-frame.story.ui.canvas :as canvas]
+            [re-frame.story.ui.multi-substrate :as multi-substrate]
+            [re-frame.story.ui.state :as state]
+            [re-frame.story.test-helpers.e2e-multi-frame :as e2e]
+            [re-frame.subs :as subs]))
+
+;; ---------------------------------------------------------------------------
+;; The subject — ordinary Hicasso views, declared at namespace load
+;; ---------------------------------------------------------------------------
+;;
+;; Declared at the top level, which is where `defview` belongs and also
+;; where its registrar alias is published: the entry is written during
+;; namespace LOAD, before any fixture runs. `reset-all!` clears the
+;; framework registrar, so the aliases are snapshotted below and folded
+;; back before each test — the same problem (and the same shape of answer)
+;; `re-frame.hicasso.view-alias-registry-cljs-test` solves by pinning its
+;; fixture baseline after the declarations.
+
+(defonce ^:private !card-runs (atom 0))
+
+(h/defview hicasso-card
+  "An ordinary boundary. It reads a subscription, so the frame it resolved
+  is observable on screen rather than only in a cell table."
+  [props]
+  (swap! !card-runs inc)
+  [:article {:class "hic-card" :data-test "hicasso-card"}
+   (str (:label props) "/" (h/sub [::counter]))])
+
+(h/defview hicasso-panel
+  "A SECOND boundary, so a row can tell one hicasso view from another
+  rather than merely from Reagent."
+  [props]
+  [:aside {:data-test "hicasso-panel"} (str "panel:" (:label props))])
+
+(def ^:private card-id  ::hicasso-card)
+(def ^:private panel-id ::hicasso-panel)
+
+(def ^:private alias-entries
+  "The registrar entries `h/defview` published at NAMESPACE LOAD, captured
+  before any fixture can clear them. `reset-all!` folds them back.
+
+  Snapshotting the WHOLE entry rather than re-deriving it keeps this
+  helper honest about what it restores: whatever `defview` actually wrote
+  is what each test reads, so a change to the alias shape reaches these
+  rows instead of being papered over by a hand-built stand-in."
+  {card-id  (rf/handler-meta :view card-id)
+   panel-id (rf/handler-meta :view panel-id)})
+
+;; ---------------------------------------------------------------------------
+;; THE RECIPE UNDER TEST — the consumer's five lines
+;; ---------------------------------------------------------------------------
+
+(defn- hicasso-render
+  "The `:hicasso` substrate render fn, exactly as a host writes it (and
+  exactly as `multi-substrate`'s ns docstring writes it out)."
+  [_variant-id view-id args]
+  (if-let [head (:hicasso/component (rf/handler-meta :view view-id))]
+    (h/as-element [head args])
+    [:div (str ":component " (pr-str view-id)
+               " is not registered as a hicasso view")]))
+
+;; ---- fixture --------------------------------------------------------------
+
+(declare register-probes!)
+
+(defn- reset-all! []
+  (story/clear-all!)
+  (rf-registrar/clear-all!)
+  (reset! frame/frames {})
+  (try (rf/init! reagent-adapter/adapter) (catch :default _ nil))
+  ;; The framework `:rf/machine` sub, re-registered after the clear — the
+  ;; lifecycle machine cannot resolve without it and the canvas parks at
+  ;; `:pre-mount` forever.
+  (subs/reg-runtime-sub :rf/machine
+    (fn [runtime-db [_ machine-id]]
+      (get-in runtime-db [:rf.runtime/machines :snapshots machine-id])))
+  (machines/reset-timers!)
+  (loaders/clear-watchers!)
+  (canvas/reset-first-rendered!)
+  (state/reset-shell-state!)
+  (story/install-canonical-vocabulary!)
+  (frame/ensure-default-frame!)
+  ;; Fold the load-time aliases back over the cleared registrar.
+  (doseq [[id entry] alias-entries]
+    (rf-registrar/register! :view id entry))
+  ;; Start every case from a KNOWN-EMPTY `:hicasso` slot: the degradation
+  ;; row wants it absent, every other row registers it.
+  (multi-substrate/unregister-substrate! :hicasso)
+  (reset! !card-runs 0)
+  (register-probes!))
+
+(defn- restore-registry!
+  "`substrate->render-fn` is a `defonce` atom that `story/clear-all!` does
+  not touch, so a `:hicasso` entry left here would leak into every
+  namespace that runs after this one."
+  []
+  (multi-substrate/unregister-substrate! :hicasso))
+
+(use-fixtures :each {:before reset-all! :after restore-registry!})
+
+;; ---- probe registrations --------------------------------------------------
+
+(defn- reagent-probe-view
+  "A REAGENT view, so every row can say WHICH authoring layer painted.
+  The two markers are mutually exclusive by construction."
+  [_args]
+  [:div {:data-test "reagent-view-render"} "rendered under reagent"])
+
+(defn- register-probes! []
+  (rf/reg-event :hicsub/bump
+    (fn [{:keys [db]} [_ n]] {:db (assoc db :n n)}))
+  (rf/reg-sub ::counter (fn [db _] (or (:n db) 0)))
+  ;; A Reagent view registered under a DIFFERENT id, reachable only
+  ;; through `rf/view`. A hicasso variant must never resolve to it.
+  (rf/reg-view* :views/reagent-probe reagent-probe-view)
+  (story/reg-story* :story.hicasso {:doc "rf2-2dbpd witness story"})
+  (story/reg-variant* :story.hicasso/card
+    {:doc        "One declared substrate, and it is the native one."
+     :component  card-id
+     :substrates #{:hicasso}
+     :args       {:label "alpha"}
+     :loaders    [[:noop/loader]]})
+  (story/reg-variant* :story.hicasso/panel
+    {:doc        "A second hicasso view under the same substrate."
+     :component  panel-id
+     :substrates #{:hicasso}
+     :args       {:label "beta"}
+     :loaders    [[:noop/loader]]})
+  (story/reg-variant* :story.hicasso/missing-view
+    {:doc        "Names a view no registrar entry answers for."
+     :component  :views/nobody-registered-this
+     :substrates #{:hicasso}
+     :loaders    [[:noop/loader]]}))
+
+;; ---- helpers --------------------------------------------------------------
+
+(def ^:private canvas-inner @#'canvas/canvas-inner)
+
+(defn- browser? []
+  (and (exists? js/document)
+       (some? (.-createElement js/document))))
+
+(defn- make-mount-node! []
+  (let [node (js/document.createElement "div")]
+    (js/document.body.appendChild node)
+    node))
+
+(defn- ready-tree
+  "Drive `variant-id`'s lifecycle to `:ready`, then render the canvas's
+  inner tree and expand it to plain hiccup. Without `:ready` + the
+  first-rendered sentinel the canvas paints a skeleton, which carries
+  NEITHER marker and would fail every assertion for the wrong reason."
+  [variant-id]
+  (rf/make-frame {:id variant-id})
+  (loaders/mount! variant-id)
+  (loaders/start-loaders! variant-id)
+  (loaders/finish-loaders! variant-id)
+  (loaders/finish-events! variant-id)
+  (canvas/mark-variant-rendered! variant-id)
+  (e2e/expand-tree (canvas-inner variant-id)))
+
+(defn- find-react-element
+  "Depth-first search for the first React element in an expanded hiccup
+  tree. `expand-tree` leaves a React element untouched (it is neither a
+  vector nor a seq), so this is how the boundary's element is located
+  inside the canvas's Reagent tree."
+  [tree]
+  (cond
+    (react/isValidElement tree) tree
+    (or (vector? tree) (seq? tree)) (some find-react-element tree)
+    :else nil))
+
+(defn- rendered-under-reagent? [tree]
+  (some? (e2e/find-by-test-id tree "reagent-view-render")))
+
+;; ===========================================================================
+;; 1 · THE SPIKE — a Hicasso boundary paints inside a REAGENT tree
+;; ===========================================================================
+
+(deftest crossing-paints-under-a-reagent-parent
+  (testing "rf2-2dbpd's mandated spike. Nothing in the repository witnessed
+            a Hicasso boundary rendering inside a REAGENT tree: the
+            crossing is designed and documented, and every witnessed parent
+            was Hicasso, native or UIx. This mounts one — a `h/defview`
+            head, minted to an element by `h/as-element`, spliced into a
+            Reagent hiccup vector under `rf/frame-provider`, committed
+            through `reagent.dom.client` into a real DOM. If this row
+            cannot be made green the registration is worthless and the
+            answer is a Hicasso finding, not a Story workaround."
+    (if-not (browser?)
+      (is true ":node-test — no DOM; :browser-test runs this row")
+      (let [variant-id :story.hicasso/card
+            mount-node (make-mount-node!)
+            root       (rdc/create-root mount-node)]
+        (rf/make-frame {:id variant-id})
+        (rf/dispatch-sync [:hicsub/bump 7] {:frame variant-id})
+        (try
+          (react-dom/flushSync
+            (fn []
+              (rdc/render root
+                [rf/frame-provider {:frame variant-id}
+                 [:div.reagent-parent
+                  (h/as-element [hicasso-card {:label "alpha"}])]])))
+          (let [el (.querySelector mount-node "[data-test=\"hicasso-card\"]")]
+            (is (some? el)
+                "THE CROSSING PAINTS — a Hicasso boundary rendered its own
+                 markup inside a Reagent parent, with no second root and no
+                 mount door called")
+            (is (= "alpha/7" (some-> el .-textContent))
+                "and it resolved the VARIANT's frame from the Reagent
+                 `frame-provider` above it: `alpha` is the props map that
+                 crossed, `7` is a subscription read in that frame. A
+                 boundary that resolved a frame of its own would read the
+                 default frame's 0."))
+          (finally
+            (try (.unmount root) (catch :default _ nil))))))))
+
+(deftest the-frame-the-reagent-provider-scoped-is-the-one-observed
+  (testing "the crossing is not merely wired at mount — a write into the
+            variant frame after the commit reaches the boundary's read. If
+            the boundary had resolved the ambient/default frame, the first
+            paint could still have been right by accident and this update
+            would not land."
+    (if-not (browser?)
+      (is true ":node-test — no DOM; :browser-test runs this row")
+      (let [variant-id :story.hicasso/card
+            mount-node (make-mount-node!)
+            root       (rdc/create-root mount-node)]
+        (rf/make-frame {:id variant-id})
+        (rf/dispatch-sync [:hicsub/bump 1] {:frame variant-id})
+        (try
+          (react-dom/flushSync
+            (fn []
+              (rdc/render root
+                [rf/frame-provider {:frame variant-id}
+                 [:div.reagent-parent
+                  (h/as-element [hicasso-card {:label "alpha"}])]])))
+          (is (= "alpha/1"
+                 (some-> (.querySelector mount-node "[data-test=\"hicasso-card\"]")
+                         .-textContent)))
+          (react-dom/flushSync
+            (fn [] (rf/dispatch-sync [:hicsub/bump 42] {:frame variant-id})))
+          (is (= "alpha/42"
+                 (some-> (.querySelector mount-node "[data-test=\"hicasso-card\"]")
+                         .-textContent))
+              "the boundary tracked the variant frame across a write")
+          (finally
+            (try (.unmount root) (catch :default _ nil))))))))
+
+(deftest a-reagent-parent-rerender-does-not-remount-the-boundary
+  (testing "the identity decision, measured on a fiber. The render fn mints
+            a FRESH element every pass and keeps no cache, which is only
+            safe because `defview` mints one stable `React.memo` wrapper
+            per head at definition time and every element rides that type.
+            Drive the Reagent parent to re-render and the boundary must
+            RE-RENDER, never remount — a remount is what a per-render
+            `h/as-component` would have produced, and it would have been
+            invisible on screen.
+
+            REMOUNT IS MEASURED ON THE DOM NODE'S IDENTITY, which is the
+            reading React itself cannot fake: a remount discards the
+            subtree's host instances and builds new ones, so the `<article>`
+            object would not survive. A text-only assertion would be green
+            either way, which is exactly how this class of defect hides."
+    (if-not (browser?)
+      (is true ":node-test — no DOM; :browser-test runs this row")
+      (let [variant-id :story.hicasso/card
+            mount-node (make-mount-node!)
+            root       (rdc/create-root mount-node)
+            render!    (fn [label]
+                         (react-dom/flushSync
+                           (fn []
+                             (rdc/render root
+                               [rf/frame-provider {:frame variant-id}
+                                [:div.reagent-parent
+                                 [:i (str "parent:" label)]
+                                 (hicasso-render variant-id card-id
+                                                 {:label label})]]))))
+            card-node  #(.querySelector mount-node "[data-test=\"hicasso-card\"]")]
+        (rf/make-frame {:id variant-id})
+        (rf/dispatch-sync [:hicsub/bump 3] {:frame variant-id})
+        (try
+          (render! "alpha")
+          (let [first-node (card-node)
+                runs-after-mount @!card-runs]
+            (is (some? first-node) "mounted")
+            (render! "beta")
+            (render! "gamma")
+            (is (= "gamma/3" (some-> (card-node) .-textContent))
+                "the boundary re-rendered with the new props")
+            (is (identical? first-node (card-node))
+                "and it did NOT remount across two further parent renders —
+                 the very same DOM node, so one stable element type carried
+                 three renders")
+            (is (> @!card-runs runs-after-mount)
+                "it really did re-render — the node survived because React
+                 reconciled it, not because the render was skipped"))
+          (finally
+            (try (.unmount root) (catch :default _ nil))))))))
+
+;; ===========================================================================
+;; 2 · the PUBLIC registry — the render fn is on the canvas's default path
+;; ===========================================================================
+
+(deftest the-registered-hicasso-render-fn-is-what-the-single-pane-reaches
+  (testing "rf2-3afns put the substrate registry ON the canvas single-pane
+            path, which is what makes registering into it worth anything.
+            A variant declaring `:substrates #{:hicasso}` must reach the
+            fn registered under `:hicasso` — and must NOT fall through to
+            `rf/view`, which answers nil for a hicasso alias and would
+            degrade to the missing-view diagnostic."
+    (story/register-substrate! :hicasso hicasso-render)
+    (let [tree (ready-tree :story.hicasso/card)
+          el   (find-react-element tree)]
+      (is (some? el)
+          "the canvas tree carries a React element — the `:hicasso` render
+           fn ran and minted one")
+      (is (not (rendered-under-reagent? tree))
+          "and nothing painted under Reagent")
+      (is (identical? (unchecked-get hicasso-card "hicassoMemo") (.-type el))
+          "the element's TYPE is the head's own stable memo wrapper, so the
+           boundary React reconciles is the one `defview` minted")
+      (is (= {:label "alpha"} (unchecked-get (.-props el) "rfProps"))
+          "and Story's resolved args crossed as the boundary's props map —
+           kebab keywords, by identity, with no camelCase round trip")
+      (story/destroy-variant! :story.hicasso/card))))
+
+(deftest two-hicasso-views-are-two-elements
+  (testing "the registry entry resolves the variant's OWN `:component`,
+            not merely 'some hicasso view'. Two variants under one
+            substrate must mint two different element types."
+    (story/register-substrate! :hicasso hicasso-render)
+    (let [card  (find-react-element (ready-tree :story.hicasso/card))
+          panel (find-react-element (ready-tree :story.hicasso/panel))]
+      (is (identical? (unchecked-get hicasso-card "hicassoMemo") (.-type card)))
+      (is (identical? (unchecked-get hicasso-panel "hicassoMemo") (.-type panel)))
+      (is (not (identical? (.-type card) (.-type panel))))
+      (story/destroy-variant! :story.hicasso/card)
+      (story/destroy-variant! :story.hicasso/panel))))
+
+(deftest element-type-is-stable-across-renders
+  (testing "THE IDENTITY DECISION, stated where it can be checked without a
+            fiber: two renders of the same story mint two DIFFERENT
+            elements with the SAME type. That is the whole basis for
+            returning a direct element mint and keeping no cache — the
+            stability React needs is already in the head."
+    (story/register-substrate! :hicasso hicasso-render)
+    (let [a (hicasso-render :story.hicasso/card card-id {:label "one"})
+          b (hicasso-render :story.hicasso/card card-id {:label "two"})]
+      (is (not (identical? a b)) "a fresh element per pass")
+      (is (identical? (.-type a) (.-type b)) "riding one stable type"))))
+
+(deftest resolution-is-late-so-a-hot-reload-reaches-the-story
+  (testing "the render fn reads `(rf/handler-meta :view id)` on EVERY
+            render rather than capturing a head. Re-evaluating a `defview`
+            replaces the registrar entry behind the same id; the story
+            must pick the new head up with no story change. Simulated the
+            way a reload works — a second entry written under the same id."
+    (story/register-substrate! :hicasso hicasso-render)
+    (let [before (.-type (hicasso-render :story.hicasso/card card-id {}))]
+      (rf-registrar/register! :view card-id
+        (assoc (get alias-entries card-id) :hicasso/component hicasso-panel))
+      (let [after (.-type (hicasso-render :story.hicasso/card card-id {}))]
+        (is (not (identical? before after))
+            "the story followed the replaced entry")
+        (is (identical? (unchecked-get hicasso-panel "hicassoMemo") after)
+            "to the NEW head, resolved at render time")))))
+
+;; ===========================================================================
+;; 3 · degradation — the two misses, each at its own level
+;; ===========================================================================
+
+(deftest a-hicasso-id-that-resolves-to-nothing-degrades-inline
+  (testing "`:component` naming a view no registrar entry answers for. The
+            render fn returns the same style of inline diagnostic
+            `reagent-render` returns — a FRAGMENT-level miss, not a grid
+            cell — and names the id so the author knows what to fix."
+    (story/register-substrate! :hicasso hicasso-render)
+    (let [tree (ready-tree :story.hicasso/missing-view)
+          text (e2e/text-nodes tree)]
+      (is (nil? (find-react-element tree))
+          "nothing was minted — there was no head to mint from")
+      (is (re-find #"is not registered as a hicasso view" text))
+      (is (re-find #"views/nobody-registered-this" text)
+          "and it names WHICH view")
+      (story/destroy-variant! :story.hicasso/missing-view))))
+
+(deftest a-hicasso-variant-with-no-registered-substrate-says-so
+  (testing "the host never called `register-substrate!`. The single pane
+            must say so — loudly, at the fragment level — rather than
+            silently painting Reagent, which is the defect rf2-3afns
+            closed and the one this substrate must not reopen."
+    (is (not (contains? @multi-substrate/substrate->render-fn :hicasso))
+        "precondition: `:hicasso` absent from the registry")
+    (let [tree (ready-tree :story.hicasso/card)
+          text (e2e/text-nodes tree)]
+      (is (re-find #"is not registered" text))
+      (is (re-find #"hicasso" text) "and it names WHICH substrate")
+      (is (not (rendered-under-reagent? tree))
+          "it did NOT fall back to Reagent — falling back silently is the
+           bug, not the remedy")
+      (story/destroy-variant! :story.hicasso/card))))
+
+(deftest rf-view-still-answers-nil-for-a-hicasso-alias
+  (testing "the premise the whole render fn is built on (rf2-5qaf4): the
+            alias entry carries NO `:handler-fn`, so `rf/view`'s *returns
+            the registered render fn* contract stays honest and answers
+            nil. If this ever became non-nil the `:reagent` substrate would
+            start painting hicasso heads as Reagent components — a plain
+            function in head position, which Hicasso refuses loudly and
+            Reagent would call with the wrong ABI."
+    (is (nil? (rf/view card-id)))
+    (is (some? (rf/handler-meta :view card-id))
+        "the entry EXISTS — the nil above is the shape, not an absence")
+    (is (nil? (:handler-fn (rf/handler-meta :view card-id))))
+    (is (identical? hicasso-card
+                    (:hicasso/component (rf/handler-meta :view card-id)))
+        "and `:hicasso/component` is the very value the `def` binds")))

--- a/tools/story/test/re_frame/story/ui/hicasso_substrate_dom_cljs_test.cljs
+++ b/tools/story/test/re_frame/story/ui/hicasso_substrate_dom_cljs_test.cljs
@@ -46,6 +46,43 @@
     type and the boundary re-renders instead of remounting. A memoized
     `as-component` would re-implement that machinery one layer up.
 
+  ## KNOWN GAP — a crossed boundary is DEAF to writes (rf2-phabt)
+
+  The spike settled what it was asked to settle and found one more thing
+  on the way, which is filed rather than fixed here (`implementation/**`
+  is outside this bead's fence):
+
+  **a boundary crossed into from a Reagent parent paints once, correctly,
+  and then never re-renders on a write into its own frame.** Body-run
+  counts say it plainly — the body is not re-invoked, so this is a
+  missing NOTIFICATION rather than a stale read.
+
+  It was measured with a live control, which is what makes the zero
+  readable: same boundary, same subscription, same Reagent adapter, same
+  drain, only the mounting route varying. Under `h/mount!` it repaints —
+  that row is [[a-write-repaints-a-boundary-under-hicassos-own-root]],
+  green, below. Crossed in with `h/as-element` it is deaf; crossed in
+  with a memoized `h/as-component` it is deaf in exactly the same way, so
+  the outward-bridge DOOR is not the variable and rf2-2dbpd's
+  pre-authorized fallback B is not the remedy. Ruled out with it: the
+  adapter, the drain, the provider object (both routes provide over the
+  same `re-frame.adapter.context/frame-context`), frame resolution across
+  the crossing (both crossed routes read the VARIANT frame's value on
+  their first paint), and React reconciliation
+  ([[a-reagent-parent-rerender-does-not-remount-the-boundary]] is green).
+
+  The two red routes were run and then REMOVED rather than shipped red or
+  pinned as a change-detector; rf2-phabt carries them verbatim. What
+  stays here is the live half, because a control with nothing to control
+  is still the row that says the harness can see a repaint at all.
+
+  **What this gap does and does not cost.** Everything this file proves
+  green is unaffected: registry dispatch, late resolution, degradation,
+  the stable element type, and a crossed boundary observing its variant
+  frame at render. What is blocked is INTERACTIVITY — a hicasso story
+  whose subject re-renders on its own writes — which is rf2-kttom's
+  concern, not this bead's.
+
   ## Two lanes, one file
 
   `-dom-cljs-test$` puts this namespace in the `:browser-test` build
@@ -56,6 +93,7 @@
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
             ["react" :as react]
             ["react-dom" :as react-dom]
+            [reagent.core :as r]
             [reagent.dom.client :as rdc]
             [re-frame.adapter.reagent :as reagent-adapter]
             [re-frame.core :as rf]
@@ -128,7 +166,7 @@
 
 ;; ---- fixture --------------------------------------------------------------
 
-(declare register-probes!)
+(declare register-probes! leave-act-environment!)
 
 (defn- reset-all! []
   (story/clear-all!)
@@ -207,6 +245,35 @@
   (and (exists? js/document)
        (some? (.-createElement js/document))))
 
+(defn- leave-act-environment!
+  "React's `act` queue is not the browser's scheduler, and
+  `IS_REACT_ACT_ENVIRONMENT` is a GLOBAL that sibling suites in this lane
+  set and never clear (`story.sub-overrides-render-dom-cljs-test` is one).
+  Left on, React parks a store notification in the act queue instead of
+  committing it, and `the-frame-the-reagent-provider-scoped-is-the-one-
+  observed` reads a stale DOM through a channel that is in fact alive —
+  measured, and it is how that row first failed. Mirrors
+  `re-frame.bench.hicasso.lane/leave-act-environment!`, which exists for
+  exactly this reason."
+  []
+  (set! (.-IS_REACT_ACT_ENVIRONMENT js/globalThis) false)
+  nil)
+
+(defn- settle!
+  "The ratom host's drain, and it is two acts rather than one — the pair
+  `re-frame.bench.hicasso.arm1.ratom-activation-dom-cljs-test` spells out.
+
+  `r/flush` runs the reactions the write enqueued, which is what turns an
+  activated node's recompute into the `notify-w` a Hicasso cell's watch
+  rides (a re-frame subscription under the ratom family IS a bare
+  `reagent.ratom/Reaction`). The empty `flushSync` then lets the sync-lane
+  `onStoreChange` that raised commit — `impl.mount/settle!`'s shape,
+  spelled here so this file needs no impl namespace."
+  []
+  (r/flush)
+  (react-dom/flushSync (fn [] nil))
+  nil)
+
 (defn- make-mount-node! []
   (let [node (js/document.createElement "div")]
     (js/document.body.appendChild node)
@@ -282,37 +349,46 @@
           (finally
             (try (.unmount root) (catch :default _ nil))))))))
 
-(deftest the-frame-the-reagent-provider-scoped-is-the-one-observed
-  (testing "the crossing is not merely wired at mount — a write into the
-            variant frame after the commit reaches the boundary's read. If
-            the boundary had resolved the ambient/default frame, the first
-            paint could still have been right by accident and this update
-            would not land."
+(deftest a-write-repaints-a-boundary-under-hicassos-own-root
+  (testing "THE LIVE HALF OF THE KNOWN GAP, and the reason the gap's zero
+            can be read at all (see this namespace's §KNOWN GAP).
+
+            The same boundary, the same subscription, the same Reagent
+            adapter, the same write and the same drain — mounted through
+            Hicasso's OWN root door rather than spliced into a Reagent
+            tree. It repaints. So when the crossed counterpart does not,
+            the difference is the CROSSING and not the substrate, the
+            harness, the drain or the adapter — a zero with no live
+            control beside it settles none of those.
+
+            It also keeps this file honest as the gap is worked: the day
+            the crossing repaints, this row is what says the two are
+            finally the same measurement."
     (if-not (browser?)
       (is true ":node-test — no DOM; :browser-test runs this row")
-      (let [variant-id :story.hicasso/card
-            mount-node (make-mount-node!)
-            root       (rdc/create-root mount-node)]
-        (rf/make-frame {:id variant-id})
-        (rf/dispatch-sync [:hicsub/bump 1] {:frame variant-id})
-        (try
-          (react-dom/flushSync
-            (fn []
-              (rdc/render root
-                [rf/frame-provider {:frame variant-id}
-                 [:div.reagent-parent
-                  (h/as-element [hicasso-card {:label "alpha"}])]])))
-          (is (= "alpha/1"
-                 (some-> (.querySelector mount-node "[data-test=\"hicasso-card\"]")
-                         .-textContent)))
-          (react-dom/flushSync
-            (fn [] (rf/dispatch-sync [:hicsub/bump 42] {:frame variant-id})))
-          (is (= "alpha/42"
-                 (some-> (.querySelector mount-node "[data-test=\"hicasso-card\"]")
-                         .-textContent))
-              "the boundary tracked the variant frame across a write")
-          (finally
-            (try (.unmount root) (catch :default _ nil))))))))
+      (let [frame-id  ::own-root-frame
+            container (make-mount-node!)]
+        (rf/make-frame {:id frame-id})
+        (rf/dispatch-sync [:hicsub/bump 1] {:frame frame-id})
+        (let [handle (h/mount! container {:frame frame-id}
+                               [hicasso-card {:label "ctl"}])]
+          (try
+            (is (= "ctl/1"
+                   (some-> (.querySelector container "[data-test=\"hicasso-card\"]")
+                           .-textContent))
+                "mounted, and read its frame")
+            (let [runs-at-mount @!card-runs]
+              (rf/dispatch-sync [:hicsub/bump 42] {:frame frame-id})
+              (settle!)
+              (is (> @!card-runs runs-at-mount)
+                  "the write re-ran the body — the notification channel is
+                   alive on this adapter, with this drain")
+              (is (= "ctl/42"
+                     (some-> (.querySelector container "[data-test=\"hicasso-card\"]")
+                             .-textContent))
+                  "and the readout moved"))
+            (finally
+              (try (h/unmount! handle) (catch :default _ nil)))))))))
 
 (deftest a-reagent-parent-rerender-does-not-remount-the-boundary
   (testing "the identity decision, measured on a fiber. The render fn mints
@@ -328,31 +404,45 @@
             reading React itself cannot fake: a remount discards the
             subtree's host instances and builds new ones, so the `<article>`
             object would not survive. A text-only assertion would be green
-            either way, which is exactly how this class of defect hides."
+            either way, which is exactly how this class of defect hides.
+
+            AND THE RE-RENDER IS DRIVEN FROM INSIDE THE TREE, by a Reagent
+            ratom, because a second top-level `rdc/render` CANNOT measure
+            this and would report a remount every time. Reagent's own
+            source says why, in a comment above `reagent.dom.client/render`:
+            each call builds a fresh `comp` fn and `reagent-root` does
+            `createElement(comp)` on it, *\"re-created on every render call
+            to ensure React will consider it a new component always\"* — a
+            new component TYPE per call, so React discards the whole tree
+            by construction. That is Reagent's root door behaving as
+            designed and says nothing about the crossing; a ratom write is
+            what a Reagent parent re-rendering actually looks like."
     (if-not (browser?)
       (is true ":node-test — no DOM; :browser-test runs this row")
       (let [variant-id :story.hicasso/card
             mount-node (make-mount-node!)
             root       (rdc/create-root mount-node)
-            render!    (fn [label]
+            !label     (r/atom "alpha")
+            parent     (fn []
+                         [:div.reagent-parent
+                          [:i (str "parent:" @!label)]
+                          (hicasso-render variant-id card-id {:label @!label})])
+            card-node  #(.querySelector mount-node "[data-test=\"hicasso-card\"]")
+            relabel!   (fn [label]
                          (react-dom/flushSync
-                           (fn []
-                             (rdc/render root
-                               [rf/frame-provider {:frame variant-id}
-                                [:div.reagent-parent
-                                 [:i (str "parent:" label)]
-                                 (hicasso-render variant-id card-id
-                                                 {:label label})]]))))
-            card-node  #(.querySelector mount-node "[data-test=\"hicasso-card\"]")]
+                           (fn [] (reset! !label label) (r/flush))))]
         (rf/make-frame {:id variant-id})
         (rf/dispatch-sync [:hicsub/bump 3] {:frame variant-id})
         (try
-          (render! "alpha")
-          (let [first-node (card-node)
+          (react-dom/flushSync
+            (fn []
+              (rdc/render root
+                [rf/frame-provider {:frame variant-id} [parent]])))
+          (let [first-node       (card-node)
                 runs-after-mount @!card-runs]
             (is (some? first-node) "mounted")
-            (render! "beta")
-            (render! "gamma")
+            (relabel! "beta")
+            (relabel! "gamma")
             (is (= "gamma/3" (some-> (card-node) .-textContent))
                 "the boundary re-rendered with the new props")
             (is (identical? first-node (card-node))

--- a/tools/story/test/re_frame/story/ui/hicasso_substrate_dom_cljs_test.cljs
+++ b/tools/story/test/re_frame/story/ui/hicasso_substrate_dom_cljs_test.cljs
@@ -166,7 +166,7 @@
 
 ;; ---- fixture --------------------------------------------------------------
 
-(declare register-probes! leave-act-environment!)
+(declare register-probes!)
 
 (defn- reset-all! []
   (story/clear-all!)
@@ -244,20 +244,6 @@
 (defn- browser? []
   (and (exists? js/document)
        (some? (.-createElement js/document))))
-
-(defn- leave-act-environment!
-  "React's `act` queue is not the browser's scheduler, and
-  `IS_REACT_ACT_ENVIRONMENT` is a GLOBAL that sibling suites in this lane
-  set and never clear (`story.sub-overrides-render-dom-cljs-test` is one).
-  Left on, React parks a store notification in the act queue instead of
-  committing it, and `the-frame-the-reagent-provider-scoped-is-the-one-
-  observed` reads a stale DOM through a channel that is in fact alive —
-  measured, and it is how that row first failed. Mirrors
-  `re-frame.bench.hicasso.lane/leave-act-environment!`, which exists for
-  exactly this reason."
-  []
-  (set! (.-IS_REACT_ACT_ENVIRONMENT js/globalThis) false)
-  nil)
 
 (defn- settle!
   "The ratom host's drain, and it is two acts rather than one — the pair


### PR DESCRIPTION
## What

rf2-2dbpd, PHASE C of rf2-5czki. Two halves, both as ruled:

1. **`SubstrateSet` widened to `#{:reagent :uix :hicasso}`** — the one closed substrate enum in the repository — **with its docstring rewritten in the same edit**, per rf2-1gy4e's axis sub-ruling. The old text claimed *"The framework supplies the closed set"*; there is no such set to mirror. `:substrates` is Story's OWN authoring-layer axis (which registered render-fn embeds the subject), and `:hicasso` is the member that separates it from the adapter enum: Hicasso ships no adapter, there is no `:rf.adapter/hicasso` anywhere, and a Hicasso app boots on UIx.
2. **The `:hicasso` render-fn**, host-registered exactly as `:uix` is (ruled placement 1). Story ships **no** `install-hicasso-substrate!`, names Hicasso nowhere in `src` outside docstrings, and `tools/story/deps.edn` is **untouched** — the "ONLY if genuinely needed" conditional resolves to NOT NEEDED, re-verified at source: `hicasso/src` is already on the top-level shadow `:source-paths`, and `clojure -M:test` from `tools/story` never compiles `.cljs`.

## The spike, and the finding it turned up

The ruling named the Reagent-parent crossing the one material uncertainty and recorded it as **unwitnessed in-repo**. It is witnessed now, and the answer is in two parts.

**It paints.** `crossing-paints-under-a-reagent-parent` mounts a `h/defview` boundary, minted by `h/as-element`, spliced into a **Reagent** hiccup tree under `rf/frame-provider`, committed through `reagent.dom.client` into a real DOM. It renders `alpha/7` — the props map that crossed, and a subscription read **in the variant frame the Reagent provider scoped** (the default frame would read 0). A second green row proves a Reagent-parent re-render **re-renders without remounting**, measured on the DOM node's identity across three renders.

**And it is then deaf.** A write into that same frame after the commit never reaches the boundary: the body-run counter says it is not re-invoked, so it is a missing notification rather than a stale read. Filed as **rf2-phabt (P1)**, with a live control that makes the zero readable — same boundary, same subscription, same Reagent adapter, same drain, only the mounting route varying:

| route | paints | repaints on a write |
|---|---|---|
| `h/mount!` (Hicasso's own root) | yes | **yes** |
| Reagent parent + `h/as-element` | yes, correct frame | **no** — body runs 1 to 1 |
| Reagent parent + memoized `h/as-component` | yes, correct frame | **no** — body runs 1 to 1 |

That rules out the adapter, the drain, the provider object (both routes provide over the same `re-frame.adapter.context/frame-context`), frame resolution across the crossing, React reconciliation — and the outward-bridge **door**, since both doors behave identically. Which also means **rf2-2dbpd's pre-authorized fallback B is not the remedy**, and I did not take it: B was run as an experiment and is deaf in exactly the same way.

**Why this is not the bead's refusal.** The bead's stop-condition is "if the crossing does not paint AT ALL". It paints, and the registration is correct and worth landing: dispatch, late resolution, degradation, stable element type and mount-time frame observation are all proven green. What is blocked is INTERACTIVITY, which belongs to rf2-kttom — **that bead should be held behind rf2-phabt**, because a worked hicasso testbed cannot have an interactive story until it lands.

The two red routes were **run and then removed** rather than shipped red or pinned as change-detectors; rf2-phabt carries them verbatim. What stays is the live half (`a-write-repaints-a-boundary-under-hicassos-own-root`), because a control with nothing to control is still the row that says the harness can see a repaint at all. The gap is recorded in the test ns's KNOWN GAP section and in `multi-substrate`'s ns docstring, so nobody adopts the substrate expecting reactivity.

## The identity decision (the phase's one real design choice)

**Ruled option A taken: a direct `(h/as-element [resolved-view eff-args])` mint. No cache.** Verified at source: `codec/memoize-boundary!` attaches ONE `React.memo` wrapper per head at definition time and `element-type` creates every element from it, so a fresh element per pass rides a **stable type**. `element-type-is-stable-across-renders` states the basis without a fiber; the no-remount row proves it on one. B's narrow trigger ("the element-splice misbehaving under Reagent reconciliation") is **not** met — reconciliation is fine, and B is deaf identically.

## Verified premises (checked at source, not inherited)

- **rf2-3afns's bypass fix is genuinely on main.** `canvas.cljs`'s `:else` branch calls `multi-substrate/render-view` with `(first substrates)`; `canonical/render-host-scope` reads `single-render-substrate` over `[:world :substrates]`. Registering into the registry reaches the default path.
- **rf2-5qaf4 landed the key I read.** The `:view` entry carries the head at `:hicasso/component` and **no** `:handler-fn`; `rf-view-still-answers-nil-for-a-hicasso-alias` pins that from the Story side.
- **One closed substrate enum, confirmed** — `git grep 'enum :reagent'` over tracked files returns `schemas.cljc` and one unrelated `spec/Spec-Schemas.md` row.
- **`:r>` was not needed** — the renderer returns a React element and adds no Reagent interop head.

## Tests

Two new files, no `*.spec.cjs`, no Playwright spec.

- `tools/story/test/re_frame/story/hicasso_substrate_cljs_test.cljc` — **`.cljc`, so BOTH arms run it** (JVM `clojure -M:test`; shadow `:node-test`, whose `cljs-test$` matches). Pure data: the enum admits `:hicasso` **and is still closed** (`:reagent-slim` and `:helix` still refused — a widen that quietly opened would pass every other row); registration accepted and still refused for a typo; plan compilation folds it to `[:world :substrates]` through `:extends`; the EDN/MCP read path round-trips it; snapshot identity **distinguishes two hicasso view ids** — the row that would have caught rf2-1gy4e's rejected option (a), since `fingerprint.cljc` folds every fn to `:rf/opaque-fn`.
- `tools/story/test/re_frame/story/ui/hicasso_substrate_dom_cljs_test.cljs` — `-dom-cljs-test`, so it rides **`:browser-test`** and **`:node-test`** (browser rows self-gate on `(browser?)` and say so rather than passing quietly). The spike, the no-remount proof and the own-root repaint reference in the browser; registry dispatch, two-views-two-elements, stable type, late resolution across a simulated hot reload, and both degradations in both.

## Quality gates — captured exit codes

Every `$?` captured on the same command line and redirected to a worktree-local file; none read through a pipeline.

| gate | runner arm | exit | result |
|---|---|---|---|
| `npm run test:browser` (shadow `:browser-test`, headless Chromium) | CLJS/browser | **0** | 1562 tests / 9881 assertions, 0 failures 0 errors |
| `npm run test:cljs` (shadow `:node-test`) | CLJS/node | **0** | 13976 tests / 70345 assertions, 0 failures 0 errors |
| `clojure -M:test` from `tools/story` | JVM | **0** | 1861 tests / 6815 assertions, 0 failures 0 errors |
| `sh scripts/check-no-hardcoded-paths.sh` | — | **0** | portability gate OK |

All four re-run on the final commit. The browser lane's log names `re-frame2-worktrees\w-2dbpd` as the tree it compiled, so its colour is this branch's.

**One local run is worth recording because its verdict was a lie in both directions.** An earlier `npm run test:cljs` hit the harness's 10-minute cap; the cap kills the shell, not the compile, so that attempt's `.exit` never appeared — NO VERDICT, not a pass — and the orphan left the `:node-test` shadow cache corrupt. The next attempt then failed with 22 `aborted par-compile` cascades waiting on `re-frame.freehand`, `re-frame.ui` and the hicasso bench arm, **zero primary errors with a source location, and no mention of either new file**. Clearing `.shadow-cljs/builds/node-test` and re-running gave the clean 0 above. Separately, the harness reported that same run as "exit code 0" while its captured `.exit` said `EXIT=1` — the captured file is what the table reports throughout. CI's own `:node-test` lane takes 12m11s, which is why the local run exceeds a 10-minute foreground cap at all.

### RED proofs — both new files proven to fail, restores hash-verified

1. **Enum reverted** to `[:set [:enum :reagent :uix]]` → JVM gate **exit 1**, 3 failures + 4 errors, **all seven in `hicasso_substrate_cljs_test.cljc`** (`substrate-set-admits-hicasso`, `a-hicasso-variant-registers`, `the-plan-carries-the-hicasso-declaration`, `the-substrate-keyword-round-trips-through-the-mcp-read-path`, `two-hicasso-view-ids-are-two-identities`). Test count identical at 1861, so the revert was scoped. Restored; `git hash-object` back to `57aeec49836c1e86f211cc1098db36f7ff106809`.
2. **`render-view` pinned to the `:reagent` entry** (the rf2-3afns bypass, reintroduced) → `npm run test:cljs` **exit 1**, 16 failures + 8 errors, of which 7 are in `hicasso_substrate_dom_cljs_test.cljs` across four deftests, alongside rf2-3afns's own witness. Test count identical at 13976. Restored; `git hash-object` back to `784132f09a33387b4fcd917a9aa32f720f9f3a4a`.

## Out of fence, not touched

`implementation/**`, `spec/*`, `implementation/shadow-cljs.edn`, `.github/workflows/*`, `tools/story/deps.edn`. No new build-id is needed: `:browser-test` selects by namespace suffix and `../tools/story/test` is already on `:source-paths`; `_browser-dom-lane-partition.test.cjs`'s partition still holds (this ns is not `re-frame.freehand.bench.*`). `tools/story/spec/` was not updated — outside this fence, and rf2-kttom owns the `spec` Substrates section and the `docs/story/09` sentence.

## Filed, not fixed

- **rf2-phabt (P1)** — the crossed-boundary deafness above. Should block rf2-kttom.
- **rf2-sc5g0 (P2)** — `plan/variant-plan` folds `:substrates` from the variant and its `:extends` chain but NOT from the parent story, so a story-level declaration reaches the canvas (via `resolve-substrate-set`) and not `render-host-scope` (which falls back to `:reagent`). A narrower residue of rf2-3afns; `:component` has the same asymmetry. Found by a JVM assertion that returned `nil`, and recorded in a comment above the plan rows.
