### PR TITLE
feat(hicasso): the topology tournament's clock table gets a driver (rf2-w01c)

### DIFF
--- a/implementation/hicasso/test/re_frame/bench/hicasso/topo/clock_app.cljs
+++ b/implementation/hicasso/test/re_frame/bench/hicasso/topo/clock_app.cljs
@@ -1,0 +1,643 @@
+(ns re-frame.bench.hicasso.topo.clock-app
+  "**THE TOPOLOGY TOURNAMENT'S CLOCK DRIVER** — the arms × operations ×
+  row-counts table the tournament pre-registered and never instrumented
+  (rf2-w01c, splitting the clock half out of rf2-hic-036).
+
+  Driven by the lane's generic driver, so it adds no driver of its own and
+  takes no new build id:
+
+      HICASSO_INIT_FN=re-frame.bench.hicasso.topo.clock-app/-main \\
+      HICASSO_OUT_DIR=out/topo-clock \\
+      HICASSO_PORT=8148 \\
+      node implementation/hicasso/test/re_frame/bench/hicasso/run.cjs
+
+  ## What was missing, and it was not a control
+
+  [The tournament](../../../../../../../docs/design/hicasso/product/topology-tournament.md)
+  froze its arms, operations, row counts, estimand, controls and stopping
+  rule before a measurement was taken, and its deterministic half then
+  landed complete at all 48 cells. The clock half published nothing, and
+  after `rf2-m6i0` the reason stopped being the control:
+
+  > What withholds those three cells now is narrower and more ordinary:
+  > **the tournament's clock cells were never instrumented.** Only the
+  > control was built, it refused first, and no driver for the 4 arms × 4
+  > operations table exists to run.
+  > — `topology-tournament.md` §2
+
+  This file is that driver. It builds nothing the lane already has: the
+  schedule, the sampling, the guard, the tally and the one meaning of
+  *verified* are [[re-frame.bench.hicasso.lane]]'s, and **the control is
+  [[re-frame.bench.hicasso.topo.control-app]]'s, called rather than
+  reimplemented** — see below.
+
+  ## THE CONSTRAINT THIS DRIVER IS BUILT AROUND
+
+  `rf2-m6i0`'s window established it and `rf2-hic-036` carries it forward
+  as the design input for exactly this file:
+
+  > A MANIPULATION CERTIFIES AN INSTRUMENT ONLY WHEN EVERY COST IN THE
+  > WINDOW MOVES WITH IT.
+
+  Two controls have now been refused on this lane and both failed the same
+  way from opposite ends — one moved only the markup while the handler and
+  the subscription layer stood still, the other moved nothing at all on
+  two of the four arms. What each left behind was a **shared constant**,
+  and a shared constant compresses a measured ratio toward 1, which reads
+  exactly like an instrument that cannot see.
+
+  So this driver does not carry a control of its own. **It calls
+  [[re-frame.bench.hicasso.topo.control-app/run-arm!]] — the
+  rendered-scale doubling with an indexed write, the one manipulation on
+  this lane in which every cost in the window moves — and takes no clock
+  cell for an arm whose control refused.** That is
+  [§1.5](../../../../../../../docs/design/hicasso/product/topology-tournament.md#15-the-controls-and-what-each-refuses)
+  as registered (*\"A published clock figure requires both to pass for
+  that arm at that row count; either failing withholds the figure\"*), and
+  it is the whole reason a second control here would be a defect rather
+  than a redundancy: a driver that minted its own would be the third
+  attempt at the manipulation two windows have already priced.
+
+  ## THE WINDOWED ARM IS NOT MEASURED, AND THAT IS A RULING
+
+  `rf2-4t36` ruled on `virtual` without taking a new measurement: at the
+  window this tournament commits to, its whole commit is 0.125–0.195 ms
+  against a fitted per-commit floor of about 0.059 ms — **47% of the
+  reading** — so a healthy instrument on a quiet box certifies that arm
+  about one run in four. Its clock cells are **UNADDRESSED**, and the
+  ruling names the two repairs that are refused: do not widen a band to
+  admit them, and do not enlarge the window to rescue them, *\"which would
+  certify a regime the cells are not published in\"*.
+
+  This file therefore holds `:virtual` in [[unaddressed]] with its reason
+  and **starts no clock on it**. Measuring it and labelling the number
+  unaddressed would publish a figure a reader can quote; not measuring it
+  cannot.
+
+  ## The floor row, which is REPORTED and decides nothing
+
+  The same ruling is the reason every row count also carries a `:noop`
+  row. `[:topo/noop-write]` moves a key no arm reads, so its window holds
+  exactly the cost that does **not** move with the arm — dispatch, the
+  `flushSync` boundary, the commit React schedules regardless. That is the
+  quantity that killed the windowed arm, and a reader handed an
+  arm-to-arm ratio without it cannot tell a topology result from a floor.
+
+  **It is published beside every cell and it adjudicates nothing.** The
+  same ruling rejected subtracting a separately-measured floor on three
+  counts, any one sufficient, and the sharpest is that there is no stable
+  floor to subtract: the identical fit returns +47% on one arm and
+  NEGATIVE constants on the other three. A quantity of that shape is the
+  intercept of an assumed cost model, not a property of the rig. So this
+  row is a **measurement placed beside the cells**, never a correction
+  applied to them, and no arithmetic here subtracts it.
+
+  ## One window
+
+  `batch-k` commits of one operation on one already-mounted page, under
+  ONE clock, then — with the clock stopped — two cell-addressed probes
+  read back and banked into `lane/tally`. The batch is `rf2-9zysg`'s
+  repair for Chrome's 100 µs clamp and the same number the control uses;
+  the read-back is `control-app`'s, cell-addressed by `data-testid`
+  rather than by the row's own text, because a row's text node
+  concatenates its label, its `n`, its draft and its button's caption and
+  a probe reading it could be satisfied by any of them moving.
+
+  **Every operation's probe pair carries one cell that MUST have moved and
+  one that MUST NOT.** The unchanged half is what makes the pair
+  load-bearing: a write that reached every row, or a page rebuilt from a
+  stale seed, satisfies the changed probe on its own. `:noop`'s pair is
+  two unchanged cells, which is the negative control stated as a
+  read-back.
+
+  ## What this file does NOT do
+
+  It does not take the window. A clock estimand needs a quiet box — one
+  measurement at a time, no other worker compiling — and that is a
+  property of the instrument rather than a scheduling preference. Building
+  the driver is edit-shaped and unconstrained; running it is not. This
+  file is the build half.
+
+  It does not pool the two estimands. The census's rows of markup travel
+  beside each cell because they are what gate it before the clock starts,
+  and they are labelled as the deterministic quantity they are —
+  [§1.4](../../../../../../../docs/design/hicasso/product/topology-tournament.md#14-the-estimand-and-the-one-substitution-that-is-refused)
+  forbids a work census standing in for a clock, and a driver that printed
+  them in one table would be doing exactly that."
+  (:require [re-frame.adapter.uix :as uix-adapter]
+            [re-frame.bench.hicasso.arm1.mount :as mount]
+            [re-frame.bench.hicasso.arm1.runtime :as rt]
+            [re-frame.bench.hicasso.lane :as lane]
+            [re-frame.bench.hicasso.topo.arms :as arms]
+            [re-frame.bench.hicasso.topo.control-app :as ctl]
+            [re-frame.bench.hicasso.topo.model :as m]
+            [re-frame.core :as rf]))
+
+;; ---------------------------------------------------------------------------
+;; Pre-registered — the whole plan, before any run
+;; ---------------------------------------------------------------------------
+
+(def measured-arms
+  "The arms whose clock cells this driver takes.
+
+  Three of the tournament's four, and the missing one is a RULING rather
+  than an omission — see [[unaddressed]]. The order is the roster's own
+  (`arms/arm-ids` less the unaddressed arm), so a reader comparing this
+  table against the census reads the columns in the same order."
+  (into [] (remove #{:virtual}) arms/arm-ids))
+
+(def unaddressed
+  "The arms this driver deliberately starts no clock on, with the reason
+  carried in the file rather than in a commit message.
+
+  `rf2-4t36` ruled the windowed arm's cells unresolvable at the committed
+  window size and handed them over as UNADDRESSED. A driver that measured
+  the arm anyway and labelled the number would publish a figure a reader
+  can quote; this one cannot."
+  {:virtual (str "rf2-4t36: at the tournament's committed window (w=20) the whole commit is "
+                 "0.125-0.195 ms against a fitted per-commit floor of ~0.059 ms — 47% of the "
+                 "reading — so this control certifies a healthy instrument about one run in "
+                 "four. The cells are UNADDRESSED. Widening the band or enlarging the window "
+                 "are both refused: either would certify a regime the cells are not published in")})
+
+(def operations
+  "The tournament's four operations, in its own registered order."
+  [:sparse :bulk :reorder :edit])
+
+(def floor-op
+  "The fifth row, and the only one that is not a tournament operation.
+
+  `[:topo/noop-write]` moves a key no arm reads, so its window holds the
+  per-commit cost that does not move with the arm. REPORTED beside the
+  cells; it corrects nothing. See the namespace docstring."
+  :noop)
+
+(def rows
+  "Every row of the table, floor last so a reader meets the operations
+  first."
+  (conj operations floor-op))
+
+(def row-counts
+  "`B ∈ {100, 300, 1000}` — the tournament's own, read from the model
+  rather than restated, so the clock table and the census table are
+  about the same three pages."
+  m/row-counts)
+
+(def target
+  "The row `sparse` and `edit` move, and the row `reorder`'s unchanged
+  probe reads.
+
+  ZERO, which is `census_dom_cljs_test`'s own choice and is copied here
+  deliberately: the clock table and the work census must describe the
+  same operation, and a different target would make them two experiments
+  wearing one name. That file's reason stands unchanged — row 0 is the
+  only index guaranteed to be in the windowed arm's DOM at every row
+  count."
+  0)
+
+(def unchanged-probe
+  "A row no narrow operation touches, adjacent to [[target]] so a page
+  that rebuilt the wrong region fails one of the two probes."
+  1)
+
+(def batch-k
+  "Operations under ONE clock — the control's own number, not a second
+  one.
+
+  Chrome clamps `performance.now()` to 100 µs and `rf2-d2tzk` records
+  what that does to a narrow row. `rf2-9zysg`'s repair is to batch, and
+  `control-app` already carries the value this lane batches at; two
+  numbers for one decision is how a table comes to be taken at a depth
+  its control was never certified at."
+  ctl/batch-k)
+
+(def sampling
+  "The control's sampling, for the same reason [[batch-k]] is the
+  control's: a cell licensed by a control taken at one depth and measured
+  at another is licensed by an experiment that was not run."
+  ctl/sampling)
+
+(def rounds ctl/rounds)
+
+;; ---------------------------------------------------------------------------
+;; The deterministic gate every cell passes BEFORE its clock starts
+;; ---------------------------------------------------------------------------
+
+(defn markup-expected
+  "Rows of markup ONE commit of `op` builds on `arm`'s page at `b` —
+  exact integers, and the tournament's own published census
+  ([§2.2](../../../../../../../docs/design/hicasso/product/topology-tournament.md#22-the-rung-2-teaching-table--rows-of-markup-built)).
+
+  This is arithmetic and not a lookup table: `fine` builds the rows that
+  changed, `coarse` rebuilds its whole view-model, `chunked` rebuilds
+  every chunk a change reaches, and a permutation moves no row's read at
+  all so `fine`'s memo bails on every one of them.
+
+  [[run-row!]] MEASURES it before starting a clock and refuses the row
+  when it disagrees. A page that is not doing the work its arithmetic
+  predicts is not the page the tournament is about, and a clock reading
+  over it would be a precise number for the wrong experiment."
+  [arm op b]
+  (case op
+    (:sparse :edit) (case arm
+                      :fine    1
+                      :coarse  b
+                      :chunked (min m/chunk-size b))
+    :bulk           b
+    :reorder        (case arm
+                      :fine    0
+                      (:coarse :chunked) b)
+    :noop           0))
+
+;; ---------------------------------------------------------------------------
+;; The read-back — pure arithmetic over the model's own seed
+;; ---------------------------------------------------------------------------
+
+(defn draft-value
+  "The string `edit`'s `committed`-th commit writes. A pure function of
+  the commit index, so the probe advances by exactly one per commit in
+  the same way `sparse`'s `n` does."
+  [committed]
+  (str "k" committed))
+
+(defn expectations
+  "What a page of `b` rows must read after `committed` commits of `op`,
+  as `{:probe :cell :want}`.
+
+  Pure, and `:cell` is DATA — `[:n i]`, `[:draft i]` or `[:head]` —
+  rather than a DOM query, so this whole arithmetic is checkable without
+  a browser and its witness can assert it under `:node-test`.
+
+  Every pair holds one cell that must have MOVED and one that must NOT.
+  A changed probe alone is satisfied by a write that reached every row
+  and by a page rebuilt from a stale seed; the unchanged half is what
+  refuses both. `:noop`'s pair is two unchanged cells, which is this
+  lane's negative control written as a read-back rather than as a
+  counter."
+  [op b committed]
+  (case op
+    :sparse  [{:probe :changed   :cell [:n target]              :want (str (+ (:n (m/row target)) committed))}
+              {:probe :unchanged :cell [:n unchanged-probe]     :want (str (:n (m/row unchanged-probe)))}]
+    ;; A broad write leaves no unchanged cell to read, so the second probe is
+    ;; the FAR END of the table — `lane/bulk-probes`' rule, in this file's
+    ;; cell-addressed spelling: a commit that got as far as the front of the
+    ;; page and no further satisfies the first probe on its own.
+    :bulk    [{:probe :changed   :cell [:n target]              :want (str (+ (:n (m/row target)) committed))}
+              {:probe :far-end   :cell [:n (dec b)]             :want (str (+ (:n (m/row (dec b))) committed))}]
+    ;; A permutation moves the ORDER and no row's data, so the pair reads
+    ;; one of each: the head of the list must have rotated exactly
+    ;; `committed` places, and the target row's own `n` must not have moved
+    ;; at all.
+    :reorder [{:probe :changed   :cell [:head]                  :want (str (mod committed b))}
+              {:probe :unchanged :cell [:n target]              :want (str (:n (m/row target)))}]
+    :edit    [{:probe :changed   :cell [:draft target]          :want (draft-value committed)}
+              {:probe :unchanged :cell [:draft unchanged-probe] :want ""}]
+    :noop    [{:probe :unchanged :cell [:n target]              :want (str (:n (m/row target)))}
+              {:probe :unchanged :cell [:head]                  :want "0"}]))
+
+(defn- read-cell
+  "Read one [[expectations]] cell out of `container`, as text, or nil.
+
+  `[:head]` reads an ATTRIBUTE and the other two read text, which is the
+  only asymmetry here and it is forced: the quantity `reorder` moves is
+  which row is first, and that is an identity rather than a value."
+  [container cell]
+  (case (first cell)
+    :n     (some-> (.querySelector container (str "[data-testid=\"n-" (second cell) "\"]"))
+                   (.-textContent))
+    :draft (some-> (.querySelector container (str "[data-testid=\"draft-" (second cell) "\"]"))
+                   (.-textContent))
+    :head  (some-> (.querySelector container "li.topo-row") (.getAttribute "data-i"))))
+
+(defn probe-misses
+  "Which of `op`'s probes `container` fails after `committed` commits. A
+  vector of maps, empty when the page committed what it claims."
+  [container op b committed]
+  (into []
+        (keep (fn [{:keys [cell want] :as e}]
+                (let [got (read-cell container cell)]
+                  (when-not (= want got) (assoc e :got got)))))
+        (expectations op b committed)))
+
+;; ---------------------------------------------------------------------------
+;; One measured window
+;; ---------------------------------------------------------------------------
+
+(defn write!
+  "Dispatch ONE commit of `op` into `frame-id`. `committed` is the page's
+  running commit count BEFORE this one, and only `:edit` reads it — its
+  cell has to carry a distinct value per commit or a read-back could be
+  satisfied by a commit that never happened."
+  [frame-id op committed]
+  (case op
+    :sparse  (rt/dispatch! frame-id [:topo/bump target])
+    :bulk    (rt/dispatch! frame-id [:topo/bump-all])
+    :reorder (rt/dispatch! frame-id [:topo/rotate])
+    :edit    (rt/dispatch! frame-id [:topo/edit target (draft-value (inc committed))])
+    :noop    (rt/dispatch! frame-id [:topo/noop-write])))
+
+(defn window!
+  "[[batch-k]] commits of `op` on `page` under ONE clock, then — with the
+  clock stopped — the two probes read back and BANKED in `t`.
+
+  Answers the elapsed milliseconds for the whole batch.
+
+  The read-back is outside the window and after the last drain, which is
+  the batched shape `lane/verified-writes!` documents and defends: no
+  macrotask runs between the first write and the last drain, so a commit
+  React has parked cannot land inside the window however many microtasks
+  pass. What the batch relaxes is microtask-scale lateness, on a
+  tolerance the unbatched window already grants.
+
+  The commit index is a LOCAL counter for the duration of the batch and
+  the page's atom is advanced once at the end, so nothing inside the
+  window touches shared state that the clock would then be measuring."
+  [t {:keys [frame-id container b committed]} op]
+  (let [start @committed
+        t0    (lane/now-ms)]
+    (dotimes [i batch-k]
+      (write! frame-id op (+ start i))
+      (mount/settle!))
+    (let [ms     (- (lane/now-ms) t0)
+          total  (swap! committed + batch-k)
+          misses (probe-misses container op b total)]
+      ;; `lane/verified-writes!`'s own `bank!`, over this file's probes: one
+      ;; tally, one meaning of "verified", one `assert-verified!`.
+      (swap! t (fn [{:keys [of bad]}]
+                 {:of (+ of (count (expectations op b total)))
+                  :bad (+ bad (count misses))}))
+      (when (seq misses)
+        (js/console.error (str ";; PROBE MISS — " (name op) " @B=" b " — " (pr-str misses))))
+      ms)))
+
+;; ---------------------------------------------------------------------------
+;; Pages
+;; ---------------------------------------------------------------------------
+
+(def ^:private frame-ids
+  (into {} (for [arm measured-arms b row-counts]
+             [[arm b] (keyword "topo.clock" (str (name arm) "-" b))])))
+
+(defn- structure-of
+  "`container`'s own structure. `:boundaries` and `:edges` come from a
+  DELTA against the runtime's live table, because all three arms' pages
+  are mounted at once and `rt/stats` counts every live cell in the
+  process rather than one container's."
+  [container before]
+  (let [{:keys [boundaries edges]} (rt/stats)]
+    {:boundaries    (- boundaries (:boundaries before))
+     :edges         (- edges (:edges before))
+     :elements      (lane/element-count container)
+     :rendered-rows (.-length (.querySelectorAll container "li.topo-row"))}))
+
+(defn- mount-page!
+  "Seed a frame at `b`, mount `arm` over it, and answer the page map the
+  rest of this file passes around — with the structure it actually
+  mounted, taken as a delta against `before`."
+  [arm b before]
+  (let [frame-id (get frame-ids [arm b])]
+    (m/make-frame! frame-id b)
+    (m/reseed! frame-id b)
+    (let [handle (mount/root! (mount/fresh-container!) frame-id [(arms/view-of arm) {}])]
+      {:arm       arm
+       :b         b
+       :frame-id  frame-id
+       :handle    handle
+       :container (:container handle)
+       :committed (atom 0)
+       :structure (structure-of (:container handle) before)})))
+
+(defn- reseed-page!
+  "Return `page` to its seed and let the commit land, outside every
+  clock. The commit counter is zeroed AFTER the settle, so the probe
+  arithmetic of the row about to run starts where the seed does."
+  [{:keys [frame-id committed b]}]
+  (rt/dispatch! frame-id [:topo/seed b m/window-size])
+  (mount/settle!)
+  (reset! committed 0)
+  nil)
+
+(defn- markup-of
+  "Rows of markup ONE commit of `op` builds on `page` — measured, on the
+  arms' own counters, outside every clock.
+
+  The counters are a single shared atom, so this runs one page at a time
+  and resets immediately before its commit."
+  [page op]
+  (arms/reset-counters!)
+  (write! (:frame-id page) op @(:committed page))
+  (mount/settle!)
+  (swap! (:committed page) inc)
+  (:markup (arms/runs)))
+
+;; ---------------------------------------------------------------------------
+;; One row of the table — one operation, one row count, every measured arm
+;; ---------------------------------------------------------------------------
+
+(defn run-row!
+  "One `(op, b)` row: check every page still builds the markup its
+  arithmetic predicts, then interleave the arms under the clock.
+
+  Answers `{:cells :ratios :guard :markup :tally}`, or `{:fatal …}` when
+  the deterministic gate refused before a clock was started.
+
+  **The arms are the manipulation and nothing else is.** Same page size,
+  same operation, same batch, same probes, same rounds, mounts and
+  releases outside every window — so what separates two cells in a row is
+  the topology or it is the floor, and the floor row is measured so a
+  reader can tell which."
+  [pages op b]
+  (let [t     (lane/tally)
+        legs  (mapv (fn [arm] {:id arm}) measured-arms)]
+    (doseq [arm measured-arms] (reseed-page! (get pages arm)))
+    (let [built (into {} (map (fn [arm] [arm (markup-of (get pages arm) op)])) measured-arms)
+          want  (into {} (map (fn [arm] [arm (markup-expected arm op b)])) measured-arms)]
+      (if (not= built want)
+        {:fatal (str (name op) " at B=" b ": a page does not build the markup the census "
+                     "publishes for it, so the clock is about to read a page the tournament "
+                     "is not about — expected " (pr-str want) ", built " (pr-str built))}
+        (let [{:keys [readings samples]}
+              (lane/rounds! legs sampling rounds
+                            (fn [a] (window! t (get pages (:id a)) op))
+                            (fn [a] (str (name (:id a)) "/" (name op) "@" b)))
+              ;; One p50 per arm per round — the within-round median every
+              ;; ratio below is a ratio OF, named here rather than in the
+              ;; caller so a published row cannot be read as a mean of
+              ;; samples (rf2-pqyxz's correction, on the other instrument).
+              per-round (mapv (fn [r]
+                                (into {} (map (fn [[id xs]] [id (:p50 (lane/summarise xs))])) r))
+                              readings)
+              centre    (into {} (map (fn [arm]
+                                        [arm (lane/summarise (mapv #(get % arm) per-round))]))
+                              measured-arms)]
+          {:markup    built
+           :cells     centre
+           :per-round per-round
+           ;; Against `fine`, which is the tournament's reference topology and
+           ;; the one arm both refused controls could address. `:straddles-1?`
+           ;; is the honesty flag: a range containing 1.0 means the two arms
+           ;; are INDISTINGUISHABLE here and the row says so rather than
+           ;; quoting a mean as a winner.
+           :ratios    (into {} (map (fn [arm] [arm (lane/ratio-between per-round arm :fine)]))
+                            (remove #{:fine} measured-arms))
+           :guard     (lane/guard! samples (str "topo clock " (name op) " @B=" b))
+           :tally     t})))))
+
+;; ---------------------------------------------------------------------------
+;; The floor, placed beside the cells and never subtracted from them
+;; ---------------------------------------------------------------------------
+
+(defn floor-shares
+  "How much of each cell's window is the per-commit cost that does NOT
+  move with the arm, as `{[arm op b] share}`.
+
+  `share` is the floor row's centre over the operation row's centre on
+  the SAME arm at the SAME row count — a ratio of two measurements, never
+  a correction applied to either. `rf2-4t36` rejected subtracting a
+  floor and the sharpest of its three reasons is that there is nothing
+  stable to subtract: the identical fit returns +47% on one arm and
+  negative constants on three.
+
+  A reader uses this exactly as that ruling used it — a cell whose window
+  is mostly floor is a cell whose arm-to-arm ratio is compressed toward
+  1, and the compression is arithmetic rather than a defect. Nothing here
+  adjudicates on it."
+  [table]
+  (into {}
+        (for [b   row-counts
+              arm measured-arms
+              op  operations
+              :let [f (get-in table [[floor-op b] :cells arm :p50])
+                    o (get-in table [[op b] :cells arm :p50])]
+              :when (and f o (pos? o))]
+          [[arm op b] (lane/round4 (/ f o))])))
+
+;; ---------------------------------------------------------------------------
+;; The control, called rather than reimplemented
+;; ---------------------------------------------------------------------------
+
+(defn run-controls!
+  "The registered positive control, once per measured arm, BEFORE any
+  cell is taken.
+
+  This is [[re-frame.bench.hicasso.topo.control-app/run-arm!]] and not a
+  copy of it: the rendered-scale doubling with an indexed write is the
+  one manipulation on this lane in which the handler, the subscription
+  layer and the render all move together, and a second spelling of it
+  here would be a second authority with nothing holding it in step.
+
+  Answers `{arm verdict}`. A refusal is not repaired and not softened —
+  the caller takes no cell for that arm, which is §1.5 as registered."
+  []
+  (reduce (fn [acc arm]
+            (let [r (ctl/run-arm! arm)]
+              (if-let [f (:fatal r)]
+                (reduced (assoc acc arm {:ok? false :why f}))
+                (do
+                  (lane/record! (keyword (str "control-" (name arm)))
+                                (select-keys r [:verdict :structure :markup]))
+                  (when (:refuse? (:guard r))
+                    (set! (.-HICASSO_GUARD_REFUSED js/window) true))
+                  ;; The lane's ONE adjudication of a read-back. It throws, and
+                  ;; it is called AFTER the record above is published.
+                  (lane/assert-verified! (:tally r)
+                                         (str "topo clock control (" (name arm) ")"))
+                  (assoc acc arm (:verdict r))))))
+          {}
+          measured-arms))
+
+;; ---------------------------------------------------------------------------
+;; The table
+;; ---------------------------------------------------------------------------
+
+(defn run-table!
+  "Every row of the table, one row count at a time. Answers
+  `{[op b] row}`, or throws through [[run-row!]]'s fatal.
+
+  All three arms' pages stand together for the whole of a row count, so
+  every cell in it is measured with the same document under it — a page
+  mounted per cell would put a different amount of DOM under each arm and
+  bill the difference to the topology. They are released before the next
+  row count mounts, so the document holds three pages and never nine."
+  []
+  (reduce
+    (fn [table b]
+      (let [pages (reduce (fn [acc arm] (assoc acc arm (mount-page! arm b (rt/stats))))
+                          {} measured-arms)]
+        (try
+          (let [wrong (into [] (remove (fn [arm]
+                                         (= (select-keys (arms/expected arm b)
+                                                         [:boundaries :edges :elements :rendered-rows])
+                                            (:structure (get pages arm)))))
+                            measured-arms)]
+            (when (seq wrong)
+              (throw (ex-info (str "at B=" b " these pages are not the arms they claim: "
+                                   (pr-str (into {} (map (fn [arm]
+                                                           [arm {:expected (arms/expected arm b)
+                                                                 :mounted  (:structure (get pages arm))}]))
+                                                 wrong)))
+                              {:b b :arms wrong})))
+            (reduce (fn [acc op]
+                      (let [r (run-row! pages op b)]
+                        (when-let [f (:fatal r)] (throw (ex-info f {:op op :b b})))
+                        (lane/record! (keyword (str (name op) "-" b))
+                                      (select-keys r [:markup :cells :ratios]))
+                        (when (:refuse? (:guard r))
+                          (set! (.-HICASSO_GUARD_REFUSED js/window) true))
+                        (lane/assert-verified! (:tally r)
+                                               (str "topo clock " (name op) " @B=" b))
+                        (assoc acc [op b] r)))
+                    table
+                    rows))
+          (finally
+            (doseq [arm measured-arms] (mount/release! (:handle (get pages arm))))))))
+    {}
+    row-counts))
+
+;; ---------------------------------------------------------------------------
+;; The run
+;; ---------------------------------------------------------------------------
+
+(defn ^:export -main []
+  (rf/init! uix-adapter/adapter)
+  (lane/leave-act-environment!)
+  (lane/self-test!)
+  (try
+    (lane/record! :design
+                  {:arms        measured-arms
+                   :unaddressed unaddressed
+                   :operations  operations
+                   :floor-row   floor-op
+                   :row-counts  row-counts
+                   :batch-k     batch-k
+                   :sampling    sampling
+                   :rounds      rounds
+                   :target      target
+                   :markup      (into {} (for [b row-counts op rows arm measured-arms]
+                                           [[arm op b] (markup-expected arm op b)]))})
+    (lane/record! :runtime (lane/runtime-label))
+    ;; THE CONTROL RUNS FIRST AND ALONE. If it refuses, the tournament's
+    ;; clock half refuses with it and the cells are never taken — which is a
+    ;; result, not a failure.
+    (let [controls (run-controls!)]
+      (lane/record! :controls (into {} (map (fn [[arm v]] [arm (select-keys v [:predicted :band :rounds :ok? :why])]))
+                                    controls))
+      (if-not (every? :ok? (vals controls))
+        (do
+          (set! (.-HICASSO_CONTROL_FAILED js/window) true)
+          (lane/fail! (str "the registered positive control refused on "
+                           (pr-str (into [] (comp (remove (comp :ok? val)) (map key)) controls))
+                           " — no clock cell is taken for an arm whose instrument is not certified, "
+                           "which is topology-tournament.md §1.5 as registered")))
+        (let [table (run-table!)]
+          (lane/record! :floor-share (floor-shares table))
+          (lane/record! :summary
+                        (into {} (for [[[op b] r] table]
+                                   [[op b] {:cells  (into {} (map (fn [[arm s]] [arm (lane/round4 (:p50 s))])) (:cells r))
+                                            :ratios (into {} (map (fn [[arm v]]
+                                                                    [arm (select-keys v [:mean :min :max :straddles-1?])]))
+                                                          (:ratios r))}]))))))
+    (catch :default e
+      (set! (.-HICASSO_CONTROL_FAILED js/window) true)
+      (lane/fail! (str "topo clock threw: " (or (ex-message e) (.-message e))))))
+  (lane/done!))

--- a/implementation/hicasso/test/re_frame/bench/hicasso/topo/clock_witness_dom_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/bench/hicasso/topo/clock_witness_dom_cljs_test.cljs
@@ -1,0 +1,288 @@
+(ns re-frame.bench.hicasso.topo.clock-witness-dom-cljs-test
+  "**THE CLOCK DRIVER'S OWN DETERMINISTIC HALF** — the arithmetic
+  [[re-frame.bench.hicasso.topo.clock-app]] gates its cells on, and the
+  witness in which its read-back refuses (rf2-w01c).
+
+  ## Why this file needs no quiet box, and the clock run does
+
+  [The budgets page](../../../../../../../docs/design/hicasso/product/budgets.md)
+  sorts performance rows into two families and its own sentence is the
+  fence: a counter *\"reads the same on a loaded box\"*. Everything
+  asserted here is an exact integer, a string read out of the DOM, or
+  pure arithmetic over the model's seed, so contention cannot move any of
+  it. This is an ordinary blocking gate that runs in CI on every PR and is
+  repeatable by anyone. Whether the instrument can SEE the differences
+  counted here is a timing question and belongs to the quiet-box run.
+
+  ## What it establishes
+
+  1. **The driver's pre-clock gate is the census's published table.**
+     `clock-app/markup-expected` is arithmetic, and arithmetic drifts; the
+     numbers it must produce are stated here as exact integers, so a
+     change to that function that stopped describing
+     [§2.2](../../../../../../../docs/design/hicasso/product/topology-tournament.md#22-the-rung-2-teaching-table--rows-of-markup-built)
+     reds instead of quietly re-baselining the tournament.
+  2. **No operation is verified by a changed probe alone.** Every pair
+     holds one cell that must have moved and one that must not, and the
+     changed half advances by exactly one per commit. A write that reached
+     every row, and a page rebuilt from a stale seed, both satisfy a
+     changed probe on its own.
+  3. **The read-back bites, on a real page.** A planted source fault
+     proves the source changed; it does not prove the runtime observed
+     the plant. So the witness below mounts a real arm and drives
+     `clock-app/window!` itself — the same function the clock run calls,
+     banking into the same `lane/tally` — with the ONE difference that
+     the commits are dispatched into a frame nothing is mounted over. The
+     page therefore never moves while the clock runs and the probes read
+     it afterwards, which is the exact fault the read-back exists to
+     catch: *the clock measured a page that did not commit what it
+     claims*. There is nothing to restore and nothing to hash.
+  4. **And it can answer true.** The same window against the page's own
+     frame reads `0 unverified`, so the refusal above is a discrimination
+     rather than a probe that always fails.
+
+  Runtime: `-dom-cljs-test`. Claims 1 and 2 hold under `:node-test` too —
+  they touch no DOM — and every DOM claim degrades to a stated skip
+  there."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [re-frame.adapter.uix :as uix-adapter]
+            [re-frame.bench.hicasso.arm1.mount :as mount]
+            [re-frame.bench.hicasso.arm1.runtime :as rt]
+            [re-frame.bench.hicasso.lane :as lane]
+            [re-frame.bench.hicasso.topo.arms :as arms]
+            [re-frame.bench.hicasso.topo.clock-app :as clock]
+            [re-frame.bench.hicasso.topo.model :as m]
+            [re-frame.test-support :as test-support]))
+
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture
+    {:adapter       uix-adapter/adapter
+     :ambient-frame nil
+     :async?        true
+     :init-fn       (fn [] (rt/reset-runtime!))}))
+
+(defn- skip! [why]
+  (is true (str "the topology clock witness needs a real React DOM — " why)))
+
+;; ---------------------------------------------------------------------------
+;; 1 — the plan, and the arm that is deliberately absent from it
+;; ---------------------------------------------------------------------------
+
+(deftest the-windowed-arm-is-unaddressed-and-says-why
+  (testing "rf2-4t36 ruled the windowed arm's clock cells unresolvable at the
+           tournament's committed window. A driver that measured it anyway and
+           labelled the number would publish a figure a reader can quote, so it
+           is absent from the roster and its reason travels in the file"
+    (is (= [:fine :coarse :chunked] clock/measured-arms))
+    (is (= #{:virtual} (set (keys clock/unaddressed))))
+    (is (re-find #"rf2-4t36" (:virtual clock/unaddressed))
+        "the reason names the ruling that made it, not this file")
+    (is (= (set arms/arm-ids)
+           (into (set clock/measured-arms) (keys clock/unaddressed)))
+        "every arm of the tournament is either measured or unaddressed — an arm
+         that fell out of both lists would vanish from the table silently")))
+
+(deftest the-floor-row-is-not-one-of-the-tournaments-operations
+  (testing "`:noop` is measured beside the cells and is not a cell. Folding it
+           into `operations` would put a row in the published table that the
+           tournament never registered"
+    (is (= [:sparse :bulk :reorder :edit] clock/operations))
+    (is (not (contains? (set clock/operations) clock/floor-op)))
+    (is (= (conj clock/operations clock/floor-op) clock/rows))))
+
+;; ---------------------------------------------------------------------------
+;; 2 — the pre-clock gate is the census's published table
+;; ---------------------------------------------------------------------------
+
+(def ^:private published-markup
+  "[§2.2](../../../../../../../docs/design/hicasso/product/topology-tournament.md#22-the-rung-2-teaching-table--rows-of-markup-built),
+  transcribed as exact integers over the three measured arms.
+
+  Stated here rather than derived, deliberately: `clock-app/markup-expected`
+  is the derivation, and a witness that re-derived it would agree with it
+  by construction whatever either of them said."
+  {[:sparse  100]  {:fine 1 :coarse 100  :chunked 25}
+   [:sparse  300]  {:fine 1 :coarse 300  :chunked 25}
+   [:sparse  1000] {:fine 1 :coarse 1000 :chunked 25}
+   [:bulk    100]  {:fine 100  :coarse 100  :chunked 100}
+   [:bulk    300]  {:fine 300  :coarse 300  :chunked 300}
+   [:bulk    1000] {:fine 1000 :coarse 1000 :chunked 1000}
+   [:reorder 100]  {:fine 0 :coarse 100  :chunked 100}
+   [:reorder 300]  {:fine 0 :coarse 300  :chunked 300}
+   [:reorder 1000] {:fine 0 :coarse 1000 :chunked 1000}
+   [:edit    100]  {:fine 1 :coarse 100  :chunked 25}
+   [:edit    300]  {:fine 1 :coarse 300  :chunked 25}
+   [:edit    1000] {:fine 1 :coarse 1000 :chunked 25}})
+
+(deftest the-drivers-pre-clock-gate-is-the-published-census
+  (testing "a clock cell is only taken on a page that builds the markup the
+           census publishes for it, so the arithmetic that decides it must be
+           that census and not a near neighbour of it"
+    (doseq [b  m/row-counts
+            op clock/operations]
+      (is (= (get published-markup [op b])
+             (into {} (map (fn [arm] [arm (clock/markup-expected arm op b)]))
+                   clock/measured-arms))
+          (str op " at B=" b)))))
+
+(deftest the-floor-row-builds-nothing-in-any-arm
+  (testing "`[:topo/noop-write]` moves a key no arm reads, so the floor window
+           holds the per-commit cost and no row of markup. A floor that built
+           markup would be measuring an operation"
+    (doseq [b   m/row-counts
+            arm clock/measured-arms]
+      (is (= 0 (clock/markup-expected arm clock/floor-op b))
+          (str arm " at B=" b)))))
+
+;; ---------------------------------------------------------------------------
+;; 3 — the probe pairs, before any page exists
+;; ---------------------------------------------------------------------------
+
+(deftest every-operation-carries-a-cell-that-must-not-have-moved
+  (testing "a changed probe alone is satisfied by a write that reached every
+           row and by a page rebuilt from a stale seed. The second half of
+           every pair is what refuses both"
+    (doseq [b  m/row-counts
+            op clock/rows]
+      (let [es (clock/expectations op b 20)]
+        (is (= 2 (count es)) (str op " at B=" b " must carry exactly two probes"))
+        (is (not= #{:changed} (set (map :probe es)))
+            (str op " at B=" b " is verified by changed probes alone"))
+        (is (apply distinct? (map :cell es))
+            (str op " at B=" b " reads one cell twice, so one probe is free"))))))
+
+(deftest the-changed-probe-advances-by-exactly-one-per-commit
+  (testing "the read-back's whole arithmetic: whatever the operation moves must
+           be a pure function of the commit count, or a window that committed
+           nineteen of its twenty writes reads as verified"
+    (doseq [b  m/row-counts
+            op clock/operations]
+      (let [changed (fn [n] (->> (clock/expectations op b n)
+                                 (remove (comp #{:unchanged} :probe))
+                                 (map :want)
+                                 vec))]
+        (is (not= (changed 20) (changed 21))
+            (str op " at B=" b ": one more commit must be visible in the probe"))
+        (is (= (changed 20) (changed 20))
+            (str op " at B=" b ": and the same commit count must read the same"))))))
+
+(deftest the-floor-rows-pair-is-two-cells-that-must-not-move
+  (testing "the negative control, written as a read-back: a window over a
+           commit no arm reads must leave the page exactly where the seed put
+           it, and BOTH probes say so"
+    (doseq [b m/row-counts]
+      (let [es (clock/expectations clock/floor-op b 20)]
+        (is (= [:unchanged :unchanged] (mapv :probe es)) (str "at B=" b))
+        (is (= (mapv :want es) (mapv :want (clock/expectations clock/floor-op b 40)))
+            (str "at B=" b ": and the expectation does not depend on how many
+                 no-op commits ran, because none of them may reach the page"))))))
+
+;; ---------------------------------------------------------------------------
+;; 4 — the read-back, on a real page
+;; ---------------------------------------------------------------------------
+
+(def ^:private page-frame ::witness)
+(def ^:private decoy-frame ::witness-decoy)
+(def ^:private witness-b 100)
+
+(defn- mount-witness!
+  "One real `fine` page at [[witness-b]] rows, seeded. Answers the page map
+  `clock-app/window!` takes."
+  []
+  (lane/leave-act-environment!)
+  (m/make-frame! page-frame witness-b)
+  (m/reseed! page-frame witness-b)
+  (arms/reset-counters!)
+  (let [handle (mount/root! (mount/fresh-container!) page-frame
+                            [(arms/view-of :fine) {}])]
+    {:handle    handle
+     :frame-id  page-frame
+     :container (:container handle)
+     :b         witness-b
+     :committed (atom 0)}))
+
+(deftest the-window-verifies-a-page-that-did-commit
+  (testing "the refusal below has to be a discrimination, so the same window
+           over the same page's own frame must read 0 unverified — a probe pair
+           that always failed would prove nothing about the one that does"
+    (if-not (mount/browser?)
+      (skip! ":node-test has no DOM")
+      (doseq [op clock/rows]
+        (let [page (mount-witness!)
+              t    (lane/tally)]
+          (try
+            (clock/window! t page op)
+            (is (= {:writes 2 :unverified 0} (lane/tally-value t))
+                (str op ": every probe of a page that committed what it claims
+                     must read back, or the instrument refuses healthy runs"))
+            (finally (mount/release! (:handle page)))))))))
+
+(deftest the-window-refuses-a-page-that-did-not-commit
+  (testing "THE FAULT THE READ-BACK EXISTS TO CATCH. The commits are dispatched
+           into a frame nothing is mounted over, so `batch-k` writes and
+           `batch-k` settles happen and the observed page never moves. The
+           clock still returns a plausible number; the probes are what refuse
+           it"
+    (if-not (mount/browser?)
+      (skip! ":node-test has no DOM")
+      ;; `:noop` is excluded and the exclusion is the point: its pair is two
+      ;; UNCHANGED cells, so a page that committed nothing satisfies it by
+      ;; construction. That is what a floor row is, and it is why the floor is
+      ;; reported beside the cells rather than trusted as one.
+      (doseq [op clock/operations]
+        (let [page (mount-witness!)
+              _    (m/make-frame! decoy-frame witness-b)
+              t    (lane/tally)]
+          (try
+            (let [ms     (clock/window! t (assoc page :frame-id decoy-frame) op)
+                  misses (clock/probe-misses (:container page) op witness-b
+                                             @(:committed page))]
+              (is (number? ms)
+                  (str op ": the clock still answers — a withheld commit does not
+                       announce itself in milliseconds, which is the whole reason
+                       the read-back is not optional"))
+              ;; The CHANGED probe is the one that has to bite, and it is
+              ;; named rather than counted. An unchanged probe is SATISFIED by a
+              ;; page that committed nothing — that is what makes it the second
+              ;; half of a pair rather than a second detector — so asserting a
+              ;; miss count here would be asserting how many probes an operation
+              ;; happens to have that can see a dead page.
+              (is (contains? (set (map :probe misses)) :changed)
+                  (str op ": the probe that must have moved must refuse a page
+                       that never moved"))
+              (is (= {:writes 2 :unverified (count misses)} (lane/tally-value t))
+                  (str op ": and the window banks exactly what the probes found —
+                       a tally that disagreed with a direct read is the accounting
+                       fault, one level out from the page"))
+              (is (thrown? js/Error
+                    (lane/assert-verified! t (str "topo clock witness " (name op))))
+                  (str op ": and the lane's ONE adjudication of a read-back must
+                       throw on it — a count that is published and never
+                       adjudicated is the fault `assert-verified!` exists for")))
+            (finally (mount/release! (:handle page)))))))))
+
+;; ---------------------------------------------------------------------------
+;; 5 — and the gate the driver runs before any clock, live
+;; ---------------------------------------------------------------------------
+
+(deftest a-real-page-builds-the-markup-the-driver-predicts
+  (testing "`markup-expected` is checked against the published census above;
+           here it is checked against a page. Both are needed: the first says
+           the driver states the tournament's numbers, this says the tournament's
+           numbers still describe the arm"
+    (if-not (mount/browser?)
+      (skip! ":node-test has no DOM")
+      (doseq [arm clock/measured-arms
+              op  clock/rows]
+        (lane/leave-act-environment!)
+        (m/make-frame! page-frame witness-b)
+        (m/reseed! page-frame witness-b)
+        (let [handle (mount/root! (mount/fresh-container!) page-frame
+                                  [(arms/view-of arm) {}])]
+          (try
+            (arms/reset-counters!)
+            (clock/write! page-frame op 0)
+            (mount/settle!)
+            (is (= (clock/markup-expected arm op witness-b) (:markup (arms/runs)))
+                (str arm "/" op " at B=" witness-b))
+            (finally (mount/release! handle))))))))


### PR DESCRIPTION
The topology tournament pre-registered a 4 arms x 4 operations clock table and never
instrumented it. `topology-tournament.md` §2 is explicit about why, and it is not the
control:

> What withholds those three cells now is narrower and more ordinary: **the tournament's
> clock cells were never instrumented.** Only the control was built, it refused first, and
> no driver for the 4 arms x 4 operations table exists to run.

**The premise held at source.** `implementation/hicasso/test/re_frame/bench/hicasso/topo/`
carried exactly five files at tip — `arms.cljs`, `census_dom_cljs_test.cljs`,
`control_app.cljs`, `control_witness_dom_cljs_test.cljs`, `model.cljs` — and no driver
among them. Establishing that is a search returning zero, so it was run against a positive
control first: `grep -F "js/performance"` finds five files across the bench lane and none
under `topo/`; `grep -F "rounds!"` finds thirteen, of which the only `topo/` member is
`control_app.cljs`, the control. `git ls-files` agrees with the working tree.

## What landed

**`topo/clock_app.cljs`** — the driver, on the lane's generic `run.cjs`, taking no new
build id:

    HICASSO_INIT_FN=re-frame.bench.hicasso.topo.clock-app/-main \
    HICASSO_OUT_DIR=out/topo-clock HICASSO_PORT=8148 \
    node implementation/hicasso/test/re_frame/bench/hicasso/run.cjs

**`topo/clock_witness_dom_cljs_test.cljs`** — its deterministic half, an ordinary PR gate
that needs no quiet box.

**The window is not taken here.** A clock estimand needs a quiet box; building its driver
does not, and that split is the standing ruling this dispatch was fenced to.

## The rf2-m6i0 constraint, and how it is honoured

> A MANIPULATION CERTIFIES AN INSTRUMENT ONLY WHEN EVERY COST IN THE WINDOW MOVES WITH IT.

Two controls have been refused on this lane and both left a **shared constant** behind,
which compresses a measured ratio toward 1 and reads exactly like an instrument that cannot
see. So **this driver carries no control of its own.** It calls
`control-app/run-arm!` — the rendered-scale doubling with an indexed write, the one
manipulation on this lane in which the handler, the subscription layer and the render all
move together — runs it FIRST and ALONE, and takes no clock cell for an arm whose control
refused. That is §1.5 as registered. A second spelling of the control here would be a
second authority with nothing holding it in step, and it would be the third attempt at a
manipulation two windows have already priced.

Three further consequences of the same constraint:

* **The windowed arm is not measured, by ruling.** rf2-4t36 established that `virtual`'s
  cells are unresolvable at the committed window (a ~0.059 ms per-commit floor against a
  0.125 ms commit — 47% of the reading), so they are UNADDRESSED. `clock-app/unaddressed`
  holds the arm with that reason and **no clock starts on it**. Nothing is widened and the
  window is not enlarged. Measuring it and labelling the number would publish a figure a
  reader can quote.
* **A `:noop` floor row is measured beside every cell and corrects nothing.** It is the one
  window that holds only the cost that does *not* move with the arm. The same ruling
  rejected subtracting a separately-measured floor on three counts — the sharpest being
  that the identical fit returns +47% on one arm and negative constants on three — so
  `floor-shares` is a ratio of two measurements placed beside the cells, never applied to
  them. Nothing adjudicates on it.
* **The arm is the only manipulation in a row.** One page size, one operation, one batch,
  one probe pair, one set of rounds; all three arms' pages stand together for a whole row
  count so no cell is billed a different amount of DOM; mounts and releases are outside
  every window.

## What is reused rather than duplicated

`lane/rounds!` (the reflecting schedule and its warm-up discipline), `lane/summarise`,
`lane/ratio-between` with its `:straddles-1?` honesty flag, `lane/guard!`, `lane/tally` +
`lane/assert-verified!` (the lane's ONE meaning of *verified*), `lane/record!`/`fail!`/
`done!`, `lane/element-count`, `arms/expected`, `arms/runs`, `m/row-counts`, and the
control's own `batch-k`/`sampling`/`rounds` rather than a second set of numbers.
**`lane.cljs` is not touched** — the fence held, and no second scheduling mechanism was
added to it.

Two things are the driver's own and are argued in place: the per-operation probe pairs
(cell-addressed by `data-testid`, because a row's text node concatenates its label, its
`n`, its draft and its button caption), and `markup-expected`, the deterministic gate each
cell passes before its clock starts.

## Quality gates

Every number below is the exit code **captured from the runner's own shell** (`echo $?` on
the same command line as the redirect), not one reported about the run.

| gate | captured exit | result |
|---|---|---|
| `npm run test:hicasso-compile` | **0** | 145 namespaces (133 walked, up from 131), **0 warnings** |
| `node scripts/compile-node-test.cjs node-test out/node-test.js` | **0** | 2406 files, 0 warnings |
| `node out/node-test.js` | **0** | Ran 14027 tests / 71408 assertions — 0 failures, 0 errors |
| **SABOTAGE** `node out/node-test.js` | **1** | Ran 14027 tests / 71408 assertions — **3 failures**, 0 errors |
| `node node_modules/shadow-cljs/cli/runner.js compile browser-test` | **0** | 1263 files, 4 warnings — all four pre-existing `:infer-warning`s in `hicasso/test/re_frame/hicasso/native_ssr_dom_cljs_test.cljs`, a file this diff does not touch |
| `node scripts/serve-and-run-browser-tests.cjs` | **0** | Ran 1578 tests / 10076 assertions — 0 failures, 0 errors |
| `npm run test:hicasso-invariants` | **0** | freeze, module reachability, complaint catalogue, budget ledger, example fence, facade inventory, guide samples — each with its self-test |
| `sh scripts/test-fast-pr.sh` | **0** | `PASS  fast PR spine` — static tier, JVM tier, node tier (14027 tests / 71408 assertions, 0 failures), per-ns isolation, hicasso invariants, hicasso lint export, hicasso bench-lane compile |

`npm run test:cljs` is COMPOUND (`compile-node-test.cjs && node out/node-test.js`) and was
run as its two halves, each in the foreground to completion, so nothing was detached and no
build cache was left to an orphan. The fast spine was detached — it does not fit the
foreground ceiling — and polled to its exit file within the same turn.

**Which tree each gate read.** `test:hicasso-compile` prints its root and named
`C:\Users\miket\code\re-frame2-worktrees\topodriver-w01c\implementation\hicasso\test\re_frame\bench\hicasso`;
the browser runner prints
`Serving C:\Users\miket\code\re-frame2-worktrees\topodriver-w01c\implementation\out\browser-test`.
The node lane prints no root, so its tree is established by the planted fault below — the
fault exists only in this worktree, so a run that had wandered into a sibling's would have
come back green.

### The red proof, and the hash-verified restore

The plant is one line in `clock-app/markup-expected`: the `:reorder` / `:fine` cell,
**0 → 1**. It is bounded (one `case` branch), discriminating (the census publishes 0 there
— *"zero rows of markup are built for a table that visibly reorders"*), and scoped so it
cannot abort a namespace: the sabotage run executed **the same 14027 tests and 71408
assertions** as the control run, so nothing after it was skipped.

    FAIL in (the-drivers-pre-clock-gate-is-the-published-census)
      (re_frame/bench/hicasso/topo/clock_witness_dom_cljs_test.cljs:123:11)
    :reorder at B=100
      actual: (not (= {:fine 0, :coarse 100, :chunked 100}
                      {:fine 1, :coarse 100, :chunked 100}))

Three failures, one per row count, each naming the planted value. The failure prints the
*actual* map, which is positive evidence the runtime observed the plant rather than serving
a stale compile — the assertion read the planted function and reported what it returned.

Restore verified by content hash against the committed object, not by a diff (this checkout
translates line endings, so a plain byte digest would report a correct restore as failed):

    before   git rev-parse HEAD:...clock_app.cljs   a4ee8f894f07d8c6b69d0ac535341f694a1214e3
    planted  git hash-object    ...clock_app.cljs   8793bcbd343e5314efd9992ed3a6da7cac3ceae6
    after    git hash-object    ...clock_app.cljs   a4ee8f894f07d8c6b69d0ac535341f694a1214e3

The planted hash differs from both, so the patch genuinely applied rather than silently
no-opping, and the restored hash is byte-identical to the committed blob.

### And the browser lane's own negative control

The DOM half of the witness needs no plant, for the reason
`control_witness_dom_cljs_test.cljs` gives about its own: it **is** the sabotage. It mounts
a real `fine` arm and drives `clock-app/window!` — the same function the clock run calls,
banking into the same `lane/tally` — with the commits dispatched into a frame nothing is
mounted over. Twenty writes and twenty settles happen, the clock returns a plausible
number, the observed page never moves, and the changed probe refuses it while
`lane/assert-verified!` throws. The matching test proves it can answer *true* as well, so
the refusal is a discrimination and not a probe that always fails. There is nothing to
restore and nothing to hash.

That namespace is compiled into the browser build
(`out/browser-test/js/cljs-runtime/re_frame.bench.hicasso.topo.clock_witness_dom_cljs_test.js`)
and referenced by the runner's namespace list in `out/browser-test/js/test.js`, so the green
above is a green over code that ran.

## The fast-spine gap

`scripts/check_fast_pr_gap.py --list` — **106 required checks this spine does not run**.
Cited as the one path rather than enumerated by hand. It is a fact about the SPINE, not a
census of what this PR ran: **the spine did run** (row above), and the gates run directly
beyond it are `test:hicasso-compile`, the two halves of `test:cljs`, the two halves of
`test:browser`, and `test:hicasso-invariants`. Local-green is not CI; the merge decision is
CI's.

**Docstring link targets checked by hand.** The new namespaces carry relative links into
`docs/design/hicasso/product/`, which no gate validates from a `.cljs` docstring. Both
files resolve (`topology-tournament.md`, `budgets.md`, seven levels up from `topo/`, the
same depth `model.cljs` already uses) and the four anchors match their headings at lines
67, 91, 227 and 340 — `#14-…`, `#15-…`, `#22-…the-rung-2-teaching-table--rows-of-markup-built`
(em dash to double hyphen, the convention that page's own internal links use). No table was
added to any markdown page by this PR.

## The bead

**rf2-w01c stays OPEN.** This PR delivers the build half; the window half remains and is
now the whole of what the bead owes. rf2-85og2 is waiting on precisely this driver.
