### PR TITLE
docs(mayor-method): clause 5 also has to read a key that LEAVES

### DIFF
--- a/docs/the-mayor-method/loops.md
+++ b/docs/the-mayor-method/loops.md
@@ -214,6 +214,16 @@ Do this **before** merging. It is easy to merge and then reason that the drift w
 harmless. It usually is, and "usually" is what the other four clauses exist to
 refuse.
 
+**And the set can move the other way, from the branch rather than the trunk.** Everything
+above is about keys ARRIVING underneath a change. A change that retires a surface REMOVES
+them, so its rollup legitimately reads below the band — and any programme that deletes a
+subsystem produces a run of such changes, so this stops being an edge case for the whole
+length of that work. **The count cannot tell a legitimate narrowing from a silent disarm.
+Read which key left, and check it against what the change itself deleted.** A check whose
+entire subject went in the same change is retirement; a check that leaves while its subject
+still stands is the fail-open shape the programme exists to hunt, and it arrives wearing
+the same number. The two readings differ by one question, and the answer is in the diff.
+
 ### Merging
 
 Check also that the diff matches its tracker item, that scope did not sprawl, that


### PR DESCRIPTION
Clause 5 is written entirely about check keys **arriving** on the trunk underneath a branch. It says nothing about the branch itself **removing** one — and that case is about to be the common one rather than an edge.

A change that retires a surface deletes the checks whose subject it deleted, so its rollup legitimately reads **below** the band. A programme that removes a subsystem produces a whole run of such changes, so for the length of that work every merge decision meets a count the clause does not cover.

**The count cannot separate the two readings.** A check whose entire subject went in the same change is retirement. A check that leaves while its subject still stands is the fail-open shape the programme exists to hunt — and it arrives wearing exactly the same number. Read which key left, and check it against what the change deleted.

Written while a live change sits at 99 contexts against a band of 100 because it narrows a workflow by 2 donor steps. That is the legitimate reading, and the only thing separating it from a disarm is asking which key went.

| gate | captured exit |
|---|---|
| `python scripts/check_doc_slugs.py` | 0 |
| `sh scripts/check-no-hardcoded-paths.sh` | 0 |

One paragraph. No fenced code blocks and no tables added or edited in the tree.