### PR TITLE
test(hicasso): phase B gets a second and third null, at slots chosen to make the +0.022 offset's cause readable (rf2-lo7uy)

### DIFF
--- a/implementation/hicasso/test/re_frame/bench/hicasso/read_profile_app.cljs
+++ b/implementation/hicasso/test/re_frame/bench/hicasso/read_profile_app.cljs
@@ -94,6 +94,8 @@
   | `commit`    | [[frames-per-window]] frames x `rt/commit-boundary!` on the harvested entry | the shipping commit half |
   | `c-local`   | faithful copy: cell mint + subscribe + activation + baseline deref + watch + dispose hook + map insert + reader membership | the ablation baseline, validated against `commit` |
   | `c-null`    | `c-local` with NOTHING ablated — the same `C-FULL` mode, under a second id | THE NEGATIVE CONTROL: `c-local - c-null` has a true cost of exactly zero, so what it reads is the instrument's own error and nothing else (rf2-3l6hf) |
+  | `c-null-twin` | `c-local` again, at the slot whose kept-sample POSITION FOOTPRINT is `c-local`'s own | the POSITION null: any cost that is a function of sweep position cancels term by term between these two arms, so what it reads is error position cannot explain (rf2-lo7uy) |
+  | `c-null-curve` | `c-local` again, at a slot sharing `c-local`'s MEAN position on a different footprint | the CURVATURE null: a linear position drift cancels here too, a curved one does not (rf2-lo7uy) |
   | `c-noactivate` | `c-local` minus `interop/activate-derived-value!` | ON THIS HOST the uncached hook resolution, a real term (rf2-tcffa); the substrate's capture run under a ratom host (rf2-lzpfj) |
   | `c-nowatch` | `c-local` minus add-watch + the disposal hook     | the watch wiring |
   | `c-nosub`   | `c-local` with `compute-sub` in place of subscribe + deref | the reaction build + cache insert (the compute is kept, priced by the swap) |
@@ -150,9 +152,9 @@
   neither a symmetric error band nor any bound on the term, and the
   `< 0.006 ms/commit` figure once floated for reader membership is withdrawn.
 
-  ## The measured null, which is what arbitrates
+  ## The measured nulls, which are what arbitrate
 
-  **[[c-null]] is the negative control this instrument lacked** (rf2-3l6hf).
+  **`c-null` is the negative control this instrument lacked** (rf2-3l6hf).
   It is `c-local` again — the same `C-FULL` mode, the same work, a second id —
   so `c-local - c-null` has a true cost of EXACTLY ZERO by construction, and
   every millisecond it reads is the estimator's own error at this shape, on
@@ -180,6 +182,74 @@
   node and recomputes nothing, without it that deref runs the body raw. One
   computation either way, so `c-local - c-noactivate` is the capture
   BOOKKEEPING and not a second evaluation of the sub.
+
+  ## Three nulls, because one null cannot say what it is measuring
+
+  rf2-3l6hf's window read that null at **+0.0234 / +0.0219 / +0.0234
+  ms/commit** — three runs of a quantity whose true value is exactly zero,
+  every reading within one grid step of the others. The offset is real and
+  it is stable, and its CAUSE was left open between a residual arm-position
+  effect, within-sweep thermal or cache drift, and the pooled median's own
+  behaviour on a right-tailed arm. One null cannot separate those, because
+  one null is one pair of slots (rf2-lo7uy).
+
+  **An arm's SLOT is a measured property of it, not a presentation
+  detail.** [[rounds-async!]] visits the arms in [[lane/slot-order]]'s
+  order, which rotates by the sample index and reflects on odd ones — and
+  it is handed the SAMPLE index, not the round, so every round runs the
+  identical schedule. An arm therefore occupies the same multiset of sweep
+  positions in every round of every run, and no number of rounds averages a
+  positional bias away. That is worth saying beside a null which repeated to
+  within a grid step across three runs: a random error would not, and a
+  fixed positional bias would.
+
+  [[slot-footprint]] computes that multiset from [[lane/slot-order]] itself
+  rather than restating its arithmetic. At the eleven arms this roster now
+  carries and this window's `2 + 8` sampling it reads:
+
+      slot  1  c-local       [1 3 4 5 6 7 8 10]   mean 5.500
+      slot  2  c-null        [0 0 2 4 5 6 7  9]   mean 4.125
+      slot  9  c-null-twin   [1 3 4 5 6 7 8 10]   mean 5.500
+      slot 10  c-null-curve  [2 3 4 5 6 7 8  9]   mean 5.500
+
+  So the three nulls ask three DIFFERENT questions of the same zero:
+
+  - `c-null` sits on a footprint displaced from `c-local`'s in both its
+    mean and its shape. It is the pair the published +0.022 was measured
+    on, and it is left exactly where it was so the two windows can be read
+    against each other.
+  - `c-null-twin` sits on `c-local`'s footprint EXACTLY. Whatever the
+    within-sweep cost curve is — linear, a first-slot warm-up, anything at
+    all that is a function of position — it cancels term by term between
+    these two arms. What this one reads is error that position cannot
+    explain.
+  - `c-null-curve` shares `c-local`'s MEAN position on a different
+    footprint, so a linear drift cancels here and a curved one does not.
+
+  **What each outcome would license.** Three nulls reading alike puts the
+  offset somewhere other than sweep position — the estimator, or drift on a
+  clock the schedule does not touch. `c-null` offset with the twin at zero
+  puts it on position. The twin at zero and the curve away from it puts it
+  on position AND says the drift is not linear. The window decides; this
+  file only makes the question askable, and takes no window itself.
+
+  **Two things the extra nulls still do not license**, both held over from
+  rf2-3l6hf. Do NOT subtract a null from a published term and call the term
+  corrected: `c-null` calibrates slot 1 against slot 2 while reader
+  membership differences slot 1 against slot 6, and the correction would
+  assume the very positional model that is under test. And do NOT read any
+  null as a bound on anything — it is a measured property of the ESTIMATOR,
+  not of a cost.
+
+  **The existing arms are untouched, and the arm COUNT is not.** The two
+  nulls are APPENDED, so every arm the published series quotes keeps its
+  slot — `commit` 0, `c-local` 1, `c-null` 2, through `b-build` 8 — and
+  every subject, mode, frame, [[frames-per-window]], [[b-rounds]] and
+  [[b-sampling]] is exactly what it was. What cannot be held fixed is `n`,
+  which is an input to [[lane/slot-order]]: eleven arms is a different sweep
+  and therefore a new series, the same way nine arms was a new series
+  against the eight-arm runs before it. Absolutes are not arm-by-arm
+  comparable across that line, and no reading here is.
 
   Owner bead: rf2-6c237. Driver: `run.cjs` with
   HICASSO_INIT_FN=re-frame.bench.hicasso.read-profile-app/-main."
