### PR TITLE
fix(story): the compiled plan carries a story-level substrate and subject (rf2-sc5g0)

### DIFF
--- a/tools/story/src/re_frame/story/plan.cljc
+++ b/tools/story/src/re_frame/story/plan.cljc
@@ -242,6 +242,14 @@
   off `ctx`. Listing them here only buys a redundant deep-merge per compile
   and misleads a reader into thinking `ctx` is the arg source.
 
+  `:substrates` and `:component` are inherited through `:extends` like the
+  rest, AND fall back to the parent STORY body when the whole chain
+  declares neither (rf2-sc5g0) — `001-Authoring.md` §Registration macros
+  makes both story-level slots the default for the story's variants, and
+  the fallback happens in `compile-body` rather than here because `ctx`
+  is the variant-chain merge and the story is ambient, exactly like
+  `:decorators` and `:tags`.
+
   `:sensitive` / `:large` (rf2-cmjly3 finding 12) carry the EP-0025 durable
   app-db classification (`{:app-db [[path]…]}`) — a plain map, so they
   merge exactly like every other context key (a child re-declaring the axis
@@ -1514,13 +1522,58 @@
         ;; order — composed fragments sit BETWEEN the ambient story
         ;; decorators and the variant-chain's own decorators (below).
         frag-decorators (vec (mapcat #(:decorators %) frag-layers))
+        ;; ---- the parent story, resolved ONCE (rf2-sc5g0) ----
+        ;; The parent story id (nil for an inline plan-map target with no
+        ;; `:variant/id`, or any id outside the variant-id grammar). Bound
+        ;; ONCE here — the story-decorator lookup, the tag fallback, the
+        ;; two ambient world keys below AND the `:story/id` stamp on the
+        ;; returned plan (rf2-xk8oz4) all read this SAME resolution, so
+        ;; they can never disagree about the parent.
+        sid          (args/parent-story-id id)
+        story-body   (when sid (story-lookup sid))
+        ;; ---- ambient (story-level) world keys ----
+        ;; `:substrates` and `:component` are declared on the VARIANT or on
+        ;; its parent STORY, and every renderer resolves them
+        ;; variant-first-then-story: `multi-substrate/resolve-substrate-set`
+        ;; and `canvas/variant-component` / `multi-substrate-grid` /
+        ;; `workspace`. The plan folded only the variant chain, so the two
+        ;; slots meant something NARROWER on the plan than they meant
+        ;; anywhere else — and both have a plan-side reader:
+        ;; `canonical/render-host-scope` takes the substrate off
+        ;; `[:world :substrates]` (rf2-3afns) and `render/prepare-render`
+        ;; takes the subject off `[:world :component]`. So a story that
+        ;; declared either ONCE, with variants inheriting it, painted
+        ;; correctly on the live canvas while `render-variant` fell back to
+        ;; the `:reagent` host default and to a nil view. Folding them here
+        ;; makes the compiled plan mean what the canvas means, which is
+        ;; what rf2-3afns established the plan is for.
+        ;;
+        ;; The precedence mirrors `resolve-substrate-set` EXACTLY —
+        ;; non-empty variant chain wins, else non-empty story, else the slot
+        ;; is absent and the render-time host default applies. `seq` rather
+        ;; than `contains?`: a variant declaring `:substrates #{}` declares
+        ;; nothing, which is already how both `resolve-substrate-set` and
+        ;; `single-render-substrate` read it.
+        ;;
+        ;; These are the only two of the `context-keys` with a
+        ;; `[:world …]` reader at all (`:modes` / `:viewport` /
+        ;; `:background` / `:xray` / `:platforms` / `:dispatch-console?` are
+        ;; folded for `:plan-hash` + explain and read off the bodies by the
+        ;; UI), so the plan carries variant scope everywhere else and this
+        ;; is a fix rather than a new inheritance rule.
+        eff-substrates (or (when (seq (:substrates ctx))        (:substrates ctx))
+                           (when (seq (:substrates story-body)) (:substrates story-body)))
         ;; ---- view arg schema + effective-args validation ----
         ;; `:effective-args` at plan time IS the resolved arg-map; the
         ;; render path layers control-panel overrides on top later. We
         ;; copy the view's explicit-input schema into the plan, validate
         ;; the effective args against it, and FAIL plan construction on a
         ;; missing-required or malformed view input (§View arg schemas).
-        component-id (:component ctx)
+        ;; The subject is the EFFECTIVE one, so a story-level `:component`
+        ;; gets its view-args schema enforced exactly like a variant-level
+        ;; one — the alternative is a contract that applies or not depending
+        ;; on which body happens to name the view.
+        component-id (or (:component ctx) (:component story-body))
         view-meta    (when component-id (view-lookup component-id))
         schema       (view-args-schema view-meta)
         eff-args     arg-map
@@ -1604,12 +1657,8 @@
         ;; plan the single source of truth, so the canvas + render-variant
         ;; resolve the identical stack. Each layer falls through to `[]`
         ;; when absent — the empty-collection concat is render-transparent.
-        ;; The parent story id (nil for an inline plan-map target with no
-        ;; `:variant/id`, or any id outside the variant-id grammar). Bound
-        ;; ONCE here — both the story-decorator lookup below AND the
-        ;; `:story/id` stamp on the returned plan (rf2-xk8oz4) read this
-        ;; SAME resolution, so they can never disagree about the parent.
-        sid          (args/parent-story-id id)
+        ;; `sid` is bound once, further up (rf2-sc5g0 moved it there so the
+        ;; ambient world keys read the same parent this does).
         story-decos  (vec (when sid (story-deco-lk sid)))
         full-decos   (vec (concat global-decos
                                   story-decos
@@ -1627,7 +1676,7 @@
         eff-tags     (tags/resolve-markers
                        (if (seq chain-tags)
                          chain-tags
-                         (set (:tags (when sid (story-lookup sid))))))
+                         (set (:tags story-body))))
         world        (cond-> {:setup          setup
                               :args           arg-map
                               :argtypes       argtypes
@@ -1681,11 +1730,15 @@
                        ;; (render-transparent).
                        (seq full-decos)             (assoc :decorators full-decos)
                        (contains? ctx :modes)       (assoc :modes (:modes ctx))
-                       (contains? ctx :substrates)  (assoc :substrates (:substrates ctx))
+                       ;; The two AMBIENT keys (rf2-sc5g0): resolved above,
+                       ;; variant chain then parent story, so
+                       ;; `render-host-scope` and `prepare-render` read what
+                       ;; the canvas reads. Absent when neither declares.
+                       (seq eff-substrates)         (assoc :substrates eff-substrates)
                        (contains? ctx :viewport)    (assoc :viewport (:viewport ctx))
                        (contains? ctx :background)  (assoc :background (:background ctx))
                        (contains? ctx :xray)        (assoc :xray (:xray ctx))
-                       (contains? ctx :component)   (assoc :component (:component ctx))
+                       (some? component-id)         (assoc :component component-id)
                        ;; rf2-cmjly3 finding 12: the EP-0025 durable app-db
                        ;; classification, carried through `:extends` like
                        ;; every other context key. Read by

--- a/tools/story/src/re_frame/story/ui/multi_substrate.cljs
+++ b/tools/story/src/re_frame/story/ui/multi_substrate.cljs
@@ -80,20 +80,31 @@
   no props-schema slot — deferred by rf2-1gy4e until someone asks for
   auto-Controls, rather than invented here.
 
-  ### One live limit, and it is not this renderer's (rf2-phabt)
+  ### The limit that WAS here is gone, and it was never the crossing
+  ### (rf2-phabt)
 
-  A Hicasso boundary crossed into from a Reagent parent — which is what
-  the canvas is — **paints once and does not re-render on a write into
-  its own frame.** Measured against a live control while this renderer
-  landed: the same boundary under `h/mount!` repaints, and both outward
-  doors (`h/as-element` and a memoized `h/as-component`) are deaf, so it
-  is the crossing rather than the door, the adapter or the drain.
+  This section used to record a live limit: *a Hicasso boundary crossed
+  into from a Reagent parent — which is what the canvas is — paints once
+  and does not re-render on a write into its own frame.* Read literally
+  that said a hicasso story could render and not respond to its own
+  dispatches, which would have made the substrate a demo rather than a
+  place to author.
 
-  So a hicasso story renders, takes its args, resolves its variant frame
-  and reads it — and does not yet respond to its own dispatches. Nothing
-  here works around it: a workaround would be a second reactivity path
-  for one substrate. It is fixed in Hicasso, and rf2-kttom's worked
-  testbed waits on it.
+  It was an artefact of the measurement, not a defect in the bridge. The
+  original comparison varied the mounting route AND the frame id at once;
+  the actual cause was `re-frame.hicasso.impl.collector/acquire-cell!`
+  REUSING a cell without rebuilding its attachment, so the notification
+  never reached a body that had already painted correctly. Fixed in
+  Hicasso, and both outward doors — `h/as-element` and a memoized
+  `h/as-component` — repaint on a write today. The two rows that measured
+  it are back, green, in
+  `re-frame.story.ui.hicasso-substrate-dom-cljs-test`
+  ([[a-write-repaints-a-crossed-boundary]] and its `as-component` pair).
+
+  So a hicasso story renders, takes its args, resolves its variant frame,
+  reads it AND responds to writes into it. Nothing here works around
+  anything: there is no second reactivity path for one substrate, because
+  none was ever needed.
 
   ## Grid layout
 

--- a/tools/story/test/re_frame/story/hicasso_substrate_cljs_test.cljc
+++ b/tools/story/test/re_frame/story/hicasso_substrate_cljs_test.cljc
@@ -112,9 +112,9 @@
 
   (testing "and the STORY body takes it too — `StoryBody` is closed
             independently of `VariantBody`, so a whole story can declare
-            the authoring layer once. (Where that story-level declaration
-            is READ is the canvas's `resolve-substrate-set`, not the
-            compiled plan; see the plan row below.)"
+            the authoring layer once. (Since rf2-sc5g0 that story-level
+            declaration reaches the compiled plan too, so the canvas and
+            `render-variant` read the same set; see the plan row below.)"
     (story/reg-story* :story.hic-all
       {:doc        "story-level declaration"
        :component  :my.app.views/article-card
@@ -138,18 +138,20 @@
 ;; 3 · plan compilation — `[:world :substrates]` is where the host reads it
 ;; ===========================================================================
 ;;
-;; MEASURED WHILE WRITING THESE ROWS, and left alone deliberately: the plan
-;; folds `:substrates` from the VARIANT and its `:extends` chain, and NOT
-;; from the parent story. `variant-plan` resolves the parent story for
-;; decorators and tags only (`plan.cljc` `sid` / `story-deco-lk`). So a
-;; substrate declared ONLY at story level reaches the canvas — which reads
-;; it through `multi-substrate/resolve-substrate-set`, story-body included
-;; — and does NOT reach `canonical/render-host-scope`, which reads
-;; `[:world :substrates]` and falls back to the `:reagent` host default.
-;; That is a narrower residue of the same disagreement rf2-3afns closed,
-;; it is not about hicasso, and both files are outside this bead's fence;
-;; it is FILED rather than fixed here, as rf2-sc5g0. The rows below pin
-;; what the plan DOES carry.
+;; MEASURED WHILE WRITING THESE ROWS and filed rather than fixed here (both
+;; files were outside rf2-2dbpd's fence): the plan folded `:substrates` from
+;; the VARIANT and its `:extends` chain and NOT from the parent story, so a
+;; substrate declared ONLY at story level reached the canvas — which reads it
+;; through `multi-substrate/resolve-substrate-set`, story-body included — and
+;; did NOT reach `canonical/render-host-scope`, which reads
+;; `[:world :substrates]` and fell back to the `:reagent` host default.
+;;
+;; FIXED under rf2-sc5g0: `plan/variant-plan` now folds the parent story's
+;; `:substrates` (and `:component`, which had the same asymmetry and no
+;; renderer-side fallback at all) with the canvas's own variant-then-story
+;; precedence. The witness is
+;; `re-frame.story.story-scope-world-keys-cljs-test`; the rows below stay
+;; scoped to what a HICASSO declaration carries.
 
 (deftest the-plan-carries-the-hicasso-declaration
   (testing "rf2-3afns routed `canonical/render-host-scope` at the COMPILED

--- a/tools/story/test/re_frame/story/story_scope_world_keys_cljs_test.cljc
+++ b/tools/story/test/re_frame/story/story_scope_world_keys_cljs_test.cljc
@@ -1,0 +1,238 @@
+(ns re-frame.story.story-scope-world-keys-cljs-test
+  "rf2-sc5g0 — a STORY-level `:substrates` / `:component` declaration must
+  reach the compiled plan.
+
+  ## The defect this namespace is the witness for
+
+  `plan/variant-plan` folded `:substrates` and `:component` from the
+  VARIANT body and its `:extends` chain only. It resolved the parent story
+  for decorators and tags and for nothing else, so a story that declared
+  either key ONCE — the shape `001-Authoring.md` calls the normal one, the
+  parent carrying the subject while variants vary by args — never had it
+  land on `[:world …]`.
+
+  Both slots have a plan-side reader, which is why that was a live defect
+  rather than an untidy plan:
+
+  - `canonical/render-host-scope` takes the substrate off
+    `[:world :substrates]` (rf2-3afns) and feeds it to
+    `multi-substrate/single-render-substrate`, which answers the `:reagent`
+    host default for an absent set. So a story declaring `#{:uix}` or
+    `#{:hicasso}` painted correctly on the live canvas — which resolves
+    variant-then-story through `multi-substrate/resolve-substrate-set` —
+    and rendered under REAGENT through `render-variant`. Exactly the
+    disagreement rf2-3afns closed, one level up.
+  - `render/prepare-render` takes the subject off `[:world :component]`
+    with NO fallback of its own, so the same story shape gave
+    `render-variant` a NIL view. Measured, not inferred: before the fix
+    `(get-in (render/prepare-render v) [:render-inputs :view])` answered
+    `nil` for a story-level `:component` and the view id for a
+    variant-level one.
+
+  ## Why the fix is on the plan and not on the two readers
+
+  rf2-3afns established that the compiled plan is the one thing the canvas
+  and `render-variant` both read, so they cannot drift. Teaching each
+  reader its own `(or variant story)` walk would have been a third and
+  fourth copy of a precedence rule that already exists in four places.
+
+  ## Scope
+
+  `:substrates` and `:component` are the only two `plan/context-keys` with
+  a `[:world …]` reader anywhere in `tools/story/src` — `:modes`,
+  `:viewport`, `:background`, `:xray`, `:platforms` and
+  `:dispatch-console?` ride the plan for `:plan-hash` + explain and are
+  read off the bodies by the UI, which resolves story scope itself. So
+  this is a fix to two slots, not a new inheritance rule for the plan.
+
+  Both arms: `.cljc` with a `-cljs-test` ns, so the JVM runner
+  (`clojure -M:test` from `tools/story`) and the shadow `:node-test` build
+  (`npm run test:cljs`) each run every row. Every claim here is about
+  DATA — the compiled plan and the host-free render-prep — so neither arm
+  needs a renderer."
+  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            [re-frame.registrar :as framework-registrar]
+            [re-frame.story.plan :as plan]
+            [re-frame.story.registrar :as registrar]
+            [re-frame.story.render :as render]))
+
+;; ---- fixture --------------------------------------------------------------
+;;
+;; Both registrars are wiped: the Story side-table (whose `:story` kind is
+;; what the plan's DEFAULT story-lookup reads — the production path, not a
+;; threaded test double) and the framework `:view` registrar (which the
+;; default view-lookup reads for the props schema).
+
+(use-fixtures :each
+  (fn [t]
+    (registrar/clear-all!)
+    (framework-registrar/clear-kind! :view)
+    (t)))
+
+(defn- reg-view-meta!
+  "Register a `:view` slot carrying `metadata` on the framework registrar —
+  the slot the plan compiler's default view-lookup reads."
+  [view-id metadata]
+  (framework-registrar/register! :view view-id
+                                 (assoc metadata :handler-fn (fn [_] nil))))
+
+;; ===========================================================================
+;; 1 · :substrates — the bead's exact repro
+;; ===========================================================================
+
+(deftest a-story-level-substrate-reaches-the-plan
+  (testing "rf2-sc5g0 — the assertion that returned `nil`. A story declares
+            the authoring layer once; its variants inherit it and declare
+            nothing. `[:world :substrates]` is where
+            `canonical/render-host-scope` reads it, so an absent slot is a
+            silent Reagent render."
+    (registrar/reg-story* :story.scope-sub
+      {:doc "declares the authoring layer once, for every variant"
+       :component  :views/probe
+       :substrates #{:hicasso}})
+    (registrar/reg-variant* :story.scope-sub/child {:doc "declares nothing"})
+    (is (= #{:hicasso}
+           (get-in (plan/variant-plan :story.scope-sub/child)
+                   [:world :substrates]))))
+
+  (testing "and it is the DEFAULT side-table lookup that resolves it — no
+            `:story-lookup` was threaded above. A fix that only worked
+            through an injected test double would leave the production path
+            exactly as broken as it was."
+    (is (= #{:hicasso}
+           (:substrates (registrar/handler-meta :story :story.scope-sub))))))
+
+(deftest the-variant-still-wins-over-its-story
+  (testing "precedence is variant-chain FIRST, then the story — the same
+            order `multi-substrate/resolve-substrate-set` applies, and the
+            same order `canvas/variant-component` applies for the subject.
+            A story-level default must not overwrite a variant that
+            deliberately differs."
+    (registrar/reg-story* :story.scope-win
+      {:doc "story default" :component :views/probe :substrates #{:reagent}})
+    (registrar/reg-variant* :story.scope-win/override
+      {:doc "this one variant is authored against another layer"
+       :substrates #{:uix}})
+    (is (= #{:uix}
+           (get-in (plan/variant-plan :story.scope-win/override)
+                   [:world :substrates])))))
+
+(deftest an-extends-chain-still-wins-over-its-story
+  (testing "the `:extends` chain is part of the VARIANT layer, so an
+            inherited declaration beats the story's too — the parent-first
+            fold this bead added sits UNDER the chain, not over it"
+    (registrar/reg-story* :story.scope-ext
+      {:doc "story default" :component :views/probe :substrates #{:reagent}})
+    (registrar/reg-variant* :story.scope-ext/base
+      {:doc "base" :substrates #{:uix}})
+    (registrar/reg-variant* :story.scope-ext/child
+      {:doc "child declares nothing of its own" :extends :story.scope-ext/base})
+    (is (= #{:uix}
+           (get-in (plan/variant-plan :story.scope-ext/child)
+                   [:world :substrates])))))
+
+(deftest an-empty-variant-set-declares-nothing
+  (testing "`#{}` on the variant is not a declaration — both
+            `resolve-substrate-set` and `single-render-substrate` already
+            read an empty set as `nothing declared`, so the plan falls
+            through to the story rather than pinning emptiness the canvas
+            would ignore. This is the row that says the fold mirrors the
+            canvas's rule instead of merely adding a fallback."
+    (registrar/reg-story* :story.scope-empty
+      {:doc "story declares" :component :views/probe :substrates #{:uix}})
+    (registrar/reg-variant* :story.scope-empty/v
+      {:doc "declares an empty set" :substrates #{}})
+    (is (= #{:uix}
+           (get-in (plan/variant-plan :story.scope-empty/v)
+                   [:world :substrates])))))
+
+(deftest nothing-declared-leaves-the-slot-absent
+  (testing "neither body declares ⇒ NO `:substrates` slot, which is what
+            lets `single-render-substrate` apply the host default. A fold
+            that wrote `#{}` or `nil` here would be render-transparent
+            today and a trap for any reader that tests presence."
+    (registrar/reg-story* :story.scope-none {:doc "declares nothing"
+                                             :component :views/probe})
+    (registrar/reg-variant* :story.scope-none/v {:doc "declares nothing"})
+    (is (not (contains? (:world (plan/variant-plan :story.scope-none/v))
+                        :substrates)))))
+
+;; ===========================================================================
+;; 2 · :component — the same asymmetry, and it was painting a nil view
+;; ===========================================================================
+
+(deftest a-story-level-component-reaches-the-plan-and-the-render-inputs
+  (testing "rf2-sc5g0 — `render/prepare-render` reads
+            `(get-in plan [:world :component])` with no fallback, so the
+            NORMAL authoring shape (`001-Authoring.md`: the parent story
+            carries the component, variants vary by args) handed
+            `render-variant` a nil view. The canvas was unaffected because
+            `canvas/variant-component` walks to the story itself."
+    (registrar/reg-story* :story.scope-cmp
+      {:doc "the parent carries the subject" :component :views/probe})
+    (registrar/reg-variant* :story.scope-cmp/v
+      {:doc "varies by args only" :args {:label "Go"}})
+    (let [p (plan/variant-plan :story.scope-cmp/v)]
+      (is (= :views/probe (get-in p [:world :component]))))
+    (let [prepared (render/prepare-render :story.scope-cmp/v)]
+      (is (= :prepared (:status prepared)))
+      (is (= :views/probe (get-in prepared [:render-inputs :view]))
+          "the subject reaches the host render hook — this is the
+           assertion that answered nil before the fix"))))
+
+(deftest a-variant-component-still-overrides-its-story
+  (testing "`:component` is documented as the per-variant OVERRIDE
+            (`schemas/VariantBody`), so the variant's value wins"
+    (registrar/reg-story* :story.scope-cmp-ovr
+      {:doc "parent subject" :component :views/parent})
+    (registrar/reg-variant* :story.scope-cmp-ovr/v
+      {:doc "names its own subject" :component :views/own})
+    (is (= :views/own
+           (get-in (plan/variant-plan :story.scope-cmp-ovr/v)
+                   [:world :component])))))
+
+(deftest no-component-anywhere-leaves-the-slot-absent
+  (testing "an events-only variant under a story that names no subject
+            carries no `:component` slot — unchanged, and the row that
+            says the fold did not start inventing one"
+    (registrar/reg-story* :story.scope-cmp-none {:doc "no subject"})
+    (registrar/reg-variant* :story.scope-cmp-none/v {:doc "no subject"})
+    (is (not (contains? (:world (plan/variant-plan :story.scope-cmp-none/v))
+                        :component)))))
+
+;; ===========================================================================
+;; 3 · the deliberate consequence — the view-args contract follows the subject
+;; ===========================================================================
+
+(deftest the-view-args-schema-follows-a-story-level-component
+  (testing "rf2-sc5g0 — folding `:component` makes the plan compiler's
+            view-args schema resolution see the story-level subject too.
+            That is the point, not a side effect: the explicit-view-input
+            contract must not apply or not apply depending on WHICH body
+            happens to name the view."
+    (reg-view-meta! :views/widget {:rf/props [:map [:label :string]]})
+    (registrar/reg-story* :story.scope-schema
+      {:doc "parent carries the subject" :component :views/widget})
+    (registrar/reg-variant* :story.scope-schema/v
+      {:doc "varies by args" :args {:label "Hi"}})
+    (is (= [:map [:label :string]]
+           (get-in (plan/variant-plan :story.scope-schema/v)
+                   [:world :view-args-schema])))))
+
+(deftest a-missing-required-view-input-fails-under-a-story-level-component
+  (testing "and the schema is ENFORCED, not merely copied — a required view
+            input the variant never supplies fails plan construction with
+            `:rf.error/story-view-args-invalid`, exactly as it does when
+            the variant names the component itself. Without this row the
+            row above would pass on a plan that carried the schema and
+            checked nothing."
+    (reg-view-meta! :views/strict {:rf/props [:map [:label :string]]})
+    (registrar/reg-story* :story.scope-strict
+      {:doc "parent carries the subject" :component :views/strict})
+    (registrar/reg-variant* :story.scope-strict/v {:doc "supplies no args"})
+    (let [e (try (plan/variant-plan :story.scope-strict/v)
+                 nil
+                 (catch #?(:clj clojure.lang.ExceptionInfo :cljs :default) e e))]
+      (is (some? e) "plan construction failed")
+      (is (= :rf.error/story-view-args-invalid (:rf.error/id (ex-data e))))
+      (is (= :views/strict (:component (ex-data e)))))))

--- a/tools/story/test/re_frame/story/ui/canvas_substrate_routing_cljs_test.cljs
+++ b/tools/story/test/re_frame/story/ui/canvas_substrate_routing_cljs_test.cljs
@@ -117,6 +117,15 @@
      :component  :views/probe
      :substrates #{:uix}
      :loaders    [[:noop/loader]]})
+  ;; rf2-sc5g0 — the same declaration, one level up. The STORY names the
+  ;; subject and the layer; the variant names neither and inherits both.
+  (story/reg-story* :story.substrate-story-scope
+    {:doc        "rf2-sc5g0 witness — story-level :component + :substrates"
+     :component  :views/probe
+     :substrates #{:uix}})
+  (story/reg-variant* :story.substrate-story-scope/inherits
+    {:doc     "Declares neither :component nor :substrates."
+     :loaders [[:noop/loader]]})
   (story/reg-variant* :story.substrate-routing/reagent-only
     {:doc        "Declares ONE substrate, Reagent — the unchanged baseline."
      :component  :views/probe
@@ -230,6 +239,59 @@
       (is (not (rendered-under-reagent? tree))
           "and not through Reagent")
       (story/destroy-variant! :story.substrate-routing/uix-only))))
+
+;; ===========================================================================
+;; rf2-sc5g0 — the same disagreement with the declaration ONE LEVEL UP
+;; ===========================================================================
+;;
+;; `plan/variant-plan` folded `:substrates` and `:component` from the VARIANT
+;; and its `:extends` chain only, so a STORY-level declaration never reached
+;; `[:world …]`. The canvas was unaffected (`variant-substrate-set` and
+;; `variant-component` walk to the story themselves) while `render-variant`
+;; read the plan and got nothing — the `:reagent` host default and a nil
+;; view. The two rows below are the pair: the canvas half is the CONTROL that
+;; was already right, the host half is the one that was wrong. Asserting only
+;; the host would not say they now agree, which is the property rf2-3afns
+;; established the plan exists to guarantee.
+
+(deftest story-level-declaration-reaches-the-render-variant-host
+  (testing "rf2-sc5g0 — a story declares the subject and the layer once; its
+            variant declares neither. `render-variant` must paint through
+            the :uix render fn. Before the fix the plan carried no
+            `:substrates` (so the host default :reagent won) and no
+            `:component` (so the view was nil)."
+    (story/register-substrate! :uix uix-stub-render)
+    (let [result (render/render-variant :story.substrate-story-scope/inherits)
+          tree   (e2e/expand-tree (:rendered result))]
+      (is (= :rendered (:status result)))
+      (is (rendered-under-uix? tree)
+          "the inherited layer reached the host — the substrate half")
+      (is (re-find #":views/probe" (e2e/text-nodes tree))
+          "and the inherited SUBJECT reached it too: the uix stub prints the
+           view-id it was handed, so a nil view would print `nil` here. This
+           is the `:component` half, which had no fallback in
+           `render/prepare-render` at all.")
+      (is (not (rendered-under-reagent? tree))
+          "and it did NOT fall back to Reagent")
+      (story/destroy-variant! :story.substrate-story-scope/inherits))))
+
+(deftest story-level-declaration-makes-canvas-and-host-agree
+  (testing "rf2-sc5g0 — the canvas single-pane path ALREADY honoured a
+            story-level declaration, which is exactly why the disagreement
+            was invisible: the live shell painted UIx while `render-variant`
+            painted Reagent, for the same variant. Both must now be UIx."
+    (story/register-substrate! :uix uix-stub-render)
+    (let [variant-id  :story.substrate-story-scope/inherits
+          canvas-tree (ready-tree variant-id)
+          host-tree   (e2e/expand-tree
+                        (:rendered (render/render-variant variant-id)))]
+      (is (and (rendered-under-uix? canvas-tree)
+               (not (rendered-under-reagent? canvas-tree)))
+          "the canvas — the control, unchanged by this fix")
+      (is (and (rendered-under-uix? host-tree)
+               (not (rendered-under-reagent? host-tree)))
+          "and the host, which is what changed")
+      (story/destroy-variant! variant-id))))
 
 ;; ===========================================================================
 ;; single-render-substrate — the policy, on its own terms


### PR DESCRIPTION
Two clustered beads on one surface: **rf2-sc5g0** (the fix) and **rf2-5czki** (the parent — one verified prose correction, then a source-located STOP).

---

## rf2-sc5g0 — story-level `:substrates` does not reach the compiled plan

### The defect, verified at source

`plan/variant-plan` (`tools/story/src/re_frame/story/plan.cljc`) folded `:substrates` and `:component` from the VARIANT body and its `:extends` chain only. It resolved the parent story for decorators and tags and for nothing else.

Both slots have a plan-side reader, which is why that was a live defect rather than an untidy plan:

| reader | slot | what it did with an absent slot |
|---|---|---|
| `canonical/render-host-scope` (`canonical.cljc:139`) | `[:world :substrates]` | `single-render-substrate` answered the `:reagent` host default |
| `render/prepare-render` (`render.cljc:253`) | `[:world :component]` | `:view` was **nil** — no fallback of its own |

So a story declaring `:substrates #{:uix}` (or `#{:hicasso}`) once, with variants inheriting it, painted correctly on the live canvas — `canvas/variant-substrate-set` → `multi-substrate/resolve-substrate-set`, whose rule is `(or variant-body story-body #{host})` — and rendered under **Reagent** through `render-variant`.

### The `:component` half — the bead's open question, answered by measurement

The bead asked whether to fix `:component` together with `:substrates` or to "state plainly that the plan carries variant-scope only". Measured before touching anything, with a throwaway JVM probe:

```
PROBE  render-inputs :view  = nil          ; story-level :component
PROBE2 render-inputs :view  = :views/probe ; variant-level :component
```

`render/prepare-render` has **no** `(or variant story)` fallback — only the canvas-side readers do. So the common authoring shape (`001-Authoring.md`: the parent story carries the subject, variants vary by args) handed `render-variant` a nil view. Same defect, not a cosmetic asymmetry, so both are fixed. **Where the bead and this PR differ, it is here, and the bead invited the decision.**

### Why the fix is on the plan and not on the two readers

rf2-3afns established that the compiled plan is the one thing the canvas and `render-variant` both read, so they cannot drift. Teaching each reader its own walk would have been a third and fourth copy of a precedence rule that already exists in four places (`resolve-substrate-set`, `canvas/variant-component`, `multi-substrate-grid`, `workspace`). Fix shape **(a)** from the bead.

Precedence mirrors `resolve-substrate-set` **exactly** — non-empty variant chain, else non-empty story, else the slot is **absent**, so the render-time host default still applies. `seq` rather than `contains?`, because `#{}` is already read as "nothing declared" by both `resolve-substrate-set` and `single-render-substrate`.

`component-id` is now the effective subject, so the explicit-view-input schema contract applies uniformly rather than depending on which body happens to name the view. Deliberate, and pinned by two rows including one that proves the schema is *enforced* and not merely copied.

`sid` moved up in the `let` and is bound once; the tag fallback now reads the same `story-body` binding rather than re-resolving it.

### Scope — why two slots and not six

`:substrates` and `:component` are the **only** two `plan/context-keys` with a `[:world …]` reader anywhere in `tools/story/src`:

```
27 :world :decorators]   25 :world :setup]   18 :world :view-args-schema]
 …     2 :world :substrates]        1 :world :component]
```

`:modes`, `:viewport`, `:background`, `:xray`, `:platforms`, `:dispatch-console?` ride the plan for `:plan-hash` + explain and are read off the bodies by the UI, which resolves story scope itself. So this is a fix to two slots, not a new inheritance rule.

### No spec change needed

`tools/story/spec/001-Authoring.md:357` already documents story-level `:substrates` as "default substrate set for variants", and `schemas/VariantBody` already says a variant "inherits its parent story's `:component` but MAY name its own". The spec was right; the compiler was not. Nothing under `spec/` or `tools/story/spec/` is touched.

---

## rf2-5czki — what is already present, and where I stopped

### Established before building — the bead's census is stale

The bead says "files mentioning hicasso: ZERO". At this base (`origin/main` @ `0874ab3474`) **five** files under `tools/story` do, and the substrate is registered on Story's authoring axis:

- `schemas.cljc` — `SubstrateSet` is `[:set [:enum :reagent :uix :hicasso]]`, and the docstring correcting the false "mirrors the framework's closed set" claim landed with it;
- `ui/multi_substrate.cljs` — the ns docstring carries the shipped five-line `:hicasso` recipe (host-registered, exactly as `:uix` is — a Story-side `install-hicasso-substrate!` was ruled out as GA-era ergonomics);
- `test/…/hicasso_substrate_cljs_test.cljc` — enum / registration / plan / MCP-EDN / snapshot-identity, both arms;
- `test/…/ui/hicasso_substrate_dom_cljs_test.cljs` — the Reagent-parent crossing proved in a real DOM, **including the two repaint rows that rf2-phabt restored green**;
- `deps.edn` — the comment block recording why no substrate coordinate is added.

So Story is not greenfield for Hicasso. rf2-3afns, rf2-1gy4e, rf2-5qaf4, rf2-2dbpd, rf2-phabt and rf2-ek9qb are all closed. **rf2-kttom is the parent's one remaining phase.**

### The one thing I found wrong, and fixed

`ui/multi_substrate.cljs:83-96` still carried rf2-2dbpd's *"One live limit"* section: that a boundary crossed into from a Reagent parent — which is what Story's canvas is — paints once and never re-renders on a write into its own frame, so "a hicasso story … does not yet respond to its own dispatches".

That is false at this base. rf2-phabt established it was an artefact of a fixture leaking a frame's cell, fixed it in `hicasso/impl/collector.cljs` (`df78bb8068`), and restored both measuring rows green. The rf2-phabt worker updated the **test** file; this **source** docstring was outside that bead's fence and was left saying the opposite. It is the last stale deafness claim under `tools/story` (a `git grep` for phabt / deaf / "does not re-render" returns this block and the test's own history notes).

It matters more than a comment usually would: this docstring **is** the shipped recipe. A programmer choosing the native substrate reads it and is told the substrate is a demo. Prose only, no code change.

### Where I STOPPED, and what I needed

The parent's own ruling says it "stays OPEN until rf2-kttom's gate is green and the docs sentence is changed". rf2-kttom's blockers (rf2-2dbpd, rf2-phabt) are both now closed, so it is dependency-ready — but it is **fence-blocked**, and I did not take it:

- rf2-kttom is ruled **sole toucher** of `implementation/shadow-cljs.edn` (a new build-id + a port in the 804x band) and of `.github/workflows/**`.
- Open PR **#8322** (`worker/retire-final`, READY, 722 files, derived with `git diff --name-only origin/main...origin/worker/retire-final` because the API's `files` field truncates at 100) touches `implementation/shadow-cljs.edn`, `.github/workflows/test.yml` and `.github/workflows/expensive-tests.yml`. It touches **zero** files under `tools/story`.

So rf2-kttom cannot be started until #8322 merges. Doing half of it — the docs sentence at `docs/story/09-multi-substrate-and-agent-loop.md:22-23`, or the play-scripts roster — would claim a testbed that does not exist and strand the hot-zone half. That sentence is left unchanged and stays rf2-kttom's.

**Nothing here needed a design decision.** The naming question was already ruled (rf2-1gy4e option (b)) and has landed.

---

## Tests

- **NEW** `tools/story/test/re_frame/story/story_scope_world_keys_cljs_test.cljc` — 10 rows, both arms (`-cljs-test` ns on a `.cljc`, so the JVM runner and the shadow `:node-test` build each run every row). Covers the repro, variant-wins precedence, `:extends`-wins precedence, `#{}`-declares-nothing, absent-slot, the `:component` half through `prepare-render`, and the view-args schema following a story-level subject.
- `ui/canvas_substrate_routing_cljs_test.cljs` — the witness the bead asked for by name. A story-level declaration row-pair that distinguishes **which substrate actually rendered** (`uix-stub-render` vs `reagent-view-render` markers, mutually exclusive by construction), plus a canvas-vs-host agreement row where the canvas is the control that was already right. The subject half is asserted through the stub printing the view-id it was handed, so a nil view is visible.
- `hicasso_substrate_cljs_test.cljc` — two now-stale comments corrected (they said this residue was filed rather than fixed).

## RED proof — both arms

**JVM.** All three edited call sites reverted, `clojure -M:test -n re-frame.story.story-scope-world-keys-cljs-test`:

```
EXIT=1
Ran 10 tests containing 15 assertions.
8 failures, 0 errors.
```

**Node.** Same defect planted, full `:node-test` recompile + run:

```
EXIT=1
Ran 14011 tests containing 70471 assertions.
11 failures, 1 errors.
```

Red rows named both new namespaces — `story_scope_world_keys_cljs_test.cljc` (8) and `ui/canvas_substrate_routing_cljs_test.cljs` (4), which is also the proof that both files are actually discovered by the node lane rather than merely compiled. The four rows that stayed green are the precedence / absent-slot regression guards, which the defect does not perturb.

Restore verified: `git status --short` empty and `git diff HEAD --exit-code` clean, then the three fixed lines re-read at `plan.cljc:1576/1737/1741`.

## Gates — all foreground, captured exit codes

| gate | lane | exit | result |
|---|---|---|---|
| `clojure -M:test` from `tools/story` | JVM | **0** | Ran 1877 tests, 6848 assertions, 0 failures 0 errors |
| `node scripts/compile-node-test.cjs node-test out/node-test.js` | CLJS node (compile) | **0** | 2403 files, 0 warnings, 72.91s |
| `node out/node-test.js` | CLJS node (run) | **0** | Ran 14011 tests, 70470 assertions, 0 failures 0 errors |
| `npx shadow-cljs compile browser-test` | browser (compile) | **0** | 1261 files, 70.95s |
| `node scripts/serve-and-run-browser-tests.cjs` | browser (run) | **0** | Ran 1568 tests, 9937 assertions, 0 failures 0 errors |
| `npm run test:story-play-scripts` | browser, live render path | **0** | Ran 30 `:play-script` rows, 0 unexpected outcomes |
| `sh scripts/check-no-hardcoded-paths.sh` | portability | **0** | no hardcoded personal/home paths |

`npm run test:cljs` is `compile && run`; both halves were run foreground as separate calls, because the combined script measures past this harness's 10-minute foreground cap. Each half completed well inside it and no run was killed, so the shadow cache was never orphaned.

The play-scripts gate was run because it is the only PR-path gate that drives the live render path, and this change is to the compiler both the canvas and `render-variant` read.

## Fence, as actually touched

```
tools/story/src/re_frame/story/plan.cljc
tools/story/src/re_frame/story/ui/multi_substrate.cljs        (docstring only)
tools/story/test/re_frame/story/hicasso_substrate_cljs_test.cljc
tools/story/test/re_frame/story/story_scope_world_keys_cljs_test.cljc   (new)
tools/story/test/re_frame/story/ui/canvas_substrate_routing_cljs_test.cljs
```

No hot zone. Re-derived against the three other open PRs at start-up and again before the first edit: #8322 `worker/retire-final` holds zero `tools/story` paths; #8371 `worker/w-benchrig` is confined to `implementation/hicasso/test/re_frame/bench/hicasso/**`; #8372 `worker/w-0fd3b` is confined to `docs/design/hicasso/product/**` plus `implementation/hicasso/src/re_frame/hicasso.cljc`. No overlap with any of them.
