### PR TITLE
bench(hicasso): apportion the `:&` spelling between call site, helper and codec (rf2-z143r)

### DIFF
--- a/docs/design/hicasso/decisions.md
+++ b/docs/design/hicasso/decisions.md
@@ -1521,7 +1521,10 @@ last write silently winning. The fold also deletes the map surgery the shorthand
 merge performed on every element carrying a shorthand; that is a structural change,
 and its clock effect is **not separately measured**. It is inside the figure *Cost,
 measured* prints — the witness's title field routes its class through `:&` — but
-nothing there apportions the fold its own share (`rf2-pqyxz`).
+nothing there apportions the fold its own share (`rf2-pqyxz`). The ladder in
+*Apportioned* does not isolate it either: it lands whole inside that ladder's rung
+(1), where `:expanded` writes the class in the tag and every other arm declares it
+(`rf2-z143r`).
 (d) The **same key and the same law hold at a crossing** (a Hicasso view head, a
 `defhost` head, `[:>]`). `:&` is merged *before* any conversion, and the conversion
 that follows is the position's own — so a forwarded `:className` crosses under the
@@ -1691,7 +1694,99 @@ claim, because `:&` without a wrapper to forward into is not a spelling anybody
 writes. It is NOT a figure for `merge-caller` alone, and nothing here apportions
 the 2.4 µs between the three; nor does it isolate (c″)'s shorthand fold, which
 rides the same measurement rather than being separated from it. Splitting them is