@@ -625,32 +695,78 @@
       (dotimes [i n]
         (subs/unsubscribe frame-id (aget roster i))))))
 
-(defn- phase-b-arms
+(def phase-b-arm-ids
+  "The phase-B roster IN SLOT ORDER — **the vector index IS the arm's
+  slot**, and a slot is a measured property of the arm (see the namespace
+  docstring's three-nulls section, rf2-lo7uy).
+
+  ONE authority. `-main` reported from a second copy of this list until
+  rf2-lo7uy, and a second copy is the shape where an arm gets sampled,
+  torn down and residue-gated on every sample and then never appears in a
+  row — invisible, because the missing arm is missing from the output that
+  would have shown it. [[phase-b-arms]] refuses to answer a roster that
+  disagrees with this one.
+
+  **The two nulls are appended and nothing is reordered**, so every slot
+  rf2-3l6hf's published window quotes is the slot it quoted."
+  [:commit :c-local :c-null :c-noactivate :c-nowatch
+   :c-nosub :c-noreaders :c-nomap :b-build :c-null-twin :c-null-curve])
+
+(def null-arm-ids
+  "Every arm whose delta against `c-local` has a TRUE COST OF EXACTLY ZERO
+  by construction — each is `c-local` again, the same `C-FULL` mode
+  through the same constructor under another id, differing from it in
+  nothing but its slot.
+
+  Three rather than one because one null is one pair of slots and so
+  cannot say whether the offset it reads is positional (rf2-lo7uy)."
+  [:c-null :c-null-twin :c-null-curve])
+
+(def ^:private delta-arm-ids
+  "The arms quoted and recorded as `c-local - arm`: every arm but the
+  shipping reference it is validated against, the base itself, and
+  `b-build`, which is not an ablation of `c-local` at all. Derived from
+  [[phase-b-arm-ids]] so a new arm cannot be sampled and then silently
+  dropped from the per-round record."
+  (into [] (remove #{:commit :c-local :b-build}) phase-b-arm-ids))
+
+(defn phase-b-arms
   "`entries` is {frame-id entry}; `sets` is {frame-id read-set};
-  `fss` is {frame-id frame-state-value} — read at setup, outside windows."
+  `fss` is {frame-id frame-state-value} — read at setup, outside windows.
+
+  Public so a witness can read the roster it BUILDS rather than the roster
+  it declares: every `:run` here is a closure, so the arms can be
+  constructed without a frame, a clock or a window."
   [entries sets fss ^js roster]
   (let [mk-local (fn [mode]
                    (fn []
                      (mapv (fn [f] (commit-local! mode f (get sets f) (get fss f)))
-                           commit-frames)))]
-    [{:id :commit
-      :run (fn []
-             (mapv (fn [f] (rt/commit-boundary! (get entries f) (fn [] nil)))
-                   commit-frames))}
-     {:id :c-local   :run (mk-local C-FULL)}
-     ;; The negative control: C-FULL again, so `c-local - c-null` has a
-     ;; true cost of exactly zero and reads the estimator's own error
-     ;; (rf2-3l6hf). It is built from the same `mk-local` as `c-local`
-     ;; rather than transcribed beside it, because a null whose code path
-     ;; could drift from the arm it nulls is not one.
-     {:id :c-null    :run (mk-local C-FULL)}
-     {:id :c-noactivate :run (mk-local C-NOACTIVATE)}
-     {:id :c-nowatch :run (mk-local C-NOWATCH)}
-     {:id :c-nosub   :run (mk-local C-NOSUB)}
-     {:id :c-noreaders :run (mk-local C-NOREADERS)}
-     {:id :c-nomap   :run (mk-local C-NOMAP)}
-     {:id :b-build
-      :run (fn [] (mapv (fn [f] (build-only! f roster)) commit-frames))}]))
+                           commit-frames)))
+        ;; Every null is built from the same `mk-local` as `c-local` rather
+        ;; than transcribed beside it, because a null whose code path could
+        ;; drift from the arm it nulls is not one (rf2-3l6hf).
+        arms [{:id :commit
+               :run (fn []
+                      (mapv (fn [f] (rt/commit-boundary! (get entries f) (fn [] nil)))
+                            commit-frames))}
+              {:id :c-local   :run (mk-local C-FULL)}
+              {:id :c-null    :run (mk-local C-FULL)}
+              {:id :c-noactivate :run (mk-local C-NOACTIVATE)}
+              {:id :c-nowatch :run (mk-local C-NOWATCH)}
+              {:id :c-nosub   :run (mk-local C-NOSUB)}
+              {:id :c-noreaders :run (mk-local C-NOREADERS)}
+              {:id :c-nomap   :run (mk-local C-NOMAP)}
+              {:id :b-build
+               :run (fn [] (mapv (fn [f] (build-only! f roster)) commit-frames))}
+              ;; The two slot nulls, APPENDED so no existing arm moves.
+              {:id :c-null-twin  :run (mk-local C-FULL)}
+              {:id :c-null-curve :run (mk-local C-FULL)}]]
+    (when-not (= phase-b-arm-ids (mapv :id arms))
+      (throw (ex-info (str "phase-B roster disagrees with `phase-b-arm-ids` — built "
+                           (pr-str (mapv :id arms)) ", declared "
+                           (pr-str phase-b-arm-ids))
+                      {:built (mapv :id arms) :declared phase-b-arm-ids})))
+    arms))
 
 (def ^:private b-sampling
   "The stability half of the rf2-3l6hf widening — see
@@ -674,6 +790,56 @@
   `read-profile-baseline-cljs-test` was written to avoid."
   []
   {:rounds b-rounds :sampling b-sampling :frames frames-per-window})
