### PR TITLE
docs(mayor-method): try splitting a compound gate before detaching it

### DIFF
--- a/docs/the-mayor-method/dispatch-prompt-template.md
+++ b/docs/the-mayor-method/dispatch-prompt-template.md
@@ -654,12 +654,21 @@ improvised. Point at the settled wording rather than restating it, and **scope t
 shortening it** — dropping the sanction along with the parts that do not apply is the same failure by a
 shorter road.
 
-**Detaching a long gate is CORRECT; ending the turn afterwards is the defect.** Where a harness hard-kills a
-foreground command well below what the full gate needs, "foreground, to completion" is not on offer however
-the brief is worded. Foreground a gate that fits inside the ceiling; **detach one that does not, then poll
-both its log and its exit-code file in a bounded loop, within the same turn.** Poll both, because they answer
-different questions: the log shows progress, while the exit file carries the verdict and appears only once the
-run is actually over.
+**But first, check whether the gate is COMPOUND — a script that chains two phases often splits into two runs
+that each fit.** This is strictly better than detaching, because it keeps every verdict in the foreground and
+removes the strand risk rather than managing it. A worker here met a build-and-run script that measured past
+the ceiling and ran each half as its own foreground call: both finished well inside it, nothing was killed,
+and no cache was left corrupt by an orphan. The same day, two workers detached the whole thing instead; both
+died at the cap, and one left a build cache so damaged that the next attempt failed with twenty-two cascading
+errors naming files it had never touched. **Read what the script actually runs before deciding it cannot be
+foregrounded.**
+
+**Where it genuinely does not split, detaching is CORRECT; ending the turn afterwards is the defect.** Where a
+harness hard-kills a foreground command well below what the full gate needs, "foreground, to completion" is not
+on offer however the brief is worded. Foreground a gate that fits inside the ceiling; **detach one that does
+not, then poll both its log and its exit-code file in a bounded loop, within the same turn.** Poll both, because
+they answer different questions: the log shows progress, while the exit file carries the verdict and appears
+only once the run is actually over.
 
 What strands a worker is ending the turn instead, waiting for a completion notification — it does not always
 arrive, and a turn that has ended has nothing left to wake. The worker then reports "standing by" through idle


### PR DESCRIPTION
The tree says to detach a gate that exceeds the harness cap and poll it in the same turn. That rule is right, and it is the **fallback**. It never mentions the step that comes first: **a script chaining two phases often splits into two runs that each fit inside the ceiling.**

Splitting is strictly better than detaching. Every verdict stays in the foreground, and the strand risk is **removed** rather than managed.

Both sides were measured in one session:

| approach | outcome |
|---|---|
| ran each half of a build-and-run script as its own foreground call | both finished well inside the ceiling; nothing killed, no cache orphaned |
| detached the whole script (2 workers) | both died at the cap; one left a build cache so damaged the next attempt failed with 22 cascading errors naming files it had never touched |

So: **read what the script actually runs** before concluding it cannot be foregrounded. Where it genuinely does not split, the existing detach-and-poll rule applies unchanged.

| gate | captured exit |
|---|---|
| `python scripts/check_doc_slugs.py` | 0 |
| `sh scripts/check-no-hardcoded-paths.sh` | 0 |

One paragraph. No fenced code blocks added or edited; the tables above are in this PR body, not in the tree.