-its own bead and its own window.
+its own bead and its own window — taken below.
+
+**APPORTIONED, and what it apportions goes to the CODEC (`rf2-z143r`).** A separate
+window — ONE run, neither pooled with the two ensembles above nor re-pricing them —
+was taken on the same instrument with two arms added BETWEEN `:expanded` and
+`:merged`, so that each step of the chain changes exactly one thing:
+
+    :expanded --(1)--> :helper --(2)--> :no-dissoc --(3)--> :merged
+
+`:helper` takes explicit arguments and writes no `:&`; `:no-dissoc` is `:helper`'s
+call sites character for character with its five spelled-out keys replaced by one
+`:&`. The five published arms, their bodies and their entries are byte-identical
+and were not touched, so nothing above is re-derived. Because the rungs are a
+CHAIN rather than three independent contrasts, (1) + (2) + (3) is
+`:merged` − `:expanded` round by round: the residual came back as floating-point
+dust (`[-0.0001 0.0001 -0.0 -0.0001 0]` ns) and it is **arithmetic, not
+corroboration**. Authored at `c63a78a219fd6ca9f3ab292f53658edc3ea7df51` on
+`worker/w-z143r`, branched from `11f8efd92368d4647d377c50f488c8ed4a53fb10` on main;
+Chromium 147.0.7727.15 under `:advanced` with `goog.DEBUG` false, the same 100
+boundaries, 1,001 elements and 400 fields, five rounds of three warm-up plus six
+samples.
+
+| rung | what changes between its two arms | whose code | ns/field | ratio |
+|---|---|---|---|---|
+| whole | `:merged` / `:expanded` | author + codec | 1,750 | 1.1754x |
+| (1) wrapper | a caller map per call site, a helper call, attributes as arguments | author's | 500 | 1.0512x |
+| (2) merge | those five attributes through `:&` instead of written as keys | **CODEC'S** | 1,625 | 1.1842x |
+| (3) round trip | `:k`/`:busy?` into the caller map and `dissoc`'d back out | author's | −500 | 0.9448x |
+
+**Two estimators sit in that table and they are not the same one.** `ns/field` is
+the MEDIAN of the five per-round differences of the two arms' within-round median
+mount times, divided by 400 — the statistic the `per :& site` columns above also
+quote. `ratio` is `lane/ratio-between`'s arithmetic MEAN of five per-round ratios,
+each itself a ratio of within-round medians. **The `ns/field` column therefore does
+not add**: (2)'s 1,625 and the author's combined −250 do not make the whole's 1,750,
+because per-column medians of different vectors never have to. Only the per-round
+vectors add, and they do, exactly:
+
+Per round, ns/field — whole `[1750 750 1625 1875 1750]`, (1) `[750 -125 500 500 625]`,
+(2) `[2000 1250 2250 1500 1625]`, (3) `[-1000 -375 -1125 -125 -500]`. Per-round
+ratios — whole `[1.1867 1.0789 1.1912 1.2143 1.2059]`, (1)
+`[1.08 0.9868 1.0588 1.0571 1.0735]`, (2) `[1.1975 1.1333 1.25 1.1622 1.1781]`, (3)
+`[0.9175 0.9647 0.9 0.9884 0.9535]`.
+
+**Rungs (1) and (3) may NOT be quoted on their own, and the ladder says so before
+it is asked.** A single helper cannot omit a key for three fields out of four
+without an `assoc`, so both new arms carry `:class nil` on the three fields that
+have no class — which is exactly what keeps them key-for-key identical and rung (2)
+clean, and it makes that key a passenger ADDED to (1) and SUBTRACTED from (3) in
+equal measure. It is not a small passenger: with the nil class the merged attribute
+map holds nine entries on all four fields and without it eight on three of them, and
+`cljs.core/PersistentArrayMap` promotes to a `PersistentHashMap` at exactly the
+ninth — so on 300 of the 400 fields those two arms are one map REPRESENTATION apart
+rather than one entry apart. That is also why (3) reads NEGATIVE, `:merged` mounting
+faster than `:no-dissoc`: it is not a `dissoc` that pays for itself. **The ladder
+answers two questions, not three** — rung (2) alone, and rungs (1) + (3) summed,
+which is the passenger-free author-side quantity: `[-250 -500 -625 375 125]`
+ns/field, median −250, straddling zero.
+
+**So the apportionment is: the codec's `merge-caller` is the term that moves, and
+the author's own code is the term this window cannot resolve at all.** (2) is
+positive in five rounds of five and its per-round ratio range `[1.1333 – 1.2500]`
+excludes 1.0; the author's combined term changes sign three times across the same
+five rounds. What does NOT follow is that no author-side change could help — only
+that the two this ladder tried (dropping the wrapper, dropping the `dissoc`) do not,
+at this instrument's resolution. **It buys attribution, not a target, and nobody has
+asked for one.**
+
+**WHAT THIS WINDOW DOES NOT ESTABLISH, stated before anything is read off it.** Its
+NULL arm was poor. `:expanded-b`/`:expanded` read `[0.9467 1.4737 1.0294 1 0.9853]`
+— four rounds inside ±5.3% of 1.0 and one at 1.4737, which on the per-field
+arithmetic is +4,500 ns on a difference that is zero by construction. That reading is
+impossible, so it BOUNDS NOTHING: it says only that this instrument's error reached
+at least 4,500 ns/field in this run, which is larger than every term in the table
+above. **No term here is claimed to be outside instrument resolution, including
+(2).** The two published windows are not available to rescue it — they are separate
+ensembles and are not pooled — and this window's own whole (1.1754x, 1,750 ns/field)
+reads BELOW both of theirs (1.217 – 1.270x and 1.216 – 1.241x); why is not known and
+is not guessed at here. As an observation and not as a rule the run was adjudicated
+under: in the four rounds whose null behaved, (2) read +16% to +25% against nulls of
+−5.3% to +2.9%. No round was excluded and all five are printed above.
+
+**The gates the run passed.** The fairness gate agreed FIVE judged arms on one
+1,001-element page (`:expanded`, `:expanded-b`, `:merged`, `:helper`, `:no-dissoc`)
+and was again proven able to answer false; the arm-order guard returned
+**reportable** on all seven arms, by predecessor and by phase; `lane/control-verdict-strict`
+put all five `:ctl-2x`/`:expanded` rounds `[2.3867 2.1974 2.0147 2.3286 1.9559]`
+inside the ±25% band with `:outside` empty; and the read-back tally was **0
+unverified of 360**. The box was bracketed by sixteen `\System\Processor Queue
+Length` samples, eight each side, every one 0 — and never sampled inside the measured
+window, where a sample reads the benchmark's own load and answers nothing. Nothing is
+claimed about within-run quietness beyond that bracketing.
+
 **Reopens** if a witness shows a merge the law cannot express without an escape.
 
 ## HD-024 — One callback form; the position selects the contract

--- a/implementation/hicasso/test/re_frame/bench/hicasso/amp_merge_clock_app.cljs
+++ b/implementation/hicasso/test/re_frame/bench/hicasso/amp_merge_clock_app.cljs
@@ -116,18 +116,31 @@
       HD-023(c″)'s shorthand fold appears in this ladder at all: the fold
       is not isolated here either, and rung (1) is an UPPER BOUND on the
       author's wrapper rather than a reading of it.
