### PR TITLE
hicasso: read_profile phase B gets a measured null, a derived grid, and a window that adjudicates against it (rf2-3l6hf)

### DIFF
--- a/docs/design/hicasso/studio/the-cold-read-mount-term.md
+++ b/docs/design/hicasso/studio/the-cold-read-mount-term.md
@@ -330,6 +330,118 @@ and settled between samples behind a residue equality gate that never fired):
 > HICASSO_OUT_DIR=out/hicasso-readprof node
 > implementation/hicasso/test/re_frame/bench/hicasso/run.cjs`.
 
+> **THE INSTRUMENT NOW HAS A MEASURED NULL, AND READER MEMBERSHIP STILL DOES
+> NOT RESOLVE** (`rf2-3l6hf`, 2026-08-16, authored head `926dd471d3` on
+> `worker/w-3l6hf`, one commit on top of the landed `29c68f6767`; instrument
+> blob `ef7a0d3787`, `:advanced`, Playwright HeadlessChrome). The authored
+> head is **this window's own edit half and so cannot yet be on main**; the
+> landed SHA beside it is the base it sits on, and the blob hash is what
+> actually identifies the instrument — it is content-addressed, so a reader
+> can verify the file the runs used without resolving either commit. Three
+> runs, `exit 0` on each, both arm-order guards reportable on each, the
+> phase-A positive control passing on each, the phase-B residue gate never
+> firing. The working tree was clean at both ends of the window, so that blob
+> is the instrument every run used.
+>
+> **What changed, and it changed BEFORE the window opened.** The predecessor
+> windows had no negative control, so a term was credited on sign stability
+> across runs and nothing measured how far a delta wanders when the thing
+> under it is nothing. `c-null` is `c-local` again — the same `C-FULL` mode
+> through the same constructor, under a second id — so `c-local − c-null` has
+> a true cost of **exactly zero by construction**. Everything it reads is the
+> estimator's own error. The window shape is otherwise `rf2-07rnj`'s
+> unchanged: 32 frames, 8 × (2 + 8) = 64 kept samples per arm, grid 0.0015625
+> ms/commit. Nine arms rather than eight, so this is a new series and its
+> absolutes are not arm-by-arm comparable with the eight-arm runs above.
+>
+> **The estimator, named as computed.** Every figure below is a **pooled
+> median over an arm's 64 kept samples**, each divided by the 32-frame window;
+> 64 being even, that median is the mean of the 32nd and 33rd order
+> statistics. It is *not* a mean of per-round medians, and the two differ —
+> run 1's null reads 0.0234 pooled and 0.0174 as a mean of its own per-round
+> deltas. Each delta is the difference of two such pooled medians.
+>
+> | term (`c-local −` the arm) | run 1 | run 2 | run 3 |
+> |---|---|---|---|
+> | **NULL CONTROL (`c-null`), true cost exactly 0** | **+0.0234** | **+0.0219** | **+0.0234** |
+> | reaction build + cache insert (`c-nosub`) | 0.4453 | 0.4531 | 0.4875 |
+> | watch wiring (`c-nowatch`) | 0.0656 | 0.0672 | 0.0844 |
+> | cell-map insert (`c-nomap`) | 0.0547 | 0.0625 | 0.0531 |
+> | activation capture (`c-noactivate`) | 0.0453 | 0.0437 | 0.0344 |
+> | **reader membership (`c-noreaders`)** | **+0.0422** | **+0.0219** | **+0.0359** |
+>
+> **READER MEMBERSHIP IS UNRESOLVED, and the null is what says so.** In run 2
+> it read `+0.0219` — the null control's run-2 reading, to the last digit. An
+> instrument that returns the same number for reader membership as it returns
+> for nothing at all has not measured reader membership. Its margins over the
+> null are `+0.0188 / 0.0000 / +0.0125`; the other four terms clear the null
+> on every run, by `+0.4219/+0.4312/+0.4641` (reaction build),
+> `+0.0422/+0.0453/+0.0610` (watch wiring), `+0.0313/+0.0406/+0.0297`
+> (cell-map insert) and `+0.0219/+0.0218/+0.0110` (activation capture).
+>
+> **No bound on the term is published and none can be read off these
+> numbers.** A null spread states what the instrument cannot see; it says
+> nothing about how large the invisible thing is. Reading it as an upper
+> bound would be the withdrawn `< 0.006 ms/commit` error moved one layer back,
+> and the withdrawal stands.
+>
+> **THE NULL IS NOT CENTRED ON ZERO, which is a finding about every delta on
+> this page.** Its three run-level readings — `+0.0234 / +0.0219 / +0.0234` —
+> sit within one grid step of each other on a quantity whose true value is
+> exactly zero. So the pooled-median delta at this shape carries a positive
+> offset of roughly +0.022 ms/commit, and the small terms above are only a
+> few multiples of it: taking each run's term against that run's own null,
+> the activation capture is 1.5–2.0 nulls, the cell-map insert 2.3–2.9, the
+> watch wiring 2.8–3.6, and reader membership 1.0–1.8. Only the reaction
+> build, at 19–21 nulls, is clear of it by any margin. **The cause of the
+> offset is not established here and this data does not discriminate between
+> the candidates** — a residual arm-position effect (`c-local` sits at slot 1
+> and every arm it is differenced against at a higher slot), within-sweep
+> thermal or cache drift, and the pooled median's own behaviour on a
+> right-tailed distribution are all live. The arm-order guard reporting
+> *reportable* on every run does not exclude the first: its tolerance is 10%
+> and this offset is 3.2–3.6% of `c-local`.
+>
+> **At round granularity neither term is separable from the null.** Across the
+> 24 rounds of the window the null's per-round deltas span `−0.1047` to
+> `+0.1578` and are positive in 17; reader membership spans `−0.1797` to
+> `+0.1672` and is positive in 18. The per-round values are recorded in the
+> transcripts under `:read-profile-commit-per-round` and
+> `-per-round-deltas`, so this window is re-adjudicable without being
+> re-taken.
+>
+> **What the null does NOT settle, and the reason it is one window and not
+> two.** `c-null` differences slot 1 against slot 2, while reader membership
+> differences slot 1 against slot 6. If the offset above is positional, a
+> single null does not calibrate the reader delta exactly — nulls at several
+> positions would. That was deliberately not attempted: a rung added between
+> runs makes the series two instruments, which is the rule that filed this
+> bead in the first place.
+>
+> **The box.** Processor Queue Length (`\System\Processor Queue Length`) was
+> sampled on its own, five samples at 1 s, immediately before the window and
+> between every pair of runs: `0,0,0,0,0` at 05:49:00, `0,0,1,0,0` at
+> 05:50:17, `0,0,0,0,0` at 05:51:36, `0,0,0,0,0` at 05:52:53 (all +10:00). The
+> single `1` was taken **between** runs 1 and 2 and not inside any measured
+> window. **Nothing was sampled inside a run**, deliberately — sampling a
+> counter inside a measured window makes the sampler part of the measurement —
+> so the quietness claim here is a bracketing claim and nothing stronger. Each
+> run's own `run.cjs` rebuilds the `:advanced` bundle before measuring, and
+> that compile saturates this box; the bracket readings sit outside those
+> compiles.
+>
+> Raw driver output for all three runs is committed beside the instrument at
+> `implementation/hicasso/test/re_frame/bench/hicasso/data/readprofile-3l6hf/`
+> (`run1.txt`, `run2.txt`, `run3.txt`), verbatim except for the one
+> `shadow-cljs - config:` banner line per file, whose absolute path is
+> replaced by `<worktree>` and marked inline as redacted — the portability
+> gate refuses a tracked personal home path. No figure, guard verdict or exit
+> line was touched. That directory's `README.md` states the redaction.
+>
+> **`rf2-07rnj` stays blocked.** This bead owned resolving the decomposition;
+> one of its original terms still does not resolve, and a decomposition with
+> an unresolved term is not one.
+
 Micro table, over the page's own roster (ns/op): `subscribe-once` 5,284;
 `compute-sub` 1,170; the raw handler invoke 227; `registrar/lookup` 67;
 `frame-state-value` 266; the `call-with-frame-resolution` wrap 206; the

--- a/implementation/hicasso/test/re_frame/bench/hicasso/data/readprofile-3l6hf/README.md
+++ b/implementation/hicasso/test/re_frame/bench/hicasso/data/readprofile-3l6hf/README.md
@@ -1,0 +1,70 @@
+# `read_profile` phase-A/B transcripts — rf2-3l6hf's null-control window
+
+Raw driver output from the three runs of `rf2-3l6hf`'s measurement window
+(2026-08-16), one file per run, in run order. This is the first window taken
+on the instrument with a **measured negative control** (`c-null`), which is
+what the merged-PR audit of #8328 named as the thing that would settle the
+reader-membership term. The window is written up in
+`docs/design/hicasso/studio/the-cold-read-mount-term.md`.
+
+**Reader membership is still UNRESOLVED, and now on direct evidence rather
+than on the arithmetic-impossibility argument.** The null control — an arm
+whose true cost is exactly zero by construction — read `+0.0234 / +0.0219 /
++0.0234` ms/commit. Reader membership read `+0.0422 / +0.0219 / +0.0359`. In
+run 2 the two are equal to the last digit: the instrument reported the same
+number for reader membership as it reported for nothing at all. **No bound on
+the term is published, and none can be read off these numbers** — a null
+spread says what the instrument cannot see, not how large the invisible thing
+is.
+
+The other four ablation terms clear the null on all three runs.
+
+## What produced them
+
+| | |
+|---|---|
+| **Commit** | `926dd471d3` |
+| **Instrument blob** | `ef7a0d3787400734eafbc9b18ad96bd34b5fee8a` (`read_profile_app.cljs`, identical before and after the window — the working tree was clean at both ends) |
+| **Window shape** | 32 frames/window, 8 × (2 + 8) = 64 kept samples per arm, grid 0.0015625 ms/commit — unchanged from `rf2-07rnj`'s window, chosen once and held for every arm of every run |
+| **Arms** | 9, one more than the predecessor window: `c-null` was added **before** the window opened |
+| **Build** | `:advanced`, `goog.DEBUG false` |
+| **Runtime** | HeadlessChrome (Playwright), see each file's own runtime banner |
+| **Outcome** | `exit 0` on all three; both arm-order guards reportable on each; phase-A positive control passing on each; phase-B residue gate never firing |
+
+## The estimator these files report
+
+Each `p50` in the phase-B arm table is a **pooled median over the 64 kept
+samples of that arm**, each sample first divided by the 32-frame window — and
+because 64 is even, that median is the mean of the 32nd and 33rd order
+statistics. It is **not** a mean of per-round medians, and the two differ
+here: run 1's null control reads 0.0234 as a pooled-p50 delta and 0.0174 as a
+mean of its own per-round deltas.
+
+Each delta is the difference of two such pooled p50s.
+
+`:read-profile-commit-per-round` and `:read-profile-commit-per-round-deltas`
+carry the per-round values — a within-round p50 over that round's 8 kept
+samples, and its delta against `c-local`. They are recorded so this window can
+be re-adjudicated without being re-taken.
+
+## Reproduction
+
+```bash
+HICASSO_INIT_FN=re-frame.bench.hicasso.read-profile-app/-main \
+HICASSO_OUT_DIR=out/hicasso-readprof \
+  node implementation/hicasso/test/re_frame/bench/hicasso/run.cjs
+```
+
+## The one redaction, stated so nobody reads these as doctored
+
+Each file is the driver's output verbatim **except for exactly one line**, the
+`shadow-cljs - config:` banner, whose absolute path is replaced by
+`<worktree>` and marked inline as redacted. Nothing else was touched — no
+figure, no guard verdict, no exit line.
+
+The path was the window's proof that every build and every gate read the
+worker's own worktree rather than the mayor checkout, which is why the line is
+kept rather than deleted. It cannot be committed as it stood: the portability
+gate (`scripts/check-no-hardcoded-paths.sh`) refuses any tracked file carrying
+a personal home path, correctly and with no escape hatch. Re-running the
+command above prints the same banner with the reader's own checkout in it.

--- a/implementation/hicasso/test/re_frame/bench/hicasso/data/readprofile-3l6hf/run1.txt
+++ b/implementation/hicasso/test/re_frame/bench/hicasso/data/readprofile-3l6hf/run1.txt
@@ -1,0 +1,223 @@
+[hicasso] cleared .shadow-cljs/builds/hicasso-bench — one build id, N arms (rf2-2rtt6.20)
+[hicasso] building :advanced bundle — re-frame.bench.hicasso.read-profile-app/-main -> out/hicasso-readprof
+[:hicasso-bench] Compiling ...
+[:hicasso-bench] Build completed. (187 files, 132 compiled, 0 warnings, 20.85s)
+shadow-cljs - config: <worktree>/implementation/shadow-cljs.edn   [PATH REDACTED — see README.md]
+;; order-guard ok   the recorded 2.01x is REFUSED  — ratio 2.0125
+;; order-guard ok   the same study's uncontaminated slope passes  — forward 2830.7 / reversed 2842.8
+;; order-guard ok   a single-order result is refused as UNCHECKED  — only 1 stratum — the question was never asked
+;; order-guard ok   overlapping ranges are indistinguishable even 20% apart in median  — medians 1.2000x apart but the ranges OVERLAP — indistinguishable
+;; order-guard ok   the measured warm-up step is caught by PHASE, which no reversal would show  — phase: FIRST-THIRD reads 1.2633x LAST-THIRD, ranges disjoint
+;; order-guard ok   an arm that reads exactly zero in both strata is indistinguishable, not infinite  — within 10%
+;; order-guard ok   cyclic rotation gives every arm exactly ONE within-round predecessor  — rotation over 6 rounds: distinct predecessors per arm 1,1,1,1 (only the round seam ever differs, and that is one sample in R)
+;; order-guard ok   the reflecting schedule gives every arm TWO, in balance  — reflected: 2,2,2,2 predecessors per arm, largest modal share 50%
+;; order-guard ok   at k=2 an ALWAYS-reflecting schedule runs one order for ever and is UNCHECKED  — always-reflect over 6 rounds of 2 arms: 1 distinct order(s), predecessors per arm 2,1 — rotating a pair by one IS reversing it, so the two cancel
+;; order-guard ok   at k=2 slot-order alternates, and every arm gets TWO predecessors in balance  — slot-order: 2 distinct orders, predecessors per arm 3,2, largest modal share 50%
+;; order-guard ok   samples whose :position went NON-FINITE refuse instead of narrowing the question  — 18 of 24 samples have NO USABLE :position (nil, absent or non-finite) in a run that records them — the harness lost them, so this contrast is over the rest and the sample count above is not it
+;; order-guard ok   a present-but-NIL :position is the same loss, and recording NONE is still excused  — 18 of 24 samples have NO USABLE :position (nil, absent or non-finite) in a run that records them — the harness lost them, so this contrast is over the rest and the sample count above is not it — and a run offering no position at all is excused, not refused
+;; harvest OK — 1202 elements, 141 reads (141 distinct), from the real page's own entry
+;; ==== ARM-ORDER GUARD — read-profile phase A (in-page ms, diagnostic) ====
+;;   every arm partitioned by WHAT RAN BEFORE IT and by WHERE IN THE RUN it was measured; tolerance 10%, overlapping ranges are indistinguishable
+;;   ctl2  (60 samples)
+;;     [ok  ] by predecessor  within 10%
+;;              warm                     n=30  p50       7.8000  [7.0000–10.8000]
+;;              ship                     n=30  p50       7.8000  [6.8000–12.4000]
+;;     [ok  ] by phase        within 10%
+;;              FIRST-THIRD              n=20  p50       7.8000  [7.3000–8.8000]
+;;              LAST-THIRD               n=20  p50       7.9000  [6.8000–12.4000]
+;;   floor  (60 samples)
+;;     [ok  ] by predecessor  within 10%
+;;              probe-fresh              n=30  p50       0.2000  [0.1000–0.4000]
+;;              warm                     n=30  p50       0.2000  [0.1000–0.3000]
+;;     [ok  ] by phase        within 10%
+;;              FIRST-THIRD              n=20  p50       0.2000  [0.1000–0.3000]
+;;              LAST-THIRD               n=20  p50       0.2000  [0.1000–0.3000]
+;;   local  (60 samples)
+;;     [ok  ] by predecessor  within 10%
+;;              ship                     n=30  p50       4.1000  [3.7000–5.2000]
+;;              no-shell                 n=30  p50       4.2000  [3.6000–5.0000]
+;;     [ok  ] by phase        within 10%
+;;              FIRST-THIRD              n=20  p50       4.1000  [3.8000–5.2000]
+;;              LAST-THIRD               n=20  p50       4.2000  [3.6000–4.7000]
+;;   no-shell  (60 samples)
+;;     [ok  ] by predecessor  within 10%
+;;              probe                    n=24  p50       3.8000  [3.7000–4.5000]
+;;              local                    n=36  p50       3.8500  [3.1000–5.7000]
+;;     [ok  ] by phase        within 10%
+;;              FIRST-THIRD              n=20  p50       3.8500  [3.6000–5.3000]
+;;              LAST-THIRD               n=20  p50       3.9000  [3.1000–5.7000]
+;;   probe  (60 samples)
+;;     [ok  ] by predecessor  within 10%
+;;              probe-fresh              n=30  p50       1.7000  [1.5000–2.9000]
+;;              no-shell                 n=30  p50       1.8000  [1.5000–2.7000]
+;;     [ok  ] by phase        medians 1.1176x apart but the ranges OVERLAP — indistinguishable
+;;              LAST-THIRD               n=20  p50       1.7000  [1.5000–2.9000]
+;;              FIRST-THIRD              n=20  p50       1.9000  [1.7000–2.7000]
+;;   probe-fresh  (60 samples)
+;;     [ok  ] by predecessor  within 10%
+;;              probe                    n=36  p50       0.9000  [0.7000–2.8000]
+;;              floor                    n=23  p50       0.9000  [0.7000–1.9000]
+;;              <none>                   n= 1  p50       1.0000  [1.0000–1.0000]
+;;     [ok  ] by phase        within 10%
+;;              LAST-THIRD               n=20  p50       0.9000  [0.7000–1.4000]
+;;              FIRST-THIRD              n=20  p50       0.9000  [0.8000–2.8000]
+;;   ship  (60 samples)
+;;     [ok  ] by predecessor  within 10%
+;;              ctl2                     n=36  p50       2.0000  [1.7000–4.7000]
+;;              local                    n=24  p50       2.0000  [1.8000–2.3000]
+;;     [ok  ] by phase        within 10%
+;;              LAST-THIRD               n=20  p50       2.0000  [1.7000–2.4000]
+;;              FIRST-THIRD              n=20  p50       2.1000  [1.8000–4.7000]
+;;   warm  (60 samples)
+;;     [ok  ] by predecessor  within 10%
+;;              floor                    n=36  p50       0.4000  [0.3000–0.9000]
+;;              ctl2                     n=24  p50       0.4000  [0.3000–0.6000]
+;;     [ok  ] by phase        within 10%
+;;              FIRST-THIRD              n=20  p50       0.4000  [0.3000–0.6000]
+;;              LAST-THIRD               n=20  p50       0.4000  [0.3000–0.6000]
+;;   VERDICT: reportable — no arm reads differently for its position in the plan
+;; HICASSO read-profile-census
+{:reads 141, :distinct 141, :by-sub-id {:conduit/your-feed? 1, :conduit/slugs 1, :conduit/tags 1, :conduit/article 69, :conduit/favorite-pending? 69}, :input-kinds {:db 141}}
+;; HICASSO read-profile-arms
+{:ship {:n 60, :min 0.2125, :max 0.5875, :p50 0.25}, :local {:n 60, :min 0.45, :max 0.65, :p50 0.5125}, :no-shell {:n 60, :min 0.3875, :max 0.7125, :p50 0.475}, :probe {:n 60, :min 0.1875, :max 0.3625, :p50 0.225}, :probe-fresh {:n 60, :min 0.0875, :max 0.35, :p50 0.1125}, :floor {:n 60, :min 0.0125, :max 0.05, :p50 0.025}, :warm {:n 60, :min 0.0375, :max 0.1125, :p50 0.05}, :ctl2 {:n 60, :min 0.85, :max 1.55, :p50 0.975}}
+;; ==== READ PROFILE, PHASE A (ms per 141-read pass; diagnostic in-page clock) ====
+;;   reads/pass 141  passes/sample 8  design 6x(4+10)
+;;   ship: p50 0.2500 [0.2125 - 0.5875] ms/pass  (1.77 us/read)
+;;   local: p50 0.5125 [0.4500 - 0.6500] ms/pass  (3.63 us/read)
+;;   no-shell: p50 0.4750 [0.3875 - 0.7125] ms/pass  (3.37 us/read)
+;;   probe: p50 0.2250 [0.1875 - 0.3625] ms/pass  (1.60 us/read)
+;;   probe-fresh: p50 0.1125 [0.0875 - 0.3500] ms/pass  (0.80 us/read)
+;;   floor: p50 0.0250 [0.0125 - 0.0500] ms/pass  (0.18 us/read)
+;;   warm: p50 0.0500 [0.0375 - 0.1125] ms/pass  (0.35 us/read)
+;;   ctl2: p50 0.9750 [0.8500 - 1.5500] ms/pass  (6.91 us/read)
+;; ==== PHASE A DELTAS (floors; stubs stated in the ns docstring) ====
+;;   copy fidelity: local/ship = 2.0500  (local is the FROZEN subscribe-once path)
+;;   the-hicasso-shell (local - no-shell): delta 0.0375 ms/pass (0.27 us/read, 7.3% of the baseline)
+;;   churn-vs-probe (local - probe, the candidate's saving): delta 0.2875 ms/pass (2.04 us/read, 56.1% of the baseline)
+;;   memo-economy (probe-fresh - probe): delta -0.1125 ms/pass (-0.80 us/read, -100.0% of the baseline)
+;;   probe-overhead (probe - floor): delta 0.2000 ms/pass (1.42 us/read, 88.9% of the baseline)
+;;   warm steady-state: 0.0500 ms/pass (0.35 us/read)
+;;   control: predicted 0.950x, measured 0.975x [0.850–1.550] — the range meets the prediction within ±25%
+;; ==== ARM-ORDER GUARD — read-profile phase B (in-page ms, diagnostic) ====
+;;   every arm partitioned by WHAT RAN BEFORE IT and by WHERE IN THE RUN it was measured; tolerance 10%, overlapping ranges are indistinguishable
+;;   b-build  (64 samples)
+;;     [ok  ] by predecessor  within 10%
+;;              commit                   n=24  p50      16.1500  [13.2000–27.6000]
+;;              c-nomap                  n=40  p50      16.5000  [12.5000–22.0000]
+;;     [ok  ] by phase        medians 1.1355x apart but the ranges OVERLAP — indistinguishable
+;;              LAST-THIRD               n=21  p50      15.5000  [12.5000–21.6000]
+;;              FIRST-THIRD              n=21  p50      17.6000  [13.4000–27.6000]
+;;   c-local  (64 samples)
+;;     [ok  ] by predecessor  within 10%
+;;              c-null                   n=32  p50      20.6500  [15.8000–28.1000]
+;;              commit                   n=32  p50      21.1000  [15.9000–27.2000]
+;;     [ok  ] by phase        within 10%
+;;              FIRST-THIRD              n=21  p50      20.6000  [15.8000–26.8000]
+;;              LAST-THIRD               n=21  p50      21.0000  [17.8000–28.1000]
+;;   c-noactivate  (64 samples)
+;;     [ok  ] by predecessor  within 10%
+;;              c-null                   n=32  p50      19.3500  [15.5000–25.5000]
+;;              c-nowatch                n=32  p50      19.4500  [15.9000–24.9000]
+;;     [ok  ] by phase        within 10%
+;;              LAST-THIRD               n=21  p50      19.3000  [16.6000–23.9000]
+;;              FIRST-THIRD              n=21  p50      19.8000  [15.5000–23.6000]
+;;   c-nomap  (64 samples)
+;;     [ok  ] by predecessor  within 10%
+;;              c-noreaders              n=32  p50      18.4500  [15.8000–24.1000]
+;;              b-build                  n=32  p50      19.9500  [15.4000–23.5000]
+;;     [ok  ] by phase        medians 1.1093x apart but the ranges OVERLAP — indistinguishable
+;;              LAST-THIRD               n=21  p50      18.3000  [15.4000–23.7000]
+;;              FIRST-THIRD              n=21  p50      20.3000  [16.0000–24.1000]
+;;   c-noreaders  (64 samples)
+;;     [ok  ] by predecessor  within 10%
+;;              c-nosub                  n=40  p50      19.2000  [15.9000–27.4000]
+;;              c-nomap                  n=24  p50      19.5500  [16.6000–26.8000]
+;;     [ok  ] by phase        medians 1.1330x apart but the ranges OVERLAP — indistinguishable
+;;              LAST-THIRD               n=21  p50      18.8000  [16.1000–26.8000]
+;;              FIRST-THIRD              n=21  p50      21.3000  [15.9000–27.4000]
+;;   c-nosub  (64 samples)
+;;     [ok  ] by predecessor  within 10%
+;;              c-noreaders              n=32  p50       6.5500  [5.1000–9.7000]
+;;              c-nowatch                n=32  p50       6.7500  [4.9000–10.2000]
+;;     [ok  ] by phase        within 10%
+;;              LAST-THIRD               n=21  p50       6.3000  [5.1000–10.2000]
+;;              FIRST-THIRD              n=21  p50       6.9000  [5.3000–9.7000]
+;;   c-nowatch  (64 samples)
+;;     [ok  ] by predecessor  within 10%
+;;              c-nosub                  n=24  p50      18.6500  [14.9000–21.7000]
+;;              c-noactivate             n=40  p50      18.8500  [14.6000–24.7000]
+;;     [ok  ] by phase        within 10%
+;;              FIRST-THIRD              n=21  p50      18.7000  [14.9000–24.7000]
+;;              LAST-THIRD               n=21  p50      19.2000  [14.6000–22.7000]
+;;   c-null  (64 samples)
+;;     [ok  ] by predecessor  within 10%
+;;              <none>                   n= 1  p50      17.4000  [17.4000–17.4000]
+;;              commit                   n= 7  p50      19.3000  [17.6000–21.1000]
+;;              c-noactivate             n=24  p50      20.3000  [17.3000–27.0000]
+;;              c-local                  n=32  p50      20.8000  [15.5000–26.1000]
+;;     [ok  ] by phase        within 10%
+;;              LAST-THIRD               n=21  p50      20.0000  [16.8000–27.0000]
+;;              FIRST-THIRD              n=21  p50      20.2000  [16.1000–25.4000]
+;;   commit  (64 samples)
+;;     [ok  ] by predecessor  within 10%
+;;              c-local                  n=32  p50      21.3500  [16.3000–25.7000]
+;;              b-build                  n=32  p50      23.1000  [18.9000–28.9000]
+;;     [ok  ] by phase        within 10%
+;;              LAST-THIRD               n=21  p50      21.5000  [18.5000–25.8000]
+;;              FIRST-THIRD              n=21  p50      23.0000  [17.5000–28.9000]
+;;   VERDICT: reportable — no arm reads differently for its position in the plan
+;; HICASSO read-profile-commit
+{:c-local {:n 64, :min 0.4938, :max 0.8781, :p50 0.6516}, :c-noreaders {:n 64, :min 0.4969, :max 0.8562, :p50 0.6094}, :c-noactivate {:n 64, :min 0.4844, :max 0.7969, :p50 0.6062}, :c-null {:n 64, :min 0.4844, :max 0.8438, :p50 0.6281}, :c-nowatch {:n 64, :min 0.4562, :max 0.7719, :p50 0.5859}, :commit {:n 64, :min 0.5094, :max 0.9031, :p50 0.7062}, :c-nomap {:n 64, :min 0.4813, :max 0.7531, :p50 0.5969}, :b-build {:n 64, :min 0.3906, :max 0.8625, :p50 0.5125}, :c-nosub {:n 64, :min 0.1531, :max 0.3187, :p50 0.2063}}
+;; HICASSO read-profile-commit-per-round
+{:c-local [0.6594 0.6047 0.5984 0.6906 0.6469 0.625 0.6734 0.7031], :c-noreaders [0.7422 0.6125 0.5969 0.6156 0.5734 0.6234 0.5672 0.5484], :c-noactivate [0.6328 0.5953 0.6469 0.5984 0.5625 0.6 0.5953 0.6109], :c-null [0.6422 0.6219 0.6094 0.6375 0.6437 0.6578 0.6391 0.6109], :c-nowatch [0.6094 0.5797 0.5734 0.6109 0.5406 0.6156 0.5656 0.6047], :commit [0.7219 0.7422 0.7203 0.6563 0.6234 0.6594 0.6953 0.6891], :c-nomap [0.6469 0.6078 0.6016 0.5766 0.6297 0.6156 0.5234 0.6], :b-build [0.5844 0.5406 0.5281 0.4891 0.4563 0.5234 0.45 0.4891], :c-nosub [0.225 0.2109 0.2016 0.1891 0.2375 0.2078 0.1844 0.2016]}
+;; HICASSO read-profile-commit-per-round-deltas
+{:c-null [0.0172 -0.0172 -0.011 0.0531 0.0032 -0.0328 0.0343 0.0922], :c-noactivate [0.0266 0.0094 -0.0485 0.0922 0.0844 0.025 0.0781 0.0922], :c-nowatch [0.05 0.025 0.025 0.0797 0.1063 0.0094 0.1078 0.0984], :c-nosub [0.4344 0.3938 0.3968 0.5015 0.4094 0.4172 0.489 0.5015], :c-noreaders [-0.0828 -0.0078 0.0015 0.075 0.0735 0.0016 0.1062 0.1547], :c-nomap [0.0125 -0.0031 -0.0032 0.114 0.0172 0.0094 0.15 0.1031]}
+;; ==== READ PROFILE, PHASE B — THE COMMIT HALF (ms per 141-key boundary commit) ====
+;;   design 8x(2+8)  window = 32 frames/commit each  kept = 64 samples/arm (EVEN — p50 is the mean of two middle clock readings)  grid = 0.001563 ms/commit
+;;   commit: p50 0.7062 [0.5094 - 0.9031] ms/pass  (5.01 us/read)
+;;   c-local: p50 0.6516 [0.4938 - 0.8781] ms/pass  (4.62 us/read)
+;;   c-null: p50 0.6281 [0.4844 - 0.8438] ms/pass  (4.45 us/read)
+;;   c-noactivate: p50 0.6062 [0.4844 - 0.7969] ms/pass  (4.30 us/read)
+;;   c-nowatch: p50 0.5859 [0.4562 - 0.7719] ms/pass  (4.16 us/read)
+;;   c-nosub: p50 0.2063 [0.1531 - 0.3187] ms/pass  (1.46 us/read)
+;;   c-noreaders: p50 0.6094 [0.4969 - 0.8562] ms/pass  (4.32 us/read)
+;;   c-nomap: p50 0.5969 [0.4813 - 0.7531] ms/pass  (4.23 us/read)
+;;   b-build: p50 0.5125 [0.3906 - 0.8625] ms/pass  (3.63 us/read)
+;; ==== PHASE B DELTAS (c-local minus ablation; floors) ====
+;;   copy fidelity: c-local/commit = 0.9226
+;;   NULL CONTROL (c-local - c-null): delta 0.0234 ms/pass (0.17 us/read, 3.6% of the baseline)
+;;     ^ true cost EXACTLY ZERO by construction — both arms are C-FULL. What it reads is this instrument's own error at this shape, and it is what the terms below are adjudicated against (rf2-3l6hf). It bounds no term's cost: a delta inside this spread is a term the window cannot SEE, which leaves its size open in both directions
+;;   activation-capture (c-local - c-noactivate): delta 0.0453 ms/pass (0.32 us/read, 7.0% of the baseline)
+;;     ^ a REAL term here, NOT a floor and not an arbiter: nothing activates on this UIx host, but the hook key is never published and so never cached, and this prices that lookup (rf2-tcffa, rf2-19usn). The capture itself is real only under the ratom family (rf2-lzpfj)
+;;   watch-wiring (c-local - c-nowatch): delta 0.0656 ms/pass (0.47 us/read, 10.1% of the baseline)
+;;   reaction-build+cache-insert (c-local - c-nosub): delta 0.4453 ms/pass (3.16 us/read, 68.3% of the baseline)
+;;   reader-membership (c-local - c-noreaders): delta 0.0422 ms/pass (0.30 us/read, 6.5% of the baseline)
+;;   cell-map-insert (c-local - c-nomap): delta 0.0547 ms/pass (0.39 us/read, 8.4% of the baseline)
+;;   b-build (build+compute, no in-window dispose): 0.5125 ms/pass (3.63 us/read)
+;; HICASSO read-profile-micro
+{:subscribe-once 5106.383, :compute-sub 886.5248, :handler-invoke 180.8511, :registrar-lookup 67.3759, :frame-state-value 287.234, :resolution-wrap 202.1277, :cache-peek-miss 24.8227, :sub-key-mint 21.2766}
+;; ==== MICRO (ns/op over the page's own roster) ====
+;;   subscribe-once: 5106.4 ns
+;;   compute-sub: 886.5 ns
+;;   handler-invoke: 180.9 ns
+;;   registrar-lookup: 67.4 ns
+;;   frame-state-value: 287.2 ns
+;;   resolution-wrap: 202.1 ns
+;;   cache-peek-miss: 24.8 ns
+;;   sub-key-mint: 21.3 ns
+;; HICASSO DONE
+;; ==== HICASSO RUNTIME ====
+;; chromium 147.0.7727.15 (playwright), :advanced, goog.DEBUG false
+;; ==== HICASSO read-profile-census ====
+{:reads 141, :distinct 141, :by-sub-id {:conduit/your-feed? 1, :conduit/slugs 1, :conduit/tags 1, :conduit/article 69, :conduit/favorite-pending? 69}, :input-kinds {:db 141}}
+;; ==== HICASSO read-profile-arms ====
+{:ship {:n 60, :min 0.2125, :max 0.5875, :p50 0.25}, :local {:n 60, :min 0.45, :max 0.65, :p50 0.5125}, :no-shell {:n 60, :min 0.3875, :max 0.7125, :p50 0.475}, :probe {:n 60, :min 0.1875, :max 0.3625, :p50 0.225}, :probe-fresh {:n 60, :min 0.0875, :max 0.35, :p50 0.1125}, :floor {:n 60, :min 0.0125, :max 0.05, :p50 0.025}, :warm {:n 60, :min 0.0375, :max 0.1125, :p50 0.05}, :ctl2 {:n 60, :min 0.85, :max 1.55, :p50 0.975}}
+;; ==== HICASSO read-profile-commit ====
+{:c-local {:n 64, :min 0.4938, :max 0.8781, :p50 0.6516}, :c-noreaders {:n 64, :min 0.4969, :max 0.8562, :p50 0.6094}, :c-noactivate {:n 64, :min 0.4844, :max 0.7969, :p50 0.6062}, :c-null {:n 64, :min 0.4844, :max 0.8438, :p50 0.6281}, :c-nowatch {:n 64, :min 0.4562, :max 0.7719, :p50 0.5859}, :commit {:n 64, :min 0.5094, :max 0.9031, :p50 0.7062}, :c-nomap {:n 64, :min 0.4813, :max 0.7531, :p50 0.5969}, :b-build {:n 64, :min 0.3906, :max 0.8625, :p50 0.5125}, :c-nosub {:n 64, :min 0.1531, :max 0.3187, :p50 0.2063}}
+;; ==== HICASSO read-profile-commit-per-round ====
+{:c-local [0.6594 0.6047 0.5984 0.6906 0.6469 0.625 0.6734 0.7031], :c-noreaders [0.7422 0.6125 0.5969 0.6156 0.5734 0.6234 0.5672 0.5484], :c-noactivate [0.6328 0.5953 0.6469 0.5984 0.5625 0.6 0.5953 0.6109], :c-null [0.6422 0.6219 0.6094 0.6375 0.6437 0.6578 0.6391 0.6109], :c-nowatch [0.6094 0.5797 0.5734 0.6109 0.5406 0.6156 0.5656 0.6047], :commit [0.7219 0.7422 0.7203 0.6563 0.6234 0.6594 0.6953 0.6891], :c-nomap [0.6469 0.6078 0.6016 0.5766 0.6297 0.6156 0.5234 0.6], :b-build [0.5844 0.5406 0.5281 0.4891 0.4563 0.5234 0.45 0.4891], :c-nosub [0.225 0.2109 0.2016 0.1891 0.2375 0.2078 0.1844 0.2016]}
+;; ==== HICASSO read-profile-commit-per-round-deltas ====
+{:c-null [0.0172 -0.0172 -0.011 0.0531 0.0032 -0.0328 0.0343 0.0922], :c-noactivate [0.0266 0.0094 -0.0485 0.0922 0.0844 0.025 0.0781 0.0922], :c-nowatch [0.05 0.025 0.025 0.0797 0.1063 0.0094 0.1078 0.0984], :c-nosub [0.4344 0.3938 0.3968 0.5015 0.4094 0.4172 0.489 0.5015], :c-noreaders [-0.0828 -0.0078 0.0015 0.075 0.0735 0.0016 0.1062 0.1547], :c-nomap [0.0125 -0.0031 -0.0032 0.114 0.0172 0.0094 0.15 0.1031]}
+;; ==== HICASSO read-profile-micro ====
+{:subscribe-once 5106.383, :compute-sub 886.5248, :handler-invoke 180.8511, :registrar-lookup 67.3759, :frame-state-value 287.234, :resolution-wrap 202.1277, :cache-peek-miss 24.8227, :sub-key-mint 21.2766}
+[hicasso] ok

--- a/implementation/hicasso/test/re_frame/bench/hicasso/data/readprofile-3l6hf/run2.txt
+++ b/implementation/hicasso/test/re_frame/bench/hicasso/data/readprofile-3l6hf/run2.txt
@@ -1,0 +1,223 @@
+[hicasso] cleared .shadow-cljs/builds/hicasso-bench — one build id, N arms (rf2-2rtt6.20)
+[hicasso] building :advanced bundle — re-frame.bench.hicasso.read-profile-app/-main -> out/hicasso-readprof
+[:hicasso-bench] Compiling ...
+[:hicasso-bench] Build completed. (187 files, 132 compiled, 0 warnings, 21.12s)
+shadow-cljs - config: <worktree>/implementation/shadow-cljs.edn   [PATH REDACTED — see README.md]
+;; order-guard ok   the recorded 2.01x is REFUSED  — ratio 2.0125
+;; order-guard ok   the same study's uncontaminated slope passes  — forward 2830.7 / reversed 2842.8
+;; order-guard ok   a single-order result is refused as UNCHECKED  — only 1 stratum — the question was never asked
+;; order-guard ok   overlapping ranges are indistinguishable even 20% apart in median  — medians 1.2000x apart but the ranges OVERLAP — indistinguishable
+;; order-guard ok   the measured warm-up step is caught by PHASE, which no reversal would show  — phase: FIRST-THIRD reads 1.2633x LAST-THIRD, ranges disjoint
+;; order-guard ok   an arm that reads exactly zero in both strata is indistinguishable, not infinite  — within 10%
+;; order-guard ok   cyclic rotation gives every arm exactly ONE within-round predecessor  — rotation over 6 rounds: distinct predecessors per arm 1,1,1,1 (only the round seam ever differs, and that is one sample in R)
+;; order-guard ok   the reflecting schedule gives every arm TWO, in balance  — reflected: 2,2,2,2 predecessors per arm, largest modal share 50%
+;; order-guard ok   at k=2 an ALWAYS-reflecting schedule runs one order for ever and is UNCHECKED  — always-reflect over 6 rounds of 2 arms: 1 distinct order(s), predecessors per arm 2,1 — rotating a pair by one IS reversing it, so the two cancel
+;; order-guard ok   at k=2 slot-order alternates, and every arm gets TWO predecessors in balance  — slot-order: 2 distinct orders, predecessors per arm 3,2, largest modal share 50%
+;; order-guard ok   samples whose :position went NON-FINITE refuse instead of narrowing the question  — 18 of 24 samples have NO USABLE :position (nil, absent or non-finite) in a run that records them — the harness lost them, so this contrast is over the rest and the sample count above is not it
+;; order-guard ok   a present-but-NIL :position is the same loss, and recording NONE is still excused  — 18 of 24 samples have NO USABLE :position (nil, absent or non-finite) in a run that records them — the harness lost them, so this contrast is over the rest and the sample count above is not it — and a run offering no position at all is excused, not refused
+;; harvest OK — 1202 elements, 141 reads (141 distinct), from the real page's own entry
+;; ==== ARM-ORDER GUARD — read-profile phase A (in-page ms, diagnostic) ====
+;;   every arm partitioned by WHAT RAN BEFORE IT and by WHERE IN THE RUN it was measured; tolerance 10%, overlapping ranges are indistinguishable
+;;   ctl2  (60 samples)
+;;     [ok  ] by predecessor  within 10%
+;;              ship                     n=30  p50       7.9500  [6.8000–11.0000]
+;;              warm                     n=30  p50       8.3500  [7.0000–12.5000]
+;;     [ok  ] by phase        within 10%
+;;              LAST-THIRD               n=20  p50       8.0000  [6.9000–12.5000]
+;;              FIRST-THIRD              n=20  p50       8.3000  [6.8000–10.8000]
+;;   floor  (60 samples)
+;;     [ok  ] by predecessor  within 10%
+;;              probe-fresh              n=30  p50       0.2000  [0.1000–0.3000]
+;;              warm                     n=30  p50       0.2000  [0.1000–0.4000]
+;;     [ok  ] by phase        within 10%
+;;              FIRST-THIRD              n=20  p50       0.2000  [0.1000–0.3000]
+;;              LAST-THIRD               n=20  p50       0.2000  [0.1000–0.3000]
+;;   local  (60 samples)
+;;     [ok  ] by predecessor  within 10%
+;;              ship                     n=30  p50       4.1000  [3.6000–7.6000]
+;;              no-shell                 n=30  p50       4.2000  [3.6000–6.6000]
+;;     [ok  ] by phase        within 10%
+;;              LAST-THIRD               n=20  p50       4.1000  [3.6000–5.5000]
+;;              FIRST-THIRD              n=20  p50       4.3000  [3.7000–7.6000]
+;;   no-shell  (60 samples)
+;;     [ok  ] by predecessor  within 10%
+;;              probe                    n=24  p50       3.9500  [3.3000–6.6000]
+;;              local                    n=36  p50       4.2000  [3.1000–5.4000]
+;;     [ok  ] by phase        within 10%
+;;              LAST-THIRD               n=20  p50       3.9000  [3.1000–4.3000]
+;;              FIRST-THIRD              n=20  p50       4.1000  [3.3000–5.6000]
+;;   probe  (60 samples)
+;;     [ok  ] by predecessor  within 10%
+;;              no-shell                 n=30  p50       1.9000  [1.6000–3.5000]
+;;              probe-fresh              n=30  p50       2.0000  [1.6000–3.4000]
+;;     [ok  ] by phase        within 10%
+;;              LAST-THIRD               n=20  p50       1.8500  [1.6000–2.3000]
+;;              FIRST-THIRD              n=20  p50       2.0000  [1.6000–3.5000]
+;;   probe-fresh  (60 samples)
+;;     [ok  ] by predecessor  within 10%
+;;              probe                    n=36  p50       0.9000  [0.7000–1.4000]
+;;              floor                    n=23  p50       0.9000  [0.7000–1.2000]
+;;              <none>                   n= 1  p50       1.0000  [1.0000–1.0000]
+;;     [ok  ] by phase        within 10%
+;;              LAST-THIRD               n=20  p50       0.9000  [0.7000–1.3000]
+;;              FIRST-THIRD              n=20  p50       0.9500  [0.8000–1.4000]
+;;   ship  (60 samples)
+;;     [ok  ] by predecessor  within 10%
+;;              local                    n=24  p50       2.1000  [1.6000–3.8000]
+;;              ctl2                     n=36  p50       2.2500  [1.6000–5.3000]
+;;     [ok  ] by phase        medians 1.1500x apart but the ranges OVERLAP — indistinguishable
+;;              LAST-THIRD               n=20  p50       2.0000  [1.7000–4.4000]
+;;              FIRST-THIRD              n=20  p50       2.3000  [1.6000–5.3000]
+;;   warm  (60 samples)
+;;     [ok  ] by predecessor  within 10%
+;;              floor                    n=36  p50       0.4000  [0.3000–0.6000]
+;;              ctl2                     n=24  p50       0.4000  [0.3000–0.9000]
+;;     [ok  ] by phase        within 10%
+;;              FIRST-THIRD              n=20  p50       0.4000  [0.3000–0.6000]
+;;              LAST-THIRD               n=20  p50       0.4000  [0.3000–0.6000]
+;;   VERDICT: reportable — no arm reads differently for its position in the plan
+;; HICASSO read-profile-census
+{:reads 141, :distinct 141, :by-sub-id {:conduit/your-feed? 1, :conduit/slugs 1, :conduit/tags 1, :conduit/article 69, :conduit/favorite-pending? 69}, :input-kinds {:db 141}}
+;; HICASSO read-profile-arms
+{:ship {:n 60, :min 0.2, :max 0.6625, :p50 0.275}, :local {:n 60, :min 0.45, :max 0.95, :p50 0.525}, :no-shell {:n 60, :min 0.3875, :max 0.825, :p50 0.5062}, :probe {:n 60, :min 0.2, :max 0.4375, :p50 0.2438}, :probe-fresh {:n 60, :min 0.0875, :max 0.175, :p50 0.1125}, :floor {:n 60, :min 0.0125, :max 0.05, :p50 0.025}, :warm {:n 60, :min 0.0375, :max 0.1125, :p50 0.05}, :ctl2 {:n 60, :min 0.85, :max 1.5625, :p50 1.0188}}
+;; ==== READ PROFILE, PHASE A (ms per 141-read pass; diagnostic in-page clock) ====
+;;   reads/pass 141  passes/sample 8  design 6x(4+10)
+;;   ship: p50 0.2750 [0.2000 - 0.6625] ms/pass  (1.95 us/read)
+;;   local: p50 0.5250 [0.4500 - 0.9500] ms/pass  (3.72 us/read)
+;;   no-shell: p50 0.5062 [0.3875 - 0.8250] ms/pass  (3.59 us/read)
+;;   probe: p50 0.2438 [0.2000 - 0.4375] ms/pass  (1.73 us/read)
+;;   probe-fresh: p50 0.1125 [0.0875 - 0.1750] ms/pass  (0.80 us/read)
+;;   floor: p50 0.0250 [0.0125 - 0.0500] ms/pass  (0.18 us/read)
+;;   warm: p50 0.0500 [0.0375 - 0.1125] ms/pass  (0.35 us/read)
+;;   ctl2: p50 1.0188 [0.8500 - 1.5625] ms/pass  (7.23 us/read)
+;; ==== PHASE A DELTAS (floors; stubs stated in the ns docstring) ====
+;;   copy fidelity: local/ship = 1.9091  (local is the FROZEN subscribe-once path)
+;;   the-hicasso-shell (local - no-shell): delta 0.0188 ms/pass (0.13 us/read, 3.6% of the baseline)
+;;   churn-vs-probe (local - probe, the candidate's saving): delta 0.2812 ms/pass (1.99 us/read, 53.6% of the baseline)
+;;   memo-economy (probe-fresh - probe): delta -0.1312 ms/pass (-0.93 us/read, -116.7% of the baseline)
+;;   probe-overhead (probe - floor): delta 0.2188 ms/pass (1.55 us/read, 89.7% of the baseline)
+;;   warm steady-state: 0.0500 ms/pass (0.35 us/read)
+;;   control: predicted 1.012x, measured 1.019x [0.850–1.563] — the range meets the prediction within ±25%
+;; ==== ARM-ORDER GUARD — read-profile phase B (in-page ms, diagnostic) ====
+;;   every arm partitioned by WHAT RAN BEFORE IT and by WHERE IN THE RUN it was measured; tolerance 10%, overlapping ranges are indistinguishable
+;;   b-build  (64 samples)
+;;     [ok  ] by predecessor  within 10%
+;;              c-nomap                  n=40  p50      15.7500  [11.7000–20.4000]
+;;              commit                   n=24  p50      15.9500  [12.3000–23.5000]
+;;     [ok  ] by phase        within 10%
+;;              LAST-THIRD               n=21  p50      15.8000  [11.7000–18.7000]
+;;              FIRST-THIRD              n=21  p50      16.5000  [13.5000–23.5000]
+;;   c-local  (64 samples)
+;;     [ok  ] by predecessor  within 10%
+;;              c-null                   n=32  p50      19.8500  [15.7000–25.3000]
+;;              commit                   n=32  p50      21.4000  [16.3000–24.7000]
+;;     [ok  ] by phase        within 10%
+;;              FIRST-THIRD              n=21  p50      19.9000  [15.7000–25.3000]
+;;              LAST-THIRD               n=21  p50      21.1000  [17.4000–25.0000]
+;;   c-noactivate  (64 samples)
+;;     [ok  ] by predecessor  within 10%
+;;              c-nowatch                n=32  p50      19.6000  [16.0000–24.9000]
+;;              c-null                   n=32  p50      19.7000  [15.1000–23.9000]
+;;     [ok  ] by phase        within 10%
+;;              FIRST-THIRD              n=21  p50      18.5000  [16.0000–24.1000]
+;;              LAST-THIRD               n=21  p50      19.7000  [17.0000–23.9000]
+;;   c-nomap  (64 samples)
+;;     [ok  ] by predecessor  within 10%
+;;              c-noreaders              n=32  p50      18.8500  [14.2000–23.0000]
+;;              b-build                  n=32  p50      19.5000  [14.9000–24.4000]
+;;     [ok  ] by phase        within 10%
+;;              LAST-THIRD               n=21  p50      18.8000  [14.2000–24.1000]
+;;              FIRST-THIRD              n=21  p50      19.0000  [14.9000–24.4000]
+;;   c-noreaders  (64 samples)
+;;     [ok  ] by predecessor  within 10%
+;;              c-nosub                  n=40  p50      20.0500  [17.2000–25.9000]
+;;              c-nomap                  n=24  p50      20.9000  [17.0000–26.9000]
+;;     [ok  ] by phase        medians 1.1198x apart but the ranges OVERLAP — indistinguishable
+;;              LAST-THIRD               n=21  p50      19.2000  [17.0000–24.5000]
+;;              FIRST-THIRD              n=21  p50      21.5000  [17.6000–25.9000]
+;;   c-nosub  (64 samples)
+;;     [ok  ] by predecessor  medians 1.1270x apart but the ranges OVERLAP — indistinguishable
+;;              c-noreaders              n=32  p50       6.3000  [5.3000–9.2000]
+;;              c-nowatch                n=32  p50       7.1000  [5.3000–11.1000]
+;;     [ok  ] by phase        medians 1.2459x apart but the ranges OVERLAP — indistinguishable
+;;              LAST-THIRD               n=21  p50       6.1000  [5.3000–9.9000]
+;;              FIRST-THIRD              n=21  p50       7.6000  [5.3000–9.2000]
+;;   c-nowatch  (64 samples)
+;;     [ok  ] by predecessor  within 10%
+;;              c-nosub                  n=24  p50      18.2500  [14.6000–20.1000]
+;;              c-noactivate             n=40  p50      19.7500  [16.1000–25.4000]
+;;     [ok  ] by phase        within 10%
+;;              FIRST-THIRD              n=21  p50      18.6000  [14.6000–25.4000]
+;;              LAST-THIRD               n=21  p50      18.7000  [16.0000–23.5000]
+;;   c-null  (64 samples)
+;;     [ok  ] by predecessor  within 10%
+;;              c-noactivate             n=24  p50      19.8500  [15.4000–23.8000]
+;;              commit                   n= 7  p50      20.1000  [18.6000–28.7000]
+;;              c-local                  n=32  p50      20.4000  [17.7000–28.4000]
+;;              <none>                   n= 1  p50      21.2000  [21.2000–21.2000]
+;;     [ok  ] by phase        within 10%
+;;              LAST-THIRD               n=21  p50      19.7000  [15.4000–22.8000]
+;;              FIRST-THIRD              n=21  p50      20.3000  [16.5000–28.4000]
+;;   commit  (64 samples)
+;;     [ok  ] by predecessor  within 10%
+;;              c-local                  n=32  p50      21.2000  [16.4000–28.6000]
+;;              b-build                  n=32  p50      23.3000  [18.5000–29.2000]
+;;     [ok  ] by phase        within 10%
+;;              LAST-THIRD               n=21  p50      21.4000  [18.5000–28.6000]
+;;              FIRST-THIRD              n=21  p50      22.9000  [18.4000–29.2000]
+;;   VERDICT: reportable — no arm reads differently for its position in the plan
+;; HICASSO read-profile-commit
+{:c-local {:n 64, :min 0.4906, :max 0.7906, :p50 0.6578}, :c-noreaders {:n 64, :min 0.5313, :max 0.8406, :p50 0.6359}, :c-noactivate {:n 64, :min 0.4719, :max 0.7781, :p50 0.6141}, :c-null {:n 64, :min 0.4813, :max 0.8969, :p50 0.6359}, :c-nowatch {:n 64, :min 0.4562, :max 0.7937, :p50 0.5906}, :commit {:n 64, :min 0.5125, :max 0.9125, :p50 0.6937}, :c-nomap {:n 64, :min 0.4438, :max 0.7625, :p50 0.5953}, :b-build {:n 64, :min 0.3656, :max 0.7344, :p50 0.4953}, :c-nosub {:n 64, :min 0.1656, :max 0.3469, :p50 0.2047}}
+;; HICASSO read-profile-commit-per-round
+{:c-local [0.5203 0.6562 0.6938 0.6469 0.6594 0.6484 0.6859 0.6328], :c-noreaders [0.7 0.6375 0.7109 0.6437 0.6688 0.6328 0.5953 0.5844], :c-noactivate [0.5578 0.6062 0.6141 0.6141 0.6578 0.6172 0.6172 0.5922], :c-null [0.625 0.6344 0.6594 0.6328 0.65 0.6406 0.5844 0.6219], :c-nowatch [0.5406 0.5813 0.5844 0.6344 0.6094 0.5844 0.5938 0.5906], :commit [0.7031 0.6578 0.7422 0.7281 0.6969 0.6906 0.6797 0.6578], :c-nomap [0.6141 0.5672 0.6063 0.6016 0.5828 0.625 0.5859 0.6047], :b-build [0.5578 0.4531 0.5109 0.5844 0.4781 0.4984 0.4922 0.4266], :c-nosub [0.2531 0.2406 0.2188 0.2422 0.1953 0.1953 0.1734 0.2078]}
+;; HICASSO read-profile-commit-per-round-deltas
+{:c-null [-0.1047 0.0218 0.0344 0.0141 0.0094 0.0078 0.1015 0.0109], :c-noactivate [-0.0375 0.05 0.0797 0.0328 0.0016 0.0312 0.0687 0.0406], :c-nowatch [-0.0203 0.0749 0.1094 0.0125 0.05 0.064 0.0921 0.0422], :c-nosub [0.2672 0.4156 0.475 0.4047 0.4641 0.4531 0.5125 0.425], :c-noreaders [-0.1797 0.0187 -0.0171 0.0032 -0.0094 0.0156 0.0906 0.0484], :c-nomap [-0.0938 0.089 0.0875 0.0453 0.0766 0.0234 0.1 0.0281]}
+;; ==== READ PROFILE, PHASE B — THE COMMIT HALF (ms per 141-key boundary commit) ====
+;;   design 8x(2+8)  window = 32 frames/commit each  kept = 64 samples/arm (EVEN — p50 is the mean of two middle clock readings)  grid = 0.001563 ms/commit
+;;   commit: p50 0.6937 [0.5125 - 0.9125] ms/pass  (4.92 us/read)
+;;   c-local: p50 0.6578 [0.4906 - 0.7906] ms/pass  (4.67 us/read)
+;;   c-null: p50 0.6359 [0.4813 - 0.8969] ms/pass  (4.51 us/read)
+;;   c-noactivate: p50 0.6141 [0.4719 - 0.7781] ms/pass  (4.36 us/read)
+;;   c-nowatch: p50 0.5906 [0.4562 - 0.7937] ms/pass  (4.19 us/read)
+;;   c-nosub: p50 0.2047 [0.1656 - 0.3469] ms/pass  (1.45 us/read)
+;;   c-noreaders: p50 0.6359 [0.5313 - 0.8406] ms/pass  (4.51 us/read)
+;;   c-nomap: p50 0.5953 [0.4438 - 0.7625] ms/pass  (4.22 us/read)
+;;   b-build: p50 0.4953 [0.3656 - 0.7344] ms/pass  (3.51 us/read)
+;; ==== PHASE B DELTAS (c-local minus ablation; floors) ====
+;;   copy fidelity: c-local/commit = 0.9482
+;;   NULL CONTROL (c-local - c-null): delta 0.0219 ms/pass (0.16 us/read, 3.3% of the baseline)
+;;     ^ true cost EXACTLY ZERO by construction — both arms are C-FULL. What it reads is this instrument's own error at this shape, and it is what the terms below are adjudicated against (rf2-3l6hf). It bounds no term's cost: a delta inside this spread is a term the window cannot SEE, which leaves its size open in both directions
+;;   activation-capture (c-local - c-noactivate): delta 0.0437 ms/pass (0.31 us/read, 6.7% of the baseline)
+;;     ^ a REAL term here, NOT a floor and not an arbiter: nothing activates on this UIx host, but the hook key is never published and so never cached, and this prices that lookup (rf2-tcffa, rf2-19usn). The capture itself is real only under the ratom family (rf2-lzpfj)
+;;   watch-wiring (c-local - c-nowatch): delta 0.0672 ms/pass (0.48 us/read, 10.2% of the baseline)
+;;   reaction-build+cache-insert (c-local - c-nosub): delta 0.4531 ms/pass (3.21 us/read, 68.9% of the baseline)
+;;   reader-membership (c-local - c-noreaders): delta 0.0219 ms/pass (0.16 us/read, 3.3% of the baseline)
+;;   cell-map-insert (c-local - c-nomap): delta 0.0625 ms/pass (0.44 us/read, 9.5% of the baseline)
+;;   b-build (build+compute, no in-window dispose): 0.4953 ms/pass (3.51 us/read)
+;; HICASSO read-profile-micro
+{:subscribe-once 4361.7021, :compute-sub 921.9858, :handler-invoke 191.4894, :registrar-lookup 63.8298, :frame-state-value 273.0496, :resolution-wrap 212.766, :cache-peek-miss 24.8227, :sub-key-mint 17.7305}
+;; ==== MICRO (ns/op over the page's own roster) ====
+;;   subscribe-once: 4361.7 ns
+;;   compute-sub: 922.0 ns
+;;   handler-invoke: 191.5 ns
+;;   registrar-lookup: 63.8 ns
+;;   frame-state-value: 273.0 ns
+;;   resolution-wrap: 212.8 ns
+;;   cache-peek-miss: 24.8 ns
+;;   sub-key-mint: 17.7 ns
+;; HICASSO DONE
+;; ==== HICASSO RUNTIME ====
+;; chromium 147.0.7727.15 (playwright), :advanced, goog.DEBUG false
+;; ==== HICASSO read-profile-census ====
+{:reads 141, :distinct 141, :by-sub-id {:conduit/your-feed? 1, :conduit/slugs 1, :conduit/tags 1, :conduit/article 69, :conduit/favorite-pending? 69}, :input-kinds {:db 141}}
+;; ==== HICASSO read-profile-arms ====
+{:ship {:n 60, :min 0.2, :max 0.6625, :p50 0.275}, :local {:n 60, :min 0.45, :max 0.95, :p50 0.525}, :no-shell {:n 60, :min 0.3875, :max 0.825, :p50 0.5062}, :probe {:n 60, :min 0.2, :max 0.4375, :p50 0.2438}, :probe-fresh {:n 60, :min 0.0875, :max 0.175, :p50 0.1125}, :floor {:n 60, :min 0.0125, :max 0.05, :p50 0.025}, :warm {:n 60, :min 0.0375, :max 0.1125, :p50 0.05}, :ctl2 {:n 60, :min 0.85, :max 1.5625, :p50 1.0188}}
+;; ==== HICASSO read-profile-commit ====
+{:c-local {:n 64, :min 0.4906, :max 0.7906, :p50 0.6578}, :c-noreaders {:n 64, :min 0.5313, :max 0.8406, :p50 0.6359}, :c-noactivate {:n 64, :min 0.4719, :max 0.7781, :p50 0.6141}, :c-null {:n 64, :min 0.4813, :max 0.8969, :p50 0.6359}, :c-nowatch {:n 64, :min 0.4562, :max 0.7937, :p50 0.5906}, :commit {:n 64, :min 0.5125, :max 0.9125, :p50 0.6937}, :c-nomap {:n 64, :min 0.4438, :max 0.7625, :p50 0.5953}, :b-build {:n 64, :min 0.3656, :max 0.7344, :p50 0.4953}, :c-nosub {:n 64, :min 0.1656, :max 0.3469, :p50 0.2047}}
+;; ==== HICASSO read-profile-commit-per-round ====
+{:c-local [0.5203 0.6562 0.6938 0.6469 0.6594 0.6484 0.6859 0.6328], :c-noreaders [0.7 0.6375 0.7109 0.6437 0.6688 0.6328 0.5953 0.5844], :c-noactivate [0.5578 0.6062 0.6141 0.6141 0.6578 0.6172 0.6172 0.5922], :c-null [0.625 0.6344 0.6594 0.6328 0.65 0.6406 0.5844 0.6219], :c-nowatch [0.5406 0.5813 0.5844 0.6344 0.6094 0.5844 0.5938 0.5906], :commit [0.7031 0.6578 0.7422 0.7281 0.6969 0.6906 0.6797 0.6578], :c-nomap [0.6141 0.5672 0.6063 0.6016 0.5828 0.625 0.5859 0.6047], :b-build [0.5578 0.4531 0.5109 0.5844 0.4781 0.4984 0.4922 0.4266], :c-nosub [0.2531 0.2406 0.2188 0.2422 0.1953 0.1953 0.1734 0.2078]}
+;; ==== HICASSO read-profile-commit-per-round-deltas ====
+{:c-null [-0.1047 0.0218 0.0344 0.0141 0.0094 0.0078 0.1015 0.0109], :c-noactivate [-0.0375 0.05 0.0797 0.0328 0.0016 0.0312 0.0687 0.0406], :c-nowatch [-0.0203 0.0749 0.1094 0.0125 0.05 0.064 0.0921 0.0422], :c-nosub [0.2672 0.4156 0.475 0.4047 0.4641 0.4531 0.5125 0.425], :c-noreaders [-0.1797 0.0187 -0.0171 0.0032 -0.0094 0.0156 0.0906 0.0484], :c-nomap [-0.0938 0.089 0.0875 0.0453 0.0766 0.0234 0.1 0.0281]}
+;; ==== HICASSO read-profile-micro ====
+{:subscribe-once 4361.7021, :compute-sub 921.9858, :handler-invoke 191.4894, :registrar-lookup 63.8298, :frame-state-value 273.0496, :resolution-wrap 212.766, :cache-peek-miss 24.8227, :sub-key-mint 17.7305}
+[hicasso] ok

--- a/implementation/hicasso/test/re_frame/bench/hicasso/data/readprofile-3l6hf/run3.txt
+++ b/implementation/hicasso/test/re_frame/bench/hicasso/data/readprofile-3l6hf/run3.txt
@@ -1,0 +1,223 @@
+[hicasso] cleared .shadow-cljs/builds/hicasso-bench — one build id, N arms (rf2-2rtt6.20)
+[hicasso] building :advanced bundle — re-frame.bench.hicasso.read-profile-app/-main -> out/hicasso-readprof
+[:hicasso-bench] Compiling ...
+[:hicasso-bench] Build completed. (187 files, 132 compiled, 0 warnings, 19.49s)
+shadow-cljs - config: <worktree>/implementation/shadow-cljs.edn   [PATH REDACTED — see README.md]
+;; order-guard ok   the recorded 2.01x is REFUSED  — ratio 2.0125
+;; order-guard ok   the same study's uncontaminated slope passes  — forward 2830.7 / reversed 2842.8
+;; order-guard ok   a single-order result is refused as UNCHECKED  — only 1 stratum — the question was never asked
+;; order-guard ok   overlapping ranges are indistinguishable even 20% apart in median  — medians 1.2000x apart but the ranges OVERLAP — indistinguishable
+;; order-guard ok   the measured warm-up step is caught by PHASE, which no reversal would show  — phase: FIRST-THIRD reads 1.2633x LAST-THIRD, ranges disjoint
+;; order-guard ok   an arm that reads exactly zero in both strata is indistinguishable, not infinite  — within 10%
+;; order-guard ok   cyclic rotation gives every arm exactly ONE within-round predecessor  — rotation over 6 rounds: distinct predecessors per arm 1,1,1,1 (only the round seam ever differs, and that is one sample in R)
+;; order-guard ok   the reflecting schedule gives every arm TWO, in balance  — reflected: 2,2,2,2 predecessors per arm, largest modal share 50%
+;; order-guard ok   at k=2 an ALWAYS-reflecting schedule runs one order for ever and is UNCHECKED  — always-reflect over 6 rounds of 2 arms: 1 distinct order(s), predecessors per arm 2,1 — rotating a pair by one IS reversing it, so the two cancel
+;; order-guard ok   at k=2 slot-order alternates, and every arm gets TWO predecessors in balance  — slot-order: 2 distinct orders, predecessors per arm 3,2, largest modal share 50%
+;; order-guard ok   samples whose :position went NON-FINITE refuse instead of narrowing the question  — 18 of 24 samples have NO USABLE :position (nil, absent or non-finite) in a run that records them — the harness lost them, so this contrast is over the rest and the sample count above is not it
+;; order-guard ok   a present-but-NIL :position is the same loss, and recording NONE is still excused  — 18 of 24 samples have NO USABLE :position (nil, absent or non-finite) in a run that records them — the harness lost them, so this contrast is over the rest and the sample count above is not it — and a run offering no position at all is excused, not refused
+;; harvest OK — 1202 elements, 141 reads (141 distinct), from the real page's own entry
+;; ==== ARM-ORDER GUARD — read-profile phase A (in-page ms, diagnostic) ====
+;;   every arm partitioned by WHAT RAN BEFORE IT and by WHERE IN THE RUN it was measured; tolerance 10%, overlapping ranges are indistinguishable
+;;   ctl2  (60 samples)
+;;     [ok  ] by predecessor  within 10%
+;;              ship                     n=30  p50       8.9000  [7.5000–10.5000]
+;;              warm                     n=30  p50       8.9000  [7.3000–10.7000]
+;;     [ok  ] by phase        within 10%
+;;              FIRST-THIRD              n=20  p50       8.9000  [7.7000–10.7000]
+;;              LAST-THIRD               n=20  p50       9.2000  [8.6000–10.4000]
+;;   floor  (60 samples)
+;;     [ok  ] by predecessor  within 10%
+;;              probe-fresh              n=30  p50       0.2000  [0.1000–0.4000]
+;;              warm                     n=30  p50       0.2000  [0.1000–0.6000]
+;;     [ok  ] by phase        within 10%
+;;              FIRST-THIRD              n=20  p50       0.2000  [0.1000–0.3000]
+;;              LAST-THIRD               n=20  p50       0.2000  [0.1000–0.6000]
+;;   local  (60 samples)
+;;     [ok  ] by predecessor  within 10%
+;;              ship                     n=30  p50       4.6000  [3.8000–7.2000]
+;;              no-shell                 n=30  p50       4.6000  [3.7000–5.3000]
+;;     [ok  ] by phase        within 10%
+;;              FIRST-THIRD              n=20  p50       4.6500  [3.9000–5.6000]
+;;              LAST-THIRD               n=20  p50       4.7000  [4.3000–5.3000]
+;;   no-shell  (60 samples)
+;;     [ok  ] by predecessor  within 10%
+;;              probe                    n=24  p50       4.3000  [3.5000–4.8000]
+;;              local                    n=36  p50       4.5500  [3.6000–9.9000]
+;;     [ok  ] by phase        within 10%
+;;              FIRST-THIRD              n=20  p50       4.3500  [3.5000–5.4000]
+;;              LAST-THIRD               n=20  p50       4.6000  [4.0000–5.2000]
+;;   probe  (60 samples)
+;;     [ok  ] by predecessor  within 10%
+;;              no-shell                 n=30  p50       2.0000  [1.6000–3.9000]
+;;              probe-fresh              n=30  p50       2.0000  [1.7000–3.8000]
+;;     [ok  ] by phase        within 10%
+;;              LAST-THIRD               n=20  p50       2.0500  [1.8000–3.8000]
+;;              FIRST-THIRD              n=20  p50       2.1000  [1.7000–3.9000]
+;;   probe-fresh  (60 samples)
+;;     [ok  ] by predecessor  within 10%
+;;              <none>                   n= 1  p50       1.0000  [1.0000–1.0000]
+;;              probe                    n=36  p50       1.0000  [0.8000–2.1000]
+;;              floor                    n=23  p50       1.1000  [0.8000–1.7000]
+;;     [ok  ] by phase        within 10%
+;;              LAST-THIRD               n=20  p50       1.1000  [0.8000–1.4000]
+;;              FIRST-THIRD              n=20  p50       1.1000  [0.8000–2.1000]
+;;   ship  (60 samples)
+;;     [ok  ] by predecessor  within 10%
+;;              ctl2                     n=36  p50       2.2000  [1.8000–3.6000]
+;;              local                    n=24  p50       2.3000  [1.8000–2.8000]
+;;     [ok  ] by phase        within 10%
+;;              LAST-THIRD               n=20  p50       2.3500  [2.0000–2.8000]
+;;              FIRST-THIRD              n=20  p50       2.4000  [1.8000–3.6000]
+;;   warm  (60 samples)
+;;     [ok  ] by predecessor  medians 1.2500x apart but the ranges OVERLAP — indistinguishable
+;;              floor                    n=36  p50       0.4000  [0.3000–0.8000]
+;;              ctl2                     n=24  p50       0.5000  [0.3000–1.0000]
+;;     [ok  ] by phase        within 10%
+;;              FIRST-THIRD              n=20  p50       0.5000  [0.4000–0.8000]
+;;              LAST-THIRD               n=20  p50       0.5000  [0.3000–1.0000]
+;;   VERDICT: reportable — no arm reads differently for its position in the plan
+;; HICASSO read-profile-census
+{:reads 141, :distinct 141, :by-sub-id {:conduit/your-feed? 1, :conduit/slugs 1, :conduit/tags 1, :conduit/article 69, :conduit/favorite-pending? 69}, :input-kinds {:db 141}}
+;; HICASSO read-profile-arms
+{:ship {:n 60, :min 0.225, :max 0.45, :p50 0.2813}, :local {:n 60, :min 0.4625, :max 0.9, :p50 0.575}, :no-shell {:n 60, :min 0.4375, :max 1.2375, :p50 0.5437}, :probe {:n 60, :min 0.2, :max 0.4875, :p50 0.25}, :probe-fresh {:n 60, :min 0.1, :max 0.2625, :p50 0.1312}, :floor {:n 60, :min 0.0125, :max 0.075, :p50 0.025}, :warm {:n 60, :min 0.0375, :max 0.125, :p50 0.0625}, :ctl2 {:n 60, :min 0.9125, :max 1.3375, :p50 1.1125}}
+;; ==== READ PROFILE, PHASE A (ms per 141-read pass; diagnostic in-page clock) ====
+;;   reads/pass 141  passes/sample 8  design 6x(4+10)
+;;   ship: p50 0.2813 [0.2250 - 0.4500] ms/pass  (1.99 us/read)
+;;   local: p50 0.5750 [0.4625 - 0.9000] ms/pass  (4.08 us/read)
+;;   no-shell: p50 0.5437 [0.4375 - 1.2375] ms/pass  (3.86 us/read)
+;;   probe: p50 0.2500 [0.2000 - 0.4875] ms/pass  (1.77 us/read)
+;;   probe-fresh: p50 0.1312 [0.1000 - 0.2625] ms/pass  (0.93 us/read)
+;;   floor: p50 0.0250 [0.0125 - 0.0750] ms/pass  (0.18 us/read)
+;;   warm: p50 0.0625 [0.0375 - 0.1250] ms/pass  (0.44 us/read)
+;;   ctl2: p50 1.1125 [0.9125 - 1.3375] ms/pass  (7.89 us/read)
+;; ==== PHASE A DELTAS (floors; stubs stated in the ns docstring) ====
+;;   copy fidelity: local/ship = 2.0444  (local is the FROZEN subscribe-once path)
+;;   the-hicasso-shell (local - no-shell): delta 0.0313 ms/pass (0.22 us/read, 5.4% of the baseline)
+;;   churn-vs-probe (local - probe, the candidate's saving): delta 0.3250 ms/pass (2.30 us/read, 56.5% of the baseline)
+;;   memo-economy (probe-fresh - probe): delta -0.1188 ms/pass (-0.84 us/read, -90.5% of the baseline)
+;;   probe-overhead (probe - floor): delta 0.2250 ms/pass (1.60 us/read, 90.0% of the baseline)
+;;   warm steady-state: 0.0625 ms/pass (0.44 us/read)
+;;   control: predicted 1.087x, measured 1.113x [0.912–1.338] — the range meets the prediction within ±25%
+;; ==== ARM-ORDER GUARD — read-profile phase B (in-page ms, diagnostic) ====
+;;   every arm partitioned by WHAT RAN BEFORE IT and by WHERE IN THE RUN it was measured; tolerance 10%, overlapping ranges are indistinguishable
+;;   b-build  (64 samples)
+;;     [ok  ] by predecessor  medians 1.1642x apart but the ranges OVERLAP — indistinguishable
+;;              c-nomap                  n=40  p50      16.7500  [12.2000–26.3000]
+;;              commit                   n=24  p50      19.5000  [12.8000–27.5000]
+;;     [ok  ] by phase        medians 1.1515x apart but the ranges OVERLAP — indistinguishable
+;;              FIRST-THIRD              n=21  p50      16.5000  [12.8000–27.5000]
+;;              LAST-THIRD               n=21  p50      19.0000  [15.4000–22.9000]
+;;   c-local  (64 samples)
+;;     [ok  ] by predecessor  within 10%
+;;              c-null                   n=32  p50      22.8000  [18.3000–36.3000]
+;;              commit                   n=32  p50      25.0000  [19.1000–32.4000]
+;;     [ok  ] by phase        medians 1.2995x apart but the ranges OVERLAP — indistinguishable
+;;              FIRST-THIRD              n=21  p50      21.7000  [19.1000–32.4000]
+;;              LAST-THIRD               n=21  p50      28.2000  [19.1000–31.5000]
+;;   c-noactivate  (64 samples)
+;;     [ok  ] by predecessor  within 10%
+;;              c-null                   n=32  p50      21.9000  [17.2000–39.0000]
+;;              c-nowatch                n=32  p50      22.1000  [16.7000–29.8000]
+;;     [ok  ] by phase        within 10%
+;;              FIRST-THIRD              n=21  p50      22.0000  [18.2000–29.4000]
+;;              LAST-THIRD               n=21  p50      23.9000  [19.3000–29.8000]
+;;   c-nomap  (64 samples)
+;;     [ok  ] by predecessor  within 10%
+;;              c-noreaders              n=32  p50      21.0000  [15.8000–41.0000]
+;;              b-build                  n=32  p50      22.5500  [16.1000–29.8000]
+;;     [ok  ] by phase        medians 1.1208x apart but the ranges OVERLAP — indistinguishable
+;;              FIRST-THIRD              n=21  p50      20.7000  [16.1000–24.7000]
+;;              LAST-THIRD               n=21  p50      23.2000  [15.8000–28.9000]
+;;   c-noreaders  (64 samples)
+;;     [ok  ] by predecessor  within 10%
+;;              c-nosub                  n=40  p50      21.4000  [15.9000–33.3000]
+;;              c-nomap                  n=24  p50      22.7000  [18.7000–30.9000]
+;;     [ok  ] by phase        medians 1.2857x apart but the ranges OVERLAP — indistinguishable
+;;              FIRST-THIRD              n=21  p50      21.0000  [18.0000–24.6000]
+;;              LAST-THIRD               n=21  p50      27.0000  [16.3000–30.9000]
+;;   c-nosub  (64 samples)
+;;     [ok  ] by predecessor  within 10%
+;;              c-noreaders              n=32  p50       7.4500  [5.7000–12.3000]
+;;              c-nowatch                n=32  p50       7.7500  [5.7000–10.5000]
+;;     [ok  ] by phase        medians 1.2329x apart but the ranges OVERLAP — indistinguishable
+;;              FIRST-THIRD              n=21  p50       7.3000  [5.7000–12.3000]
+;;              LAST-THIRD               n=21  p50       9.0000  [5.7000–10.8000]
+;;   c-nowatch  (64 samples)
+;;     [ok  ] by predecessor  within 10%
+;;              c-nosub                  n=24  p50      20.3000  [16.8000–33.2000]
+;;              c-noactivate             n=40  p50      20.7500  [16.7000–34.1000]
+;;     [ok  ] by phase        medians 1.2587x apart but the ranges OVERLAP — indistinguishable
+;;              FIRST-THIRD              n=21  p50      20.1000  [17.7000–34.1000]
+;;              LAST-THIRD               n=21  p50      25.3000  [17.2000–28.6000]
+;;   c-null  (64 samples)
+;;     [ok  ] by predecessor  within 10%
+;;              <none>                   n= 1  p50      21.5000  [21.5000–21.5000]
+;;              commit                   n= 7  p50      21.8000  [21.1000–30.7000]
+;;              c-noactivate             n=24  p50      22.3500  [18.7000–33.6000]
+;;              c-local                  n=32  p50      23.0500  [17.3000–33.3000]
+;;     [ok  ] by phase        medians 1.1963x apart but the ranges OVERLAP — indistinguishable
+;;              FIRST-THIRD              n=21  p50      21.9000  [18.7000–28.4000]
+;;              LAST-THIRD               n=21  p50      26.2000  [19.4000–33.3000]
+;;   commit  (64 samples)
+;;     [ok  ] by predecessor  medians 1.1032x apart but the ranges OVERLAP — indistinguishable
+;;              c-local                  n=32  p50      23.2500  [17.7000–37.8000]
+;;              b-build                  n=32  p50      25.6500  [19.5000–34.1000]
+;;     [ok  ] by phase        medians 1.2906x apart but the ranges OVERLAP — indistinguishable
+;;              FIRST-THIRD              n=21  p50      23.4000  [19.5000–29.9000]
+;;              LAST-THIRD               n=21  p50      30.2000  [17.7000–34.2000]
+;;   VERDICT: reportable — no arm reads differently for its position in the plan
+;; HICASSO read-profile-commit
+{:c-local {:n 64, :min 0.5719, :max 1.1344, :p50 0.7219}, :c-noreaders {:n 64, :min 0.4969, :max 1.0406, :p50 0.6859}, :c-noactivate {:n 64, :min 0.5219, :max 1.2188, :p50 0.6875}, :c-null {:n 64, :min 0.5406, :max 1.05, :p50 0.6984}, :c-nowatch {:n 64, :min 0.5219, :max 1.0656, :p50 0.6375}, :commit {:n 64, :min 0.5531, :max 1.1813, :p50 0.7859}, :c-nomap {:n 64, :min 0.4938, :max 1.2813, :p50 0.6687}, :b-build {:n 64, :min 0.3812, :max 0.8594, :p50 0.5313}, :c-nosub {:n 64, :min 0.1781, :max 0.3844, :p50 0.2344}}
+;; HICASSO read-profile-commit-per-round
+{:c-local [0.6703 0.6922 0.6875 0.7047 0.8281 0.8984 0.8984 0.6922], :c-noreaders [0.6828 0.6141 0.6641 0.6484 0.6609 0.8641 0.8797 0.6797], :c-noactivate [0.6859 0.7234 0.6484 0.6422 0.6781 0.8438 0.8641 0.6281], :c-null [0.6984 0.6781 0.6688 0.6297 0.6703 0.8063 0.9109 0.7109], :c-nowatch [0.6391 0.6031 0.5906 0.6188 0.6359 0.8406 0.8125 0.6281], :commit [0.7484 0.7063 0.7109 0.6922 0.9484 0.9984 0.9766 0.7391], :c-nomap [0.6609 0.6422 0.6281 0.5844 0.7047 0.8344 0.7984 0.6797], :b-build [0.5344 0.5 0.5094 0.475 0.6031 0.7031 0.65 0.5344], :c-nosub [0.2281 0.2672 0.2141 0.2688 0.2297 0.2953 0.3062 0.2297]}
+;; HICASSO read-profile-commit-per-round-deltas
+{:c-null [-0.0281 0.0141 0.0187 0.075 0.1578 0.0921 -0.0125 -0.0187], :c-noactivate [-0.0156 -0.0312 0.0391 0.0625 0.15 0.0546 0.0343 0.0641], :c-nowatch [0.0312 0.0891 0.0969 0.0859 0.1922 0.0578 0.0859 0.0641], :c-nosub [0.4422 0.425 0.4734 0.4359 0.5984 0.6031 0.5922 0.4625], :c-noreaders [-0.0125 0.0781 0.0234 0.0563 0.1672 0.0343 0.0187 0.0125], :c-nomap [0.0094 0.05 0.0594 0.1203 0.1234 0.064 0.1 0.0125]}
+;; ==== READ PROFILE, PHASE B — THE COMMIT HALF (ms per 141-key boundary commit) ====
+;;   design 8x(2+8)  window = 32 frames/commit each  kept = 64 samples/arm (EVEN — p50 is the mean of two middle clock readings)  grid = 0.001563 ms/commit
+;;   commit: p50 0.7859 [0.5531 - 1.1813] ms/pass  (5.57 us/read)
+;;   c-local: p50 0.7219 [0.5719 - 1.1344] ms/pass  (5.12 us/read)
+;;   c-null: p50 0.6984 [0.5406 - 1.0500] ms/pass  (4.95 us/read)
+;;   c-noactivate: p50 0.6875 [0.5219 - 1.2188] ms/pass  (4.88 us/read)
+;;   c-nowatch: p50 0.6375 [0.5219 - 1.0656] ms/pass  (4.52 us/read)
+;;   c-nosub: p50 0.2344 [0.1781 - 0.3844] ms/pass  (1.66 us/read)
+;;   c-noreaders: p50 0.6859 [0.4969 - 1.0406] ms/pass  (4.86 us/read)
+;;   c-nomap: p50 0.6687 [0.4938 - 1.2813] ms/pass  (4.74 us/read)
+;;   b-build: p50 0.5313 [0.3812 - 0.8594] ms/pass  (3.77 us/read)
+;; ==== PHASE B DELTAS (c-local minus ablation; floors) ====
+;;   copy fidelity: c-local/commit = 0.9185
+;;   NULL CONTROL (c-local - c-null): delta 0.0234 ms/pass (0.17 us/read, 3.2% of the baseline)
+;;     ^ true cost EXACTLY ZERO by construction — both arms are C-FULL. What it reads is this instrument's own error at this shape, and it is what the terms below are adjudicated against (rf2-3l6hf). It bounds no term's cost: a delta inside this spread is a term the window cannot SEE, which leaves its size open in both directions
+;;   activation-capture (c-local - c-noactivate): delta 0.0344 ms/pass (0.24 us/read, 4.8% of the baseline)
+;;     ^ a REAL term here, NOT a floor and not an arbiter: nothing activates on this UIx host, but the hook key is never published and so never cached, and this prices that lookup (rf2-tcffa, rf2-19usn). The capture itself is real only under the ratom family (rf2-lzpfj)
+;;   watch-wiring (c-local - c-nowatch): delta 0.0844 ms/pass (0.60 us/read, 11.7% of the baseline)
+;;   reaction-build+cache-insert (c-local - c-nosub): delta 0.4875 ms/pass (3.46 us/read, 67.5% of the baseline)
+;;   reader-membership (c-local - c-noreaders): delta 0.0359 ms/pass (0.25 us/read, 5.0% of the baseline)
+;;   cell-map-insert (c-local - c-nomap): delta 0.0531 ms/pass (0.38 us/read, 7.4% of the baseline)
+;;   b-build (build+compute, no in-window dispose): 0.5313 ms/pass (3.77 us/read)
+;; HICASSO read-profile-micro
+{:subscribe-once 5744.6808, :compute-sub 1099.2908, :handler-invoke 262.4113, :registrar-lookup 88.6525, :frame-state-value 333.3333, :resolution-wrap 283.6879, :cache-peek-miss 31.9149, :sub-key-mint 39.0071}
+;; ==== MICRO (ns/op over the page's own roster) ====
+;;   subscribe-once: 5744.7 ns
+;;   compute-sub: 1099.3 ns
+;;   handler-invoke: 262.4 ns
+;;   registrar-lookup: 88.7 ns
+;;   frame-state-value: 333.3 ns
+;;   resolution-wrap: 283.7 ns
+;;   cache-peek-miss: 31.9 ns
+;;   sub-key-mint: 39.0 ns
+;; HICASSO DONE
+;; ==== HICASSO RUNTIME ====
+;; chromium 147.0.7727.15 (playwright), :advanced, goog.DEBUG false
+;; ==== HICASSO read-profile-census ====
+{:reads 141, :distinct 141, :by-sub-id {:conduit/your-feed? 1, :conduit/slugs 1, :conduit/tags 1, :conduit/article 69, :conduit/favorite-pending? 69}, :input-kinds {:db 141}}
+;; ==== HICASSO read-profile-arms ====
+{:ship {:n 60, :min 0.225, :max 0.45, :p50 0.2813}, :local {:n 60, :min 0.4625, :max 0.9, :p50 0.575}, :no-shell {:n 60, :min 0.4375, :max 1.2375, :p50 0.5437}, :probe {:n 60, :min 0.2, :max 0.4875, :p50 0.25}, :probe-fresh {:n 60, :min 0.1, :max 0.2625, :p50 0.1312}, :floor {:n 60, :min 0.0125, :max 0.075, :p50 0.025}, :warm {:n 60, :min 0.0375, :max 0.125, :p50 0.0625}, :ctl2 {:n 60, :min 0.9125, :max 1.3375, :p50 1.1125}}
+;; ==== HICASSO read-profile-commit ====
+{:c-local {:n 64, :min 0.5719, :max 1.1344, :p50 0.7219}, :c-noreaders {:n 64, :min 0.4969, :max 1.0406, :p50 0.6859}, :c-noactivate {:n 64, :min 0.5219, :max 1.2188, :p50 0.6875}, :c-null {:n 64, :min 0.5406, :max 1.05, :p50 0.6984}, :c-nowatch {:n 64, :min 0.5219, :max 1.0656, :p50 0.6375}, :commit {:n 64, :min 0.5531, :max 1.1813, :p50 0.7859}, :c-nomap {:n 64, :min 0.4938, :max 1.2813, :p50 0.6687}, :b-build {:n 64, :min 0.3812, :max 0.8594, :p50 0.5313}, :c-nosub {:n 64, :min 0.1781, :max 0.3844, :p50 0.2344}}
+;; ==== HICASSO read-profile-commit-per-round ====
+{:c-local [0.6703 0.6922 0.6875 0.7047 0.8281 0.8984 0.8984 0.6922], :c-noreaders [0.6828 0.6141 0.6641 0.6484 0.6609 0.8641 0.8797 0.6797], :c-noactivate [0.6859 0.7234 0.6484 0.6422 0.6781 0.8438 0.8641 0.6281], :c-null [0.6984 0.6781 0.6688 0.6297 0.6703 0.8063 0.9109 0.7109], :c-nowatch [0.6391 0.6031 0.5906 0.6188 0.6359 0.8406 0.8125 0.6281], :commit [0.7484 0.7063 0.7109 0.6922 0.9484 0.9984 0.9766 0.7391], :c-nomap [0.6609 0.6422 0.6281 0.5844 0.7047 0.8344 0.7984 0.6797], :b-build [0.5344 0.5 0.5094 0.475 0.6031 0.7031 0.65 0.5344], :c-nosub [0.2281 0.2672 0.2141 0.2688 0.2297 0.2953 0.3062 0.2297]}
+;; ==== HICASSO read-profile-commit-per-round-deltas ====
+{:c-null [-0.0281 0.0141 0.0187 0.075 0.1578 0.0921 -0.0125 -0.0187], :c-noactivate [-0.0156 -0.0312 0.0391 0.0625 0.15 0.0546 0.0343 0.0641], :c-nowatch [0.0312 0.0891 0.0969 0.0859 0.1922 0.0578 0.0859 0.0641], :c-nosub [0.4422 0.425 0.4734 0.4359 0.5984 0.6031 0.5922 0.4625], :c-noreaders [-0.0125 0.0781 0.0234 0.0563 0.1672 0.0343 0.0187 0.0125], :c-nomap [0.0094 0.05 0.0594 0.1203 0.1234 0.064 0.1 0.0125]}
+;; ==== HICASSO read-profile-micro ====
+{:subscribe-once 5744.6808, :compute-sub 1099.2908, :handler-invoke 262.4113, :registrar-lookup 88.6525, :frame-state-value 333.3333, :resolution-wrap 283.6879, :cache-peek-miss 31.9149, :sub-key-mint 39.0071}
+[hicasso] ok

--- a/implementation/hicasso/test/re_frame/bench/hicasso/read_profile_app.cljs
+++ b/implementation/hicasso/test/re_frame/bench/hicasso/read_profile_app.cljs
@@ -93,6 +93,7 @@
   |-------------|---------------------------------------------------|----------------|
   | `commit`    | [[frames-per-window]] frames x `rt/commit-boundary!` on the harvested entry | the shipping commit half |
   | `c-local`   | faithful copy: cell mint + subscribe + activation + baseline deref + watch + dispose hook + map insert + reader membership | the ablation baseline, validated against `commit` |
+  | `c-null`    | `c-local` with NOTHING ablated — the same `C-FULL` mode, under a second id | THE NEGATIVE CONTROL: `c-local - c-null` has a true cost of exactly zero, so what it reads is the instrument's own error and nothing else (rf2-3l6hf) |
   | `c-noactivate` | `c-local` minus `interop/activate-derived-value!` | ON THIS HOST the uncached hook resolution, a real term (rf2-tcffa); the substrate's capture run under a ratom host (rf2-lzpfj) |
   | `c-nowatch` | `c-local` minus add-watch + the disposal hook     | the watch wiring |
   | `c-nosub`   | `c-local` with `compute-sub` in place of subscribe + deref | the reaction build + cache insert (the compute is kept, priced by the swap) |
@@ -136,14 +137,26 @@
   beside them as the price of one unpublishable hook resolution per key. What
   it cannot do is arbitrate whether the window is wide enough, which is the
   job [[frames-per-window]] gave it and which that docstring now withdraws.
-  **No measured null exists on this instrument.** The arithmetic-impossibility
-  residual is not one either: `c-noreaders` has an unknown positive true cost,
-  so a negative reading of it establishes neither a symmetric error band nor
-  any bound on the term, and the `< 0.006 ms/commit` figure once floated for
-  reader membership is withdrawn. Reader membership is simply UNRESOLVED at
-  this window. A genuine negative control — an arm ablating nothing at all —
-  has to be added deliberately; coordinate one with rf2-3l6hf rather than
-  promoting an existing arm into the role.
+  The arithmetic-impossibility residual cannot do it either: `c-noreaders` has
+  an unknown positive true cost, so a negative reading of it establishes
+  neither a symmetric error band nor any bound on the term, and the
+  `< 0.006 ms/commit` figure once floated for reader membership is withdrawn.
+
+  ## The measured null, which is what arbitrates
+
+  **[[c-null]] is the negative control this instrument lacked** (rf2-3l6hf).
+  It is `c-local` again — the same `C-FULL` mode, the same work, a second id —
+  so `c-local - c-null` has a true cost of EXACTLY ZERO by construction, and
+  every millisecond it reads is the estimator's own error at this shape, on
+  this box, against a pair of arms of this size. That is the one quantity the
+  ablation deltas needed and could not supply themselves.
+
+  **Read what it licenses and not one step more.** It measures THE
+  INSTRUMENT, so it says whether a term is distinguishable from zero here. It
+  does NOT bound any term's true cost: an ablation delta that lands inside the
+  null's spread is a term this window cannot see, which leaves its size open
+  in both directions. Promoting a null spread into an upper bound on a cost is
+  the same error as the withdrawn `< 0.006`, one layer further back.
 
   The arm still earns its place, because the term is NOT a no-op under the
   ratom family, where a `Reaction` learns its sources only
@@ -185,15 +198,28 @@
   "How many identically-seeded frames ONE phase-B window commits
   (rf2-3l6hf). It was 4, and 4 could not decompose the commit half.
 
-  **A window's resolution is set here and nowhere else, because the
-  reported statistic is a p50.** `lane/now-ms` is `performance.now`,
-  which Chrome clamps to 100 µs, so every raw window reading is a
-  multiple of 0.1 ms; [[lane/summarise]] takes the mean of the two middle
-  order statistics on an even sample count, which halves that to 0.05 ms;
-  and the row divides by the frame count. The grid a phase-B delta can
-  land on is therefore exactly `0.05 / frames-per-window` ms/commit — at
-  4 frames, 0.0125, which is precisely the spacing every delta rf2-d360z
-  published turned out to be a multiple of.
+  **A window's resolution is set here and by the KEPT SAMPLE COUNT'S
+  PARITY, because the reported statistic is a p50.** `lane/now-ms` is
+  `performance.now`, which Chrome clamps to 100 µs, so every raw window
+  reading is a multiple of 0.1 ms; [[lane/summarise]] takes the mean of
+  the two middle order statistics on an EVEN sample count, which halves
+  that to 0.05 ms, and a single order statistic on an ODD one, which does
+  not halve it at all; and the row divides by the frame count. So the
+  grid a phase-B delta can land on is `0.05 / frames-per-window` at even
+  parity and `0.1 / frames-per-window` at odd — at 4 frames and the even
+  parity of the day, 0.0125, which is precisely the spacing every delta
+  rf2-d360z published turned out to be a multiple of.
+
+  **The frame count is the only knob you would REACH for, and it is not
+  the only one that moves the grid.** This docstring claimed resolution
+  was set HERE AND NOWHERE ELSE; [[b-rounds]] and [[b-sampling]] are
+  separate vars, no contract holds their product even, and an odd kept
+  total would double the grid under a design line still printing the
+  halved one (merged-PR audit of #8328). [[phase-b-grid-ms]] therefore
+  DERIVES the grid from the parity rather than asserting a constant, and
+  [[phase-b-design-line]] prints what it derives, so the two can no
+  longer disagree. `read-profile-grid-cljs-test` pins that by driving the
+  design line at both parities.
 
   **More SAMPLES cannot move that grid.** A median of quantised readings
   is itself a grid value whatever the sample count; more samples make the
@@ -212,21 +238,26 @@
   reads, still 200x the clock's own quantum, and the run stays under a
   minute of sampling.
 
-  **This window has no arbiter, and `c-noactivate` is not one** (rf2-tcffa).
-  This docstring gave that arm the job on the ground that it ablates a routed
-  no-op and so reads the instrument's own floor. It does not: the call it
-  ablates resolves a hook key that is never published on this host and so can
-  never be cached, which is real work — rf2-07rnj's runs read the arm LARGER
-  than the cell-map insert in two of three. The namespace docstring carries
-  the mechanism. Nor does the arithmetic-impossibility residual serve as a
-  floor: `c-noreaders` has an unknown positive true cost, so a negative
-  reading of it bounds nothing.
+  **`c-noactivate` is not this window's arbiter** (rf2-tcffa). This docstring
+  gave that arm the job on the ground that it ablates a routed no-op and so
+  reads the instrument's own floor. It does not: the call it ablates resolves
+  a hook key that is never published on this host and so can never be cached,
+  which is real work — rf2-07rnj's runs read the arm LARGER than the cell-map
+  insert in two of three. The namespace docstring carries the mechanism. Nor
+  does the arithmetic-impossibility residual serve as a floor: `c-noreaders`
+  has an unknown positive true cost, so a negative reading of it bounds
+  nothing.
+
+  **The arbiter is [[c-null]], added by rf2-3l6hf**, and it is an arbiter
+  precisely because its true cost is zero by construction rather than
+  argued to be small. It reads the estimator's error directly, so a term
+  can be adjudicated against a measured null instead of against sign
+  stability alone.
 
   So the case for 32 is the grid arithmetic above and nothing else, and it is
-  a case about RESOLUTION, not about trust in any particular delta. Until a
-  real negative control exists (rf2-3l6hf), a term is credited on sign
-  stability across runs — which is exactly why rf2-07rnj published four terms
-  and refused the fifth."
+  a case about RESOLUTION, not about trust in any particular delta. What the
+  null adds is the other half: resolution says how finely a delta CAN land,
+  the null says how far it wanders when the thing under it is nothing."
   32)
 
 (def commit-frames
@@ -599,6 +630,12 @@
              (mapv (fn [f] (rt/commit-boundary! (get entries f) (fn [] nil)))
                    commit-frames))}
      {:id :c-local   :run (mk-local C-FULL)}
+     ;; The negative control: C-FULL again, so `c-local - c-null` has a
+     ;; true cost of exactly zero and reads the estimator's own error
+     ;; (rf2-3l6hf). It is built from the same `mk-local` as `c-local`
+     ;; rather than transcribed beside it, because a null whose code path
+     ;; could drift from the arm it nulls is not one.
+     {:id :c-null    :run (mk-local C-FULL)}
      {:id :c-noactivate :run (mk-local C-NOACTIVATE)}
      {:id :c-nowatch :run (mk-local C-NOWATCH)}
      {:id :c-nosub   :run (mk-local C-NOSUB)}
@@ -618,6 +655,46 @@
   {:warmup 2 :samples 8})
 
 (def ^:private b-rounds 8)
+
+(defn phase-b-shape
+  "The phase-B window shape as data: `{:rounds :sampling :frames}`.
+
+  ONE authority, read by the design line and by
+  `read-profile-grid-cljs-test`'s live-shape row. A witness that
+  restated the three numbers would go green on the shape it remembered
+  rather than the shape the window runs, which is the same vacuity
+  `read-profile-baseline-cljs-test` was written to avoid."
+  []
+  {:rounds b-rounds :sampling b-sampling :frames frames-per-window})
+
+(def clock-clamp-ms
+  "The quantum of [[lane/now-ms]] on this host: Chrome clamps
+  `performance.now` to 100 µs, so the difference of two readings — which
+  is every raw window sample phase B takes — is a multiple of 0.1 ms."
+  0.1)
+
+(defn phase-b-grid-ms
+  "The grid one phase-B row or delta can land on, in ms/commit, DERIVED
+  from the shape rather than asserted (merged-PR audit of #8328).
+
+  Three steps, and the middle one is the one that was being taken for
+  granted. Raw samples are multiples of [[clock-clamp-ms]].
+  [[lane/summarise]]'s p50 is the MEAN OF THE TWO MIDDLE order statistics
+  when the kept count is even, which puts it on a half-clamp grid, and a
+  SINGLE order statistic when it is odd, which leaves it on the full
+  clamp. The row then divides by the frame count. A delta is a difference
+  of two p50s, so it lands on the same grid either way.
+
+  `rounds` x `:samples` is the kept count, and nothing in this file
+  constrains its parity: [[b-rounds]] and [[b-sampling]] are independent
+  vars, so an editor moving either could halve the instrument's
+  resolution while the design line went on advertising the finer grid.
+  Deriving it here is what stops that — the number printed and the number
+  the arithmetic supports are now one expression."
+  [rounds {:keys [samples]} frames]
+  (let [kept (* rounds samples)]
+    (/ (if (even? kept) (/ clock-clamp-ms 2.0) clock-clamp-ms)
+       frames)))
 
 (defn residue-settle!
   "**The one point behind which every phase-B residue reading is taken** —
@@ -667,18 +744,26 @@
   visits every arm in [[lane/slot-order]]'s order; warm-up samples are
   taken and discarded; between samples the arm's teardowns run, the
   runtime settles behind [[residue-settle!]], and the residue gate must
-  answer clean. Mirrors `lane/rounds!`, which cannot yield."
+  answer clean. Mirrors `lane/rounds!`, which cannot yield.
+
+  **Readings come back BUCKETED BY ROUND**, one map per round, which is
+  what `lane/rounds!` has always answered and what this fn used to
+  flatten into a single bucket. Pooling is unchanged — [[arm-rows]]
+  `mapcat`s the buckets before it summarises, so the published p50 is the
+  same number over the same 64 samples — but the per-round structure now
+  survives into the record, and a published window can be re-adjudicated
+  without being re-taken (rf2-3l6hf)."
   [arms {:keys [warmup samples]} rounds' baseline]
   (let [k    (count arms)
         coll (lane/sample-collector)
-        acc  (atom (zipmap (map :id arms) (repeat [])))]
+        acc  (atom (vec (repeat rounds' (zipmap (map :id arms) (repeat [])))))]
     (-> (lane/chain
           nil
-          (for [_round (range rounds')
-                s      (range (+ warmup samples))
-                j      (lane/slot-order k s)]
-            [s j])
-          (fn [_ [s j]]
+          (for [round (range rounds')
+                s     (range (+ warmup samples))
+                j     (lane/slot-order k s)]
+            [round s j])
+          (fn [_ [round s j]]
             (let [{:keys [id run]} (nth arms j)
                   t0        (lane/now-ms)
                   teardowns (run)
@@ -697,9 +782,9 @@
                                           {:arm id :baseline baseline :residue now})))
                         (when (>= s warmup)
                           (lane/collect! coll (name id) ms)
-                          (swap! acc update id conj ms))
+                          (swap! acc update-in [round id] conj ms))
                         nil)))))))
-        (.then (fn [_] {:readings [@acc] :samples (:samples @coll)})))))
+        (.then (fn [_] {:readings @acc :samples (:samples @coll)})))))
 
 ;; ---------------------------------------------------------------------------
 ;; Micro benches — the per-read primitives
@@ -735,12 +820,64 @@
 
 (defn- fmt [x n] (.toFixed ^number x n))
 
+(defn phase-b-design-line
+  "The `design …` line phase B prints, as a pure fn of the shape, so the
+  parity claim inside it can be witnessed without running a window.
+
+  It prints the kept count, names its parity and says which statistic
+  that parity makes the p50, because the grid is only checkable by a
+  reader who is told all three (merged-PR audit of #8328). The number at
+  the end is [[phase-b-grid-ms]]'s, not a constant standing beside it."
+  [rounds {:keys [warmup samples] :as sampling} frames]
+  (let [kept       (* rounds samples)
+        even-kept? (even? kept)]
+    (str ";;   design " rounds "x(" warmup "+" samples ")"
+         "  window = " frames " frames/commit each"
+         "  kept = " kept " samples/arm (" (if even-kept? "EVEN" "ODD")
+         " — p50 is " (if even-kept?
+                        "the mean of two middle clock readings"
+                        "a single clock reading")
+         ")  grid = " (fmt (phase-b-grid-ms rounds sampling frames) 6)
+         " ms/commit")))
+
 (defn- arm-rows [arm-ids readings per-window]
   (into {}
         (map (fn [id]
                (let [xs (mapcat #(get % id) readings)]
                  [id (lane/summarise (mapv #(/ % per-window) xs))])))
         arm-ids))
+
+(defn- per-round-p50s
+  "`{arm-id [p50-of-round-0 p50-of-round-1 …]}` in ms/commit — the same
+  division by `per-window` [[arm-rows]] performs, applied WITHIN each
+  round instead of across the pool.
+
+  **Recorded so a published window is re-adjudicable without a re-run.**
+  A pooled p50 answers one question and refuses every follow-up: whether
+  a term's sign held round by round, whether one round carried a
+  contaminated span, how far the null control wandered inside a single
+  run. All three were asked of windows that had kept only the pool, and
+  the only way to answer was to take the window again (rf2-3l6hf)."
+  [arm-ids readings per-window]
+  (into {}
+        (map (fn [id]
+               [id (mapv (fn [round]
+                           (lane/round4
+                             (:p50 (lane/summarise
+                                     (mapv #(/ % per-window) (get round id))))))
+                         readings)]))
+        arm-ids))
+
+(defn- per-round-deltas
+  "`c-local - arm`, per round, for each ablation arm — the per-round form
+  of the delta lines, on the same values [[per-round-p50s]] records."
+  [p50s base-id arm-ids]
+  (let [base (get p50s base-id)]
+    (into {}
+          (map (fn [id]
+                 [id (mapv (fn [b a] (lane/round4 (- b a)))
+                           base (get p50s id))]))
+          arm-ids)))
 
 (defn- us-per-read [ms] (* 1e3 (/ ms 141)))
 
@@ -822,8 +959,10 @@
                           (js/console.log (str ";;   control: " (:why ctl))))
                         (when (:refuse? gv)
                           (set! (.-HICASSO_GUARD_REFUSED js/window) true))
-                        ;; ---- Phase B setup: four identically-seeded frames,
-                        ;; entries harvested through the door.
+                        ;; ---- Phase B setup: [[frames-per-window]]
+                        ;; identically-seeded frames (32, not the 4 this
+                        ;; comment named until rf2-3l6hf), entries
+                        ;; harvested through the door.
                         (doseq [f commit-frames] (seed-frame! f))
                         (let [entries (into {} (map (fn [f]
                                                       (rt/render-body f (fn [_] (sub-pass! roster) [:span]) {})
@@ -838,23 +977,29 @@
                                                         b-sampling b-rounds baseline))))
                               (.then
                                 (fn [{:keys [readings samples]}]
-                                  (let [ids  [:commit :c-local :c-noactivate :c-nowatch :c-nosub :c-noreaders :c-nomap :b-build]
+                                  (let [ids  [:commit :c-local :c-null :c-noactivate :c-nowatch :c-nosub :c-noreaders :c-nomap :b-build]
                                         rows (arm-rows ids readings frames-per-window)
+                                        p50s (per-round-p50s ids readings frames-per-window)
                                         gv-b (lane/guard! samples "read-profile phase B (in-page ms, diagnostic)")]
                                     (lane/record! :read-profile-commit
                                                   (into {} (map (fn [[k v]] [k (-> v (update :min lane/round4)
                                                                                    (update :max lane/round4)
                                                                                    (update :p50 lane/round4))])) rows))
+                                    (lane/record! :read-profile-commit-per-round p50s)
+                                    (lane/record! :read-profile-commit-per-round-deltas
+                                                  (per-round-deltas p50s :c-local
+                                                                    [:c-null :c-noactivate :c-nowatch
+                                                                     :c-nosub :c-noreaders :c-nomap]))
                                     (js/console.log ";; ==== READ PROFILE, PHASE B — THE COMMIT HALF (ms per 141-key boundary commit) ====")
-                                    (js/console.log (str ";;   design " b-rounds "x(" (:warmup b-sampling) "+" (:samples b-sampling)
-                                                         ")  window = " frames-per-window " frames/commit each"
-                                                         "  grid = " (fmt (/ 0.05 frames-per-window) 6) " ms/commit"))
+                                    (js/console.log (phase-b-design-line b-rounds b-sampling frames-per-window))
                                     (doseq [id ids]
                                       (js/console.log (arm-line id (get rows id))))
                                     (js/console.log ";; ==== PHASE B DELTAS (c-local minus ablation; floors) ====")
                                     (let [commit' (:p50 (get rows :commit))
                                           clocal  (:p50 (get rows :c-local))]
                                       (js/console.log (str ";;   copy fidelity: c-local/commit = " (fmt (/ clocal commit') 4)))
+                                      (js/console.log (delta-line "NULL CONTROL (c-local - c-null)" clocal (:p50 (get rows :c-null))))
+                                      (js/console.log ";;     ^ true cost EXACTLY ZERO by construction — both arms are C-FULL. What it reads is this instrument's own error at this shape, and it is what the terms below are adjudicated against (rf2-3l6hf). It bounds no term's cost: a delta inside this spread is a term the window cannot SEE, which leaves its size open in both directions")
                                       (js/console.log (delta-line "activation-capture (c-local - c-noactivate)" clocal (:p50 (get rows :c-noactivate))))
                                       (js/console.log ";;     ^ a REAL term here, NOT a floor and not an arbiter: nothing activates on this UIx host, but the hook key is never published and so never cached, and this prices that lookup (rf2-tcffa, rf2-19usn). The capture itself is real only under the ratom family (rf2-lzpfj)")
                                       (js/console.log (delta-line "watch-wiring (c-local - c-nowatch)" clocal (:p50 (get rows :c-nowatch))))

--- a/implementation/hicasso/test/re_frame/bench/hicasso/read_profile_baseline_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/bench/hicasso/read_profile_baseline_cljs_test.cljs
@@ -35,10 +35,12 @@
 
   ## Shape
 
-  Four frames, one body run each through the same [[rt/render-body]] door
-  phase B's setup uses, and the same [[rt/commit-boundary!]] seam its
-  `commit` arm rides. Nothing here is timed and no number is published —
-  the claim is about reachability, not cost.
+  Four frames — see [[commit-frames]] for why four is right here and why
+  it is NOT phase B's count — one body run each through the same
+  [[rt/render-body]] door phase B's setup uses, and the same
+  [[rt/commit-boundary!]] seam its `commit` arm rides. Nothing here is
+  timed and no number is published — the claim is about reachability,
+  not cost.
 
   Which is exactly why row 2 arms its macrotask at the FIRST mint rather
   than after the harvest: a reap horizon is a duration from one entry's
@@ -62,7 +64,14 @@
      :init-fn (fn [] (rt/reset-runtime!))}))
 
 (def ^:private commit-frames
-  "Phase B's four identically-seeded frames, in miniature."
+  "Phase B's identically-seeded commit frames, in miniature — FOUR here
+  against the instrument's 32 (rf2-3l6hf raised that count, and this
+  docstring went on attributing four to phase B itself).
+
+  Four is right for THIS file and the shortfall costs it nothing: the
+  claim below is that an unclaimed entry is still reachable at the
+  baseline, which is a property of one entry's own reap horizon. It does
+  not sharpen with more of them."
   [::b1 ::b2 ::b3 ::b4])
 
 (defn- seeded! []

--- a/implementation/hicasso/test/re_frame/bench/hicasso/read_profile_grid_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/bench/hicasso/read_profile_grid_cljs_test.cljs
@@ -1,0 +1,184 @@
+(ns re-frame.bench.hicasso.read-profile-grid-cljs-test
+  "PHASE B'S PRINTED GRID IS DERIVED FROM THE KEPT COUNT'S PARITY —
+  pinned (rf2-3l6hf, merged-PR audit of #8328).
+
+  `read_profile_app`'s phase B prints a `grid = …` figure that tells a
+  reader the finest spacing any row or delta below it can land on. It is
+  the number a reader uses to decide whether a term is one grid step or
+  thirty, so a grid line that overstates the resolution invites exactly
+  the reading the instrument exists to prevent.
+
+  ## The defect this pins
+
+  The line printed `0.05 / frames-per-window` as a CONSTANT over a
+  variable, and the 0.05 was only ever true at even parity. The chain is
+  three links: `lane/now-ms` is clamped to 100 µs, so a raw window sample
+  is a multiple of 0.1 ms; `lane/summarise` takes the MEAN OF THE TWO
+  MIDDLE order statistics when the kept count is even — putting the p50
+  on a half-clamp grid — and a SINGLE order statistic when it is odd,
+  where no halving happens; and the row then divides by the frame count.
+
+  Nothing held the parity. `b-rounds` and `b-sampling` are independent
+  vars in that file, their product is the kept count, and an editor
+  moving either one to an odd product would have doubled the real grid
+  while the line went on advertising the halved one. No test would have
+  noticed: the arithmetic was in a docstring and the number was a
+  literal.
+
+  ## What is pinned, and what deliberately is not
+
+  Rows 1–2 pin the MECHANISM — `lane/summarise`'s parity behaviour — at
+  the level the derivation depends on, because a change there is the
+  other way the printed grid could quietly stop being true.
+
+  Row 3 pins the DERIVATION at both parities, and row 4 pins that the
+  design line prints what the derivation returns rather than a constant
+  standing next to it. Row 4 is the one that actually forecloses the
+  defect: it drives the line at an ODD kept count, which the live shape
+  is not, so it fails the moment the number goes back to being a
+  literal.
+
+  Row 5 reads the LIVE shape through `app/phase-b-shape` and states its
+  parity and grid. It is not a bar on the shape — the instrument is free
+  to move to any parity, and the point of deriving is that it may — it
+  simply records which arm of the derivation the shipped window is on,
+  so a shape change shows up as a diff here rather than as a silently
+  different grid in a published transcript.
+
+  Nothing here reads a clock, times anything, or mounts a frame. The
+  claim is arithmetic."
+  (:require [cljs.test :refer-macros [deftest is testing]]
+            [clojure.string :as str]
+            [re-frame.bench.hicasso.lane :as lane]
+            [re-frame.bench.hicasso.read-profile-app :as app]))
+
+(defn- multiple-of?
+  "`x` is a multiple of `g`, to within the float slop of dividing two
+  decimal quantities that are exact in neither base."
+  [g x]
+  (let [q (/ x g)]
+    (< (js/Math.abs (- q (js/Math.round q))) 1e-9)))
+
+;; ===========================================================================
+;; 1 — an ODD kept count leaves the p50 on the raw clock grid
+;; ===========================================================================
+
+(deftest an-odd-sample-count-keeps-the-p50-on-the-full-clock-grid
+  (testing "`lane/summarise` on an odd count answers a member of its own
+           input, so a set of clamp-multiples summarises to a
+           clamp-multiple and nothing finer is reachable"
+    (let [xs [0.1 0.2 0.2 0.3 0.5]
+          p  (:p50 (lane/summarise xs))]
+      (is (= 5 (count xs)) "the fixture is odd, which is the whole point")
+      (is (some #{p} xs)
+          "an odd-count p50 IS one of the readings, not a blend of two")
+      (is (multiple-of? app/clock-clamp-ms p)
+          "so it lands on the full 0.1 ms clock grid"))))
+
+;; ===========================================================================
+;; 2 — an EVEN kept count halves it, and can land BETWEEN two clock ticks
+;; ===========================================================================
+
+(deftest an-even-sample-count-halves-the-grid
+  (testing "`lane/summarise` on an even count averages the two middle
+           readings, which reaches values no single clock reading can
+           take — that is the halving the design line depends on"
+    (let [xs [0.1 0.2 0.3 0.5]
+          p  (:p50 (lane/summarise xs))]
+      (is (= 4 (count xs)) "the fixture is even")
+      (is (multiple-of? (/ app/clock-clamp-ms 2.0) p)
+          "the p50 is on the half-clamp grid")
+      (is (not (multiple-of? app/clock-clamp-ms p))
+          "and this one is strictly OFF the full-clamp grid — 0.25 is a
+           p50 no individual reading could have produced, which is what
+           makes the halving real rather than nominal"))))
+
+;; ===========================================================================
+;; 3 — the derivation follows the parity
+;; ===========================================================================
+
+(deftest the-derived-grid-follows-the-kept-counts-parity
+  (testing "even kept total → half-clamp over frames"
+    (is (= (/ 0.05 32) (app/phase-b-grid-ms 8 {:warmup 2 :samples 8} 32))
+        "8 x 8 = 64 kept, even")
+    (is (= (/ 0.05 4) (app/phase-b-grid-ms 4 {:warmup 2 :samples 6} 4))
+        "4 x 6 = 24 kept, even — the shape rf2-d360z published, whose
+         deltas were all multiples of 0.0125"))
+
+  (testing "odd kept total → the FULL clamp over frames, twice as coarse"
+    (is (= (/ 0.1 32) (app/phase-b-grid-ms 9 {:warmup 2 :samples 7} 32))
+        "9 x 7 = 63 kept, odd")
+    (is (= (/ 0.1 4) (app/phase-b-grid-ms 1 {:warmup 2 :samples 1} 4))
+        "1 x 1 = 1 kept, odd"))
+
+  (testing "the two parities differ by exactly the factor the halving is"
+    (is (= 2.0 (/ (app/phase-b-grid-ms 9 {:warmup 2 :samples 7} 32)
+                  (app/phase-b-grid-ms 8 {:warmup 2 :samples 8} 32)))))
+
+  (testing "frames scale it independently of parity"
+    (is (= 8.0 (/ (app/phase-b-grid-ms 8 {:warmup 2 :samples 8} 4)
+                  (app/phase-b-grid-ms 8 {:warmup 2 :samples 8} 32))))))
+
+;; ===========================================================================
+;; 4 — the design LINE prints the derivation, not a constant
+;; ===========================================================================
+
+(deftest the-design-line-prints-the-derived-grid-at-both-parities
+  (testing "at the even shape the window ships, the line carries the
+           halved grid and says so"
+    (let [line (app/phase-b-design-line 8 {:warmup 2 :samples 8} 32)]
+      (is (re-find #"kept = 64 samples/arm \(EVEN" line))
+      (is (re-find #"mean of two middle clock readings" line))
+      (is (re-find #"grid = 0\.001563 ms/commit" line)
+          "0.05/32, the figure the published transcripts carry")))
+
+  (testing "it is the PRODUCT that decides, so moving the sample count
+           alone need not flip anything — 8 x 7 is still even"
+    (let [line (app/phase-b-design-line 8 {:warmup 2 :samples 7} 32)]
+      (is (re-find #"kept = 56 samples/arm \(EVEN" line))
+      (is (re-find #"grid = 0\.001563 ms/commit" line))))
+
+  (testing "AT AN ODD PRODUCT THE SAME LINE DOUBLES. This is the row the
+           defect could not have survived: the old line held 0.05 as a
+           literal and would print 0.001563 here, understating the real
+           grid by 2x"
+    (let [line (app/phase-b-design-line 9 {:warmup 2 :samples 7} 32)]
+      (is (re-find #"kept = 63 samples/arm \(ODD" line))
+      (is (re-find #"a single clock reading" line))
+      (is (re-find #"grid = 0\.003125 ms/commit" line)
+          "0.1/32 — twice the even-parity grid, printed as such")))
+
+  (testing "the line's grid figure IS `phase-b-grid-ms`'s, at every shape
+           tried, rather than a second expression that happens to agree"
+    (doseq [[r s f] [[8 8 32] [9 7 32] [4 6 4] [3 5 16] [7 3 128]]]
+      (let [sampling {:warmup 2 :samples s}
+            expected (.toFixed (app/phase-b-grid-ms r sampling f) 6)]
+        (is (str/includes? (app/phase-b-design-line r sampling f)
+                           (str "grid = " expected " ms/commit"))
+            (str "shape " r "x" s " over " f " frames"))))))
+
+;; ===========================================================================
+;; 5 — which arm of the derivation the SHIPPED window is on
+;; ===========================================================================
+
+(deftest the-live-shape-is-recorded-with-its-parity
+  (let [{:keys [rounds sampling frames]} (app/phase-b-shape)
+        kept (* rounds (:samples sampling))]
+    (testing "the live shape's own numbers, read off the instrument"
+      (is (pos? rounds))
+      (is (pos? (:samples sampling)))
+      (is (pos? frames)))
+
+    (testing "the grid the live shape derives is the grid its design line
+             prints — the two cannot drift, because there is one
+             expression"
+      (is (re-find (re-pattern (str "grid = "
+                                    (.toFixed (app/phase-b-grid-ms rounds sampling frames) 6)
+                                    " ms/commit"))
+                   (app/phase-b-design-line rounds sampling frames))))
+
+    (testing "and the parity the line names is the parity the kept count
+             actually has"
+      (is (re-find (re-pattern (str "kept = " kept " samples/arm \\("
+                                    (if (even? kept) "EVEN" "ODD")))
+                   (app/phase-b-design-line rounds sampling frames))))))


### PR DESCRIPTION
## Reader membership is UNRESOLVED, and now on measured evidence

`rf2-3l6hf` owned resolving `read_profile` phase B's decomposition. **One of its terms still does not resolve, and this PR says so with a negative control rather than with the arithmetic-impossibility argument.**

The merged-PR audit of #8328 named what would settle it: *a genuine null or control arm, or another valid resolution route.* This adds the null arm, and the null answers.

## The edit half — taken BEFORE the window opened

A rung added to an instrument mid-run makes the series two instruments, so every rig change landed first and the window ran against a clean tree at both ends.

- **`c-null`, the negative control.** `c-local` again — the same `C-FULL` mode through the same `mk-local`, under a second id — so `c-local − c-null` has a true cost of **exactly zero by construction**. Everything it reads is the estimator's own error.
- **The parity-dependent grid.** The design line printed `0.05 / frames` with the `0.05` a literal, and `0.05` is only right at even parity: `lane/summarise` averages the two middle order statistics on an even kept count and takes a single one on an odd count. `b-rounds` and `b-sampling` are independent vars and nothing holds their product even, so an odd product would have doubled the real grid while the line advertised the halved one. `phase-b-grid-ms` now **derives** it; `phase-b-design-line` prints what it derives; the line also names the kept count, its parity, and which statistic that parity makes the p50.
- **`read-profile-grid-cljs-test`**, the narrow regression witness — `lane/summarise`'s parity behaviour, the derivation at both parities, and the row that forecloses the defect: the design line **doubles at an odd product**, which the live shape is not. It reads the live shape through `phase-b-shape` rather than restating its three numbers.
- **Per-round retention.** `rounds-async!` buckets by round the way `lane/rounds!` always has, instead of flattening. Pooling is unchanged — `arm-rows` mapcats before summarising, so the published p50 is the same number over the same 64 samples — but the window is now re-adjudicable without a re-take.
- **The stale prose.** The `phase B setup: four identically-seeded frames` comment said 4 at a 32-frame shape; `frames-per-window`'s "set here and nowhere else" claim now names the parity, and its "no arbiter" paragraph points at `c-null`. Its sibling in `read_profile_baseline_cljs_test` carried the same false attribution (`Phase B's four identically-seeded frames, in miniature`) and is corrected in the third commit — four is still right for that witness, and the docstring now says why rather than implying it mirrors the instrument.

