### PR TITLE
docs(hicasso): REWRITE-NOTES instructs h/event, the carrier the door ships (rf2-5ayg7)

### DIFF
--- a/docs/design/hicasso/draft-guide/REWRITE-NOTES.md
+++ b/docs/design/hicasso/draft-guide/REWRITE-NOTES.md
@@ -103,7 +103,7 @@ is not taught.
 
 ### Event callbacks
 
-The guide uses `h/fn` consistently. `:handler` remains a valid `defhost`
+The guide uses `h/event` consistently. `:handler` remains a valid `defhost`
 callback-contract value and is not the same thing as an `h/handler` macro.
 
 An `:on-submit` intent auto-prevents — the one position that does, and no second
@@ -127,7 +127,7 @@ These names are taught as the current guide contract but were identified by
 the source audit as names requiring explicit naming-ledger approval or final
 implementation confirmation:
 
-- `h/fn` and `h/frame`
+- `h/frame` (the callback form is settled: `h/event`, under `rf2-hic-066`)
 - artifact coordinates for Hicasso
 - root lifecycle configuration around `h/mount!`, `h/hydrate!`, `h/render!`,
   and `h/unmount!`
@@ -192,14 +192,15 @@ The following older draft ideas are not restored:
 - position-dependent callback forms
 - Chromium-only IME wording
 - pre-React-19 ref contracts
-- invented `h/event` spelling (product form is `h/fn`)
+- the retired `h/fn` spelling (the product form is `h/event`, renamed under
+  `rf2-hic-066`)
 - `::motion/*` override keys (shipped markers remain `::h/mounting` /
   `::h/unmounting`)
 
-The current guide teaches `h/fn` as the one callback form, `(rf/capture-frame
-(h/frame))` at foreign edges, app-db state ownership, CSS tokens, two server
-policies, a dedicated motion/presence chapter, user-visible budgets, and the
-browser-neutral controlled-input contract.
+The current guide teaches `h/event` as the one callback form,
+`(rf/capture-frame (h/frame))` at foreign edges, app-db state ownership, CSS
+tokens, two server policies, a dedicated motion/presence chapter, user-visible
+budgets, and the browser-neutral controlled-input contract.
 
 ## Chapter-level preservation record
 


### PR DESCRIPTION
Executes the mayor's 2026-08-16 03:20 ruling on rf2-5ayg7. The sweep half of that bead already landed as `e37b1a971d`; this is the residual it deferred.

## The ruling applied

The mayor's test is whether the text is a **RECORD** or an **INSTRUCTION**, and it does not turn on which directory the file sits in. Records freeze — their whole value is evidence of what was believed on a date. Instructions are read forward by someone about to act, so an inverted one makes them do the wrong thing.

- **FROZEN, untouched:** `docs/design/hicasso/decisions.md` and `docs/design/hicasso/studio/**`.
- **CORRECTED:** `docs/design/hicasso/draft-guide/REWRITE-NOTES.md` — this PR, and nothing else.

## Verified at source before editing

`implementation/hicasso/src/re_frame/hicasso.cljc` exports exactly three macros — `defview` (:102), `event` (:302), `defhost` (:333) — and the `:require-macros` at :86 refers those same three. There is **no `fn` macro at all** (`grep` for one exits 1).

The shipped guide agrees: `docs/core/hicasso/03-events-as-data.md:98` is headed `## One callback form: h/event`, and `h/event` appears across 17 files under `docs/core/hicasso/`. The single `h/fn` left in that tree is `index.md:61`, which records the rename itself.

## Where the line was drawn, file-internally

Four sites corrected — each makes a **present-tense claim about the current guide or the current product**, so each is read forward and each is now false:

| Line | Was | Why it instructs |
|---|---|---|
| 106 | "The guide uses `h/fn` consistently" | A cross-chapter consistency rule a maintainer follows |
| 130 | `h/fn` listed as "still needs naming governance" | A pending-work list; that governance is in fact **closed** |
| 195 | "invented `h/event` spelling (product form is `h/fn`)" | The inverted instruction the ruling named |
| 199 | "The current guide teaches `h/fn` as the one callback form" | Claims the shipped corpus |

One site deliberately **left as a record**:

- **:229–230**, under `## Chapter-level preservation record` → `### 03 — Events as data`: "Retained event-position detection, … `h/fn`, plain-function behaviour, …". Past tense, and its whole value is evidence of what the rewrite preserved on its date. This is a record living inside an instruction file, exactly the class the ruling said stays.

The line drawn: **present-tense claim about what is → corrected; past-tense account of what was done → frozen.**

On :130 specifically — naming-ledger row 1 (`hfn` → `h/event`) reads **RULED (operator, 2026-08-11)** and **SWEPT `rf2-hic-066`, 2026-08-15**, so the callback carrier no longer belongs on a list of names awaiting governance. `h/frame` stays on it, because row 18 **STOPPED** as semantic and is still genuinely open. The ledger was read only, never edited — it lives on a peer surface.

## Discrepancy worth recording

The ruling describes REWRITE-NOTES.md as "a work list addressed to whoever performs the rewrite". The file's own header (:3–9) says the rewrite **has shipped** under `rf2-0yp7w` and that the file "is a record of how the rewrite was done". Under a whole-file reading that would freeze it.

The correction still holds, and holds harder: the ruling's test applies to the **text**, not the file, and the four corrected sites assert things about a **shipped corpus a reader can go and check** — where they are now simply wrong. The record-class text inside the file was left alone.

## Scope and fences

- Not widened into a general rename sweep. One file, four hunks.
- Frozen trees untouched: `decisions.md`, `studio/**`.
- Peer surfaces untouched: `docs/design/hicasso/product/**` (read-only inspection of `naming-ledger.md` for evidence, no edit) and the retirement pre-cut set (`.github/**`, `TESTING.md`, `docs/design/retirement/**`, and the rest).
- No fenced code block under `docs/core/freehand/` touched — nowhere near it.
- No table touched, so no column count to hand-verify.
- `.beads` paths untouched.

## Gates

`mkdocs build --strict` is **not** nominated: `mkdocs.yml`'s `exclude_docs` keeps `docs/design/**` out of the site. Captured exits quoted in the thread.