### PR TITLE
bench(hicasso): split the author's share of the `:&` price into two clean pairs (rf2-v5oto)

### DIFF
--- a/implementation/hicasso/test/re_frame/bench/hicasso/amp_merge_arms_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/bench/hicasso/amp_merge_arms_cljs_test.cljs
@@ -1,0 +1,229 @@
+(ns re-frame.bench.hicasso.amp-merge-arms-cljs-test
+  "THE CLIFF THE `:&` LADDER FELL OFF, AND THE PAIRS THAT DO NOT (rf2-v5oto).
+
+  `amp_merge_clock_app`'s decomposition ladder prices the codec's
+  `merge-caller` cleanly and the AUTHOR's share only as a SUM, and the
+  reason is not statistical. One helper cannot omit a key for three
+  fields out of four without an `assoc`, so `field-explicit` writes
+  `:class` unconditionally and both of `rf2-z143r`'s rungs carry a
+  `:class nil` passenger — which would be a single map entry if a map
+  entry were a smooth cost. It is not:
+  `cljs.core/PersistentArrayMap`'s `HASHMAP-THRESHOLD` is EIGHT, and the
+  entry that would make nine promotes the whole map to a
+  `PersistentHashMap`. Rungs (1) and (3) were therefore comparing two
+  map REPRESENTATIONS, not two maps.
+
+  `rf2-v5oto` repairs that with two arms whose pairs stay on one side of
+  the cliff. This file is what stops the repair rotting: a rung whose
+  arms drift back across the boundary reads as a number rather than as a
+  fault, which is the class of defect the whole lane exists to refuse.
+
+  ## What is checked mechanically and what is checked by reading
+
+  Every field HELPER on the page is called here — the arms' own code,
+  never a copy of it — and what the helper contributes to the element's
+  attribute map is pinned exactly.
+
+  The CALL-SITE literals are not reachable. They live inside bodies that
+  read subscriptions, and `hicasso`'s `sub` refuses outside a boundary
+  render (`:rf.error/hicasso-sub-outside-render`), so a test cannot
+  evaluate one. Where a claim needs a call site, this file supplies the
+  remainder map ITSELF and hands the SAME map to both arms of the pair —
+  which is the stronger statement anyway, because it makes the two arms
+  provably differ by the thing under test and by nothing else.
+
+  The one fact held by reading is [[expanded-attr-keys]], `:expanded`'s
+  own eight keys in its own order. `:expanded` is a FROZEN arm — the
+  published figure is read off it — so the half of rung (1')'s equality
+  that cannot change is the half this file cannot reach, and the half
+  that can change is pinned below.
+
+  ## Anti-vacuity
+
+  [[the-old-rungs-crossed-the-cliff]] asserts the DEFECT: on a classless
+  field the ladder's own helpers land a nine-entry `PersistentHashMap`
+  where the frozen arms land an eight-entry `PersistentArrayMap`. Unless
+  that reads true, every equality above it is an equality between two
+  things that were never in danger of differing, and this file would
+  pass while checking nothing."
+  (:require [cljs.test :refer-macros [deftest is testing]]
+            [re-frame.bench.hicasso.amp-merge-clock-app :as amp]
+            [re-frame.hicasso.impl.codec :as codec]))
+
+;; ---------------------------------------------------------------------------
+;; The witness's own inputs
+;; ---------------------------------------------------------------------------
+;;
+;; Plain data, handed to BOTH arms of every pair. The arms' own call sites
+;; are unreachable (see the namespace docstring), and re-spelling them here
+;; would be the second-authority shape this lane refuses everywhere else —
+;; so nothing here claims to be a copy of one.
+
+(def ^:private draft
+  {:title "A title" :description "A description" :body "A body" :tagList "a,b"
+   :busy? false})
+
+(def ^:private errors {:description "can't be blank 0"})
+
+(def ^:private id 0)
+
+(def ^:private classless-remainder
+  "A field with no class — 300 of the page's 400."
+  {:type "text" :name "description" :placeholder "What's this article about?"
+   :data-testid "editor-description"})
+
+(def ^:private classless-remainder+nil-class
+  "The same field as `rf2-z143r`'s two rungs write it: one helper cannot
+  omit a key for three fields out of four, so the key is written and the
+  value is nil. THE PASSENGER, spelled out."
+  {:class nil
+   :type "text" :name "description" :placeholder "What's this article about?"
+   :data-testid "editor-description"})
+
+(def ^:private title-remainder
+  "The title field — 100 of 400, and the only one carrying a class."
+  {:class "form-control-lg"
+   :type "text" :name "title" :placeholder "Article Title"
+   :data-testid "editor-title"})
+
+(def ^:private expanded-attr-keys
+  "`expanded-body`'s attribute keys, in the order it writes them.
+
+  READ from the frozen arm rather than computed, because a body that
+  reads subscriptions cannot be evaluated outside a boundary render. It
+  is safe to hold this way and only this way: `:expanded` is frozen —
+  the published `:&` figure is read off it — so the vector cannot go
+  stale without the freeze breaking first, and it is `field-lean`, the
+  arm that CAN move, whose keys are pinned against it below."
+  [:type :name :placeholder :data-testid :value :disabled :on-blur :on-input])
+
+;; ---------------------------------------------------------------------------
+;; Reading a helper's answer
+;; ---------------------------------------------------------------------------
+
+(defn- input-of
+  "The `[:input …]` vector a field helper builds: the fieldset's first
+  child."
+  [hiccup]
+  (nth hiccup 1))
+
+(defn- attrs-of
+  "The attribute map a field helper writes into its element."
+  [hiccup]
+  (nth (input-of hiccup) 1))
+
+(defn- presented
+  "The map the CODEC actually meets — `merge-caller` run over the
+  element's attribute map, which folds a `:&` remainder in and answers
+  the map by identity when there is none. The `:&` arms and the
+  spelled-key arms are therefore read through one function rather than
+  two, so a comparison between them is a comparison of the same
+  quantity."
+  [hiccup]
+  (codec/merge-caller (attrs-of hiccup)))
+
+;; ---------------------------------------------------------------------------
+;; The cliff itself
+;; ---------------------------------------------------------------------------
+
+(deftest the-array-map-cliff-is-where-the-ladder-says-it-is
+  (testing "`PersistentArrayMap`'s own threshold, in the ClojureScript compiled here"
+    (is (= 8 (.-HASHMAP-THRESHOLD PersistentArrayMap))
+        "the ladder's whole diagnosis rests on this number"))
+
+  (testing "eight entries is an array map and the NINTH promotes"
+    (let [eight (reduce (fn [m i] (assoc m (keyword (str "k" i)) i)) {} (range 8))
+          nine  (assoc eight :k8 8)]
+      (is (= 8 (count eight)))
+      (is (instance? PersistentArrayMap eight))
+      (is (= 9 (count nine)))
+      (is (instance? PersistentHashMap nine)
+          "one more entry, and the map is a different data structure")))
+
+  (testing "the COMPILER draws the same line: a nine-key literal is a hash map"
+    (is (instance? PersistentArrayMap
+                   {:a 1 :b 2 :c 3 :d 4 :e 5 :f 6 :g 7 :h 8}))
+    (is (instance? PersistentHashMap
+                   {:a 1 :b 2 :c 3 :d 4 :e 5 :f 6 :g 7 :h 8 :i 9}))))
+
+;; ---------------------------------------------------------------------------
+;; Rung (1') — the author's wrapper, cleanly
+;; ---------------------------------------------------------------------------
+
+(deftest rung-1-prime-writes-expandeds-eight-keys-and-no-ninth
+  (let [lean (attrs-of (amp/field-lean draft errors id :description false
+                                       classless-remainder))]
+    (testing "`field-lean` writes `:expanded`'s keys, in `:expanded`'s order"
+      (is (= expanded-attr-keys (vec (keys lean)))))
+    (testing "and therefore stays on `:expanded`'s side of the cliff"
+      (is (= 8 (count lean)))
+      (is (instance? PersistentArrayMap lean)))
+    (testing "no `:class` key reaches the element at all"
+      (is (not (contains? lean :class))
+          "the passenger is absent, which is the whole of the repair"))
+    (testing "and the codec meets that map by identity — there is no `:&` here"
+      (is (identical? lean (codec/merge-caller lean))))))
+
+(deftest the-lg-helper-differs-from-the-plain-one-by-the-TAG-alone
+  (let [plain (amp/field-lean    draft errors id :description false classless-remainder)
+        lg    (amp/field-lean-lg draft errors id :description false classless-remainder)]
+    (testing "same remainder in, same attribute map out"
+      (is (= (attrs-of plain) (attrs-of lg)))
+      (is (= (vec (keys (attrs-of plain))) (vec (keys (attrs-of lg))))
+          "in the same order, so the codec walks them identically")
+      (is (= (type (attrs-of plain)) (type (attrs-of lg)))))
+    (testing "the title's extra class rides the tag, the way `:expanded` has it"
+      (is (= :input.form-control (nth (input-of plain) 0)))
+      (is (= :input.form-control.form-control-lg (nth (input-of lg) 0))))))
+
+;; ---------------------------------------------------------------------------
+;; Rung (3') — the author's round trip, cleanly
+;; ---------------------------------------------------------------------------
+
+(deftest rung-3-primes-two-arms-present-the-codec-the-same-map
+  (doseq [[label k remainder entries representation]
+          [["a classless field" :description classless-remainder 8 PersistentArrayMap]
+           ["the title field"   :title       title-remainder     9 PersistentHashMap]]]
+    (testing label
+      (let [;; `:merged` puts `:k` and `:busy?` INTO the caller map and
+            ;; its helper takes them back out; `:no-dissoc-lean` passes
+            ;; them as arguments. Both are handed the SAME remainder, so
+            ;; the round trip is the only thing between them.
+            merged (presented (amp/field draft errors id
+                                         (merge {:k k :busy? false} remainder)))
+            lean   (presented (amp/field-no-dissoc draft errors id k false
+                                                   remainder))]
+        (is (= merged lean) "the same attribute map")
+        (is (= (vec (keys merged)) (vec (keys lean))) "in the same order")
+        (is (= (type merged) (type lean)) "and in the same REPRESENTATION")
+        (is (= entries (count merged)))
+        (is (instance? representation merged))
+        (is (instance? representation lean))))))
+
+;; ---------------------------------------------------------------------------
+;; Anti-vacuity — the defect rf2-v5oto repairs, asserted rather than described
+;; ---------------------------------------------------------------------------
+
+(deftest the-old-rungs-crossed-the-cliff
+  (testing "rung (1): `field-explicit` writes `:class` whether or not there is one"
+    (let [old (attrs-of (amp/field-explicit draft errors id :description false
+                                            classless-remainder))]
+      (is (contains? old :class))
+      (is (nil? (:class old)) "the passenger, and its value is nil")
+      (is (= 9 (count old)))
+      (is (instance? PersistentHashMap old)
+          "a hash map where `:expanded` and `field-lean` build an array map")))
+
+  (testing "rung (3): the `:class nil` call site crosses where `:merged` does not"
+    (let [merged (presented (amp/field draft errors id
+                                       (merge {:k :description :busy? false}
+                                              classless-remainder)))
+          old    (presented (amp/field-no-dissoc draft errors id :description false
+                                                 classless-remainder+nil-class))]
+      (is (= 8 (count merged)))
+      (is (instance? PersistentArrayMap merged))
+      (is (= 9 (count old)))
+      (is (instance? PersistentHashMap old))
+      (is (not= (type merged) (type old))
+          (str "rung (3)'s two arms were a map REPRESENTATION apart on 300 of "
+               "the page's 400 fields, which is why it read NEGATIVE")))))

--- a/implementation/hicasso/test/re_frame/bench/hicasso/amp_merge_clock_app.cljs
+++ b/implementation/hicasso/test/re_frame/bench/hicasso/amp_merge_clock_app.cljs
@@ -69,6 +69,20 @@
                  five spelled-out keys replaced by one `:&`. Nothing else
                  differs between the two, which is what makes the pair a
                  price for `merge-caller` and for nothing else.
+    :helper-lean RUNG (1) AGAIN, AS A CLEAN PAIR (rf2-v5oto). `:helper`
+                 with the `:class` passenger taken out: no call site
+                 carries a `:class` key, and the title's extra class
+                 rides the TAG exactly as `:expanded` has it. Its
+                 attribute map is `:expanded`'s key for key and in
+                 `:expanded`'s order, so `:helper-lean`/`:expanded`
+                 differ only by the wrapper.
+    :no-dissoc-lean
+                 RUNG (3) AGAIN, AS A CLEAN PAIR (rf2-v5oto).
+                 `:no-dissoc` with the same passenger taken out: the
+                 three classless call sites drop `:class nil`, so every
+                 field's merged attribute map holds exactly what
+                 `:merged`'s holds. `:merged`/`:no-dissoc-lean` differ
+                 only by the `:k`/`:busy?` round trip.
 
   ## The decomposition ladder (rf2-z143r)
 
@@ -129,18 +143,74 @@
       SUM is, and it is passenger-free.
 
       **The passenger is not small, and the reason is a cliff rather
-      than a key.** With the nil class the merged attribute map holds
-      NINE entries on all four fields; without it, eight on three of
-      them — and `cljs.core/PersistentArrayMap` promotes to a
-      `PersistentHashMap` at exactly the ninth. So on 300 of the page's
-      400 fields the two arms are not one map entry apart but one map
-      REPRESENTATION apart, and no reading of rung (1) or rung (3) alone
-      should be quoted as the wrapper's or the round trip's price.
+      than a key.** `cljs.core/PersistentArrayMap`'s
+      `HASHMAP-THRESHOLD` is 8 and its `-assoc` promotes to a
+      `PersistentHashMap` on the entry that would make nine; the
+      compiler's `array-map-threshold` is the same 8, so a nine-key map
+      LITERAL is emitted straight as a `PersistentHashMap`. Both halves
+      matter here, because `merge-caller` builds the merged map by
+      `merge`ing the four owned entries onto the caller's remainder.
+      Against `:merged` — nine entries on the title, eight on the other
+      three — the nil class puts `:no-dissoc` a map REPRESENTATION
+      apart on 300 of the page's 400 fields. Against `:expanded` it is
+      all 400: `:expanded` carries no `:class` key at ALL, its four
+      literals are eight entries each, and `:helper`'s are nine each.
+      No reading of rung (1) or rung (3) alone should be quoted as the
+      wrapper's or the round trip's price.
 
-  So the ladder answers TWO questions and not three: rung (2) is the
+  So the three rungs answer TWO questions and not three: rung (2) is the
   CODEC'S share and is clean, and rungs (1) + (3) summed are the
-  AUTHOR'S share and are clean. Splitting the author's share into its
-  wrapper and its round trip needs an arm this ladder does not have.
+  AUTHOR'S share and are clean. That sum is the quantity a reader of
+  this ladder actually wants, and the record used to make them add two
+  printed vectors to get it — so it is a key of its own now, `:author`,
+  term by term and round by round over values already in the record.
+
+  ## Splitting the author's share — the clean pairs (rf2-v5oto)
+
+  A sum is not a split. `:helper-lean` and `:no-dissoc-lean` are the two
+  arms that make each half a pair differing by ONE thing whose two
+  members sit on the SAME SIDE of the array-map cliff on every one of
+  the 400 fields.
+
+    (1') THE AUTHOR'S WRAPPER, CLEANLY — `:helper-lean` / `:expanded`.
+         The helper writes the eight keys `:expanded` writes, in
+         `:expanded`'s order, and no ninth; the title's
+         `form-control-lg` rides the TAG in both arms. Both are a
+         `PersistentArrayMap` on all four fields, and what is left
+         between them is a remainder map built at the call site, a
+         function call, and the field key arriving as an argument rather
+         than as a literal. This rung also sheds the SECOND passenger
+         named above: the title's class reaches the emitted class slot
+         by the same route in both arms, so `fold-shorthand!` takes it
+         by identity in both and HD-023(c″)'s shorthand fold is no
+         longer inside the rung.
+
+         The lean arm spends TWO helpers to do it — `field-lean-lg` is
+         `field-lean` with one extra class on the tag and nothing else —
+         because the alternative is a branch inside one helper, and a
+         per-field branch is a passenger in the very rung this arm
+         exists to clean. Two functions cost the call site nothing: each
+         site still writes one map and makes one call.
+
+    (3') THE AUTHOR'S ROUND TRIP, CLEANLY — `:merged` /
+         `:no-dissoc-lean`. Dropping `:class nil` from the three
+         classless call sites makes each remainder map exactly the map
+         `:merged`'s helper hands to `:&` after its `dissoc` — same
+         keys, same order — so both arms hold nine entries on the title
+         and eight on the other three. What is left between them is
+         `:merged`'s call sites putting `:k` and `:busy?` INTO the
+         caller map and its helper taking them back out.
+
+  **THE TWO CLEAN RUNGS ARE NOT A CHAIN, and their sum is not
+  `:author`.** Each is a pair against a frozen arm and nothing joins
+  `:helper-lean` to `:no-dissoc-lean` in one step, so the record carries
+  `:split-residual` — `:author` minus (1') minus (3') — precisely so a
+  reader who subtracts is told the answer is NOT zero by construction.
+  It reduces to `(:helper-lean − :helper) − (:no-dissoc-lean −
+  :no-dissoc)`: the `:class` passenger costs a different amount on the
+  spelled-keys path than on the `:&` path, and the title's class reaches
+  the slot through the tag in (1') but through `:&` in (3'). A residual
+  with contents, not a check.
 
   ## The control is adjudicated STRICTLY, and per round (rf2-egdaq)
 
@@ -312,7 +382,15 @@
 ;; where the expanded arm spells the composition itself. The fairness gate
 ;; is what proves the two land on the same string.
 
-(defn- field
+;; EVERY FIELD HELPER ON THIS PAGE IS PUBLIC, and only so that
+;; `amp_merge_arms_cljs_test` can call the arms' OWN code rather than keep
+;; a second copy of it — the second-authority shape this lane refuses
+;; everywhere else. In ClojureScript `defn-` is `(defn ^:private …)` and
+;; `:private` is analyzer metadata alone: the emitted function is the same
+;; function, so no arm's behaviour, allocation or timing moves. The
+;; frozen arms' bodies are otherwise untouched.
+
+(defn field
   [draft errors id {:keys [k busy?] :as attrs}]
   [:fieldset.form-group
    [:input.form-control {:&        (dissoc attrs :k :busy?)
@@ -366,7 +444,7 @@
 ;; too. It costs one map entry and one `class-names` call that `:merged`
 ;; does not pay, and the docstring's rung (3) says which way that leans.
 
-(defn- field-explicit
+(defn field-explicit
   "RUNG 1's helper. Explicit arguments, no `:&`, no `dissoc` — the five
   forwarded attributes are read off the remainder map and written as
   ordinary keys, so the codec meets a plain attribute map and
@@ -389,7 +467,7 @@
                          :on-input    [:amp/edit id k ::h/value]}]
    (when-some [e (get errors k)] [:div.error-messages e])])
 
-(defn- field-no-dissoc
+(defn field-no-dissoc
   "RUNG 2's helper. `field-explicit` with its five spelled-out keys
   replaced by one `:&`, and nothing else changed. No `dissoc`: the field
   key and the busy flag arrive as arguments, so the remainder map is
@@ -455,6 +533,120 @@
                        :placeholder "Enter tags (comma-separated)"
                        :data-testid "editor-tags"})]))
 
+;; ---------------------------------------------------------------------------
+;; THE TWO CLEAN PAIRS — the same page a fifth and a sixth way (rf2-v5oto)
+;; ---------------------------------------------------------------------------
+;;
+;; Each of these is differenced against ONE FROZEN ARM, so what matters
+;; about each is what it shares with that partner rather than with its
+;; sibling here. `:helper-lean` holds `:expanded`'s eight attribute keys
+;; in `:expanded`'s order and carries the title's class on the TAG the way
+;; `:expanded` does. `:no-dissoc-lean` holds `:merged`'s remainder maps
+;; key for key and in their order — which is `:no-dissoc`'s call sites
+;; with `:class nil` gone from the three fields that have no class, the
+;; only edit either arm makes to the rung it repairs.
+;;
+;; Neither pair crosses the array-map cliff on any of the 400 fields, and
+;; that is the whole point of them: the ladder's rungs (1) and (3) each
+;; compare an eight-entry map against a nine-entry one, which is a
+;; `PersistentArrayMap` against a `PersistentHashMap`.
+
+(defn field-lean
+  "RUNG (1')'s helper. `field-explicit` with no `:class` key at all —
+  eight keys, `:expanded`'s eight, written in `:expanded`'s order — so
+  the codec meets an attribute map of the same size, the same shape and
+  the same representation the frozen arm hands it.
+
+  The two rebindings (`typ`, `nm`) are `field-explicit`'s and are there
+  for its reason: `type` and `name` are `cljs.core` fns."
+  [draft errors id k busy? {typ :type nm :name
+                            :keys [placeholder data-testid]}]
+  [:fieldset.form-group
+   [:input.form-control {:type        typ
+                         :name        nm
+                         :placeholder placeholder
+                         :data-testid data-testid
+                         :value       (get draft k)
+                         :disabled    busy?
+                         :on-blur     [:amp/blur id k]
+                         :on-input    [:amp/edit id k ::h/value]}]
+   (when-some [e (get errors k)] [:div.error-messages e])])
+
+(defn field-lean-lg
+  "[[field-lean]] with `form-control-lg` on the TAG and nothing else
+  changed — the title field's helper, and the reason no call site in this
+  arm needs a `:class` key.
+
+  A SECOND FUNCTION RATHER THAN A BRANCH, deliberately. One helper taking
+  an `lg?` flag would run a per-field test `:expanded` does not run, and
+  rung (1') exists to be free of exactly that class of passenger. The
+  call site pays the same either way — one map, one call — so the branch
+  would buy nothing and cost a term."
+  [draft errors id k busy? {typ :type nm :name
+                            :keys [placeholder data-testid]}]
+  [:fieldset.form-group
+   [:input.form-control.form-control-lg {:type        typ
+                                         :name        nm
+                                         :placeholder placeholder
+                                         :data-testid data-testid
+                                         :value       (get draft k)
+                                         :disabled    busy?
+                                         :on-blur     [:amp/blur id k]
+                                         :on-input    [:amp/edit id k ::h/value]}]
+   (when-some [e (get errors k)] [:div.error-messages e])])
+
+(defn lean-body
+  [{:keys [id]}]
+  (let [draft  (h/sub [:amp/draft id])
+        errors (h/sub [:amp/errors id])
+        busy?  (:busy? draft)]
+    [:fieldset
+     (field-lean-lg draft errors id :title busy?
+                    {:type "text" :name "title" :placeholder "Article Title"
+                     :data-testid "editor-title"})
+     (field-lean draft errors id :description busy?
+                 {:type "text" :name "description"
+                  :placeholder "What's this article about?"
+                  :data-testid "editor-description"})
+     (field-lean draft errors id :body busy?
+                 {:type "text" :name "body"
+                  :placeholder "Write your article (in markdown)"
+                  :data-testid "editor-body"})
+     (field-lean draft errors id :tagList busy?
+                 {:type "text" :name "tags"
+                  :placeholder "Enter tags (comma-separated)"
+                  :data-testid "editor-tags"})]))
+
+(defn no-dissoc-lean-body
+  "RUNG (3')'s page: [[field-no-dissoc]] — `:no-dissoc`'s own helper,
+  reused rather than re-spelled — over `:merged`'s remainder maps.
+
+  Each map here is what `:merged`'s `(dissoc attrs :k :busy?)` answers,
+  key for key and in the order `dissoc` leaves them: `:class` first on
+  the title, absent everywhere else. So the only thing this arm and
+  `:merged` do differently is where `:k` and `:busy?` travel."
+  [{:keys [id]}]
+  (let [draft  (h/sub [:amp/draft id])
+        errors (h/sub [:amp/errors id])
+        busy?  (:busy? draft)]
+    [:fieldset
+     (field-no-dissoc draft errors id :title busy?
+                      {:class "form-control-lg"
+                       :type "text" :name "title" :placeholder "Article Title"
+                       :data-testid "editor-title"})
+     (field-no-dissoc draft errors id :description busy?
+                      {:type "text" :name "description"
+                       :placeholder "What's this article about?"
+                       :data-testid "editor-description"})
+     (field-no-dissoc draft errors id :body busy?
+                      {:type "text" :name "body"
+                       :placeholder "Write your article (in markdown)"
+                       :data-testid "editor-body"})
+     (field-no-dissoc draft errors id :tagList busy?
+                      {:type "text" :name "tags"
+                       :placeholder "Enter tags (comma-separated)"
+                       :data-testid "editor-tags"})]))
+
 (defn floor-body
   "The crossing carrying nothing. A boundary is reached through a hiccup
   vector whatever its body answers, so the floor is the crossing and not
@@ -462,12 +654,14 @@
   [_]
   nil)
 
-(h/defview expanded-arm   [props] (expanded-body props))
-(h/defview expanded-arm-b [props] (expanded-body props))
-(h/defview merged-arm     [props] (merged-body props))
-(h/defview explicit-arm   [props] (explicit-body props))
-(h/defview no-dissoc-arm  [props] (no-dissoc-body props))
-(h/defview floor-arm      [props] (floor-body props))
+(h/defview expanded-arm       [props] (expanded-body props))
+(h/defview expanded-arm-b     [props] (expanded-body props))
+(h/defview merged-arm         [props] (merged-body props))
+(h/defview explicit-arm       [props] (explicit-body props))
+(h/defview no-dissoc-arm      [props] (no-dissoc-body props))
+(h/defview lean-arm           [props] (lean-body props))
+(h/defview no-dissoc-lean-arm [props] (no-dissoc-lean-body props))
+(h/defview floor-arm          [props] (floor-body props))
 
 ;; ---------------------------------------------------------------------------
 ;; The page — identical for every arm but the body
@@ -515,7 +709,15 @@
    {:id :helper :k 1 :elements page-elements
     :mount (mount-page explicit-arm) :unmount unmount-page}
    {:id :no-dissoc :k 1 :elements page-elements
-    :mount (mount-page no-dissoc-arm) :unmount unmount-page}])
+    :mount (mount-page no-dissoc-arm) :unmount unmount-page}
+   ;; THE TWO CLEAN PAIRS' arms, appended for the same reason (rf2-v5oto):
+   ;; every entry above keeps its position, so no arm the published rows
+   ;; or the ladder's rungs are read off changes slot. Neither is
+   ;; `:parity-exempt?` — both build the judged page.
+   {:id :helper-lean :k 1 :elements page-elements
+    :mount (mount-page lean-arm) :unmount unmount-page}
+   {:id :no-dissoc-lean :k 1 :elements page-elements
+    :mount (mount-page no-dissoc-lean-arm) :unmount unmount-page}])
 
 (defn- arm-named [id] (first (filter #(= id (:id %)) arms)))
 
@@ -544,14 +746,17 @@
   THE ARM COUNT IS NOT THE LEVER, and this settles it for `rf2-v5oto`.
   `run.cjs` names `fewer arms per round` as one of the three moves, and
   `rf2-z143r` taking the schedule from five arms to seven is the lead the
-  bead was filed on. The schedule arithmetic answers it: at n = 5, 7 and 8
-  every arm still banks 30 samples per run, every arm's phase strata are
-  still rounds 1-2 against rounds 4-5 at the same prior-execution counts,
-  and the null's true predecessor distribution keeps its kind
-  (`:expanded` 20, `:merged` 10). The null's POSITION did not move when
-  the ladder landed. Arm count buys wall-clock per round and a different
-  set of neighbours; it does not touch the axis the null failed on. So the
-  ladder stays whole and `rf2-v5oto`'s eighth arm is not blocked by this.
+  bead was filed on. The schedule arithmetic answers it: replaying
+  [[lane/rounds!]] against `order-guard/slot-order` at n = 5, 7, 8 and 9
+  on the sampling that failed, every arm still banks 30 samples per run,
+  every arm's phase strata are still rounds 1-2 against rounds 4-5 at the
+  same prior-execution counts, and the null's true predecessor
+  distribution is `{:expanded 20, :merged 10}` at every one of the four.
+  The null's POSITION did not move when the ladder landed. Arm count buys
+  wall-clock per round and a different set of neighbours; it does not
+  touch the axis the null failed on. So the ladder stays whole, and
+  `rf2-v5oto`'s two clean-pair arms — the eighth and the ninth — are not
+  blocked by this either.
 
   WHAT IS LEFT IS WARM-UP, and three is below the step the lane itself
   records: `lane.cljs`'s live reproduction read one control `10.32 10.26
@@ -686,6 +891,26 @@
                  p50s)]
     (assoc (lane/summarise vs) :per-round vs)))
 
