### PR TITLE
docs(hicasso): the live authoring pages teach the carrier the door ships (rf2-5ayg7)

### DIFF
--- a/docs/design/hicasso/authoring.md
+++ b/docs/design/hicasso/authoring.md
@@ -105,7 +105,7 @@ rf2-d03av).
   placeholder (~97% of corpus handler sites become pure data). Ordinary functions
   remain legal at event positions.
 - Census-weighted policy defaults: `:on-submit` intents auto-prevent (the rare
-  opt-out is the `h/fn` escape — a callback holds the event, so it owns it); a
+  opt-out is the `h/event` escape — a callback holds the event, so it owns it); a
   data key-map `{:on-keydown {"Enter" [...] "Escape" [...]}}` with the
   composition law centralised — a composing Enter (IME, including the
   keyCode-229 legacy signal) commits nothing.
@@ -136,11 +136,11 @@ rf2-d03av).
 
 ### When a vector is not enough: one form, and the position decides (HD-024)
 
-There is **one** callback form, `h/fn`, and it is an **ordinary function**:
+There is **one** callback form, `h/event`, and it is an **ordinary function**:
 
 ```clojure
 [:input {:type "file"
-         :on-change (h/fn [e] [:upload/picked (js/Array.from (.. e -target -files))])}]
+         :on-change (h/event [e] [:upload/picked (js/Array.from (.. e -target -files))])}]
 ```
 
 | Position | Contract |
@@ -159,7 +159,7 @@ form: the codec already hands functions to React by identity so `React.memo` and
 handler-identity bail-outs keep working.
 
 **The declared contract governs every carrier at that position**, not just the
-`h/fn`. An intent vector and a key-map are each a dispatch and nothing else, so
+`h/event`. An intent vector and a key-map are each a dispatch and nothing else, so
 they are accepted at `:event` and refused at `:handler` and `:render` with
 `:rf.error/hicasso-intent-at-a-non-event-contract` — otherwise the value would be
 selecting the contract, which is the thing the row above forbids.
@@ -169,7 +169,7 @@ and a key-map's key lookup read the DOM event from **argument one** — what a
 native position hands them and what `onDraft(event)` hands them. A value-first
 foreign invoker (`onPick(value, event)`) raises
 `:rf.error/hicasso-intent-needs-the-event` naming the position, rather than the
-engine's `value.preventDefault is not a function`; `h/fn` is the spelling there,
+engine's `value.preventDefault is not a function`; `h/event` is the spelling there,
 since it receives every argument in order. An intent carrying neither a marker nor
 a decorator never reads its argument, so it is correct under any invoker contract.
 

--- a/docs/design/hicasso/product/authoring-report-slice.md
+++ b/docs/design/hicasso/product/authoring-report-slice.md
@@ -48,7 +48,7 @@ So the shape the convention asks for cannot carry a marker:
 
 Nothing catches it. The six checks in the artefact's clj-kondo export are `deferred-read`, `parked-read`, `unkeyed-mapped-child`, `nameless-interactive-element`, `function-in-head-position` and `direct-view-call`; a nested marker is none of them.
 
-The escape hatch exists — `(h/fn [e] [::events/edit {… :value (.. e -target -value)}])` restores the map payload — and it costs a closure per field per render plus the property route-links are sold on, that two renders of one intent are `=`. It also reintroduces the hand-written `.. e -target -value` that `::h/value` exists to delete.
+The escape hatch exists — `(h/event [e] [::events/edit {… :value (.. e -target -value)}])` restores the map payload — and it costs a closure per field per render plus the property route-links are sold on, that two renders of one intent are `=`. It also reintroduces the hand-written `.. e -target -value` that `::h/value` exists to delete.
 
 There is a consequence beyond taste, and Conventions names it in its own list: a **positional argument is not path-addressable**, so trace/error redaction cannot classify it. Under the fail-open EP-0025 model a controlled field carrying a secret ships its value raw into every trace sink, and the marker is precisely what forces that field's event into the positional shape.
 

--- a/docs/design/hicasso/product/authoring-report-todo.md
+++ b/docs/design/hicasso/product/authoring-report-todo.md
@@ -106,7 +106,7 @@ Every path here is under `/hicasso-todo`, and `routes.cljs`'s docstring states w
 
 ### N1. The key map is the reason this application contains no callback, and the door never mentions it
 
