### PR TITLE
fix(hicasso): the acquire wires the cell it reuses (rf2-phabt)

### DIFF
--- a/implementation/hicasso/src/re_frame/hicasso/impl/collector.cljs
+++ b/implementation/hicasso/src/re_frame/hicasso/impl/collector.cljs
@@ -762,7 +762,14 @@
     (set! (.-reaction cell) nil)
     (js/queueMicrotask
       (fn []
-        (when-not (.-disposed cell)
+        ;; `(nil? (.-reaction cell))` because [[acquire-cell!]] rebuilds the
+        ;; attachment too, the moment a commit reuses a cell this call left
+        ;; empty (rf2-phabt). Wiring a cell that already holds a reaction
+        ;; would add a SECOND `add-on-dispose!` hook to it, so the next
+        ;; disposal would invalidate twice, wire twice and compound — the
+        ;; guard is what makes the two writers idempotent with respect to
+        ;; each other rather than merely both correct.
+        (when (and (not (.-disposed cell)) (nil? (.-reaction cell)))
           (if (nil? (frame/frame-incarnation-token (.-frameKw cell)))
             (dispose-cell! cell)
             (do (wire-cell! cell)
@@ -940,6 +947,24 @@
                    (wire-cell! fresh)
                    (swap! !cells assoc sub-key fresh)
                    fresh))]
+    ;; **A REUSED cell may be holding nothing** (rf2-phabt).
+    ;; [[invalidate-cell!]] drops the reaction synchronously and defers the
+    ;; rewire to the microtask checkpoint, so between those two moments the
+    ;; table holds a cell with no reaction and no watch. A reader attached to
+    ;; it then is unreachable by [[mark-dirty!]] — the boundary renders the
+    ;; right value (a reaction-less cell takes [[cold-read!]]'s probe) and
+    ;; nothing notifies it until the deferred rewire lands. Measured: a
+    ;; boundary mounted in that window painted once and did not move on a
+    ;; write taken in the same turn.
+    ;;
+    ;; So the acquire wires it, and that is not a second owner of the rewire
+    ;; — it is this function keeping the promise its own first line makes.
+    ;; The deferral exists because `invalidate-cell!` is called from inside
+    ;; the registrar's hooks and frame teardown, *\"and none of them is a
+    ;; place to subscribe\"*; a commit is precisely such a place, which is why
+    ;; the whole cell table is commit-owned. Whichever of the two gets here
+    ;; first wires the cell and the other finds a reaction and does nothing.
+    (when (nil? (.-reaction cell)) (wire-cell! cell))
     (.push (.-readers cell) reg)
     cell))
 

--- a/implementation/hicasso/test/re_frame/hicasso/foreign_root_bridge_dom_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/foreign_root_bridge_dom_cljs_test.cljs
@@ -1,0 +1,345 @@
+(ns re-frame.hicasso.foreign-root-bridge-dom-cljs-test
+  "rf2-phabt — WHO OWNS THE ROOT IS NOT THE VARIABLE, AND AN INVALIDATED
+  CELL IS.
+
+  ## What this file was written to settle, and what it found instead
+
+  rf2-phabt reported that a boundary crossed into from a REAGENT parent
+  *\"paints once and is then deaf to writes\"*, with `h/mount!` as a live
+  control, and asked whether a UIx parent was deaf too — because that
+  would make it the outward bridge generally rather than a Reagent story.
+
+  **Neither is deaf.** §1 below drives FIVE mounting routes — Hicasso's
+  own root, a Reagent root through each of the two bridge doors, a plain
+  `react-dom/client` root, and a UIx `defui` parent under a plain root —
+  with one boundary, one subscription, one adapter and one drain, and
+  every one of them re-runs its body and moves the DOM on a write into
+  its own frame. So a Hicasso view inside a foreign React host is
+  reactive, and the answer the bead's first move asks for is *a UIx
+  parent repaints*.
+
+  **What IS deaf is a boundary that acquires a cell whose reaction was
+  dropped**, and that has nothing to do with the crossing: §2 reproduces
+  it under `h/mount!`, where there is no crossing at all. The reported
+  measurement varied two things at once — the mounting route AND the
+  frame id — and the second was carrying the defect.
+
+  ## The defect, and why the acquire is where it is repaired
+
+  `impl.collector/invalidate-cell!` drops a cell's reaction
+  SYNCHRONOUSLY and defers rebuilding the attachment to the microtask
+  checkpoint, because it is called from inside the registrar's
+  registration and replacement hooks and from frame teardown, and *\"none
+  of them is a place to subscribe\"*. Between those two moments the cell
+  table holds a cell with no reaction and no watch.
+
+  A boundary that COMMITS in that window is handed that cell by
+  `acquire-cell!`, and used to be handed it as it stood. It then rendered
+  the right value — a reaction-less cell takes the cold probe — and
+  nothing could notify it, because `mark-dirty!` rides the watch the cell
+  does not have. A commit is exactly a place to subscribe, so the acquire
+  now wires what it reuses; the deferred rewire guards on the reaction
+  still being nil, so the two are idempotent with respect to each other.
+
+  The window opens on any first-time `reg-sub` of a query some live cell
+  already holds — a lazily loaded module, a hot reload, or a test fixture
+  that clears the registrar and re-registers — which is why §2 opens it
+  that way.
+
+  ## Two lanes, one file
+
+  `-dom-cljs-test$` puts this namespace in `:browser-test` (real React,
+  real DOM) and in `:node-test`, whose `cljs-test$` matches the same
+  suffix. Every row here needs a fiber, so each degrades in Node to a
+  stated skip rather than to a false green."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [reagent.core :as r]
+            [reagent.dom.client :as rdc]
+            [re-frame.adapter.reagent :as reagent-adapter]
+            [re-frame.core :as rf]
+            [re-frame.frame :as frame]
+            [re-frame.hicasso :as h]
+            [re-frame.hicasso.impl.collector :as collector]
+            [re-frame.hicasso.impl.inventory :as inventory]
+            [re-frame.hicasso.impl.mount :as mount]
+            [re-frame.hicasso.roots-frames-support :as support]
+            [re-frame.registrar :as rf-registrar]
+            [re-frame.test-support :as test-support]
+            [uix.core :as uix :refer-macros [defui]]
+            ["react" :as react]
+            ["react-dom" :as react-dom]
+            ["react-dom/client" :as react-dom-client]))
+
+(defonce ^:private !runs
+  ;; Body runs for [[card]] alone. `impl.collector/body-runs` counts every
+  ;; boundary in the process; this file mounts one at a time and wants the
+  ;; per-row delta unambiguous. `defonce` takes no docstring.
+  (atom 0))
+
+(rf/reg-sub ::counter (fn [db _] (or (:n db) 0)))
+(rf/reg-event ::bump (fn [{:keys [db]} [_ n]] {:db (assoc db :n n)}))
+
+(h/defview card
+  "One ordinary boundary, reached by every route below. It reads a
+  subscription, so the frame it resolved is observable on screen, and it
+  bumps a counter, so a re-render is a NUMBER rather than an appearance —
+  a boundary React skipped and a boundary React ran are what separate a
+  missing notification from a stale read."
+  [props]
+  (swap! !runs inc)
+  [:article {:data-test "card"} (str (:label props) "/" (h/sub [::counter]))])
+
+(def ^:private bridged
+  "THE OUTWARD BRIDGE, minted once at top level beside the view it
+  bridges — the law, because it allocates a component."
+  (h/as-component card))
+
+(def ^:private memo-bridged (react/memo bridged))
+
+(defui uix-parent
+  "The third parent the bridge's docstring names — *`n/defcomponent`, UIx,
+  or plain JavaScript* — rendering the same minted bridge, so a
+  difference between rows is a difference between PARENTS rather than
+  between three bridges that happened to agree."
+  [{:keys [label]}]
+  (uix/$ :div (uix/$ bridged {:label label})))
+
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture
+    {:adapter       reagent-adapter/adapter
+     :ambient-frame nil
+     :init-fn       (fn []
+                      (support/leave-act-environment!)
+                      (reset! !runs 0)
+                      (collector/reset-runtime!))}))
+
+;; ---------------------------------------------------------------------------
+;; Harness
+;; ---------------------------------------------------------------------------
+
+(defn- drain!
+  "The ratom host's drain, and it is two acts rather than one. `r/flush`
+  runs the reactions the write enqueued — a re-frame subscription under
+  the ratom family IS a bare `reagent.ratom/Reaction`, and running it is
+  what fires the watch a Hicasso cell rides. The empty `flushSync` then
+  lets the sync-lane `onStoreChange` that raised commit."
+  []
+  (r/flush)
+  (react-dom/flushSync (fn [] nil))
+  nil)
+
+(defn- seat! [frame-kw n]
+  (rf/make-frame {:id frame-kw})
+  (rf/dispatch-sync [::bump n] {:frame frame-kw})
+  frame-kw)
+
+(defn- text-of [node]
+  (some-> (.querySelector node "[data-test=\"card\"]") .-textContent))
+
+(defn- readers-of [frame-kw]
+  (count (inventory/cell-readers [frame-kw [::counter]])))
+
+(defn- wired?
+  "Does this frame's cell hold a live reaction? The cell is the only thing
+  a watch can hang off, so this is the commit-owned fact a repaint
+  depends on — and it is readable before any DOM is."
+  [frame-kw]
+  (some? (some-> ^js (get @collector/!cells [frame-kw [::counter]]) (.-reaction))))
+
+;; ---------------------------------------------------------------------------
+;; The five routes — one boundary, one subscription, one adapter, one drain
+;; ---------------------------------------------------------------------------
+
+(defn- hicasso-root
+  "THE CONTROL. Hicasso's own root door, and no crossing at all."
+  [node frame-kw]
+  (let [handle (h/mount! node {:frame frame-kw} [card {:label "ctl"}])]
+    (fn [] (try (h/unmount! handle) (catch :default _ nil)))))
+
+(defn- reagent-root-as-element
+  "The bead's route 2: a REAGENT root, `rf/frame-provider` above, and the
+  boundary spliced in as a React element by `h/as-element`."
+  [node frame-kw]
+  (let [root (rdc/create-root node)]
+    (react-dom/flushSync
+      (fn []
+        (rdc/render root
+                    [rf/frame-provider {:frame frame-kw}
+                     [:div.reagent-parent (h/as-element [card {:label "alpha"}])]])))
+    (fn [] (try (.unmount root) (catch :default _ nil)))))
+
+(defn- reagent-root-as-component
+  "The bead's route 3: the same Reagent root through the OTHER bridge
+  door, memoized on the head as the report spells it."
+  [node frame-kw]
+  (let [root (rdc/create-root node)]
+    (react-dom/flushSync
+      (fn []
+        (rdc/render root
+                    [rf/frame-provider {:frame frame-kw}
+                     [:div.reagent-parent
+                      (react/createElement memo-bridged #js {"label" "brg"})]])))
+    (fn [] (try (.unmount root) (catch :default _ nil)))))
+
+(defn- plain-react-root
+  "A root the CONSUMER opened with `react-dom/client` itself, with no
+  Reagent and no UIx anywhere in the tree — the sharpest reading of *who
+  owns the root*, because it differs from [[hicasso-root]] in nothing
+  else."
+  [node frame-kw]
+  (let [root (react-dom-client/createRoot node)]
+    (react-dom/flushSync
+      (fn []
+        (.render root (mount/provider frame-kw
+                                      (react/createElement
+                                        "div" nil
+                                        (h/as-element [card {:label "plain"}]))))))
+    (fn [] (try (.unmount root) (catch :default _ nil)))))
+
+(defn- uix-parent-plain-root
+  "THE ROW THE BEAD'S FIRST MOVE ASKS FOR: a UIx `defui` parent, under a
+  root Hicasso did not open."
+  [node frame-kw]
+  (let [root (react-dom-client/createRoot node)]
+    (react-dom/flushSync
+      (fn []
+        (.render root (mount/provider frame-kw (uix/$ uix-parent {:label "uix"})))))
+    (fn [] (try (.unmount root) (catch :default _ nil)))))
+
+(def ^:private routes
+  "Every mounting route §1 drives, with the frame each takes and the label
+  its own parent writes. Declared as data so the row cannot quietly stop
+  reaching one of them."
+  [{:route :root/hicasso     :frame ::r1 :label "ctl"   :mount hicasso-root}
+   {:route :crossed/reagent-as-element   :frame ::r2 :label "alpha" :mount reagent-root-as-element}
+   {:route :crossed/reagent-as-component :frame ::r3 :label "brg"   :mount reagent-root-as-component}
+   {:route :crossed/plain-react-root     :frame ::r4 :label "plain" :mount plain-react-root}
+   {:route :crossed/uix-parent           :frame ::r5 :label "uix"   :mount uix-parent-plain-root}])
+
+;; ===========================================================================
+;; 1 · A WRITE REPAINTS THROUGH EVERY MOUNTING ROUTE
+;; ===========================================================================
+
+(deftest a-write-repaints-through-every-mounting-route
+  (testing "rf2-phabt's headline claim, driven rather than argued: *a
+            Hicasso view rendered inside any React-shaped host that is not
+            a Hicasso root is non-reactive*. It is not. One boundary, one
+            subscription, one adapter and one drain; only the root and the
+            parent vary, and every route re-runs the body and moves the
+            DOM.
+
+            BODY RUNS ARE THE DIAGNOSTIC and the DOM text is the
+            corroboration — the report is explicit that the failure it saw
+            was a missing NOTIFICATION rather than a stale read, so the
+            reading that answers it is the one that says the body was
+            invoked again."
+    (if-not (mount/browser?)
+      (support/skip! ":node-test has no DOM")
+      (doseq [{:keys [route frame label mount]} routes]
+        (testing (str route)
+          (seat! frame 1)
+          (let [node (mount/fresh-container!)
+                stop (mount node frame)]
+            (try
+              (is (= (str label "/1") (text-of node))
+                  "it painted, reading ITS OWN frame's seeded value — a
+                   boundary that resolved some other frame would read 0")
+              (is (= 1 (readers-of frame))
+                  "and the commit acquired the key, which is the fact a
+                   repaint hangs off and is readable before the DOM is")
+              (let [runs (deref !runs)]
+                (rf/dispatch-sync [::bump 42] {:frame frame})
+                (drain!)
+                (is (< runs (deref !runs))
+                    "THE WRITE RE-RAN THE BODY — the notification reached
+                     this boundary")
+                (is (= (str label "/42") (text-of node))
+                    "and the readout moved with it"))
+              (finally (stop)))))))))
+
+;; ===========================================================================
+;; 2 · THE CELL THE ACQUIRE USED TO REUSE WITHOUT WIRING
+;; ===========================================================================
+;;
+;; `invalidate-cell!` drops a cell's reaction now and rebuilds the
+;; attachment at the microtask checkpoint. A boundary committing inside
+;; that window is handed the empty cell, and before rf2-phabt it was
+;; handed it as it stood — right value, no watch, no way to be notified.
+;;
+;; The window is opened here the way a per-test fixture opens it: the
+;; registrar is cleared and the query registered from cold, which is a
+;; FIRST registration and reaches `first-registration!`. That is the
+;; transition no disposal announces, and it invalidates every live cell
+;; holding the id.
+
+(defn- open-the-window!
+  "Leave a live cell for `frame-kw`'s read, then invalidate it — and
+  answer nothing, because the two `is` in the row below are what say the
+  window is genuinely open."
+  [frame-kw mount-fn]
+  (seat! frame-kw 1)
+  (let [node (mount/fresh-container!)
+        stop (mount-fn node frame-kw)]
+    (stop))
+  ;; A first-time `reg-sub` of a query a live cell holds. The registrar
+  ;; clear is what makes it first-time; a fixture, a lazily loaded module
+  ;; and a hot reload all reach the same hook.
+  (rf-registrar/clear-all!)
+  (rf/reg-sub ::counter (fn [db _] (or (:n db) 0)))
+  (rf/reg-event ::bump (fn [{:keys [db]} [_ n]] {:db (assoc db :n n)}))
+  (reset! frame/frames {})
+  (frame/ensure-default-frame!)
+  (seat! frame-kw 1)
+  nil)
+
+(deftest a-boundary-acquiring-an-invalidated-cell-is-notified-in-the-same-turn
+  (testing "THE ROW THE BEAD'S MEASUREMENT ACTUALLY TOOK, with the
+            crossing held OUT of it. The cell for this frame's read is
+            still in the table and its reaction has been dropped; a
+            boundary now mounts through Hicasso's OWN root — no bridge, no
+            foreign parent, nothing crossed — writes, and drains, all in
+            one turn.
+
+            Before rf2-phabt this row read `ctl/1` after a write of 42 and
+            the body run count did not move: `acquire-cell!` reused the
+            empty cell without wiring it, so `mark-dirty!` had no watch to
+            ride and nothing asked the boundary to render again. The value
+            on the first paint was RIGHT throughout, which is why a
+            witness that stopped at the mount would pass on the broken
+            runtime as happily as on the fixed one.
+
+            SAME TURN is the whole claim. The deferred rewire does repair
+            the cell at the microtask checkpoint, so a row that yielded
+            first would be green either way and would be measuring the
+            deferral rather than the acquire."
+    (if-not (mount/browser?)
+      (support/skip! ":node-test has no DOM")
+      (doseq [[label frame mount-fn painted]
+              [["h/mount!"         ::w1 hicasso-root           "ctl"]
+               ["a Reagent parent" ::w2 reagent-root-as-element "alpha"]]]
+        (testing label
+          (open-the-window! frame mount-fn)
+          (is (contains? (support/cell-keys) [frame [::counter]])
+              "PRECONDITION: the cell is still in the table — its reaper is
+               a macrotask and nothing has yielded")
+          (is (not (wired? frame))
+              "PRECONDITION: and its reaction has been dropped. Without
+               this the row mounts against an ordinary live cell and
+               proves nothing")
+          (let [node (mount/fresh-container!)
+                stop (mount-fn node frame)]
+            (try
+              (is (wired? frame)
+                  "THE ACQUIRE WIRED WHAT IT REUSED — the commit did not
+                   leave a reader attached to an empty cell")
+              (is (= (str painted "/1") (text-of node))
+                  "it painted the right value, as it always did — a
+                   reaction-less cell takes the cold probe")
+              (let [runs (deref !runs)]
+                (rf/dispatch-sync [::bump 42] {:frame frame})
+                (drain!)
+                (is (< runs (deref !runs))
+                    "so the write re-ran the body, in the same turn")
+                (is (= (str painted "/42") (text-of node))
+                    "and the readout moved"))
+              (finally (stop)))))))))

--- a/tools/story/test/re_frame/story/ui/hicasso_substrate_dom_cljs_test.cljs
+++ b/tools/story/test/re_frame/story/ui/hicasso_substrate_dom_cljs_test.cljs
@@ -46,42 +46,38 @@
     type and the boundary re-renders instead of remounting. A memoized
     `as-component` would re-implement that machinery one layer up.
 
-  ## KNOWN GAP — a crossed boundary is DEAF to writes (rf2-phabt)
+  ## THE GAP THAT WAS HERE IS CLOSED, and it was not the crossing
+  ## (rf2-phabt)
 
-  The spike settled what it was asked to settle and found one more thing
-  on the way, which is filed rather than fixed here (`implementation/**`
-  is outside this bead's fence):
+  This section used to record a KNOWN GAP: *a boundary crossed into from
+  a Reagent parent paints once, correctly, and then never re-renders on a
+  write into its own frame.* Two rows measuring it were run red and
+  removed rather than shipped, and rf2-phabt carried them.
 
-  **a boundary crossed into from a Reagent parent paints once, correctly,
-  and then never re-renders on a write into its own frame.** Body-run
-  counts say it plainly — the body is not re-invoked, so this is a
-  missing NOTIFICATION rather than a stale read.
+  **They are back, green** — [[a-write-repaints-a-crossed-boundary]] and
+  [[a-write-repaints-a-boundary-crossed-in-by-as-component]] below — and
+  the crossing was never the variable. The measurement that produced the
+  gap varied the mounting route AND the frame id at once, and it was the
+  second that carried the defect: `:story.hicasso/card`'s cell is still
+  in Hicasso's table when the row below it runs (this file's fixture
+  clears the registrar and re-registers `::counter`, which is a FIRST
+  registration and invalidates that cell), while the `h/mount!` control
+  named a frame no other row uses and so mounted against a clean table.
+  `impl.collector/acquire-cell!` reused the invalidated cell without
+  rebuilding its attachment, so the boundary got the right value from the
+  cold probe and no watch to be notified through.
 
-  It was measured with a live control, which is what makes the zero
-  readable: same boundary, same subscription, same Reagent adapter, same
-  drain, only the mounting route varying. Under `h/mount!` it repaints —
-  that row is [[a-write-repaints-a-boundary-under-hicassos-own-root]],
-  green, below. Crossed in with `h/as-element` it is deaf; crossed in
-  with a memoized `h/as-component` it is deaf in exactly the same way, so
-  the outward-bridge DOOR is not the variable and rf2-2dbpd's
-  pre-authorized fallback B is not the remedy. Ruled out with it: the
-  adapter, the drain, the provider object (both routes provide over the
-  same `re-frame.adapter.context/frame-context`), frame resolution across
-  the crossing (both crossed routes read the VARIANT frame's value on
-  their first paint), and React reconciliation
-  ([[a-reagent-parent-rerender-does-not-remount-the-boundary]] is green).
+  The repair is in the acquire, and the witness that pins it — with the
+  crossing held OUT of the row, under `h/mount!`, where the same
+  deafness reproduces — is
+  `re-frame.hicasso.foreign-root-bridge-dom-cljs-test`. That file also
+  drives five mounting routes, a UIx `defui` parent among them, and every
+  one repaints.
 
-  The two red routes were run and then REMOVED rather than shipped red or
-  pinned as a change-detector; rf2-phabt carries them verbatim. What
-  stays here is the live half, because a control with nothing to control
-  is still the row that says the harness can see a repaint at all.
-
-  **What this gap does and does not cost.** Everything this file proves
-  green is unaffected: registry dispatch, late resolution, degradation,
-  the stable element type, and a crossed boundary observing its variant
-  frame at render. What is blocked is INTERACTIVITY — a hicasso story
-  whose subject re-renders on its own writes — which is rf2-kttom's
-  concern, not this bead's.
+  **This file's fixture still does not reset the Hicasso runtime**, and
+  that is deliberate rather than an oversight: the two returned rows earn
+  their keep precisely because they mount against a cell an earlier row
+  left behind.
 
   ## Two lanes, one file
 
@@ -139,6 +135,14 @@
 
 (def ^:private card-id  ::hicasso-card)
 (def ^:private panel-id ::hicasso-panel)
+
+(def ^:private bridged-card
+  "THE OTHER BRIDGE DOOR, minted once at top level — the law, because
+  `h/as-component` allocates a component and minting one inside a render
+  would hand React a fresh element type every pass. Memoized on the head
+  the way rf2-phabt's route 3 spells it, so the two returned rows differ
+  by the DOOR and by nothing else."
+  (react/memo (h/as-component hicasso-card)))
 
 (def ^:private alias-entries
   "The registrar entries `h/defview` published at NAMESPACE LOAD, captured
@@ -375,6 +379,91 @@
                   "and the readout moved"))
             (finally
               (try (h/unmount! handle) (catch :default _ nil)))))))))
+
+(defn- write-and-settle!
+  "Write `n` into `frame-kw` and drain, the way a story's own interaction
+  would — [[settle!]] is this file's ratom-host pair."
+  [frame-kw n]
+  (rf/dispatch-sync [:hicsub/bump n] {:frame frame-kw})
+  (settle!)
+  nil)
+
+(deftest a-write-repaints-a-crossed-boundary
+  (testing "rf2-phabt's ROUTE 2, restored. It ran red once and was removed
+            rather than shipped red: a boundary spliced into a Reagent
+            tree by `h/as-element` painted `alpha/1` and then did not move
+            on a write into its own frame, with the body run count saying
+            so — 1 to 1, a missing notification rather than a stale read.
+
+            It is green because `impl.collector/acquire-cell!` now rebuilds
+            the attachment of a cell it REUSES. This row mounts on
+            `:story.hicasso/card`, whose cell an earlier row in this file
+            leaves in Hicasso's table and this file's fixture then
+            invalidates by re-registering `::counter` from cold — which is
+            the state the original red was taken in, and the reason the
+            frame id is this one rather than a fresh one.
+
+            BODY RUNS ARE THE ASSERTION and the DOM text corroborates: the
+            defect's first paint was always right, so a row that stopped
+            at the mount passes on the broken runtime as happily as on the
+            fixed one."
+    (if-not (browser?)
+      (is true ":node-test — no DOM; :browser-test runs this row")
+      (let [variant-id :story.hicasso/card
+            mount-node (make-mount-node!)
+            root       (rdc/create-root mount-node)
+            card-text  #(some-> (.querySelector mount-node "[data-test=\"hicasso-card\"]")
+                                .-textContent)]
+        (rf/make-frame {:id variant-id})
+        (write-and-settle! variant-id 1)
+        (try
+          (react-dom/flushSync
+            (fn []
+              (rdc/render root
+                [rf/frame-provider {:frame variant-id}
+                 [:div.reagent-parent
+                  (h/as-element [hicasso-card {:label "alpha"}])]])))
+          (is (= "alpha/1" (card-text)) "it painted, reading the variant's frame")
+          (let [runs-at-mount @!card-runs]
+            (write-and-settle! variant-id 42)
+            (is (> @!card-runs runs-at-mount)
+                "THE WRITE RE-RAN THE BODY — the notification crossed")
+            (is (= "alpha/42" (card-text)) "and the readout moved"))
+          (finally
+            (try (.unmount root) (catch :default _ nil))))))))
+
+(deftest a-write-repaints-a-boundary-crossed-in-by-as-component
+  (testing "rf2-phabt's ROUTE 3, restored — the same claim through the
+            OTHER bridge door, memoized on the head. It is here because
+            the original measurement used the two doors to eliminate the
+            door as the variable, and the pair is worth keeping now that
+            both are green: a repair that reached `as-element` and not
+            `as-component` would leave one of the two documented parents
+            deaf, and this row is what would say so."
+    (if-not (browser?)
+      (is true ":node-test — no DOM; :browser-test runs this row")
+      (let [variant-id :story.hicasso/card
+            mount-node (make-mount-node!)
+            root       (rdc/create-root mount-node)
+            card-text  #(some-> (.querySelector mount-node "[data-test=\"hicasso-card\"]")
+                                .-textContent)]
+        (rf/make-frame {:id variant-id})
+        (write-and-settle! variant-id 1)
+        (try
+          (react-dom/flushSync
+            (fn []
+              (rdc/render root
+                [rf/frame-provider {:frame variant-id}
+                 [:div.reagent-parent
+                  (react/createElement bridged-card #js {"label" "brg"})]])))
+          (is (= "brg/1" (card-text)) "it painted through the bridge")
+          (let [runs-at-mount @!card-runs]
+            (write-and-settle! variant-id 42)
+            (is (> @!card-runs runs-at-mount)
+                "and the write re-ran the body here too")
+            (is (= "brg/42" (card-text)) "and the readout moved"))
+          (finally
+            (try (.unmount root) (catch :default _ nil))))))))
 
 (deftest a-reagent-parent-rerender-does-not-remount-the-boundary
   (testing "the identity decision, measured on a fiber. The render fn mints


### PR DESCRIPTION
## rf2-phabt — the crossing was not the variable

**The bead's first move, answered first and plainly: a UIx parent REPAINTS.** So does a plain `react-dom/client` root, and so do both Reagent-parent routes the bead reports as deaf. The premise *"a Hicasso view rendered inside any React-shaped host that is not a Hicasso root is non-reactive"* does not hold.

Measured in real Chromium (`npm run test:browser`), one boundary, one subscription, one adapter, one drain, only the root and the parent varying:

| route | paints | repaints on a write | body runs |
|---|---|---|---|
| `h/mount!` (control) | `ctl/1` | **YES** `ctl/42` | 1 → 2 |
| Reagent root + `h/as-element` | `alpha/1` | **YES** `alpha/42` | +1 |
| Reagent root + memoized `h/as-component` | `brg/1` | **YES** `brg/42` | +1 |
| plain `createRoot` + `h/as-element` | `plain/1` | **YES** `plain/42` | +1 |
| plain `createRoot` + UIx `defui` parent | `uix/1` | **YES** `uix/42` | +1 |

## What the report actually measured

Its control varied **two** things — the mounting route *and* the frame id. The `h/mount!` row named `::own-root-frame`, which no other row uses, so it mounted against a clean cell table. The two crossed rows named `:story.hicasso/card`, whose cell an earlier row in that same file leaves behind and whose reaction that file's fixture then drops by re-registering `::counter` from cold (a registrar clear makes it a FIRST registration, which reaches `first-registration!`).

Reproduced, and the deafness follows the **frame id**, not the crossing: with the same precondition it reproduces under `h/mount!`, where nothing is crossed at all.

## The cause

`impl.collector/invalidate-cell!` drops a cell's reaction synchronously and defers rebuilding the attachment to the microtask checkpoint — correctly, because it is called from inside the registrar's registration and replacement hooks and from frame teardown, and none of those is a place to subscribe. Between those two moments the table holds a cell with **no reaction and no watch**.

`impl.collector/acquire-cell!` reused such a cell as it stood. The boundary then rendered the right value (a reaction-less cell takes the cold probe) and `mark-dirty!` had no watch to ride, so nothing asked it to render again.

## The repair

A commit **is** a place to subscribe — the whole cell table is commit-owned — so the acquire wires a reused cell that holds no reaction, and the deferred rewire guards on the reaction still being nil. Whichever gets there first wires it; the other finds a reaction and does nothing. The guard is load-bearing: wiring twice would add a second `add-on-dispose!` hook and compound on the next disposal.

Two lines of behaviour, in `implementation/hicasso/src/re_frame/hicasso/impl/collector.cljs`.

## Witnesses

- **`re-frame.hicasso.foreign-root-bridge-dom-cljs-test`** (new) — §1 the five routes above; §2 the invalidated-cell row, with the crossing held OUT of it, asserting the repaint lands **in the same turn** (a row that yielded first would be green either way and would be measuring the deferral rather than the acquire).
- **`re-frame.story.ui.hicasso-substrate-dom-cljs-test`** — the two rows rf2-2dbpd ran red and removed are **returned**, green, on `:story.hicasso/card` so they keep mounting against a cell an earlier row left behind. The §KNOWN GAP section is replaced by what was actually found. That file's fixture still does not reset the Hicasso runtime, deliberately — that leak is what gives the returned rows their teeth.

## Red proof

See the comment below.

## Fence

- `implementation/hicasso/src/re_frame/hicasso/impl/collector.cljs`
- `implementation/hicasso/test/re_frame/hicasso/foreign_root_bridge_dom_cljs_test.cljs` (new)
- `tools/story/test/re_frame/story/ui/hicasso_substrate_dom_cljs_test.cljs`

No `implementation/shadow-cljs.edn` change — the new file's `-dom-cljs-test` suffix puts it in `:browser-test` by the existing `ns-regexp`, and `hicasso/test` is already a source path.
