### PR TITLE
rig(hicasso): retain the null per round; refuse the warm-up mechanism (rf2-j7o9w, rf2-ydqzt)

### DIFF
--- a/implementation/hicasso/test/re_frame/bench/hicasso/amp_merge_clock_app.cljs
+++ b/implementation/hicasso/test/re_frame/bench/hicasso/amp_merge_clock_app.cljs
@@ -181,6 +181,14 @@
   with its range and beside the null arm's, which is the same arithmetic
   over a difference known to be zero.
 
+  **Both carry their per-round vector** (rf2-j7o9w). They did not, and the
+  null was the single figure this instrument kept no round-by-round record
+  of — so `rf2-adld3`, whose whole window turned on the null, had to
+  reconstruct it from the ladder's rungs before it could state a
+  resolution bound. Every ns/field row now comes through the one
+  summariser [[ns-terms]], so nothing here needs a sibling row to be
+  re-adjudicated.
+
   Owner: rf2-pqyxz. Witness: `front/census_article_editor_cljs_test`'s
   ported RealWorld article-editor fieldset (HD-023, *Demonstrated, not
   asserted*), scaled to [[boundaries]] boundaries because a page of one
@@ -643,24 +651,36 @@
 
 (defn- fmt [x n] (.toFixed (double x) n))
 