No gate, tolerance or knob moved.

## The window

Three runs, unchanged 32-frame / 64-kept-sample shape, `exit 0` on each, both arm-order guards **reportable** on each, phase-A positive control **passing** on each, phase-B residue gate **never firing**. Nine arms rather than eight, so this is a new series and its absolutes are not arm-by-arm comparable with #8329's.

**The estimator, named as computed:** a **pooled median over an arm's 64 kept samples**, each divided by the 32-frame window; 64 being even, the mean of the 32nd and 33rd order statistics. It is *not* a mean of per-round medians, and the two differ here (run 1's null: 0.0234 pooled vs 0.0174 as a mean of its per-round deltas). Each delta is a difference of two such pooled medians.

| term (`c-local −` the arm) | run 1 | run 2 | run 3 |
|---|---|---|---|
| **NULL CONTROL (`c-null`), true cost exactly 0** | **+0.0234** | **+0.0219** | **+0.0234** |
| reaction build + cache insert (`c-nosub`) | 0.4453 | 0.4531 | 0.4875 |
| watch wiring (`c-nowatch`) | 0.0656 | 0.0672 | 0.0844 |
| cell-map insert (`c-nomap`) | 0.0547 | 0.0625 | 0.0531 |
| activation capture (`c-noactivate`) | 0.0453 | 0.0437 | 0.0344 |
| **reader membership (`c-noreaders`)** | **+0.0422** | **+0.0219** | **+0.0359** |

