### PR TITLE
feat(bench): the allocation arm's work unit, opened by site across the round sequence (rf2-rs8q6)

### DIFF
--- a/implementation/core/test/re_frame/bench/p0_heap.cljs
+++ b/implementation/core/test/re_frame/bench/p0_heap.cljs
@@ -1018,6 +1018,22 @@
 (defonce ^:private alloc-sink (volatile! 0.0))
 (defonce ^:private alloc-samples (volatile! nil))
 
+;; ## SAMPLES PER ITERATION — the BY-SITE stride (rf2-rs8q6)
+;;
+;; 2 is the shipped window and every published figure was taken under it:
+;; one reading before the work unit and one after, so a leg is ONE step and
+;; the work unit is opaque. 3 opens the unit at its only seam — see
+;; [[alloc-window!]] — and is a DIAGNOSTIC MODE the driver arms with
+;; `P0_ALLOC_BY_SITE=1`. It is off by default and no published row takes it.
+;;
+;; It lives beside the buffer because it SIZES the buffer, and a stride that
+;; disagreed with the allocation would write off the end of a
+;; `Float64Array` — which does not throw in JavaScript, it silently drops
+;; the store, and the row would read a zero leg it could not distinguish
+;; from a collection. [[alloc-prepare!]] is the one place both are set, so
+;; they cannot drift.
+(defonce ^:private alloc-sites (volatile! 2))
+
 ;; The written value, MONOTONE FOR THE LIFE OF THE PAGE rather than
 ;; restarting at 1 in every window.
 ;;
@@ -1057,12 +1073,23 @@
   clean `FixedDoubleArray` of `d` unboxed 8-byte slots, so the copy costs
   a **predicted 8d bytes**. That prediction is the whole point of a
   control — a figure the instrument has to hit, not one it gets to
-  report."
-  [d n]
-  (vreset! alloc-template (when (pos? d) (.fill (js/Array. d) 0.5)))
-  (vreset! alloc-sink 0.0)
-  (vreset! alloc-samples (js/Float64Array. (+ 1 (* 2 (long n)))))
-  nil)
+  report.
+
+  `sites` is the samples-per-iteration stride and is the ONE place it is
+  set (rf2-rs8q6). Anything but 3 is 2, which is the shipped window, so a
+  caller that passes nothing — every caller before this bead — gets
+  today's buffer to the byte. The buffer is sized from the same number
+  [[alloc-window!]] indexes with, because a stride the buffer was not
+  sized for writes past the end of a `Float64Array`, which does not throw
+  and is indistinguishable afterwards from a leg that allocated nothing."
+  ([d n] (alloc-prepare! d n 2))
+  ([d n sites]
+   (let [k (if (= 3 sites) 3 2)]
+     (vreset! alloc-template (when (pos? d) (.fill (js/Array. d) 0.5)))
+     (vreset! alloc-sink 0.0)
+     (vreset! alloc-sites k)
+     (vreset! alloc-samples (js/Float64Array. (+ 1 (* k (long n))))))
+   nil))
 
 (defn- alloc-control!
   "One control allocation: a `.slice` of the template, dropped on the next
@@ -1108,30 +1135,86 @@
   `useSyncExternalStore` spine needs to commit in this window — the same
   split `p0-arms/subs-bulk-arm` makes, so the write is like-for-like.
 
+  ## THE BY-SITE STRIDE — opening the work unit at its one seam (rf2-rs8q6)
+
+  At the shipped stride of 2 a leg is ONE step and the work unit is
+  opaque: the row can say a leg allocated 19,256 B and cannot say what
+  did. `rf2-rs8q6` measured a leg dispersion that is a function of the
+  ROUND INDEX in six of six independent browser launches, and identifying
+  a mechanism from a single opaque number is not possible in principle.
+
+  The work unit has exactly two statements that allocate and exactly one
+  seam between them, and both are visible in the `write?` branch below:
+
+    site 1  DISPATCH — `write-page!`/`write-all!`, which is a
+            `dispatch-sync` through the event pipeline and the signal
+            graph, plus whatever render the substrate schedules or runs
+            synchronously inside it.
+    site 2  DRAIN    — the `flushSync`, which is React's commit (or
+            Reagent's own synchronous flush).
+
+  At stride 3 the counter is read AT THAT SEAM, so leg `k` decomposes as
+  `dispatch_k + drain_k`, exactly and by construction — the outer pair is
+  the same pair the stride-2 window reads, so the leg total is unchanged
+  arithmetic over unchanged readings.
+
+  **There is no third seam that does not change what the arm measures.**
+  Splitting inside `dispatch-sync` would mean instrumenting re-frame's own
+  pipeline from a bench fixture, and an arm carrying instrumentation is
+  not the arm whose figures are published. Two sites is what the work unit
+  affords, and it is the split that separates the framework's write from
+  the substrate's commit — which is the distinction every question on this
+  row turns on.
+
+  **What it costs, stated.** One more `mem` read per leg, inside the
+  measured region. It is a property read on a host object and the driver's
+  `idle` window — driven at the SAME stride — is what prices it, exactly
+  as it prices the two reads already there. It is a CONSTANT per leg, so
+  it shifts every leg by the same amount and can neither create nor
+  destroy the dispersion this mode exists to attribute. Absolute leg
+  magnitudes taken at stride 3 are therefore not comparable, byte for
+  byte, with those taken at stride 2, and the driver refuses to publish
+  under it.
+
   Nothing here collects, logs, or crosses CDP. The driver collects before
   the window and reads the counter on both sides of it, and those two
   readings are what the in-page rising-step sum is checked against."
   [n kind drain]
   (let [n       (long n)
         ^js buf @alloc-samples
+        k       (long @alloc-sites)
+        site?   (= 3 k)
         all?    (= kind "write-all")
         write?  (or (= kind "write") all?)
         ctl?    (= kind "control")
-        reagent? (= drain "reagent")]
+        reagent? (= drain "reagent")
+        tick0   @alloc-tick]
     (aset buf 0 (mem))
     (dotimes [i n]
-      (aset buf (inc (* 2 i)) (mem))
-      (cond
-        write? (do (vswap! alloc-tick inc)
-                   (if all?
-                     (arms/write-all! @alloc-tick)
-                     (arms/write-page! @alloc-tick))
-                   (if reagent?
-                     (react-dom/flushSync (fn [] (r/flush)))
-                     (react-dom/flushSync (fn [] nil))))
-        ctl?   (alloc-control!)
-        :else  nil)
-      (aset buf (+ 2 (* 2 i)) (mem)))
+      (let [base (* k i)]
+        (aset buf (inc base) (mem))
+        (cond
+          write? (do (vswap! alloc-tick inc)
+                     (if all?
+                       (arms/write-all! @alloc-tick)
+                       (arms/write-page! @alloc-tick))
+                     ;; THE SEAM. At stride 2 this is a test of a boolean
+                     ;; local and nothing else — the same class of branch
+                     ;; as the `reagent?` test immediately below it, which
+                     ;; has always sat inside the measured region.
+                     (when site? (aset buf (+ 2 base) (mem)))
+                     (if reagent?
+                       (react-dom/flushSync (fn [] (r/flush)))
+                       (react-dom/flushSync (fn [] nil))))
+          ;; The controls have no seam of their own, and that is what makes
+          ;; them the control for this mode: the mid sample is taken with
+          ;; NOTHING between it and the leg's opening reading, so site 1 of
+          ;; an idle leg is one sampler read's own footprint and nothing
+          ;; else. That is the constant the arms' site figures carry.
+          ctl?   (do (when site? (aset buf (+ 2 base) (mem)))
+                     (alloc-control!))
+          :else  (when site? (aset buf (+ 2 base) (mem))))
+        (aset buf (+ k base) (mem))))
     ;; The read-back, OUTSIDE the window: the text of one boundary, which
     ;; at R reads of a page written to `v` is `(str (* R v))`. A row whose
     ;; writes never reached the page is the cheapest row in any table, and
@@ -1142,6 +1225,18 @@
       #js {:samples (js/Array.from buf)
            :n       n
            :kind    kind
+           ;; THE STRIDE RIDES BACK WITH THE SAMPLES (rf2-rs8q6). The
+           ;; driver decodes the stream by it rather than by the switch it
+           ;; believes it set, so a stride that failed to reach the page
+           ;; is a decode against the wrong shape rather than a silent
+           ;; misreading of a well-formed one.
+           :sites   k
+           ;; The tick at the window's OPEN, beside the tick at its close.
+           ;; `alloc-tick` is monotone for the life of the page, so this
+           ;; pair is what places a window in the page's own work-unit
+           ;; sequence — and "where in that sequence" is the only thing a
+           ;; round index is.
+           :tick0   tick0
            :tick    @alloc-tick
            :text    (when cell (.-textContent cell))})))
 
@@ -1293,7 +1388,7 @@
              ;; trip — the whole method is that nothing collects and
              ;; nothing else runs between two readings of the counter —
              ;; and the driver owns everything on either side of it.