-(defn- per-element-ns
-  "The per-round difference of two arms' raw p50 mount times, in
-  nanoseconds per `:&` site. Raw and not floor-normalised, deliberately:
-  the two terms are measured in the SAME round, so an additive drift
-  differences out, and dividing by the floor would rescale a difference by
-  a quantity that has nothing to do with it."
-  [p50s a b]
-  (lane/summarise
-    (mapv (fn [r] (/ (* 1e6 (- (get r a) (get r b))) amp-sites)) p50s)))
-
 (defn- ns-terms
-  "The same arithmetic as [[per-element-ns]], with the PER-ROUND vector
-  kept beside the summary.
+  "The per-round difference of two arms' raw p50 mount times, in
+  nanoseconds per `:&` site — the PER-ROUND VECTOR, and the summary over
+  it. Every ns/field row this file prints comes through here.
 
-  It is kept because a ladder that prints only its summaries cannot be
-  re-adjudicated without being re-run, and this instrument has already
-  had one window re-taken for exactly that. `per-element-ns` is left
-  alone so the two published rows keep the shape they were published in."
+  Raw and not floor-normalised, deliberately: the two terms are measured
+  in the SAME round, so an additive drift differences out, and dividing by
+  the floor would rescale a difference by a quantity that has nothing to
+  do with it.
+
+  ## THE VECTOR IS THE POINT, and this file has already paid for the
+  ## version that kept only the summary (rf2-j7o9w)
+
+  A second summariser used to serve the two published rows and answered
+  `{:n :min :max :p50}` and nothing else — so the NULL, the quantity every
+  resolution claim this instrument makes rests on, was the ONE quantity it
+  did not retain round by round. `rf2-adld3`'s window recovered the null's
+  five values anyway, by arithmetic over the ladder's rungs: each round's
+  `:expanded` median falls out of a rung's own per-round ns and ratio, and
+  the null's difference follows. The recovery was exact and checked against
+  the rig's own printed `{min max p50}` in all three runs. **That it was
+  NEEDED is the defect**, and it needed a SIBLING ROW to be possible at
+  all — an instrument should not be re-adjudicable only by way of a
+  neighbour that happens to keep better records. One summariser now, so
+  the effect, the null and the four rungs are all re-adjudicable from what
+  the run printed.
+
+  The summary is taken over the ROUNDED vector rather than beside it, so a
+  reader can check `{:min :max :p50}` against the printed `:per-round` and
+  get an exact match instead of a near one."
   [p50s a b]
   (let [vs (mapv (fn [r] (lane/round4 (/ (* 1e6 (- (get r a) (get r b))) amp-sites)))
                  p50s)]
@@ -760,8 +780,8 @@
                                arms)
                 effect   (lane/ratio-between ratios :merged :expanded)
                 null     (lane/ratio-between ratios :expanded-b :expanded)
-                eff-ns   (per-element-ns p50s :merged :expanded)
-                null-ns  (per-element-ns p50s :expanded-b :expanded)
+                eff-ns   (ns-terms p50s :merged :expanded)
+                null-ns  (ns-terms p50s :expanded-b :expanded)
                 gv       (lane/guard! samples "amp-merge clock arms (in-page ms)")
                 ;; THE POSITIVE CONTROL, per round and strictly (rf2-egdaq).
                 ;; `:ctl-2x` is `:expanded`'s own operation performed twice
@@ -839,9 +859,11 @@
             (js/console.log
               (str ";;   PER-ELEMENT effect: " (fmt (:p50 eff-ns) 1) " ns/:& site ["
                    (fmt (:min eff-ns) 1) " - " (fmt (:max eff-ns) 1) "]"))
+            (js/console.log (str ";;     ns per-round: " (pr-str (:per-round eff-ns))))
             (js/console.log
               (str ";;   PER-ELEMENT null:   " (fmt (:p50 null-ns) 1) " ns/site ["
                    (fmt (:min null-ns) 1) " - " (fmt (:max null-ns) 1) "]"))
+            (js/console.log (str ";;     ns per-round: " (pr-str (:per-round null-ns))))
             (js/console.log (str ";;   control (" (name (:rule ctl)) ", ctl-2x/expanded): "
                                  (:why ctl)))
             (js/console.log (str ";;   control per-round: " (pr-str (:per-round ctl))))

--- a/implementation/hicasso/test/re_frame/bench/hicasso/lane.cljs
+++ b/implementation/hicasso/test/re_frame/bench/hicasso/lane.cljs
@@ -617,9 +617,9 @@
 
   SO RAISING `warmup` IS A BLUNT LEVER — it buys round one's pre-warm at
   `rounds` times its cost, which on these clocks is five — and the
-  targeted repair is a run-level `:prewarm`
-  that runs the arms P times, discarded, before the first round, leaving
-  `warmup` as a small per-round settling allowance. **It is not built**,
+  targeted repair is a run-level `:prewarm` that runs the arms P times,
+  discarded, before the first round, leaving `warmup` as a small per-round
+  settling allowance. **It is not built**,
   because the knob sufficed: rf2-h904p raised the two clocks to `8`, which
   puts the +27% step this lane records after a site's sixth execution
   inside the warm-up, and rf2-adld3's three-run window on that warmed rig

--- a/implementation/hicasso/test/re_frame/bench/hicasso/lane.cljs
+++ b/implementation/hicasso/test/re_frame/bench/hicasso/lane.cljs
@@ -598,7 +598,37 @@
   disjoint by construction and the guard refuses a contamination that is
   really just the witness table.
 
-  Answers `{:readings [{id [ms …]} …] :samples [guard-samples]}`."
+  Answers `{:readings [{id [ms …]} …] :samples [guard-samples]}`.
+
+  ## WARM-UP IS CHARGED PER ROUND, AND THE RAMP IT GUARDS IS RUN-LEVEL
+
+  Known, priced, and deliberately NOT repaired (rf2-ydqzt). `warmup`
+  discarded samples are spent per arm inside EVERY round, but the ramp
+  [[collect!]]'s `:position` exists to expose does not restart at a round
+  boundary — that is [[sample-collector]]'s own reason for counting
+  position across the whole run. Replaying this loop against
+  [[slot-order]] prices the asymmetry exactly: the FIRST measured sample
+  of a run has had exactly `warmup` prior executions of its arm however
+  many rounds follow, while at `{:warmup 8 :samples 12}` over five rounds
+  the run's last third sits at 72–99 prior executions (32–44 at
+  `{:warmup 3 :samples 6}`). Round one is the only round that needs
+  warming, and rounds two to five each pay `warmup` mounts that warm
+  nothing.
+
+  SO RAISING `warmup` IS A BLUNT LEVER — it buys round one's pre-warm at
+  five times its cost — and the targeted repair is a run-level `:prewarm`
+  that runs the arms P times, discarded, before the first round, leaving
+  `warmup` as a small per-round settling allowance. **It is not built**,
+  because the knob sufficed: rf2-h904p raised the two clocks to `8`, which
+  puts the +27% step this lane records after a site's sixth execution
+  inside the warm-up, and rf2-adld3's three-run window on that warmed rig
+  then returned REPORTABLE on every arm by predecessor AND by phase, with
+  the null it was opened on inside ±7.9% of 1.0 across fifteen rounds.
+
+  WHAT WOULD WARRANT BUILDING IT: a window whose guard refuses on `:phase`
+  at `:warmup 8` with the first-third stratum dominated by round one. Ten
+  bench apps ride this loop and every one of them would inherit the new
+  schedule, so the trigger is stated here rather than left to judgement."
   ([arms sampling rounds measure-one!]
    (rounds! arms sampling rounds measure-one! (fn [arm] (name (:id arm)))))
   ([arms {:keys [warmup samples] :as _sampling} rounds measure-one! label]

--- a/implementation/hicasso/test/re_frame/bench/hicasso/lane.cljs
+++ b/implementation/hicasso/test/re_frame/bench/hicasso/lane.cljs
@@ -612,11 +612,12 @@
   many rounds follow, while at `{:warmup 8 :samples 12}` over five rounds
   the run's last third sits at 72–99 prior executions (32–44 at
   `{:warmup 3 :samples 6}`). Round one is the only round that needs