**In run 2 reader membership read `+0.0219` — the null control's run-2 reading, to the last digit.** An instrument that returns the same number for reader membership as it returns for nothing at all has not measured reader membership. Margins over the null: `+0.0188 / 0.0000 / +0.0125`. The other four terms clear the null on every run.

**No bound is published and none can be read off these numbers.** A null spread states what the instrument cannot *see*; it says nothing about how large the invisible thing is. The withdrawn `< 0.006 ms/commit` stays withdrawn, and reading a null spread as an upper bound would be that same error one layer back.

### The second finding, which is about every delta on the page

**The null is not centred on zero.** Its three run-level readings sit within one grid step of each other on a quantity whose true value is exactly zero, so the pooled-median delta at this shape carries a positive offset of about **+0.022 ms/commit**. Against each run's own null the small terms are only a few multiples of it — activation capture 1.5–2.0, cell-map insert 2.3–2.9, watch wiring 2.8–3.6, reader membership 1.0–1.8; only the reaction build (19–21) is clear by any margin.

**The cause is not established and this data does not discriminate between the candidates**: a residual arm-position effect (`c-local` is at slot 1, every arm it is differenced against at a higher slot), within-sweep thermal or cache drift, and the pooled median's behaviour on a right-tailed distribution are all live. The order guard reporting *reportable* on every run does not exclude the first — its tolerance is 10% and this offset is 3.2–3.6% of `c-local`.

