### PR TITLE
ci(test.yml): two stale-count comments stop citing numbers that rot (rf2-nuhru, rf2-badrf)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1039,9 +1039,14 @@ jobs:
           python-version: '3.12'
 
       # Self-test first, then the live round trip — the order every other
-      # pure-Python contract in this workflow uses. The self-test drives each of
-      # the eight rules red in turn, so a green live run below is a verdict
-      # rather than a checker that has quietly stopped firing.
+      # pure-Python contract in this workflow uses. The self-test drives each
+      # rule red in turn, so a green live run below is a verdict rather than a
+      # checker that has quietly stopped firing. HOW MANY rules is not written
+      # here on purpose (rf2-nuhru), the same call `hicasso-budget-ledger`
+      # below makes for the same reason: nothing links a count in this file to
+      # the rule list in that one, so this sentence read "eight" through the
+      # arrival of R9 and then R10. The self-test names its own cases as it
+      # runs.
       - name: Self-test the complaint-catalogue round trip
         run: python implementation/hicasso/scripts/check_complaint_catalogue.py --self-test
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1175,20 +1175,29 @@ jobs:
   # instance of the shape above and the cleanest case of the four.
   #
   # `implementation/hicasso/scripts/check_guide_samples.py` reads TWO input
-  # families (measured at the script, not assumed — `GUIDE_DIR` L121 and
-  # `SOURCE_ROOTS` L128-131):
+  # families, named at the script by `GUIDE_DIR` and `SOURCE_ROOTS`:
   #
-  #   docs/core/hicasso/**                        the 25 guide pages whose 188
-  #                                               fenced blocks it pins
+  #   docs/core/hicasso/**                          the guide pages whose fenced
+  #                                                 blocks it pins
   #   implementation/hicasso/src, .../test_kit/src  the sources it resolves the
-  #                                               34 hicasso verb use-sites against
+  #                                                 hicasso verb use-sites against
+  #
+  # BY SYMBOL AND WITHOUT COUNTS, ON PURPOSE (rf2-badrf). This block used to
+  # cite line numbers for both symbols and integers for pages, blocks and use-
+  # sites, over the words "measured at the script, not assumed" — and every one
+  # of the five had rotted before the PR that noticed, sending a reader who
+  # trusted the phrase to a line in the middle of the divergence ledger. A
+  # symbol survives an edit above it where a line number does not, and the
+  # counts are not needed here at all: the live run below PRINTS how many pages,
+  # blocks and use-sites it covered, which is the one place they cannot go
+  # stale.
   #
   # It is chained into `npm run test:hicasso-invariants`, whose only hosted
   # invocation is a step of the `cljs` job under
   # `needs.detect_changed_surfaces.outputs.cljs_node_test == 'true'`. ONLY THE
   # SECOND FAMILY ARMS THAT OUTPUT. The guide tree arms NOTHING AT ALL —
   # `.github/scripts/report-changed-surfaces.sh docs/core/hicasso/00-installation.md`
-  # returns ALL THIRTY-TWO outputs false, exit 0 — so a guide-only PR, which is
+  # returns EVERY ONE of its outputs false, exit 0 — so a guide-only PR, which is
   # precisely the edit this gate exists to police and by far the commonest one
   # against a documentation tree, runs the check NOWHERE. It would then next
   # redden on somebody else's source PR, over a block they did not write.


### PR DESCRIPTION
Two comment defects in `.github/workflows/test.yml`, same file, same class: a sentence that tells a reader how much a green tick proves, carrying integers that stopped being true. Neither bead changes any job's behaviour.

Both premises held at tip. Every figure below was re-derived in this worktree rather than copied from the beads — the whole deliverable is counts, and shipping fresh wrong ones would have been a poor joke.

## rf2-nuhru — the complaint-catalogue self-test comment

**Premise held.** The step comment claimed the self-test "drives each of the **eight** rules red in turn".

