### PR TITLE
docs(hicasso): S8's strict-verdict window was taken, and it refused at the arm-order guard (rf2-zcgps)

### DIFF
--- a/docs/design/hicasso/product/budgets.md
+++ b/docs/design/hicasso/product/budgets.md
@@ -498,9 +498,61 @@ containment statement above stands only as stated, against the aggregate
 denominator, and run 2's exclusion rests on the same aggregate — it is the
 conservative direction, and the published figure is run 1 alone either way.
 The instrument now records `:per-round` for the control alongside the escape,
-so the **next** run's verdict is readable from what it keeps. Taking that run
-is its own window and its own bead (`rf2-zcgps`); nothing here re-adjudicates
-`0.7418x`, which is an escape figure and not a control one.
+so the **next** run's verdict is readable from what it keeps.
+
+**That next run was taken on 2026-08-16, and it REFUSED — at the arm-order
+guard, not at the control (`rf2-zcgps`).** One run of the instrument as it now
+stands, on P-DEV-1, with `\System\Processor Queue Length` reading `0` across
+eight samples immediately before the run and `0` across eight immediately
+after. **No sample was taken inside the measured window** — a sample taken
+there reads the benchmark's own load — so nothing here claims the box was quiet
+*within* the window beyond that bracketing. The fairness gate agreed at 601
+elements two ways and was proven able to answer false, and `0` of `225`
+measured mounts failed their own read-back. The arm-order guard then refused:
+`:hiccup` read a `p50` of `2.3000 ms` `[2.1000–4.9000]` over the first third of
+the run against `1.9000 ms` `[1.7000–2.0000]` over the last — `1.2105×` apart
+with **disjoint** ranges — and a figure whose value depends on where in the plan
+it was measured is not a figure. `run.cjs` exited `2` and the guard's own
+verdict line is that no figure from the run may be published as measured.
+
+**`0.7418x` does not come off the page, and S8 still carries no strict
+verdict.** Those are two findings and not one. The rule `rf2-zcgps` was given
+is that the published escape falls if the STRICT CONTROL refuses, and it did
+not: computed on this run's samples it read `:ok? true`, all five rounds inside
+`[1.500–2.500]`. But `:hiccup` is the denominator of the control *and* of the
+escape, so the guard's refusal reaches both legs of the run that produced that
+verdict — it is recorded below as data, never quoted as a verdict, and **the
+absence this section records stands unchanged.** The published figure is still
+run 1's, on run 1's own basis, and no window has yet re-adjudicated it.
+
+**The refused run's per-round values, so it can be re-adjudicated without being
+re-run.** This is the durability the two published runs lack, and it is kept
+here whether or not the run was reportable:
+
+- Control, per-round `:ctl-2x`/`:hiccup`: `[1.7143, 2.0714, 1.9535, 1.9167,
+  2.0263]` against the band `[1.500–2.500]`, `:outside` empty — worst round
+  `14.3%` under the `2.00x` prediction, best `3.6%` over.
+- Escape, per-round `:direct`/`:hiccup`: `[0.6250, 0.8095, 0.7907, 0.7778,
+  0.7895]`, whose `0.7585x` is an **arithmetic mean of those five per-round
+  ratios, each itself a ratio of within-round medians** — not a median at run
+  level.
+- Absolute per-mount `p50`s across the five rounds: floor `0.2500 ms`, hiccup
+  `2.1000 ms`, direct `1.7000 ms`, ctl-2x `4.2000 ms`.
+
+**The drift the guard caught is not `:hiccup`'s alone, and this page does not
+say what caused it.** All three page-mounting arms read slower in the run's
+first third than in its last by a similar factor — `:hiccup` `1.2105×`,
+`:ctl-2x` `1.2338×`, `:direct` `1.2000×` — and only `:hiccup`'s two ranges were
+disjoint, its last-third range being the tightest of the three at
+`[1.7000–2.0000]`. Every by-predecessor contrast passed on every arm. A common
+within-run decay of that shape is what an under-warmed run looks like, but one
+run, three warm-up samples per arm per round and a box read quiet only at its
+two ends do not separate warm-up from anything else that decayed over the same
+run, and no second cause was measured or excluded. Repairing it is the arm's
+job and the guard names the moves — more warm-up, fewer arms per round, a
+longer measured window — which is a rig change with its own bead (`rf2-h904p`)
+rather than a tolerance this page may widen. S8's strict verdict waits on that
+repair and a fresh window.
 
 ### The §6 user-visible budgets
 