-             :allocPrepare   (fn [d n] (alloc-prepare! d n))
+             :allocPrepare   (fn [d n sites] (alloc-prepare! d n sites))
              :allocWindow    (fn [n kind drain] (alloc-window! n kind drain))
              :boundariesPerRoot #js {:list rows-per-root :grid per-root}})
   nil)

--- a/implementation/core/test/re_frame/bench/p0_ladder_structural.test.cjs
+++ b/implementation/core/test/re_frame/bench/p0_ladder_structural.test.cjs
@@ -61,6 +61,11 @@ const {
   ALLOC_PLAN_SHAPES,
   allocPlanArms,
   summariseAlloc,
+  allocSiteSplit,
+  allocSiteWitness,
+  allocSiteReport,
+  ALLOC_SITES,
+  ALLOC_SITE_NAMES,
 } = require('./p0_run.cjs');
 
 const tests = [];
@@ -533,15 +538,17 @@ test('the tolerance is CALIBRATED, pinned, and has no dial on it', () => {
   );
   // And the driver reads the module constant at every measurement site: the
   // `tolerance` parameter exists for the τ sweep below and for nothing else.
-  // Both sites split the prime off first (rf2-oiy1) and then adjudicate the
-  // MEASURED region — one adjudicator, one τ, two windows.
-  has(
-    /const \{ primeLegs, measured \} = allocPrimeSplit\(w\.samples\);/,
-    'the control windows split the prime off'
-  );
-  has(
-    /const \{ primeLegs, measured \} = allocPrimeSplit\(win\.samples\);/,
-    'and so do the arm windows'
+  // Both sites COLLAPSE the by-site stream first (rf2-rs8q6) — which is the
+  // identity off the diagnostic mode — then split the prime off (rf2-oiy1) and
+  // adjudicate the MEASURED region. One adjudicator, one τ, two windows.
+  has(/const site = allocSiteSplit\(w\.samples, w\.sites\);/, 'the control window collapses first');
+  has(/const site = allocSiteSplit\(win\.samples, win\.sites\);/, 'and so does the arm window');
+  assert.strictEqual(
+    (SRC.match(/const \{ primeLegs, measured \} = allocPrimeSplit\(site\.collapsed\);/g) || [])
+      .length,
+    2,
+    'and both then split the prime off the COLLAPSED stream, which is the stream the shipped ' +
+      'stride would have filled'
   );
   has(/const s = allocSteps\(measured\);/, 'and what is adjudicated is the measured region');
   lacks(
@@ -805,10 +812,30 @@ test('the prime is CONFIGURED IN ONE PLACE and the divisor is not it', () => {
   // And the window is driven at the full count at every site, warm-ups
   // included — a warm-up smaller than the window is the defect the warm-up
   // pass exists to avoid.
+  // THE CALL SHAPE MOVED, SO THIS PIN MOVED WITH IT (rf2-rs8q6). `allocPrepare`
+  // gained a stride argument, and the old literal `allocPrepare(dd, n)` would
+  // have matched nothing from that day on — a `lacks` that matches nothing
+  // passes, silently, for ever. Anchored on the argument ARRAY instead, which
+  // is where the count it is about actually lives.
   lacks(
-    /allocPrepare\(dd?, n\), \[[^\]]*ALLOC_WRITES\]/,
+    /allocPrepare\([^)]*\),\s*\[[^\]]*\bALLOC_WRITES\b/,
     'no sample buffer is sized for the measured writes alone'
   );
+  // And the positive half, counted, so it bites in both directions: EVERY
+  // `allocPrepare` in the driver sizes for the window count AND states the
+  // stride, because a buffer sized for one stride and indexed at another
+  // writes past the end of a `Float64Array` — which does not throw, it drops
+  // the store, and the leg reads zero.
+  const prepares = SRC.match(/window\.P0H\.allocPrepare\([^)]*\),\s*\[[^\]]*\]/g) || [];
+  assert.strictEqual(
+    prepares.length,
+    3,
+    `every allocPrepare call site is accounted for: ${JSON.stringify(prepares)}`
+  );
+  for (const p of prepares) {
+    assert.match(p, /ALLOC_WINDOW_WRITES/, `sized for the window it drives: ${p}`);
+    assert.match(p, /ALLOC_SITES/, `and the stride is stated at the same call: ${p}`);
+  }
   has(/\[ALLOC_WINDOW_WRITES, drain, ALLOC_WRITE_SPEC\.kind\]/, 'the window drives the full count');
   // NO DIAL. The prime decides what a window MEANS, so it is a constant for
   // `ALLOC_LEG_TOLERANCE`'s reason: a knob on it is a knob on the certificate.
@@ -849,6 +876,290 @@ test('the prime is CLAMPED, so a short stream cannot read off the end', () => {
   // — which is what lets every `allocSteps` pin above stand unedited.
   const raw = stream([1000, 1000]);
   assert.deepStrictEqual(allocPrimeSplit(raw, 0), { primeLegs: [], measured: raw });
+});
+
+// ===========================================================================
+// THE BY-SITE INSTRUMENT — rf2-rs8q6
+// ===========================================================================
+//
+// WHAT IT IS FOR. rf2-e9wr measured 72 floor-arm windows and found the leg
+// dispersion to be a function of the ROUND INDEX — round 2 (n=11) at
+// 2.66%–20.37% with none below 2.66%, round 3 (n=11) at 0.00%–0.19% with all
+// at or below 0.19% — holding in each of six independent browser launches
+// separately. The excesses are positive legs against a byte-identical cohort
+// with zero falling steps, so they are allocation by the page's own heap.
+//
+// WHY THE SHIPPED STRIDE CANNOT IDENTIFY IT, as a matter of shape. A leg is
+// ONE step: read before the unit, read after, everything between is a single
+// number. "Which part of the work unit allocates" is not recoverable from a
+// scalar per leg, however the scalars are analysed. The mode opens the unit at
+// its one seam and the pins below are what say it did so without moving
+// anything the row publishes.
+//
+// HERMETIC, exactly as the prime's pins are. `siteStream` builds the stride-3
+// buffer `p0-heap/alloc-window!` would have filled from stated per-site
+// allocations, so every case here is a fixture rather than something that has
+// to be provoked out of a browser.
+
+// `[s0, pre0, mid0, post0, pre1, mid1, post1, ...]` — the stride-3 shape, from
+// `[dispatch, drain]` pairs. Same base heap as `stream`, so a collapsed
+// stride-3 stream is directly comparable with the stride-2 one built from the
+// same leg totals.
+function siteStream(pairs) {
+  let h = 10000000;
+  const out = [h];
+  for (const [d, f] of pairs) {
+    out.push(h);
+    h += d;
+    out.push(h);
+    h += f;
+    out.push(h);
+  }
+  return out;
+}
+
+// One window in the shape rf2-e9wr actually measured: the B = 4 floor window
+// quoted on rf2-oiy1 — six alike legs of 19,256 B with a 26,044 B prime — with
+// ONE leg carrying the median recurring excess the bead reports (+2,640 B), and
+// with each of the two terms placed at a stated site.
+const siteWindow = ({ primeAt, excessAt, excess = 2640, primeExcess = 6788 }) => {
+  const base = { dispatch: 1200, drain: 18056 };
+  const at = (site, extra) => [
+    base.dispatch + (site === 'dispatch' ? extra : 0),
+    base.drain + (site === 'drain' ? extra : 0),
+  ];
+  return siteStream([
+    at(primeAt, primeExcess),
+    at(null, 0),
+    at(null, 0),
+    at(excessAt, excess),
+    at(null, 0),
+    at(null, 0),
+    at(null, 0),
+  ]);
+};
+
+test('THE COLLAPSE IS THE IDENTITY AT THE SHIPPED STRIDE — every gate above stands unedited', () => {
+  // This is the property that lets the whole mode be additive. Off it, the
+  // driver runs the pre-bead path through a function that returns what it was
+  // given, and `collapsed` is the SAME ARRAY rather than a copy of it: nothing
+  // is rebuilt, so nothing can be rebuilt differently.
+  const s = stream([19256, 19256, 19256]);
+  const split = allocSiteSplit(s, 2);
+  assert.deepStrictEqual(split, { sites: 2, collapsed: s, siteLegs: [] });
+  assert.strictEqual(split.collapsed, s, 'the shipped stream is passed through, not reconstructed');
+  // And anything that is not the by-site stride is the shipped one. A mode
+  // armed with a typo must fall back to the instrument that publishes, never
+  // to a third shape nothing decodes.
+  for (const k of [0, 1, 4, undefined, null, '3']) {
+    assert.strictEqual(allocSiteSplit(s, k).sites, 2, `stride ${JSON.stringify(k)} is not the seam`);
+  }
+});
+
+test('THE COLLAPSED STREAM IS THE ONE THE SHIPPED WINDOW WOULD HAVE FILLED', () => {
+  // The claim the whole mode rests on, driven rather than argued: decoding a
+  // stride-3 window and dropping its mid samples yields, sample for sample,
+  // the stride-2 stream the same work would have produced — so `allocSteps`
+  // computes the certificate, the falls gate and every published figure over
+  // the same shape by the same code.
+  const raw = siteWindow({ primeAt: 'dispatch', excessAt: 'drain' });
+  const { sites, collapsed, siteLegs } = allocSiteSplit(raw, 3);
+  assert.strictEqual(sites, 3);
+  assert.deepStrictEqual(
+    collapsed,
+    stream([26044, 19256, 19256, 21896, 19256, 19256, 19256]),
+    'the collapsed stream is the stride-2 stream of the same legs'
+  );
+  // Every reading in it is a reading actually taken — nothing is averaged,
+  // folded or synthesised.
+  for (const x of collapsed) assert.ok(raw.includes(x), `${x} is a sample the window really took`);
+  // And the gate reads what it would have read.
+  const { primeLegs, measured } = allocPrimeSplit(collapsed, 1);
+  assert.deepStrictEqual(primeLegs, [26044]);
+  const s = allocSteps(measured);
+  assert.deepStrictEqual(s.legs, [19256, 19256, 21896, 19256, 19256, 19256]);
+  assert.strictEqual(s.legMedian, 19256);
+  assert.strictEqual(s.falls, 0);
+  // A LEG IS ITS SITES, EXACTLY. Not approximately and not up to a rounding:
+  // the outer pair is the same pair, so the decomposition is a subtraction
+  // identity rather than a model.
+  assert.strictEqual(siteLegs.length, 7);
+  for (const l of siteLegs) {
+    assert.strictEqual(l.dispatch + l.drain, l.leg, JSON.stringify(l));
+  }
+  assert.deepStrictEqual(siteLegs[3], { dispatch: 1200, drain: 20696, leg: 21896 });
+});
+
+test('THE ATTRIBUTION NAMES THE SITE — in both directions, so a swap cannot pass', () => {
+  // The mechanism question, and the one thing this instrument exists to
+  // answer. A fixture whose recurring excess is entirely in the DRAIN must be
+  // attributed to the drain, and the mirror fixture to the dispatch. Testing
+  // one direction alone would admit an attribution that names the other site
+  // every time.
+  for (const site of ALLOC_SITE_NAMES) {
+    const other = ALLOC_SITE_NAMES.find((s) => s !== site);
+    const { siteLegs } = allocSiteSplit(
+      siteWindow({ primeAt: 'dispatch', excessAt: site }),
+      3
+    );
+    const w = allocSiteWitness(siteLegs, 1);
+    assert.strictEqual(w.dominant, site, `the window's dispersion is in the ${site}`);
+    assert.strictEqual(w.legs[2].site, site, 'and so is the deviant leg`s own');
+    assert.strictEqual(w.legs[2].by[site], 2640, 'by the whole of the excess');
+    assert.strictEqual(w.legs[2].by[other], 0, `and none of it in the ${other}`);
+    assert.strictEqual(w.legs[2].deviation, 2640, 'which is the leg deviation the gate sees');
+    // The cohort's own medians are the alike legs', not the deviant one's.
+    assert.strictEqual(w.medians.dispatch, 1200);
+    assert.strictEqual(w.medians.drain, 18056);
+    assert.strictEqual(w.medians.leg, 19256);
+  }
+});
+
+test('THE PRIME IS OUT OF THE BY-SITE COHORT TOO, and its excess is placed', () => {
+  // rf2-oiy1 removed the first-leg term from the measured region; a by-site
+  // cohort that included the prime would have that term sitting back inside
+  // its own medians and every site figure would be wrong by a share of it.
+  const { siteLegs } = allocSiteSplit(siteWindow({ primeAt: 'dispatch', excessAt: 'drain' }), 3);
+  const w = allocSiteWitness(siteLegs, 1);
+  assert.deepStrictEqual(w.primeSites, [{ dispatch: 7988, drain: 18056, leg: 26044 }]);
+  assert.strictEqual(w.legs.length, 6, 'the prime is not one of the six measured legs');
+  assert.deepStrictEqual(w.primeExcessBySite, { dispatch: 6788, drain: 0 });
+  assert.strictEqual(w.primeSite, 'dispatch');
+  // Clamped like `allocPrimeSplit`, and for the same reason.
+  const short = allocSiteWitness(siteLegs.slice(0, 1), 1);
+  assert.deepStrictEqual(short.legs, []);
+  assert.strictEqual(short.primeSite, null, 'nothing to compare against is not a site');
+  assert.strictEqual(short.sameSite, null);
+});
+
+test('THE SAME-TERM HYPOTHESIS IS ANSWERABLE, and answers three ways', () => {
+  // The bead's "exclude this first": the recurring excesses (+476 to +7,456 B,
+  // median 2,640) overlap the prime excess's own scale (median 6,864), which
+  // would suggest THE SAME TERM RECURRING rather than a distinct one.
+  //
+  // SITES DISAGREEING SETTLES IT — one term cannot be in two places.
+  const apart = allocSiteWitness(
+    allocSiteSplit(siteWindow({ primeAt: 'dispatch', excessAt: 'drain' }), 3).siteLegs,
+    1
+  );
+  assert.strictEqual(apart.primeSite, 'dispatch');
+  assert.strictEqual(apart.dominant, 'drain');
+  assert.strictEqual(apart.sameSite, false, 'two sites is two terms');
+
+  // SITES AGREEING NARROWS IT and does not settle it — a site is two
+  // statements wide and two terms can live in one. The magnitudes are what is
+  // read next, which is why they are reported beside the verdict.
+  const together = allocSiteWitness(
+    allocSiteSplit(siteWindow({ primeAt: 'drain', excessAt: 'drain' }), 3).siteLegs,
+    1
+  );
+  assert.strictEqual(together.sameSite, true);
+  assert.deepStrictEqual(together.primeExcessBySite, { dispatch: 0, drain: 6788 });
+  assert.strictEqual(together.legs[2].by.drain, 2640, 'and the two magnitudes are 2.6x apart');
+
+  // NO DISPERSION IS `null`, NOT `false`. A round-3 window whose legs are
+  // byte-identical has no excess to place, and reporting "the sites disagree"
+  // about a window with nothing in it would be the instrument inventing a
+  // finding. This is the case eleven of rf2-e9wr's round-3 windows are in.
+  const flat = allocSiteWitness(
+    allocSiteSplit(
+      siteStream([[7988, 18056], ...Array.from({ length: 6 }, () => [1200, 18056])]),
+      3
+    ).siteLegs,
+    1
+  );
+  assert.strictEqual(flat.dominant, null, 'byte-identical legs have no site to name');
+  assert.strictEqual(flat.sameSite, null, 'and no verdict to give');
+  assert.deepStrictEqual(flat.totals, { dispatch: 0, drain: 0 });
+  assert.strictEqual(flat.primeSite, 'dispatch', 'while the prime excess is still placed');
+});
+
+test('THE MODE IS OFF BY DEFAULT, AND τ IS UNTOUCHED BY IT', () => {
+  // Driven in a fresh process through the same env surface an operator
+  // configures, for `constUnderEnv`'s reason: configuration is read once, at
+  // require.
+  assert.strictEqual(constUnderEnv('ALLOC_BY_SITE', { P0_ALLOC_BY_SITE: '' }), false);
+  assert.strictEqual(constUnderEnv('ALLOC_SITES', { P0_ALLOC_BY_SITE: '' }), 2);
+  assert.strictEqual(ALLOC_SITES, 2, 'and this process is running the shipped stride');
+  assert.strictEqual(constUnderEnv('ALLOC_SITES', { P0_ALLOC_BY_SITE: '1' }), 3);
+  // Anything that is not the switch is off — a diagnostic that turned itself
+  // on for `P0_ALLOC_BY_SITE=0` would take every published row with it.
+  for (const v of ['0', 'yes', 'true', '3', ' 1']) {
+    assert.strictEqual(constUnderEnv('ALLOC_SITES', { P0_ALLOC_BY_SITE: v }), 2, `P0_ALLOC_BY_SITE=${v}`);
+  }
+  // AND IT IS NOT A DIAL ON THE GATE. rf2-e9wr established that no honest τ
+  // calibration exists on the arms' data in either direction; an instrument
+  // that answered the round-index question by moving τ would be answering a
+  // different question. Every constant the certificate is read off is
+  // identical with the mode armed.
+  for (const c of ['ALLOC_LEG_TOLERANCE', 'ALLOC_FALL_THRESHOLD_B', 'ALLOC_MIN_WRITES',
+                   'ALLOC_PRIME_WRITES', 'ALLOC_WINDOW_WRITES']) {
+    assert.strictEqual(
+      constUnderEnv(c, { P0_ALLOC_BY_SITE: '1' }),
+      constUnderEnv(c, { P0_ALLOC_BY_SITE: '' }),
+      `${c} must not move when the diagnostic is armed`
+    );
+  }
+});
+
+test('THE CERTIFICATE NEVER SEES A BY-SITE STREAM, and the stride is the PAGE`S', () => {
+  // The collapse happens FIRST, at both window sites, and what is adjudicated
+  // is the collapsed stream. A mid-leg sample reaching `allocSteps` would
+  // split one step into two and change `rise`, `falls` and `maxStep` — all
+  // published — for a diagnostic's convenience.
+  has(/const site = allocSiteSplit\(w\.samples, w\.sites\);/, 'the control window collapses first');
+  has(/const site = allocSiteSplit\(win\.samples, win\.sites\);/, 'and so does the arm window');
+  assert.strictEqual(
+    (SRC.match(/allocPrimeSplit\(site\.collapsed\)/g) || []).length,
+    2,
+    'both window sites hand the collapsed stream to the prime split'
+  );
+  lacks(
+    /allocPrimeSplit\((?:w|win)\.samples\)/,
+    'neither site adjudicates the raw stream any more'
+  );
+  // THE STRIDE IS READ OFF THE DATA, not off the switch the driver believes it
+  // set. A page serving an older build would fill a stride-2 buffer and hand
+  // back a well-formed stream; decoding it against the driver's own constant
+  // would read site figures out of readings that are not at a seam.
+  lacks(
+    /allocSiteSplit\((?:w|win)\.samples, ALLOC_SITES\)/,
+    'the driver decodes by the stride the page reported'
+  );
+  has(/if \(probe\.sites !== ALLOC_SITES\)/, 'and the two are made to agree before anything is measured');
+});
+
+test('THE REPORT RUNS — the mode is not merely defined', () => {
+  // "The mode is defined" and "the mode runs" are different claims, and this
+  // file already makes that point about `summariseAlloc`. Drive a collected
+  // row through the reporter and read what an operator would have seen.
+  const witnessOf = (spec) => {
+    const { siteLegs } = allocSiteSplit(siteWindow(spec), 3);
+    return { sites: 3, siteLegs, siteWitness: allocSiteWitness(siteLegs, 1) };
+  };
+  const row = {
+    bySite: true,
+    sites: 3,
+    siteNames: ALLOC_SITE_NAMES,
+    perRound: [
+      {
+        round: 1,
+        controls: { idle: witnessOf({ primeAt: 'dispatch', excessAt: null, excess: 0 }) },
+        arms: { 'hicasso|floor': { ...witnessOf({ primeAt: 'dispatch', excessAt: 'drain' }), tick0: 22, tick: 29 } },
+      },
+    ],
+  };
+  const lines = allocSiteReport(row);
+  assert.ok(lines.length > 0, 'the mode armed must print something');
+  const text = lines.join('\n');
+  assert.match(text, /dispatch/, 'the site names appear');
+  assert.match(text, /hicasso\|floor/, 'and the window is named');
+  assert.match(text, /22–29/, 'with the tick range that places it in the page`s work-unit sequence');
+  assert.match(text, /AGREE in 0 of 1/, 'and the hypothesis is answered on the data');
+  // OFF THE MODE IT IS SILENT, so a published run's summary is unchanged to
+  // the byte.
+  assert.deepStrictEqual(allocSiteReport({ ...row, bySite: false }), []);
+  assert.deepStrictEqual(allocSiteReport({ bySite: false, perRound: [] }), []);
 });
 
 // --- the row-level witness the driver actually exits on --------------------

--- a/implementation/core/test/re_frame/bench/p0_run.cjs
+++ b/implementation/core/test/re_frame/bench/p0_run.cjs
@@ -1308,6 +1308,78 @@ const ALLOC_PRIME_WRITES = 1;
 // published quantity is per MEASURED write and the prime is not one.
 const ALLOC_WINDOW_WRITES = ALLOC_WRITES + ALLOC_PRIME_WRITES;
 
+// ---------------------------------------------------------------------------
+// THE BY-SITE MODE — attributing a leg's bytes to a site in the work unit
+// (rf2-rs8q6)
+// ---------------------------------------------------------------------------
+//
+// THE OBSERVATION IT EXISTS FOR. rf2-e9wr's window measured 72 floor-arm
+// windows and found the relative dispersion of a window's MEASURED work legs
+// to be a function of the ROUND INDEX — not of the page, the write or the
+// substrate. Restricting to windows with no observed collection: round 2
+// (n=11) reads 2.66%–20.37% with none below 2.66%, and round 3 (n=11) reads
+// 0.00%–0.19% with all at or below 0.19%. That holds in each of six
+// independent browser launches separately, so machine load cannot be it, and
+// the excesses are POSITIVE legs against a byte-identical cohort with zero
+// falling steps — allocation by the page's own heap rather than a collector
+// artefact or another process.
+//
+// WHY THE SHIPPED INSTRUMENT CANNOT IDENTIFY IT, as a matter of shape rather
+// than of effort. At the shipped stride a leg is ONE step: the counter is read
+// before the work unit and after it, and everything between is one number. A
+// mechanism is a claim about WHICH PART of the work unit allocates, and no
+// analysis of a scalar per leg can answer it. The bead says so — "identifying
+// the mechanism needs an instrument a measurement window may not build
+// mid-window" — and this is that instrument.
+//
+// WHAT IT DOES. `P0_ALLOC_BY_SITE=1` drives the window at a stride of 3: one
+// extra counter reading at the work unit's ONE seam, between the
+// `dispatch-sync` and the `flushSync` drain. Leg `k` then decomposes as
+// `dispatch_k + drain_k`, exactly, by construction, over the same outer pair
+// the shipped window reads.
+//
+// WHAT IT DELIBERATELY DOES NOT DO, and each is a rule this row already holds:
+//
+//   - IT IS OFF BY DEFAULT AND PUBLISHES NOTHING. Every row taken without the
+//     switch is byte-identical to today, and `allocSiteSplit` below is the
+//     identity on a stride-2 stream — which is what lets every `allocSteps`
+//     and `allocPrimeSplit` pin stand unedited, exactly as rf2-oiy1's split
+//     did.
+//   - IT DOES NOT TOUCH τ. `ALLOC_LEG_TOLERANCE` is unmoved, in either
+//     direction. rf2-e9wr established that no honest calibration exists on
+//     the arms' data, and an instrument that answered the question by
+//     widening the gate would be answering a different one.
+//   - IT DOES NOT ADJUDICATE. The certificate is read off the COLLAPSED
+//     stride-2 stream, so `allocSteps` never sees a by-site stream and the
+//     gate is the same gate. A mid-leg sample would otherwise split one
+//     step into two and change `rise`, `falls` and `maxStep` — published
+//     quantities — for a diagnostic's convenience.
+//
+// WHAT IT COSTS, STATED. One more `mem` read per leg inside the measured
+// region. The `idle` control is driven at the SAME stride and prices it: an
+// idle leg's two site figures are one sampler read's own footprint and
+// nothing else. Being a constant per leg it can neither create nor destroy
+// dispersion, which is the quantity under investigation — but it does mean
+// absolute leg magnitudes at stride 3 are not comparable byte for byte with
+// those at stride 2, and the falsifiable form of that claim is that the
+// idle control's leg difference between the two strides accounts for the
+// whole of the arms'. A window can check it; this bead builds it.
+const ALLOC_BY_SITE = process.env.P0_ALLOC_BY_SITE === '1';
+
+// Samples per iteration. 2 is the shipped window and the page defaults to it;
+// 3 opens the seam. Sent to `allocPrepare`, which SIZES THE BUFFER from it —
+// one number, one place, so the stride the page indexes with and the stride
+// the buffer was sized for cannot disagree.
+const ALLOC_SITES = ALLOC_BY_SITE ? 3 : 2;
+
+// The site names, in the order the work unit runs them, as ONE spelling the
+// driver, the summary and the pins all read. `dispatch` is the `dispatch-sync`
+// through the event pipeline and the signal graph; `drain` is the `flushSync`
+// commit. There is no third: see `p0-heap/alloc-window!` for why a finer split
+// would mean instrumenting re-frame from inside the arm, and an arm carrying
+// instrumentation is not the arm whose figures are published.
+const ALLOC_SITE_NAMES = ['dispatch', 'drain'];
+
 // The sizing, as a PURE FUNCTION of the config — the same shape and for the
 // same reason as `allocSteps` and `allocRefusedWindows`: it needs neither a
 // release build nor a Chromium, so it is pinned on every PR by
@@ -1504,6 +1576,144 @@ function allocPrimeSplit(samples, prime = ALLOC_PRIME_WRITES) {
   const primeLegs = [];
   for (let k = 0; k < p; k++) primeLegs.push(samples[2 * k + 2] - samples[2 * k + 1]);
   return { primeLegs, measured: samples.slice(2 * p) };
+}
+
+// The BY-SITE decomposition of one window's raw samples (rf2-rs8q6). Pure, for
+// `allocPrimeSplit`'s reason: the pin can DRIVE it rather than read the source
+// and hope.
+//
+// TWO ANSWERS OUT OF ONE STREAM, and the first is why every gate below stands
+// unedited:
+//
+//   `collapsed` — `[s0, pre0, post0, pre1, post1, ...]`, WHICH IS THE STREAM
+//     THE SHIPPED WINDOW WOULD HAVE FILLED from the same work. Every reading
+//     in it is a reading actually taken; the mid samples are dropped, not
+//     averaged, folded or synthesised. This is what `allocPrimeSplit` and
+//     `allocSteps` are handed, so the certificate, the falls gate and every
+//     published figure are computed by the same code over the same shape as
+//     on a run that never armed the mode.
+//   `siteLegs` — one `{dispatch, drain, leg}` per work unit, where
+//     `dispatch + drain === leg` exactly, and `leg` is the same subtraction
+//     the collapsed stream yields.
+//
+// AT STRIDE 2 IT IS THE IDENTITY: `collapsed` is the argument itself and
+// `siteLegs` is empty. A driver that never arms the mode is running the
+// pre-bead path through one function that returns what it was given, and the
+// pins drive that rather than asserting it.
+//
+// `sites` is a parameter and the driver passes the constant, exactly as
+// `allocPrimeSplit`'s `prime` is — but the DRIVER passes the stride the PAGE
+// reported rather than the one it configured, so a switch that failed to reach
+// the page decodes against the wrong shape and is caught, instead of silently
+// misreading a well-formed stream of the other stride.
+function allocSiteSplit(samples, sites = ALLOC_SITES) {
+  if (sites !== 3) return { sites: 2, collapsed: samples, siteLegs: [] };
+  const w = Math.max(0, Math.floor((samples.length - 1) / 3));
+  const collapsed = samples.length ? [samples[0]] : [];
+  const siteLegs = [];
+  for (let i = 0; i < w; i++) {
+    const pre = samples[3 * i + 1];
+    const mid = samples[3 * i + 2];
+    const post = samples[3 * i + 3];
+    collapsed.push(pre, post);
+    siteLegs.push({ dispatch: mid - pre, drain: post - mid, leg: post - pre });
+  }
+  return { sites: 3, collapsed, siteLegs };
+}
+
+// Which site a set of per-site figures sits in — the one whose magnitude is
+// largest, and `null` when they are all zero, because a window with no
+// deviation has no site to attribute it to and naming one would be the
+// instrument answering a question nobody asked.
+function allocDominantSite(bySite) {
+  let owner = null;
+  let best = 0;
+  for (const s of ALLOC_SITE_NAMES) {
+    if (Math.abs(bySite[s]) > Math.abs(best)) {
+      best = bySite[s];
+      owner = s;
+    }
+  }
+  return owner;
+}
+
+// THE WITNESS THE BEAD ASKS FOR (rf2-rs8q6): the arm work unit's allocation by
+// site, and where the excess sits.
+//
+// It is handed the whole window's site legs and splits the prime off itself,
+// on `allocPrimeSplit`'s rule and clamped the same way — the prime is one work
+// unit and the cohort is the rest, and a by-site cohort that included the
+// prime would have the term rf2-oiy1 removed sitting back inside its medians.
+//
+// WHAT IT ANSWERS, and this is the whole point of the mode:
+//
+//   `dominant`  — which site the MEASURED legs' dispersion is in. This is the
+//     mechanism question. `dispatch` says the term is in the event pipeline
+//     and the signal graph; `drain` says it is in React's commit.
+//   `primeSite` and `primeExcessBySite` — the same decomposition of the PRIME
+//     leg's excess over the measured cohort.
+//   `sameSite` — whether those two agree. THIS IS THE HYPOTHESIS THE BEAD
+//     NAMES AS THE ONE TO EXCLUDE FIRST: the recurring excesses (+476 to
+//     +7,456 B, median 2,640 B) overlap the prime excess's own scale (median
+//     6,864 B), which would suggest THE SAME TERM RECURRING rather than a
+//     distinct one.
+//
+// WHAT IT DOES NOT CLAIM. `sameSite` is agreement about a SITE, and a site is
+// two statements wide. Two different terms can live in one site, so agreement
+// is necessary for the same-term reading and not sufficient for it —
+// DISAGREEMENT SETTLES THE HYPOTHESIS, agreement narrows it. The magnitudes
+// are reported beside it for that reason: the prime excess's own spread is
+// tight (p25 6,800, p75 6,888 — an interquartile width of 88 B, 1.3% of its
+// median), so a recurring term of the same identity has a magnitude to hit,
+// and the summary prints both rather than collapsing them to a verdict.
+function allocSiteWitness(siteLegs, prime = ALLOC_PRIME_WRITES) {
+  const p = Math.max(0, Math.min(prime, siteLegs.length));
+  const primeSites = siteLegs.slice(0, p);
+  const measured = siteLegs.slice(p);
+  if (!measured.length) {
+    return {
+      sites: ALLOC_SITE_NAMES,
+      primeSites,
+      medians: null,
+      legs: [],
+      totals: null,
+      dominant: null,
+      primeExcessBySite: null,
+      primeSite: null,
+      sameSite: null,
+    };
+  }
+
+  const medians = { leg: median(measured.map((l) => l.leg)) };
+  for (const s of ALLOC_SITE_NAMES) medians[s] = median(measured.map((l) => l[s]));
+
+  const totals = Object.fromEntries(ALLOC_SITE_NAMES.map((s) => [s, 0]));
+  const legs = measured.map((l, k) => {
+    const by = {};
+    for (const s of ALLOC_SITE_NAMES) {
+      by[s] = l[s] - medians[s];
+      totals[s] += Math.abs(by[s]);
+    }
+    return { leg: k + 1, deviation: l.leg - medians.leg, by, site: allocDominantSite(by) };
+  });
+
+  const dominant = allocDominantSite(totals);
+  const primeExcessBySite = p
+    ? Object.fromEntries(ALLOC_SITE_NAMES.map((s) => [s, primeSites[0][s] - medians[s]]))
+    : null;
+  const primeSite = primeExcessBySite ? allocDominantSite(primeExcessBySite) : null;
+
+  return {
+    sites: ALLOC_SITE_NAMES,
+    primeSites,
+    medians,
+    legs,
+    totals,
+    dominant,
+    primeExcessBySite,
+    primeSite,
+    sameSite: dominant && primeSite ? dominant === primeSite : null,
+  };
 }
 
 // Rising and falling steps, accumulated separately, from one window's raw
@@ -1730,11 +1940,30 @@ async function allocRow(chromium) {
   // Without `--enable-precise-memory-info` Chrome quantises the in-page
   // counter to 100 KB buckets and every figure here would be noise. A
   // quantised counter is not a small error; it is a different instrument.
-  await page.evaluate(([d, n]) => window.P0H.allocPrepare(d, n), [ALLOC_D, ALLOC_WINDOW_WRITES]);
+  await page.evaluate(
+    ([d, n, s]) => window.P0H.allocPrepare(d, n, s),
+    [ALLOC_D, ALLOC_WINDOW_WRITES, ALLOC_SITES]
+  );
   const probe = await page.evaluate(
     (n) => window.P0H.allocWindow(n, 'control', 'react'),
     ALLOC_WINDOW_WRITES
   );
+  // THE STRIDE, PROVED RATHER THAN TRUSTED, on the same probe and for the same
+  // reason as the flag above (rf2-rs8q6). A page that ignored the third
+  // argument — an older build served out of a stale cache is the way that
+  // happens — would fill a stride-2 buffer and hand back a well-formed stream
+  // the driver would then decode against a stride of 3, reading site figures
+  // out of readings that are not at a seam. The page reports the stride it
+  // used; this is where the two are made to agree, once, before anything is
+  // measured.
+  if (probe.sites !== ALLOC_SITES) {
+    await browser.close();
+    throw new Error(
+      `the page filled its window at a stride of ${probe.sites} where the driver asked for ` +
+        `${ALLOC_SITES} (P0_ALLOC_BY_SITE=${ALLOC_BY_SITE ? '1' : 'unset'}): nothing decoded from ` +
+        'these samples would mean what it says'
+    );
+  }
   const rounded = probe.samples.filter((x) => x % 100000 === 0).length;
   const precise = rounded < probe.samples.length;
   if (!precise) {
@@ -1755,7 +1984,10 @@ async function allocRow(chromium) {
 
     // --- the three controls, in situ, before this round's arms ----------
     const controlOf = async (kind, d) => {
-      await page.evaluate(([dd, n]) => window.P0H.allocPrepare(dd, n), [d, ALLOC_WINDOW_WRITES]);
+      await page.evaluate(
+        ([dd, n, s]) => window.P0H.allocPrepare(dd, n, s),
+        [d, ALLOC_WINDOW_WRITES, ALLOC_SITES]
+      );
       await gc();
       const pre = await read();
       const w = await page.evaluate(
@@ -1769,7 +2001,12 @@ async function allocRow(chromium) {
       // deviation at <= 1% against the arms' 26-46% — so priming them changes
       // no control figure, and a control taken under a different window shape
       // from the arms would not be one.
-      const { primeLegs, measured } = allocPrimeSplit(w.samples);
+      // THE COLLAPSE COMES FIRST AND THE STRIDE IS THE PAGE'S (rf2-rs8q6).
+      // Off the mode this is the identity and the two lines below are the
+      // pre-bead ones; on it, the certificate is still read off the stride-2
+      // stream, and the site figures ride alongside as a diagnostic.
+      const site = allocSiteSplit(w.samples, w.sites);
+      const { primeLegs, measured } = allocPrimeSplit(site.collapsed);
       const s = allocSteps(measured);
       return {
         kind,
@@ -1779,6 +2016,12 @@ async function allocRow(chromium) {
         primeExcess: primeLegs.length ? primeLegs[0] - s.legMedian : null,
         perIter: s.rise / ALLOC_WRITES,
         cdpBracket: post.cdp - pre.cdp,
+        // THE CONTROL IS THE MODE'S OWN CONTROL. An idle leg's two site
+        // figures are one sampler read's footprint and nothing else, which
+        // is the constant sitting inside every arm site figure below.
+        sites: site.sites,
+        siteLegs: site.siteLegs,
+        siteWitness: site.siteLegs.length ? allocSiteWitness(site.siteLegs) : null,
       };
     };
     const idle = await controlOf('idle', 0);
@@ -1845,7 +2088,10 @@ async function allocRow(chromium) {
         // window's prime leg is. The warm-ups are what stop the arm's own
         // cold-start from reaching the window at all, and that job is theirs
         // still.
-        await page.evaluate(([dd, n]) => window.P0H.allocPrepare(dd, n), [0, ALLOC_WINDOW_WRITES]);
+        await page.evaluate(
+          ([dd, n, s]) => window.P0H.allocPrepare(dd, n, s),
+          [0, ALLOC_WINDOW_WRITES, ALLOC_SITES]
+        );
         for (let w = 0; w < ALLOC_WARMUPS; w++) {
           await page.evaluate(
             ([n, d, k]) => window.P0H.allocWindow(n, k, d),
@@ -1860,7 +2106,11 @@ async function allocRow(chromium) {
         );
         const post = await read();
         await page.evaluate(() => window.P0H.release());
-        const { primeLegs, measured } = allocPrimeSplit(win.samples);
+        // THE COLLAPSE COMES FIRST AND THE STRIDE IS THE PAGE'S (rf2-rs8q6),
+        // exactly as at the control site above. Off the mode `collapsed` IS
+        // `win.samples` and the line below it is the pre-bead one.
+        const site = allocSiteSplit(win.samples, win.sites);
+        const { primeLegs, measured } = allocPrimeSplit(site.collapsed);
         const s = allocSteps(measured);
         // THE WRITE READ-BACK, and the row exits on it. At R reads of a
         // page whose cells were all written to `v`, a ladder boundary's
@@ -1893,6 +2143,21 @@ async function allocRow(chromium) {
           perWrite: s.rise / ALLOC_WRITES,
           perBoundaryPerWrite: s.rise / ALLOC_WRITES / B,
           cdpBracket: post.cdp - pre.cdp,
+          // BY SITE, AND ACROSS THE ROUND SEQUENCE (rf2-rs8q6). `siteLegs` is
+          // the raw decomposition and `siteWitness` is where the excess sits;
+          // both are `null`/empty off the mode, so the record's shape is
+          // unchanged for every published run.
+          sites: site.sites,
+          siteLegs: site.siteLegs,
+          siteWitness: site.siteLegs.length ? allocSiteWitness(site.siteLegs) : null,
+          // WHERE THIS WINDOW SITS IN THE PAGE'S OWN WORK-UNIT SEQUENCE.
+          // `alloc-tick` is monotone for the life of the page — the warm-ups
+          // advance it too — so this pair is what a round index actually IS,
+          // stated in the quantity the arm's own write is parameterised by.
+          // A round-indexed effect is an effect indexed by these numbers, and
+          // no analysis could reach for them while they were not recorded.
+          tick0: win.tick0,
+          tick: win.tick,
         };
       }
     }
@@ -1948,6 +2213,13 @@ async function allocRow(chromium) {
     // many actually ran.
     primeWrites: ALLOC_PRIME_WRITES,
     windowWrites: ALLOC_WINDOW_WRITES,
+    // WHETHER THIS ROW WAS TAKEN BY SITE (rf2-rs8q6), on criterion 6's rule
+    // that a reader of any row can tell FROM THE ROW how it was taken. Site
+    // figures carry one extra sampler read per leg, so a leg magnitude here is
+    // not comparable byte for byte with one from a row where this reads 2.
+    bySite: ALLOC_BY_SITE,
+    sites: ALLOC_SITES,
+    siteNames: ALLOC_SITE_NAMES,
     warmups: ALLOC_WARMUPS,
     rounds: ALLOC_ROUNDS,
     preciseMemory: precise,
@@ -1971,6 +2243,130 @@ async function allocRow(chromium) {
     perRound: rounds,
     allocFits: fits,
   };
+}
+
+// THE BY-SITE REPORT (rf2-rs8q6), as LINES rather than as `console.log` calls,
+// for the reason this file already gives about `summariseAlloc`: "the mode is
+// defined" and "the mode runs" are different claims, and a pin that can only
+// read the source can only check the first. Returning the lines lets the pin
+// DRIVE a collected row through the reporter and read what an operator would
+// have seen.
+//
+// EMPTY OFF THE MODE, so a published run's summary is unchanged to the byte.
+function allocSiteReport(row) {
+  const out = [];
+  if (!row.bySite) return out;
+
+  const windows = (row.perRound || []).flatMap((r) =>
+    Object.entries(r.arms || {}).map(([key, a]) => ({ round: r.round, key, a }))
+  );
+  const idles = (row.perRound || [])
+    .map((r) => (r.controls || {}).idle)
+    .filter((c) => c && c.siteWitness);
+
+  out.push(';;');
+  out.push(
+    ';;   BY SITE (rf2-rs8q6) — the arm work unit opened at its ONE seam, across the round sequence.'
+  );
+  out.push(';;     dispatch = the dispatch-sync through the event pipeline and the signal graph');
+  out.push(';;     drain    = the flushSync commit that follows it');
+  out.push(
+    ';;   A leg is exactly `dispatch + drain`, over the same outer pair of readings the shipped'
+  );
+  out.push(
+    ';;   stride takes — so the certificate above is unchanged, and these figures adjudicate nothing.'
+  );
+  out.push(
+    ';;   EVERY FIGURE HERE CARRIES ONE EXTRA SAMPLER READ PER LEG. It is a constant per leg, so it'
+  );
+  out.push(
+    ';;   can neither create nor destroy dispersion, but no magnitude below is comparable byte for'
+  );
+  out.push(';;   byte with one taken at a stride of 2. The idle control is what prices it:');
+
+  if (idles.length) {
+    for (const s of row.siteNames) {
+      const xs = idles.map((c) => c.siteWitness.medians[s]);
+      out.push(
+        `;;     idle ${s.padEnd(8)} ${n0(median(xs))} B per leg, median over ${xs.length} idle windows ` +
+          `[${n0(Math.min(...xs))}–${n0(Math.max(...xs))}]`
+      );
+    }
+  } else {
+    out.push(';;     no idle control window carried a site split to price it with.');
+  }
+
+  if (!windows.length) {
+    out.push(';;   no arm window was measured, so there is nothing to attribute.');
+    return out;
+  }
+
+  // --- where each window's dispersion sits ---------------------------------
+  out.push(';;');
+  out.push(
+    ';;   round  window                                  ticks        legMed  dispMed  drainMed  worst-dev site'
+  );
+  for (const { round, key, a } of windows) {
+    const w = a.siteWitness;
+    if (!w || !w.medians) continue;
+    const worst = w.legs.reduce((m, l) => (Math.abs(l.deviation) > Math.abs(m.deviation) ? l : m));
+    out.push(
+      `;;   ${String(round).padEnd(6)} ${key.slice(0, 40).padEnd(40)} ` +
+        `${String(a.tick0 ?? '—').padStart(6)}–${String(a.tick ?? '—').padEnd(6)} ` +
+        `${n0(w.medians.leg).padStart(7)} ${n0(w.medians.dispatch).padStart(8)} ` +
+        `${n0(w.medians.drain).padStart(9)}  ${String(w.dominant || 'none — the legs are alike')}`
+    );
+    if (worst.deviation !== 0) {
+      out.push(
+        `;;          worst leg ${worst.leg}: ${worst.deviation > 0 ? '+' : ''}${n0(worst.deviation)} B = ` +
+          row.siteNames.map((s) => `${s} ${worst.by[s] > 0 ? '+' : ''}${n0(worst.by[s])}`).join(' + ')
+      );
+    }
+  }
+
+  // --- the hypothesis the bead names as the one to exclude first -----------
+  out.push(';;');
+  out.push(
+    ';;   THE SAME-TERM HYPOTHESIS (the bead\'s "exclude this first"): the recurring excesses overlap'
+  );
+  out.push(
+    ';;   the PRIME excess\'s own scale, which would suggest the same term recurring rather than a'
+  );
+  out.push(';;   distinct one. Sites disagreeing SETTLES it; sites agreeing narrows it.');
+  out.push(
+    ';;   round  window                                  prime disp  prime drain  prime sits in  measured sits in'
+  );
+  let agree = 0;
+  let judged = 0;
+  for (const { round, key, a } of windows) {
+    const w = a.siteWitness;
+    if (!w || !w.primeExcessBySite) continue;
+    if (typeof w.sameSite === 'boolean') {
+      judged++;
+      if (w.sameSite) agree++;
+    }
+    out.push(
+      `;;   ${String(round).padEnd(6)} ${key.slice(0, 40).padEnd(40)} ` +
+        `${n0(w.primeExcessBySite.dispatch).padStart(10)} ${n0(w.primeExcessBySite.drain).padStart(12)}  ` +
+        `${String(w.primeSite || '—').padEnd(14)} ${String(w.dominant || '— (no dispersion to place)')}`
+    );
+  }
+  out.push(
+    judged
+      ? `;;   the two sites AGREE in ${agree} of ${judged} windows that had a dispersion to place.`
+      : ';;   no window had both a prime excess and a measured dispersion, so the hypothesis is untested here.'
+  );
+  out.push(
+    ';;   A site is two statements wide, so agreement is necessary for the same-term reading and not'
+  );
+  out.push(
+    ';;   sufficient: read the magnitudes beside it. The prime excess is TIGHT across windows (p25'
+  );
+  out.push(
+    ';;   6,800, p75 6,888 B on rf2-e9wr\'s 72 windows), so a recurring term of the same identity has'
+  );
+  out.push(';;   a magnitude to hit and not merely a site to share.');
+  return out;
 }
 
 function summariseAlloc(row, refused) {
@@ -2186,6 +2582,10 @@ function summariseAlloc(row, refused) {
   } else {
     console.log(';;   no window carried a prime leg to report.');
   }
+
+  // THE BY-SITE REPORT (rf2-rs8q6). Empty off the mode, so nothing above or
+  // below moves on a published run.
+  for (const line of allocSiteReport(row)) console.log(line);
 
   console.log(
     `;;   windows refused: ${refusedCount} of ${wins}, ${refused.length} refusal reason` +
@@ -2789,6 +3189,18 @@ module.exports = {
   ALLOC_PRIME_WRITES,
   ALLOC_WRITES,
   ALLOC_WINDOW_WRITES,
+  // The by-site instrument (rf2-rs8q6), exported on the same rule as the prime
+  // split above: the decomposition, the attribution and the reporter are all
+  // pure, so the pins DRIVE them rather than read the source and hope. The two
+  // constants come too, because the mode's most important property — that it
+  // is OFF and the row is byte-identical without it — is a claim about the
+  // resolved constants and can only be pinned from outside the process.
+  allocSiteSplit,
+  allocSiteWitness,
+  allocSiteReport,
+  ALLOC_BY_SITE,
+  ALLOC_SITES,
+  ALLOC_SITE_NAMES,
   // The measurement surface (rf2-gxrr), exported so the structural pin can
   // DRIVE it rather than read its source: the tables as values, the plan
   // filter as a pure function, and the two resolved selections so the env


### PR DESCRIPTION
## What this is

The **edit half of rf2-rs8q6** and only the edit half: the instrument the bead
asks for, built and proved, with **no measurement window taken**.

`rf2-e9wr` measured a leg dispersion that is a function of the **round index**
in six of six independent browser launches — round 2 (n=11) at 2.66%–20.37%
with none below 2.66%, round 3 (n=11) at 0.00%–0.19% with all at or below
0.19%, on collection-free windows — and could not identify the mechanism. That
is not a shortfall of effort. **The shipped instrument cannot express a
mechanism**: a leg is one step, the counter is read before the work unit and
after it, and "which part of the work unit allocates" is not recoverable from a
scalar per leg however the scalars are analysed.

## The premises, checked at source

| the brief's claim | at source |
|---|---|
| the evidence landed on main (PR #8377) | **holds** — `docs/design/hicasso/studio/the-arms-spread-does-not-collapse.md` was on main at `e37ea4c8bd`, and both named sections carry the quoted figures verbatim |
| "PR #8322 is live and mid-gate" | **went stale inside this dispatch's own lifetime** — it merged while the first spine was running. Consequences are in *The rebase* below; it still never touched any of the three files here. |
| the bead's own sequencing comment | its tracker timestamp is `2026-08-16 02:33Z` and its prose reads `12:33 AUSEST` — **the same instant**, so item order and prose agree. It rules: dispatch the tick after #8377 merges, fenced to the edit half, with the same-term hypothesis as the thing to exclude first. That is what this is. |
| `allocation-instrument-rework.md` may already specify part of this | **does not** — its Part A is the boundary-proportional write, Part B the observed-collection witness, its Addendum the prime. Its "option held in reserve" is **six single-write windows**, i.e. smaller windows, not finer sampling *inside* a work unit. No parallel design exists; this one is not a duplicate. |
| `p0_ladder_structural.test.cjs` covers this surface and affords a plant | **holds** — 66 passed before, 74 after, and the plant reds it (below) |
| `npm run test:cljs` covers this surface | **does NOT hold, so it is nominated nowhere below.** `re-frame.bench.p0-heap` is required only by `p0_app`, `retention_probe` and `z3vlz_probe` — all browser-build namespaces — and the `:node-test` build never compiles it. Running it and calling it cover would have been a green over an uncompiled file. The gate that *does* compile it is `npm run test:hicasso-compile`, whose roster carries `re-frame.bench.p0-app` explicitly, and **the spine already runs it** (`scripts/test-fast-pr.sh`, "hicasso bench-lane compile"). |

## What was built

`P0_ALLOC_BY_SITE=1` drives the allocation window at a stride of **3** instead
of 2: one extra counter reading at the work unit's **one seam**.

```
site 1  dispatch — write-page!/write-all!, a dispatch-sync through the event
                   pipeline and the signal graph
site 2  drain    — the flushSync commit (or Reagent's own flush)
```

A leg then decomposes as `dispatch + drain`, **exactly**, over the same outer
pair of readings the shipped window takes — a subtraction identity, not a
model.

**There is no third seam that does not change what the arm measures.** A finer
split means instrumenting re-frame's own pipeline from inside a bench fixture,
and an arm carrying instrumentation is not the arm whose figures are published.
Two sites is what the work unit affords, and it is the split that separates the
framework's write from the substrate's commit.

New surface, all of it pure and exported so the pins **drive** it rather than
read the source and hope:

- `allocSiteSplit(samples, sites)` → `{ sites, collapsed, siteLegs }`.
  `collapsed` is the stride-2 stream the shipped window *would* have filled;
  every reading in it is a reading actually taken.
- `allocSiteWitness(siteLegs, prime)` → where the excess sits: `dominant` (the
  measured legs' site), `primeSite` and `primeExcessBySite` (the prime leg's),
  and `sameSite`.
- `allocSiteReport(row)` → the operator-facing table, as lines, so a pin can
  read what an operator would have seen.
- `tick0` / `tick` ride back with every window. `alloc-tick` is monotone for
  the life of the page, so that pair is what a round index **is**, and nothing
  could reach for it while it was not recorded.

### Additive by construction

- **Off by default**, and `allocSiteSplit` is the **identity** on a stride-2
  stream — same array, not a copy. Every `allocSteps` and `allocPrimeSplit`
  pin stands unedited, the same shape rf2-oiy1's prime split used.
- **The certificate is read off the collapsed stream.** A mid-leg sample
  reaching `allocSteps` would split one step into two and move `rise`, `falls`
  and `maxStep` — all published — for a diagnostic's convenience.
- **τ is not touched, in either direction.** rf2-e9wr established that no
  honest calibration exists on the arms' data; a pin drives
  `ALLOC_LEG_TOLERANCE`, `ALLOC_FALL_THRESHOLD_B`, `ALLOC_MIN_WRITES`,
  `ALLOC_PRIME_WRITES` and `ALLOC_WINDOW_WRITES` in fresh processes **with the
  mode armed and without it** and requires them equal.
- **The stride is proved, not trusted.** The page reports the stride it used;
  the driver decodes by that rather than by the switch it believes it set, and
  the precise-memory probe refuses a disagreement before anything is measured.
  A page serving an older build would otherwise hand back a well-formed
  stride-2 stream that the driver would read site figures out of.

### What it costs, stated

One more `mem` read per leg inside the measured region. The `idle` control runs
at the **same** stride, so an idle leg's two site figures are one sampler
read's own footprint and nothing else — that is the constant sitting inside
every arm site figure. Being a **constant per leg** it can neither create nor
destroy dispersion, which is the quantity under investigation; but leg
magnitudes at stride 3 are not comparable byte for byte with those at stride 2,
and the row records `bySite`/`sites` so a reader can tell from the row.

## The hypothesis the bead names as the one to exclude first

**Not excluded, and this dispatch could not exclude it** — settling it needs a
window, which is fenced out here. What changed is that it is now *decidable*.

The bead's candidate is that the recurring excesses (+476 to +7,456 B, median
2,640 B) are **the same term as the prime excess** (median 6,864 B) recurring,
rather than a distinct one. The instrument answers it by site, and the logic is
asymmetric, which the code and the pins both say out loud:

- **Sites disagreeing settles it.** One term cannot be in two places.
- **Sites agreeing narrows it.** A site is two statements wide, so agreement is
  necessary and not sufficient — which is why the magnitudes are printed beside
  the verdict rather than collapsed into it.
- **No dispersion is `null`, not `false`.** Eleven of rf2-e9wr's round-3
  windows are byte-identical; reporting "the sites disagree" about a window
  with nothing in it would be the instrument inventing a finding.

A **preliminary reading from published data only** — no new window — leans
*against* the same-term hypothesis, and is offered as a lean and not a verdict:
the prime excess is extraordinarily tight (p25 6,800, p75 6,888 — an
interquartile width of 88 B, 1.3% of its median, constant in absolute bytes
across B ∈ {4, 24, 96} and identical under both writes), so it has a *magnitude*
to hit; the recurring excesses sit at 38% of it at the median and span a 15.7×
range. The bead's own note that the byte values fall into no clean quanta points
the same way. **But magnitude is a weak discriminator** — it cannot separate "a
different term" from "the same term partially recurring" — and the two
populations were never paired window by window. Site is the strong one, and
site needs the window.

## Quality gates

| gate | what it covers here | captured exit |
|---|---|---|
| `node core/test/re_frame/bench/p0_ladder_structural.test.cjs` | the structural gate over this exact surface | **0** — `74 passed` |
| the same, **sabotaged** | the negative control | **1** — `3/74 failed` |
| the same, after restore | | **0** — `74 passed` |
| `node …p0_ladder_structural.test.cjs` — again **on the final base** | | **0** — `74 passed` |
| `scripts/test-fast-pr.sh` — pre-rebase, base `e37ea4c8bd` | the fast pre-checkin spine (not edited) | **0** — `PASS fast PR spine`, 0 FAIL lines |
| `scripts/test-fast-pr.sh` — **on the final base** `6994410caf` | same | **0** — `PASS fast PR spine`, 0 FAIL lines |
| `python scripts/check_fast_pr_gap.py --list` — on the final base | the spine-vs-CI gap | **0** — 94 |

### The rebase, and why the re-run was not a formality

The first spine ran on base `e37ea4c8bd`. While it ran, **PR #8322's atomic
ui + freehand retire landed** — 722 files, `implementation/ui/` and
`implementation/freehand/` deleted, `.github/workflows/**`, `TESTING.md`,
`scripts/test-fast-pr.sh` and `implementation/package.json` all moved. A
pre-rebase green would have been evidence about a tree that no longer exists in
a material way, so the branch was rebased onto `6994410caf` and every gate
re-run there.

The merge-base (three-dot) diff was read for what it would **revert**, not for
conflicts: all 35 deleted lines are the exact lines this change replaces, and
none of them is a sibling's landing. **None of the three edited files was
touched by the retire** — only `lane_cache_wiring.test.cjs` in the same
directory, which this change does not go near. The two gates this change
depends on both survive the retire (`test:script-helpers` still runs
`p0_ladder_structural.test.cjs`; `test:hicasso-compile` is unchanged), while
`test:bspine-compile` went with `implementation/freehand`.

`.shadow-cljs/builds/{node-test,hicasso-bench}` were cleared before the re-run:
both cached a tree that still contained the two deleted source roots, and a
stale cache there fails as cascading errors naming files the change never
touched.

`74 passed` is 66 + 8. The 66 is not taken from the brief: `git show
origin/main:…p0_ladder_structural.test.cjs | grep -c '^test('` reads **66**, the
same file here reads **74**, so eight were added and none removed.

The spine's tiers for this diff: JVM `implementation/core`, node/CLJS, and
clj-kondo — docs tier and spine self-test correctly skipped. **Two of its node
steps are what cover the CLJS half of this change**, and they are the reason no
separate gate is nominated for it:

- `npm run test:script-helpers` runs `node
  core/test/re_frame/bench/p0_ladder_structural.test.cjs`;
- `npm run test:hicasso-compile` is **the gate that compiles
  `p0_heap.cljs`** — its roster carries `re-frame.bench.p0-app`, which requires
  `re-frame.bench.p0-heap`.

Both spine runs printed their gate root as
`/c/Users/miket/code/re-frame2-worktrees/dispersion-rs8q6`, so each read this
worktree and not a sibling's — that is the "check the root it prints" route.
The structural gate prints no root, so its discrimination is the planted-fault
red below: the fault exists only in this tree, so a run that had wandered into
a sibling's would have come back green.

Every number above is the one **captured** by the running shell (`> log 2>&1;
echo "CAPTURED_EXIT=$?" | tee exitfile`, redirect and echo on one command line
in one shell), never one reported about the run by anything else.

Not run, with reasons: no browser lane and **no allocation window** — this is
the edit half by the bead's own sequencing, and the box was not quiet (#8322's
722-file retire was running heavyweight suites on it throughout, so any window
taken here would have been contaminated and the arm-order guard would likely
have refused it). `mkdocs build --strict` is in no tier for this diff, which
touches no documentation surface.

### The negative control

Planted at a single line in `allocDominantSite` — the site returned is swapped
for the other one, which makes the by-site attribution wrong in exactly the way
the witness must notice, and is bounded enough not to abort any namespace.

- pre-plant `git hash-object`: `beb680a679eae7dcf676469e6c4ea0328b2b4248`
- planted: `f07a474df15cf76987e554089c1bf2aa13f9ba1d` — **the plant applied**
- gate **red**, captured exit **1**, `3/74 failed`, and each failure names the
  plant: `+ actual 'drain' / - expected 'dispatch'` in *THE ATTRIBUTION NAMES
  THE SITE*, *THE PRIME IS OUT OF THE BY-SITE COHORT TOO* and *THE SAME-TERM
  HYPOTHESIS IS ANSWERABLE*. 71 of 74 still ran, so the plant was scoped.
- restored `git hash-object`: `beb680a679eae7dcf676469e6c4ea0328b2b4248` —
  **byte-identical to pre-plant**, verified against version control's own
  content hash rather than by reading a diff
- gate green again, captured exit **0**, `74 passed`

The plant is discriminating in both directions on purpose: the attribution pin
asserts the excess is named for the drain in a drain-fixture *and* for the
dispatch in the mirror fixture, so an attribution that always names one site
cannot pass either.

This gate reads the driver as a file and requires it in-process — there is no
watcher or build between source and runtime — so the red is direct evidence the
runtime observed the plant, not merely that the source changed.

### One existing pin was repaired rather than left to rot

`allocPrepare` gained a stride argument, and the pre-existing
`lacks(/allocPrepare\(dd?, n\), \[...ALLOC_WRITES\]/)` would have matched
nothing from that day on — **a `lacks` that matches nothing passes, silently,
for ever.** It is re-anchored on the argument array, where the count it is
about actually lives, and paired with a counted positive half asserting all
three call sites size for `ALLOC_WINDOW_WRITES` **and** state `ALLOC_SITES`.
Two `has` pins on `allocPrimeSplit(w.samples)` / `(win.samples)` were likewise
moved to the new call shape and counted, not deleted.

## The fast-spine / required-CI gap

`python scripts/check_fast_pr_gap.py --list` — **94 required checks the spine
does not run** on the final base (captured exit 0). Cited as the one path
rather than enumerated by hand.

**That is a fact about the spine, not a census of this PR.** The spine **did**
run here — twice, the second time on the final base — with tiers JVM
`implementation/core`, node/CLJS and clj-kondo; docs tier and spine self-test
correctly skipped. Run **directly**, over and above it: the structural gate
three times (green / sabotaged-red / green).

**94 is the re-read, and the re-read mattered.** Before the rebase the same
command answered **106**; the retire deleted two workflows' worth of required
checks, and a count carried across the rebase would have been quietly false of
the trunk. `test:hicasso-compile` moved with it and is **no longer in the gap
at all** — it is now covered — which is a second reason it is not nominated
separately above; its sibling `test:bspine-compile` left the list by being
deleted with `implementation/freehand`. What that job still contributes to the
gap is one step, `npm run build:hicasso-release`, and a red there would report
under the job's name rather than as a test.

## Not done, deliberately

- **No measurement window.** The bead was filed rather than chased for exactly
  this reason, and the mayor's sequencing comment fences this dispatch to the
  edit half.
- **No gate, band or threshold moved.** τ, the falls threshold, the averaging
  floor, the prime and the control slack are all where rf2-e9wr left them, and
  a pin drives that under the new switch.
- **The mechanism is not identified.** rf2-rs8q6 therefore **stays OPEN** — the
  bead is about the mechanism, and an instrument is not a mechanism.
  **rf2-ojehu** files what the window needs: the exact configuration (rf2-e9wr's
  own, so the two windows line up window for window), the quiet box, and — first,
  because the window is not readable without it — the idle control's per-site
  figures. **If the idle figure turns out comparable to the arm excesses
  (~2,640 B), the mode's resolution is insufficient and that is the finding**;
  the instrument does not assume its way past that.