| | measured at tip | command |
|---|---|---|
| distinct rule ids in the checker | **10** (R1..R10) | `git grep -o -E 'R[0-9]+' -- implementation/hicasso/scripts/check_complaint_catalogue.py \| sed 's/.*://' \| sort -u -V` |
| rule cases armed by the self-test | **10** (R1..R10, one comment per case) | `git grep -n -E '^\s+# R[0-9]+ ' -- implementation/hicasso/scripts/check_complaint_catalogue.py` |
| self-test verdict | green | `python implementation/hicasso/scripts/check_complaint_catalogue.py --self-test` → `OK: check_complaint_catalogue self-test passed` |

So the bead's predicted ten is right, and it is right for the self-test as well as for the checker — the arms are there, not just the ids.

**Wording chosen: drop the number** ("drives each rule red in turn"), the bead's own second option and the mayor's ruling. Two reasons beyond the ruling. First, nothing links an integer in this file to the case list in that one, so the count rots silently every time a rule lands — it has now been wrong twice, at R9 and again at R10. Second, `hicasso-budget-ledger` directly below already made exactly this call for exactly this reason (rf2-93u6) and says so in its own comment; the two siblings now read the same way instead of one carrying a number and the other explaining why it does not.

The load-bearing half is kept verbatim: the self-test drives each rule red in turn, so a green live run below is a verdict rather than a checker that has quietly stopped firing.

## rf2-badrf — the guide-samples arming rationale

**Premise held, and the bead's own "actual" column still holds at tip.** The concern that PR #8322 (722-file ui/freehand retire) had moved these figures again turned out not to bite — it deleted no guide page and no fenced block.

