### PR TITLE
docs(hicasso): 0.9718 is a historical reading, not one held by cancellation (rf2-gttif)

### DIFF
--- a/docs/design/hicasso/studio/the-cold-read-mount-term.md
+++ b/docs/design/hicasso/studio/the-cold-read-mount-term.md
@@ -76,7 +76,7 @@ and settled between samples behind a residue equality gate that never fired):
 
 | term | delta ms/commit | share of `c-local` |
 |---|---|---|
-| whole commit (`commit`, shipping seam) | 0.8875 [0.8000–1.0750] | — (6.29 µs/key; copy fidelity c-local/commit = 0.9718) |
+| whole commit (`commit`, shipping seam) | 0.8875 [0.8000–1.0750] | — (6.29 µs/key; copy fidelity c-local/commit = 0.9718, a **HISTORICAL reading** authored at `cb41ee537b`, landed on main as `12e50c5b36` — see the ratio note below) |
 | — **reaction build + cache insert** (`c-local − c-nosub`) | **0.4125** | **47.8%** |
 | — index write (`c-local − c-noindex`) — **arm and structure both retired since; see the window note below** | 0.0750 | 8.7% |
 | — cell-map insert (`c-local − c-nomap`) | 0.0375 | 4.3% |
@@ -98,10 +98,27 @@ and settled between samples behind a residue equality gate that never fired):
 > only change to have landed under these rows. **The four deltas do not
 > move at all**: the mint was bound above `commit-local!`'s `C-NOWATCH` guard
 > and present in every mode, so it stood on both sides of each and cancelled
-> exactly. **Nor does the fidelity ratio** — both arms carried the mint and
-> both have since lost it, so it is common-mode there too; and the copy is
-> once again *structurally* identical to the seam it prices, which warrants
-> the `c-*` ablations better than a clock agreement on its own ever did.
+> exactly — a delta is a *difference*, and an equal term standing on both
+> sides of a difference cancels out of it identically. **The fidelity ratio is
+> the other case, and the same premise does not carry across to it.** An equal
+> cost `m` removed from both arms of a RATIO leaves it where it was only when
+> `m` is zero or the arms are equal: `(A − m)/(B − m) = A/B` iff `m = 0` or
+> `A = B`. Here `A` = 0.8625 and `B` = 0.8875 are not equal, so removing the
+> 0.002–0.005 ms/commit the window note below extrapolates for the mint —
+> 141 × a 14–32 ns micro reading, never a differenced arm, because no arm
+> here ever priced a minting commit against a non-minting one — moves
+> 0.971831 to 0.971767–0.971671. Those digits are past what four-digit inputs
+> support and are quoted only for direction and scale; the point is not the
+> size of the shift but that **the cancellation argument is unsound for a
+> ratio rather than merely imprecise**, and it was the only thing this page
+> offered for carrying 0.9718 forward. (§1's render half is the `A = B` case —
+> `local/ship` = 1.0000, which an equal two-sided removal genuinely does leave
+> alone.) What the mint's removal does warrant is the ablation **design**: the
+> copy is once again *structurally* identical to the seam it prices, which
+> warrants the `c-*` arms better than a clock agreement on its own ever did.
+> It does not warrant carrying a measured ratio forward, and the ratio is now
+> published as the historical reading it is. (Merged-PR audit of #8335;
+> `rf2-gttif` reopened on it.)
 
 > **THE QUIET-BOX RE-TAKE HAS NOW RUN, AND THE FIGURES ABOVE STAND UNRESTATED**
 > (`rf2-d360z`, 2026-08-15, `2c95c22386`, instrument blob `7f2a7edccf`,
@@ -176,17 +193,33 @@ and settled between samples behind a residue equality gate that never fired):
 > at all. Phase B needs a longer window before it can decompose anything again;
 > that is filed too, and deliberately not attempted mid-window.
 >