+(defn- ns-combine
+  "Combine two or more [[ns-terms]] records with `f`, term by term and
+  round by round, and summarise the result the way [[ns-terms]]
+  summarises its own — over the combined vector, so `{:min :max :p50}`
+  matches the printed `:per-round` exactly rather than nearly.
+
+  EXACT ARITHMETIC OVER VALUES ALREADY IN THE RECORD. No arm is read a
+  second time and no estimator is re-run; a reader with the printed
+  vectors can reproduce every key this builds with a pencil.
+
+  Two callers, both of them quantities a reader was previously left to
+  compute: the AUTHOR'S passenger-free share, which is the sum of two
+  rungs that are individually uninterpretable, and the clean pairs'
+  residual, which is a difference of two such sums."
+  [f & terms]
+  (let [vs (apply mapv
+                  (fn [& xs] (lane/round4 (apply f xs)))
+                  (map :per-round terms))]
+    (assoc (lane/summarise vs) :per-round vs)))
+
 (defn- ladder-rung
   "One rung: the ratio of two arms over the floor-normalised per-round
   ratios, and the same pair's raw per-round difference in nanoseconds per
@@ -697,6 +922,31 @@
    :standing  standing
    :ratio     (lane/ratio-between ratios a b)
    :ns-per-site (ns-terms p50s a b)})
