### PR TITLE
docs(mayor-method): the '## Quality gates' heading is read by agents, not by an audit script (rf2-820hx)

### DIFF
--- a/docs/the-mayor-method/dispatch-prompt-template.md
+++ b/docs/the-mayor-method/dispatch-prompt-template.md
@@ -590,8 +590,19 @@ the worker to look there first.
 ## Quality gates — which gate
 
 Every editing dispatch runs the project's pre-checkin gate before opening a change, and lists what ran in a
-change-body section headed **exactly** `## Quality gates` with pass and fail counts. A verbatim heading is a
-contract for automated audits.
+change-body section headed **exactly** `## Quality gates` with pass and fail counts. **The readers are the
+mayor's merge sweep and the merged-PR audits — both of them agents, and no machinery whatever.** An earlier
+version of this line called the verbatim heading a contract for automated audits, and no such audit exists: a
+fixed-string search for `Quality gates` across the tracked tree returns this file, the two mayor command
+files, the tracker export, one design page, and two test docstrings that point a reader at a PR's own section
+— no script, no workflow, no audit tool. The search was controlled by matching that same fixed string inside
+`docs/the-mayor-method/`, so the zero is a real absence and not a wrong pattern. **Exactly** stays regardless,
+because it is what lets a reader jump to the section in a long change body rather than read the whole thing.
+What the false justification cost is measured: PR #8376 headed its section `## Gates — captured exit codes`
+and carried every fact the rule asks for, and the mayor hand-edited the missing word into it seven seconds
+before merging it on 2026-08-16. **A heading that does not conform is a note to the worker and nothing more.**
+It is never grounds to edit somebody else's change body, and never a merge blocker — the five clauses are the
+merge criterion, and this is not among them.
 
 - **Gate the transitive surface, not just the file you changed.** A public-surface change breaks its
   *consumers*, not itself. Gate every artefact reachable from the diff through import edges.


### PR DESCRIPTION
Corrects one paragraph of `docs/the-mayor-method/dispatch-prompt-template.md` (rf2-820hx). The heading requirement is unchanged — `## Quality gates` stays **exactly** — and only its justification moves.

**One file, one paragraph, +13/−2.** `.claude/commands/mayor-dispatch.md` and `.claude/commands/mayor-merge.md` are deliberately untouched: they cite the heading correctly, and a second copy of this reasoning in either is the two-copies-of-one-rule failure the method-reread loop exists to catch.

## The premise, re-derived at source — and it holds

The line claimed *"A verbatim heading is a contract for automated audits."* There is no such audit.

`git grep -lF "Quality gates"` across the tracked tree returns seven paths, every one of them prose: this file; `.claude/commands/mayor-dispatch.md` and `mayor-merge.md` (instructions an agent reads); `.beads/issues.jsonl` (the tracker export); `docs/design/freehand/studio/compiled-tier-browser-worth-it.md:694` ("see the PR's `## Quality gates`"); and two security-test docstrings pointing a reader at a PR's own section. No script, no workflow, no audit tool. Nothing under `scripts/`, `.github/`, `.beads/hooks/` or `scripts/git-hooks/` matches at all.

**The search was controlled in both directions**, because this bead's entire finding is a zero:

| control | result |
|---|---|
| same fixed string restricted to `docs/the-mayor-method/` (must match) | matches — pattern works |
| `git grep -lF "ZZZ-no-such-string-QQQ"` (must not match) | exit 1 — no false positives |
| case-insensitive `quality gate` widened across the tree | 37 paths, all prose; exactly one lies under `scripts/` or `.github/`, and it is a comment on line 4 of `scripts/test-fast-pr.sh` |

There is also no merged-PR audit script: `git grep -lF "audit merged PR"` returns only the tracker export and `mayor-merge.md` prose, and neither `.beads/hooks/*` nor `scripts/git-hooks/*` reads a PR body. Those audits are agent-driven, which is exactly consistent with the finding.

## The incident, confirmed from GitHub's own edit history

The bead names PR #8376. `userContentEdits` on that PR records the body's gates heading as `## Gates — captured exit codes` at 02:11:21Z, and as `## Quality gates — captured exit codes` at **02:23:02Z — seven seconds before the merge at 02:23:09Z**. The word was hand-edited in at merge time. The body had already carried every fact the rule asks for: captured exit codes, a table, and a red proof.

## What the paragraph now says

