### PR TITLE
ci(spine): the fast-PR spine asserts every workflow file is well-formed YAML (rf2-cb7hs)

### DIFF
--- a/scripts/check_workflow_yaml.py
+++ b/scripts/check_workflow_yaml.py
@@ -1,0 +1,205 @@
+#!/usr/bin/env python3
+"""Assert that every file under `.github/workflows/` is well-formed YAML.
+
+WHY THIS EXISTS (rf2-cb7hs).  Four scripts in this repo READ the workflow files
+— `check_gate_scheduling.py`, `check_fast_pr_gap.py`, `check_jvm_lane_rosters.py`
+and `check_ci_reproduce_commands.py` — and every one of them is a hand-rolled
+line reader.  Measured, not assumed: with an unmatched quote planted on line 1
+of `.github/workflows/test.yml`, PyYAML refuses the file and ALL FOUR still
+exit 0.  `check_gate_scheduling.py` cannot see the class at all, because it
+strips comments by design (rf2-6ckzl).  `actionlint` appears nowhere in the
+tracked tree.  So until this file landed, nothing at any tier asserted that a
+workflow even PARSED.
+
+WHAT IT IS NOT.  It is not `actionlint`, and it deliberately does not validate
+the GitHub Actions grammar — no job wiring, no `needs:` graph, no `if:`
+conditions, no schema.  Those are separate claims with separate costs; this one
+answers exactly one question, in milliseconds: is the file YAML?
+
+It is also not a SAFETY gate, and the bead says so plainly.  A workflow that
+fails to parse does not run, so the PR's rollup comes back short of the required
+band and the merge criterion refuses it.  What this buys is the round trip: a
+local error naming the file and the line, instead of a push, a CI wait, and a
+confusing partial rollup.
+
+Usage (from anywhere — the root is derived from this file's location, or given):
+    python scripts/check_workflow_yaml.py [--repo-root DIR] [--verbose]
+    python scripts/check_workflow_yaml.py --self-test [--verbose]
+
+Exit codes:
+    0  every workflow file parsed
+    1  at least one workflow file is not well-formed YAML
+    2  usage error, or the workflow directory holds no files to check
+       (a sweep that examined nothing is not a pass)
+    3  PyYAML is not importable — NOT CHECKED, and the caller must say so
+"""
+from __future__ import annotations
+
+import argparse
+import pathlib
+import sys
+
+WORKFLOW_DIR = pathlib.Path(".github") / "workflows"
+SUFFIXES = (".yml", ".yaml")
+
+
+def _diagnose(text: str):
+    """Return a one-line diagnosis of `text`, or None if it is well-formed YAML.
+
+    PyYAML's exception already carries the position; pulling `problem_mark` out
+    of it is what turns "the workflows are broken" into a line number a reader
+    can go to.  `str(exc)` alone is a four-line block whose first line is the
+    least useful part of it.
+    """
+    import yaml  # imported by the caller's guarantee; see main()
+
+    try:
+        yaml.safe_load(text)
+    except yaml.YAMLError as exc:
+        mark = getattr(exc, "problem_mark", None)
+        where = (
+            f"line {mark.line + 1}, column {mark.column + 1}"
+            if mark is not None
+            else "position unreported"
+        )
+        problem = getattr(exc, "problem", None) or str(exc).splitlines()[0].strip()
+        context = getattr(exc, "context", None)
+        return f"{where}: {context}, {problem}" if context else f"{where}: {problem}"
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Self-test.  A green live sweep over a tree that happens to be clean cannot
+# tell you the difference between "the workflows parse" and "the checker has
+# stopped looking" — the same argument the residue sweeps in this directory
+# make for their own self-test arms.  So drive it red on four break shapes that
+# are each a plausible hand-edit, and green on a valid workflow.
+# ---------------------------------------------------------------------------
+_VALID = """\
+name: tests
+on:
+  pull_request:
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "hello"
+"""
+
+_BREAKS = (
+    ("unmatched quote", 'name: "tests\non:\n  pull_request:\n'),
+    ("tab indentation", "name: tests\njobs:\n\tbuild:\n"),
+    ("unclosed flow sequence", "name: tests\njobs: [build, lint\n"),
+    ("two colons in one key", "name: tests\non: push: true\n"),
+)
+
+
+def run_self_test(verbose: bool) -> int:
+    failures = []
+
+    diagnosis = _diagnose(_VALID)
+    if diagnosis is not None:
+        failures.append(f"a VALID workflow was rejected: {diagnosis}")
+    elif verbose:
+        print("  ok  valid workflow accepted")
+
+    for label, text in _BREAKS:
+        diagnosis = _diagnose(text)
+        if diagnosis is None:
+            failures.append(f"break shape not detected: {label}")
+        elif verbose:
+            print(f"  ok  {label} -> {diagnosis}")
+
+    if failures:
+        print("FAIL check_workflow_yaml self-test:", file=sys.stderr)
+        for problem in failures:
+            print(f"  - {problem}", file=sys.stderr)
+        return 1
+
+    print(f"PASS check_workflow_yaml self-test ({1 + len(_BREAKS)} cases)")
+    return 0
+
+
+def run_check(root: pathlib.Path, verbose: bool) -> int:
+    directory = root / WORKFLOW_DIR
+    if not directory.is_dir():
+        print(
+            f"ERROR: no workflow directory at {directory}. Wrong --repo-root?",
+            file=sys.stderr,
+        )
+        return 2
+
+    files = sorted(p for p in directory.iterdir() if p.suffix in SUFFIXES and p.is_file())
+    if not files:
+        # A sweep that found nothing is not a sweep that passed.
+        print(f"ERROR: no {'/'.join(SUFFIXES)} files under {directory}.", file=sys.stderr)
+        return 2
+
+    broken = []
+    for path in files:
+        try:
+            text = path.read_text(encoding="utf-8")
+        except OSError as exc:
+            broken.append((path, f"unreadable: {exc}"))
+            continue
+        diagnosis = _diagnose(text)
+        if diagnosis is None:
+            if verbose:
+                print(f"  ok  {path.relative_to(root).as_posix()}")
+        else:
+            broken.append((path, diagnosis))
+
+    if broken:
+        print("FAIL workflow YAML is not well-formed:", file=sys.stderr)
+        for path, diagnosis in broken:
+            print(f"  {path.relative_to(root).as_posix()}: {diagnosis}", file=sys.stderr)
+        print(
+            "\nGitHub will refuse to run a workflow it cannot parse, so the PR's\n"
+            "rollup comes back SHORT rather than red. Fix the line above.",
+            file=sys.stderr,
+        )
+        return 1
+
+    print(f"PASS workflow YAML well-formed ({len(files)} files under {WORKFLOW_DIR.as_posix()})")
+    return 0
+
+
+def main(argv=None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("--self-test", action="store_true", help="run the checker's own cases")
+    parser.add_argument("--verbose", action="store_true", help="name every file checked")
+    parser.add_argument(
+        "--repo-root",
+        default=None,
+        help="repository root (default: this script's parent directory's parent)",
+    )
+    args = parser.parse_args(argv)
+
+    # ONE probe, at the top, so the two arms below can assume the import.  The
+    # message names the remedy rather than the traceback: PyYAML is not in
+    # requirements.txt in its own right, it arrives as a dependency of mkdocs.
+    try:
+        import yaml  # noqa: F401
+    except ImportError:
+        print(
+            "NOT CHECKED: workflow YAML. PyYAML is not importable on this\n"
+            "  interpreter, so nothing here examined .github/workflows/.  This is\n"
+            "  NOT a pass.  Install it (pip install -r requirements.txt, which\n"
+            "  pulls PyYAML in through mkdocs) and re-run.",
+            file=sys.stderr,
+        )
+        return 3
+
+    if args.self_test:
+        return run_self_test(args.verbose)
+
+    root = (
+        pathlib.Path(args.repo_root).resolve()
+        if args.repo_root
+        else pathlib.Path(__file__).resolve().parent.parent
+    )
+    return run_check(root, args.verbose)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/test-fast-pr.sh
+++ b/scripts/test-fast-pr.sh
@@ -993,6 +993,59 @@ run "test-lane bijection self-test" "python scripts/check_test_lane_bijection.py
 run "test-lane bijection (rf2-4hc9p)" "python scripts/check_test_lane_bijection.py" \
   python "$spine_root/scripts/check_test_lane_bijection.py" --repo-root "$spine_root"
 
+# WORKFLOW YAML WELL-FORMEDNESS (rf2-cb7hs) — placed AHEAD of the three gates
+# below that read `.github/workflows/`, deliberately.
+#
+# Every one of those is a hand-rolled line reader, and over a file PyYAML
+# refuses they all come back GREEN.  Measured at tip 959c34204a with an
+# unmatched quote planted on line 1 of test.yml: `check_jvm_lane_rosters`,
+# `check_fast_pr_gap`, `check_ci_reproduce_commands` and `check_gate_scheduling`
+# each exited 0 over a file `yaml.safe_load` rejects with "while parsing a block
+# mapping".  `check_gate_scheduling` cannot see the class at all — it strips
+# comments by design (rf2-6ckzl) — and `actionlint` appears nowhere in the
+# tracked tree, so before this line NOTHING at any tier asserted that a workflow
+# even parsed.  Validating the file before three gates parse it by hand is the
+# ordering that makes their greens mean something.
+#
+# NOT A MIRROR OF A CI JOB.  Every other line in this always-on block pairs with
+# a required check; this one has no CI counterpart, and that absence IS the
+# bead.  Nor is it a safety gate: a workflow that fails to parse does not run,
+# so the PR's rollup comes back SHORT of the required band and the merge
+# criterion refuses it.  What it buys is the ROUND TRIP — a local error naming
+# the file and the line, instead of a push, a CI wait, and a confusing partial
+# rollup.  Always-on because `.github/workflows/**` is owned by no tier of this
+# spine (a workflow-only diff reaches the classifier's `mark_all` or falls to
+# the unknown-surface fallback, and neither decides anything here), and because
+# it is ~0.05s over eleven files, which cannot grow with the tree.
+#
+# DELIBERATELY NOT actionlint, and not schema validation of the Actions grammar
+# — no job wiring, no `needs:` graph, no `if:` conditions.  One question, in
+# milliseconds: is the file YAML?
+#
+# PyYAML is probed rather than assumed.  It is not a direct entry in
+# requirements.txt; it arrives as a dependency of mkdocs, so a checkout that
+# never installed the docs toolchain has no parser.  Absent, this is a LOUD SKIP
+# with the gap named — the same treatment `mkdocs --strict` and the pinned
+# clj-kondo get below, and for the same reason: a gate that reports success
+# without having examined anything is the failure mode this spine exists to
+# avoid.  Self-test first (proves it fires on four distinct break shapes and
+# stays green on a valid workflow), then the live sweep.
+if python -c "import yaml" >/dev/null 2>&1; then
+  run "workflow YAML self-test" "python scripts/check_workflow_yaml.py --self-test --verbose" \
+    python "$spine_root/scripts/check_workflow_yaml.py" --self-test --verbose
+
+  run "workflow YAML well-formed (rf2-cb7hs)" "python scripts/check_workflow_yaml.py --verbose" \
+    python "$spine_root/scripts/check_workflow_yaml.py" --repo-root "$spine_root"
+else
+  printf '\n    NOT CHECKED: workflow YAML — PyYAML is not importable on this\n'
+  printf '      interpreter, so nothing read .github/workflows/ this run.  This is\n'
+  printf '      NOT a pass: the three gates below parse those files by hand and\n'
+  printf '      return 0 over a file no YAML parser accepts.  Left with NO local\n'
+  printf '      gate: every file under .github/workflows/.  Install it\n'
+  printf '      (pip install -r requirements.txt pulls PyYAML in through mkdocs).\n'
+  note_skipped "workflow YAML well-formedness — PyYAML unimportable, so no local lane parsed .github/workflows/ this run (rf2-cb7hs)"
+fi
+
 # JVM roster <-> CI required-job bijection (rf2-as6bg).  The gate above READS
 # the two JVM rosters to discover the JVM lanes, so an artefact missing from a
 # roster is not a violation to it — it is simply not a lane.  That blind spot

--- a/scripts/test-fast-pr.sh
+++ b/scripts/test-fast-pr.sh
@@ -993,7 +993,7 @@ run "test-lane bijection self-test" "python scripts/check_test_lane_bijection.py
 run "test-lane bijection (rf2-4hc9p)" "python scripts/check_test_lane_bijection.py" \
   python "$spine_root/scripts/check_test_lane_bijection.py" --repo-root "$spine_root"
 
-# WORKFLOW YAML WELL-FORMEDNESS (rf2-cb7hs) — placed AHEAD of the three gates
+# WORKFLOW YAML WELL-FORMEDNESS (rf2-cb7hs) — placed AHEAD of all four gates
 # below that read `.github/workflows/`, deliberately.
 #
 # Every one of those is a hand-rolled line reader, and over a file PyYAML
@@ -1004,8 +1004,10 @@ run "test-lane bijection (rf2-4hc9p)" "python scripts/check_test_lane_bijection.
 # mapping".  `check_gate_scheduling` cannot see the class at all — it strips
 # comments by design (rf2-6ckzl) — and `actionlint` appears nowhere in the
 # tracked tree, so before this line NOTHING at any tier asserted that a workflow
-# even parsed.  Validating the file before three gates parse it by hand is the
-# ordering that makes their greens mean something.
+# even parsed.  Validating the file before four gates parse it by hand is the
+# ordering that makes their greens mean something.  (All four sit below this
+# line: the two roster/gap pairs immediately following, then
+# `check_ci_reproduce_commands` and `check_gate_scheduling` further down.)
 #
 # NOT A MIRROR OF A CI JOB.  Every other line in this always-on block pairs with
 # a required check; this one has no CI counterpart, and that absence IS the
@@ -1034,12 +1036,12 @@ if python -c "import yaml" >/dev/null 2>&1; then
   run "workflow YAML self-test" "python scripts/check_workflow_yaml.py --self-test --verbose" \
     python "$spine_root/scripts/check_workflow_yaml.py" --self-test --verbose
 
-  run "workflow YAML well-formed (rf2-cb7hs)" "python scripts/check_workflow_yaml.py --verbose" \
+  run "workflow YAML well-formed (rf2-cb7hs)" "python scripts/check_workflow_yaml.py" \
     python "$spine_root/scripts/check_workflow_yaml.py" --repo-root "$spine_root"
 else
   printf '\n    NOT CHECKED: workflow YAML — PyYAML is not importable on this\n'
   printf '      interpreter, so nothing read .github/workflows/ this run.  This is\n'
-  printf '      NOT a pass: the three gates below parse those files by hand and\n'
+  printf '      NOT a pass: the four gates below parse those files by hand and\n'
   printf '      return 0 over a file no YAML parser accepts.  Left with NO local\n'
   printf '      gate: every file under .github/workflows/.  Install it\n'
   printf '      (pip install -r requirements.txt pulls PyYAML in through mkdocs).\n'


### PR DESCRIPTION
Closes rf2-cb7hs.

## The premise held, and here is how its zero was controlled

The bead's premise is an ABSENCE — "no workflow-syntax validation exists at any
tier" — and a search that returns zero is not a check that passed. So both halves
were controlled.

**No `actionlint`.** `git grep -lF 'actionlint'` over the tracked tree returns
exactly one path, `.beads/issues.jsonl`, which is the bead's own description.
Controlled against `clj-kondo`, where the identical method returns
`.clj-kondo/config.edn`, `.clj-kondo/hooks/re_frame/core.clj`,
`.github/scripts/install-clojure-cli.sh` and more. `git grep -nF 'safe_load'` and
a sweep for `import yaml` over `scripts/` and `.github/` return nothing but the
same tracker export.

**The four hand-rolled readers really do pass over unparseable YAML.**
Re-measured at tip `959c34204a`, third independent verification. An unmatched
quote planted on line 1 of `.github/workflows/test.yml` (`name: tests` ->
`name: "tests`):

```
PyYAML REJECTS: while parsing a block mapping
check_gate_scheduling exit=0
check_fast_pr_gap exit=0
check_jvm_lane_rosters exit=0
check_ci_reproduce_commands exit=0
```

Restored and hash-verified: `git hash-object` and `git rev-parse HEAD:` both read
`24ca208c804b11b5095133d6f53c312e716cdf2d`.

## Where the check lives, and why

`scripts/check_workflow_yaml.py` — a new script, following the convention of its
twenty-odd `scripts/check_*.py` neighbours rather than an inline `python -c`,
because the spine's gap map derives this spine's coverage by matching the literal
shape `python "$spine_root/scripts/check_<name>.py"` out of the runner's source.
An inline form would be invisible to it.

It is wired into the **always-on block of `scripts/test-fast-pr.sh`**, placed
**ahead of all four gates that read `.github/workflows/` by hand** — the
roster/gap pair immediately following it, then `check_ci_reproduce_commands` and
`check_gate_scheduling` further down. That ordering is the point: validate the
file, then let four line readers parse it, so their greens mean something.

Scope held to the bead exactly. **Refused**: `actionlint`; Actions-schema or
grammar validation; job wiring, `needs:` graphs and `if:` conditions; any new CI
job; any edit to `.github/workflows/*.yml`. One question, in milliseconds — is the
file YAML.

The one thing beyond `yaml.safe_load` is a PyYAML **probe**. PyYAML is not a
`requirements.txt` entry in its own right; it arrives transitively through
mkdocs, so a checkout that never installed the docs toolchain has no parser.
Absent, the spine prints a loud `NOT CHECKED` and calls `note_skipped` — the same
treatment `mkdocs --strict` and the pinned clj-kondo already get in this file, and
for the reason that file states repeatedly: a gate that reports success without
having examined anything is the failure mode the spine exists to remove. Making
it a hard failure instead would red every local run on a machine without the docs
toolchain, on diffs that never touch a workflow.

## Proof it fires on a workflow-only change

Two independent legs.

**Structural.** The invocation sits in the unconditional always-on block, above
every tier branch in the runner. The only conditional around it is the PyYAML
probe.

**Measured, and it is why always-on is the only correct placement.** Feeding
single workflow paths to the CI classifier the spine delegates to:

| changed file | surfaces armed by `report-changed-surfaces.sh` |
| --- | --- |
| `.github/workflows/test.yml` | 28 (`mark_all`) |
| `.github/workflows/lint.yml` | 0 |
| `.github/workflows/docs.yml` | 0 |

Only `test.yml` and `expensive-tests.yml` are `mark_all` triggers. The other nine
workflow files arm **no surface at all**, so a `lint.yml`-only or `docs.yml`-only
diff reaches the runner's `conservative fallback (unknown surface)` branch — and
`.github/workflows/**` is on no documentation surface and no spine-self surface
either. A tier-gated lane would therefore have missed nine of the eleven files it
exists to check.

**End to end.** The sabotage run below is itself the demonstration: a parse break
in a workflow file, reported red by this spine, naming the file and the line.

## The sabotage control

Planted the same unmatched quote on `.github/workflows/test.yml` line 1 and ran
the whole spine. It went red:

```
gate root: /c/Users/miket/code/re-frame2-worktrees/ymlparse-cb7hs
=== fast PR spine: docs=true jvm=true node=true (spine self-change (every tier)) ===
...
PASS check_workflow_yaml self-test (5 cases)
==> workflow YAML well-formed (rf2-cb7hs)
FAIL workflow YAML is not well-formed:
  .github/workflows/test.yml: line 5, column 4: while parsing a block mapping, expected <block end>, but found '<scalar>'
FAIL workflow YAML well-formed (rf2-cb7hs)
repro: python scripts/check_workflow_yaml.py --verbose
```

`CAPTURED_EXIT=1`, echoed from the runner's own `$?` on the same command line as
the redirect. The `gate root:` line names this worktree, so the red is about this
tree and not a sibling's.

Restored and hash-verified against the committed object, not by reading a diff:

```
RESTORED_HASH=24ca208c804b11b5095133d6f53c312e716cdf2d
COMMITTED_HASH=24ca208c804b11b5095133d6f53c312e716cdf2d
```

The checker's `--self-test` is the other half of the control: it drives four
distinct break shapes (unmatched quote, tab indentation, unclosed flow sequence,
two colons in one key) and asserts a valid workflow is still accepted, so a
detector that quietly stops firing goes red by name rather than being covered for
by a clean corpus.

## The fast-spine gap

Cited from the one path that owns it, `scripts/check_fast_pr_gap.py --list`, on
both sides of the change, each measured with the runner's source hash-verified
against its committed object:

| | required checks this spine does not run |
| --- | --- |
| before (`HEAD~1`, blob `2ca6aaf078`) | **94** |
| after (`HEAD`, blob `a7d4456e9a`) | **94** |

Unchanged, and it must be: the number counts required CI checks with no local
lane, and this change adds a local lane with no CI counterpart. It is a fact about
the spine, not a census of what this PR ran — what ran directly is below.

## Quality gates

`scripts/test-fast-pr.sh` — run before and after. Editing the runner puts the diff
on the spine-self surface, so **every tier armed** (`docs=true jvm=true node=true`,
reason `spine self-change (every tier)`) plus the spine's own tiering self-test.

Invoked by absolute path with the redirect and the `echo $?` on one command line,
detached because a full every-tier run exceeds the foreground cap, then polled to
completion in-turn.

| run | what | captured exit |
| --- | --- | --- |
| attempt 1 (sabotage) | full spine, parse break planted in `test.yml` | `CAPTURED_EXIT=1` — RED at the new gate, naming the file |
| attempt 2 | full spine, tree restored | `CAPTURED_EXIT=143` — **aborted, not a verdict** |
| attempt 3 (final) | full spine, final tree | **`CAPTURED_EXIT=0`** — 83 steps, 0 `FAIL` lines, `PASS fast PR spine` |

Attempt 2 is reported rather than quietly dropped. Reviewing my own diff I found
a wrong count in the comment I had just written — it said three hand-rolled
readers sit below the new gate where there are four — and a running bash script
cannot be edited in place without corrupting its own execution, so I SIGTERMed
that run at a safe point (a pure-Python docs check, no build cache in flight),
fixed the count in its own commit, and re-ran the whole spine. `143` is that
signal. Worth noting because **the harness reported that same run as "exit code
0"**: the captured number is the one quoted here throughout.

Directly, ahead of the spine:

| check | captured exit |
| --- | --- |
| `bash -n scripts/test-fast-pr.sh` | 0 |
| `python scripts/check_workflow_yaml.py --self-test --verbose` (5 cases) | 0 |
| `python scripts/check_workflow_yaml.py --verbose` (11 files) | 0 |
| `python scripts/check_fast_pr_gap.py --self-test` | 0 |
| `python scripts/check_fast_pr_gap.py --check` | 0 |
| `bash scripts/_test_fixtures/test_fast_pr_docs_gate/run-self-test.sh` (44/44) | 0 |

Nothing was skipped, and no gate was piped through a filter. Each artefact is
named for the worktree and the attempt; the final log carries **zero NUL bytes**
(measured as `wc -c` minus `tr -d '\000' | wc -c`, with a positive control that
reports 1 on a planted NUL) and exactly one `gate root:`, one `run pid:` and one
`PASS fast PR spine` — one writer, no splice.

The spine's own honest gap on the final run: three entries — the pinned
clj-kondo lane (no file under a `--lint` root changed), the twenty JVM artefact
suites the diff did not touch, and the standing browser/bundle/adapter/tooling
set that is CI-only.

**Total checks on this PR: 88** — 23 pass, 65 skipping, 0 failing. That is the
post-retire band, not a partial rollup.

## Diff hygiene

`git diff --stat origin/main...HEAD` is 260 insertions and **0 deletions** across
two files, so this push reverts nothing a sibling landed while it was open. No
file under `.github/`, `.beads/` or any other worker's fence is touched.

`main` gained 12 commits while this was open. None touches `scripts/` or
`.github/` (five are beads checkpoints; the rest are the hicasso bench re-home
and the disposition records), so the local green is not stale for the surfaces
this change reads, and the PR's own checks run on the merge ref regardless.
