### PR TITLE
docs(disposition): the donor view surfaces get one record, and the bench tree gets its marker (rf2-hic-062)

### DIFF
--- a/docs/design/retirement/donor-surfaces.md
+++ b/docs/design/retirement/donor-surfaces.md
@@ -12,7 +12,7 @@ than any marker and needs no argument re-run here. What this page does is record
 three in one place, with the authority for each, so nobody re-derives the scope a fourth
 time.
 
-Measured on `origin/main` at `a724be0d6d`, 2026-08-16 15:06 AUSEST.
+Measured on `origin/main` at `83029f9a63`, 2026-08-16 15:31 AUSEST.
 
 ## The three surfaces
 
@@ -20,7 +20,7 @@ Measured on `origin/main` at `a724be0d6d`, 2026-08-16 15:06 AUSEST.
 |---|---|---|---|
 | `implementation/ui/` (`re-frame.ui`, the compiled-view substrate) | **REMOVE** — executed | Operator ruling, Mike 2026-08-14 (`rf2-0yp7w`); plan at [`freehand-and-ui.md`](freehand-and-ui.md) | Gone. `git ls-files implementation/ui` returns **0** |
 | `implementation/freehand/` (`re-frame.freehand`) | **REMOVE** — executed | Same ruling and plan | Gone. `git ls-files implementation/freehand` returns **0** |
-| `implementation/hicasso/test/re_frame/bench/hicasso/` (the frozen Hicasso bench tree) | **KEEP AS EVIDENCE** | `implementation/hicasso/frozen-sources.edn` and `rf2-0xgk`; tree marker at the tree's own [`README.md`](../../../implementation/hicasso/test/re_frame/bench/hicasso/README.md) | Present — 220 tracked files at the stamped commit, before this change adds its marker — and actively worked |
+| `implementation/hicasso/test/re_frame/bench/hicasso/` (the frozen Hicasso bench tree) | **KEEP AS EVIDENCE** | `implementation/hicasso/frozen-sources.edn` and `rf2-0xgk`; tree marker at the tree's own [`README.md`](../../../implementation/hicasso/test/re_frame/bench/hicasso/README.md) | Present — 221 tracked files at the stamped commit, before this change adds its marker — and actively worked |
 
 ### `re-frame.ui` and Freehand — removed, not archived
 
@@ -35,8 +35,8 @@ a search with a wrong pathspec answer in the same voice:
 
 ```
 git ls-files implementation/ui implementation/freehand | wc -l   ->   0
-git ls-files implementation/hicasso                    | wc -l   -> 458   (positive control)
-git ls-files implementation/adapters/uix              | wc -l   ->  16   (positive control)
+git ls-files implementation/hicasso                    | wc -l   -> 459   (positive control)
+git ls-files implementation/adapters/uix               | wc -l   ->  16   (positive control)
 ```
 
 The second control matters for a second reason. `re-frame2-ui` is a **prefix of

--- a/docs/design/retirement/donor-surfaces.md
+++ b/docs/design/retirement/donor-surfaces.md
@@ -20,7 +20,7 @@ Measured on `origin/main` at `a724be0d6d`, 2026-08-16 15:06 AUSEST.
 |---|---|---|---|
 | `implementation/ui/` (`re-frame.ui`, the compiled-view substrate) | **REMOVE** — executed | Operator ruling, Mike 2026-08-14 (`rf2-0yp7w`); plan at [`freehand-and-ui.md`](freehand-and-ui.md) | Gone. `git ls-files implementation/ui` returns **0** |
 | `implementation/freehand/` (`re-frame.freehand`) | **REMOVE** — executed | Same ruling and plan | Gone. `git ls-files implementation/freehand` returns **0** |
-| `implementation/hicasso/test/re_frame/bench/hicasso/` (the frozen Hicasso bench tree) | **KEEP AS EVIDENCE** | `implementation/hicasso/frozen-sources.edn` and `rf2-0xgk`; tree marker at the tree's own [`README.md`](../../../implementation/hicasso/test/re_frame/bench/hicasso/README.md) | Present, 220 tracked files, actively worked |
+| `implementation/hicasso/test/re_frame/bench/hicasso/` (the frozen Hicasso bench tree) | **KEEP AS EVIDENCE** | `implementation/hicasso/frozen-sources.edn` and `rf2-0xgk`; tree marker at the tree's own [`README.md`](../../../implementation/hicasso/test/re_frame/bench/hicasso/README.md) | Present — 220 tracked files at the stamped commit, before this change adds its marker — and actively worked |
 
 ### `re-frame.ui` and Freehand — removed, not archived
 