--- a/docs/design/hicasso/product/budgets.md
+++ b/docs/design/hicasso/product/budgets.md
@@ -519,10 +519,11 @@ verdict line is that no figure from the run may be published as measured.
 verdict.** Those are two findings and not one. The rule `rf2-zcgps` was given
 is that the published escape falls if the STRICT CONTROL refuses, and it did
 not: computed on this run's samples it read `:ok? true`, all five rounds inside
-`[1.500–2.500]`. But `:hiccup` is the denominator of the control *and* of the
-escape, so the guard's refusal reaches both legs of the run that produced that
-verdict — it is recorded below as data, never quoted as a verdict, and **the
-absence this section records stands unchanged.** The published figure is still
+`[1.500–2.500]`. But the arm the guard refused is `:hiccup`, and `:hiccup` is
+the denominator the control and the escape are each divided by — so the
+refusal lands under the verdict rather than beside it. That verdict is
+recorded below as data, never quoted as a verdict, and **the absence this
+section records stands unchanged.** The published figure is still
 run 1's, on run 1's own basis, and no window has yet re-adjudicated it.
 
 **The refused run's per-round values, so it can be re-adjudicated without being
@@ -530,8 +531,9 @@ re-run.** This is the durability the two published runs lack, and it is kept
 here whether or not the run was reportable:
 
 - Control, per-round `:ctl-2x`/`:hiccup`: `[1.7143, 2.0714, 1.9535, 1.9167,
-  2.0263]` against the band `[1.500–2.500]`, `:outside` empty — worst round
-  `14.3%` under the `2.00x` prediction, best `3.6%` over.
+  2.0263]` against the band `[1.500–2.500]`, `:outside` empty — the round
+  furthest below the `2.00x` prediction reads `1.7143` (`14.3%` under) and the
+  round furthest above reads `2.0714` (`3.6%` over).
 - Escape, per-round `:direct`/`:hiccup`: `[0.6250, 0.8095, 0.7907, 0.7778,
   0.7895]`, whose `0.7585x` is an **arithmetic mean of those five per-round
   ratios, each itself a ratio of within-round medians** — not a median at run


### PR DESCRIPTION
## What this is

`rf2-zcgps` was **the measurement window**, not a code change. `rf2-gsn62` had routed `direct_return_clock_app`'s positive control to `lane/control-verdict-strict` on the per-round `:ctl-2x`/`:hiccup` ratio and made the instrument record `:per-round`, but it could not answer the question retrospectively — S8's two published runs kept only `summarise`'s across-round `n`/`min`/`max`/`p50`, so their per-round control ratios are gone. This bead was to take the run that supplies a strict verdict.

**The window was taken and it REFUSED — at the arm-order guard, not at the control.** This PR publishes that outcome in `budgets.md` §S8. The change is prose only.

## The rig, verified at source before relying on it

The bead asserts `rf2-gsn62` already did the routing. Confirmed by reading:

- `implementation/hicasso/test/re_frame/bench/hicasso/direct_return_clock_app.cljs` builds `ctl-ratio` as `(lane/ratio-between ratios :ctl-2x :hiccup)`, passes `(:per-round ctl-ratio)` to `lane/control-verdict-strict` with `predicted 2.0` and `slack 0.25`, and records the whole verdict map under `:control`.
- `lane.cljs`'s `control-verdict-strict` returns `:per-round` and `:outside` in that map, so the values reach `window.HICASSO_RESULTS` and the driver's printed record.

The rig matched what the bead asserts.

## The window

One run. `HICASSO_INIT_FN=re-frame.bench.hicasso.direct-return-clock-app/-main`, every other driver variable unset, so `run.cjs` is the published instrument. A real `npm ci --prefix implementation` in this worktree (101 packages, a real directory and not a junction into the mayor's `node_modules`).

**Box quietness** — `Get-Counter '\System\Processor Queue Length'`, sampled on its own, never alongside anything else:

| when | time (+10:00) | readings |
|---|---|---|
| session start | 04:29:25–04:29:29 | `0 0 0 0 0` |
| immediately before the run | 04:31:41–04:31:48 | `0 0 0 0 0 0 0 0` |
| immediately after the run | 04:32:58–04:33:05 | `0 0 0 0 0 0 0 0` |

The run itself spanned roughly 04:32:10–04:32:50. **No sample was taken inside the measured window** — a sample taken there measures the benchmark's own load and answers nothing. **No claim is made about within-run quietness beyond that bracketing**, and the page says so.

## The verdict

**The strict control PASSED:**

```
:control {:rule :every-round :predicted 2 :slack 0.25 :band [1.5 2.5]
          :per-round [1.7143 2.0714 1.9535 1.9167 2.0263]
          :measured {:n 5 :min 1.7143 :max 2.0714 :p50 1.9535}
          :stated? true :outside [] :ok? true}
