### PR TITLE
test(hicasso): measure the layer-1 vs layer-2 recomputation contrast (rf2-18u0)

### DIFF
--- a/docs/design/hicasso/product/per-keystroke.md
+++ b/docs/design/hicasso/product/per-keystroke.md
@@ -19,6 +19,7 @@ which are a different tree measuring different questions.
 
 [apps]: ../../../../implementation/hicasso/test/re_frame/hicasso/examples/
 [census]: ../../../../implementation/hicasso/test/re_frame/hicasso/examples/per_keystroke_dom_cljs_test.cljs
+[contrast]: ../../../../implementation/hicasso/test/re_frame/hicasso/examples/grid/row_total_layer2_dom_cljs_test.cljs
 [kit]: ../../../../implementation/hicasso/test_kit/src/re_frame/hicasso/test/mounted.cljs
 
 **Two findings up front, because they are the ones a reader should leave with.**
@@ -215,8 +216,143 @@ count the addresses their event writes.
 The remedy, where one is wanted, is the ordinary one and is not a new mechanism:
 a derived read stated as a layer-2 subscription over its own inputs is memoised
 on *those inputs* rather than on app-db, so it does not re-run when they have not
-moved. Nothing in this corpus has measured that contrast yet, and this page does
-not claim it — it is named as the next question rather than as an answer.
+moved. **That contrast has since been measured**, and §4.1 reports it. It is a
+measurement and not a recommendation: the applications are unchanged, and
+adopting the spelling in `examples/grid` would be a separate decision.
+
+### 4.1 The layer-2 contrast, measured
+
+[`rf2-18u0`][contrast] restates the grid's `::row-total` as a layer-2
+subscription over its own row's cells and re-runs the census with that one
+substitution made. The arm lives in the suite and **the witness applications are
+untouched** — `examples/grid/subs.cljs` and `examples/grid/views.cljs` are
+unchanged by this measurement, and its layer-1 arm re-reads §3's figures on the
+same tree to say so — for the reason
+`grid.scaling-dom-cljs-test`'s coarse shapes live there too: an application is
+evidence about the public door, and a spelling nobody has adopted does not belong
+in one. Both arms are measured in the same file on the census's own counter, made
+public rather than copied, so the contrast below is a subtraction between two
+readings taken together rather than between two instruments run in two places.
+
+| Subscription recomputations, one keystroke into `[3 4]` | 5×5 | 10×10 |
+|---|---:|---:|
+| `::row-total` as a **layer-1** reader — the application, and §3's row | **31** | **111** |
+| `::row-total` restated as a **layer-2** read over its row's cells | **27** | **102** |
+| difference | −4 | −9 |
+
+And the attribution, which is where the whole reading is:
+
+| Arm | `::cell` | the row total | `::dimensions` |
+|---|---:|---:|---:|
+| 5×5, layer-1 | 25 | 5 | 1 |
+| 5×5, layer-2 | 25 | **1** | 1 |
+| 10×10, layer-1 | 100 | 10 | 1 |
+| 10×10, layer-2 | 100 | **1** | 1 |
+
+**The row-total term goes from `rows` to one, and stops following the mount.**
+That is the thing §4 predicted and the thing it declined to claim: a layer-1
+reader is memoised on the whole of app-db, which a keystroke always moves, so
+every mounted row's fold re-runs; a layer-2 read is memoised on the `cols` cell
+values it names, and nine of the ten rows at 10×10 have not moved one of them.
+
+**And the linear term survives, which is the half of this result a reader is
+likeliest to misread.** `::cell` is a layer-1 reader in *both* arms and there are
+a hundred of them mounted, so a hundred bodies run either way. The saving is
+`rows − 1` recomputations — **9 of 111** at 10×10 and **4 of 31** at 5×5, which
+is roughly 8% and 13% — and the count that remains still follows the mounted cell
+count rather than the change: 102 for a hundred cells and 27 for twenty-five. So
+this does not overturn §4's headline sentence. What it does is remove exactly the
+term §4 named as *the one that would bite first on a page with an expensive
+derived read per row*, and leave standing the term §4 called cheap. **On a page
+whose derived read is expensive, the shape of the saving matters more than this
+page's fraction of it does**, and the shape is what the two rows of ones above
+report.
+
+**Boundary runs did not move: two, both arms, both sizes.** The contrast is about
+which *subscription* bodies re-run, and that row is what says the layer-2
+spelling bought it without changing what the page re-renders — a restatement that
+had broadened notification would read higher and a dead one would read lower.
+The arm's liveness has its own positive control beside it: row 3's rendered total
+goes `345` → `652` across the keystroke (the seeded row sums 30…39 = 345, and
+cell `[3 4]` becomes `341`), so the single body run counted is a real recompute
+of a real new value.
+
+**What the spelling costs the author, stated because it is not nothing.** A
+`:parametric` sub's `input-fn` is pure in the *query vector* and cannot read
+app-db, so the row's width has to arrive in the query itself —
+`[::row-total-l2 row cols]` where the layer-1 spelling was `[::row-total row]`.
+Here the width is to hand, because the row's own body already read the dimensions
+to lay its cells out. **A derived read whose input set is not knowable from its
+query vector cannot take this spelling at all**, and that, rather than any
+per-keystroke figure, is the first question a reader should ask of their own
+page. In exchange, `input-fn` runs once per cache entry at materialisation, so
+the entry's topology is fixed for its lifetime and a resize mints a new entry
+rather than leaving one folding a stale width.
+
+**What §4.1 does not conclude.** No clock: the figures are body-run counters, and
+nine fewer executions of a ten-cell `parseInt` fold is not a latency claim — this
+page owns no instrument that could turn it into one, for [§6](#6-the-visible-echo-and-the-budget-that-is-refused)'s
+reason. No general claim about layer-2 subscriptions: one derived read, on one
+page, at two sizes. And no adoption — see the head of this subsection.
+
+**Provenance.** `P-DEV-1`, browser lane, `npm run test:browser`, on a branch
+based on `c68844184c9912479b0220778b2ec6161e33f5b7` (on `main`). The captured
+exit below is the runner's; the lane's `shadow-cljs compile browser-test` step
+ran ahead of runs 1–4 and returned `0` each time, and runs 5 and 6 re-ran the
+runner against run 4's compiled bundle because the tree had not moved.
+
+| Run | What | Captured exit | Result |
+|---|---|---:|---|
+| 1 | the contrast arm, before its boundary-count row | `0` | 1,554 tests, 9,867 assertions, 0 failures |
+| 2 | **sabotage** — the layer-2 arm's 10×10 total and 5×5 attribution inverted | `1` | captured red naming both lines, below |
+| 3 | restored, unchanged from run 1 | `0` | 1,554 / 9,867, 0 failures — **no figure moved** |
+| 4 | the boundary-count row added | `1` | two reds, both in the async-nav back-button suites; this file clean |
+| 5 | re-run, no tree change | `1` | one red, the browser-heap `requestGC` handshake; this file clean |
+| 6 | re-run, no tree change | `0` | 1,554 / **9,868**, 0 failures |
+
+**Runs 4 and 5 are flakes, and run 6 is what says so.** Runs 4, 5 and 6 were
+taken on the identical tree *and the identical compiled bundle*, so the green one
+settles it: nothing in that bundle can be responsible for a red the same bundle
+also produces green. The reds
+were different tests each time — two `poll-until` timeouts on the real Back
+button in run 4, an absent `requestGC` handshake in run 5, all three in browser
+suites this change does not touch — and the contrast arm's own namespace printed
+no failure in either run.
+
+**Run 1 to run 6 is `+0` tests and `+1` assertion**, which is exactly the
+boundary-count row: it lives inside a `deftest` that already existed, so the test
+count cannot move and the assertion count moves by the one row added. That
+arithmetic is a consistency check and not the proof the rows ran — run 2 is.
+
+**Run 2 is the sabotage control, and it is what makes runs 1, 3 and 6 mean
+something.** Inverting the layer-2 arm's 10×10 total and its 5×5 attribution
+produced a captured failure naming both lines and printing the readings from the
+failure path, so the numbers
+above are witnessed by something other than the passing assertion that reports
+them:
+
+```
+FAIL in (the-layer-2-row-total-recomputes-once-where-the-layer-1-one-recomputes-per-row)
+  (re_frame/hicasso/examples/grid/row_total_layer2_dom_cljs_test.cljs:277:13)
+expected: (= 999 (:sub-runs l2-100))
+  actual: (not (= 999 102))
+
+FAIL in (the-layer-2-row-total-recomputes-once-where-the-layer-1-one-recomputes-per-row)
+  (re_frame/hicasso/examples/grid/row_total_layer2_dom_cljs_test.cljs:278:13)
+expected: (= {…grid.subs/cell 999, …/row-total-l2 999, …grid.subs/dimensions 999}
+             (:by-sub l2-25))
+  actual: (not (= {…999, …999, …999}
+                  {…grid.subs/cell 25, …grid.subs/dimensions 1, …/row-total-l2 1}))
+```
+
+A red naming the file proves the rows **execute** — a skipped row cannot fail —
+and the printed right-hand sides are the 10×10 total (`102`) and the 5×5
+attribution (`{25, 1, 1}`, summing to 27) read out of the failure path rather
+than out of the passing assertion that reports them. The namespace prefixes are
+elided for width; nothing else in the two reports is. The line numbers pin the
+**sabotage tree**, in which the boundary-count row above them had not yet been
+written; the same two assertions are at 286 and 287 in the file as it ships. The
+file was restored and run 3 re-took every figure unchanged.
 
 ---
 
@@ -366,7 +502,11 @@ above.
 
 Every figure above was taken on `P-DEV-1`
 ([budgets §1](budgets.md#1-the-named-reference-profiles)) by the browser lane,
-`npm run test:browser`, from [the census suite][census]. Runs 1–7 were taken on
+`npm run test:browser`, from [the census suite][census] — **except §4.1's, which
+come from a different suite on the same lane and the same profile and carry
+[their own run table](#41-the-layer-2-contrast-measured)**. The runs numbered
+below are this section's; §4.1's are numbered separately and independently.
+Runs 1–7 were taken on
 a branch based on `52275d7b19b3de2bdc48708e46e4102104c3199d`; the branch was then
 rebased onto `b44c5e854cae93a2a6ec520f1667f1da56c19e8b` and **run 8 re-took every
 figure on that base without one of them moving**. Both are on `main`.
@@ -498,8 +638,11 @@ everything, and this one published a good deal.
   `rf2-hic-089`'s surface and not this bead's. `U1`'s entry in §9.2 has been
   updated to point here; the rows are filed as follow-up work.
 - **No remedy for §4's amplification, and no claim that it needs one.** The
-  layer-2 contrast named at the end of §4 is a measurement nobody has taken.
-  Naming it is not proposing it.
+  layer-2 contrast named at the end of §4 has now been measured — §4.1 — and
+  measuring it is still not adopting it. The applications are unchanged, the
+  saving it reports is `rows − 1` recomputations against a count that stays
+  linear in the mounted grid, and whether `examples/grid` should be rewritten
+  that way is a decision this page does not take.
 - **No attribution of §5's `name` churn beyond React's own documented reason.**
   The trace shows what happens and the refusal experiment shows which pass owns
   it; why React 19 spells the atomicity guarantee that way is React's business

--- a/implementation/hicasso/test/re_frame/hicasso/examples/grid/row_total_layer2_dom_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/examples/grid/row_total_layer2_dom_cljs_test.cljs
@@ -1,0 +1,308 @@
+(ns re-frame.hicasso.examples.grid.row-total-layer2-dom-cljs-test
+  "L3 — THE LAYER-1 / LAYER-2 CONTRAST THE PER-KEYSTROKE CENSUS NAMES AND
+  DECLINES TO CLAIM (rf2-18u0).
+
+  > The remedy, where one is wanted, is the ordinary one and is not a new
+  > mechanism: a derived read stated as a layer-2 subscription over its own
+  > inputs is memoised on *those inputs* rather than on app-db, so it does
+  > not re-run when they have not moved. Nothing in this corpus has
+  > measured that contrast yet, and this page does not claim it — it is
+  > named as the next question rather than as an answer.
+  >
+  > — `docs/design/hicasso/product/per-keystroke.md` §4
+
+  This file measures it. Nothing else about the grid changes: the
+  application's `::subs/row-total` is a LAYER-1 reader over the whole of
+  `app-db`, so a keystroke re-runs every mounted row's fold and nine of
+  the ten at 10x10 recompute a total that did not move. [[row-total-l2]]
+  below is the same arithmetic stated as a layer-2 subscription over the
+  row's own cells, and the question is what the census reads with that one
+  substitution made.
+
+  ## The arm is HERE, and the application is untouched
+
+  `examples.grid.subs` and `examples.grid.views` are byte-identical to
+  what they were before this file existed, and rf2-18u0's fence is why:
+  *the witness applications model proper re-frame2 and are evidence about
+  the public door. If a layer-2 spelling wins, changing `examples/grid` is
+  a separate decision with its own bead — this one measures a contrast, it
+  does not adopt one.* So the contrast arm lives in the suite, beside
+  `grid.scaling-dom-cljs-test`'s coarse anti-shapes, for the same reason
+  those do.
+
+  ## Both arms on ONE instrument, in one file
+
+  [[per-keystroke/with-counted-subs]] is the census's own counter, made
+  public for this file rather than copied into it. Both arms are measured
+  here — the application's layer-1 spelling AND the layer-2 restatement —
+  so the contrast is a reading rather than an arithmetic comparison
+  between two instruments run in two places. The census's published
+  figures (111 at 10x10, 31 at 5x5) are then a CROSS-CHECK on this file's
+  layer-1 arm rather than one half of its subtraction.
+
+  ## What the layer-2 spelling costs the author, and it is not nothing
+
+  A `:parametric` sub's `input-fn` is pure in the QUERY VECTOR — it cannot
+  read `app-db` — so a row's width has to arrive in the query itself:
+  `[::row-total-l2 row cols]`, where the layer-1 spelling was
+  `[::subs/row-total row]`. The width is to hand (the row's own body
+  already read the dimensions to lay its cells out), but the read is no
+  longer addressed by row alone, and a page whose derived read's INPUT SET
+  is not knowable from its query vector cannot take this spelling at all.
+  That is a real authoring difference and it is reported beside the
+  counts rather than under them.
+
+  It buys a property as well as a cost: `input-fn` runs ONCE per cache
+  entry at materialisation (`re-frame.subs/build-and-cache!*` — *the
+  entry's topology is FIXED for its lifetime*), so `[::row-total-l2 3 10]`
+  and `[::row-total-l2 3 12]` are distinct entries and a resize cannot
+  leave an entry folding a stale width.
+
+  ## What this file does NOT measure
+
+  A clock, for `budgets.md` §2's reason and the census's: every figure
+  here is a monotone counter, so it reads the same on a loaded box as on a
+  quiet one. It also does not measure the fold's per-cell work directly —
+  what is counted is BODY RUNS, and the `cols` `parseInt`s inside one body
+  are read off the body rather than counted by anything."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [re-frame.adapter.uix :as uix-adapter]
+            [re-frame.core :as rf]
+            [re-frame.hicasso :as h]
+            [re-frame.hicasso.examples.grid.app :as app]
+            [re-frame.hicasso.examples.grid.events :as events]
+            [re-frame.hicasso.examples.grid.subs :as subs]
+            [re-frame.hicasso.examples.grid.views :as views]
+            [re-frame.hicasso.examples.per-keystroke-dom-cljs-test :as census]
+            [re-frame.hicasso.test.mounted :as hm]
+            [re-frame.test-support :as test-support]))
+
+;; ---------------------------------------------------------------------------
+;; The contrast arm — the SAME arithmetic, stated over its own inputs
+;; ---------------------------------------------------------------------------
+
+(rf/reg-sub ::row-total-l2
+  {:doc "The sum of one row's cells, as a LAYER-2 read over that row's
+  cells.
+
+  `examples.grid.subs/row-total` computes exactly this from `app-db`, and
+  the difference is which value the memo wrapper compares. A layer-1
+  reader is memoised on the whole of `app-db`, which a keystroke always
+  moves, so its body runs once per mounted row per keystroke. This one is
+  memoised on the `cols` cell values it names, so it runs when one of
+  THOSE moved.
+
+  The `cols` in the query vector is not decoration — see the namespace
+  docstring. `input-fn` is pure in the query vector and cannot read
+  `app-db`, so the row's width has to be told to it."}
+  ;; input-fn — pure `query-v -> [query-vector*]`, run once per cache entry.
+  (fn [[_ row cols]]
+    (mapv (fn [col] [::subs/cell row col]) (range cols)))
+  ;; computation fn — a parametric sub is handed a VECTOR of input values.
+  (fn [cell-values _]
+    (transduce (map (fn [s] (if (seq s) (js/parseInt s 10) 0)))
+               +
+               0
+               cell-values)))
+
+(h/defview row-total-l2
+  "`views/row-total` with its subscription restated. Same markup, same
+  `.total` class, same `data-total` — so the same selector reads it and
+  the arms differ in exactly one expression."
+  [{:keys [row cols]}]
+  [:td.total {:data-total (str row)} (str (h/sub [::row-total-l2 row cols]))])
+
+(h/defview grid-row-l2
+  "`views/grid-row` with [[row-total-l2]] in place of `views/row-total`.
+
+  The cells are the APPLICATION's `views/cell`, required and used
+  unchanged: the contrast is one subscription's spelling, and a re-typed
+  cell would put a second difference into a two-arm measurement."
+  [{:keys [row]}]
+  (let [{:keys [cols]} (h/sub [::subs/dimensions])]
+    [:tr {:data-row (str row)}
+     (for [col (range cols)]
+       [views/cell {:key (str col) :row row :col col}])
+     [row-total-l2 {:key "total" :row row :cols cols}]]))
+
+(h/defview grid-l2
+  "`views/grid` over [[grid-row-l2]]."
+  [_]
+  (let [{:keys [rows]} (h/sub [::subs/dimensions])]
+    [:main#hundred-cell-grid
+     [:h1 "Grid"]
+     [:table
+      [:tbody
+       (for [row (range rows)]
+         [grid-row-l2 {:key (str row) :row row}])]]]))
+
+;; The fixture snapshots the registrar where THIS form is evaluated, so it
+;; sits below the registration above — a `use-fixtures` at the top of the
+;; file would strand `::row-total-l2` and every layer-2 mount would refuse.
+;; Same reason `grid.scaling-dom-cljs-test` puts its own here.
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture
+    {:adapter       uix-adapter/adapter
+     :ambient-frame nil}))
+
+;; ---------------------------------------------------------------------------
+;; The instrument — the census's counter, plus a keystroke
+;; ---------------------------------------------------------------------------
+
+(defn- browser? []
+  (and (exists? js/document) (some? js/document) (some? (.-body js/document))))
+
+(defn- skip! [why]
+  (is true (str "a mounted React root needs a real DOM — " why)))
+
+(def ^:private counted-sub-ids
+  "Both arms count the same four ids, so an arm that never ran its own
+  total shows up as an ABSENT key rather than as a smaller sum."
+  [::subs/cell ::subs/dimensions ::subs/row-total ::row-total-l2])
+
+(defn- grid-node [m row col]
+  (.querySelector (:container m) (str "#" (events/cell-id row col))))
+
+(defn- total-text [m row]
+  (.-textContent (.querySelector (:container m) (str "[data-total='" row "']"))))
+
+(defn- set-native-value! [n v]
+  (let [d (js/Object.getOwnPropertyDescriptor js/HTMLInputElement.prototype "value")]
+    (.call (.-set d) n v)))
+
+(defn- type-into! [n text]
+  (set-native-value! n (str (.-value n) text))
+  (.dispatchEvent n (js/Event. "input" #js {:bubbles true}))
+  nil)
+
+(defn- census-of
+  "Mount `form` at `dimensions`, type one accepted digit into `[3 4]`, and
+  answer the reading.
+
+  `:total-before` / `:total-after` are the row's rendered total either
+  side of the keystroke, and they are the arm's POSITIVE CONTROL: a
+  layer-2 body run count of one is only interesting if that one run
+  produced the new number. A total that did not move would make the count
+  a measure of a dead subscription."
+  [form dimensions]
+  (census/with-counted-subs counted-sub-ids
+    (fn [sub-runs reset-subs!]
+      (let [m (hm/mount! form {:initial-events (app/initial-events dimensions)})
+            n (grid-node m 3 4)]
+        (hm/settle! m)
+        (let [before (total-text m 3)]
+          (reset-subs!)
+          (let [bodies (hm/bodies-run (fn [] (type-into! n "1") (hm/settle! m)))
+                runs   (sub-runs)]
+            (try
+              {:sub-runs     (census/total runs)
+               :by-sub       runs
+               :bodies       bodies
+               :total-before before
+               :total-after  (total-text m 3)
+               :cell-value   (.-value (grid-node m 3 4))}
+              (finally (hm/unmount! m)))))))))
+
+(def ^:private small {:rows 5 :cols 5})
+(def ^:private full {:rows 10 :cols 10})
+
+;; ---------------------------------------------------------------------------
+;; The restatement is FAITHFUL before it is fast
+;; ---------------------------------------------------------------------------
+
+(deftest the-layer-2-total-renders-what-the-layer-1-total-renders
+  ;; The premise. A cheaper subscription that answers a different number
+  ;; is not a contrast, it is a bug, and every count below would be
+  ;; measuring the wrong thing.
+  (if-not (browser?)
+    (skip! "the faithfulness premise")
+    (let [l1 (hm/mount! [views/grid {}] {:initial-events (app/initial-events full)})
+          l2 (hm/mount! [grid-l2 {}] {:initial-events (app/initial-events full)})]
+      (is (= (mapv #(total-text l1 %) (range 10))
+             (mapv #(total-text l2 %) (range 10)))
+          "every row's total, both spellings, at 10x10")
+      (is (= "345" (total-text l1 3))
+          "and the value is the seeded row's real sum (30+31+…+39), so the
+           row above is not two spellings agreeing on nil")
+      (hm/unmount! l1)
+      (hm/unmount! l2))))
+
+;; ---------------------------------------------------------------------------
+;; The contrast
+;; ---------------------------------------------------------------------------
+
+(deftest the-layer-2-row-total-recomputes-once-where-the-layer-1-one-recomputes-per-row
+  (if-not (browser?)
+    (skip! "the contrast")
+    (let [l1-100 (census-of [views/grid {}] full)
+          l2-100 (census-of [grid-l2 {}] full)
+          l1-25  (census-of [views/grid {}] small)
+          l2-25  (census-of [grid-l2 {}] small)]
+
+      (testing "the arm is live — the one run produced the new number"
+        ;; Before the counts, because a count of 1 that recomputed nothing
+        ;; would read exactly the same.
+        (is (= ["345" "652"] [(:total-before l2-100) (:total-after l2-100)])
+            "row 3 seeds as 30+31+…+39 = 345; the keystroke turns cell
+             [3 4] from `34` into `341`, so the total becomes
+             345 - 34 + 341 = 652. The single layer-2 body run counted
+             below is therefore a real recompute of a real new value, and
+             not a subscription that has stopped firing")
+        (is (= ["345" "652"] [(:total-before l1-100) (:total-after l1-100)])
+            "and the layer-1 arm answers the same, either side")
+        (is (= "341" (:cell-value l2-100))
+            "and the accepted digit is on the glass in the layer-2 arm too"))
+
+      (testing "the layer-1 arm — the census's own figures, re-read here"
+        (is (= {::subs/cell 100 ::subs/row-total 10 ::subs/dimensions 1}
+               (:by-sub l1-100))
+            "10x10: every mounted cell, every row total, and the
+             dimensions cell that nothing moved. Identical to
+             `examples.per-keystroke-dom-cljs-test`'s attribution, taken
+             on the same counter — so this file's subtraction is between
+             two readings it took itself")
+        (is (= 111 (:sub-runs l1-100)))
+        (is (= {::subs/cell 25 ::subs/row-total 5 ::subs/dimensions 1}
+               (:by-sub l1-25)))
+        (is (= 31 (:sub-runs l1-25))))
+
+      (testing "the layer-2 arm — the row-total term collapses to ONE"
+        (is (= {::subs/cell 100 ::row-total-l2 1 ::subs/dimensions 1}
+               (:by-sub l2-100))
+            "10x10: ONE row-total body where the layer-1 spelling ran ten.
+             The nine that did not run are the nine rows whose cells did
+             not move — the layer-2 memo compares those `cols` cell VALUES
+             and finds them `=`, where the layer-1 memo compares the whole
+             of `app-db` and finds it moved")
+        (is (= 102 (:sub-runs l2-100)))
+        (is (= {::subs/cell 25 ::row-total-l2 1 ::subs/dimensions 1}
+               (:by-sub l2-25))
+            "and at 5x5 the same ONE — the term is flat in the grid, where
+             the layer-1 spelling's was linear in `rows`")
+        (is (= 27 (:sub-runs l2-25))))
+
+      (testing "the contrast, stated as the two shapes"
+        (is (= [10 5] [(::subs/row-total (:by-sub l1-100))
+                       (::subs/row-total (:by-sub l1-25))])
+            "layer-1 row-total runs = rows: 10 at 10x10, 5 at 5x5 — it
+             GROWS with the page")
+        (is (= [1 1] [(::row-total-l2 (:by-sub l2-100))
+                      (::row-total-l2 (:by-sub l2-25))])
+            "layer-2 row-total runs = 1 at both sizes — it does NOT")
+
+        (is (= 100 (::subs/cell (:by-sub l1-100)) (::subs/cell (:by-sub l2-100)))
+            "AND THE LINEAR TERM SURVIVES, which is the half of this
+             measurement a reader is likeliest to misread. `::cell` is a
+             layer-1 reader in BOTH arms and there are a hundred of them
+             mounted, so a hundred bodies run either way. What the layer-2
+             spelling removes is the row-total term and nothing else.")
+        (is (= [9 4] [(- (:sub-runs l1-100) (:sub-runs l2-100))
+                      (- (:sub-runs l1-25) (:sub-runs l2-25))])
+            "so the whole saving is nine recomputations out of 111 at
+             10x10 (111 -> 102) and four out of 31 at 5x5 (31 -> 27):
+             `rows - 1`, exactly the row totals that were recomputing a
+             value that had not moved. Stated as a fraction it is 8% and
+             13% of the census's number, and stated as a shape it is the
+             difference between a term that grows with the page and one
+             that does not — which is why the fraction is the less
+             interesting of the two readings.")))))

--- a/implementation/hicasso/test/re_frame/hicasso/examples/grid/row_total_layer2_dom_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/examples/grid/row_total_layer2_dom_cljs_test.cljs
@@ -251,7 +251,16 @@
         (is (= ["345" "652"] [(:total-before l1-100) (:total-after l1-100)])
             "and the layer-1 arm answers the same, either side")
         (is (= "341" (:cell-value l2-100))
-            "and the accepted digit is on the glass in the layer-2 arm too"))
+            "and the accepted digit is on the glass in the layer-2 arm too")
+        (is (= 2 (:bodies l1-100) (:bodies l2-100) (:bodies l1-25) (:bodies l2-25))
+            "AND THE BOUNDARY COUNT DID NOT MOVE — two bodies, both arms,
+             both sizes: the cell that was typed into and its row's total.
+             The contrast is about which SUBSCRIPTION BODIES re-run, and
+             this row is what says the layer-2 spelling bought that
+             without changing what the page re-renders. A restatement
+             that had broadened notification would read higher here and a
+             dead one would read lower, and either would make the
+             recomputation saving below meaningless."))
 
       (testing "the layer-1 arm — the census's own figures, re-read here"
         (is (= {::subs/cell 100 ::subs/row-total 10 ::subs/dimensions 1}

--- a/implementation/hicasso/test/re_frame/hicasso/examples/per_keystroke_dom_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/examples/per_keystroke_dom_cljs_test.cljs
@@ -184,10 +184,17 @@
 ;; Instrument 2 — subscription recomputations
 ;; ---------------------------------------------------------------------------
 
-(defn- with-counted-subs
+(defn with-counted-subs
   "Install a counting wrapper on each of `sub-ids`' registered
   `:handler-fn`, call `(f read-counts reset-counts)`, and restore every
   registration in a `finally`.
+
+  PUBLIC because it has a second consumer:
+  `examples.grid.row-total-layer2-dom-cljs-test` (rf2-18u0) measures the
+  layer-1/layer-2 contrast §4 of `per-keystroke.md` names, and it has to
+  read that contrast on the SAME instrument as the census — a copied
+  counter would make the two numbers an arithmetic comparison between two
+  wrappers rather than one reading. Nothing else about it moved.
 
   `read-counts` answers `{sub-id n}` for the wrappers that ran;
   `reset-counts` zeroes them, which is what lets one mount take a
@@ -215,7 +222,11 @@
         (doseq [[id meta] originals]
           (registrar/register! :sub id meta))))))
 
-(defn- total [counts] (reduce + 0 (vals counts)))
+(defn total
+  "The census's one number, summed over the per-sub attribution. Public
+  for the same second consumer as [[with-counted-subs]]."
+  [counts]
+  (reduce + 0 (vals counts)))
 
 ;; ---------------------------------------------------------------------------
 ;; Instrument 3 — the commit, in glass writes and DOM mutations


### PR DESCRIPTION
Closes rf2-18u0.

`per-keystroke.md` §4 named the layer-1/layer-2 contrast and explicitly declined
to claim it — *"Nothing in this corpus has measured that contrast yet"*. This
measures it.

## Which case the bead was in

**The instrument existed; only the window was missing.** The census's
`with-counted-subs` already counts author-body invocations per sub id and needed
no rig change, exactly as the bead predicted. What did not exist was the layer-2
arm to point it at, and that is what this PR adds.

## What was measured

One accepted keystroke into cell `[3 4]`, both grid sizes, both spellings of
`::row-total`, on the census's own counter.

| Subscription recomputations | 5×5 | 10×10 |
|---|---:|---:|
| `::row-total` as a layer-1 reader (the application) | **31** | **111** |
| `::row-total` restated as a layer-2 read over its row's cells | **27** | **102** |

Attribution:

| Arm | `::cell` | the row total | `::dimensions` |
|---|---:|---:|---:|
| 5×5, layer-1 | 25 | 5 | 1 |
| 5×5, layer-2 | 25 | **1** | 1 |
| 10×10, layer-1 | 100 | 10 | 1 |
| 10×10, layer-2 | 100 | **1** | 1 |

**The row-total term goes from `rows` to one and stops following the mount.**
**The linear term survives** — `::cell` is layer-1 in both arms, so a hundred
bodies run either way, and the saving is `rows − 1` recomputations (9 of 111 at
10×10, 4 of 31 at 5×5). Boundary runs are **2** in both arms at both sizes.

The arm's liveness has a positive control: row 3's rendered total moves
`345` → `652` across the keystroke, so the single layer-2 body run is a real
recompute of a real new value and not a subscription that stopped firing.

## What is NOT concluded

No clock — every figure is a monotone counter and nothing here says the saving is
measurable in time. No general claim about layer-2: one derived read, one page,
two sizes. **No adoption**: `examples/grid/subs.cljs` and
`examples/grid/views.cljs` are untouched, per the bead's fence, and the arm lives
in the suite beside `grid.scaling-dom-cljs-test`'s coarse shapes.

One authoring cost is reported rather than buried: a `:parametric` `input-fn` is
pure in the query vector and cannot read app-db, so the row's width has to arrive
in the query — `[::row-total-l2 row cols]`. A derived read whose input set is not
knowable from its query vector cannot take this spelling at all.

## Did any count move between runs?

**No.** Runs 1 and 3 (same tree, sabotage in between) read identically, and the
sabotage's failure path printed the same `102` and `{25, 1, 1}` the passing
assertions report.

## Gates — captured exit codes

Runner matched to extension: the arm is a `.cljs` file, so it runs on the
**browser lane** (`shadow-cljs :browser-test`) and loads-and-skips on the **node
lane**; no `clojure -M:test` was used or could be.

| Gate | Command | Captured exit |
|---|---|---:|
| browser lane, run 1 (before the boundary row) | `shadow-cljs compile browser-test` then `serve-and-run-browser-tests.cjs` | `0` / `0` |
| browser lane, run 2 — **sabotage** | same | `1` (red naming this file; actuals printed) |
| browser lane, run 3 — restored | same | `0` (1,554 / 9,867, identical to run 1) |
| browser lane, run 4 — boundary row added | same | `1` (two async-nav back-button flakes; this file clean) |
| browser lane, run 5 — no tree change | runner only | `1` (one `requestGC` handshake flake; this file clean) |
| browser lane, run 6 — no tree change | runner only | `0` (1,554 / **9,868**, 0 failures) |
| node lane | `npm run test:cljs` | `0` (13,973 tests / 70,350 assertions) |
| hicasso invariants | `npm run test:hicasso-invariants` | `0` |
| doc slugs | `python scripts/check_doc_slugs.py` | `0` |
| doc slugs — **planted broken anchor** | same | `1` (named the file and the anchor) |
| provenance pins, self-test | `--self-test --verbose` | `0` (68 self-tests) |
| provenance pins, changed pages | `--changed-since origin/main --verbose` | `0` (1 page, 5 pins, 5 landed) |
| clj-kondo (CI's pinned command) | `python scripts/lint_kondo.py` | `0` (errors: 0; no finding on either changed file) |
| portability | `sh scripts/check-no-hardcoded-paths.sh` | `0` |

**Runs 4 and 5 are flakes and run 6 is what says so** — 4, 5 and 6 were taken on
the identical tree *and the identical compiled bundle*, the reds were different
tests each time, both were in browser suites this change does not touch, and this
file's namespace printed no failure in either.

`scripts/test-fast-pr.sh` was started and reached `mkdocs --strict` (built, 79s)
and every gate before it green; the harness killed the shell inside the final
`clj-kondo` step at the 10-minute cap, so that attempt has **no captured exit and
is reported as no verdict**. The one unverified step was then run on its own —
`python scripts/lint_kondo.py`, exit `0` — which is the row above.

## Docs verified by hand

`docs/design/hicasso/product/per-keystroke.md` is **not** a published copy (the
exhaustive list is `decision-brief.md`, `specification.md`, `lanes/`), so it is
tracked-native and editable. `mkdocs build --strict` does not cover
`docs/design/**` (`exclude_docs`); `check_doc_slugs.py` does, and it was proved
live by planting a broken anchor and watching it go red. Nothing validates
tables, so **all 11 tables on the page were column-checked by hand** (a script
that splits on unquoted `|` — 11 tables, 0 mismatches), including the three new
ones. The published arithmetic was re-derived: 30…39 = 345; 345 − 34 + 341 = 652;
111 − 102 = 9 = `rows − 1`; 31 − 27 = 4 = `rows − 1`; 9/111 ≈ 8%, 4/31 ≈ 13%.