-  warming, and rounds two to five each pay `warmup` mounts that warm
+  warming; every round after it pays a full `warmup` block that warms
   nothing.
 
   SO RAISING `warmup` IS A BLUNT LEVER — it buys round one's pre-warm at
-  five times its cost — and the targeted repair is a run-level `:prewarm`
+  `rounds` times its cost, which on these clocks is five — and the
+  targeted repair is a run-level `:prewarm`
   that runs the arms P times, discarded, before the first round, leaving
   `warmup` as a small per-round settling allowance. **It is not built**,
   because the knob sufficed: rf2-h904p raised the two clocks to `8`, which

--- a/implementation/hicasso/test/re_frame/bench/hicasso/lane_schedule_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/bench/hicasso/lane_schedule_cljs_test.cljs
@@ -46,7 +46,26 @@
   after `rf2-z143r`'s ladder, and the eighth arm `rf2-v5oto` wants. The
   fault is invariant to all of them, which is the same arithmetic that
   settles `rf2-6ta5r`'s arm-count question: the schedule length does not
-  move it."
+  move it.
+
+  ## The second thing this file replays: HOW WARM the arm was (rf2-ydqzt)
+
+  `order-guard` strata a banked sample by its `:predecessor` and by its
+  `:phase`, and the two need different facts about the same schedule. The
+  deftests above are the predecessor's. The last two are the phase's:
+  warm-up is charged PER ROUND while the ramp `:phase` exists to catch is
+  RUN-LEVEL, and `rounds!`'s own docstring now quotes the prior-execution
+  span that follows from it. A quoted number nothing checks is the class of
+  claim this directory exists to refuse, so both samplings the lane's
+  page-mount clocks have run are replayed and the span is asserted.
+
+  Those two deftests are also what a future `:prewarm` has to walk past.
+  The bead that priced this asymmetry declined to build one — the knob
+  sufficed, and rf2-adld3's window on the warmed rig came back reportable
+  on phase — so what is recorded here is a REFUSAL and its arithmetic. A
+  change that moves the warm-up out of the round loop turns these red,
+  which is the point: it should not be possible to land the mechanism and
+  leave the reasoning that declined it standing."
   (:require [cljs.test :refer-macros [deftest is testing]]
             [re-frame.bench.hicasso.lane :as lane]))
 
@@ -174,3 +193,88 @@
             (str n " arms: one reading map per round"))
         (is (every? (fn [m] (every? (fn [[_ xs]] (= samples (count xs))) m)) readings)
             (str n " arms: every arm contributes `samples` readings to every round"))))))