-`{"Enter" […] "Escape" […]}` at an `:on-*` prop is a first-class lowered shape — built once per render into a plain string→handler map, one `.key` lookup per event, and composition-gated centrally so an IME's Enter commits nothing. It is exactly the Todo class's shape, and it is why this application's `views.cljs` contains no `h/fn`, no `.-key` test and no `.preventDefault`.
+`{"Enter" […] "Escape" […]}` at an `:on-*` prop is a first-class lowered shape — built once per render into a plain string→handler map, one `.key` lookup per event, and composition-gated centrally so an IME's Enter commits nothing. It is exactly the Todo class's shape, and it is why this application's `views.cljs` contains no `h/event`, no `.-key` test and no `.preventDefault`.
 
 It is also **absent from the public door.** `re-frame.hicasso`'s own docstrings enumerate the markers, `defview`, `defhost`'s `:slots` and `:callbacks`, `portal`, `as-element`, `as-component` and the root lifecycle — and never state that a map at an event position means anything at all. The four event-value shapes are written out in exactly one place a reader can reach them, `re-frame.hicasso.impl.intent`'s namespace docstring, in the namespace the door's first paragraph tells authors they never need to open. (The draft guide's `03-events-as-data.md` and `docs/design/hicasso/authoring.md` both teach it well; neither is the door, and neither is what an editor shows on `h/`.)
 


### PR DESCRIPTION
`rf2-hic-066` renamed the one callback form to **`h/event`** and swept the door, but three live design pages still taught **`h/fn`** — a symbol `re-frame.hicasso` does not export. Verified at source: the door carries exactly `(defmacro defview`, `(defmacro event` and `(defmacro defhost` (`implementation/hicasso/src/re_frame/hicasso.cljc` :102/:300/:331) and **no `fn` macro at all**, so the samples were uncompilable and the load-bearing sentence named a form that does not exist.

## Changed — live teaching surface only (7 lines, 3 files)

`docs/design/hicasso/authoring.md` — the page's own header calls it *"design intent for the v0 dogfood and the eventual guide"*, so every site is live:

| Line | Before → after |
|---|---|
| 108 | the `` `h/fn` `` escape → the `` `h/event` `` escape |
| 139 | *There is **one** callback form, `` `h/fn` ``* → `` `h/event` `` |
| 143 | `:on-change (h/fn [e] …)` → `(h/event [e] …)` |
| 162 | *not just the* `` `h/fn` `` → `` `h/event` `` |
| 172 | `` `h/fn` `` *is the spelling there* → `` `h/event` `` |

`docs/design/hicasso/product/authoring-report-slice.md:51` — the escape-hatch code sample.

`docs/design/hicasso/product/authoring-report-todo.md:109` — N1's *"contains no `h/fn`"*. **Beyond the bead's enumerated list**, same criterion, same class, and the claim was re-verified against the source it describes: `implementation/hicasso/test/re_frame/hicasso/examples/todo/views.cljs` contains no callback of *either* spelling, so the sentence stays true under the new name.

## Deliberately NOT changed

- **Rename records** keep `h/fn` on purpose: `naming-ledger.md` row 1, `naming-packet.md`, `naming-findings-cp2.md`, `post-rename-recertification.md`, `invariants.md:79`, `docs/core/hicasso/index.md:61` and `hicasso.cljc`'s docstrings. Sweeping them would destroy the record of the rename.
- **Awaiting a ruling**, untouched: `decisions.md`, `studio/**`, `draft-guide/REWRITE-NOTES.md` (:195 is inverted — *"invented `h/event` spelling (product form is `h/fn`)"*).
- **`facade-freeze.md:196`** — reported, not edited. Not in the bead's `:45/:223/:229` record list, but it sits inside a dated *"Amended 2026-08-13 by operator ruling on `rf2-j6fn`"* blockquote transcribing a **frozen law**, and this page's established convention (`rf2-hic-090`) is to *annotate* rather than rewrite. Needs the same ruling as the group above.
- **`virtualizer-recipe.md` :25/:34 — still stale on `main`, and claimed.** PR #8343 (`rf2-hic-047`, OPEN, not merged) modifies exactly that one file. Left alone to avoid a conflict.
- **`decision-brief.md` :81/:83** — published copy per `product/README.md`'s Refresh contract; `rf2-rbme3`'s operator hold. No change needed there anyway: both lines already read correctly.

## Gates

Verdicts and captured exit codes in a comment below. No tables were modified — the HD-024 position table at :146–153 is untouched.