| claim in the comment | measured at tip | command |
|---|---|---|
| `GUIDE_DIR` L121 | **L242** | `git grep -n -E 'GUIDE_DIR\|SOURCE_ROOTS' -- implementation/hicasso/scripts/check_guide_samples.py` |
| `SOURCE_ROOTS` L128-131 | **L249-252** | same |
| 25 guide pages | **29** | `git ls-files 'docs/core/hicasso/*.md' \| wc -l` |
| 188 fenced blocks | **217** | `git grep -c '^```' -- 'docs/core/hicasso/*.md' \| awk -F: '{s+=$2} END {print s}'` → 434 delimiters = 217 blocks |
| 34 hicasso verb use-sites | **104** | `python implementation/hicasso/scripts/check_guide_samples.py` |

The live run prints all three counts in one line, which is the independent check on the two greps:

```
Hicasso guide samples: 217 fenced blocks pinned across 29 pages (206 Clojure),
104 hicasso verb use-sites resolved, ... 1 declared divergence(s) + 0 absent
namespace(s) still live.
```

**A sixth stale figure, not on the bead.** The same block asserts the classifier probe "returns ALL THIRTY-TWO outputs false, exit 0". Measured at tip it returns **28**:

```
sh .github/scripts/report-changed-surfaces.sh docs/core/hicasso/00-installation.md | wc -l   → 28
sh .github/scripts/report-changed-surfaces.sh docs/core/hicasso/00-installation.md | grep -c '=false'   → 28
```

#8322 removed four outputs along with the ui surface. Leaving a known-stale integer sitting beside the five I was removing would have been absurd, so it goes the same way: the sentence now says *every one of its outputs*, which is the claim that was ever load-bearing and which a job deletion cannot move.

**What stays.** The argument is untouched and whole: the guide tree arms no classifier output, so a guide-only PR would run the checker nowhere, so the job must be unconditional. Only the decoration goes. Both input families are now named **by symbol** (`GUIDE_DIR`, `SOURCE_ROOTS`) rather than by line number — a symbol survives an edit above it where a line number does not, and this pair had already moved twice. The counts are not restored anywhere, because the live run below prints pages, blocks and use-sites as it covers them, which is the one place they cannot go stale.

**One number I deliberately kept**, per the ruling's "say which and why rather than restoring it silently": `measured 0.31s self-test + 0.61s live`. It is the only figure in the block that carries the argument rather than decorating it — cost is *why* the job can be unconditional. It also still holds: `time python .../check_guide_samples.py --self-test` reads 0.171s and the live run 0.251s on this machine, both comfortably inside the "sub-second" claim the sentence makes. A wall-clock timing is machine-dependent by nature, so it is not a pinned integer that a page addition invalidates — it is not the rotting class.

## The diff is comment-only

Confirmed three ways, not asserted:

1. Every added and removed line begins with `#`. Zero non-comment changed lines:
   `git diff origin/main...HEAD -- .github/workflows/test.yml | grep -E '^[+-]' | grep -v -E '^[+-]{3}' | grep -v -E '^[+-]\s*#' | wc -l` → **0**
2. No `jobs:` key, `if:`, `needs:`, `run:` or `uses:` line is touched — implied by (1) and visible in the diff.
3. **Strongest:** `yaml.safe_load` of the file before and after serialises to an identical digest, so GitHub Actions is handed literally the same workflow.
   `sha256(json(parse(origin/main:test.yml))) == sha256(json(parse(HEAD:test.yml)))` → `a82f2754...` both sides; 73 jobs both sides; job id list identical.

That last check also answers "does the workflow still parse" — it does, and it parses to the same thing. A comment edit can break a block scalar if it lands inside one; neither of mine does, and (3) is what proves it rather than eyeballing.

## What covers this file, and how I established it

Derived from the configs, not taken on nomination. Four gates read `.github/workflows/test.yml`, found via `git grep -n -F '.github/workflows' -- scripts/*.py`:

- `scripts/check_gate_scheduling.py` — reads `run:` values
- `scripts/check_fast_pr_gap.py` — parses jobs/steps
- `scripts/check_jvm_lane_rosters.py` — roster ↔ CI bijection
- `scripts/check_ci_reproduce_commands.py` — reproduce-command contract

**None of them validates a comment, by design.** `check_gate_scheduling.py` documents this at length (rf2-6ckzl): it deliberately excludes comments because `test.yml` "carries paragraph-long comments above nearly every job", and matching them let a deleted `run:` line read as still scheduled. So the honest answer is that **nothing in this repository validates comment text in this file** — which is why the numbers in both beads could rot in the first place.

**Nothing validates that the file is well-formed YAML either.** That is a genuine finding and I established it with a planted fault rather than by reading. I inserted a line that PyYAML rejects (`mapping values are not allowed here, line 1223`) and ran all four gates:

| gate | exit under a genuinely YAML-invalid `test.yml` |
|---|---|
| `check_jvm_lane_rosters.py` | 0 |
| `check_ci_reproduce_commands.py` | 0 |
| `check_fast_pr_gap.py` | 0 |
| `check_gate_scheduling.py` | 0 |

All four are hand-rolled line-based readers; there is no `actionlint` anywhere in the tree (`git grep -i -F actionlint` → empty) and `lint.yml` has no YAML job. GitHub itself is the only YAML validator, at workflow-load time. So I verified parsing by hand, as above, and the hand check is itself controlled: the same `yaml.safe_load` went red naming the planted line, so it bites.

**Negative controls, and that they discriminated this worktree.** `scripts/test-fast-pr.sh` prints `gate root: /c/Users/miket/code/re-frame2-worktrees/ymlcounts-cluster`, naming this checkout. For the silent gates I used the planted-fault route instead. Renaming the guide-samples `run:` script moved `check_fast_pr_gap.py` from **94** unrun to **95** — a fault that exists only in this tree, so a run that had wandered into a sibling's would have reported 94.

Both plants were restored and each restore verified by hashing the bytes, not by reading a diff: `git hash-object .github/workflows/test.yml` → `24ca208c804b11b5095133d6f53c312e716cdf2d`, equal to `git rev-parse HEAD:.github/workflows/test.yml`, with `git status --porcelain` empty.

## Quality gates

`scripts/test-fast-pr.sh` — the fast pre-checkin spine — **ran, in full, to completion, on the final post-rebase base.** Editing `.github/workflows/test.yml` is a `mark_all` trigger in `.github/scripts/report-changed-surfaces.sh`, so this workflow-only diff arms *every* surface: the spine ran `docs=false jvm=true node=true`, not the trivial subset a comment change might suggest.

| gate | how it was run | captured exit |
|---|---|---|
| `scripts/test-fast-pr.sh --repo-root <worktree>` | detached, redirect + `echo $?` on one command line in one shell, polled to completion | **0** |
| `scripts/check_gate_scheduling.py --verbose` | foreground | **0** |
| `scripts/check_jvm_lane_rosters.py` | foreground | **0** |
| `scripts/check_ci_reproduce_commands.py` | foreground | **0** |
| `scripts/check_fast_pr_gap.py --list` | foreground | **0** |
| `implementation/hicasso/scripts/check_complaint_catalogue.py --self-test` | foreground | **0** |
| `implementation/hicasso/scripts/check_guide_samples.py` (live) | foreground | **0** |

Spine counts: **62 steps run, 0 `FAIL` lines, final line `PASS fast PR spine`.** Within it, `gate-scheduling` reports 35 gate commands / 30 scheduled / 5 declared; `check_jvm_lane_rosters` 31 rostered artefacts with a clean bijection; `check_ci_reproduce_commands` 43 checker steps in sync; the node tier's `:node-test` build completed 1984 files, 0 warnings, and every per-namespace isolation sweep passed.

Every exit code above is the one **captured** by the shell that ran the gate, written to its own `.exit` file — not a number reported about the run by anything else.

*On how the spine was run.* A `test.yml` edit arms every tier, so the spine needs longer than the 10-minute foreground cap and the first attempt's shell was killed mid-compile. It was not split, because its tiers share one classification pass and it exposes no tier flag to split on; it was detached instead, with per-worktree **and** per-attempt names on both the log and the exit file, and polled on both within the turn — the log for progress, the exit file for the verdict. Worth recording that the spine defends this itself: it opened attempt 4 with `REAPING A PREVIOUS RUN: pid 1358924 is still live in this tree ... left alone it would interleave into this log and mutate out/node-test.js underneath the isolation sweep` (rf2-ketqy), and reaped the earlier attempt's orphan before starting. The cited run is therefore uncontended.

No gate was skipped by choice. `mkdocs --strict` is outside the spine's tiers for this diff (`docs=false`), which the spine's own PASS line enumerates.

The run was re-done from scratch after rebasing onto the final base (`a724be0d6d`). The pre-rebase run is not cited: it is evidence about a tree that no longer exists.

## Fast-spine vs required CI

`python scripts/check_fast_pr_gap.py --list` — cited as the single path rather than enumerated by hand. It reads **94** required checks the spine does not run, across 80 required jobs in 3 workflows (30 fully covered by the spine, 5 partly, 45 not at all). That is a fact about the **spine**, not a census of what this PR ran; the spine itself did run, in full, as recorded above.

## Merge-base read

`git diff --name-only origin/main...HEAD` (three-dot) → `.github/workflows/test.yml`, and nothing else. Read for reverts, not conflicts: `main` has moved since this branch forked, but `git log 6cf64aa9a1..origin/main -- .github/workflows/test.yml` is **empty**, so no sibling change to this file is being undone. The rebase was clean.

Fence re-derived at start-up and again before pushing: the two open PRs (#8384 `worker/slotnulls-lo7uy`, #8388 `worker/benchgate-peorl`) touch only `implementation/hicasso/test/**` and `TESTING.md`, and no worktree holds an uncommitted edit under `.github/workflows/`. This branch is the sole toucher.

**Total check count on this PR: 88** (`gh pr checks 8389 --json name | jq length`). That is the expected post-#8322 figure, not a partial rollup — the retire removed twelve required jobs, so a count near 88 rather than 100 is correct. It also independently confirms the diff moved no job key: had this PR added or removed one, the total would have moved with it.

Closes rf2-nuhru. Closes rf2-badrf.