**What the null does not settle:** `c-null` differences slot 1 against slot 2 while reader membership differences slot 1 against slot 6, so if the offset is positional a single null does not calibrate the reader delta exactly. Nulls at several positions would. Deliberately not attempted — that rung would have made this two instruments.

### Per-round values, retained

At round granularity neither term is separable from the other: across the window's 24 rounds the null spans `−0.1047 … +0.1578` (positive in 17) and reader membership spans `−0.1797 … +0.1672` (positive in 18). Full per-round p50s and deltas are in the transcripts under `:read-profile-commit-per-round` and `-per-round-deltas`.

### The box

Processor Queue Length sampled **on its own**, 5 samples at 1 s, immediately before the window and between every pair of runs:

| time (+10:00) | PQL |
|---|---|
| 05:49:00 (pre-window) | 0,0,0,0,0 |
| 05:50:17 (between runs 1 and 2) | 0,0,1,0,0 |
| 05:51:36 (between runs 2 and 3) | 0,0,0,0,0 |
| 05:52:53 (window close) | 0,0,0,0,0 |

The single `1` was taken **between** runs and not inside any measured window. **Nothing was sampled inside a run** — sampling a counter inside a measured window makes the sampler part of the measurement — so **this is a bracketing claim and nothing stronger**; I claim nothing about within-run quietness beyond it. `run.cjs` rebuilds the `:advanced` bundle before measuring on every run and that compile saturates this box; the bracket readings sit outside those compiles.