+
+;; ---------------------------------------------------------------------------
+;; What the per-round warm-up charge actually buys (rf2-ydqzt)
+;; ---------------------------------------------------------------------------
+
+(def ^:private samplings
+  "Both samplings the lane's page-mount clocks have run, each with the span
+  of PRIOR EXECUTIONS OF ITS OWN ARM that the run's last third sits at.
+
+  `lane/rounds!`'s docstring quotes both spans as the reason a run-level
+  pre-warm was declined; these are the same two numbers, checked. The
+  file-level [[sampling]] above stays pinned at the pair the predecessor
+  fault was found under — that fault is invariant to the numbers and this
+  one is entirely about them."
+  [{:sampling {:warmup 3 :samples 6}  :last-third [32 44]}
+   {:sampling {:warmup 8 :samples 12} :last-third [72 99]}])
+
+(defn- prior-executions
+  "Every banked sample, tagged with how many times ITS OWN ARM had already
+  run in this run.
+
+  Counted off the true execution recording, warm-up included, and not
+  re-derived from `slot-order` — the same reason [[replay]] gives: a
+  re-derivation is a second copy of the rule under test and would agree
+  with a broken one."
+  [{:keys [samples truth]}]
+  (let [before (:out (reduce (fn [{:keys [seen out]} nm]
+                               {:seen (update seen nm (fnil inc 0))
+                                :out  (conj out (get seen nm 0))})
+                             {:seen {} :out []}
+                             truth))]
+    (mapv (fn [{:keys [arm value position]}]
+            {:arm arm :position position :prior (nth before value)})
+          samples)))
+
+(deftest warm-up-is-charged-in-every-round-and-not-once-per-run
+  (testing "The mechanism, asserted directly. `rounds!` spends `warmup`
+           discarded executions per arm inside EVERY round, so at five
+           rounds four fifths of the run's whole warm-up spend falls in
+           rounds that were already warm. This is not a defect — it is the
+           shape a run-level `:prewarm` would change — and it is asserted
+           so that changing it cannot leave `rounds!`'s recorded reasoning
+           standing."
+    (doseq [{:keys [sampling]} samplings
+            n                  arm-counts]
+      (let [{:keys [warmup samples]} sampling
+            {truth :truth samps :samples} (replay n sampling rounds)
+            banked   (set (map :value samps))
+            per-round (partition (* n (+ warmup samples)) (range (count truth)))]
+        (is (= rounds (count per-round))
+            (str n " arms " (pr-str sampling) ": the run is `rounds` blocks of executions"))
+        (doseq [[r idxs] (map-indexed vector per-round)]
+          (is (= (* n warmup) (count (remove banked idxs)))
+              (str n " arms " (pr-str sampling) ": round " (inc r)
+                   " discards `warmup` executions of every arm")))
+        (is (= (* n warmup (dec rounds))
+               (- (count (remove banked (range (count truth)))) (* n warmup)))
+            (str n " arms " (pr-str sampling)
+                 ": every round after the first pays a full warm-up block"))))))
+
+(deftest the-ramp-the-phase-factor-catches-is-run-level-not-round-level
+  (testing "The consequence, and the two numbers `rounds!` quotes. The
+           FIRST measured sample of a run has had exactly `warmup` prior
+           executions of its arm however many rounds follow — round one's
+           warm-up is the only warm-up in front of it — while the run's
+           last third sits an order of magnitude higher. Per-round warm-up
+           does not close that gap and cannot: it restarts, and the ramp
+           does not."
+    (doseq [{:keys [sampling last-third]} samplings
+            n                             arm-counts]
+      (let [{:keys [warmup samples]} sampling
+            by-pos (vec (sort-by :position (prior-executions (replay n sampling rounds))))
+            total  (count by-pos)
+            third  (quot total 3)
+            priors (mapv :prior (subvec by-pos (- total third)))]
+        (is (= (* n samples rounds) total)
+            (str n " arms " (pr-str sampling) ": every banked sample is accounted for"))
+        (is (= warmup (:prior (first by-pos)))
+            (str n " arms " (pr-str sampling)
+                 ": the run's first measured sample is warmed by round one's warm-up "
+                 "and by nothing else"))
+        (is (= last-third [(apply min priors) (apply max priors)])
+            (str n " arms " (pr-str sampling)
+                 ": the run's last third sits at " (pr-str last-third)
+                 " prior executions of its own arm"))))))