-    - RUNG (3) ALSO CARRIES THREE `:class nil` KEYS. One helper cannot
-      omit a key for three fields out of four without an `assoc`, so
-      `:helper` writes `:class` unconditionally and `:no-dissoc`'s call
-      sites carry `:class nil` on the three fields that have no class —
-      which is what keeps those two arms key-for-key identical. `:merged`
-      is frozen and its call sites carry no such key, so `:no-dissoc`
-      does slightly MORE work than `:merged` on those three fields and
-      rung (3) is biased UP by that much.
+    - RUNGS (1) AND (3) SHARE A PASSENGER, WITH OPPOSITE SIGNS: three
+      `:class nil` keys. One helper cannot omit a key for three fields
+      out of four without an `assoc`, so `field-explicit` writes `:class`
+      unconditionally and BOTH new arms' call sites carry `:class nil` on
+      the three fields that have no class — which is exactly what keeps
+      them key-for-key identical and rung (2) clean. `:expanded` and
+      `:merged` are frozen and carry no such key. So the passenger is
+      ADDED to rung (1) (`:helper` has it, `:expanded` does not) and
+      SUBTRACTED from rung (3) (`:no-dissoc` has it, `:merged` does not),
+      in equal measure. Neither rung is separately interpretable; their
+      SUM is, and it is passenger-free.
 
-  The two passengers were put where they do least harm on purpose. Rung
-  (2) is the term this programme owns, and it is the one both are kept
-  out of.
+      **The passenger is not small, and the reason is a cliff rather
+      than a key.** With the nil class the merged attribute map holds
+      NINE entries on all four fields; without it, eight on three of
+      them — and `cljs.core/PersistentArrayMap` promotes to a
+      `PersistentHashMap` at exactly the ninth. So on 300 of the page's
+      400 fields the two arms are not one map entry apart but one map
+      REPRESENTATION apart, and no reading of rung (1) or rung (3) alone
+      should be quoted as the wrapper's or the round trip's price.
+
+  So the ladder answers TWO questions and not three: rung (2) is the
+  CODEC'S share and is clean, and rungs (1) + (3) summed are the
+  AUTHOR'S share and are clean. Splitting the author's share into its
+  wrapper and its round trip needs an arm this ladder does not have.
 
   ## The control is adjudicated STRICTLY, and per round (rf2-egdaq)
 

--- a/implementation/hicasso/test/re_frame/bench/hicasso/amp_merge_clock_app.cljs
+++ b/implementation/hicasso/test/re_frame/bench/hicasso/amp_merge_clock_app.cljs
@@ -58,6 +58,76 @@
                  per-sample additive constants double with it and the
                  prediction is a clean 2.00x rather than a modelled one.
                  rf2-5yn9 records the same construction and its reason.
