### PR TITLE
docs(hicasso): HD-023's :& control re-taken under the strict per-round rule (rf2-20uei)

### DIFF
--- a/docs/design/hicasso/decisions.md
+++ b/docs/design/hicasso/decisions.md
@@ -1665,11 +1665,11 @@ run-means 0.970 – 1.027, two intervals that do not touch. **The headline `25% 
 mount` and `2.4 µs per site` are left exactly as published.** This window was
 taken to settle the control's verdict, and re-pricing an effect on the strength
 of a run taken to test something else is the move this lane refuses; the two
-windows are also not one ensemble and are not pooled here. The remaining
-per-round vectors, printed for the same durability reason — effect
-`[1.41 1.2111 1.1188 1.2184 1.2469]`, `[1.2641 1.2526 1.1556 1.2584 1.1477]`,
-`[1.2872 1.2353 1.1566 1.2317 1.2368]`; null
-`[0.98 0.9889 0.8911 0.9655 1.0247]`, `[1.0189 1.0 1.0333 1.0337 1.0227]`,
+windows are also not one ensemble and are not pooled here. The window's remaining
+per-round vectors are printed for the same durability reason as the control's.
+Effect: `[1.41 1.2111 1.1188 1.2184 1.2469]`,
+`[1.2641 1.2526 1.1556 1.2584 1.1477]`, `[1.2872 1.2353 1.1566 1.2317 1.2368]`.
+Null: `[0.98 0.9889 0.8911 0.9655 1.0247]`, `[1.0189 1.0 1.0333 1.0337 1.0227]`,
 `[1.0532 1.0118 1.0602 1.0244 0.9868]`.
 
 **And what the re-take's dispersion may NOT be attributed to.** R1's null

--- a/docs/design/hicasso/decisions.md
+++ b/docs/design/hicasso/decisions.md
@@ -1624,6 +1624,66 @@ re-adjudicate without re-running the window. **These three runs recorded only th
 aggregate, so their strict verdict is not recoverable from what was kept, and
 none is claimed here.**
 