### PR DESCRIPTION
The EDIT half of two rig beads on the Hicasso bench instruments. **No window taken, no figure published, no figure re-taken, nothing pooled.** Both beads were filed by measurement workers who declined to fix them in place.

Four measurement windows are queued behind this one (rf2-6zc2q, rf2-v5oto, rf2-w01c, rf2-85og2) and `lane/rounds!` is ridden by ten bench apps, so this PR is deliberately conservative: one dead summariser deleted, one docstring paragraph added to the shared lane, one test namespace extended. No arm, no boundary count, no sampling and no schedule is changed.

## rf2-j7o9w — the null is retained per round

**Premise verified at source, and it holds.** `amp_merge_clock_app.cljs` carried two ns/field summarisers. `ns-terms` assoc'd `:per-round` onto its summary and served the ladder's four rungs; `per-element-ns` answered `lane/summarise`'s `{:n :min :max :p50}` and nothing else, and it was what `:per-element-ns {:effect .. :null ..}` was built from.

**It is a retention gap, not a data loss, and I agree with that reading.** rf2-adld3 (`docs/design/hicasso/decisions.md`, landed at `4529c1fc68`) recovered the null's five per-round values exactly by arithmetic over the ladder's rungs, and checked all three runs against the rig's own printed `{min max p50}`. The data was there. What was missing is that the instrument needed a **sibling row** to be re-adjudicable.

**One delta against the bead, and it sharpens the diagnosis.** The bead says the effect's ns/field is unretained too. Strictly true of the `:per-element-ns` row — but the effect's per-round ns/field was already in the record, because `:ladder :whole :ns-per-site` is `ns-terms p50s :merged :expanded`, the identical quantity. rf2-adld3's own commit message confirms it recorded "per-round vectors for the effect, all three ladder rungs and the control". **Only the null was genuinely absent from the record**, which is exactly why that window and no other had to reconstruct anything.

**The fix is the bead's own remedy and nothing more:** delete `per-element-ns`, point both published rows at `ns-terms`. The docstring's reason for keeping the second one — *"so the two published rows keep the shape they were published in"* — was checked before acting on it and does not hold: `ns-terms` is a superset, the same map with one key added.

**What moves, stated exactly.** `ns-terms` summarises the `round4`'d vector, so `{:min :max :p50}` shift by at most 5e-5 ns/field on figures printed to one decimal place — no console line changes. In exchange the summary becomes exactly reproducible from the printed `:per-round` rather than nearly so (with an odd round count, `round4` is monotone, so the summary of the rounded vector *is* the rounded summary). The record gains a key and loses none; nothing outside the app reads `:per-element-ns` — `git grep` finds one app file plus prose in `decisions.md`, and `run.cjs` echoes records without parsing them. **No published figure is invalidated.**

## rf2-ydqzt — REFUSED, with the arithmetic pinned in source

**Premise verified at source, and it holds exactly.** `lane/rounds!` spends `warmup` discarded samples per arm inside every round, while the ramp the guard's `:phase` factor exists to catch is run-level. Replaying the schedule: the first measured sample of a run has exactly `warmup` prior executions of its arm however many rounds follow; the run's last third sits at 72–99 (at `{:warmup 8 :samples 12}`) or 32–44 (at `3/6`). Both spans reproduce the bead's numbers exactly, at all four arm counts.