```

Round by round against `[1.500–2.500]`: 1 `1.7143` in, 2 `2.0714` in, 3 `1.9535` in, 4 `1.9167` in, 5 `2.0263` in. The round furthest below the `2.00x` prediction reads `1.7143` (14.3% under) and the round furthest above reads `2.0714` (3.6% over); the round closest to it is a third one, `1.9535` (2.3% under).

**The RUN refused anyway, at a prior gate.** `run.cjs` captured exit **2** — the arm-order guard:

```
hiccup (30 samples)
  [ok  ] by predecessor  within 10%
  [FAIL] by phase   FIRST-THIRD reads 1.2105x LAST-THIRD, ranges disjoint
           LAST-THIRD   n=10  p50 1.9000  [1.7000–2.0000]
           FIRST-THIRD  n=10  p50 2.3000  [2.1000–4.9000]
VERDICT: REFUSE — no figure above may be published as measured
```

## What that costs, stated as two findings and not one

- **`0.7418x` does NOT come off the page.** The rule this bead was given fires when *the strict control* refuses. It did not. Not widening a band, not re-labelling a figure, not re-running until it passes — the antecedent simply was not met.
- **S8 still carries no strict verdict.** `:hiccup` is the denominator of the control as well as of the escape, so the guard's refusal reaches the legs the verdict was computed from. The verdict is recorded as **data**, never quoted as a verdict, and the absence §S8 records stands unchanged.

**One run only.** The guard's refusal was not re-run for a friendlier answer; re-running a refused gate until it passes is the same fishing the control rule forbids.

## Per-round values reach the record

This is the whole reason the re-run existed, and it holds even though the run refused — the window is re-adjudicable under either rule without being taken again:

- control `:ctl-2x`/`:hiccup` — `[1.7143, 2.0714, 1.9535, 1.9167, 2.0263]`
- escape `:direct`/`:hiccup` — `[0.6250, 0.8095, 0.7907, 0.7778, 0.7895]`
- absolute per-mount `p50`s across rounds — floor `0.2500 ms`, hiccup `2.1000`, direct `1.7000`, ctl-2x `4.2000`

**The estimator is named as computed.** `0.7585x` is `lane/ratio-between`'s `:mean` — an **arithmetic mean of the five per-round ratios, each a ratio of within-round medians**. Not a median at run level. (Arithmetic checked: the five sum to `3.7925`, over 5 is `0.7585`.)

## The drift is not attributed

All three page-mounting arms read slower in the run's first third than its last by a similar factor — `:hiccup` `1.2105×`, `:ctl-2x` `1.2338×`, `:direct` `1.2000×` — and only `:hiccup`'s two ranges were disjoint, its last-third range being the tightest of the three at `[1.7000–2.0000]`. Every by-predecessor contrast passed on every arm. That shape is what an under-warmed run looks like, **but this window measured no second cause and excludes none**: one run, three warm-up samples per arm per round, and a box read quiet only at its two ends cannot separate warm-up from anything else that decayed over the same run. The page says so rather than naming a cause.

Repairing the arm is the guard's own named remedy — more warm-up, fewer arms per round, a longer measured window — and the guard's tolerance is not the arm's to move. That is a **rig change**, so it is not this window's to make: filed as **`rf2-h904p`**. S8's strict verdict waits on that repair and a fresh window.

## Gates — captured exit codes

Every gate run foreground to completion, never piped into a filter, exit code captured to a `.exit` file and read from there.

| gate | exit |
|---|---|
| `npm ci --prefix implementation` | `0` |
| the measurement run (`run.cjs`) | **`2`** — the arm-order guard refused; this is the finding, not a gate failure to repair |
| `python scripts/check_doc_slugs.py` | `0` |
| `python scripts/check_provenance_pins.py --changed-since origin/main` | `0` — 1 page, 5 pins, 5 landed, 0 findings |
| `sh scripts/check-no-hardcoded-paths.sh` | `0` |

The measurement log holds **exactly one** summary block and **zero** NUL bytes.

`mkdocs build --strict` is NOT nominated: `mkdocs.yml`'s `exclude_docs` keeps `docs/design/hicasso/` out of the site, so it does not cover this edit.

## Tables verified by hand

Nothing validates table rendering or column counts, so it was checked by hand:

- The diff touches **zero** table rows (`git diff -U0 | grep -c '^[+-]|'` is `0`) — the change is prose and one bullet list.
- All **14** table blocks in `budgets.md` are rectangular, none ragged.
- Both S8 rows still match their headers: line 391 is 5 columns under a 5-column header, line 1208 is 8 columns under an 8-column header.

Closes rf2-zcgps.