+
+;; ---------------------------------------------------------------------------
+;; Where an arm actually sits in the sweep (rf2-lo7uy)
+;; ---------------------------------------------------------------------------
+
+(defn slot-positions
+  "The sweep POSITIONS `slot` occupies across ONE round's KEPT samples,
+  with `n` arms under [[lane/slot-order]] and this `sampling`.
+
+  Read OUT of the schedule, never restated: the positions come from
+  `lane/slot-order` itself, which takes them from the order guard, so a
+  change to the plan moves these numbers instead of leaving them behind
+  as a second authority nothing holds in step.
+
+  Warm-up samples are excluded because the row is, and the row is what
+  carries the offset — [[rounds-async!]] runs every sample and collects
+  from `s >= warmup`. **The schedule does not vary by round**: it is
+  indexed by the sample, so this multiset is the arm's footprint in every
+  round of every run, and rounds cannot average a positional bias out of
+  it."
+  [n slot {:keys [warmup samples]}]
+  (into []
+        (map (fn [s]
+               (let [order (lane/slot-order n s)]
+                 (first (keep-indexed (fn [pos j] (when (= j slot) pos)) order)))))
+        (range warmup (+ warmup samples))))
+
+(defn slot-footprint
+  "`{:positions <sorted> :mean-position <ms-weight>}` for one slot.
+
+  The MEAN is what a linear within-sweep drift would price; the sorted
+  MULTISET is what any drift at all would, which is why both are kept.
+  Two arms sharing a footprint cancel every position-driven cost between
+  them exactly, whatever shape that cost has."
+  [n slot sampling]
+  (let [ps (slot-positions n slot sampling)]
+    {:positions     (vec (sort ps))
+     :mean-position (/ (reduce + ps) (count ps))}))
+
+(defn phase-b-slot-plan
+  "Every phase-B arm with its slot and its kept-sample position
+  footprint, in slot order — recorded into the transcript so a published
+  window carries the layout it was taken on and can be adjudicated
+  without anyone re-deriving the schedule by hand (rf2-lo7uy)."
+  ([] (phase-b-slot-plan phase-b-arm-ids (:sampling (phase-b-shape))))
+  ([arm-ids sampling]
+   (let [n (count arm-ids)]
+     (mapv (fn [slot id]
+             (assoc (slot-footprint n slot sampling) :id id :slot slot))
+           (range n) arm-ids))))
 
 (def clock-clamp-ms
   "The quantum of [[lane/now-ms]] on this host: Chrome clamps
@@ -985,7 +1151,8 @@
                                                         b-sampling b-rounds baseline))))
                               (.then
                                 (fn [{:keys [readings samples]}]
-                                  (let [ids  [:commit :c-local :c-null :c-noactivate :c-nowatch :c-nosub :c-noreaders :c-nomap :b-build]
+                                  (let [ids  phase-b-arm-ids
+                                        plan (phase-b-slot-plan)
                                         rows (arm-rows ids readings frames-per-window)
                                         p50s (per-round-p50s ids readings frames-per-window)
                                         gv-b (lane/guard! samples "read-profile phase B (in-page ms, diagnostic)")]
@@ -995,11 +1162,16 @@
                                                                                    (update :p50 lane/round4))])) rows))
                                     (lane/record! :read-profile-commit-per-round p50s)
                                     (lane/record! :read-profile-commit-per-round-deltas
-                                                  (per-round-deltas p50s :c-local
-                                                                    [:c-null :c-noactivate :c-nowatch
-                                                                     :c-nosub :c-noreaders :c-nomap]))
+                                                  (per-round-deltas p50s :c-local delta-arm-ids))
+                                    (lane/record! :read-profile-slot-plan
+                                                  (mapv #(update % :mean-position lane/round4) plan))
                                     (js/console.log ";; ==== READ PROFILE, PHASE B — THE COMMIT HALF (ms per 141-key boundary commit) ====")
                                     (js/console.log (phase-b-design-line b-rounds b-sampling frames-per-window))
+                                    (js/console.log ";;   slot plan (each arm's kept-sample sweep positions — the schedule is indexed by SAMPLE, so this footprint repeats identically every round; rf2-lo7uy):")
+                                    (doseq [{:keys [id slot positions mean-position]} plan]
+                                      (js/console.log (str ";;     slot " slot " " (name id)
+                                                           ": " (pr-str positions)
+                                                           "  mean " (fmt mean-position 3))))
                                     (doseq [id ids]
                                       (js/console.log (arm-line id (get rows id))))
                                     (js/console.log ";; ==== PHASE B DELTAS (c-local minus ablation; floors) ====")
@@ -1008,6 +1180,11 @@
                                       (js/console.log (str ";;   copy fidelity: c-local/commit = " (fmt (/ clocal commit') 4)))
                                       (js/console.log (delta-line "NULL CONTROL (c-local - c-null)" clocal (:p50 (get rows :c-null))))
                                       (js/console.log ";;     ^ true cost EXACTLY ZERO by construction — both arms are C-FULL. What it reads is this instrument's own error at this shape, and it is what the terms below are adjudicated against (rf2-3l6hf). It bounds no term's cost: a delta inside this spread is a term the window cannot SEE, which leaves its size open in both directions")
+                                      (js/console.log ";;     ^ slot 1 against slot 2, on footprints that differ in BOTH mean position and shape. The two nulls below hold that zero and move the SLOT, which is what makes the offset's cause readable rather than only its size (rf2-lo7uy)")
+                                      (js/console.log (delta-line "NULL CONTROL, position TWIN (c-local - c-null-twin)" clocal (:p50 (get rows :c-null-twin))))
+                                      (js/console.log ";;     ^ same zero, and this arm's kept-sample position footprint IS c-local's, so ANY cost that is a function of sweep position cancels term by term. A reading here is error sweep position cannot explain; a reading of zero here beside a non-zero c-null puts the offset ON position")
+                                      (js/console.log (delta-line "NULL CONTROL, equal MEAN position (c-local - c-null-curve)" clocal (:p50 (get rows :c-null-curve))))
+                                      (js/console.log ";;     ^ same zero, c-local's MEAN position on a DIFFERENT footprint: a linear within-sweep drift cancels here, a curved one does not. Read the three nulls together — alike means the offset is not positional; c-null alone means it is; c-null and this one means it is and is not linear")
                                       (js/console.log (delta-line "activation-capture (c-local - c-noactivate)" clocal (:p50 (get rows :c-noactivate))))
                                       (js/console.log ";;     ^ a REAL term here, NOT a floor and not an arbiter: nothing activates on this UIx host, but the hook key is never published and so never cached, and this prices that lookup (rf2-tcffa, rf2-19usn). The capture itself is real only under the ratom family (rf2-lzpfj)")
                                       (js/console.log (delta-line "watch-wiring (c-local - c-nowatch)" clocal (:p50 (get rows :c-nowatch))))

--- a/implementation/hicasso/test/re_frame/bench/hicasso/read_profile_slots_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/bench/hicasso/read_profile_slots_cljs_test.cljs
@@ -1,0 +1,196 @@
+(ns re-frame.bench.hicasso.read-profile-slots-cljs-test
+  "PHASE B'S NULLS SIT AT THREE DIFFERENT SLOTS, AND THE SLOTS ARE THE
+  POINT — pinned (rf2-lo7uy).
+
+  ## What this exists to catch
+
+  rf2-3l6hf's window measured a quantity whose true value is exactly zero
+  — `c-local - c-null`, the same `C-FULL` mode differenced against itself
+  under a second id — and read `+0.0234 / +0.0219 / +0.0234 ms/commit`,
+  three runs inside one grid step. Every phase-B term is a `c-local - X`
+  delta on that instrument, and most are only a few multiples of that
+  offset, so its CAUSE matters and one null cannot supply it: one null is
+  one pair of slots.
+
+  `read_profile_app` therefore carries three nulls, and the whole of their
+  value is WHERE THEY SIT. `rounds-async!` visits arms in
+  `lane/slot-order`'s reflecting rotation, indexed by the SAMPLE and not
+  the round, so every arm occupies a fixed multiset of sweep positions —
+  the same multiset in every round of every run. The layout was chosen so
+  that
+
+  - `c-null-twin` occupies `c-local`'s footprint EXACTLY, making any
+    position-driven cost cancel term by term between them;
+  - `c-null-curve` occupies a different footprint with `c-local`'s MEAN
+    position, so a linear drift cancels and a curved one does not;
+  - `c-null` stays where the published window had it, displaced in both.
+
+  **A null at the wrong slot still compiles, still runs, still reports a
+  number, and answers a different question from the one the transcript
+  says it answers.** Nothing else in the tree would notice: the arms are
+  built from one `mk-local`, so every null is byte-identical work, and the
+  only thing distinguishing them is a vector index. That is what these
+  rows hold.
+
+  ## What is deliberately NOT here
+
+  No clock, no frame, no window, no measurement. The claims are the
+  schedule's arithmetic and the roster's shape, and both are decidable
+  without running a bench. Whether the offset IS positional is a question
+  for the window this layout was built to make askable; this namespace
+  only refuses to let the instrument drift out from under it."
+  (:require [cljs.test :refer-macros [deftest is testing]]
+            [re-frame.bench.hicasso.lane :as lane]
+            [re-frame.bench.hicasso.read-profile-app :as app]))
+
+(defn- slot-of [id]
+  (first (keep-indexed (fn [i x] (when (= x id) i)) app/phase-b-arm-ids)))
+
+(defn- footprint [id]
+  (first (filter (comp #{id} :id) (app/phase-b-slot-plan))))
+
+;; ===========================================================================
+;; 1 — the roster has ONE authority
+;; ===========================================================================
+
+(deftest the-built-roster-is-the-declared-roster
+  (testing "`phase-b-arms` builds exactly the arms `phase-b-arm-ids`
+           declares, in exactly that order — the vector index IS the slot,
+           so a roster that disagreed would put every printed delta on a
+           different pair of slots from the one its label names"
+    (is (= app/phase-b-arm-ids
+           (mapv :id (app/phase-b-arms {} {} {} nil)))))
+
+  (testing "ids are distinct, because `arm-rows` keys by id and a duplicate
+           would silently pool two arms into one row"
+    (is (= (count app/phase-b-arm-ids)
+           (count (set app/phase-b-arm-ids)))))
+
+  (testing "every null is on the roster it is a null of"
+    (is (every? (set app/phase-b-arm-ids) app/null-arm-ids))
+    (is (= 3 (count app/null-arm-ids))
+        "three, because one null cannot say whether what it reads is
+         positional")))
+
+;; ===========================================================================
+;; 2 — the published slots did not move
+;; ===========================================================================
+
+(deftest the-nulls-were-appended-and-nothing-was-reordered
+  (testing "the nine arms rf2-3l6hf published hold the slots it published
+           them at. Their deltas are quoted as slot-1-against-slot-N, so
+           moving one silently re-labels a number that is already in a
+           committed transcript"
+    (is (= [:commit :c-local :c-null :c-noactivate :c-nowatch
+            :c-nosub :c-noreaders :c-nomap :b-build]
+           (subvec app/phase-b-arm-ids 0 9))))
+
+  (testing "and the two added nulls sit at HIGHER slots than the null they
+           join, which is what let the roster grow without a reorder"
+    (is (< (slot-of :c-null) (slot-of :c-null-twin)))
+    (is (< (slot-of :c-null) (slot-of :c-null-curve)))))
+
+;; ===========================================================================
+;; 3 — the footprint is READ OUT of the schedule, not restated beside it
+;; ===========================================================================
+
+(deftest the-footprint-comes-from-the-schedule-itself
+  (let [{:keys [sampling]} (app/phase-b-shape)
+        {:keys [warmup samples]} sampling
+        n (count app/phase-b-arm-ids)]
+
+    (testing "an arm's position at a kept sample is its index in that
+             sample's `lane/slot-order`, arm for arm"
+      (doseq [s (range warmup (+ warmup samples))]
+        (let [order (lane/slot-order n s)]
+          (doseq [slot (range n)]
+            (is (= (nth (app/slot-positions n slot sampling) (- s warmup))
+                   (first (keep-indexed (fn [p j] (when (= j slot) p)) order)))
+                (str "slot " slot " at sample " s))))))
+
+    (testing "so at every kept sample the arms occupy positions 0..n-1
+             exactly once between them — a permutation, which is a
+             property of the plan and not of any transcription of it"
+      (doseq [s (range warmup (+ warmup samples))]
+        (is (= (set (range n))
+               (into #{}
+                     (map (fn [slot]
+                            (nth (app/slot-positions n slot sampling) (- s warmup))))
+                     (range n)))
+            (str "sample " s))))
+
+    (testing "every arm is sampled the same number of times, so no
+             footprint is longer than another's"
+      (is (= #{samples}
+             (into #{} (map (fn [{:keys [positions]}] (count positions)))
+                   (app/phase-b-slot-plan)))))))
+
+;; ===========================================================================
+;; 4 — THE LAYOUT: three nulls, three footprints, three questions
+;; ===========================================================================
+
+(deftest the-three-nulls-sit-on-three-different-footprints
+  (let [base      (footprint :c-local)
+        twin      (footprint :c-null-twin)
+        curve     (footprint :c-null-curve)
+        displaced (footprint :c-null)]
+
+    (testing "THE TWIN IS c-local's FOOTPRINT EXACTLY — every position, not
+             merely the mean. That is the whole of its value: a cost that
+             is any function at all of sweep position cancels term by term
+             between these two arms, so what the pair reads is error that
+             position cannot explain"
+      (is (= (:positions base) (:positions twin))
+          "if these differ, `c-null-twin` is at the wrong slot and the
+           transcript's claim about it is false")
+      (is (= (:mean-position base) (:mean-position twin)))
+      (is (not= (:slot base) (:slot twin))
+          "and it is a genuinely different slot, not the same arm twice"))
+
+    (testing "THE CURVE shares the mean position and not the footprint, so
+             a linear within-sweep drift cancels here and a curved one
+             survives — which is the only thing that separates those two
+             once the twin has spoken"
+      (is (= (:mean-position base) (:mean-position curve)))
+      (is (not= (:positions base) (:positions curve))
+          "equal footprints here would make this null a second twin and
+           the curvature question unasked"))
+
+    (testing "THE DISPLACED null — the pair rf2-3l6hf published +0.022 on
+             — differs from c-local in both mean and shape, and is left
+             exactly where it was so the two windows can be read against
+             each other"
+      (is (not= (:mean-position base) (:mean-position displaced)))
+      (is (not= (:positions base) (:positions displaced))))
+
+    (testing "so the three nulls are three questions rather than one asked
+             three times"
+      (is (= 3 (count (into #{} (map :positions) [displaced twin curve])))))))
+
+;; ===========================================================================
+;; 5 — why the question is worth asking: the published rig's null WAS
+;;     positionally displaced
+;; ===========================================================================
+
+(deftest the-published-nine-arm-null-differenced-two-different-footprints
+  (let [sampling (:sampling (app/phase-b-shape))]
+
+    (testing "this row is about the NINE-arm rig rf2-3l6hf ran, and it is
+             only about that rig while the sampling is the one it used"
+      (is (= {:warmup 2 :samples 8} sampling)
+          "if this fails the row below describes a rig that never ran, and
+           it should be re-derived rather than adjusted"))
+
+    (testing "at nine arms `c-local` sat on slot 1 and `c-null` on slot 2,
+             and those two slots do NOT share a footprint — so the +0.022
+             the window reported was measured across a positional
+             difference, which is exactly the confound the new nulls exist
+             to resolve"
+      (let [a (app/slot-footprint 9 1 sampling)
+            b (app/slot-footprint 9 2 sampling)]
+        (is (not= (:positions a) (:positions b)))
+        (is (= 4.5 (:mean-position a)))
+        (is (= 3.375 (:mean-position b))
+            "the null's arm sat over a mean position more than a slot
+             earlier in the sweep than the arm it was differenced against,
+             in every round of every run")))))


### PR DESCRIPTION
Rig half of **rf2-lo7uy**. **No measurement window is taken here and no figure is published** — per Mike's 2026-08-14 ruling on rf2-2rtt6.140 (build the instrument now, on a loaded box; run the window when the fleet is idle) and the bead's own words, "adding arms is a rig change and belongs BEFORE the window". Four other workers were compiling on this box throughout.

## The premise, checked at source

Every claim in the dispatch holds where the tree says it should:

- `phase-b-arms` really did place `:c-local` at vector index 1 and `:c-noreaders` at index 6 — the "slot 1" and "slot 6" the studio page names.
- `docs/design/hicasso/studio/the-cold-read-mount-term.md` carries the three run-level null readings `+0.0234 / +0.0219 / +0.0234` and the un-discriminated candidate list.
- `implementation/hicasso/test/re_frame/bench/hicasso/data/readprofile-3l6hf/run{1,2,3}.txt` carry the same numbers in the transcripts.
- PR #8378 (`rf2-ml3kt`) had indeed rewritten this file ~10 minutes before dispatch; this branch is built on the merged version and every one of its distinctive passages survives verbatim (checked by fixed-string grep, each found exactly once).

One premise did **not** hold, and it could not: the brief asked that adding arms "leave the existing arms', subjects', sampling and schedule identical". The arm COUNT is an input to `lane/slot-order`, so any added arm changes the sweep. What is held identical is everything that can be: every existing arm's subject, mode, frames and slot index, and `frames-per-window` / `b-rounds` / `b-sampling`. Eleven arms is a new series, exactly as the studio page already says of nine against eight — "Nine arms rather than eight, so this is a new series and its absolutes are not arm-by-arm comparable with the eight-arm runs above."

## The arms added, and at which slots

Two `C-FULL` nulls, **appended** so no existing arm moves:

| slot | arm | footprint (kept-sample sweep positions) | mean |
|---|---|---|---|
| 1 | `c-local` | `[1 3 4 5 6 7 8 10]` | 5.500 |
| 2 | `c-null` (existing) | `[0 0 2 4 5 6 7 9]` | 4.125 |
| 9 | **`c-null-twin`** (new) | `[1 3 4 5 6 7 8 10]` | 5.500 |
| 10 | **`c-null-curve`** (new) | `[2 3 4 5 6 7 8 9]` | 5.500 |

Both are built from the same `mk-local C-FULL` as `c-local`, so all three deltas have a true cost of exactly zero by construction and differ from `c-local` in nothing but their slot.

## Why this layout discriminates (a) from (b) and (c)

`rounds-async!` visits arms in `lane/slot-order`'s reflecting rotation, and it hands that function the **sample** index, not the round. So the schedule is identical in every round: an arm occupies the *same* multiset of sweep positions in every round of every run, and no number of rounds averages a positional bias out. That alone is worth recording beside a null that repeated to within one grid step across three runs — a random error would not, a fixed positional bias would.

The bead framed candidate (a) as predicting a **monotone relationship with slot distance**. Reading the schedule out rather than assuming it shows that is not what a rotation produces — the physical quantity is the position *footprint*, and the three nulls were placed to separate the outcomes directly rather than to sample a distance axis:

- **`c-null-twin` occupies `c-local`'s footprint exactly.** Any cost that is a function of sweep position — linear, a first-slot warm-up, any shape at all — cancels term by term between these two arms. This is the sharpest single instrument on the rig: a non-zero reading here is error that position *cannot* explain.
- **`c-null-curve` shares `c-local`'s mean position on a different footprint.** A linear within-sweep drift cancels here; a curved one does not.
- **`c-null` stays exactly where the published window had it**, displaced in both mean and shape, so the two windows can be read against each other.

Which gives the window three distinguishable outcomes rather than one number:

| reading | conclusion |
|---|---|
| all three nulls alike | the offset is not sweep position — (b) as a global drift, or (c) |
| `c-null` offset, twin ≈ 0 | the offset is positional — (a) |
| twin ≈ 0, curve away from 0 | positional **and** non-linear |

The naive monotone-in-distance prediction is also readable off the same three arms (distances 1, 8, 9), and it is a *different* shape from the footprint prediction, so the window separates those too.

## Evidence that no existing arm's measurement changed

- The nulls are appended, never inserted: `subvec phase-b-arm-ids 0 9` is still `[:commit :c-local :c-null :c-noactivate :c-nowatch :c-nosub :c-noreaders :c-nomap :b-build]`, pinned by row 2 of the new witness.
- No `:run` body of any existing arm is touched. The only deletions inside `phase-b-arms` are the re-indent that moved the arms vector into a `let` binding so the roster assertion could read it, plus the `c-null` comment being generalised to cover all three nulls. Every `mk-local <MODE>` pairing is what it was, modulo leading whitespace: `:c-local`/`:c-null` → `C-FULL`, `:c-noactivate` → `C-NOACTIVATE`, `:c-nowatch` → `C-NOWATCH`, `:c-nosub` → `C-NOSUB`, `:c-noreaders` → `C-NOREADERS`, `:c-nomap` → `C-NOMAP`, and `:commit` / `:b-build` byte-identical.
- Eight hunks in the app file: three in the namespace docstring, one on `phase-b-arms`, one adding the three new pure fns after `phase-b-shape`, and three in `-main`'s phase-B reporting block. No hunk falls inside `commit-local!`, `build-only!`, `rounds-async!`, `residue-settle!`, `micro-table`, or any phase-A code.
- `commit-local!`, `build-only!`, `C-FULL`…`C-NOACTIVATE`, `commit-frames`, `frames-per-window` (32), `b-rounds` (8), `b-sampling` (`{:warmup 2 :samples 8}`), `residue-settle!`, the residue gate and `rounds-async!` are all unmodified.
- `lane.cljs` — the shared scheduling surface — **is not touched**. `slot-positions` reads `lane/slot-order` rather than restating its arithmetic, so the new fns needed no change there. (`worker/ampsplit-v5oto` and `worker/topodriver-w01c` were working the same directory and have since landed as `ff0be2e097` and `23f3d13064`; their files are `amp_merge_*`, `lane_schedule_cljs_test.cljs` and `topo/*`, disjoint from these two. This branch was rebased onto both and re-gated.)
- The merge-base diff (`origin/main...HEAD`, three-dot) was read for **reverts** before every push. It carries exactly two files and 27 deleted lines, all of them lines this change itself replaced. PR #8378's rewrite of this same file ten minutes before dispatch is fully intact — its distinctive passages (`That multiplier is the arm's and must not travel with the number`, `audit #8328 had to retract once already`, `rf2-19usn priced`, `0.0422 / 0.0484 / 0.0562`) each survive, found once apiece by fixed-string grep.
- Phase A is untouched end to end.

What *does* change, stated plainly: the arm count (9 → 11), and therefore the sweep. `-main`'s duplicate arm-id literal is also folded into `phase-b-arm-ids`, which `phase-b-arms` now refuses to disagree with — that literal was a real staleness hazard, since an arm added to the roster but not to the literal would have been sampled, torn down and residue-gated on every sample and then never appeared in a row.

## The red proof, and the hash-verified restore

Sabotage: `:c-null-twin` moved from slot 9 to slot 8 (swapped with `:b-build`) — a **wrong slot for a new null**, anchored to the single line of the `phase-b-arm-ids` vector that carries both keywords.

The build observed the plant (`compile-node-test.cjs` deletes `:output-to` before compiling and recompiled clean, exit 0), and the witness went red:

```
CAPTURED_EXIT=1
Ran 5 tests containing 116 assertions.
4 failures, 1 errors.

ERROR in (the-built-roster-is-the-declared-roster)
  "phase-B roster disagrees with `phase-b-arm-ids` — built […:b-build :c-null-twin…],
   declared […:c-null-twin :b-build…]"
FAIL in (the-nulls-were-appended-and-nothing-was-reordered)
  actual: (not (= […:c-nomap :b-build] […:c-nomap :c-null-twin]))
FAIL in (the-three-nulls-sit-on-three-different-footprints)
  "if these differ, `c-null-twin` is at the wrong slot and the transcript's claim about it is false"
  actual: (not (= [1 3 4 5 6 7 8 10] [0 0 2 4 5 6 7 9]))
  actual: (not (= 5.5 4.125))
  actual: (not (= 3 2))          ; the three nulls collapse to two footprints
```

The red names exactly what was planted, and it is a red only reachable from this tree — the fault existed nowhere else, so a run that had wandered into a sibling worktree would have come back green. **Plant scoped correctly**: control and sabotage runs both executed `5 tests containing 116 assertions`, so nothing was aborted part-way.

**Restore verified by content hash, not by diff** (`git hash-object`, version control's own hash against the committed object, on a CRLF-translating checkout):

| | `read_profile_app.cljs` |
|---|---|
| pre-plant | `c220a8c23c44ca6e19f9cab90528d932f271a784` |
| planted | `87fb98b1ac82026b7afd501a15cc3404fb092b14` |
| post-restore | `c220a8c23c44ca6e19f9cab90528d932f271a784` ✓ |
| after all three rebases | `c220a8c23c44ca6e19f9cab90528d932f271a784` ✓ |

The planted hash differs from both, so the patch genuinely applied rather than silently no-opping.

## Quality gates

Every number below is the exit code **captured by the shell that ran the gate** (`cmd > log 2>&1; echo "CAPTURED_EXIT=$?"`, one command line, one shell, no pipeline), not a number reported about the run.

**The trunk moved twice under this branch and every gate was re-run on the final base each time** — first onto the landed 722-file `ui`+`freehand` retire (#8322), then onto `ff0be2e097` (rf2-v5oto) and `23f3d13064` (rf2-w01c), both of which add namespaces to *this very directory* and so change what the hicasso compile gate walks (144 → 147 namespaces). A pre-rebase green would have been evidence about a tree that no longer existed. The figures below are all from the final base; a last rebase after them carried `.beads/issues.jsonl` checkpoints only, with no code, docs or config delta, so nothing was re-run for it.

| gate | captured exit | result |
|---|---|---|
| `npm run test:hicasso-compile` | **0** | 147 namespaces, 449 files, **0 warnings** (warnings are failures here) |
| `npm run test:hicasso-invariants` | **0** | all freeze / reachability / catalogue / ledger / fence / inventory / guide-sample checks + their self-tests |
| `test:cljs` — compile half (`node scripts/compile-node-test.cjs node-test out/node-test.js`) | **0** | |
| `test:cljs` — run half (`node out/node-test.js`) | **0** | `Ran 11771 tests containing 59589 assertions. 0 failures, 0 errors.` |
| `test:cljs` — focused (`--test=…read-profile-slots-cljs-test`) | **0** | `Ran 5 tests containing 116 assertions. 0 failures, 0 errors.` |
| **sabotage** run of the focused witness | **1** | 4 failures, 1 error — see above |
| `scripts/test-fast-pr.sh` (detached, polled in-turn) | **0** | `PASS fast PR spine`, zero `FAIL` lines. Docs tier skipped (surface unchanged); JVM tier ran `implementation/core` + `implementation/hicasso`; node/CLJS tier ran; clj-kondo at CI's pin (2026.04.15) ran `errors: 0`; its last step re-ran `test:hicasso-compile` |

`test:cljs` is compound and was **split into its two halves, each foregrounded to completion**, rather than detached — both finished well inside the harness ceiling. The fast-PR spine does not split by flag and does not fit; attempt 1 was hard-killed at the 10-minute foreground cap leaving **no exit file at all** (no verdict, not a pass), and it was re-run detached and polled to completion within the turn.

**Which tree each gate read.** `test:hicasso-compile` and `test-fast-pr.sh` both print their root, and both named `…/re-frame2-worktrees/slotnulls-lo7uy` (`gate root: /c/Users/miket/code/re-frame2-worktrees/slotnulls-lo7uy`). `test:cljs` prints no root, so the discrimination there is the planted red above.

**Gate coverage was checked, not assumed.** `:node-test` selects `ns-regexp "cljs-test$"` plus transitive requires; the new witness matches and the compile gate's directory walk picks it up (`--list` confirms). A fixed-string grep of `out/node-test.js` for the namespace returned a near-zero that was a **false zero** (CLJS name munging) — caught by re-running the check as `node out/node-test.js --test=<ns>`, which is what actually proves the namespace is in the bundle and runs.

**Fast-spine vs required-CI gap: `python scripts/check_fast_pr_gap.py --list`** — 94 required checks the spine does not run, measured on this branch after the rebase (it read 106 before the retire landed; PR #8386 is separately moving that number, so cite the script and not this figure). The spine **did** run, to completion, on the final base; the gates listed above were also run directly.

## What is deliberately not done

- **No window, no measurement, no published figure.**
- **No null subtracted from any published term as a "correction"** — `c-null` calibrates slot 1 against slot 2 while reader membership differences slot 1 against slot 6, and the correction would assume the very positional model under test.
- **No offset read as a bound on anything.** It is a measured property of the estimator, not of a cost.
- **`docs/design/hicasso/studio/the-cold-read-mount-term.md` untouched.** It is a faithful record of rf2-3l6hf's window and remains true; the record of the *new* window belongs to the window dispatch.

## Bead status

**rf2-lo7uy stays OPEN** — this is the rig half only, and it is now window-only. rf2-07rnj remains blocked on it.