**No mechanism is built.** The bead states its own revisit trigger — *a window whose guard refuses on phase at `:warmup 8` with the first-third stratum dominated by round one* — and names rf2-adld3 as one of the two windows that would show it. **That window has since landed and the trigger did not fire:** all three runs returned the arm-order guard **reportable on every arm, by predecessor AND by phase**, with the null inside ±7.9% of 1.0 across fifteen rounds. The bead was filed at 09:45 and that window landed at 10:49 the same morning, so the bead's conclusion was written before its own evidence arrived — and the evidence confirms it. The existing knob sufficed. Ten bench apps ride `rounds!` and every one would inherit a `:prewarm`.

What lands instead is the refusal, located in the source that would have changed: a paragraph in `rounds!`'s docstring naming the per-round charge, the run-level ramp, the alternative not built, and the trigger that would warrant it.

## The test, and its red proof

`lane_schedule_cljs_test` already replays `rounds!` with a stub recording the true execution order. Two deftests added on that machinery, over both samplings at all four arm counts (4/5/7/8):

- `warm-up-is-charged-in-every-round-and-not-once-per-run` — every round discards `warmup` executions of every arm, so every round after the first pays a full block that warms nothing.
- `the-ramp-the-phase-factor-catches-is-run-level-not-round-level` — the first banked sample sits at `warmup` prior executions; the last third sits at the quoted span.

**Red proof.** The planted defect was the mechanism itself — warm-up hoisted out of the round loop in `lane/rounds!`, i.e. precisely what rf2-ydqzt proposed and this PR declines. Result: **48 failures, exit 1**, of which 40 are the two new deftests (`the-ramp-…` 8, `warm-up-is-charged-…` 32; the last third read `[48 67]` instead of `[72 99]`). Source restored and verified by `sha256sum -c`; recompiled and re-run green. That is the property worth having: the mechanism cannot land while the reasoning that declined it still stands.

## Quality gates — captured exit codes

| gate | captured exit |
|---|---|
| `node scripts/compile-node-test.cjs node-test out/node-test.js` (compile half of `test:cljs`) | **0** |
| `node out/node-test.js` (run half) at the final tree — 14017 tests, 71302 assertions, 0 failures, 0 errors | **0** |
| `node out/node-test.js --test=…lane-schedule-cljs-test` — 6 tests, 832 assertions | **0** |
| the same, with the mechanism planted — 48 failures | **1** (red proof) |
| `npm run test:hicasso-compile` — 143 namespaces, zero warnings | **0** |
| `npm run test:hicasso-invariants` | **0** |
| `sh scripts/check-no-hardcoded-paths.sh` | **0** |

`test:cljs` was split into its two halves so each finished inside the foreground cap; the run half was then taken to completion in the background and its exit captured — nothing was left detached and unread. One earlier attempt at the run half was killed by the harness at the cap with **no `.exit` file written**; that is recorded as no verdict, not a pass, and it was re-run twice to completion (both 0), the second at the exact final tree.

`mkdocs build --strict` was not run and is not applicable — no page under `docs/` is touched, so `check_doc_slugs.py` and `check_provenance_pins.py` have no changed surface here either. No browser gate was run: nothing in this PR changes what any page mounts, and the clock apps are reached by `test:hicasso-compile`, which is the only compile that sees them.

## Fences and constraints

- **Touched:** `implementation/hicasso/test/re_frame/bench/hicasso/{amp_merge_clock_app.cljs, lane.cljs, lane_schedule_cljs_test.cljs}` — three files, all clear of PR #8322's 722 (derived with `git diff --name-only origin/main...origin/worker/retire-final`, not the API).
- **NOT touched:** `docs/design/hicasso/product/budgets.md`, `implementation/hicasso/scripts/check_budget_ledger.py`.
- The arm-order guard is untouched — its tolerance, its rule, its thirds partition and its exit-2 path are unchanged, and so is its input.
- Nothing changes what any window MEASURES: no `boundaries`, no arm count, no arm, no subject, no sampling, no schedule.
- `docs/design/hicasso/decisions.md` is deliberately not amended. Its sentence *"the rig cannot print them"* describes the rig at that window's own checkout and stays true of it; four queued windows will each append to that file, and an edit from here would be a conflict magnet for them.

