### PR TITLE
docs(hicasso): the amp-merge null holds on the warmed rig, and does not confirm warm-up (rf2-adld3)

### DIFF
--- a/docs/design/hicasso/decisions.md
+++ b/docs/design/hicasso/decisions.md
@@ -1787,6 +1787,101 @@ Length` samples, eight each side, every one 0 — and never sampled inside the m
 window, where a sample reads the benchmark's own load and answers nothing. Nothing is
 claimed about within-run quietness beyond that bracketing.
 
+**THE NULL, RE-READ ON THE WARMED RIG — it holds, and the 1.4737 did not recur
+(`rf2-adld3`).** `rf2-6ta5r` was the EDIT half and deliberately took no window: it
+moved this instrument's sampling from `{:warmup 3 :samples 6}` to
+`{:warmup 8 :samples 12}` and left the seven arms untouched, settling the arm-count
+question with schedule arithmetic rather than by shrinking the ladder. This is the
+READ half, and it read the null first because that is the whole of what it was
+opened to do. **A separate window of three runs, pre-registered as three before any
+data was seen, all three reported, none selected and none discarded**, taken back to
+back at `e272390602fe` on the instrument exactly as `rf2-6ta5r` merged it, with no
+edit made inside the window.
+
+| run | NULL `:expanded-b`/`:expanded`, per round | mean | range | worst excursion |
+|---|---|---|---|---|
+| N1 | `1.0128 1.0253 1.0132 0.9540 1.0426` | 1.0096x | 0.9540 – 1.0426 | −4.6% |
+| N2 | `0.9551 1.0787 0.9756 1.0000 1.0206` | 1.0060x | 0.9551 – 1.0787 | +7.9% |
+| N3 | `1.0000 0.9722 1.0000 1.0143 1.0190` | 1.0011x | 0.9722 – 1.0190 | −2.8% |
+
+**Fifteen rounds, every one inside ±7.9% of 1.0 and fourteen of the fifteen inside
+±5%.** The reading this window was opened on — one round at **1.4737**, +47.4% on a
+quantity that is 1.0 by construction — did not recur. In `ns/field` the null's
+per-round readings are `[125 250 125 −500 500]`, `[−500 875 −250 0 250]` and
+`[0 −250 0 125 250]`: the largest error this instrument demonstrated on a difference
+known to be zero was **875 ns/field**, against the **4,500 ns/field** the
+`rf2-z143r` window's bad round implied.
+
+**What that licenses, and what it does not.** It licenses a resolution bound *for the
+warmed rig, in this window*: a two-arm per-round difference below about 875 ns/field
+is not distinguishable here from the instrument's own error. It does **not**
+retroactively rescue the `rf2-z143r` window above — that window ran the `3/6`
+sampling, which is a different instrument, and its own null failed; the disclaimer it
+wrote against itself stands exactly as published. And it does **not** establish that
+warm-up PRODUCED the 1.4737. The sampling change is the *named* difference between
+the two windows but it is not the only one — different day, different checkout,
+freshly installed dependencies — and nothing here separates them. Taking the earlier
+window's one-bad-round-in-five at face value as a rate, fifteen clean rounds would
+arrive with probability 0.8¹⁵ ≈ 3.5%; but that rate is estimated from a single event
+and its interval is far too wide for 3.5% to be read as a test. **The leading
+candidate survives and is not confirmed.**
+
+**The estimator, named as computed.** Every ratio above is `lane/ratio-between`'s
+`:mean` — the ARITHMETIC MEAN of five per-round ratios, each itself a ratio of the two
+arms' within-round MEDIAN (`p50` over twelve samples) mount times, each normalised
+against the floor measured in that same round. A mean over medians, not a median at
+run level. The `ns/field` vectors are per-round differences of those same within-round
+medians, ×10⁶/400.
+
+**The null's per-round `ns/field` vectors are DERIVED, because the rig cannot print
+them (`rf2-j7o9w`, filed not fixed).** `ns-terms` keeps `:per-round` beside its
+summary and feeds the ladder's four rungs, but the effect and the null go through
+`per-element-ns`, which keeps only `{:n :min :max :p50}` — so the null this window
+turns on is the one quantity not retained round by round. The rig is frozen inside a
+window, so that was filed rather than repaired. The vectors above are recovered
+exactly from what the rig did print: the whole rung's per-round `ns/field` and
+per-round ratio give each round's `:expanded` median as `ns/(2500·(r−1))`, and the
+null's difference is that times `(r_null−1)·2500`. All three recoveries were checked
+against the rig's own printed `{min max p50}` for the null and match in every one.
+
+**This window is not pooled with any above and re-prices nothing.** It was taken to
+read a control, and re-pricing an effect on a window taken for that is the move this
+lane refuses: the headline `25% of mount` and `2.4 µs per site` are untouched, as is
+the apportionment table. Its own figures are recorded for durability only, and whole.
+Effect `:merged`/`:expanded` per round — `[1.2308 1.2025 1.1842 1.3103 1.1702]`,
+`[1.1348 1.3258 1.2073 1.1489 1.2062]`, `[1.1948 1.1667 1.2143 1.2571 1.1810]`
+(run means 1.2196x, 1.2046x, 1.2028x). Rung (2), the CODEC'S share, `ns/field` —
+`[2250 1625 1750 1375 2000]`, `[2250 2875 1625 2125 2000]`,
+`[1500 1375 1625 1625 2250]`. Rung (1) — `[1125 625 1000 2000 500]`,
+`[500 750 1000 625 1000]`, `[875 875 750 625 1250]`. Rung (3) —
+`[−1125 −250 −1000 0 −500]`, `[−1250 0 −500 −1000 −500]`,
+`[−500 −750 −500 0 −1125]`.
+
+**One thing this window does settle on its own data, because both terms come out of
+the same runs.** All fifteen of rung (2)'s per-round readings lie between 1,375 and
+2,875 `ns/field`, and the largest excursion the null reached across those same fifteen
+rounds is 875 `ns/field`. The codec's term sits clear of the instrument's demonstrated
+error at every round, by a factor of 1.57 at the tightest point — a statement about
+this window's numbers and not a confidence interval. Rung (1) does not clear it: its
+smallest readings are 500 `ns/field`, inside the null's excursion. That is the same
+conclusion the apportionment above reached by a different route — the author's share
+is the term this instrument cannot resolve.
+
+**The gates.** In all three runs the fairness gate agreed five judged arms on one
+1,001-element page and was proven able to answer false (`:bytes` 83,214, identical
+across the three); the arm-order guard returned **reportable** on all seven arms, by
+predecessor and by phase; `lane/control-verdict-strict` put all five
+`:ctl-2x`/`:expanded` rounds inside the ±25% band with `:outside` empty —
+`[2.2692 1.9873 2.0789 2.1149 1.9149]`, `[1.9213 2.0899 2.0000 1.9574 2.0515]`,
+`[2.0390 2.0278 2.0000 2.3857 2.0000]`; and the read-back tally was **0 unverified of
+800** in each. Chromium 147.0.7727.15 under `:advanced` with `goog.DEBUG` false, 24
+hardware threads. `\System\Processor Queue Length` was sampled ONLY between runs —
+eight samples at each of four points, before N1 and after each run — and 31 of those
+32 read 0, the one reading of 1 landing in the bracket taken seconds after N1
+finished. **Nothing is claimed about within-run quietness beyond that bracketing**;
+the only other thing running alongside a measured window was a `test -f` poll of that
+run's own exit file at 15- to 60-second intervals.
+
 **Reopens** if a witness shows a merge the law cannot express without an escape.
 
 ## HD-024 — One callback form; the position selects the contract

--- a/implementation/hicasso/test/re_frame/bench/hicasso/clock_exit_path.test.cjs
+++ b/implementation/hicasso/test/re_frame/bench/hicasso/clock_exit_path.test.cjs
@@ -5830,8 +5830,23 @@ function fixtureRoundsTask(over) {
       const out = `${r.stdout}${r.stderr}`;
       assert.strictEqual(r.status, 4, `the program must exit 4 on raw evidence lost after eligibility — got ${r.status}: ${out.slice(-1500)}`);
       assert.match(out, /RAW EVIDENCE LOST AFTER ELIGIBILITY/, 'the loss is announced where the interval would have printed');
-      assert.match(out, /run1\.json: row M1, pair `hicasso \/ uix-subs`/, 'the exit roster names the file and the pair');
-      assert.match(out, /run1\.json: row M1, pair `hicasso \/ reagent-subs`/, 'both hicasso pairs of the blanked segment');
+      // THE ROSTER ASSERTIONS CARRY THE ROSTER INTO THEIR OWN FAILURE MESSAGE.
+      // The exit-code assertion above already prints the output's tail when it
+      // fails and these two did not, so a CI-only failure here reported that
+      // the roster was wrong and never what the roster actually SAID — which
+      // is a bisect nobody can run from the log, and one was run from this
+      // line on 2026-08-16 without ever seeing the string that failed to
+      // match. THE REGEXES AND THE CORPUS ARE UNCHANGED: this widens what a
+      // FAILURE reports, never what a PASS accepts. A negative control that
+      // cannot say what it saw is still a negative control, but it costs a
+      // worker a day to read.
+      const ri = out.indexOf(';; EXIT 4');
+      const sawRoster =
+        ri >= 0
+          ? `roster as printed:\n${out.slice(ri, ri + 2000)}`
+          : `NO ";; EXIT 4" BLOCK IN THE OUTPUT — tail was:\n${out.slice(-2000)}`;
+      assert.match(out, /run1\.json: row M1, pair `hicasso \/ uix-subs`/, `the exit roster names the file and the pair — ${sawRoster}`);
+      assert.match(out, /run1\.json: row M1, pair `hicasso \/ reagent-subs`/, `both hicasso pairs of the blanked segment — ${sawRoster}`);
       // THE AUDIT'S OWN SENTENCE, scoped to the row it demonstrated on: the M1
       // block must not publish "an interval over 7 reportable run(s)" where 8
       // cleared the gates. (`narrow` legitimately pools 7 of 8 on this


### PR DESCRIPTION
## What this is

`rf2-6ta5r` (PR #8371) was the EDIT half of the amp-merge clock's rig repair and
deliberately took no window: it moved the sampling from `{:warmup 3 :samples 6}` to
`{:warmup 8 :samples 12}` and left the seven arms untouched. **This is the READ
half.**

Both premises verified at source before the window was taken: `sampling` is
`{:warmup 8 :samples 12}` at `amp_merge_clock_app.cljs:567`, and `arms` holds seven
entries (`:floor :expanded :expanded-b :merged :ctl-2x :helper :no-dissoc`).

## THE NULL, first, because that is what the bead asked for

`:expanded-b`/`:expanded` is a second boundary head over an identical body. Its true
value is **1.0 by construction**. The prior window read
`[0.9467 1.4737 1.0294 1 0.9853]` — one round at +47.4% on a quantity that is
exactly 1.0.

| run | NULL per round | mean | range | worst |
|---|---|---|---|---|
| N1 | `1.0128 1.0253 1.0132 0.9540 1.0426` | 1.0096x | 0.9540 – 1.0426 | −4.6% |
| N2 | `0.9551 1.0787 0.9756 1.0000 1.0206` | 1.0060x | 0.9551 – 1.0787 | +7.9% |
| N3 | `1.0000 0.9722 1.0000 1.0143 1.0190` | 1.0011x | 0.9722 – 1.0190 | −2.8% |

**Fifteen rounds, every one inside ±7.9% of 1.0; fourteen inside ±5%. The 1.4737 did
not recur.** In ns/field the null read `[125 250 125 −500 500]`,
`[−500 875 −250 0 250]`, `[0 −250 0 125 250]` — largest demonstrated error on a
difference known to be zero, **875 ns/field**, against the 4,500 ns/field the
`rf2-z143r` window's bad round implied.

## What is claimed, and what is refused

- **Claimed:** a resolution bound for the warmed rig *in this window* — 875 ns/field.
- **REFUSED — that warm-up produced the 1.4737.** The sampling change is the *named*
  difference between the two windows, not the only one (different day, checkout,
  freshly installed deps). Taking the old one-in-five at face value, 0.8¹⁵ ≈ 3.5%;
  but that rate rests on a single event and its interval is far too wide to read as
  a test. **The leading candidate survives unconfirmed** — which the bead explicitly
  licensed, since confirming it was never the success condition.
- **REFUSED — rescuing the `rf2-z143r` window.** It ran the `3/6` sampling, a
  different instrument. Its own disclaimer stands as published.
- **REFUSED — re-pricing the effect.** This window was taken to read a control. The
  headline `25% of mount` / `2.4 µs per site` and the apportionment table are
  untouched, and this window is pooled with nothing.

The one thing it settles on its own data, both terms coming from the same runs: all
fifteen rung-(2) readings (1,375–2,875 ns/field) clear the null's largest excursion
(875), by 1.57× at the tightest point. Rung (1)'s smallest (500) does not — the
author's share stays unresolvable, the same conclusion as before by a different
route.

**Estimator named as computed:** `lane/ratio-between`'s `:mean` is the arithmetic
mean of five per-round ratios, each a ratio of within-round medians (`p50` over
twelve samples). Not a median at run level.

## Rig gap found — FILED, not fixed (`rf2-j7o9w`)

`per-element-ns` keeps only `{:n :min :max :p50}`, so the effect and the **null** —
the figure this whole window turns on — are the two quantities *not* retained per
round; `ns-terms` does retain them but feeds only the ladder. The rig is frozen
inside a window, so this was filed. The null's per-round ns/field were instead
**derived** from the whole rung's printed per-round ns and ratio, each of the three
checked against the rig's own printed `{min max p50}` — exact match in all three.

## Gates — captured exit codes

| gate | exit |
|---|---|
| `npm ci --prefix implementation` (real install, no junction) | **0** |
| amp-merge run N1 | **0** |
| amp-merge run N2 | **0** |
| amp-merge run N3 | **0** |
| `python scripts/check_doc_slugs.py` | **0** |
| `python scripts/check_provenance_pins.py --changed-since origin/main` | **0** |
| `npm run test:hicasso-compile` | **0** — 143 namespaces, zero warnings |
| `sh scripts/check-no-hardcoded-paths.sh` | **0** |
| `clock_exit_path.test.cjs` (6 runs pre-change, 1 post) | **0** — 375 passed each |
| `npm run test:script-policy` (CI job, half 1) | **0** |
| `npm run test:script-helpers` (CI job, half 2) | **0** |

In-run gates, all three measurement runs: fairness gate agreed 5 arms @ 1,001
elements with `can-fail? true` (`:bytes` 83,214 identically); arm-order guard
**reportable** on all seven arms by predecessor and by phase;
`control-verdict-strict` put all five `:ctl-2x`/`:expanded` rounds inside ±25% with
`:outside` empty; read-back tally **0 unverified of 800**.

`mkdocs build --strict` is NOT nominated: `docs/design/**` is excluded from the site
by `mkdocs.yml`'s `exclude_docs`.

**Table rendering and column counts verified BY HAND** — nothing validates them. The
one table added to `decisions.md` is 5 columns: header 5, separator 5, and each of
the three body rows 5. No headings and no links were added, so no anchors changed.

## The box

Only a CLOCK estimand needs a quiet machine and this is one. `\System\Processor
Queue Length`, sampled **on its own** and **never inside a measured window**, eight
samples at each of four points: 10:41:15–22 all 0; 10:42:52–59 one 1 then seven 0;
10:44:04–11 all 0; 10:46:04–11 all 0. **31 of 32 read 0**, the single 1 landing
seconds after N1 finished. Nothing is claimed about within-run quietness beyond that
bracketing; the only other thing alive during a measured window was a `test -f` poll
of that run's own exit file.

Three runs were **pre-registered as three before any data was seen**. All three are
reported. None was selected, discarded, or re-run.

---

## Addendum — the red on `JS harness self-tests`, and what it was NOT (`rf2-vam35`)

The first CI run failed one assertion of 375 in `clock_exit_path.test.cjs`: the
`rf2-8a746` mutation witness, on `the exit roster names the file and the pair`.

**The proposed cause does not hold, and it was checked at source.** That witness's
"committed corpus" is
`implementation/hicasso/test/re_frame/bench/hicasso/data/clock-emvod/run1..run8.json`
(`corpus()` resolves `path.join(__dirname, 'data', dir)`), **not**
`docs/design/hicasso/decisions.md`. Neither `clock_exit_path.test.cjs` nor
`clock_readjudicate.cjs` mentions `decisions.md` or `docs/design/hicasso` anywhere.

Ruled out, each at source: the diff (one markdown file at the time); corpus drift
(tracked == on-disk, exactly 8 files); a stale base (the base differed from the last
green main run by `.beads/issues.jsonl` alone); `maxBuffer` (85,122 bytes of stdout
against 64 MiB); date/TZ (no `Date`, `process.env` or platform reads in the
readjudicator); path separators (the roster prints a full path and the regex is
unanchored, matching on both platforms). It does **not** reproduce locally — 6/6 full
green runs of the file, plus an instrumented replication of the witness that passes
all five of the job's assertions.

**No cause was found, so nothing was invented.** What changed is diagnosability: the
two roster assertions now carry the `;; EXIT 4` roster block — or the output tail
when there is none — into their failure message, exactly as the exit-code assertion
two lines above already did. **The regexes and the corpus are byte-identical.** The
negative control was not weakened, not narrowed to exclude anything, and not deleted;
only what a FAILURE reports changed, never what a PASS accepts. Teeth were re-proved
against a roster naming the wrong file and against an absent roster — both still
fail, and both now name what they saw.

The measurement is untouched: no null vector, per-round value or published figure
moved. `rf2-vam35` carries the full elimination list, so the next occurrence starts
from the roster rather than from scratch.

The CI job is the compound `test:script-policy && test:script-helpers`; it was split
into its two halves locally so each ran foreground to completion.
