### PR TITLE
fix(registrar): :different-fn? reads the slot the registration named (rf2-5qaf4)

### DIFF
--- a/implementation/core/src/re_frame/registrar.cljc
+++ b/implementation/core/src/re_frame/registrar.cljc
@@ -535,6 +535,36 @@
     ;; Dev: retain documentation for tooling / agent inspection.
     metadata))
 
+(defn- executable-identity
+  "The value that IS this registration's executable identity — the thing
+  `:different-fn?` compares, and the thing a devtool has to refresh its
+  view of when it rotates.
+
+  For every kind the framework registers through its own `reg-*` macros
+  that value is the `:handler-fn`. A registration whose executable
+  identity lives SOMEWHERE ELSE says where, by naming the key under
+  `:executable-key`.
+
+  One registration needs that today and it is the reason this indirection
+  exists. Hicasso's authoring-time `:view` alias
+  (`re-frame.hicasso.impl.collector/publish-view-alias!`, rf2-5qaf4)
+  carries its minted head at `:hicasso/component` and deliberately has NO
+  `:handler-fn` — a boundary is a React component, not a hiccup-returning
+  render fn, so `rf/view` must keep answering nil for it. Comparing
+  `:handler-fn` on that shape compares nil with nil, which reports
+  `:different-fn? false` for a real component swap and tells every
+  hot-reload consumer the reload was idempotent when it was not.
+
+  It POINTS at the slot rather than duplicating the head into a second
+  one: one home for the value, and a registrar that stays ignorant of
+  which substrate wrote the entry — it reads a key the registration
+  itself named. Absent `:executable-key` — every framework `reg-*` in
+  the tree — this is exactly `(:handler-fn metadata)`, so no existing
+  kind changes behaviour. A non-map `metadata` answers nil, as the bare
+  `:handler-fn` lookup it replaces did."
+  [metadata]
+  (get metadata (get metadata :executable-key :handler-fn)))
+
 (defn register!
   "Register an id under kind with the given metadata. Re-registering the
   same id replaces the slot atomically (per Spec 001 §Hot-reload semantics
@@ -546,8 +576,10 @@
   re-registration (per Spec 001 §Hot-reload trace surface + Spec 009 —
   devtools refresh their view from this event). The trace's `:tags`
   carry `:different-fn?` so tooling can branch idempotent reloads from
-  real fn-identity changes without re-emitting through a separate
-  surface."
+  real changes of the registration's executable identity, without
+  re-emitting through a separate surface. That identity is the
+  `:handler-fn` unless the registration named another slot under
+  `:executable-key` — see `executable-identity`."
   [kind id metadata]
   (when-not (valid-kind? kind)
     (error/throw-error!
@@ -599,7 +631,8 @@
     (cond
       ;; Re-registration path — fire hooks and emit handler-replaced.
       previous
-      (let [different? (not= (:handler-fn previous) (:handler-fn metadata))]
+      (let [different? (not= (executable-identity previous)
+                             (executable-identity metadata))]
         ;; Hot-reload notifications. Hooks run isolated — listener failures
         ;; don't propagate. Hooks fire on EVERY re-registration so dependent
         ;; namespaces can clean up their caches even on idempotent reloads

--- a/implementation/hicasso/src/re_frame/hicasso.cljc
+++ b/implementation/hicasso/src/re_frame/hicasso.cljc
@@ -250,7 +250,9 @@
   `:advanced` + `goog.DEBUG=false` nothing registers and a production
   Hicasso app still holds no registry at runtime — the entry serves
   tools. Re-evaluating a declaration replaces the entry behind the same
-  id, which is the registrar's own behaviour and needed nothing added.
+  id — the registrar's own behaviour, with nothing added for it beyond
+  the slot naming where its executable identity lives, so that the
+  replacement a tool is told about is the one that happened.
   [[re-frame.hicasso.impl.collector/publish-view-alias!]] carries the
   slot's shape and why it is written there rather than through
   `rf/reg-view*`."

--- a/implementation/hicasso/src/re_frame/hicasso/impl/collector.cljs
+++ b/implementation/hicasso/src/re_frame/hicasso/impl/collector.cljs
@@ -2084,13 +2084,27 @@
   the head, and `:hicasso/component` is `identical?` to the value the
   `def` binds whether an adapter is installed or not.
 
-  ## Hot reload needs nothing added
+  ## Hot reload — the slot needed nothing added, the NOTIFICATION did
 
   Re-evaluating a `defview` re-registers the SAME id, and the registrar
   replaces the slot atomically — one entry, never two, with the fresh
   head. The provenance is unchanged across a save, so the registrar's
   collision warning stays correctly silent; a genuine cross-source clash
   on one id still surfaces, because it surfaces for every kind.
+
+  What the entry DID have to say out loud is where its executable
+  identity lives, and `:executable-key` says it. `register!` tags every
+  `:rf.registry/handler-replaced` — and every replacement-hook call —
+  with `:different-fn?`, derived by default from `:handler-fn`. This
+  entry has none by design, so the default derivation compares nil with
+  nil and reports `:different-fn? false` for a genuine swap of one
+  component for another: a hot-reload consumer branching on that tag
+  would read every Hicasso view edit as an idempotent reload and decline
+  to refresh. Naming `:hicasso/component` as the executable slot makes
+  the tag truthful without a second HMR surface, without a hicasso-side
+  replacement hook, and without putting anything in `:handler-fn`
+  (rf2-5qaf4, merged-PR audit #8332). The registrar reads the key this
+  registration named; it learns nothing about Hicasso.
 
   Called ONLY from inside the `defview` expansion's
   `(when re-frame.interop/debug-enabled? …)` gate — the same gate the
@@ -2101,7 +2115,9 @@
 
   Answers `view-id`, per Conventions §`reg-*` return-value."
   [view-id slot head]
-  (registrar/register! :view view-id (assoc slot :hicasso/component head))
+  (registrar/register! :view view-id (assoc slot
+                                       :hicasso/component head
+                                       :executable-key    :hicasso/component))
   view-id)
 
 ;; ---------------------------------------------------------------------------

--- a/implementation/hicasso/test/re_frame/hicasso/view_alias_registry_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/view_alias_registry_cljs_test.cljs
@@ -17,6 +17,7 @@
   | `:ns` / `:file` / `:line` / `:column` | the coordinate, at the top level, where `reg-view` puts it |
   | `:doc` | the author's docstring, when they wrote one |
   | `:hicasso/component` | the minted head, `identical?` to what the `def` binds |
+  | `:executable-key` | `:hicasso/component` — where this entry's executable identity lives, so the registrar's `:different-fn?` tells a real reload from an idempotent one |
   | `:handler-fn` | **absent** |
 
   ## The peer registration is the point of comparison, not decoration
@@ -48,6 +49,7 @@
             [re-frame.core :as rf]
             [re-frame.hicasso :as h]
             [re-frame.hicasso.impl.collector :as collector]
+            [re-frame.registrar :as registrar]
             [re-frame.test-support :as test-support]))
 
 ;; ---------------------------------------------------------------------------
@@ -217,3 +219,78 @@
               `:handler-fn`, still the coordinate"
       (is (not (contains? (slot ::aliased-row) :handler-fn)))
       (is (= coords (select-keys (slot ::aliased-row) coord-keys))))))
+
+;; ---------------------------------------------------------------------------
+;; What the reload TELLS a tool — the `:different-fn?` discriminator
+;; ---------------------------------------------------------------------------
+;;
+;; Replacing the entry is half the contract; the other half is what
+;; `register!` says about the replacement, and the row above never looked.
+;; `:different-fn?` is derived by default from `:handler-fn`, and this entry
+;; has none by design — so the default derivation compares nil with nil and
+;; calls a real component rotation idempotent. A hot-reload consumer branching
+;; on the tag would decline to refresh on every Hicasso view edit. The slot
+;; names `:hicasso/component` as its executable identity under
+;; `:executable-key`, and `re-frame.registrar/executable-identity` reads the
+;; key the registration named (merged-PR audit #8332 on rf2-5qaf4).
+;;
+;; The HOOK is the seam asserted here rather than the trace bus, and it
+;; covers both surfaces: `register!` binds `different?` ONCE and hands the
+;; same value to every replacement hook and to the
+;; `:rf.registry/handler-replaced` `:tags`. A hook also fires on EVERY
+;; re-registration, where the trace emit is additionally dedup-by-shape gated
+;; — so the hook can witness the idempotent row below, and the trace cannot.
+
+(defonce ^:private recorded
+  ;; nil except while a row below is recording. The registrar has no
+  ;; remove-hook door, so the hook installed beside it lives for the whole
+  ;; process and MUST stay inert for every other namespace in the shared
+  ;; `:node-test` bundle.
+  (atom nil))
+
+(defonce ^:private recording-hook
+  (do (registrar/add-replacement-hook!
+        (fn [m]
+          (when @recorded
+            (swap! recorded conj (select-keys m [:kind :id :different-fn?])))))
+      true))
+
+(defn- while-recording
+  "Run `f`, answering the replacement-hook calls it provoked. The
+  `finally` is what keeps a failing row from leaving the hook live for
+  every namespace that loads after this one."
+  [f]
+  (reset! recorded [])
+  (try (f)
+       @recorded
+       (finally (reset! recorded nil))))
+
+(deftest a-reloaded-head-is-reported-as-a-real-change-not-an-idempotent-reload
+  (let [coords (select-keys (slot ::aliased-row) coord-keys)
+        head   #(:hicasso/component (slot ::aliased-row))]
+
+    (testing "the slot names where its executable identity lives, which is
+              what lets the registrar tell the two cases apart without
+              learning anything about Hicasso"
+      (is (= :hicasso/component (:executable-key (slot ::aliased-row))))
+      (is (contains? (slot ::aliased-row) (:executable-key (slot ::aliased-row)))))
+
+    (testing "a save that changes the boundary's body mints a NEW head, and
+              the replacement is reported as a real change — the tag a
+              devtool refreshes on"
+      (let [rotated (fn rotated-row [_] nil)
+            calls   (while-recording
+                      #(collector/publish-view-alias! ::aliased-row coords rotated))]
+        (is (= 1 (count calls)) "exactly one replacement, not zero and not two")
+        (is (= {:kind :view :id ::aliased-row :different-fn? true}
+               (first calls)))))
+
+    (testing "and it is a DISCRIMINATOR, not a constant: re-publishing the
+              head already in the slot is the idempotent reload it looks
+              like, and still says so"
+      (let [same  (head)
+            calls (while-recording
+                    #(collector/publish-view-alias! ::aliased-row coords same))]
+        (is (= 1 (count calls)) "the hook fires on every re-registration")
+        (is (= {:kind :view :id ::aliased-row :different-fn? false}
+               (first calls)))))))


### PR DESCRIPTION
Discharges the merged-PR audit (#8332) that reopened **rf2-5qaf4**. The ruled shape from rf2-1gy4e option (b) is untouched; this fixes what the registrar *said* about a reload, not what it stored.

## The defect, at source

`registrar/register!` derived both the replacement-hook argument and the `:rf.registry/handler-replaced` `:different-fn?` tag from `(:handler-fn previous)` vs `(:handler-fn metadata)`.

Hicasso's authoring-time `:view` alias has **no** `:handler-fn` by design — a boundary is a React component, not a hiccup-returning render fn, so `rf/view` must keep answering nil for it (ruling b, and the landed test asserts it). Both sides of that comparison are therefore nil forever, so replacing one component with another reported `{:component-replaced? true, :different-fn? false}`: a real component rotation tagged as an idempotent reload. A hot-reload consumer branching on the tag — which is the only reason the tag exists — would decline to refresh on every Hicasso view edit.

## The change

The registration says where its executable identity lives; the registrar reads the key it named.

- `implementation/core/src/re_frame/registrar.cljc` — new private `executable-identity`: `(get metadata (get metadata :executable-key :handler-fn))`, used for `different?`. **Absent `:executable-key` — every framework `reg-*` in the tree — this is exactly the `(:handler-fn metadata)` it replaces**, so no existing kind changes behaviour, and a non-map `metadata` still answers nil.
- `implementation/hicasso/src/re_frame/hicasso/impl/collector.cljs` — `publish-view-alias!` adds `:executable-key :hicasso/component` to the slot.

It **points at** the slot rather than duplicating the head into a second one: one home for the value, and a registrar that stays ignorant of which substrate wrote the entry.

What it deliberately is not: no parallel HMR surface, no hicasso-side replacement hook, nothing placed in `:handler-fn`, no change to the metadata-only slot, no new registrar kind. One lookup in core, one key in the slot.

## The spec question

**The code was wrong, not the spec.** Checked at source:

- [`Spec-Schemas.md` §Per-kind refinements, L351](spec/Spec-Schemas.md) is the governing row for the `:view` slot's shape, and it is explicit: *"Open-map convention applies — hosts and tools may attach further keys additively without breaking conformance."* Both `:hicasso/component` (landed) and `:executable-key` (here) are licensed by it. No spec edit needed.
- Neither `:handler-fn` nor `:different-fn?` appears anywhere in Spec 001 or Spec 009. `:handler-fn` is a CLJS-reference-local registration-metadata key, and `:different-fn?` is documented only in `register!`'s own docstring (Spec 013 names it for flows, which emit their own event from their own single store, deriving `different?` from `:derive` rather than `:handler-fn` — the same "executable identity is not always `:handler-fn`" fact, solved locally there). So the contract this contradicted is implementation-level, and the fix is too.
- Key naming: bare `:executable-key`, matching the registration-metadata grammar it joins (`:handler-fn`, `:doc`, `:schema`, `:tags` are all bare — Conventions regime 1, closed local grammar). Nothing reserved is touched; no `:rf.*` namespace is widened.

**One spec gap reported, not papered over:** [`001-Registration.md` L299](spec/001-Registration.md) per-kind row reads `| :view | Replace the view fn | …`, which presumes every `:view` entry has a view fn. The hicasso alias entry has none. That row is in a hot-zone file outside this bead's fence, so it is left for a ruling rather than edited here.

## Facade classification

**No facade change.** `publish-view-alias!` is `impl/collector.cljs` (implementation tier, not the `re-frame.hicasso` door); `executable-identity` is `defn-` private in core and is not exported from `re-frame.core`. `check_facade_inventory.py` runs clean in the invariants chain below, and its count is unchanged at 16 names on `re-frame.hicasso` / 43 inventory rows.

## Tests — and the RED proof

`the-slot-is-written-adapter-neutrally` etc. proved the slot is *replaced*; nothing looked at what the replacement *said*. One narrow witness added at the replacement-hook seam, `a-reloaded-head-is-reported-as-a-real-change-not-an-idempotent-reload`:

- a rotated head → `{:kind :view :id ::aliased-row :different-fn? true}`
- the head already in the slot → `:different-fn? false` (it is a discriminator, not a constant)

The hook is the right seam and it covers the trace too: `register!` binds `different?` **once** and hands the same value to every replacement hook and to the `:tags`. A hook also fires on *every* re-registration where the trace emit is additionally dedup-by-shape gated, so the hook can witness the idempotent row and the trace cannot. The recording hook is inert unless a row is recording (the registrar has no remove-hook door and this rides a shared `:node-test` bundle), and its `finally` restores that on a failing row.

RED proof and gate exit codes are in the thread below.

Fence: `implementation/hicasso/{src,test}` **plus `implementation/core/src/re_frame/registrar.cljc`** — reported explicitly, because the bead's original fence was written for the initial implementation and the audit's finding is located in core. A truthful discriminator cannot be built on the hicasso side without either a parallel HMR surface or a `:handler-fn`, both of which ruling (b) forbids.

Closes rf2-5qaf4.
