### PR TITLE
docs(mayor-method): an item's list of sites goes stale in membership, not magnitude

### DIFF
--- a/docs/the-mayor-method/dispatch-prompt-template.md
+++ b/docs/the-mayor-method/dispatch-prompt-template.md
@@ -173,6 +173,21 @@ item's number. Measured drifts in one session: 8 to 9; "four hits" to 23 lines; 
 Better still, when the number will keep moving: brief the fix to name the **class** rather
 than the count. A rule written as a class does not re-drift.
 
+**An item's LIST OF SITES goes stale the same way, and it is worse than a count, because it
+drifts in MEMBERSHIP rather than in magnitude.** A count that has drifted is obviously
+suspect once re-run. A list looks equally authoritative whether or not its entries are still
+true, and it is wrong in two directions at once: an entry somebody else already fixed sends
+a worker to edit correct text — or to revert a repair — while a site the list never had is
+left live. Four items in one session named sites that were already amended, or asserted a
+verification that a different change had since falsified; one named "three of four" when the
+standing state was one.
+
+**So require the list be RE-DERIVED at the current tip, and require the DELTA to be
+reported.** The delta is a deliverable in its own right, not bookkeeping: it is the only
+signal that the item was stale, and without it the next reader inherits the same list with
+the same confidence. Where a worker returns "two of these five were already done", that is
+the item being corrected by the work, which is the system functioning.
+
 ---
 
 ## A lean is a claim too — demand the number that decides it


### PR DESCRIPTION
The tree already says counts are claims and must be re-run at the current tip. It says nothing about an item's **list of sites**, which drifts differently and worse.

A count that has drifted is obviously suspect the moment it is re-run. A list looks equally authoritative whether or not its entries are still true, and it is wrong in **two directions at once**: an entry somebody else already fixed sends a worker to edit correct text — or to revert a repair — while a site the list never had is left live.

Four items in one session:

| item | what its list said | what the tree said |
|---|---|---|
| rf2-0fd3b | 2 files still live | both already amended with dated citations |
| rf2-h3tke | guide teaches the rejected feature | already discharged; a different file was live |
| rf2-0yp7w.8 | verified independent of another bead | reproduced as false — it looked for paths, the coupling was a build id |
| rf2-3l6hf | three of four terms unresolved | one |

Each was caught by a worker reading the tree instead of the list. **That is the system functioning**, and the point of this change is to make it required rather than lucky.

So require the list be re-derived at the current tip, and require the **delta** to be reported. The delta is the deliverable, not bookkeeping: it is the only signal that the item was stale, and without it the next reader inherits the same list with the same confidence.

| gate | captured exit |
|---|---|
| `python scripts/check_doc_slugs.py` | 0 |
| `sh scripts/check-no-hardcoded-paths.sh` | 0 |

One paragraph. No fenced code blocks added or edited; the tables above are in this PR body, not in the tree.