### PR TITLE
docs(mayor-method): the remote branch set is not a subset of the local one

### DIFF
--- a/docs/the-mayor-method/loops.md
+++ b/docs/the-mayor-method/loops.md
@@ -698,6 +698,12 @@ version control's own object database. Never spray that acknowledgement across a
 
 Delete merged local and remote worker branches — **never one whose change is not verifiably merged**.
 
+**Enumerate the remote set separately, because it is not a subset of the local one.** Everything else in
+this loop starts from the worktrees, which is right for reaping and blind here: a branch whose worktree
+was removed and whose local ref was deleted still exists on the remote, and nothing you are looking at
+mentions it. One sat merged and undeleted through two hygiene passes, surfacing only when the remote list
+happened to be printed.
+
 **"Verifiably merged" needs a test, and where the project merges by REBASE the two obvious ones are
 both wrong — in opposite directions.** A rebase replays every commit under a new identity, so a
 merged branch never becomes an ancestor of the trunk and never stops reading as *ahead* of it.


### PR DESCRIPTION
Every other part of the hygiene loop starts from the worktrees. That is right for reaping and blind for branches: a branch whose worktree was removed and whose local ref was deleted still exists on the remote, and nothing the worktree-driven sweep looks at mentions it.

`worker/w-lane-est` sat merged and undeleted through **two** hygiene passes tonight. It had no worktree and no local ref; its change had merged as #8333 and `git cherry` confirmed 0 unmerged commits. It surfaced only because the remote list happened to be printed on the third pass.

The command file already prescribes listing remote branches. This says **why** that line is in the list, which is what makes it get run.

| gate | captured exit |
|---|---|
| `python scripts/check_doc_slugs.py` | 0 |
| `sh scripts/check-no-hardcoded-paths.sh` | 0 |

One paragraph. No fenced code blocks and no tables added or edited in the tree.