+    :helper      LADDER RUNG 1 (rf2-z143r). The same page written with a
+                 helper that takes EXPLICIT ARGUMENTS and writes no `:&`:
+                 each call site builds a remainder map, the helper is
+                 called with it, and the helper spells the five forwarded
+                 attributes out as ordinary keys. Call-site map plus
+                 helper call, no merge.
+    :no-dissoc   LADDER RUNG 2 (rf2-z143r). `:helper`'s call sites
+                 CHARACTER FOR CHARACTER, and `:helper`'s helper with its
+                 five spelled-out keys replaced by one `:&`. Nothing else
+                 differs between the two, which is what makes the pair a
+                 price for `merge-caller` and for nothing else.
+
+  ## The decomposition ladder (rf2-z143r)
+
+  The five arms above price the authoring change WHOLE and apportion
+  nothing, and the three things inside it do not have the same standing:
+  the caller map and the `dissoc` are the AUTHOR'S code and an author can
+  change them, while `merge-caller` is the CODEC'S and only this
+  programme can. `:helper` and `:no-dissoc` are two rungs placed BETWEEN
+  `:expanded` and `:merged` so that each step changes exactly one thing.
+
+      :expanded --(1)--> :helper --(2)--> :no-dissoc --(3)--> :merged
+
+  (1) THE AUTHOR'S WRAPPER. A remainder map built at each call site, a
+      function call, and the five forwarded attributes arriving as
+      arguments rather than as literals in the element's own map.
+  (2) THE CODEC'S MERGE. The same five attributes routed through `:&`
+      instead of written as keys, so this rung is exactly what
+      `merge-caller` does on a present remainder: the `dissoc` of the
+      owned map, the `denied-slots` fold over it, the filter of the
+      caller and the union. **The only term here that this programme
+      owns.**
+  (3) THE AUTHOR'S `:k`/`:busy?` ROUND TRIP. `:merged`'s call sites put
+      the field key and the busy flag INTO the caller map and its helper
+      `dissoc`s them back out; `:no-dissoc`'s pass them as arguments
+      instead. An author owns both spellings, and the second is the
+      repair for the first.
+
+  **The three sum to the whole by construction, not by luck.** The rungs
+  are a chain rather than three independent contrasts, so
+  (1) + (2) + (3) is `:merged` − `:expanded` term by term and round by
+  round. There is therefore no residual, and the absence of one is
+  arithmetic rather than evidence: it corroborates nothing.
+
+  **What a rung is NOT.** A rung is the difference between ITS TWO ARMS —
+  a bundle, not a platonic component — and two of these bundles are known
+  to carry a passenger. Both are named here rather than corrected,
+  because correcting either would mean touching a frozen arm:
+
+    - RUNG (1) ALSO CARRIES THE TITLE FIELD'S CLASS. `:expanded` writes
+      it in the TAG (`.form-control.form-control-lg`, which
+      `fold-shorthand!` takes by identity); every other arm DECLARES it,
+      so `class-names` composes instead. That is 100 of the 400 fields,
+      it is paid identically by both arms of rungs (2) and (3), and it
+      therefore lands entirely in (1). It is also the only place
+      HD-023(c″)'s shorthand fold appears in this ladder at all: the fold
+      is not isolated here either, and rung (1) is an UPPER BOUND on the
+      author's wrapper rather than a reading of it.
+    - RUNG (3) ALSO CARRIES THREE `:class nil` KEYS. One helper cannot
+      omit a key for three fields out of four without an `assoc`, so
+      `:helper` writes `:class` unconditionally and `:no-dissoc`'s call
+      sites carry `:class nil` on the three fields that have no class —
+      which is what keeps those two arms key-for-key identical. `:merged`
+      is frozen and its call sites carry no such key, so `:no-dissoc`
+      does slightly MORE work than `:merged` on those three fields and
+      rung (3) is biased UP by that much.
+
+  The two passengers were put where they do least harm on purpose. Rung
+  (2) is the term this programme owns, and it is the one both are kept
+  out of.
 
   ## The control is adjudicated STRICTLY, and per round (rf2-egdaq)
 
@@ -124,7 +194,14 @@
 
 (def ^:private amp-sites
   "How many elements on the measured page carry a `:&` in the merged arm —
-  the divisor of every per-element figure this file prints."
+  the divisor of every per-element figure this file prints.
+
+  It is also the FIELD count, which is what makes it the right divisor for
+  the ladder's rungs too (rf2-z143r): `:helper` writes no `:&` at all, but
+  every rung's cost is per field, and a field is a `:&` site in the arms
+  that have one. A ladder row therefore reads `ns/field`, and the two
+  published rows keep reading `ns/:& site` — the same number, named for
+  what it divides in each case."
   (* fields-per-boundary boundaries))
 
 ;; ---------------------------------------------------------------------------
@@ -247,6 +324,116 @@
              :type "text" :name "tags" :placeholder "Enter tags (comma-separated)"
              :data-testid "editor-tags"})]))
 