@@ -99,10 +99,10 @@ manifest states what each retirement cost.
 
 The published guide teaches one view story. `docs/core/views.md` sends a reader to the
 supported adapters (Reagent, reagent-slim, UIx) and to Hicasso as re-frame2's own native
-view layer, and names no donor; the `Hicasso: the view layer` nav section is the
-twenty-three-chapter guide plus its reference, cookbook, troubleshooting and escape
-ladder. `docs/core/freehand/`'s twenty-two pages went to zero on 2026-08-14 (`rf2-7cuns`)
-and the site nav changed with them.
+view layer, and names no donor; the `Hicasso: the view layer` nav section is a
+twenty-three-chapter guide plus its landing page, API reference, cookbook,
+troubleshooting, escape ladder and glossary. `docs/core/freehand/`'s twenty-two pages went
+to zero on 2026-08-14 (`rf2-7cuns`) and the site nav changed with them.
 
 One published page still presented a retired model as a live choice when this record was
 written, and it is fixed in the same change: `docs/skills/index.md`'s opening blurb

--- a/docs/design/retirement/donor-surfaces.md
+++ b/docs/design/retirement/donor-surfaces.md
@@ -1,0 +1,123 @@
+# Donor view surfaces — the disposition record
+
+re-frame2 spent a year with three overlapping view models in the tree at once. A reader
+arriving today must meet **one** taught story — Hicasso, its native tier, and the
+supported adapters — and every experimental donor surface must be dispositioned rather
+than merely quiet. This page is that record, filed under `rf2-hic-062`.
+
+It is short because two thirds of the question answered itself. `rf2-hic-062` was written
+in Phase 6 to weigh *archive / remove / keep-as-evidence* for three trees. By the time it
+was dispatched, two of the three had been **deleted**, which is a stronger disposition
+than any marker and needs no argument re-run here. What this page does is record all
+three in one place, with the authority for each, so nobody re-derives the scope a fourth
+time.
+
+Measured on `origin/main` at `a724be0d6d`, 2026-08-16 15:06 AUSEST.
+
+## The three surfaces
+
+| Donor surface | Disposition | Authority | State in the tree today |
+|---|---|---|---|
+| `implementation/ui/` (`re-frame.ui`, the compiled-view substrate) | **REMOVE** — executed | Operator ruling, Mike 2026-08-14 (`rf2-0yp7w`); plan at [`freehand-and-ui.md`](freehand-and-ui.md) | Gone. `git ls-files implementation/ui` returns **0** |
+| `implementation/freehand/` (`re-frame.freehand`) | **REMOVE** — executed | Same ruling and plan | Gone. `git ls-files implementation/freehand` returns **0** |
+| `implementation/hicasso/test/re_frame/bench/hicasso/` (the frozen Hicasso bench tree) | **KEEP AS EVIDENCE** | `implementation/hicasso/frozen-sources.edn` and `rf2-0xgk`; tree marker at the tree's own [`README.md`](../../../implementation/hicasso/test/re_frame/bench/hicasso/README.md) | Present, 220 tracked files, actively worked |
+
+### `re-frame.ui` and Freehand — removed, not archived
+
+PR #8322 deleted both trees on 2026-08-16 — 231 files and 376 files, every one status `D`
+— together with the docs, skills and examples that taught them. The plan that ordered the
+work, its census, and the reasoning behind each phase are recorded at
+[`freehand-and-ui.md`](freehand-and-ui.md), and that page is the authority; nothing here
+re-argues it.
+
+Both zeros were controlled rather than trusted, because a search that returns nothing and
+a search with a wrong pathspec answer in the same voice:
+
+```
+git ls-files implementation/ui implementation/freehand | wc -l   ->   0
+git ls-files implementation/hicasso                    | wc -l   -> 458   (positive control)
+git ls-files implementation/adapters/uix              | wc -l   ->  16   (positive control)
+```
+
+The second control matters for a second reason. `re-frame2-ui` is a **prefix of
+`re-frame2-uix`**, so an unanchored search for the retired artefact over-counts the UIx
+adapter, which is first-class and actively supported. Any sweep of this surface must
+anchor its pattern; one written from the bare prefix would propose deleting live code.
+
+**The `re-frame.ui` tooling-tier question is answered by the deletion.** `rf2-hic-062`
+asked it as an open question — whether a fixture-only tier of `re-frame.ui` should stay
+for the tools — citing the `rf2-hic-076` census. That census found the primary tool paths
+donor-free, and the fixture-only remainder went with the tree. One live reference is
+deliberate and stays: `tools/xray/src/day8/re_frame2_xray/mount.cljs` holds
+`:rf.adapter/ui` and `:rf.adapter/freehand` in the set of adapter kinds whose `:render`
+takes React elements, on the same defensive footing as the already-removed
+`:rf.adapter/helix`, because a stale co-loaded build could still present the kind. That is
+Xray's disposition and it is recorded in
+[`../hicasso/product/tool-consumer-census.md`](../hicasso/product/tool-consumer-census.md).
+
+Note also that `:rf.ui/*` **keys** are not `re-frame.ui`. They are the surviving tree
+ABI that Spec 004B holds live spec files to, and they are not donor residue.
+
+### The Hicasso bench tree — kept, because it is the evidence
+
+This tree is the measurement harness the Hicasso programme's numbers were taken on: the
+clock rows, the ladders, the topology tournament and the SSR spike are all readings taken
+from that source. Twelve files in it are the donors `re-frame.hicasso` was copied out of,
+and their divergence from the package is expected and permanent — a fix landing in the
+package leaves the bench file the stale copy, and back-porting is refused because it
+would invalidate the readings the package's own budgets are set against.
+
+Deleting or archiving it would delete the evidence base. It is kept, and the tree now
+carries the marker `rf2-hic-062` owed it: a
+[`README.md`](../../../implementation/hicasso/test/re_frame/bench/hicasso/README.md) at
+its root that names the twelve frozen donors, states the four rules a reader can act on,
+and separates them from the live harness around them. That distinction is the point of a
+tree-level marker: *keep as evidence* bounds what the tree may be used for, and does not
+mean *do not touch* — new benchmark arms land there routinely.
+
+`implementation/hicasso/frozen-sources.edn` is the executable authority for both halves,
+and `implementation/hicasso/scripts/check_freeze.py` is its check. It reports
+`1 frozen row(s)` today: only `front/slot.cljc` is still digest-pinned, the other eleven
+donors having been retired across three recorded retirements rather than re-pinned. The
+manifest states what each retirement cost.
+
+## What this record does not cover
+
+- **Spec prose.** `spec/` residue naming either retired tree belongs to `rf2-0yp7w.9`, the
+  retirement's own prose sweep, and is deliberately untouched here.
+- **Comment and docstring residue** left in `implementation/core/src`,
+  `implementation/ssr/src`, `examples/` and `migration/reagent-to-hicasso/codemod/`, and
+  the two generated-adjacent API pages `docs/api/re-frame.core.md` (its
+  `:rf.adapter/freehand` roster) and `docs/api/re-frame.ssr.md` (its `re-frame.ui.tree`
+  provenance). Same owner.
+- **The `docs/EP/` programme records.** EP-0030 to EP-0036 are the reason the withdrawal
+  is legible, and [`freehand-and-ui.md`](freehand-and-ui.md) rules explicitly that this
+  work does not delete them. They are history, they are not in the published nav, and a
+  reader who meets them has met history rather than a live choice.
+
+## The taught path, swept
+
+The published guide teaches one view story. `docs/core/views.md` sends a reader to the
+supported adapters (Reagent, reagent-slim, UIx) and to Hicasso as re-frame2's own native
+view layer, and names no donor; the `Hicasso: the view layer` nav section is the
+twenty-three-chapter guide plus its reference, cookbook, troubleshooting and escape
+ladder. `docs/core/freehand/`'s twenty-two pages went to zero on 2026-08-14 (`rf2-7cuns`)
+and the site nav changed with them.
+
+One published page still presented a retired model as a live choice when this record was
+written, and it is fixed in the same change: `docs/skills/index.md`'s opening blurb
+offered *"maintaining views on the retired `re-frame.ui` compiled-view substrate"* among
+the reasons to reach for a skill, and both it and `skills/README.md` counted **ten**
+skills against the nine that are actually in `skills/` and in the site nav — the residue
+of `skills/re-frame2-ui/` going with the tree.
+
+Both were found by an anchored sweep of the published tree:
+
+```
+git grep -cil -F freehand -- 'docs/*' ':!docs/design/*' ':!docs/tools/playground/*'
+git grep -cEi -- 're[-_]frame2?[-_.]ui($|[^x[:alnum:]])' -- 'docs/*' ':!docs/design/*' ':!docs/tools/playground/*'
+```
+
+Everything else those two searches return is one of the three exclusions above, or is
+`docs/release-process.md` and `docs/AUTHORING.md` stating the retirement as settled fact —
+which is the record working, not residue.