+
+(defn- derived-ns
+  "A ladder entry with no arm pair behind it: `:ns-per-site` built by
+  [[ns-combine]] from entries already in the record, and `:derived-from`
+  naming them so the row can be checked rather than trusted."
+  [standing from ns]
+  {:standing standing :derived-from from :ns-per-site ns})
+
+(defn- log-rung!
+  "One printed ladder row: the ns/field summary, the ratio when the row
+  has an arm pair behind it, and every per-round vector it carries. A
+  derived row has no ratio — a ratio of a SUM of differences is not a
+  ratio of anything — and prints without one rather than with a made-up
+  one."
+  [label {:keys [ratio ns-per-site]}]
+  (js/console.log
+    (str ";;   " label ": " (fmt (:p50 ns-per-site) 1) " ns/field ["
+         (fmt (:min ns-per-site) 1) " - " (fmt (:max ns-per-site) 1) "]"
+         (when ratio
+           (str "  ratio " (fmt (:mean ratio) 4)
+                " [" (fmt (:min ratio) 4) " - " (fmt (:max ratio) 4) "]"
+                (when (:straddles-1? ratio) "  <- ratio STRADDLES 1.0")))))
+  (js/console.log (str ";;     ns per-round:    " (pr-str (:per-round ns-per-site))))
+  (when ratio
+    (js/console.log (str ";;     ratio per-round: " (pr-str (:per-round ratio))))))
 
 (defn- measurement-method []
   (str "a SAMPLE is " boundaries " boundaries mounted into a fresh container "
@@ -715,7 +965,13 @@
        "and :no-dissoc are the DECOMPOSITION LADDER's two rungs (rf2-z143r), "
        "placed between :expanded and :merged so each step changes exactly one "
        "thing; they are judged by the fairness gate with the other three and are "
-       "differenced, never published as a figure of their own. Arms "
+       "differenced, never published as a figure of their own. :helper-lean and "
+       ":no-dissoc-lean are rf2-v5oto's CLEAN PAIRS — the same two author-side "
+       "steps, each taken against a frozen arm, with the :class key that put "
+       "rungs (1) and (3) on the far side of cljs.core/PersistentArrayMap's "
+       "eight-entry HASHMAP-THRESHOLD from their partners removed, so no pair's "
+       "two members differ in map REPRESENTATION on any field; they are "
+       "differenced too and never published alone. Arms "
        "interleaved at the SAMPLE level under the lane's rotating AND REFLECTING "
        "schedule, so no arm always follows the same neighbour; " rounds
        " rounds of " (:warmup sampling) " warm-up + " (:samples sampling)
@@ -795,19 +1051,50 @@
                 ;; rungs sum to `:whole` term by term and there is no
                 ;; residual to report; `:standing` is what the reader
                 ;; came for.
-                ladder   {:whole      (ladder-rung ratios p50s :merged :expanded
-                                                   :author-and-codec)
-                          :wrapper    (ladder-rung ratios p50s :helper :expanded
-                                                   :authors-code)
-                          :merge      (ladder-rung ratios p50s :no-dissoc :helper
-                                                   :codecs-code)
-                          :round-trip (ladder-rung ratios p50s :merged :no-dissoc
-                                                   :authors-code)}
+                rung     (fn [a b standing] (ladder-rung ratios p50s a b standing))
+                whole    (rung :merged :expanded :author-and-codec)
+                wrapper  (rung :helper :expanded :authors-code)
+                merge-r  (rung :no-dissoc :helper :codecs-code)
+                trip     (rung :merged :no-dissoc :authors-code)
+                ;; THE CLEAN PAIRS (rf2-v5oto). Each is one author-side
+                ;; step against a FROZEN arm, with the `:class` passenger
+                ;; that put rungs (1) and (3) a map REPRESENTATION apart
+                ;; taken out. They are two pairs and not a chain, so
+                ;; their total is compared with the derived `:author`
+                ;; sum rather than assumed equal to it.
+                wrap-c   (rung :helper-lean :expanded :authors-code)
+                trip-c   (rung :merged :no-dissoc-lean :authors-code)
+                author   (ns-combine + (:ns-per-site wrapper) (:ns-per-site trip))
+                author-c (ns-combine + (:ns-per-site wrap-c) (:ns-per-site trip-c))
+                ladder   {:whole            whole
+                          :wrapper          wrapper
+                          :merge            merge-r
+                          :round-trip       trip
+                          ;; The quantity rungs (1) and (3) only imply:
+                          ;; passenger-free by cancellation, and the one
+                          ;; author-side figure the three-rung ladder is
+                          ;; entitled to quote.
+                          :author           (derived-ns :authors-code
+                                                        [:wrapper :round-trip]
+                                                        author)
+                          :wrapper-clean    wrap-c
+                          :round-trip-clean trip-c
+                          :author-clean     (derived-ns :authors-code
+                                                        [:wrapper-clean :round-trip-clean]
+                                                        author-c)
+                          ;; NOT ZERO BY CONSTRUCTION, unlike
+                          ;; `:ladder-sum-residual` below. The flag is in
+                          ;; the record so a reader who subtracts is told
+                          ;; so by the run rather than by a docstring.
+                          :split-residual   (assoc (derived-ns :authors-code
+                                                               [:author :author-clean]
+                                                               (ns-combine - author author-c))
+                                                   :zero-by-construction? false)}
                 sum-check (mapv (fn [w r m t] (lane/round4 (- w (+ r m t))))
-                                (:per-round (:ns-per-site (:whole ladder)))
-                                (:per-round (:ns-per-site (:wrapper ladder)))
-                                (:per-round (:ns-per-site (:merge ladder)))
-                                (:per-round (:ns-per-site (:round-trip ladder))))
+                                (:per-round (:ns-per-site whole))
+                                (:per-round (:ns-per-site wrapper))
+                                (:per-round (:ns-per-site merge-r))
+                                (:per-round (:ns-per-site trip)))
                 tv       (lane/tally-value tally)]
             (lane/assert-teardown-clean! "the measured rounds")
             (lane/record! :amp-merge-clock
@@ -873,19 +1160,31 @@
             (doseq [[k label] [[:whole      "WHOLE      merged/expanded    (author + codec)"]
                                [:wrapper    "(1) wrapper   helper/expanded    AUTHOR'S code"]
                                [:merge      "(2) merge     no-dissoc/helper   CODEC'S code"]
-                               [:round-trip "(3) roundtrip merged/no-dissoc   AUTHOR'S code"]]]
-              (let [{:keys [ratio ns-per-site]} (get ladder k)]
-                (js/console.log
-                  (str ";;   " label ": " (fmt (:p50 ns-per-site) 1) " ns/field ["
-                       (fmt (:min ns-per-site) 1) " - " (fmt (:max ns-per-site) 1)
-                       "]  ratio " (fmt (:mean ratio) 4)
-                       " [" (fmt (:min ratio) 4) " - " (fmt (:max ratio) 4) "]"
-                       (when (:straddles-1? ratio) "  <- ratio STRADDLES 1.0")))
-                (js/console.log (str ";;     ns per-round:    " (pr-str (:per-round ns-per-site))))
-                (js/console.log (str ";;     ratio per-round: " (pr-str (:per-round ratio))))))
+                               [:round-trip "(3) roundtrip merged/no-dissoc   AUTHOR'S code"]
+                               ;; The derived key. (1) and (3) each carry the
+                               ;; `:class` passenger with opposite signs, so
+                               ;; only their sum is interpretable — and until
+                               ;; now only a reader with a pencil had it.
+                               [:author     "(1)+(3)  AUTHOR'S share, passenger-free (derived)"]]]
+              (log-rung! label (get ladder k)))
             (js/console.log
               (str ";;   ladder sum residual (ns/field, ZERO BY CONSTRUCTION — the rungs "
                    "are a chain): " (pr-str sum-check)))