A **shakedown run** was taken after the edit half and before the window, to prove the new arm and the per-round retention worked rather than discovering a crash on measured run 1. **Its numbers are discarded and appear nowhere** above or in the transcripts.

## Gates — captured exit codes

| gate | captured exit |
|---|---|
| `sh scripts/assert-worker-worktree.sh` | 0 (`WORKTREE_ROOT=/c/Users/miket/code/re-frame2-worktrees/w-3l6hf`) |
| `npm ci --prefix implementation` | 0 (real `node_modules`, 101 entries, not a junction) |
| `npm run test:cljs` | 0 — 13,995 tests / 70,439 assertions, 0 failures, 0 errors |
| `npm run test:cljs` (deliberate failing probe in the new witness) | **1**, exactly 1 failure — proof the witness runs and is load-bearing |
| `python scripts/check_doc_slugs.py` | 0 |
| `python scripts/check_provenance_pins.py --changed-since origin/main` | 0 — 35 pins, 15 accompanied in scope, 0 findings |
| `sh scripts/check-no-hardcoded-paths.sh` | 0 (plus an independent `grep -F` over the staged transcripts: no match) |
| `sh scripts/test-fast-pr.sh` | **0** — 79 steps, zero `FAIL` lines, 13,995 tests / 70,439 assertions, 0 failures / 0 errors; clj-kondo 0 errors on the CI-pinned 2026.04.15 |