+;; ---------------------------------------------------------------------------
+;; THE TWO LADDER RUNGS — the same page a third and a fourth way (rf2-z143r)
+;; ---------------------------------------------------------------------------
+;;
+;; These two exist to be DIFFERENCED, against `:expanded` below them and
+;; `:merged` above, so what matters about them is what they share. They
+;; share their call sites exactly — the same four remainder maps, written
+;; out twice rather than passed through a common function, because a
+;; higher-order call is itself a cost and it would land on the ladder
+;; instead of the thing being priced. And they share every owned attribute
+;; the helper writes. The ONE difference between them is whether the five
+;; forwarded attributes are spelled as keys or handed to `:&`, which is
+;; what makes rung (2) a price for `merge-caller`.
+;;
+;; `:class nil` on three of the four call sites is deliberate and is the
+;; ladder's stated asymmetry: `field-explicit` writes `:class`
+;; unconditionally because one helper cannot omit a key for three fields
+;; out of four without an `assoc`, so the remainder maps carry the key
+;; too. It costs one map entry and one `class-names` call that `:merged`
+;; does not pay, and the docstring's rung (3) says which way that leans.
+
+(defn- field-explicit
+  "RUNG 1's helper. Explicit arguments, no `:&`, no `dissoc` — the five
+  forwarded attributes are read off the remainder map and written as
+  ordinary keys, so the codec meets a plain attribute map and
+  `merge-caller` returns it by identity.
+
+  The three rebindings (`cls`, `typ`, `nm`) are there because `type` and
+  `name` are `cljs.core` fns and a bench arm may not be the place a reader
+  has to work out which one is in scope."
+  [draft errors id k busy? {cls :class typ :type nm :name
+                            :keys [placeholder data-testid]}]
+  [:fieldset.form-group
+   [:input.form-control {:class       cls
+                         :type        typ
+                         :name        nm
+                         :placeholder placeholder
+                         :data-testid data-testid
+                         :value       (get draft k)
+                         :disabled    busy?
+                         :on-blur     [:amp/blur id k]
+                         :on-input    [:amp/edit id k ::h/value]}]
+   (when-some [e (get errors k)] [:div.error-messages e])])
+
+(defn- field-no-dissoc
+  "RUNG 2's helper. `field-explicit` with its five spelled-out keys
+  replaced by one `:&`, and nothing else changed. No `dissoc`: the field
+  key and the busy flag arrive as arguments, so the remainder map is
+  already the map the merge wants."
+  [draft errors id k busy? attrs]
+  [:fieldset.form-group
+   [:input.form-control {:&        attrs
+                         :value    (get draft k)
+                         :disabled busy?
+                         :on-blur  [:amp/blur id k]
+                         :on-input [:amp/edit id k ::h/value]}]
+   (when-some [e (get errors k)] [:div.error-messages e])])
+
+(defn explicit-body
+  [{:keys [id]}]
+  (let [draft  (h/sub [:amp/draft id])
+        errors (h/sub [:amp/errors id])
+        busy?  (:busy? draft)]
+    [:fieldset
+     (field-explicit draft errors id :title busy?
+                     {:class "form-control-lg"
+                      :type "text" :name "title" :placeholder "Article Title"
+                      :data-testid "editor-title"})
+     (field-explicit draft errors id :description busy?
+                     {:class nil
+                      :type "text" :name "description"
+                      :placeholder "What's this article about?"
+                      :data-testid "editor-description"})
+     (field-explicit draft errors id :body busy?
+                     {:class nil
+                      :type "text" :name "body"
+                      :placeholder "Write your article (in markdown)"
+                      :data-testid "editor-body"})
+     (field-explicit draft errors id :tagList busy?
+                     {:class nil
+                      :type "text" :name "tags"
+                      :placeholder "Enter tags (comma-separated)"
+                      :data-testid "editor-tags"})]))
+
+(defn no-dissoc-body
+  [{:keys [id]}]
+  (let [draft  (h/sub [:amp/draft id])
+        errors (h/sub [:amp/errors id])
+        busy?  (:busy? draft)]
+    [:fieldset
+     (field-no-dissoc draft errors id :title busy?
+                      {:class "form-control-lg"
+                       :type "text" :name "title" :placeholder "Article Title"
+                       :data-testid "editor-title"})
+     (field-no-dissoc draft errors id :description busy?
+                      {:class nil
+                       :type "text" :name "description"
+                       :placeholder "What's this article about?"
+                       :data-testid "editor-description"})
+     (field-no-dissoc draft errors id :body busy?
+                      {:class nil
+                       :type "text" :name "body"
+                       :placeholder "Write your article (in markdown)"
+                       :data-testid "editor-body"})
+     (field-no-dissoc draft errors id :tagList busy?
+                      {:class nil
+                       :type "text" :name "tags"
+                       :placeholder "Enter tags (comma-separated)"
+                       :data-testid "editor-tags"})]))
+
 (defn floor-body
   "The crossing carrying nothing. A boundary is reached through a hiccup
   vector whatever its body answers, so the floor is the crossing and not
@@ -257,6 +444,8 @@
 (h/defview expanded-arm   [props] (expanded-body props))
 (h/defview expanded-arm-b [props] (expanded-body props))
 (h/defview merged-arm     [props] (merged-body props))
+(h/defview explicit-arm   [props] (explicit-body props))
+(h/defview no-dissoc-arm  [props] (no-dissoc-body props))
 (h/defview floor-arm      [props] (floor-body props))
 
 ;; ---------------------------------------------------------------------------
@@ -297,7 +486,15 @@
    {:id :merged :k 1 :elements page-elements
     :mount (mount-page merged-arm) :unmount unmount-page}
    {:id :ctl-2x :k 2 :elements page-elements :parity-exempt? true
-    :mount (mount-page expanded-arm) :unmount unmount-page}])
+    :mount (mount-page expanded-arm) :unmount unmount-page}
+   ;; THE TWO LADDER RUNGS, appended so the five above keep their entries
+   ;; exactly (rf2-z143r). Neither is `:parity-exempt?`: both build the
+   ;; judged page and both belong in the equality, so the fairness gate
+   ;; holds five arms to one 1,001-element page rather than three.
+   {:id :helper :k 1 :elements page-elements
+    :mount (mount-page explicit-arm) :unmount unmount-page}
+   {:id :no-dissoc :k 1 :elements page-elements
+    :mount (mount-page no-dissoc-arm) :unmount unmount-page}])
 
 (defn- arm-named [id] (first (filter #(= id (:id %)) arms)))
 
@@ -389,6 +586,31 @@
   (lane/summarise
     (mapv (fn [r] (/ (* 1e6 (- (get r a) (get r b))) amp-sites)) p50s)))
 
+(defn- ns-terms
+  "The same arithmetic as [[per-element-ns]], with the PER-ROUND vector
+  kept beside the summary.
+
+  It is kept because a ladder that prints only its summaries cannot be
+  re-adjudicated without being re-run, and this instrument has already
+  had one window re-taken for exactly that. `per-element-ns` is left
+  alone so the two published rows keep the shape they were published in."
+  [p50s a b]
+  (let [vs (mapv (fn [r] (lane/round4 (/ (* 1e6 (- (get r a) (get r b))) amp-sites)))
+                 p50s)]
+    (assoc (lane/summarise vs) :per-round vs)))
+
+(defn- ladder-rung
+  "One rung: the ratio of two arms over the floor-normalised per-round
+  ratios, and the same pair's raw per-round difference in nanoseconds per
+  field. `:standing` records WHOSE code the rung prices, which is the
+  whole question rf2-z143r was opened to answer."
+  [ratios p50s a b standing]
+  {:from      b
+   :to        a
+   :standing  standing
+   :ratio     (lane/ratio-between ratios a b)
+   :ns-per-site (ns-terms p50s a b)})
+
 (defn- measurement-method []
   (str "a SAMPLE is " boundaries " boundaries mounted into a fresh container "
        "inside ONE react-dom/flushSync window, containers created and attached "
@@ -402,7 +624,11 @@
        "the run can be re-adjudicated without being re-run. :expanded-b is the "
        "NULL arm — a second boundary head over the same "
        "body, carrying no effect by construction, so its reading against "
-       ":expanded is this instrument's resolution rather than a result. Arms "
+       ":expanded is this instrument's resolution rather than a result. :helper "
+       "and :no-dissoc are the DECOMPOSITION LADDER's two rungs (rf2-z143r), "
+       "placed between :expanded and :merged so each step changes exactly one "
+       "thing; they are judged by the fairness gate with the other three and are "
+       "differenced, never published as a figure of their own. Arms "
        "interleaved at the SAMPLE level under the lane's rotating AND REFLECTING "
        "schedule, so no arm always follows the same neighbour; " rounds
        " rounds of " (:warmup sampling) " warm-up + " (:samples sampling)
@@ -478,6 +704,23 @@
                 ctl-ratio (lane/ratio-between ratios :ctl-2x :expanded)
                 ctl      (lane/control-verdict-strict
                            2.0 (:per-round ctl-ratio) control-slack)
+                ;; THE APPORTIONMENT (rf2-z143r). A chain, so the three
+                ;; rungs sum to `:whole` term by term and there is no
+                ;; residual to report; `:standing` is what the reader
+                ;; came for.
+                ladder   {:whole      (ladder-rung ratios p50s :merged :expanded
+                                                   :author-and-codec)
+                          :wrapper    (ladder-rung ratios p50s :helper :expanded
+                                                   :authors-code)
+                          :merge      (ladder-rung ratios p50s :no-dissoc :helper
+                                                   :codecs-code)
+                          :round-trip (ladder-rung ratios p50s :merged :no-dissoc
+                                                   :authors-code)}
+                sum-check (mapv (fn [w r m t] (lane/round4 (- w (+ r m t))))
+                                (:per-round (:ns-per-site (:whole ladder)))
+                                (:per-round (:ns-per-site (:wrapper ladder)))
+                                (:per-round (:ns-per-site (:merge ladder)))
+                                (:per-round (:ns-per-site (:round-trip ladder))))
                 tv       (lane/tally-value tally)]
             (lane/assert-teardown-clean! "the measured rounds")
             (lane/record! :amp-merge-clock
@@ -497,6 +740,8 @@
                            :null        null
                            :per-element-ns {:effect eff-ns :null null-ns}
                            :control     ctl
+                           :ladder      ladder
+                           :ladder-sum-residual sum-check
                            :writes      tv})
             (js/console.log ";; ==== AMP-MERGE CLOCK (rf2-pqyxz) ====")
             (js/console.log (str ";;   " boundaries " boundaries/page, " page-elements
@@ -533,6 +778,25 @@
             (js/console.log (str ";;   control (" (name (:rule ctl)) ", ctl-2x/expanded): "
                                  (:why ctl)))
             (js/console.log (str ";;   control per-round: " (pr-str (:per-round ctl))))
+            ;; THE LADDER (rf2-z143r). Printed with every per-round value,
+            ;; so the apportionment is re-adjudicable without a re-run.
+            (js/console.log ";; ---- APPORTIONMENT (rf2-z143r) ----")
+            (doseq [[k label] [[:whole      "WHOLE      merged/expanded    (author + codec)"]
+                               [:wrapper    "(1) wrapper   helper/expanded    AUTHOR'S code"]
+                               [:merge      "(2) merge     no-dissoc/helper   CODEC'S code"]
+                               [:round-trip "(3) roundtrip merged/no-dissoc   AUTHOR'S code"]]]
+              (let [{:keys [ratio ns-per-site]} (get ladder k)]
+                (js/console.log
+                  (str ";;   " label ": " (fmt (:p50 ns-per-site) 1) " ns/field ["
+                       (fmt (:min ns-per-site) 1) " - " (fmt (:max ns-per-site) 1)
+                       "]  ratio " (fmt (:mean ratio) 4)
+                       " [" (fmt (:min ratio) 4) " - " (fmt (:max ratio) 4) "]"
+                       (when (:straddles-1? ratio) "  <- ratio STRADDLES 1.0")))
+                (js/console.log (str ";;     ns per-round:    " (pr-str (:per-round ns-per-site))))
+                (js/console.log (str ";;     ratio per-round: " (pr-str (:per-round ratio))))))
+            (js/console.log
+              (str ";;   ladder sum residual (ns/field, ZERO BY CONSTRUCTION — the rungs "
+                   "are a chain): " (pr-str sum-check)))
             (js/console.log (str ";;   writes: " (:unverified tv) " unverified of "
                                  (:writes tv)))
             (when (pos? (:unverified tv))


### PR DESCRIPTION
**rf2-z143r.** The published `:&` figure prices the authoring change whole and apportions nothing between the caller map, the `dissoc` and the codec's `merge-caller` — three things with very different standing. This adds a decomposition ladder BESIDE the five published arms, and takes one window on it.

    :expanded --(1)--> :helper --(2)--> :no-dissoc --(3)--> :merged

## The answer

**It goes to the codec.** Rung (2) — the same five attributes routed through `:&` instead of written as keys, which is `merge-caller` and nothing else — is positive in five rounds of five, per-round ratio `[1.1975 1.1333 1.25 1.1622 1.1781]`, range excluding 1.0. The author's two rungs summed (the passenger-free author-side quantity) read `[-250 -500 -625 375 125]` ns/field and change sign three times.

| rung | what changes between its two arms | whose code | ns/field | ratio |
|---|---|---|---|---|
| whole | `:merged` / `:expanded` | author + codec | 1,750 | 1.1754x |
| (1) wrapper | caller map per call site, helper call, attributes as arguments | author's | 500 | 1.0512x |
| (2) merge | those five attributes through `:&` instead of written as keys | **CODEC'S** | 1,625 | 1.1842x |
| (3) round trip | `:k`/`:busy?` into the caller map and `dissoc`'d back out | author's | -500 | 0.9448x |

**Estimators, both named.** `ns/field` is the MEDIAN of five per-round differences of within-round median mount times over 400 fields (`lane/summarise`'s `:p50`) — the same statistic the published `per :& site` column quotes. `ratio` is `lane/ratio-between`'s `:mean`, an ARITHMETIC MEAN of five per-round ratios, each a ratio of within-round medians. **The `ns/field` column does not add** (1,625 + -250 != 1,750): per-column medians of different vectors need not, and only the per-round vectors add. They do, exactly — residual `[-0.0001 0.0001 -0.0 -0.0001 0]` ns, which is floating-point dust from `round4`.

**No residual is claimed as corroboration.** The rungs are a chain, so (1)+(2)+(3) is `:merged` - `:expanded` term by term by construction. That is arithmetic, and the page and the file both say so in those words.

## Two terms, not three — the ladder's own limit, stated

A single helper cannot omit a key for three fields of four without an `assoc`, so both new arms carry `:class nil` on the three classless fields — which is what keeps them key-for-key identical and rung (2) clean. That makes the key a passenger ADDED to (1) and SUBTRACTED from (3) in equal measure, cancelling in their sum. It is **not small**: with the nil class the merged attribute map holds nine entries on all four fields and without it eight on three of them, and `PersistentArrayMap` promotes to `PersistentHashMap` at exactly the ninth — so on 300 of 400 fields the arms are one map REPRESENTATION apart. That is why (3) came back negative, `:merged` mounting faster than `:no-dissoc`. **Neither (1) nor (3) may be quoted alone.** Filed as `rf2-v5oto`.

## What this window does NOT establish

Its **NULL arm was poor**: `[0.9467 1.4737 1.0294 1 0.9853]`, four rounds within ±5.3% of 1.0 and one at 1.4737 — +4,500 ns/field on a difference zero by construction. An impossible reading bounds nothing, so **no term here is claimed outside instrument resolution, the codec's included**, and the apportionment rests on the per-round sign pattern. The two published windows are separate ensembles and are not pooled to rescue it. This window's own whole (1.1754x, 1,750 ns/field) reads BELOW both published windows (1.217-1.270x, 1.216-1.241x); the page does not guess why. Filed as `rf2-6ta5r` (P2).

## Discipline

- **The five published arms are untouched.** `git diff` of the first commit removes exactly three lines: the `amp-sites` docstring's closing line, the arms vector's closing paren, and one sentence of `measurement-method`. `expanded-body`, `merged-body`, `field`, `floor-body`, the four original defviews and all five arm maps are byte-identical.
- **Edit half first, then the window.** The rig was frozen once measuring began. The guard did NOT refuse; no arm was warmed, no band widened, no re-run taken.
- **One post-window commit, prose only.** `46c9612ae0` corrects a docstring claim the data falsified (the passenger's rung and its sign). Every line it touches is indented docstring text — verified by filtering the diff for non-docstring-indented changed lines, which is empty. No code line, computed value or emitted key changed, so the published run was produced by the code as `c63a78a219` left it.
- **Per-round values reach the record** for every rung, both estimators, plus the sum residual — the window is re-adjudicable without a re-run.

## Box

`\System\Processor Queue Length` sampled ON ITS OWN, never inside the measured window:
- pre-window 05:05:50-05:05:57 +10:00, 8 samples, all **0**
- window 05:06:09-05:06:51 +10:00
- post-window 05:09:38-05:09:45 +10:00, 8 samples, all **0** (taken 2m47s after the window closed, while its log was being read — stated rather than rounded away)

Nothing is claimed about within-run quietness beyond that bracketing.

## Gates — captured exit codes, none piped

| gate | exit |
|---|---|
| `shadow-cljs compile hicasso-bench` (arm init-fn), pre-window | **0** — 164 compiled, 0 warnings |
| the window: `run.cjs` with `HICASSO_INIT_FN=...amp-merge-clock-app/-main` | **0** |
| `shadow-cljs compile` re-check after the docstring fix | **0** — 164 compiled, 0 warnings |
| `python scripts/check_doc_slugs.py` | **0** |
| `python scripts/check_provenance_pins.py --changed-since origin/main` | **0** — 4 pins, 3 landed, 1 stranded accompanied in scope |
| `sh scripts/check-no-hardcoded-paths.sh` | **0** |

In-run gates: fairness gate `:agree? true` across FIVE judged arms at 1,001 elements each with `:can-fail? true`; arm-order guard **reportable** on all seven arms by predecessor and by phase; `lane/control-verdict-strict` `:ok? true` with `[2.3867 2.1974 2.0147 2.3286 1.9559]` inside `[1.500-2.500]` and `:outside` empty; read-back **0 unverified of 360**.

**`docs/design/**` is outside `mkdocs build --strict` and is not nominated.** Nothing validates table rendering or column counts, so **the new 5-column table was verified by hand**: header, separator and all four rows carry 6 pipes each. The amended `(c")` line is prose inside an existing paragraph and adds no table.