+            ;; THE AUTHOR'S SHARE, SPLIT (rf2-v5oto). Two pairs, each one
+            ;; step against a frozen arm, neither crossing the array-map
+            ;; cliff on any field — so unlike (1) and (3) each is
+            ;; separately interpretable.
+            (js/console.log ";; ---- THE AUTHOR'S SHARE, SPLIT (rf2-v5oto) ----")
+            (doseq [[k label] [[:wrapper-clean    "(1') wrapper   helper-lean/expanded    AUTHOR'S code"]
+                               [:round-trip-clean "(3') roundtrip merged/no-dissoc-lean   AUTHOR'S code"]
+                               [:author-clean     "(1')+(3') AUTHOR'S share, split total"]]]
+              (log-rung! label (get ladder k)))
+            (log-rung!
+              (str "split residual (1)+(3) - (1')-(3') — NOT zero by construction; "
+                   "the `:class` key prices differently on the spelled-keys path than "
+                   "on the `:&` path, and the title's class rides the TAG in (1') but "
+                   "`:&` in (3')")
+              (:split-residual ladder))
             (js/console.log (str ";;   writes: " (:unverified tv) " unverified of "
                                  (:writes tv)))
             (when (pos? (:unverified tv))

--- a/implementation/hicasso/test/re_frame/bench/hicasso/lane_schedule_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/bench/hicasso/lane_schedule_cljs_test.cljs
@@ -42,11 +42,12 @@
 
   ## Arm counts
 
-  4, 5, 7 and 8 — `direct_return_clock`'s, `amp_merge_clock`'s before and
-  after `rf2-z143r`'s ladder, and the eighth arm `rf2-v5oto` wants. The
-  fault is invariant to all of them, which is the same arithmetic that
-  settles `rf2-6ta5r`'s arm-count question: the schedule length does not
-  move it.
+  4, 5, 7, 8 and 9 — `direct_return_clock`'s, `amp_merge_clock`'s before
+  `rf2-z143r`'s ladder and after it, the count `lane/observe!`'s own
+  docstring prices the fault at, and `amp_merge_clock`'s again once
+  `rf2-v5oto`'s two clean-pair arms land. The fault is invariant to all
+  of them, which is the same arithmetic that settles `rf2-6ta5r`'s
+  arm-count question: the schedule length does not move it.
 
   ## The second thing this file replays: HOW WARM the arm was (rf2-ydqzt)
 
@@ -74,9 +75,9 @@
 ;; ---------------------------------------------------------------------------
 
 (def ^:private arm-counts
-  "Every arm count this lane's page-mount harnesses run at, plus the one
-  `rf2-v5oto` proposes."
-  [4 5 7 8])
+  "Every arm count this lane's page-mount harnesses run at, including the
+  nine `rf2-v5oto` takes `amp_merge_clock` to."
+  [4 5 7 8 9])
 
 (defn- replay
   "Run `lane/rounds!` over `n` arms with a stub that records the true


### PR DESCRIPTION
**rf2-v5oto, RIG HALF ONLY. No measurement window was taken** — four other workers were
compiling on this box, so any window would have measured the fleet. Per Mike's 2026-08-14
ruling on rf2-2rtt6.140 the instrument is built now, on a loaded box, and the window runs
when the fleet is idle. The bead's own text agrees: the wanted pair "belongs in the SAME
rig change, never after a window". **rf2-v5oto stays OPEN and is now window-only.**

## The premise, checked at source before anything was built

The bead's diagnosis rests on one number and it holds, in the ClojureScript this repo
actually compiles against (`org.clojure/clojurescript 1.12.145`, `:lite-mode` set nowhere —
`grep -rF lite-mode` over the tracked tree returns zero against a positive control that
hits):

- **Runtime.** `cljs/core.cljs:7083` — `(set! (.-HASHMAP-THRESHOLD PersistentArrayMap) 8)`.
  `PersistentArrayMap`'s `-assoc` (core.cljs:7011) promotes to a `PersistentHashMap` when
  `(< cnt 8)` fails, i.e. on the entry that would make **nine**.
- **Compiler.** `cljs/compiler.cljc:422` — `array-map-threshold` is 8, and `emit-map` emits
  `new cljs.core.PersistentArrayMap(...)` for `(<= (count keys) 8)` and
  `cljs.core.PersistentHashMap.fromArrays(...)` otherwise. A nine-key **literal** is a hash
  map before it is ever assoc'd.
- Both halves matter, because `codec/merge-caller` builds the merged map as
  `(merge (without-slots caller …) owned)` — it starts from the caller's remainder and
  `conj`s the four owned entries onto it, so a 5-key remainder crosses on the ninth.

**One premise was narrower than stated, and the file now says so.** The docstring's "on 300
of the page's 400 fields the two arms are one map REPRESENTATION apart" is exact for rung
(3) — `:merged` is nine entries on the title and eight on the other three. For rung (1) the
figure is **400 of 400**: `:expanded` carries no `:class` key *at all* (the title's class is
in the tag), so its four literals are eight entries each while `:helper`'s are nine each.
The correction strengthens the case for the repair rather than weakening it.

## The two arms

Each is a pair against **one frozen arm**, and neither pair crosses the cliff on any of the
400 fields.

**`:helper-lean` — rung (1'), the author's wrapper.** `field-lean` writes exactly
`:expanded`'s eight keys in `:expanded`'s order and no ninth; `field-lean-lg` is the same
function with `form-control-lg` on the **tag**, which is where `:expanded` has it. Both arms
are a `PersistentArrayMap` on all four fields, and what is left between them is a remainder
map built at the call site, a function call, and the field key arriving as an argument.

This also sheds the *second* passenger the ladder names: the title's class reaches the
emitted class slot by the same route in both arms, so `fold-shorthand!` takes it by identity
in both and HD-023(c″)'s shorthand fold is no longer inside the rung.

*Two helpers rather than one branching helper* — a per-field `if` would be a passenger in
the very rung the arm exists to clean, and the call site pays the same either way (one map,
one call), so the branch would buy nothing and cost a term.

**`:no-dissoc-lean` — rung (3'), the author's round trip.** `field-no-dissoc` reused
unchanged, over `:merged`'s remainder maps: the three classless call sites drop
`:class nil`, so each remainder is key-for-key and order-for-order the map `:merged`'s
helper hands to `:&` after its `dissoc` (`dissoc` on a `PersistentArrayMap` preserves the
order of what remains). Both arms hold nine entries on the title and eight on the other
three. What is left between them is `:merged` putting `:k`/`:busy?` **into** the caller map
and taking them back out.

**They are two pairs, not a chain**, and the record says so rather than leaving a reader to
discover it by subtraction.

## The derived key

`ladder` gains `:author` — the passenger-free author-side share, the term-by-term,
round-by-round sum of rungs (1) and (3), which is the one author-side figure the three-rung
ladder is entitled to quote and which a reader previously had to add two printed vectors to
get. Exact arithmetic over values already in the record (`ns-combine`), no arm read twice
and no estimator re-run.

Beside it: `:wrapper-clean`, `:round-trip-clean`, `:author-clean` (the split's total) and
`:split-residual` — carrying `:zero-by-construction? false`, unlike `:ladder-sum-residual`.
It reduces to `(:helper-lean − :helper) − (:no-dissoc-lean − :no-dissoc)`, and the docstring
names what lives in it.

## Two edits that are not arms

- **The field helpers are now `defn` rather than `defn-`**, so `amp_merge_arms_cljs_test`
  calls the arms' OWN code instead of keeping a second copy of it. In ClojureScript
  `defn-` is `(defn ^:private …)` and `:private` is analyzer metadata alone — the emitted
  function is the same function, so no arm's behaviour, allocation or timing moves. The
  frozen arms' bodies are otherwise untouched.
- **`lane_schedule_cljs_test` gains n = 9.** Replaying `lane/rounds!` against
  `order-guard/slot-order` at the sampling the null failed on (`{:warmup 3 :samples 6}` × 5
  rounds), every arm banks 30 samples and the null's predecessor distribution is
  `{:expanded 20, :merged 10}` at n = 5, 7, 8 **and 9** alike — so the arm-count paragraph
  in `sampling`'s docstring, which previously said "the eighth arm rf2-v5oto wants", is now
  correct for the ninth as well and says how it was checked.

## The control — a planted fault, red, restored, hash-verified

The compile gate cannot see this property: a ninth key compiles perfectly. So the control is
`amp_merge_arms_cljs_test`, and the plant is exactly the fault the bead exists to remove —
`:class nil` added to `field-lean`'s literal map, pushing `:helper-lean` across the
array-map/hash-map threshold.

- pre-plant `git hash-object`: `66bc6b1eff60b15aa3dee73edfe1c58cd8dd79be`
- post-plant: `e53e2c5633751b92e4a03b1d924174be9797e4fd` — **the plant applied**
- the runtime observed it: the sabotage recompile reported `3 compiled` (not 0), so the
  build graph picked the edit up
- sabotage run: **captured exit 1**, `7 failures, 0 errors` out of 14022 tests / 71650
  assertions (the control was run before the rebase, hence 14022 rather than the post-retire
  11756 in the table below — the same seven assertions are in both bundles), **all seven in `re-frame.bench.hicasso.amp-merge-arms-cljs-test`** and each
  naming the plant:
  - `(= 8 (count lean))` → `(not (= 8 9))`
  - `(instance? PersistentArrayMap lean)` → `cljs.core/PersistentHashMap`
  - `(not (contains? lean :class))` → `(not (not true))`
  - the key-order assertion came back
    `[:placeholder :disabled :name :value :on-blur :type :data-testid :class :on-input]` —
    scrambled, which **is** the hash-map representation showing itself
- restored with `git checkout HEAD --`, then hash-verified against the committed object
  (this checkout translates line endings, so `git hash-object`, not a byte digest):
  restored `66bc6b1eff60b15aa3dee73edfe1c58cd8dd79be` = committed
  `66bc6b1eff60b15aa3dee73edfe1c58cd8dd79be`, tree clean.

The witness is also anti-vacuous by construction: `the-old-rungs-crossed-the-cliff` asserts
the DEFECT — on a classless field the ladder's own helpers land a nine-entry
`PersistentHashMap` where the frozen arms land an eight-entry `PersistentArrayMap`.

**Which tree the gates read.** `compile_gate.cjs` and the spine both print their root and
both named `C:\Users\miket\code\re-frame2-worktrees\ampsplit-v5oto`. For the node-test run,
which prints no root, the discrimination is the red itself: the planted fault existed only
in this worktree, so a run that had wandered into a sibling's would have come back green.

## Quality gates

Every number below is the exit code **this shell captured** (`ec=$?` on the same command
line as the redirect), never one the harness reported about the same run. Nothing was piped
through a filter.

| gate | pass/fail | captured exit |
|---|---|---|
| `npm run test:hicasso-compile` (after the change) | 144 namespaces, **0 warnings** (143 before — the new witness is auto-covered by the directory walk) | **0** |
| `node scripts/compile-node-test.cjs node-test out/node-test.js` (`test:cljs`, half 1) | 2406 files, 0 warnings | **0** |
| `node out/node-test.js` (`test:cljs`, half 2) | **14022 tests / 71650 assertions, 0 failures, 0 errors** | **0** |
| the same two halves with the fault planted | **7 failures**, all in `amp-merge-arms-cljs-test` | **1** (the red proof) |
| `npm run test:hicasso-invariants` | all self-tests fire, all checks pass | **0** |
| `scripts/test-fast-pr.sh` | **PASS fast PR spine** — JVM core 2243 tests / 11681 assertions, JVM hicasso 3 / 92, JS harness helpers all green, CLJS node **11756 tests / 59367 assertions, 0 failures, 0 errors**, per-ns isolation sweep clean, hicasso invariants + bench-lane compile clean | **0** |
| `scripts/test-fast-pr.sh --plan` | `docs=false jvm=true node=true`; JVM artefacts `implementation/core implementation/hicasso` | **0** |

`test:cljs` is COMPOUND (`compile && run`) and was split into two foreground calls rather
than detached — both finished well inside the harness ceiling, nothing was killed, and no
build cache was left to an orphan. `scripts/test-fast-pr.sh` does not split, so it was
detached and polled — log and exit file both — inside the same turn.

**Not run, with reasons:** no browser/DOM lane (`npm run test:browser*`) — this change adds
no DOM behaviour and the fairness gate that would exercise it runs inside the measurement
window, which this PR deliberately does not take. No `mkdocs build --strict` — the spine
classified `docs=false` and no page under `docs/` is touched; in particular
`docs/design/hicasso/decisions.md` is deliberately **not** amended (it is a queued conflict
magnet for four pending windows, and the next window to append will describe the rig as it
then is).

**The fast-spine-versus-required-CI gap:** `scripts/check_fast_pr_gap.py --list` — **94**
required checks the spine does not run on this base. (It read 106 before the rebase; PR #8322's
retire removed jobs, which is exactly why this number is cited by its command and not carried
forward by hand.) The spine DID run, to completion, and reported the three tiers it skipped:
the documentation gates (surface unchanged), the JVM artefact suites the diff does not touch,
and the browser/bundle/perf/Xray/mcp-conformance/tool-JVM lanes that are CI-only.
Local-green is not CI; the merge decision is CI's.

## Rebase

Rebased onto `origin/main` at `7682e306c9` **after** PR #8322 (the atomic ui+freehand
retire) landed, and **every gate above was re-run on that final base** — which changed the numbers
rather than merely reconfirming them: the CLJS suite reads 11756 tests where the pre-rebase run
read 14022, because the retire deleted the `ui` and `freehand` suites, and the required-check gap
moved from 106 to 94. The merge-base diff
(`git diff origin/main...HEAD`) is three files, all in
`implementation/hicasso/test/re_frame/bench/hicasso/`, and every deleted line is prose or
code this PR itself rewrites — nothing a sibling landed is reverted. `lane.cljs` is not
touched: the new arms needed no change there.
