### PR TITLE
docs(hicasso): fence c-noactivate's per-commit multiplier to the arm; refuse rf2-5zmul as already delivered (rf2-ml3kt, rf2-5zmul)

### DIFF
--- a/implementation/hicasso/test/re_frame/bench/hicasso/read_profile_app.cljs
+++ b/implementation/hicasso/test/re_frame/bench/hicasso/read_profile_app.cljs
@@ -124,8 +124,16 @@
   call. A key no adapter on this host ever publishes therefore misses both
   slots on every call: two atom derefs and two hash-map misses, once per key
   of the read set, which is 141 calls per boundary commit in this arm's own
-  loop. rf2-19usn carries that cost where it is paid in shipping code and is
-  the reason this delta is not zero.
+  loop. **That multiplier is the arm's and must not travel with the number.**
+  `c-local` mints a fresh cell every iteration, so this arm genuinely runs the
+  cold path 141 times per window; shipping code pays the same per-call cost
+  once per NEW-OR-REWIRED cell (`collector.cljs:947` on a cells-map miss,
+  `:967` on a post-invalidation rewire) and once per observation-handle
+  acquire (`observation.cljc:2160`), while a steady-state commit reaches
+  `:968` — push a reader — and stops. Neither is per commit. rf2-19usn priced
+  the mechanism at that real frequency and closed won't-fix; the per-call
+  number is what makes this delta non-zero, and the every-commit reading of it
+  is what audit #8328 had to retract once already (rf2-ml3kt).
 
   It measures accordingly. Over rf2-07rnj's three runs the arm read
   0.0422 / 0.0484 / 0.0562 ms/commit — one sign on every run, and LARGER than


### PR DESCRIPTION
## What this delivers

Two beads. One is a one-file docstring correction; the other is a **premise-does-not-hold refusal**, with the evidence below.

### rf2-ml3kt — FIXED (1 file, +10/-2)

`read_profile_app.cljs`'s `c-noactivate` docstring scoped `:126` carefully — "141 calls per boundary commit **in this arm's own loop**" — and then handed the number straight on at `:127` as a cost "paid in shipping code". Read together those two sentences say *shipping pays 141 per commit*, which is the every-commit framing merged-PR audit #8328 already had to retract once. This docstring is the instrument's own write-up and is what the next measurement pass quotes from, so the claim regenerates from a green run.

**Verified at source before rewriting** (the point of the bead is that a plausible frequency claim survived three tellings):

| site | what it actually is | frequency |
| --- | --- | --- |
| `implementation/hicasso/src/re_frame/hicasso/impl/collector.cljs:947` | `(wire-cell! fresh)` in the fresh-cell mint arm | cells-map **miss** only |
| `…/collector.cljs:967` | `(when (nil? (.-reaction cell)) (wire-cell! cell))` | **post-invalidation rewire** only |
| `…/collector.cljs:968` | `(.push (.-readers cell) reg)` | where a **steady-state commit stops** |
| `implementation/core/src/re_frame/substrate/observation.cljc:2160` | `(build-node-handle! target frame-id query reaction on-change)` inside `acquire!` | once per **acquire** |

Both cold path; neither per commit. The per-call number the arm measures is sound and is kept verbatim — only the frequency multiplier is fenced to the arm, with the real shipping frequency and its four call sites named so the claim cannot regenerate. rf2-19usn's close reason (won't-fix) is where the corrected framing was established, and it names this exact line as the residue it could not edit.

### rf2-5zmul — REFUSED: the premise does not hold at tip

The bead reads "nothing reconciles the runtime's `:recovery` argument against its Spec 009 row". **That reconciler exists, is armed, and bites.** It is R10 in `implementation/hicasso/scripts/check_complaint_catalogue.py`, and all three of its commits are ancestors of `origin/main`:

| commit | date | subject |
| --- | --- | --- |
| `33c0650243` | 2026-08-15 19:02 +1000 | `feat(hicasso): R10 anchors the complaint catalogue to the runtime's :recovery (rf2-5zmul)` |
| `008c3b38cc` | 2026-08-15 21:12 +1000 | `fix(hicasso): R10's coverage arm is per emit site, not per id (rf2-5zmul)` |
| `592180344d` | 2026-08-16 02:33 +1000 | `fix(hicasso): R10 keeps the emit site whose ID it cannot read (rf2-5zmul)` |