+**RE-TAKEN under the strict rule, and it PASSES (`rf2-20uei`).** A SEPARATE
+window of three runs — not a continuation of the ensemble above — was taken back
+to back at commit `2f6cf3165818` on the instrument as it now stands: the same
+five arms, the same five rounds of three warm-up plus six samples, the fairness
+gate again agreeing 1,001 elements three ways and again proven able to answer
+false, Chromium 147.0.7727.15 under `:advanced` with `goog.DEBUG` false, the
+arm-order guard reportable and 0 unverified writes of 270 in each run.
+`lane/control-verdict-strict` adjudicated `:ctl-2x`/`:expanded` ROUND BY ROUND
+against 2.00x with a ±25% band of [1.500 – 2.500], and **all fifteen rounds sat
+inside it** — `:outside` was empty in all three, so no good round vouched for a
+bad one. The values are printed rather than summarised, which is the whole point:
+this window is re-adjudicable under either rule without being re-run.
+
+| re-take | round 1 | round 2 | round 3 | round 4 | round 5 | strict verdict |
+|---|---|---|---|---|---|---|
+| R1 | 2.0400 | 1.9667 | 1.8812 | 2.0230 | 2.1111 | inside, 5 of 5 |
+| R2 | 2.0566 | 2.0211 | 1.9667 | 2.1573 | 1.9659 | inside, 5 of 5 |
+| R3 | 2.0532 | 1.9765 | 1.9277 | 2.0366 | 2.0000 | inside, 5 of 5 |
+
+The lowest of the fifteen is 1.8812, 5.9% under the prediction, and the highest
+2.1573, 7.9% over; the band's edges sit 25% away, so the strict rule was nowhere
+near refusing. **That is what this re-take settles, and the only thing it
+settles**: the control holds every round on this instrument, not merely on
+aggregate overlap.
+
+| re-take | `:merged`/`:expanded` | per-round range | NULL `:expanded-b`/`:expanded` | per `:&` site |
+|---|---|---|---|---|
+| R1 | 1.2410x | 1.1188 – 1.4100 | 0.9700x | 2,375 ns |
+| R2 | 1.2157x | 1.1477 – 1.2641 | 1.0217x | 2,875 ns |
+| R3 | 1.2295x | 1.1566 – 1.2872 | 1.0273x | 2,375 ns |
+
+Same estimator as the table above — a mean of per-round ratios of within-round
+medians — and these CORROBORATE rather than replace. The re-take's effect
+run-means span 1.216 – 1.241 against the original three's 1.217 – 1.270,
+overlapping at the low end and sitting a little under them, and its per-site
+figures read 2,375 ns twice and 2,875 ns once. The separation holds inside the
+new window on its own terms: effect run-means 1.216 – 1.241 against null
+run-means 0.970 – 1.027, two intervals that do not touch. **The headline `25% of
+mount` and `2.4 µs per site` are left exactly as published.** This window was
+taken to settle the control's verdict, and re-pricing an effect on the strength
+of a run taken to test something else is the move this lane refuses; the two
+windows are also not one ensemble and are not pooled here. The remaining
+per-round vectors, printed for the same durability reason — effect
+`[1.41 1.2111 1.1188 1.2184 1.2469]`, `[1.2641 1.2526 1.1556 1.2584 1.1477]`,
+`[1.2872 1.2353 1.1566 1.2317 1.2368]`; null
+`[0.98 0.9889 0.8911 0.9655 1.0247]`, `[1.0189 1.0 1.0333 1.0337 1.0227]`,
+`[1.0532 1.0118 1.0602 1.0244 0.9868]`.
+
+**And what the re-take's dispersion may NOT be attributed to.** R1's null
+run-mean is 0.970 with a per-round low of 0.8911, further from 1.0 than any of
+the original three's null run-means, which ran 1.001 – 1.013; R1 also carries the
+widest effect per-round range of the RE-TAKE's three — though not of the six on
+this page, a span the original run 2's 0.968 – 1.409 still holds. What is known
+about the box is bounded and is stated as such: `\System\Processor Queue Length`
+was sampled ONLY between runs, never inside a measured window — a sample taken
+there reads the benchmark's own load and answers nothing — and of the 31 samples
+so taken, 29 read 0 and two read 1. So this page does not attribute that spread
+to the instrument alone, and does not attribute it to the box either. It is
+printed and left unapportioned, which is all the sampling licenses.
+
 **What that figure is, and what it is not.** It prices the AUTHORING CHANGE whole:
 the caller map each call site builds, the `dissoc` the helper performs on it, and
 the codec's `merge-caller`. That is the honest denominator for HD-023's ergonomic


### PR DESCRIPTION
## What this settles, stated narrowly

PR #8326's three amp-merge windows recorded the positive control as a **cross-round aggregate only** — `lane/record!` stored `:absolute-ms` as `summarise`'s n/min/max/p50 across rounds, and no per-round control value reached the record, the console, the PR body or the page. Their STRICT verdict was therefore unrecoverable, and PR #8333 correctly declined to claim one. `rf2-20uei` is the re-take that recovers it.

**The control PASSES strictly. All fifteen rounds sat inside the band.** That is what this window settles, and the only thing it settles.

## The window

A **separate** window of three runs — not a continuation of the published ensemble — taken back to back at commit `2f6cf3165818` on the instrument as it now stands, on a box drained of every other worker.

- Same five arms (`:floor`, `:expanded`, `:expanded-b`, `:merged`, `:ctl-2x`), same 5 rounds x (3 warm-up + 6 samples).
- Fairness gate: `{:agree? true, :counts {:expanded 1001, :expanded-b 1001, :merged 1001}, :can-fail? true}` in all three.
- Arm-order guard: `reportable` in all three. Writes: `0 unverified of 270` in all three.
- Chromium 147.0.7727.15, `:advanced`, `goog.DEBUG` false.
- Driver exit code **0** for each of the three runs.

**Rig verified at source before relying on the bead's assertion.** `amp_merge_clock_app.cljs:478-480` computes `(lane/ratio-between ratios :ctl-2x :expanded)` and passes `(:per-round ctl-ratio)` to `lane/control-verdict-strict` with `predicted 2.0` and `control-slack 0.25`; the verdict map (which carries `:per-round vs`) is recorded under `:control` at line 483. The bead's description of the rig is accurate.