--- a/docs/design/retirement/freehand-and-ui.md
+++ b/docs/design/retirement/freehand-and-ui.md
@@ -7,6 +7,11 @@ in what order it must fall, and what proves the build never breaks between steps
 
 Filed under `rf2-0yp7w` phase 1. Census re-taken at `85a70687e4` on 2026-08-15 15:34 AUSEST.
 
+This page is the *plan*, and its subject is the two trees that go. The one-page record of
+what became of all three donor view surfaces — including the Hicasso bench tree, which is
+kept as evidence and is no part of this plan — is [`donor-surfaces.md`](donor-surfaces.md)
+(`rf2-hic-062`).
+
 ## Why this page is not in `docs/design/freehand/`
 
 The obvious home is the withdrawn programme's own design tree — but that tree is one of the things

--- a/docs/skills/index.md
+++ b/docs/skills/index.md
@@ -1,10 +1,10 @@
 # Skills
 
-> Ten Claude Code skills that travel with the re-frame2 repo — for authoring code, maintaining views on the retired `re-frame.ui` compiled-view substrate, critiquing existing code, bootstrapping a project, migrating from v1, rewriting Reagent views into Hicasso, building a new re-frame2 implementation, touring the Xray devtools panel, pair-programming with a running app, and running a retrospective on a pairing session.
+> Nine Claude Code skills that travel with the re-frame2 repo — for authoring code, critiquing existing code, bootstrapping a project, migrating from v1, rewriting Reagent views into Hicasso, building a new re-frame2 implementation, touring the Xray devtools panel, pair-programming with a running app, and running a retrospective on a pairing session.
 
 A **skill** is a small package of agent-shaped instructions plus optional scripts and reference leaves. When you load a skill into Claude Code (or any other Anthropic-skill-compatible agent), the model picks up its system prompt and its operating contract — so the same conversation that was *"help me write a re-frame2 event handler"* becomes a focused interaction that knows the canonical shapes, the cardinal rules, and where the depth lives.
 