It names the real readers (the mayor's merge sweep and the merged-PR audits, both agents and no machinery); records that an earlier version got this wrong, with the measurement and its control; keeps **exactly**, because it is what lets a reader jump to the section in a long change body; and states the sanction plainly — a non-conforming heading is a note to the worker, never grounds to edit somebody else's change body, and never a merge blocker, the five clauses being the merge criterion and this not among them.

## Quality gates

Every number below is the one **captured** from the runner's own shell (`cmd > log 2>&1; echo $? > exit`, redirect and echo on one command line), never a harness-reported status. All re-run on the **final rebased base** (`ab500e1781`); the pre-rebase runs agreed.

| gate | captured exit |
|---|---|
| `sh scripts/test-fast-pr.sh` — fast pre-checkin spine, `docs=true jvm=false node=false (classified)`, `PASS fast PR spine` | **0** |
| `python scripts/check_doc_slugs.py` — baseline, before any edit | **0** |
| `python scripts/check_doc_slugs.py` — after the edit | **0** |
| `python scripts/check_doc_slugs.py` — **with a fault planted** | **1** (red proof) |
| `python scripts/check_doc_slugs.py` — after restore | **0** |
| `mkdocs build --strict` — inside the spine's docs tier | **0** |
| `python scripts/check_fast_pr_gap.py --list` | **0** |

**The spine ran, in full and in the foreground**, and it was not split or detached — the docs tier is the only armed tier for this diff and it finished well inside the ceiling. Run directly as well: `check_doc_slugs.py` (five times, above) and `check_fast_pr_gap.py --list`.

### Red proof, and the restore verified by hash

`check_doc_slugs.py` reds on one broken link target. The fault was planted on a **single-line anchor** in the paragraph being edited — `` `docs/the-mayor-method/` `` became a link to `./no-such-page-820hx.md`:

```
1 broken target file(s) found:
  BROKEN TARGET: docs\the-mayor-method\dispatch-prompt-template.md:599 -> ./no-such-page-820hx.md
      (missing: docs\the-mayor-method\no-such-page-820hx.md)
```

The failure names exactly what was planted, and the plant is confirmed to have genuinely applied rather than silently no-opped: the file's content hash moved `3ec9af569a…` → `614bf00bcc…`. Restored with `git checkout HEAD --`, then verified with **git's own content hash against the committed object** rather than a byte digest (this checkout translates line endings): `git rev-parse HEAD:<path>` and `git hash-object <path>` both read `3ec9af569ad4893a6e7b259eaa70738ee60dc68e`. Gate green again afterwards, working tree clean.

### Which tree the gates read

Verified by **both** available routes rather than assumed. `mkdocs` prints its root, and it named this worktree: `Building documentation to directory: C:\Users\miket\code\re-frame2-worktrees\qgates-820hx\site`. `check_doc_slugs.py` prints only repository-relative paths, which cannot discriminate two checkouts — so there the discrimination is **the red itself**, since `no-such-page-820hx.md` existed in no other tree and a run that had wandered into a sibling would have come back green.

## Fast-spine gap

`python scripts/check_fast_pr_gap.py --list` — **106** required checks the spine does not run, across the three required contexts (`All required checks passed`, `Lint required`, `Docs required`). Cited as one path rather than enumerated here. That is a fact about the *spine*; what **this** PR ran is the table above: the spine in full, plus `check_doc_slugs.py` and the gap report directly.

## One correction to the dispatch brief, reported rather than acted on

The brief instructed that `mkdocs build --strict` "is NOT nominated and must not be", on the ground that `mkdocs.yml`'s `exclude_docs` keeps the surface out of the site — and told me to read that config myself rather than take its word. **Read, and the reason does not hold for this path.** `exclude_docs` lists only `tools/playground/`, the two codemod trees, `design/freehand/`, `design/hicasso/` and `design/retirement/`; `docs/the-mayor-method/` is not among them. mkdocs resolves here as `python -m mkdocs` 1.6.1, the spine runs `mkdocs build --strict` as a hard gate in its docs tier, and the page really is built — `site/the-mayor-method/dispatch-prompt-template/` exists, listed only as an INFO not-in-nav page, which `--strict` does not fail on. So the gate genuinely covers this edit and it ran green; it is reported here rather than suppressed. (`check_doc_slugs.py` remains the stronger gate for link and anchor targets — the spine's own comment notes mkdocs 1.6 grades a missing anchor INFO — and it names `docs/the-mayor-method/` as a deliberately covered tree at `scripts/check_doc_slugs.py:58`, rf2-qdqf.)

## Fences

- **Touched:** `docs/the-mayor-method/dispatch-prompt-template.md`, one paragraph.
- **NOT touched:** `.claude/commands/mayor-dispatch.md`, `.claude/commands/mayor-merge.md`, every other paragraph of this file, and `.beads/**`. No enforcement script was added — the bead does not ask for one and it would be the gold-plating the stance rejects.
- The merge-base diff (`git diff origin/main...HEAD`, three-dot) was read before pushing for anything it would revert: one file, +13/−2, nothing else. The four commits main gained during this work touched `docs/design/hicasso/**`, `implementation/core/test/…/p0_run.cjs` and the tracker export — none of them this file.