The bead was reopened twice by merged-PR audits (#8315, #8323), each naming a narrow repair. **Both repairs are on main, and both audits' fixtures are pinned verbatim in the committed self-test** (`check_complaint_catalogue.py`, the `THE KNOWN-PLUS-UNREADABLE-SIBLING FIXTURE` and `THE COMPUTED-ID SIBLING` blocks).

I replayed each audit's own fixture against three generations of the checker, independently of the committed self-test, to confirm the fixtures discriminate rather than merely pass:

```
=== checker as of 33c0650243 ===   (PR #8315 head)
  KeyError: recoveries_in returns a bare dict — no unreadable-site list at all
=== checker as of 008c3b38cc ===   (PR #8323 head)
  #8315 unreadable-RECOVERY sibling   identical-to-one-site=False  unreadable=1  <-- RETAINED
  #8323 unreadable-ID sibling         identical-to-one-site=True   unreadable=0  <-- BLIND SPOT (audit reproduces)
=== checker as of HEAD (origin/main) ===
  #8315 unreadable-RECOVERY sibling   identical-to-one-site=False  unreadable=1  <-- RETAINED
  #8323 unreadable-ID sibling         identical-to-one-site=False  unreadable=1  <-- RETAINED
```

The middle generation reproducing audit #8323's blind spot byte-for-byte is what makes the HEAD result meaningful: the fixture is capable of coming back "blind", and does not.

**The arming instruction is moot too.** The dispatch asked me to ship the checker unarmed and file a follow-up bead for CI arming. It is already armed, by both arms:

- `.github/workflows/test.yml:1033` job `hicasso-complaint-catalogue` ("Hicasso complaint-catalogue contract (rf2-hic-021)"), running `--self-test` at `:1050` and the live gate at `:1053`, and listed in the required-checks aggregation at `:6877`;
- `implementation/package.json:65` `test:hicasso-invariants`, which `scripts/test-fast-pr.sh:1516` runs in the spine.

So **no follow-up bead was filed** — filing one would ask for work that is already merged. Two existing open beads already own the only residue in that job, and both are correctly held for a `test.yml` PR: **rf2-nuhru** (the job's comment says "eight rules"; there are ten — its existence is itself independent confirmation the job is armed and runs R10) and **rf2-badrf** (the `hicasso-guide-samples` arming rationale cites stale measurements).

## The red proof (rf2-5zmul's control)

The nominated sabotage is the rf2-15bqc shape — a stale spelling of a renamed form at one emit site, disagreeing with its Spec 009 row.

- **Planted** at `implementation/hicasso/src/re_frame/hicasso/impl/portal.cljs:99`, single-line anchor: `:give-the-portal-a-dom-container-that-exists` → `:give-the-portal-a-dom-node-that-exists`. Hash moved `fde8e838…` → `80fb830a…`, so the patch genuinely applied rather than silently no-opping.
- **Gate went RED, captured exit `1`**, naming the site and *both* spellings:

  > `R10 :rf.error/hicasso-portal-no-target is RAISED with the recovery :give-the-portal-a-dom-node-that-exists, which its Spec 009 row does not carry (the row has :give-the-portal-a-dom-container-that-exists, :target). The runtime is the anchor: either the emit site is giving advice no catalogue documents, or Spec 009 has been left behind by a rename.`

- **Restored and verified by hashing the bytes**, not by reading a diff: `git hash-object` of the working file is `fde8e8381828a7a039f3479d3fad4bb58e6f5b42`, identical to `git rev-parse HEAD:implementation/hicasso/src/re_frame/hicasso/impl/portal.cljs`. Gate back to exit `0`; `git status --porcelain` clean for that path. **This PR's diff does not contain the plant.**

The plant existed only in this worktree, so a run that had wandered into a sibling checkout would have come back green — the red is itself the proof the gate read the right tree.

## Quality gates

Every code quoted below is the exit code **captured by the same shell that ran the gate** (`cmd > log 2>&1; echo "EXIT=$?"`), never a harness-reported one, and no gate was piped through a filter.

| gate | captured exit | result |
| --- | --- | --- |
| `check_complaint_catalogue.py` (live, real tree) | `0` | PASS — 77 live / 5 reserved / 1 pending retirement / 1 retired; R10 covers 74 subject ids, every raised recovery rowed, none skipped, 3 corpus-owned |
| `check_complaint_catalogue.py --self-test` | `0` | PASS — all R1–R10 arms driven red in turn |
| `check_complaint_catalogue.py` **with drift planted** | `1` | **RED as designed** — 1 failure, naming site + both spellings |
| `check_complaint_catalogue.py` after restore | `0` | PASS — control restored |
| `npm run test:hicasso-invariants` | `0` | PASS — 14 checker invocations (7 checkers × self-test + live); 0 failures |
| `npm run test:hicasso-compile` | `0` | PASS — 143 namespaces, 445 files, 444 compiled, **0 warnings** |
| `scripts/check_fast_pr_gap.py --list` | `0` | derived the gap below |
| `scripts/test-fast-pr.sh` (full spine) | `0` | **PASS** — final line `PASS fast PR spine`. JVM `implementation/core` 2243 tests / 11691 assertions, 0 failures 0 errors; JVM `implementation/hicasso` 3 tests / 92 assertions, 0 failures 0 errors; CLJS node integration 14017 tests / 71302 assertions, 0 failures 0 errors; plus clj-kondo (pinned), per-ns isolation, hicasso invariants, hicasso lint export, hicasso bench-lane compile |

The spine was **detached** (its plan showed JVM + node + kondo tiers, well past the foreground cap) and then **polled to completion in the same turn** on both its log and its exit-code file — the exit file is the verdict and it was written. Its log was checked for splicing before being believed: 6626 lines, **0 real NUL bytes**, exactly one `PASS fast PR spine` line and exactly one `gate root:` line. (The first NUL check used `$'\0'`, which bash collapses to an empty pattern that matches every line; it was re-run with `tr -dc '\000'`, and the search was confirmed against a control pattern that does match.)

**Which tree each gate read.** Two gates print their root and both named this worktree: `test:hicasso-compile` printed `C:\Users\miket\code\re-frame2-worktrees\hicgate-5zmul\implementation\…`, and the spine printed `gate root: /c/Users/miket/code/re-frame2-worktrees/hicgate-5zmul`. `check_complaint_catalogue.py` prints no root, so its discrimination is the planted red above.

**Fast-spine versus required CI, per `scripts/check_fast_pr_gap.py --list` (the single cited path).** It derives **106 required checks the spine does not run** — (A) steps inside jobs the spine does run, in `test.yml`'s repo-invariant / JVM-freehand / CLJS jobs and `docs.yml`'s MkDocs and provenance-pins jobs; and (B) 53 required jobs with no spine lane at all (48 in `test.yml` under `All required checks passed`, 4 in `lint.yml` under `Lint required`, 1 in `docs.yml` under `Docs required`). That is a fact about the **spine**, not a census of this PR, so separately: **the spine did run** (classified `docs=false jvm=true node=true`, JVM tier `implementation/core` + `implementation/hicasso`, plus clj-kondo), and the gates I ran **directly** are the six rows above it. The merge decision is CI's.

**Skipped, with reasons.** `mkdocs build --strict` — not nominated and not applicable: this PR touches no `docs/` page, and `mkdocs.yml`'s `exclude_docs` keeps `docs/design/**` off the site anyway. No browser, bundle, adapter, Xray, MCP or tool-JVM gate runs in any spine tier (the spine says so itself); those are CI's.

## The fence, as actually touched

Re-derived at start-up **and** again before the first edit, from `gh pr list --state open` plus per-branch `git diff --name-only origin/main...<branch>` — not from the dispatch's list, which had gone stale inside this dispatch's own lifetime:

- **PR #8322 `worker/retire-final`** (722 files) holds `implementation/hicasso/scripts/check_budget_ledger.py` but **not** `check_complaint_catalogue.py`, and not this bench file. Not touched. `spec/009-Instrumentation.md` read only, never edited. **`.github/workflows/test.yml` and `scripts/test-fast-pr.sh` were run but never edited**, exactly as fenced.
- **PR #8376 `worker/w-rig2`** — **merged during this dispatch**, while I was rebasing. Its three commits (`ce62c8edb2`, `8e964e93dd`, `0eac98dd53`) are now on main and left `read_profile_app.cljs` untouched. That also clears rf2-ml3kt's own mayor fence on its stated terms ("WHAT CLEARS IT: #8376 merging, or its worker reporting done"). Rebased onto `0eac98dd53` and **re-ran every gate on that final base**.
- **`worker/w-e9wr` and `worker/w-t32wg`** — no such remote branches exist; not started, no contention over the bench lane.
- **`worker/retire-delete`** — `examples/**` and adapter scripts; no overlap.
- Nothing under `.beads/` is in this diff.

Diff read against its **merge base** (`git diff origin/main...HEAD`, three-dot) before pushing: one file, +10/−2, reverting nothing a sibling landed.

**Rebased twice, gates re-run on the final base each time.** First onto `0eac98dd53` (PR #8376's three commits had landed — full spine and all targeted gates ran on that base). Then onto `9a315502db`; the entire trunk delta for that second move is five `chore(beads): checkpoint` commits touching `.beads/issues.jsonl` and nothing else, which no gate here reads, so the targeted gates were re-run on it (`check_complaint_catalogue.py` exit `0`; `npm run test:hicasso-compile` exit `0`, 445 files / 444 compiled / 0 warnings, again printing this worktree as its root) and the ~21-minute spine was not, on the stated ground that a `.beads`-only delta cannot change its verdict. The merge-base diff was re-read after the rebase and is unchanged at one file, +10/−2.