The spine's first attempt was killed at the harness's 10-minute shell cap and produced **no `.exit` file at all**. Per this repo's own rule a missing `.exit` is *no verdict, not a pass*, so it was discarded and re-run rather than read — its apparent `FAIL CLJS node integration` was the harness killing the child mid-run, and the log stopped growing at the moment of the kill. The exit quoted above is attempt 2's captured code.

**The spine compiled the final tree, verified rather than assumed:** the docstring commit edited `read_profile_baseline_cljs_test.cljs` at 06:15:26 and shadow-cljs regenerated that namespace's analyzer cache at **06:20:38**, during the spine's run. `read_profile_app.cljs` and the new witness were content-unchanged since their own green compiles, so their caches were reused — and every one of the 13,995 tests, including the witness's five, was executed by the run regardless.

## Verified by hand, because nothing validates it

`docs/design/**` is outside `mkdocs build --strict`, and **nothing validates table rendering or column counts**. I checked every table on `the-cold-read-mount-term.md` mechanically for cell-count consistency: 13 tables, all internally consistent, including the new 4-column one. The tables in this PR body and in the transcripts' `README.md` were checked the same way.

## Downstream

**`rf2-07rnj` stays BLOCKED.** This bead owned resolving the decomposition; one of its original terms still does not resolve, and a decomposition with an unresolved term is not one.