-re-frame2 ships ten skills plus a shared protocol layer (`skills/shared/`), colocated under [`skills/`](https://github.com/day8/re-frame2/tree/main/skills) in this repo. Each skill is self-contained: its own `SKILL.md`, its own `references/` leaves, its own packaging metadata.
+re-frame2 ships nine skills plus a shared protocol layer (`skills/shared/`), colocated under [`skills/`](https://github.com/day8/re-frame2/tree/main/skills) in this repo. Each skill is self-contained: its own `SKILL.md`, its own `references/` leaves, its own packaging metadata.
 
 ## How to load a skill
 
@@ -19,7 +19,7 @@ It is idempotent and refuses to clobber a non-link copy without `--force`/`-Forc
 
 The repo's [`SKILL-REDIRECT.md`](https://github.com/day8/re-frame2/blob/main/SKILL-REDIRECT.md) is the deep-dive index for the **spec-consuming** skills — they point at it for spec-corpus depth and EP rationale. (Two skills route their deep-dives elsewhere: `re-frame2-xray` cites its own `tools/xray/spec/*` tree, and `re-frame2-improver` routes to `skills/re-frame2/patterns/` + `spec/`.)
 
-## The ten skills
+## The nine skills
 
 | Skill | Pitch |
 |---|---|

--- a/implementation/hicasso/test/re_frame/bench/hicasso/README.md
+++ b/implementation/hicasso/test/re_frame/bench/hicasso/README.md
@@ -1,0 +1,94 @@
+# The Hicasso bench tree
+
+**Disposition: KEEP AS EVIDENCE.** This tree is the measurement harness the Hicasso
+programme's numbers were taken on. It is not shipped, it is not a second implementation
+you may build against, and nothing under `implementation/hicasso/src/` may import it.
+It is also not archived: the harness is live and actively worked. Twelve files inside it
+are frozen donors, and this page exists so a reader can tell which is which.
+
+This is the tree-level marker `rf2-hic-062` owns. `front/controlled.cljs`'s namespace
+docstring carries one file's share of it (`rf2-u9o8k`, PR #8230) and points here for the
+rest; eleven sibling forks stand in exactly the same relation to their package
+namespaces and carry no such paragraph, which is the ambiguity this page answers once
+instead of twelve times.
+
+220 tracked files, of which 46 are measurement records under `data/`.
+
+## What is live here
+
+Most of this tree is ordinary, maintained test and benchmark code, and a change to it is
+an ordinary change. The clock arms, the ladders, the topology and shape suites, the SSR
+spike, the `*_cljs_test.cljs` suites and the Node runners are all driven by the package's
+own scripts — `npm run bench:hicasso`, `npm run test:hicasso-compile`,
+`npm run ssr:hicasso-bake`, and the roster of `.test.cjs` exit-path checks inside
+`test:script-helpers` (see `implementation/package.json`). New arms land here as a matter
+of course.
+
+So do not read *keep as evidence* as *do not touch*. It bounds what this tree may be used
+FOR — it is where measurements are taken, not where product code is grown — and it
+protects the twelve files below.
+
+## What is frozen here, and why
+
+`re-frame.hicasso` was copied out of this tree. Twelve files were the donors, and the
+copy's rename table is the roster —
+[`frozen-sources.edn`](../../../../frozen-sources.edn)'s `:renames`, seven under `front/`
+and five under `arm1/`:
+
+| Frozen donor | Package namespace it was copied into |
+|---|---|
+| `front/codec.cljs` | `re-frame.hicasso.impl.codec` |
+| `front/controlled.cljs` | `re-frame.hicasso.impl.controlled` |
+| `front/intent.cljs` | `re-frame.hicasso.impl.intent` |
+| `front/presence.cljs` | `re-frame.hicasso.impl.presence` |
+| `front/route_link.cljs` | `re-frame.hicasso.impl.route-link` |
+| `front/slot.cljc` | `re-frame.hicasso.impl.slot` |
+| `front/state.cljc` | `re-frame.hicasso.impl.state` |
+| `arm1/runtime.cljs` | split into `impl.{collector,generation,frames,roots,evidence,inventory}` |
+| `arm1/boundary.cljs` | `re-frame.hicasso.impl.boundary` |
+| `arm1/mount.cljs` | `re-frame.hicasso.impl.mount` |
+| `arm1/presence.cljs` | `re-frame.hicasso.impl.presence-react` |
+| `arm1/lang.clj` | `re-frame.hicasso` |
+
+**Their divergence from the package is expected and permanent.** A fix landing in the
+package leaves the file here the stale copy, and back-porting it is refused: this tree is
+a *measured* artefact — the clock rows, the ladders and the SSR spike are readings taken
+from this exact source — so editing a donor to carry a facility invented afterwards would
+invalidate the readings the package's own budgets are set against, to buy a digest.
+`rf2-0xgk` states the rule in one line: **the package is the artefact from that commit
+forward.**
+
+The authority is executable rather than prose. `frozen-sources.edn` carries the ruling in
+its header and records all three retirements that got the manifest to its present state;
+`scripts/check_freeze.py` beside it is the check.
+
+**One row remains pinned.** `check_freeze.py` reports `1 frozen row(s)` today, and it is
+`front/slot.cljc` — it survives for the honest reason that it raised no refusal and so
+needed no edit, not because anyone arranged for a row to remain. The other eleven are
+unpinned as well as undeclared. That is the recorded outcome of three retirements, not
+drift, and the manifest states what each one cost.
+
+## Rules a reader can act on
+
+1. **Do not import it.** `frozen-sources.edn`'s `:forbidden-import-prefixes` bars
+   `re-frame.bench.` and `re-frame.freehand.` from every file under
+   `implementation/hicasso/`, and `check_freeze.py`'s SEALED scan is package-wide. Prose
+   may name a bench namespace — a docstring citing the witness that pins a behaviour is
+   worth more than a clean grep.
+2. **Do not read a donor for what ships.** The live element path, runtime, mount and
+   authoring macros are under `implementation/hicasso/src/re_frame/hicasso/`. Read the
+   package.
+3. **Do not repair a donor against the package.** Divergence is the freeze working. Where
+   a difference has to be understood, read it off git rather than off a summary — for
+   example `git log --oneline 93ec92d491.. -- implementation/hicasso/src/re_frame/hicasso/impl/controlled.cljs`
+   lists the package changes `front/controlled.cljs` deliberately does not carry.
+4. **A donor edit is a measurement decision.** If a reading has to be re-taken on changed
+   source, that is a bench decision with a record, not a drive-by fix.
+
+## Where this sits in the wider record
+
+Hicasso had two contemporaries — `re-frame.ui` and `re-frame.freehand` — and both were
+retired and removed from the tree. The three donor surfaces and their dispositions are
+recorded together at
+[`docs/design/retirement/donor-surfaces.md`](../../../../../../docs/design/retirement/donor-surfaces.md).
+This tree is the one that was kept.

--- a/implementation/hicasso/test/re_frame/bench/hicasso/README.md
+++ b/implementation/hicasso/test/re_frame/bench/hicasso/README.md
@@ -12,7 +12,9 @@ rest; eleven sibling forks stand in exactly the same relation to their package
 namespaces and carry no such paragraph, which is the ambiguity this page answers once
 instead of twelve times.
 
-220 tracked files, of which 46 are measurement records under `data/`.
+The tree is large and still grows, so no file count is quoted here — one would be stale
+within the week. The durable facts are the twelve donors named below and the single
+digest-pinned row among them.
 
 ## What is live here
 

--- a/skills/README.md
+++ b/skills/README.md
@@ -24,13 +24,13 @@ once after cloning, and re-run with `--force` once to retire any stale copy
 a previous copy-install left behind.
 
 The docs-site landing page mirrors this index at
-[`docs/skills/index.md`](../docs/skills/index.md) — same ten skills,
+[`docs/skills/index.md`](../docs/skills/index.md) — same nine skills,
 hosted on the mkdocs site (it carries the human-facing decision flow;
 edit routing here first).
 
 ## Current skills
 
-re-frame2 ships **ten** skills plus a shared protocol layer
+re-frame2 ships **nine** skills plus a shared protocol layer
 ([`shared/`](shared) — see §Layout convention), grouped by
 the situation they cover:
 


### PR DESCRIPTION
Closes `rf2-hic-062`.

## What the bead asked for, and what was actually left

`rf2-hic-062` was written in Phase 6 to disposition **three** donor view surfaces —
`implementation/ui/` (`re-frame.ui`), the Freehand tree, and the frozen Hicasso bench
tree — each *archive / remove / keep-as-evidence*, with a record and a taught-path sweep.

**Two of the three no longer exist.** PR #8322 deleted them on 2026-08-16. Re-derived
here rather than inherited, and each zero controlled, because a wrong pathspec and a real
absence answer in the same voice:

Measured at the rebase base `83029f9a63`:

| Measurement | Result |
|---|---|
| `git ls-files implementation/ui implementation/freehand \| wc -l` | **0** |
| `git ls-files implementation/hicasso \| wc -l` (positive control) | **459** |
| `git ls-files implementation/adapters/uix \| wc -l` (positive control) | **16** |
| `git ls-files implementation/hicasso/test/re_frame/bench/hicasso \| wc -l` | **221** |

The second control is load-bearing twice: it proves the pathspec form works, and it is the
tree an unanchored `re-frame2-ui` pattern over-counts — `re-frame2-ui` is a **prefix of
`re-frame2-uix`**, and the UIx adapter is first-class and actively supported. Every
donor sweep in this change uses an anchored pattern (`re[-_]frame2?[-_.]ui($|[^x[:alnum:]])`),
verified against a four-line fixture where `re-frame.ui` and `re-frame2-ui` match and
`re-frame.uix` and `re-frame2-uix` do not.

So the deliverable shrank to: the bench tree's marker, a record written for a world where
two of the three are *gone* rather than *marked archive*, and the fresh-reader sweep.

**The scope is smaller than filed, and that is the finding.** "Deleted in PR #8322" is a
stronger disposition than any marker; a record saying *archive* about a directory that
does not exist would be worse than no record.

## What landed

**`implementation/hicasso/test/re_frame/bench/hicasso/README.md`** — new. The tree-level
marker the 2026-08-14 note on the bead asked for, and the one
`front/controlled.cljs`'s namespace docstring already points at ("`rf2-hic-062` owns the
tree-level disposition marker that will say so once, and this paragraph is only this
file's share of it"). It names the **twelve** frozen donors from `frozen-sources.edn`'s
`:renames` (seven under `front/`, five under `arm1/`) with the package namespace each was
copied into, records that `check_freeze.py` reports **`1 frozen row(s)`** today — only
`front/slot.cljc` is still digest-pinned — and gives four rules a reader can act on.

It deliberately separates the frozen twelve from the live harness around them. *Keep as
evidence* bounds what the tree may be used **for**; it is not *do not touch*, and reading
it that way would chill ordinary bench work in a tree where new arms land routinely — PR
#8384 landed one into that tree while this branch was open, which is the point made
concrete rather than argued.

**`docs/design/retirement/donor-surfaces.md`** — new. The disposition record: three rows,
an authority for each, the controls behind the two zeros, an explicit answer to the bead's
second deliverable (the `re-frame.ui` tooling-tier question, answered by the deletion, with
Xray's one deliberate surviving reference named), and an explicit list of what the record
does **not** cover. Filed beside `freehand-and-ui.md` — the same `docs/design/retirement/`
tree, for the reason that page states: a record of a demolition should not live inside the
demolition site.

**`docs/design/retirement/freehand-and-ui.md`** — one paragraph pointing at the new record,
so a reader of the plan finds the third surface it deliberately does not cover.

**`docs/skills/index.md`** + **`skills/README.md`** — the one live fresh-reader defect the
sweep found. The published landing page offered *"maintaining views on the retired
`re-frame.ui` compiled-view substrate"* among the reasons to reach for a skill, and both
pages counted **ten** skills against the **nine** actually in `skills/` and in `mkdocs.yml`'s
nav — residue of `skills/re-frame2-ui/` going with the tree. Counts verified against the
enumerated lists: 9 bullets under `skills/README.md` §Current skills, 9 table rows in each
of `docs/skills/index.md`'s two tables, 9 nav rows.

`## The ten skills` → `## The nine skills` changes a heading anchor. `git grep -F
the-ten-skills` returns **no matches** repo-wide (positive control:
`git grep -c -F skill-routing--single-source` finds 5 files), so no inbound link breaks.

## Scope refusals — stated, not silent

- **`spec/` untouched.** Spec prose naming either retired tree is `rf2-0yp7w.9`'s.
- **`docs/api/re-frame.core.md`** (its `:rf.adapter/freehand` roster) and
  **`docs/api/re-frame.ssr.md`** (its `re-frame.ui.tree` provenance) untouched — both are
  downstream of `implementation/*/src` docstrings and are named in `rf2-0yp7w.9`'s R6 list;
  editing the page alone would drift it from its source and risk the `doc-api-check` JVM
  gate.
- **`docs/EP/`** untouched. `freehand-and-ui.md` rules explicitly that EP-0030…EP-0036 are
  the reason the withdrawal is legible and are not deleted. They are also not in the
  published nav.
- **Comment residue** in `examples/real-apps/realworld_*/article_editor.cljs`,
  `examples/scripts/check-examples-assets.cjs` and
  `migration/reagent-to-hicasso/codemod/{README.md,deps.edn,test/.../shared_rule_test.clj}`
  untouched — same owner. None presents a live choice; several already say "Freehand is
  retired".
- **`docs/design/hicasso/decisions.md`** untouched (declared conflict magnet).
- **No build wiring touched** in the bench tree — `worker/benchgate-peorl` holds
  `implementation/package.json` and `compile_gate` there. This change adds one `.md`.

## Quality gates

Every number below was captured with the runner's own exit code echoed on the **same
command line** as the redirect. No gate was piped through a filter.

| Gate | Command | Exit |
|---|---|---|
| Doc link/anchor slugs | `python scripts/check_doc_slugs.py --verbose` | **0** |
| README links (repo-wide) | `python scripts/check_readme_links.py --ci` | **0** |
| Freeze manifest | `python implementation/hicasso/scripts/check_freeze.py` | **0** |
| Fast pre-checkin spine (pre-rebase) | `bash scripts/test-fast-pr.sh` | **0** |
| Fast pre-checkin spine (final base) | `bash scripts/test-fast-pr.sh` | **0** |

`check_doc_slugs.py` is the gate for this diff and it was derived, not nominated: its
`DEFAULT_ROOTS = ("docs","spec","skills","migration")` covers `docs/design/retirement/*`,
`docs/skills/index.md` and `skills/README.md`. It reported **379 docs / 173 skills** files
inspected. `check_readme_links.py` is the gate for the bench-tree README — that file is
under `implementation/`, which `check_doc_slugs.py` does **not** walk, and
`check_readme_links.py`'s `EXCLUDE_DIR_NAMES` / `DOCS_GATE_ROOTS` do not exclude
`implementation/`. Both run unconditionally in `test.yml`'s `verify-readme-links` job.

`scripts/check_provenance_pins.py` is **not** a gate here: its `DEFAULT_ROOT` is
`docs/design/hicasso`, and this change touches no page in that tree.

`mkdocs build --strict` runs **inside the spine's documentation tier** (`--plan` prints
`mkdocs --strict: python -m mkdocs`) and is the gate for `docs/skills/index.md`, which is
published. `docs/design/retirement/` is in `mkdocs.yml`'s `exclude_docs`, so mkdocs is
correctly not the gate for the two pages there.

**Verified by hand, because nothing gates them** (per the bead's doc-surface protocol):
markdown table column counts are uniform in every table this change adds or edits —
bench README 14 rows × 2 columns; `donor-surfaces.md` 5 rows × 4 columns;
`docs/skills/index.md` 11 × 2 and 11 × 2 — and all 7 relative `.md`/`.edn` link targets
resolve on disk.

### The red proof, and the hash-verified restore

The gates were shown to bite, and shown to be reading **this** worktree — a planted fault
exists only here, so a run that had wandered into a sibling checkout would have come back
green.

Two plants, each anchored to a single line, each a broken link target:

| Gate | Sabotage | Exit | Failure named the plant |
|---|---|---|---|
| `check_doc_slugs.py` | `donor-surfaces.md:56` → `../hicasso/product/rf2-hic-062-sabotage-no-such-page.md` | **1** | `BROKEN TARGET: docs\design\retirement\donor-surfaces.md:56 -> ../hicasso/product/rf2-hic-062-sabotage-no-such-page.md` |
| `check_readme_links.py --ci` | bench `README.md:93` → `../../../../../../docs/design/retirement/rf2-hic-062-sabotage-no-such-page.md` | **1** | `BROKEN TARGET: implementation\hicasso\test\re_frame\bench\hicasso\README.md:93 -> …rf2-hic-062-sabotage-no-such-page.md` |

The `check_doc_slugs.py` plant also proves the *second* half of what needed proving: it
fires from a page under `docs/design/retirement/`, which is excluded from the mkdocs site
— confirming that the slug gate really does cover a tree mkdocs does not.

**The plants applied** (content hashes moved: `d28285f0…` → `5cfb9293…`, `ce65514d…` →
`b330a3e3…`), which rules out the failure mode where a patch silently no-ops and the
sabotage run comes back green over an unbroken file.

**The restore was verified by hashing the bytes**, not by reading a diff, using git's own
content hash against the committed object — this checkout translates line endings, so a
byte digest would be the wrong instrument:

```
docs/design/retirement/donor-surfaces.md              working=d28285f0… committed=d28285f0…  MATCH
implementation/.../bench/hicasso/README.md            working=ce65514d… committed=ce65514d…  MATCH
```

### The spine-versus-CI gap

`python scripts/check_fast_pr_gap.py --list` reports **94** required checks the fast spine
does not run. **That is a fact about the SPINE, not a census of what this PR ran**, so
here is what was actually run: the spine end to end, twice, with tiers
`docs=true jvm=false node=true` — the classifier arms `cljs_node_test` and `cljs_browser`
off the bench-tree `.md` — plus `check_doc_slugs.py`, `check_readme_links.py --ci` and
`check_freeze.py` invoked directly. Inside those tiers the spine ran `mkdocs build
--strict` (21.8s), the pinned clj-kondo, the JS harness helpers, the `:node-test` shadow
build (1984 files, 0 warnings), the CLJS node integration suite, per-namespace isolation
(16 namespaces, 190 tests, 700 assertions, all green standalone) and the hicasso bench-lane
compile (146 namespaces). The JVM tier was skipped by the classifier, not by hand.

Both runs were detached and polled — log and `.exit` file both, in a bounded loop inside
the turn — because the node tier's cold compile does not fit the foreground ceiling. The
spine is not compound in a way that splits: `--with-docs`/`--no-docs` toggle the docs tier
only, and there is no flag that separates the node tier from the rest.

`--plan` printed `gate root: /c/Users/miket/code/re-frame2-worktrees/disposition-hic062`,
and the shadow-cljs run echoed
`config: C:\Users\miket\code\re-frame2-worktrees\disposition-hic062\implementation\shadow-cljs.edn`
— the printed-root route to proving which tree a gate read, alongside the planted-fault
route above.

**Deps note:** the worktree carried no `implementation/node_modules`, so one was junctioned
at the mayor checkout's real tree for the node tier. **The LINK is removed as the last act
of this dispatch, never its target** — a `git worktree remove` that follows the junction
empties the mayor's real `node_modules`, which has happened twice. The mayor's tree read
**101** by `ls implementation/node_modules | wc -l` before the junction and is re-checked
against that same measure afterwards.

### Rebase, and the gates re-run on the final base

Branched at `a724be0d6d`; rebased onto `83029f9a63`. `origin/main` moved four commits
during the work — three `chore(beads): checkpoint` and **PR #8384**, which landed
`read_profile_app.cljs` and a new `read_profile_slots_cljs_test.cljs` **in the very bench
tree this change marks**. That is a real change to the node tier's compile surface, not an
inert one, so the spine was re-run end to end on the final base rather than the pre-rebase
green being carried forward. The record's stamp and both its control counts were re-taken
at the same commit in the third commit of this branch.

The moving count is also why the tree README quotes **no** file total: the number taken at
14:00 was wrong by 15:30. A count that decides nothing and rots weekly does not belong in a
marker; it belongs in the record, where it carries the commit it was taken at.

### Nothing reverted

`git diff origin/main...HEAD --numstat` — three-dot, so it reads what *this branch* changes
rather than what main did. Every file is additive except six replaced lines in the two
skills pages. Nothing a sibling landed is undone: W4 (`rf2-0yp7w.12`, PR #8387) merged into
this exact neighbourhood minutes before this branch was cut, and this change **extends**
its sweep — W4 cut the donor skill *rows*, this cuts the *counts* and the blurb clause it
left behind.

## Follow-on

- **`rf2-hic-069`** (docs nav, links, fresh-reader protocol) is unblocked. Left for it:
  the nav is already clean of donor surfaces, so `069` inherits an integration pass rather
  than a repair. Its fresh-reader run should treat `docs/skills/index.md` as newly correct
  and the `docs/EP/` tree as history that a reader can meet without being misled.
- **`rf2-0yp7w.9`** (R6 prose sweep) owns everything listed under *Scope refusals* above.