## The strict verdict, per round

Band `[1.500 – 2.500]`, `:rule :every-round`, `:outside []` in all three runs.

| re-take | round 1 | round 2 | round 3 | round 4 | round 5 |
|---|---|---|---|---|---|
| R1 | 2.0400 | 1.9667 | 1.8812 | 2.0230 | 2.1111 |
| R2 | 2.0566 | 2.0211 | 1.9667 | 2.1573 | 1.9659 |
| R3 | 2.0532 | 1.9765 | 1.9277 | 2.0366 | 2.0000 |

Lowest of the fifteen 1.8812 (5.9% under prediction); highest 2.1573 (7.9% over). The band's edges are 25% away, so the rule was nowhere near refusing.

## What is NOT claimed

- **The headline `25% of mount` and `2.4 µs per site` are left exactly as published.** This window was taken to settle the control's verdict. Re-pricing an effect on a run taken to test something else is the move this lane refuses, and the two windows are not one ensemble and are not pooled.
- **The estimator is named as computed.** `lane/ratio-between` stores an **arithmetic mean of per-round ratios** in `:mean`, each of which is a ratio of within-round medians. It is not a median at the run level, and the page says so.
- **The dispersion is left unapportioned.** `\System\Processor Queue Length` was sampled ONLY between runs, never inside a measured window (a sample there reads the benchmark's own load). Of 31 samples, 29 read 0 and two read 1. The page therefore attributes the run-to-run spread to neither the instrument alone nor the box.
- **A self-caught overclaim, corrected before commit.** A first draft said R1 carried "the widest effect per-round range of the six runs on this page". It does not — the original run 2's `0.968 – 1.409` (width 0.441) is wider than R1's `1.1188 – 1.4100` (width 0.291). The sentence now says "of the RE-TAKE's three" and names the original run 2 as the wider span.

## Durability — the defect this replaces

The fifteen per-round control values are published on the page, as are the effect and null per-round vectors. **This window is re-adjudicable under either rule without being re-run**, which is exactly what the original three could not offer.

## Corroboration (printed, not leaned on)

| re-take | `:merged`/`:expanded` | per-round range | NULL `:expanded-b`/`:expanded` | per `:&` site |
|---|---|---|---|---|
| R1 | 1.2410x | 1.1188 – 1.4100 | 0.9700x | 2,375 ns |
| R2 | 1.2157x | 1.1477 – 1.2641 | 1.0217x | 2,875 ns |
| R3 | 1.2295x | 1.1566 – 1.2872 | 1.0273x | 2,375 ns |

Effect run-means `1.216 – 1.241` overlap the original three's `1.217 – 1.270` at the low end. Within this window the effect run-means and the null run-means (`0.970 – 1.027`) do not touch.

## Gates — captured exit codes

Every gate was run in the foreground, redirected to a worktree-local file, with `$?` captured on the same command line. No gate was piped.

| gate | captured exit |
|---|---|
| `npm ci --prefix implementation` (real install, no junction; 101 packages) | 0 |
| amp-merge measurement run 1 | 0 |
| amp-merge measurement run 2 | 0 |
| amp-merge measurement run 3 | 0 |
| `python scripts/check_doc_slugs.py` | 0 |
| `python scripts/check_provenance_pins.py --changed-since origin/main` | 0 |
| `sh scripts/check-no-hardcoded-paths.sh` | 0 |

`check_provenance_pins` reports `1 page inspected, 2 cited pins — 2 landed, 0 stranded, 0 unresolvable, 0 foreign; 0 findings`. Each measurement log holds exactly one summary block and one `HICASSO DONE`, and contains zero NUL bytes — no orphan wrote into a restarted run's file.

## Manual verification the gates do not perform

`docs/design/**` is outside `mkdocs build --strict`, and nothing validates table rendering or column counts. **Both new tables were checked by hand**: the control table is 7 cells on the header, the separator and every row; the corroboration table is 5 on each, matching the existing HD-023 table it sits beside. Every published figure was re-extracted from the three run logs and compared against the page.

Diff is docs-only (one file, +60 lines), so no code suite applies.
