### PR TITLE
bench(hicasso): warm the two clock arms, and stop the guard being told a predecessor that never ran (rf2-h904p, rf2-6ta5r)

### DIFF
--- a/implementation/hicasso/test/re_frame/bench/hicasso/amp_merge_clock_app.cljs
+++ b/implementation/hicasso/test/re_frame/bench/hicasso/amp_merge_clock_app.cljs
@@ -550,8 +550,12 @@
   10.26 10.26 10.33 10.28` and then `8.12` for ever, a +27% step falling
   after the SIXTH execution of the site. `{:warmup 8 :samples 12}` puts
   that step inside the warm-up, doubles each phase stratum to n = 20, and
-  is what `coldmount_app`, `p0_converge_app` and `p0_reagent_app` — every
-  other full-page-mount harness on this instrument — already run.
+  is what every other harness riding [[lane/mount-batch!]] already runs.
+  That set is checkable and small — `(lane/mount-batch!` has five call
+  sites on this lane, this file, `direct_return_clock_app`,
+  `coldmount_app`, `p0_converge_app` and `p0_reagent_app` — and the last
+  three all sample at 8/12, so the two clocks were the lane's only
+  batched-mount outliers.
 
   WHAT THIS DOES NOT CLAIM. That warm-up PRODUCED the 1.4737. One round of
   five, no second window, and a box bracketed quiet at its two ends but

--- a/implementation/hicasso/test/re_frame/bench/hicasso/amp_merge_clock_app.cljs
+++ b/implementation/hicasso/test/re_frame/bench/hicasso/amp_merge_clock_app.cljs
@@ -511,7 +511,57 @@
 
 (defn- arm-named [id] (first (filter #(= id (:id %)) arms)))
 
-(def ^:private sampling {:warmup 3 :samples 6})
+(def ^:private sampling
+  "THE LANE'S PAGE-MOUNT SAMPLING, which this arm now runs (rf2-6ta5r).
+
+  It ran `{:warmup 3 :samples 6}`, and on that sampling the NULL arm
+  degraded: `:expanded-b`/`:expanded` read `[0.9467 1.4737 1.0294 1
+  0.9853]` on a quantity that is 1.0 BY CONSTRUCTION — the same body under
+  a second boundary head. Four rounds sit within 5.3% of 1.0 and round two
+  reads +47%, which on the per-field arithmetic is +4,500 ns on a
+  difference of zero. An impossible reading bounds nothing, so that window
+  claimed no term inside instrument resolution, its own included.
+
+  ROUND TWO IS A WARM-UP ROUND, and that is the connection to `rf2-h904p`
+  on `direct_return_clock_app`. Replaying [[lane/rounds!]] against
+  `order-guard/slot-order` puts every arm's FIRST-THIRD phase stratum at
+  rounds one and two — 3 to 15 prior executions of the arm — and its
+  LAST-THIRD at rounds four and five, 32 to 44. The null degraded inside
+  exactly the span the other harness's guard refused on. `p50` over six
+  samples cannot be moved 1.47x by one outlier: at least three of the six
+  were elevated, so the round-two event was sustained across half that
+  arm's round rather than a single pause, which is the shape of a ramp and
+  not of a transient.
+
+  THE ARM COUNT IS NOT THE LEVER, and this settles it for `rf2-v5oto`.
+  `run.cjs` names `fewer arms per round` as one of the three moves, and
+  `rf2-z143r` taking the schedule from five arms to seven is the lead the
+  bead was filed on. The schedule arithmetic answers it: at n = 5, 7 and 8
+  every arm still banks 30 samples per run, every arm's phase strata are
+  still rounds 1-2 against rounds 4-5 at the same prior-execution counts,
+  and the null's true predecessor distribution keeps its kind
+  (`:expanded` 20, `:merged` 10). The null's POSITION did not move when
+  the ladder landed. Arm count buys wall-clock per round and a different
+  set of neighbours; it does not touch the axis the null failed on. So the
+  ladder stays whole and `rf2-v5oto`'s eighth arm is not blocked by this.
+
+  WHAT IS LEFT IS WARM-UP, and three is below the step the lane itself
+  records: `lane.cljs`'s live reproduction read one control `10.32 10.26
+  10.26 10.26 10.33 10.28` and then `8.12` for ever, a +27% step falling
+  after the SIXTH execution of the site. `{:warmup 8 :samples 12}` puts
+  that step inside the warm-up, doubles each phase stratum to n = 20, and
+  is what `coldmount_app`, `p0_converge_app` and `p0_reagent_app` — every
+  other full-page-mount harness on this instrument — already run.
+
+  WHAT THIS DOES NOT CLAIM. That warm-up PRODUCED the 1.4737. One round of
+  five, no second window, and a box bracketed quiet at its two ends but
+  never sampled inside a measured window cannot separate a ramp from
+  anything else that decayed over the same run. What is established is
+  that the seven-arm schedule is not implicated and that the reading
+  landed inside the run's least-warmed span; the rest is the next window's
+  to confirm, and it should read the null before it reads anything else."
+  {:warmup 8 :samples 12})
+
 (def ^:private rounds 5)
 (def ^:private control-slack 0.25)
 

--- a/implementation/hicasso/test/re_frame/bench/hicasso/coldmount_app.cljs
+++ b/implementation/hicasso/test/re_frame/bench/hicasso/coldmount_app.cljs
@@ -492,10 +492,6 @@
 ;; One round of this page's row in one segment
 ;; ---------------------------------------------------------------------------
 
-(defn- mark-predecessor! [coll id]
-  (swap! coll assoc :prev id)
-  nil)
-
 (defn- mount-round!
   [coll t {:keys [row-key props arms-for] :as spec} segment-id]
   (let [arms   (arms-for segment-id)
@@ -517,7 +513,7 @@
             (if (>= s (:warmup mount-sampling))
               (do (lane/collect! coll label ms)
                   (swap! acc update (:id arm) conj ms))
-              (mark-predecessor! coll label))))))
+              (lane/observe! coll label))))))
     @acc))
 
 (defn- run-round!

--- a/implementation/hicasso/test/re_frame/bench/hicasso/direct_return_clock_app.cljs
+++ b/implementation/hicasso/test/re_frame/bench/hicasso/direct_return_clock_app.cljs
@@ -249,10 +249,13 @@
   `:warmup 3` a step of that shape lands INSIDE the measured samples and
   splits round one, which is the contrast the guard reported; at
   `:warmup 8` it lands inside the warm-up and no measured sample straddles
-  it. `{:warmup 8 :samples 12}` is also what every other full-page-mount
-  harness on this instrument already runs — `coldmount_app`,
-  `p0_converge_app` and `p0_reagent_app` between them — so this arm stops
-  being the lane's outlier rather than acquiring a figure of its own.
+  it. `{:warmup 8 :samples 12}` is also what every other harness riding
+  [[lane/mount-batch!]] already runs. That set is checkable and small —
+  `(lane/mount-batch!` has five call sites on this lane, this file,
+  `amp_merge_clock_app`, `coldmount_app`, `p0_converge_app` and
+  `p0_reagent_app` — and the last three all sample at 8/12, so the two
+  clocks were the lane's only batched-mount outliers. This arm stops
+  being one rather than acquiring a figure of its own.
 
   WHAT WAS DELIBERATELY NOT MOVED. Not the guard's tolerance, which is not
   the arm's to move. Not [[boundaries]]: lengthening the flushSync window

--- a/implementation/hicasso/test/re_frame/bench/hicasso/direct_return_clock_app.cljs
+++ b/implementation/hicasso/test/re_frame/bench/hicasso/direct_return_clock_app.cljs
@@ -228,7 +228,46 @@
    {:id :ctl-2x :k 2 :elements page-elements :parity-exempt? true
     :mount (mount-page hiccup-arm) :unmount unmount-page}])
 
-(def ^:private sampling {:warmup 3 :samples 6})
+(def ^:private sampling
+  "THE LANE'S PAGE-MOUNT SAMPLING, which this arm now runs (rf2-h904p).
+
+  It ran `{:warmup 3 :samples 6}`, and the arm-order guard refused the S8
+  window at exit 2 on a PHASE contrast: `:hiccup`'s first third read
+  `2.3000 ms [2.1000-4.9000]` against a last third of
+  `1.9000 ms [1.7000-2.0000]`, `1.2105x` apart with disjoint ranges, while
+  the other two page-mounting arms drifted `1.2338x` (`:ctl-2x`) and
+  `1.2000x` (`:direct`) and passed only because their ranges overlapped.
+  Every by-predecessor contrast passed on every arm. A decay common to all
+  three mounting arms and absent from the by-predecessor axis is a
+  POSITION effect, and three warm-up mounts is what this file was giving
+  it.
+
+  THREE SITS BELOW THE STEP THE LANE ITSELF RECORDS. `lane.cljs`'s live
+  reproduction read one control `10.32 10.26 10.26 10.26 10.33 10.28` and
+  then `8.12` for ever — a +27% step falling after the SIXTH execution of
+  the site, with nothing varying but how many times it had run. At
+  `:warmup 3` a step of that shape lands INSIDE the measured samples and
+  splits round one, which is the contrast the guard reported; at
+  `:warmup 8` it lands inside the warm-up and no measured sample straddles
+  it. `{:warmup 8 :samples 12}` is also what every other full-page-mount
+  harness on this instrument already runs — `coldmount_app`,
+  `p0_converge_app` and `p0_reagent_app` between them — so this arm stops
+  being the lane's outlier rather than acquiring a figure of its own.
+
+  WHAT WAS DELIBERATELY NOT MOVED. Not the guard's tolerance, which is not
+  the arm's to move. Not [[boundaries]]: lengthening the flushSync window
+  is the third move `run.cjs` names, but it would change the SUBJECT
+  budgets.md S8 already publishes — `on a 200-boundary mount` — and make
+  the next window incomparable to run 1 for a reason that has nothing to
+  do with the refusal. And not the arm count, which the same repair on
+  `amp_merge_clock_app` settles with the schedule arithmetic.
+
+  This re-tunes the conditions under which S8 is measured, so run 1's
+  published figure is NOT comparable to what this file will read next.
+  That was already the position: the refusal left S8 waiting on a fresh
+  window, and this is the rig change it was waiting for."
+  {:warmup 8 :samples 12})
+
 (def ^:private rounds 5)
 (def ^:private control-slack 0.25)
 

--- a/implementation/hicasso/test/re_frame/bench/hicasso/lane.cljs
+++ b/implementation/hicasso/test/re_frame/bench/hicasso/lane.cljs
@@ -542,12 +542,12 @@
   siblings.
 
   What never got the repair was [[rounds!]] — the SHARED loop every other
-  harness on this lane rides. Nine bench apps ran on it carrying the
-  fault, and the two that had fixed it were the two that did not use it.
-  This is that fix moved to the one place it belongs, and the private
-  copies now call it: a second authority with nothing holding it in step
-  is the shape that let the `k = 2` degeneracy in [[slot-order]] survive a
-  fix to its own sibling.
+  harness on this lane rides. TEN bench apps call it and every one of them
+  carried the fault, and the two that had fixed it were exactly the two
+  that do not call it. This is that fix moved to the one place it belongs,
+  and the private copies now call it: a second authority with nothing
+  holding it in step is the shape that let the `k = 2` degeneracy in
+  [[slot-order]] survive a fix to its own sibling.
 
   ## What it cost on the two clocks this bead came from
 

--- a/implementation/hicasso/test/re_frame/bench/hicasso/lane.cljs
+++ b/implementation/hicasso/test/re_frame/bench/hicasso/lane.cljs
@@ -596,7 +596,7 @@
                             ;; is what the next measured sample actually
                             ;; followed; [[observe!]] carries that across
                             ;; the gap so the guard's `:predecessor` factor
-                            ;; strata what ran rather than what was banked.
+                            ;; stratifies what ran rather than what was banked.
                             (observe! coll (label arm))))))
                     @acc))
                 (range rounds))]

--- a/implementation/hicasso/test/re_frame/bench/hicasso/lane.cljs
+++ b/implementation/hicasso/test/re_frame/bench/hicasso/lane.cljs
@@ -518,26 +518,48 @@
   (atom {:pos 0 :prev nil :samples []}))
 
 (defn observe!
-  "Record that arm `id` RAN, without banking a sample.
+  "Advance the collector's `:prev` pointer WITHOUT banking a sample.
+  Warm-up samples call this.
 
-  A WARM-UP SAMPLE IS STILL A PREDECESSOR. [[collect!]] carries `:prev`
-  forward from the last sample it BANKED, so across a round's warm-up gap
-  it named the previous round's last measured arm — and the arm that
-  actually ran immediately before was a warm-up sample nobody told it
-  about. Replaying this schedule shows the cost precisely: on every arm
-  count tried (4, 5, 7, 8) exactly one arm — the one holding the first
-  slot at `s = warmup` — carried 5 of its 30 samples under a predecessor
-  that never preceded it. On the seven-arm `amp_merge_clock` schedule that
-  arm is `:expanded-b`, the NULL, and 4 of its samples were filed under
-  `floor`, which never runs before it; on the five-arm schedule the same 4
-  were filed under `expanded-b` ITSELF, which is not a predecessor any
-  schedule can produce.
+  A WARM-UP SAMPLE IS STILL A PREDECESSOR. [[collect!]] both banks a
+  sample and advances the pointer, so a harness that skips it during
+  warm-up leaves the first RECORDED sample of a block tagged with whatever
+  ran before the warm-up — an arm that has not touched the site for a
+  whole warm-up block. A predecessor label that names something which did
+  not run immediately before is not a weaker fact than a real one; it is a
+  different fact wearing its clothes.
 
-  That is a fabricated stratum in the guard's `:predecessor` factor, and a
-  guard adjudicating a contrast that did not happen is the fail-open
-  shape this lane exists to refuse. The repair is to tell the collector
-  about every execution and to bank only the measured ones — the position
-  counter is untouched, because a discarded sample has no position."
+  ## This repair was made TWICE before it was made here (rf2-6ta5r)
+
+  `p0_converge_app` and `coldmount_app` hand-roll their sampling loops,
+  both hit this, and both fixed it locally — as a private
+  `mark-predecessor!` whose body was these same three lines. Their
+  incident is recorded: `p0_converge`'s first cut published the fault and
+  the guard REFUSED it, `narrow/reagent-subs/ctl-2x` contaminated by a
+  two-sample stratum labelled `M1/reagent-subs/reagent-subs`, an arm from
+  a different ROW; `rf2-2rtt6.4` met the same class from the other side,
+  where the untagged samples became a `<none>` stratum reading 1.35x its
+  siblings.
+
+  What never got the repair was [[rounds!]] — the SHARED loop every other
+  harness on this lane rides. Nine bench apps ran on it carrying the
+  fault, and the two that had fixed it were the two that did not use it.
+  This is that fix moved to the one place it belongs, and the private
+  copies now call it: a second authority with nothing holding it in step
+  is the shape that let the `k = 2` degeneracy in [[slot-order]] survive a
+  fix to its own sibling.
+
+  ## What it cost on the two clocks this bead came from
+
+  Replaying the schedule prices it exactly: at every arm count this lane
+  uses (4, 5, 7, 8) one arm — whichever holds the first slot at
+  `s = warmup` — carried 5 of its 30 samples under an adjacency that did
+  not happen. On the seven-arm `amp_merge_clock` schedule that arm is
+  `:expanded-b`, THE NULL, with 4 samples filed under `floor`, which never
+  runs before it; on the five-arm schedule those same 4 were filed under
+  `expanded-b` ITSELF, which no schedule can produce. The position counter
+  is untouched by this function, because a discarded sample has no
+  position."
   [coll id]
   (swap! coll assoc :prev id)
   nil)

--- a/implementation/hicasso/test/re_frame/bench/hicasso/lane.cljs
+++ b/implementation/hicasso/test/re_frame/bench/hicasso/lane.cljs
@@ -517,9 +517,38 @@
   []
   (atom {:pos 0 :prev nil :samples []}))
 
+(defn observe!
+  "Record that arm `id` RAN, without banking a sample.
+
+  A WARM-UP SAMPLE IS STILL A PREDECESSOR. [[collect!]] carries `:prev`
+  forward from the last sample it BANKED, so across a round's warm-up gap
+  it named the previous round's last measured arm — and the arm that
+  actually ran immediately before was a warm-up sample nobody told it
+  about. Replaying this schedule shows the cost precisely: on every arm
+  count tried (4, 5, 7, 8) exactly one arm — the one holding the first
+  slot at `s = warmup` — carried 5 of its 30 samples under a predecessor
+  that never preceded it. On the seven-arm `amp_merge_clock` schedule that
+  arm is `:expanded-b`, the NULL, and 4 of its samples were filed under
+  `floor`, which never runs before it; on the five-arm schedule the same 4
+  were filed under `expanded-b` ITSELF, which is not a predecessor any
+  schedule can produce.
+
+  That is a fabricated stratum in the guard's `:predecessor` factor, and a
+  guard adjudicating a contrast that did not happen is the fail-open
+  shape this lane exists to refuse. The repair is to tell the collector
+  about every execution and to bank only the measured ones — the position
+  counter is untouched, because a discarded sample has no position."
+  [coll id]
+  (swap! coll assoc :prev id)
+  nil)
+
 (defn collect!
   "Bank one sample for arm `id` at `value`, tagged with what ran
-  immediately before it and where in the run it sits."
+  immediately before it and where in the run it sits.
+
+  `:prev` is maintained by this function AND by [[observe!]]; a caller
+  that runs unbanked samples must call the latter for them or the
+  predecessor recorded here is fiction."
   [coll id value]
   (swap! coll (fn [{:keys [pos prev samples]}]
                 {:pos      (inc pos)
@@ -560,9 +589,15 @@
                       (doseq [j (slot-order k s)]
                         (let [arm (nth arms j)
                               ms  (measure-one! arm)]
-                          (when (>= s warmup)
-                            (collect! coll (label arm) ms)
-                            (swap! acc update (:id arm) conj ms)))))
+                          (if (>= s warmup)
+                            (do (collect! coll (label arm) ms)
+                                (swap! acc update (:id arm) conj ms))
+                            ;; DISCARDED, BUT NOT UNSEEN. A warm-up sample
+                            ;; is what the next measured sample actually
+                            ;; followed; [[observe!]] carries that across
+                            ;; the gap so the guard's `:predecessor` factor
+                            ;; strata what ran rather than what was banked.
+                            (observe! coll (label arm))))))
                     @acc))
                 (range rounds))]
      {:readings out :samples (:samples @coll)})))

--- a/implementation/hicasso/test/re_frame/bench/hicasso/lane_schedule_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/bench/hicasso/lane_schedule_cljs_test.cljs
@@ -1,0 +1,176 @@
+(ns re-frame.bench.hicasso.lane-schedule-cljs-test
+  "WHAT THE GUARD IS TOLD RAN BEFORE WHAT (rf2-6ta5r, rf2-h904p).
+
+  [[re-frame.bench.hicasso.lane/rounds!]] runs warm-up samples and throws
+  their VALUES away. It must not throw away the fact that they RAN: a
+  warm-up sample is what the next measured sample actually followed, and
+  `order-guard`'s `:predecessor` factor strata every banked sample by
+  exactly that.
+
+  It did throw it away. [[lane/collect!]] carried `:prev` forward from the
+  last sample it BANKED, so at each round's first measured sample the
+  predecessor it recorded was the PREVIOUS ROUND'S last measured arm —
+  never the warm-up sample that had just run. Replaying the schedule
+  prices it: on every arm count this lane uses, exactly one arm carried 5
+  of its 30 samples under an adjacency that did not happen. On the
+  seven-arm `amp_merge_clock` schedule that arm is `:expanded-b`, THE NULL
+  — 4 of its samples filed under `floor`, which never runs before it — and
+  on the five-arm schedule those same 4 were filed under `expanded-b`
+  ITSELF, a predecessor no schedule can produce.
+
+  A guard that adjudicates a contrast which did not happen is the
+  fail-open shape the lane exists to refuse, so this is a fault in the
+  instrument and not in any arm.
+
+  ## Why the stub returns the execution INDEX
+
+  So the check needs no second model of the schedule. `measure-one!`
+  answers the position of its own call in the TRUE execution sequence, so
+  each banked sample carries, in its `:value`, the index at which it ran.
+  The predecessor it SHOULD have recorded is then just the sequence's
+  previous entry, read off the recording rather than re-derived from
+  `slot-order` — a re-derivation would be a second copy of the rule under
+  test and would agree with a broken one.
+
+  ## Anti-vacuity
+
+  [[the-schedule-really-does-bank-across-the-warm-up-gap]] runs FIRST and
+  asserts the crossing exists: unless some banked sample really does
+  follow a discarded one, the assertion above is true of an empty set and
+  tests nothing. A `:warmup` of 0 — or a `rounds!` that stopped
+  interleaving — would fail there rather than pass everything silently.
+
+  ## Arm counts
+
+  4, 5, 7 and 8 — `direct_return_clock`'s, `amp_merge_clock`'s before and
+  after `rf2-z143r`'s ladder, and the eighth arm `rf2-v5oto` wants. The
+  fault is invariant to all of them, which is the same arithmetic that
+  settles `rf2-6ta5r`'s arm-count question: the schedule length does not
+  move it."
+  (:require [cljs.test :refer-macros [deftest is testing]]
+            [re-frame.bench.hicasso.lane :as lane]))
+
+;; ---------------------------------------------------------------------------
+;; The replay
+;; ---------------------------------------------------------------------------
+
+(def ^:private arm-counts
+  "Every arm count this lane's page-mount harnesses run at, plus the one
+  `rf2-v5oto` proposes."
+  [4 5 7 8])
+
+(defn- replay
+  "Run `lane/rounds!` over `n` arms with a stub that records the true
+  execution order and answers each call's index in it.
+
+  Answers `{:samples … :readings … :truth […]}`, where `truth` is EVERY
+  execution in order — warm-up and measured alike."
+  [n sampling rounds]
+  (let [truth (atom [])
+        arms  (mapv (fn [i] {:id (keyword (str "arm-" i))}) (range n))
+        out   (lane/rounds! arms sampling rounds
+                            (fn [arm]
+                              (let [i (count @truth)]
+                                (swap! truth conj (name (:id arm)))
+                                i)))]
+    (assoc out :truth @truth)))
+
+(def ^:private sampling
+  "The sampling both clocks ran when they failed, kept HERE rather than
+  raised with them: this file is about a fault that is invariant to the
+  numbers, and pinning the old ones keeps it able to see the fault at the
+  size it was found."
+  {:warmup 3 :samples 6})
+
+(def ^:private rounds 5)
+
+(defn- followed-a-discarded-execution
+  "The banked samples whose immediate predecessor was a warm-up execution
+  — the only place the fault can appear."
+  [{:keys [samples]}]
+  (let [banked (set (map :value samples))]
+    (filterv (fn [{:keys [value]}]
+               (and (pos? value) (not (contains? banked (dec value)))))
+             samples)))
+
+;; ---------------------------------------------------------------------------
+;; Anti-vacuity, first
+;; ---------------------------------------------------------------------------
+
+(deftest the-schedule-really-does-bank-across-the-warm-up-gap
+  (testing "**the anti-vacuity guard.** Every round runs its warm-up
+           samples and then banks, so exactly one banked sample per round
+           follows a DISCARDED execution — and those are the only samples
+           at which the fault below can show. A schedule that stopped
+           crossing the gap, or a `:warmup` of 0, would make the next
+           deftest an assertion about an empty set."
+    (doseq [n arm-counts]
+      (let [r       (replay n sampling rounds)
+            crossed (followed-a-discarded-execution r)]
+        (is (= rounds (count crossed))
+            (str n " arms: one banked sample per round should follow a warm-up sample"))
+        (is (pos? (count crossed))
+            (str n " arms: nothing crosses the warm-up gap — the fault below is untestable"))))))
+
+;; ---------------------------------------------------------------------------
+;; The fault
+;; ---------------------------------------------------------------------------
+
+(deftest every-recorded-predecessor-is-what-actually-ran
+  (testing "The whole claim `collect!`'s docstring makes — *tagged with
+           what ran immediately before it* — checked against the recording
+           of what did run, on every banked sample of every arm count."
+    (doseq [n arm-counts]
+      (let [{:keys [samples truth]} (replay n sampling rounds)]
+        (is (pos? (count samples)) (str n " arms: no samples were banked"))
+        (doseq [{:keys [arm value predecessor]} samples]
+          (let [ran-before (when (pos? value) (nth truth (dec value)))]
+            (is (= ran-before predecessor)
+                (str n " arms: the sample banked at execution " value
+                     " for " arm " ran after " (pr-str ran-before)
+                     " and was filed under " (pr-str predecessor)))))))))
+
+(deftest no-sample-is-recorded-as-its-own-predecessor
+  (testing "The five-arm `amp_merge_clock` schedule filed 4 of the null
+           arm's samples under `expanded-b` — the null arm itself. No
+           schedule can run an arm twice in a row: `slot-order` visits
+           every arm exactly once per sample index, so an arm can repeat
+           only across a sample-index boundary, and then only if it holds
+           both the last slot of one order and the first of the next. This
+           is that impossibility asserted directly, because an impossible
+           reading is information about the INSTRUMENT."
+    (doseq [n arm-counts]
+      (let [{:keys [samples truth]} (replay n sampling rounds)]
+        (doseq [{:keys [arm value predecessor]} samples]
+          (when (and predecessor (= arm predecessor))
+            ;; Only a genuine back-to-back execution may say so.
+            (is (= arm (nth truth (dec value)))
+                (str n " arms: " arm " filed as its own predecessor at execution "
+                     value ", but " (pr-str (nth truth (dec value)))
+                     " is what ran"))))))))
+
+;; ---------------------------------------------------------------------------
+;; The accounting the phase factor rests on
+;; ---------------------------------------------------------------------------
+
+(deftest warm-up-samples-run-and-are-discarded-and-positions-stay-contiguous
+  (testing "`:position` is the index in the WHOLE RUN, which is what makes
+           `order-guard`'s `:phase` factor a beginning-versus-end contrast
+           rather than a within-round one. It must therefore count the
+           BANKED samples densely — a discarded sample has no position —
+           while the executions behind them include the warm-up."
+    (doseq [n arm-counts]
+      (let [{:keys [warmup samples]} sampling
+            {samps :samples truth :truth readings :readings} (replay n sampling rounds)
+            per-arm-banked (* samples rounds)
+            per-arm-run    (* (+ warmup samples) rounds)]
+        (is (= (* n per-arm-run) (count truth))
+            (str n " arms: every arm runs warm-up + samples in every round"))
+        (is (= (* n per-arm-banked) (count samps))
+            (str n " arms: only the measured samples are banked"))
+        (is (= (vec (range (count samps))) (mapv :position samps))
+            (str n " arms: positions are dense and in banking order"))
+        (is (= rounds (count readings))
+            (str n " arms: one reading map per round"))
+        (is (every? (fn [m] (every? (fn [[_ xs]] (= samples (count xs))) m)) readings)
+            (str n " arms: every arm contributes `samples` readings to every round"))))))

--- a/implementation/hicasso/test/re_frame/bench/hicasso/p0_converge_app.cljs
+++ b/implementation/hicasso/test/re_frame/bench/hicasso/p0_converge_app.cljs
@@ -185,9 +185,13 @@
   labelled with an arm from a DIFFERENT ROW, an artefact of the shared
   collector advancing its predecessor pointer only for recorded samples.
   The repairs are one ROW per page (a quarter of the work in a page, and
-  no cross-row adjacency to mislabel) and [[mark-predecessor!]] (the
-  warm-up advances the pointer without banking a sample, so every recorded
-  sample carries its real predecessor). The tolerance was not touched.
+  no cross-row adjacency to mislabel) and
+  [[re-frame.bench.hicasso.lane/observe!]] (the warm-up advances the
+  pointer without banking a sample, so every recorded sample carries its
+  real predecessor). The tolerance was not touched. That second repair
+  lived HERE, as a private `mark-predecessor!`, until `rf2-6ta5r` found
+  the same fault still standing in `lane/rounds!` — the shared loop this
+  entry does not use — and moved the one copy to the lane.
 
   ## What this entry does NOT measure
 
@@ -244,27 +248,6 @@
 
 (defonce ^:private gen (atom 1000))
 (defn- next-gen! [] (swap! gen inc))
-
-(defn- mark-predecessor!
-  "Advance the sample collector's `:previous` pointer WITHOUT banking a
-  sample. Warm-up samples call this.
-
-  `lane/collect!` both banks a sample and advances the pointer, so a
-  harness that skips it during warm-up leaves the first RECORDED sample of
-  a block tagged with whatever ran before the warm-up — an arm that has
-  not touched the site for twenty operations. The first cut of this entry
-  published exactly that and the guard refused it: `narrow/reagent-subs/
-  ctl-2x` was contaminated by a two-sample stratum labelled
-  `M1/reagent-subs/reagent-subs`, an arm from a different ROW. rf2-2rtt6.4
-  met the same class from the other side, where the untagged samples
-  became a `<none>` stratum reading 1.35x its siblings.
-
-  A predecessor label that names something that did not run immediately
-  before is not a weaker fact than a real one; it is a different fact
-  wearing its clothes."
-  [coll id]
-  (swap! coll assoc :prev id)
-  nil)
 
 ;; ---------------------------------------------------------------------------
 ;; Segments
@@ -768,7 +751,7 @@
                   (swap! acc update (:id arm) conj ms))
               ;; A warm-up sample is DISCARDED but it still ran, so it is
               ;; still the next sample's predecessor.
-              (mark-predecessor! coll label))))))
+              (lane/observe! coll label))))))
     @acc))
 
 ;; ---------------------------------------------------------------------------
@@ -865,7 +848,7 @@
                                        (swap! legs update [kind segment-id id] (fnil conj [])
                                               {:write write-ms :gap gap-ms :force force-ms})
                                        (update-in acc [:readings id] conj ms))
-                                   (do (mark-predecessor! coll label)
+                                   (do (lane/observe! coll label)
                                        acc))))))))))
 
 ;; ---------------------------------------------------------------------------


### PR DESCRIPTION
Two RIG repairs to the Hicasso bench clocks, filed hours apart by two measurement workers who found the defects mid-window and deliberately did not fix them. **This is the edit half — no measurement window was taken, and no figure was published, re-taken or pooled.**

---

## rf2-h904p — the direct-return clock's arm-order guard refuses on `:hiccup` phase drift

**Cause established: the drift is on the POSITION axis, not adjacency.** Every by-predecessor contrast passed on every arm, while all three page-mounting arms decayed within the run by a similar factor (`:hiccup` 1.2105x, `:ctl-2x` 1.2338x, `:direct` 1.2000x). `:hiccup` tripped disjointness because its last-third range was tightest, not because it drifted most.

Two pieces of evidence make warming the right answer, and neither is a timing run:

1. **`lane.cljs` already records the step's length.** Its live reproduction read one control `10.32 10.26 10.26 10.26 10.33 10.28` and then `8.12` for ever — a +27% step landing after the **sixth** execution of the site, nothing varying but how many times it had run. At `:warmup 3` a step of that shape falls **inside** the measured samples and splits round one; at `:warmup 8` it falls inside the warm-up.
2. **These two clocks are the lane's warm-up outliers.** Every other full-page-mount harness on this instrument — `coldmount_app`, `p0_converge_app`, `p0_reagent_app` — already runs `{:warmup 8 :samples 12}`. The two harnesses that produced these two defects were the only two at `{:warmup 3 :samples 6}`.

**Still hypothesis:** that under-warming *produced* the drift. One run, and a box read quiet only at its two ends, cannot exclude a second cause that decayed over the same run. Nothing here claims otherwise.

---

## rf2-6ta5r — the amp-merge clock's NULL arm read 1.4737

**The seven-arm schedule is NOT implicated — settled, not assumed.** Replaying `lane/rounds!` against `order-guard/slot-order` at n = 4, 5, 7 and 8: every arm banks 30 samples per run; every arm's phase strata are rounds 1–2 (3–15 prior executions) against rounds 4–5 (32–44) at **every** arm count; the null's true predecessor distribution keeps its kind (`:expanded` 20, `:merged` 10) at n = 5, 7 **and** 8. **The null's position did not move when `rf2-z143r`'s ladder landed.**

So the ladder stays whole and **`rf2-v5oto`'s eighth arm is not blocked by this defect** — the bead asked for the arm count to be settled first, and that is the answer.

**What the reading is connected to.** Round two's measured samples sit at 3–15 prior executions — inside the first-third stratum, the same least-warmed span the *other* harness's guard refused on. And `p50` over six samples cannot be moved 1.47x by one outlier: at least three of six were elevated, so the event was sustained across half that arm's round — a ramp's shape, not a transient's.

**Not claimed:** that warm-up produced the 1.4737. Characterised, not speculatively fixed.

**Checked and rejected as the cause:** `:ctl-2x` mounts `expanded-arm` (k = 2), so the null's two heads are mounted 3:1. Real at the mount level — but each minted boundary runs 100x per page mount, so both heads are past 300 invocations before the first measured sample and far past any tier-up threshold. Not claiming it, and not changing `:ctl-2x`'s construction on the strength of it.

---

## A third fault, found while replaying the schedule — and it had already been fixed twice

`lane/collect!` carried `:prev` forward from the last sample it **banked**, so across each round's warm-up gap it named the previous round's last *measured* arm — never the warm-up sample that had just run. On every arm count this lane uses, exactly one arm carried **5 of its 30 samples under an adjacency that did not happen**. On the seven-arm `amp_merge_clock` schedule that arm is `:expanded-b` — **the null** — with 4 samples filed under `floor`, which never runs before it. On the five-arm schedule those same 4 were filed under `expanded-b` **itself**, which no schedule can produce.

Then the corroboration: **`coldmount_app` and `p0_converge_app` had each already fixed this locally**, as a private `mark-predecessor!` whose body was the same three lines — `(swap! coll assoc :prev id) nil`. `p0_converge`'s docstring records what it cost: the guard **refused** `narrow/reagent-subs/ctl-2x` on a two-sample stratum labelled with an arm from a different ROW, and `rf2-2rtt6.4` met the same class from the other side.

What never got the repair was `lane/rounds!` — the shared loop. **Ten bench apps call it and every one carried the fault; the two that had fixed it are exactly the two that do not call it.** Rather than add a third copy, the three become one: `lane/observe!` holds the rule and both private copies now call it. Behaviour at those two call sites is unchanged — the bodies were identical.

This makes the guard's input truthful. It may cause future runs to refuse where they previously did not, which is the correct direction.

---

## What was deliberately NOT done

- **The guard was not weakened.** Its tolerance, its rule, its thirds partition and its exit-2 path are untouched. The only guard-adjacent change makes its *input* truthful.
- **`boundaries` was not moved** on either clock. It is the third move `run.cjs` names, but it changes the SUBJECT `budgets.md` S8 publishes (`on a 200-boundary mount`) and would make the next window incomparable to run 1 for a reason unrelated to the refusal.
- **The arm count was not reduced.** The schedule arithmetic says it is not the lever.
- **No run-level pre-warm was built.** `lane/rounds!` charges warm-up *per round*, so four fifths of it warms nothing — a real structural observation, filed as `rf2-ydqzt` rather than built, because the beads authorised "more warm-up" and an existing knob sufficed.
- **`docs/design/hicasso/product/budgets.md` and `implementation/hicasso/scripts/check_budget_ledger.py` were NOT touched** (both held by open PR #8322). Checked early: `budgets.md`'s passage is a past-tense record of the refused run that already names `rf2-h904p` as the rig-change bead, and `check_budget_ledger.py` pins population/subject, not sampling. Neither needed editing.

## Consequence for the published figures

Both clocks are re-tuned, so S8's run 1 figure is not comparable to what these files read next. That was already the position — the refusal left S8 waiting on a fresh window, and this is the rig change it was waiting for. Follow-on windows filed: **rf2-adld3** (re-read the amp-merge null) and the S8 re-take.

## Test, and its RED proof

`lane_schedule_cljs_test.cljs` checks every banked sample's recorded predecessor against a **recording of what actually ran** — the stub `measure-one!` returns its own index in the true execution sequence, so no second model of the schedule is needed (a re-derivation would agree with a broken rule). It runs at n = 4, 5, 7 and 8, and leads with an **anti-vacuity** deftest asserting the schedule crosses the warm-up gap at all.

**RED proof, done and confirmed.** The `observe!` call was reverted in `rounds!` so the loop body was byte-identical to `origin/main`, and the suite was re-run:

```
Ran 14003 tests containing 71205 assertions.
24 failures, 0 errors.            <- exit 1
  20 FAIL in (every-recorded-predecessor-is-what-actually-ran)
   4 FAIL in (no-sample-is-recorded-as-its-own-predecessor)
```

Both counts match the independent replication exactly: **5 mis-attributed samples per arm count × 4 arm counts = 20**, and **4 self-predecessor samples at n = 5** — the `expanded-b`-filed-under-`expanded-b` impossibility. Sample failure text:

```
4 arms: the sample banked at execution 12 for arm-2 ran after "arm-1" and was filed under nil
5 arms: arm-2 filed as its own predecessor at execution 60, but "arm-1" is what ran
```

The assertion total also moves by exactly 4 between the runs (71201 green → 71205 red), which is the conditional `is` in the self-predecessor deftest firing 4 times under the defect and 0 times under the fix.

Restore verified by `git diff HEAD` on the file returning **empty** — byte-identical to the committed version.

## Gates

| gate | exit |
|---|---|
| `npm run test:cljs` (green, attempt 1) | **0** — 14003 tests, 71201 assertions, 0 failures, 0 errors |
| `npm run test:cljs` (RED, defect planted, attempt 2) | **1** — 24 failures, all in the two new deftests |
| `npm run test:cljs` (green, final source, attempt 3) | **0** — 14003 tests, 71201 assertions, 0 failures, 0 errors |
| `npm run test:browser` | **0** — 1568 tests, 9937 assertions, 0 failures, 0 errors |
| `npm run test:hicasso-compile` (attempts 1, 2) | **0**, **0** — 143 namespaces, 444 files, zero warnings |
| `npm run test:hicasso-invariants` | **0** (includes `check_budget_ledger.py` self-test + run) |
| `scripts/check-no-hardcoded-paths.sh` (attempts 1, 2) | **0**, **0** |

Runners matched to the extension: these are `.cljs` files, so `npm run test:cljs` and `npm run test:browser` — never `clojure -M:test`, which cannot load a `.cljs` file.

`npm run test:hicasso-compile` is the gate that matters most here and is easy to miss: the two clock apps are **not** `-cljs-test` namespaces, so no test build compiles them — only the `:hicasso-bench` compile gate does.

No `docs/design/**` page was touched, so `check_doc_slugs.py` / `check_provenance_pins.py` are not implicated.