-> **The fidelity ratio is not restated either, and does not need to be.** It
-> read 0.8864 / 0.9444 / 0.9189 against the published 0.9718 — a spread of
-> 0.058 lying wholly *below* it, so this window neither reproduces the
-> published ratio nor brackets it, and none of it is offered as confirmation.
-> What holds 0.9718 in place is not clock agreement but the reason `rf2-gttif`
-> gave, in the narrow form that reason actually takes: the keyword mint left
-> the copy and the seam alike, so it cancels out of the ratio. `rf2-lzpfj`'s
-> activation is the one term that did not move on both sides — it joined
-> `c-local` alone, restoring parity with work the seam was already performing,
-> and on this UIx host that work is expected at the noise floor. It was never a
-> term that joined both arms together.
+> **The fidelity ratio is not restated either — it is RELABELLED rather than
+> carried.** It read 0.8864 / 0.9444 / 0.9189 against the published 0.9718 —
+> a spread of 0.058 lying wholly *below* it, so this window neither reproduces
+> the published ratio nor brackets it, and none of it is offered as
+> confirmation. **And nothing else holds 0.9718 in place either.** The reason
+> `rf2-gttif` first gave — the keyword mint left the copy and the seam alike,
+> so it cancels out of the ratio — is a sound argument about a *difference*
+> and an unsound one about a ratio: `(A − m)/(B − m)` equals `A/B` only when
+> `m = 0` or `A = B`, and the two arms behind 0.9718 are 0.8625 and 0.8875.
+> The note directly under §1's commit-half table carries that arithmetic.
+> `rf2-lzpfj`'s activation
+> is then not a perturbation of the argument but its refutation: it joined
+> `c-local` ALONE — restoring parity with work the seam was already performing
+> — and a one-sided term cancels from neither a difference nor a ratio,
+> whatever its size. (The widened-window re-take below measures that term at
+> 0.0422–0.0562 ms/commit, roughly 8–28× the mint's extrapolated cost; it was taken at
+> a window shape these 2026-08-02 absolutes were not, so no transferred figure
+> is offered and none is needed — the one-sidedness is structural, not a
+> matter of magnitude. That same re-take is also why the "expected at the noise
+> floor" reading this paragraph previously gave the activation is withdrawn:
+> the term resolves with one sign on every run.) **0.9718 therefore stands as
+> a HISTORICAL reading** — what the arms of `cb41ee537b`, landed on main as
+> `12e50c5b36`, returned before the mint left, the index write was retired and
+> the activation arrived — and not as a figure this tree would return. The
+> structural parity `rf2-6wh9o` restored still warrants the `c-*` ablation
+> DESIGN, which is the job it can do; it cannot preserve a measured ratio
+> numerically. (Merged-PR audit of #8335; `rf2-gttif` reopened on it.)
 
 > **THE WHOLE RE-TAKE RAN ON THE WIDENED WINDOW, AND IT DOES NOT PUBLISH**
 > (`rf2-07rnj`, 2026-08-16, commit `a43aa8609f`, instrument blob


### PR DESCRIPTION
Closes `rf2-gttif` (REOPEN by merged-PR audit of #8335).

One file, prose and ledger only: `docs/design/hicasso/studio/the-cold-read-mount-term.md`.

## What was wrong

PR #8335 correctly removed an impossible bracketing claim and an unsupported
sole-noise attribution, and correctly said its window neither reproduces nor
confirms 0.9718. It left the older central premise in force: that the keyword
mint left the copy and the seam alike, so it cancels out of the ratio, and
therefore 0.9718 still holds.

Equal additive work cancels from a **difference**, not from a **ratio**. For
numerator `A`, denominator `B` and removed cost `m`:

```
(A - m)/(B - m) = A/B   iff   m = 0  or  A = B
```

I checked this against the numbers on the page rather than taking the audit's
word for it. `A` = 0.8625 (`c-local`), `B` = 0.8875 (`commit`):

| m | (A−m)/(B−m) | shift from A/B |
|---|---|---|
| 0 | 0.9718309859 | — |
| 0.002 | 0.9717673631 | −6.36e−05 |
| 0.005 | 0.9716713881 | −1.60e−04 |

So the published 0.9718 does move, and the cancellation argument is **unsound
for a ratio rather than merely imprecise**. It was the only thing the page
offered for carrying the figure forward. `rf2-lzpfj`'s activation then joined
`c-local` alone; a one-sided term cancels from neither form, whatever its size.

## What the page now says, and what licenses each sentence

- **The cell** (§1 commit-half table, `whole commit` row) keeps 0.9718 and
  labels it a **HISTORICAL reading** on its provenance — authored at
  `cb41ee537b`, landed on main as `12e50c5b36`. Licensed by the page's own
  provenance paragraph at §1 (lines 53–57), which already establishes that
  pair.
- **The 2026-08-03 note under that table** now states the ratio arithmetic
  explicitly, and names the estimator it actually has for the mint:
  `141 × a 14–32 ns micro reading`, an **extrapolation**, never a differenced
  arm — no arm on this page ever priced a minting commit against a
  non-minting one. Licensed by the window note's own 0.002–0.005 ms/commit
  derivation.
- It also records the `A = B` case for contrast: §1's render half publishes
  `local/ship` = 1.0000, which an equal two-sided removal genuinely does
  leave alone. Licensed by the render-half table row itself.
- **The `rf2-d360z` window paragraph** keeps #8335's correct half verbatim
  (0.8864 / 0.9444 / 0.9189 lies wholly below 0.9718; neither reproduces nor
  brackets; offered as no confirmation) and replaces "what holds 0.9718 in
  place" with "nothing else holds 0.9718 in place either", plus the
  refutation from one-sidedness.
- The comparison in it is checked: the widened window measures activation at
  0.0422–0.0562 ms/commit against the mint's extrapolated 0.002–0.005, i.e.
  8.44–28.1×, published as "roughly 8–28×". It is explicitly flagged as taken
  at a **different window shape** from the 2026-08-02 absolutes, so **no
  transferred figure is offered** — the one-sidedness is structural, not a
  matter of magnitude.
- The paragraph's previous "on this UIx host that work is expected at the
  noise floor" reading of the activation is **withdrawn**, and said to be so.
  Licensed by the page's own later `rf2-07rnj` block, which finds
  `c-noactivate` resolves with one sign on every run and "is a term and not
  the noise floor".
- **What survives is stated**: the structural parity `rf2-6wh9o` restored
  still warrants the `c-*` ablation **design**; it cannot preserve a measured
  ratio numerically.

Both corrections carry the page's own attribution device:
`(Merged-PR audit of #8335; rf2-gttif reopened on it.)`

## Scope held

- **No measurement was taken.** No benchmark run, no clock reading, no quiet
  box requested. The audit says none is needed and five workers are live.
- **No new ratio derived at a desk.** The point is that the number is stale,
  not that a better one is computable.
- **The four DELTA rows are untouched.** The mint stood on both sides of each
  difference and cancelled there legitimately — the same arithmetic working
  the other way.
- `rf2-0qj9w` and `rf2-2rtt6.76` are not bundled.
- No fenced code block under `docs/core/freehand/` was added or edited (none
  is anywhere near this diff), so `samples_coverage_jvm_test.clj` is
  unaffected.

## Published-copy check

`docs/design/hicasso/product/README.md` §Refresh contract names the exhaustive
published set: *"The copies here are `decision-brief.md`, `specification.md`,
and everything under `lanes/`"*. This file is
`docs/design/hicasso/studio/the-cold-read-mount-term.md` — not in that list, and
under `studio/` rather than `product/`. It is tracked-native (`git ls-files`
confirms) and no publication overwrites it.

## Gates — foreground, captured exit codes

| gate | captured exit |
|---|---|
| `python scripts/check_provenance_pins.py --changed-since origin/main --verbose` | **0** |
| `python scripts/check_doc_slugs.py` | **0** |
| `sh scripts/check-no-hardcoded-paths.sh` | **0** |

The provenance gate is the load-bearing one here, and it inspected this page:
`1 page inspected, 33 cited pins — 19 landed, 14 stranded, 0 unresolvable, 0 foreign; 14 accompanied in scope; 0 findings`.
It confirms the new table cell specifically:
`the-cold-read-mount-term.md:79  cb41ee537b [STRANDED] — not a finding: 12e50c5b36 on line 79 is in the same block and is an ancestor of origin/main`
— which matters because a table row is its own accompaniment scope, so the
landed SHA had to go **in the same cell**.

`mkdocs build --strict` is deliberately **not** nominated: `mkdocs.yml`'s
`exclude_docs` keeps `docs/design/` out of the site.

## Table column counts — verified by hand

Nothing validates table rendering or column counts, so I checked them. The
edited table (§1 commit half) has header `| term | delta ms/commit | share of
c-local |` = **3 columns**, separator `|---|---|---|` = 3, and the edited row
carries 4 pipes → 3 cells, with no literal `|` inside any cell text. I then
confirmed that reading mechanically across the whole page: **12 tables, 0 with
mismatched column counts** (widths 4/3/4/4/4/3/3/7/5/2/2/3, each internally
consistent).
