### PR TITLE
feat(story): a hicasso deck paints in Story's canvas, on the PR-path play gate (rf2-kttom)

### DIFF
--- a/.github/scripts/report-changed-surfaces.sh
+++ b/.github/scripts/report-changed-surfaces.sh
@@ -263,11 +263,24 @@ mark_all() {
 # story-feature-load + xray-feature-gate Playwright runners (their
 # variant graph IS what the gate exercises), so a runtime-extension
 # change there does fire the gate.
+#
+# rf2-kttom — `.html` is on the list, and its absence was a real hole.
+# The browser runners do not merely compile a testbed: each one COPIES the
+# testbed's hand-written `index.html` into the served output dir and then
+# navigates a browser to it (`stageTestbedHtml` in
+# examples/scripts/serve-and-run-story-play-scripts.cjs and its
+# feature-load sibling; the `:dev-http` roots in
+# implementation/shadow-cljs.edn resolve the same file). So the served
+# document IS a testbed source file — break its `<script src>`, its
+# `#app` node or its charset and every play in that deck fails — yet an
+# HTML-only change used to classify as no-surface and skip the gate
+# entirely. It is a runtime path by the same test as the others: change
+# it and the browser sees something different.
 is_story_xray_runtime_path() {
   case "$1" in
     tools/story/src/*|tools/xray/src/*|tools/story/testbeds/*|tools/xray/testbeds/*)
       case "$1" in
-        *.cljs|*.cljc|*.js|*.cjs|*.css|*.scss)
+        *.cljs|*.cljc|*.js|*.cjs|*.css|*.scss|*.html)
           return 0 ;;
         *)
           return 1 ;;

--- a/docs/story/09-multi-substrate-and-agent-loop.md
+++ b/docs/story/09-multi-substrate-and-agent-loop.md
@@ -19,9 +19,21 @@ body independent from the renderer:
    :substrates #{:reagent}})
 ```
 
-Today, the tutorial and scaffolded Story path are Reagent-focused. The broader
-contract leaves room for UIx as adapter coverage matures. The design
-reason is still worth understanding now: a variant should describe a state and
+The tutorial and the scaffolded path are Reagent-focused because that is where
+most readers start, but the substrate set is not a Reagent set. A member of
+`:substrates` names which registered render fn embeds the subject — the
+authoring layer — and not which adapter `rf/init!` installed. `:hicasso` is
+the member that makes the difference visible, since Hicasso ships no adapter
+of its own: a deck declaring `:substrates #{:hicasso}` runs in a
+Reagent-hosted shell, resolves its own frame through React context, and
+responds to writes into it. There is a worked one at
+`tools/story/testbeds/hicasso_counter/`, and it rides the same PR-path play
+gate every Reagent deck does.
+
+Story installs the `:reagent` render fn itself and leaves `:uix` and
+`:hicasso` to the host application, because each one's only dependency is
+the host's — five lines at boot, and Story core never names them. The design
+reason is still worth understanding: a variant should describe a state and
 behaviour, not smuggle a renderer-specific render function into the artifact.
 
 When a substrate cannot render a variant, Story should say that. This is the

--- a/examples/scripts/serve-and-run-story-play-scripts.cjs
+++ b/examples/scripts/serve-and-run-story-play-scripts.cjs
@@ -2,14 +2,35 @@
 /*
  * Story `:play-script` CI-as-test runner.
  *
- * Compiles the counter-with-stories Story testbed, serves it, opens
- * the Story shell in Playwright, enumerates every registered variant
+ * Compiles every testbed in the ROSTER below, serves them, opens each
+ * one's Story shell in Playwright, enumerates every registered variant
  * whose body carries a non-empty `:play-script` or `:plays` slot (via
  * the `window.__rf2_story_ci` global installed by
  * `re-frame.story.play.ci-runner/install-ci-hooks!`), navigates the
  * shell to each variant, waits for each play's terminal status (`:pass`,
  * `:fail`, or `:cannot-run`), and prints a per-play report. `:cannot-run` is
  * terminal but never expected, so it produces a failed row without a timeout.
+ *
+ * The roster (rf2-kttom)
+ * ----------------------
+ * This runner drove ONE hardcoded testbed until the Hicasso deck landed.
+ * `TESTBEDS` is now the list, modelled on the roster/clean/compile/stage
+ * loop the sibling `serve-and-run-story-feature-load-tests.cjs` already
+ * keeps. Each entry owns its build id, HTML source, output dir, base path
+ * AND ITS OWN NON-VACUITY FLOOR — the floors differ on purpose:
+ *
+ *   counter-with-stories  four rows, both sides. It owns proof of THIS
+ *                         RUNNER's pass/fail semantics, so its seeded
+ *                         expected-fail fixtures must stay discovered.
+ *   hicasso-counter       one row, pass side only. It owns proof that a
+ *                         view authored on the NATIVE substrate paints
+ *                         and responds inside Story. Manufacturing a
+ *                         failing hicasso variant would test the runner
+ *                         twice without strengthening that claim, and
+ *                         requiring four rows would pad the deck.
+ *
+ * Each testbed is served under its own base path and boots its own shell,
+ * so one deck's variants can never satisfy another's floor.
  *
  * Multi-play
  * ----------
@@ -75,22 +96,6 @@ const FAILURE_REPORT_PATH = path.join(
   FAILURE_REPORT_DIR,
   'failure-report.json',
 );
-const TESTBED_BUILD = 'examples/counter-with-stories';
-const TESTBED_DIR_NAME = 'counter-with-stories';
-const TESTBED_HTML = path.join(
-  REPO_ROOT,
-  'tools',
-  'story',
-  'testbeds',
-  'counter_with_stories',
-  'index.html',
-);
-const TESTBED_OUT = path.join(OUT_ROOT, TESTBED_DIR_NAME);
-// Path-only (no hash) so we can compose `?variant=...#/stories` URLs
-// per the share-link convention — query params MUST come BEFORE the
-// hash route or `window.location.search` will be empty and the share
-// hydrator will skip the variant select.
-const TESTBED_BASE = `/${TESTBED_DIR_NAME}/`;
 const STORY_FRAGMENT = '#/stories';
 const READY_TIMEOUT_MS = 30000;
 const TERMINAL_TIMEOUT_MS = Number(
@@ -151,21 +156,24 @@ function log(line) {
   process.stdout.write(`${line}\n`);
 }
 
-// Clean-stage boundary (rf2-bf4vdy): remove + recreate the testbed's output
+// Clean-stage boundary (rf2-bf4vdy): remove + recreate each testbed's output
 // dir BEFORE shadow-cljs compiles into it, so every served file is produced
 // from the current source this run — no stale file from a previous run can
 // satisfy a browser request the current testbed no longer produces. Cleans
-// only this one dir (not the shared OUT_ROOT); the helper path-guards the
-// target to live strictly under OUT_ROOT.
-function cleanTestbedOutDir() {
-  cleanStageDirs([TESTBED_OUT], OUT_ROOT);
+// only the roster's own dirs (not the shared OUT_ROOT); the helper
+// path-guards every target to live strictly under OUT_ROOT.
+function cleanTestbedOutDirs() {
+  cleanStageDirs(TESTBEDS.map((t) => t.outDir), OUT_ROOT);
 }
 
-function compileTestbed() {
+function compileTestbeds() {
   // Spawn the resolved shadow-cljs JS entry-point under THIS node binary,
   // shell-free (rf2-y9o5e3). Quiet-on-success: capture output and surface
-  // it only on failure (or under RF2_VERBOSE_TESTS).
-  const args = [shadowCljsRunner(), 'compile', TESTBED_BUILD];
+  // it only on failure (or under RF2_VERBOSE_TESTS). ONE invocation for the
+  // whole roster — shadow-cljs compiles the builds against a single JVM, so
+  // the second testbed costs a fraction of the first.
+  const builds = TESTBEDS.map((t) => t.build);
+  const args = [shadowCljsRunner(), 'compile', ...builds];
   const result = spawnSync(process.execPath, args, {
     cwd: IMPL_ROOT,
     encoding: 'utf8',
@@ -175,19 +183,21 @@ function compileTestbed() {
     process.stdout.write(output);
   }
   if (result.status !== 0) {
-    console.error(`> shadow-cljs compile ${TESTBED_BUILD}`);
+    console.error(`> shadow-cljs compile ${builds.join(' ')}`);
     throw new Error(`shadow-cljs compile failed (exit ${result.status})`);
   }
 }
 
 function stageTestbedHtml() {
-  if (!fs.existsSync(TESTBED_OUT)) {
-    throw new Error(`Build output dir missing: ${TESTBED_OUT}`);
+  for (const testbed of TESTBEDS) {
+    if (!fs.existsSync(testbed.outDir)) {
+      throw new Error(`Build output dir missing: ${testbed.outDir}`);
+    }
+    if (!fs.existsSync(testbed.htmlSrc)) {
+      throw new Error(`HTML source missing: ${testbed.htmlSrc}`);
+    }
+    fs.copyFileSync(testbed.htmlSrc, path.join(testbed.outDir, 'index.html'));
   }
-  if (!fs.existsSync(TESTBED_HTML)) {
-    throw new Error(`HTML source missing: ${TESTBED_HTML}`);
-  }
-  fs.copyFileSync(TESTBED_HTML, path.join(TESTBED_OUT, 'index.html'));
 }
 
 /**
@@ -225,12 +235,12 @@ function variantIdToParam(idStr) {
  * shape (`?variant=story.foo/bar#/stories`). The query is placed BEFORE the
  * hash route because shell hydration reads `window.location.search`.
  */
-async function navigateToVariant(page, baseUrl, variantId) {
+async function navigateToVariant(page, baseUrl, basePath, variantId) {
   const variantStr = variantIdToParam(variantId);
   // Share-link convention: search params BEFORE the hash route, so
   // `window.location.search` carries `?variant=...` and the share
   // hydrator picks it up on shell mount.
-  const target = `${baseUrl}${TESTBED_BASE}?variant=${encodeURIComponent(variantStr)}${STORY_FRAGMENT}`;
+  const target = `${baseUrl}${basePath}?variant=${encodeURIComponent(variantStr)}${STORY_FRAGMENT}`;
   // Always full-load (not reload) — each variant gets a fresh shell
   // mount so the auto-run fires deterministically without inheriting
   // previous run-state.
@@ -356,8 +366,8 @@ async function discoverVariants(page) {
   });
 }
 
-async function bootShell(page, baseUrl) {
-  await navigate(page, `${baseUrl}${TESTBED_BASE}${STORY_FRAGMENT}`, {
+async function bootShell(page, baseUrl, basePath) {
+  await navigate(page, `${baseUrl}${basePath}${STORY_FRAGMENT}`, {
     timeoutMs: NAV_TIMEOUT_MS,
   });
   await page.evaluate(() => {
@@ -392,8 +402,13 @@ function summariseResults(results) {
     const tag = r.matched ? 'OK  ' : 'MISS';
     const actual = (r.runState && r.runState.status) || 'no-state';
     const playLabel = r.playKey ? `[${r.playKey}]` : '';
+    // The testbed prefix is what makes a row attributable once the roster
+    // holds more than one deck: two testbeds may legitimately register
+    // variants under similar ids, and a bare row would not say which shell
+    // produced it.
+    const bed = r.testbed ? `${r.testbed}  ` : '';
     lines.push(
-      `${tag} ${r.variantId}${playLabel}  expected=${r.expected} actual=${actual}  steps=${r.runState ? r.runState.total : '?'}`,
+      `${tag} ${bed}${r.variantId}${playLabel}  expected=${r.expected} actual=${actual}  steps=${r.runState ? r.runState.total : '?'}`,
     );
     if (!r.matched) {
       // The CLJS `project-state` serialises `:passed?` as the literal
@@ -451,6 +466,7 @@ function writeFailureReport(failures, allResults, browserMessages, pageErrors = 
     uncaughtPageErrors: pageErrors.length,
     pageErrors: pageErrors.slice(-40),
     failures: failures.map((r) => ({
+      testbed: r.testbed || null,
       variantId: r.variantId,
       playKey: r.playKey || null,
       expected: r.expected,
@@ -514,6 +530,57 @@ function computeExitCode({ failures, pageErrors }) {
 // only one side of the contract is still a trust hole.
 const MIN_PLAY_ROWS = 4;
 
+// rf2-kttom — THE ROSTER.
+//
+// One entry per Story testbed this gate drives. `vacuity` is the entry's
+// own non-vacuity floor, and the two floors differ because the two
+// testbeds prove different things (see this file's header). Nothing about
+// the counter entry changed: it keeps `MIN_PLAY_ROWS` and both sides.
+const TESTBEDS = [
+  {
+    label: 'counter-with-stories',
+    build: 'examples/counter-with-stories',
+    dirName: 'counter-with-stories',
+    htmlSrc: path.join(
+      REPO_ROOT, 'tools', 'story', 'testbeds', 'counter_with_stories', 'index.html',
+    ),
+    outDir: path.join(OUT_ROOT, 'counter-with-stories'),
+    vacuity: {
+      minRows: MIN_PLAY_ROWS,
+      requireBothSides: true,
+      seededBy:
+        'the counter-with-stories testbed seeds eight rows across six ' +
+        'variants (stories.cljs §`:script` CI fixtures), both sides included',
+    },
+  },
+  {
+    label: 'hicasso-counter',
+    build: 'examples/hicasso-counter',
+    dirName: 'hicasso-counter',
+    htmlSrc: path.join(
+      REPO_ROOT, 'tools', 'story', 'testbeds', 'hicasso_counter', 'index.html',
+    ),
+    outDir: path.join(OUT_ROOT, 'hicasso-counter'),
+    vacuity: {
+      minRows: 1,
+      requireBothSides: false,
+      seededBy:
+        'the hicasso-counter deck seeds ONE meaningful play — mount the ' +
+        'boundary, click it, assert the resulting DOM and frame state ' +
+        '(rf2-kttom). Zero rows means the :hicasso registration, the view ' +
+        'alias, or the deck has drifted',
+    },
+  },
+];
+
+// Path-only (no hash) so we can compose `?variant=...#/stories` URLs per
+// the share-link convention — query params MUST come BEFORE the hash route
+// or `window.location.search` will be empty and the share hydrator will
+// skip the variant select.
+function basePathFor(testbed) {
+  return `/${testbed.dirName}/`;
+}
+
 /**
  * rf2-54xbp: NON-VACUOUS guard over the discovered play-script rows.
  *
@@ -529,24 +596,37 @@ const MIN_PLAY_ROWS = 4;
  *
  * The invariant is deliberately stronger than `rows.length > 0`:
  *
- *   1. At least `MIN_PLAY_ROWS` discovered rows (the seeded fixtures
- *      produce eight; a near-empty set is a drift signal, not success).
+ *   1. At least `minRows` discovered rows (default `MIN_PLAY_ROWS`; the
+ *      counter's seeded fixtures produce eight, and a near-empty set is a
+ *      drift signal, not success).
  *   2. At least one EXPECTED-PASS row AND at least one EXPECTED-FAIL row,
  *      so a drift that strips the expected-fail fixtures — leaving the
  *      runner's failure path uncovered — also trips, even if the floor
  *      is otherwise met.
+ *
+ * rf2-kttom made BOTH halves per-testbed, because a roster of decks that
+ * prove different things cannot share one floor. `requireBothSides` is the
+ * second half's switch and it defaults TRUE, so the counter entry — and
+ * any caller that passes no opts, including every existing unit case —
+ * keeps exactly the invariant rf2-54xbp wrote. A deck opts OUT only by
+ * saying so in the roster, and only where it has a reason: the hicasso
+ * deck's job is to prove the native substrate paints, not to re-prove the
+ * runner's failure path, which the counter already holds under continuous
+ * coverage. `minRows` still applies on the pass side, so an opted-out deck
+ * that discovers ZERO rows is still a loud red.
  *
  * Pure (rows in → verdict out) so it is unit-testable without a browser:
  * a simulated empty / under-floor / one-sided discovery must yield
  * `{ ok: false }` with a clear diagnostic.
  *
  * @param {Array} rows discovered ci-rows (each `{ 'variant-id', 'play-key', ... }`)
- * @param {{ minRows?: number }} [opts]
+ * @param {{ minRows?: number, requireBothSides?: boolean, seededBy?: string }} [opts]
  * @returns {{ ok: boolean, diagnostic: (string|null), rowCount: number,
  *             passRows: number, failRows: number }}
  */
 function checkRowsNonVacuous(rows, opts = {}) {
   const minRows = opts.minRows == null ? MIN_PLAY_ROWS : opts.minRows;
+  const requireBothSides = opts.requireBothSides !== false;
   const list = Array.isArray(rows) ? rows : [];
   let passRows = 0;
   let failRows = 0;
@@ -581,13 +661,15 @@ function checkRowsNonVacuous(rows, opts = {}) {
       failRows,
       diagnostic:
         `Only ${rowCount} :play-script / :plays row(s) discovered — below ` +
-        `the non-vacuous floor of ${minRows}. The counter-with-stories ` +
-        `testbed seeds eight rows across six variants; a near-empty set is ` +
+        `the non-vacuous floor of ${minRows}. ${
+          opts.seededBy ||
+          'the counter-with-stories testbed seeds eight rows across six variants'
+        }; a near-empty set is ` +
         `a discovery/registration/lowering drift signal, not success. ` +
         `Refusing to pass a vacuous gate (rf2-54xbp).`,
     };
   }
-  if (passRows === 0 || failRows === 0) {
+  if (requireBothSides && (passRows === 0 || failRows === 0)) {
     return {
       ok: false,
       rowCount,
@@ -600,6 +682,23 @@ function checkRowsNonVacuous(rows, opts = {}) {
         `counter-with-stories testbed seeds both (e.g. .../passing and ` +
         `.../failing); a one-sided discovery means the failure path is no ` +
         `longer under coverage. Refusing to pass a one-sided gate (rf2-54xbp).`,
+    };
+  }
+  if (!requireBothSides && passRows === 0) {
+    // The opt-out drops the EXPECTED-FAIL requirement and only that. A deck
+    // whose every discovered row is an expected-fail has no successful play
+    // at all, which for an opted-out entry is the whole of what it was
+    // rostered to prove — so it is still a red (rf2-kttom).
+    return {
+      ok: false,
+      rowCount,
+      passRows,
+      failRows,
+      diagnostic:
+        `Discovered ${rowCount} row(s) and NONE of them is expected-pass. ` +
+        `This entry waives the expected-fail requirement, not the pass one: ` +
+        `${opts.seededBy || 'its floor is at least one successful play'}. ` +
+        `Refusing to pass a gate with no successful play (rf2-kttom).`,
     };
   }
   return { ok: true, rowCount, passRows, failRows, diagnostic: null };
@@ -619,7 +718,20 @@ function groupRowsByVariant(rows) {
   return grouped;
 }
 
-async function runAllVariants(browser, baseUrl) {
+/**
+ * Drive ONE roster entry: boot its shell, discover its rows, guard them
+ * against ITS floor, and run every play.
+ *
+ * Returns `{ results, browserMessages, pageErrors }` for the caller to
+ * aggregate; the verdict is computed once, over the whole roster, so a red
+ * from either testbed reds the gate and neither can mask the other.
+ *
+ * Each entry gets its OWN browser context, which is what keeps the decks
+ * independent: localStorage (the Story shell's help-dialog prime and its
+ * shell state) and any in-page globals are per-context, so one testbed's
+ * shell can neither hydrate from nor leak into the next one's.
+ */
+async function runTestbed(browser, baseUrl, testbed) {
   const context = await browser.newContext();
   const page = await context.newPage();
   const browserMessages = [];
@@ -640,11 +752,17 @@ async function runAllVariants(browser, baseUrl) {
     browserMessages.push(message);
   });
 
+  const basePath = basePathFor(testbed);
+
   try {
-    await bootShell(page, baseUrl);
+    log('');
+    log(`--- ${testbed.label} (${testbed.build}) at ${basePath} ---`);
+    await bootShell(page, baseUrl, basePath);
     const discovery = await discoverVariants(page);
     if (discovery.error || !Array.isArray(discovery.variants)) {
-      throw new Error(`variant discovery failed: ${discovery.error || JSON.stringify(discovery)}`);
+      throw new Error(
+        `${testbed.label}: variant discovery failed: ${discovery.error || JSON.stringify(discovery)}`,
+      );
     }
     const variants = discovery.variants;
     // Prefer the per-play `rows` enumeration; fall back to the
@@ -654,7 +772,7 @@ async function runAllVariants(browser, baseUrl) {
         ? discovery.context.rows
         : variants.map((vid) => ({ 'variant-id': vid, 'play-key': null, name: null }));
     log(
-      `Discovered ${variants.length} variant(s) with :play-script / :plays — ${rows.length} play row(s) total`,
+      `${testbed.label}: discovered ${variants.length} variant(s) with :play-script / :plays — ${rows.length} play row(s)`,
     );
     if (VERBOSE) {
       for (const r of rows) {
@@ -670,11 +788,15 @@ async function runAllVariants(browser, baseUrl) {
     // rows is a discovery/registration/lowering regression, NOT "nothing
     // to assert". Fail closed with a clear diagnostic, mirroring the
     // adjacent static gates' vacuous-scan guards.
-    const vacuity = checkRowsNonVacuous(rows);
+    const vacuity = checkRowsNonVacuous(rows, testbed.vacuity);
     if (!vacuity.ok) {
       log('');
-      log(`Non-vacuous play-script guard FAILED: ${vacuity.diagnostic}`);
-      throw new Error(`vacuous play-script gate: ${vacuity.diagnostic}`);
+      log(
+        `Non-vacuous play-script guard FAILED for ${testbed.label}: ${vacuity.diagnostic}`,
+      );
+      throw new Error(
+        `vacuous play-script gate (${testbed.label}): ${vacuity.diagnostic}`,
+      );
     }
 
     const results = [];
@@ -682,11 +804,12 @@ async function runAllVariants(browser, baseUrl) {
     for (const [vid, variantRows] of grouped.entries()) {
       let navOk = true;
       try {
-        await navigateToVariant(page, baseUrl, vid);
+        await navigateToVariant(page, baseUrl, basePath, vid);
       } catch (err) {
         navOk = false;
         for (const row of variantRows) {
           results.push({
+            testbed: testbed.label,
             variantId: vid,
             playKey: row['play-key'],
             expected: expectedStatusFor(vid, row['play-key']),
@@ -715,6 +838,7 @@ async function runAllVariants(browser, baseUrl) {
           : await waitForTerminalState(page, vid);
         const actual = (runState && runState.status) || null;
         results.push({
+          testbed: testbed.label,
           variantId: vid,
           playKey,
           expected,
@@ -724,30 +848,53 @@ async function runAllVariants(browser, baseUrl) {
       }
     }
 
-    const { lines, failures } = summariseResults(results);
-    log(lines);
-    // rf2-wf5al(1): an uncaught browser `pageerror` is fatal even when
-    // every play row matched its expected status — otherwise a runtime
-    // regression (shell/hydration/dispatch exception) false-greens the
-    // gate behind a clean play-status summary.
-    if (pageErrors.length > 0) {
-      log('');
-      log(
-        `Detected ${pageErrors.length} uncaught browser pageerror(s) — failing the gate (rf2-wf5al).`,
-      );
-    }
-    const gateFailed = failures.length > 0 || pageErrors.length > 0;
-    if (gateFailed && browserMessages.length > 0) {
-      log('--- browser diagnostics ---');
-      for (const msg of browserMessages.slice(-40)) log(msg);
-    }
-    if (gateFailed) {
-      writeFailureReport(failures, results, browserMessages, pageErrors);
-    }
-    return computeExitCode({ failures, pageErrors });
+    return { results, browserMessages, pageErrors };
   } finally {
     await context.close();
   }
+}
+
+/**
+ * Drive the whole roster and compute the ONE verdict.
+ *
+ * Every testbed runs before the verdict is taken, so a red in the first
+ * does not hide what the second would have said — the summary names both,
+ * and a maintainer reading a failed CI log sees the full picture rather
+ * than the first casualty.
+ */
+async function runAllVariants(browser, baseUrl) {
+  const results = [];
+  const browserMessages = [];
+  const pageErrors = [];
+
+  for (const testbed of TESTBEDS) {
+    const run = await runTestbed(browser, baseUrl, testbed);
+    results.push(...run.results);
+    browserMessages.push(...run.browserMessages);
+    pageErrors.push(...run.pageErrors);
+  }
+
+  const { lines, failures } = summariseResults(results);
+  log(lines);
+  // rf2-wf5al(1): an uncaught browser `pageerror` is fatal even when
+  // every play row matched its expected status — otherwise a runtime
+  // regression (shell/hydration/dispatch exception) false-greens the
+  // gate behind a clean play-status summary.
+  if (pageErrors.length > 0) {
+    log('');
+    log(
+      `Detected ${pageErrors.length} uncaught browser pageerror(s) — failing the gate (rf2-wf5al).`,
+    );
+  }
+  const gateFailed = failures.length > 0 || pageErrors.length > 0;
+  if (gateFailed && browserMessages.length > 0) {
+    log('--- browser diagnostics ---');
+    for (const msg of browserMessages.slice(-40)) log(msg);
+  }
+  if (gateFailed) {
+    writeFailureReport(failures, results, browserMessages, pageErrors);
+  }
+  return computeExitCode({ failures, pageErrors });
 }
 
 async function main() {
@@ -757,8 +904,8 @@ async function main() {
   });
   const baseUrl = `http://127.0.0.1:${port}`;
 
-  cleanTestbedOutDir();
-  compileTestbed();
+  cleanTestbedOutDirs();
+  compileTestbeds();
   stageTestbedHtml();
 
   // Serve implementation/out/examples on loopback. The shared harness owns
@@ -828,4 +975,9 @@ module.exports = {
   // browser (symmetric with the computeExitCode unit coverage).
   checkRowsNonVacuous,
   MIN_PLAY_ROWS,
+  // rf2-kttom: the roster, exported so the script-policy gate can assert
+  // it names BOTH testbeds and that each entry carries its own floor —
+  // a deck silently dropped from the roster is a gate that stopped
+  // running without going red.
+  TESTBEDS,
 };

--- a/implementation/README.md
+++ b/implementation/README.md
@@ -412,6 +412,7 @@ preserving first-seen order.
 | `:examples/counter-with-stories` | http://localhost:8042/ · `/#/stories` |
 | `:examples/login-form` | http://localhost:8043/ · `/#/stories` |
 | `:examples/linearlite` | http://localhost:8044/ |
+| `:examples/hicasso-counter` | http://localhost:8045/ · `/#/stories` |
 | `:testbeds/tenant-switcher` | http://localhost:8060/ |
 | `:hicasso/hmr-testbed` | http://localhost:8061/ |
 

--- a/implementation/scripts/_changed-surfaces.test.cjs
+++ b/implementation/scripts/_changed-surfaces.test.cjs
@@ -117,6 +117,36 @@ test('Xray feature_matrix testbed .cljs changes trigger story_xray_browser', () 
   assert.equal(result.story_xray_browser, 'true');
 });
 
+// rf2-kttom — the `.html` hole. The browser runners COPY each testbed's
+// hand-written index.html into the served output dir and navigate to it
+// (`stageTestbedHtml` in serve-and-run-story-play-scripts.cjs and its
+// feature-load sibling), so the served document is a testbed SOURCE file:
+// break its `<script src>` or its `#app` node and every play in that deck
+// fails. It was not in the runtime-extension predicate, so an HTML-only
+// regression classified as no-surface and skipped the browser gate.
+test('Story testbed .html changes trigger story_xray_browser (the runner serves it — rf2-kttom)', () => {
+  const exemplar = 'tools/story/testbeds/hicasso_counter/index.html';
+  assert.ok(
+    fs.existsSync(path.join(REPO_ROOT, exemplar)),
+    `${exemplar} must exist — this row's whole claim is "a real served testbed document"`,
+  );
+  assert.equal(classify(exemplar).story_xray_browser, 'true');
+});
+
+test('Xray testbed .html changes trigger story_xray_browser (rf2-kttom)', () => {
+  const result = classify('tools/xray/testbeds/feature_matrix/index.html');
+  assert.equal(result.story_xray_browser, 'true');
+});
+
+// The predicate widened by ONE extension and only under the two testbed /
+// src trees. An .html elsewhere under tools/story — the spec tree, say —
+// is still inert, which is what keeps the widening a fix rather than a
+// blanket arm.
+test('Story spec-tree .html changes do NOT trigger story_xray_browser (rf2-kttom)', () => {
+  const result = classify('tools/story/spec/diagrams/overview.html');
+  assert.equal(result.story_xray_browser, 'false');
+});
+
 test('Story spec-only .md changes do NOT trigger story_xray_browser (rf2-k9ekz)', () => {
   const result = classify('tools/story/spec/Spec.md');
   assert.equal(result.story_xray_browser, 'false');

--- a/implementation/scripts/_story-script-runners-policy.test.cjs
+++ b/implementation/scripts/_story-script-runners-policy.test.cjs
@@ -59,6 +59,7 @@ const {
   isTerminalStatus,
   checkRowsNonVacuous,
   MIN_PLAY_ROWS,
+  TESTBEDS,
 } = require(PLAY_SCRIPTS_RUNNER);
 
 const { test, run } = createPolicyTestSuite('story-script-runners-policy');
@@ -271,17 +272,120 @@ test('checkRowsNonVacuous: seeded inventory shape (8 rows, 5 pass / 3 fail) → 
 
 // Pin the runtime call-site so a refactor can't drop the non-vacuous
 // guard back to the old "empty rows → 0 / nothing to assert" false-green.
+// The trailing `[,)]` admits rf2-kttom's per-testbed opts argument while
+// still refusing a call over anything but the discovered `rows`.
 test('play-scripts runner gates discovery on checkRowsNonVacuous (rf2-54xbp / rf2-ljyp9)', () => {
   const src = fs.readFileSync(PLAY_SCRIPTS_RUNNER, 'utf8');
   assert.match(
     src,
-    /checkRowsNonVacuous\(\s*rows\s*\)/,
-    'runAllVariants must call checkRowsNonVacuous(rows) over the discovered rows.',
+    /checkRowsNonVacuous\(\s*rows\s*[,)]/,
+    'runTestbed must call checkRowsNonVacuous(rows, …) over the discovered rows.',
   );
   assert.match(
     src,
     /if\s*\(\s*!\s*vacuity\.ok\s*\)/,
     'the runner must fail closed (throw) when the non-vacuous verdict is not ok.',
+  );
+});
+
+// ---- rf2-kttom: the roster, and the per-testbed floors ----
+//
+// The runner drove ONE hardcoded testbed until the Hicasso deck landed.
+// A deck silently dropped from the roster is a gate that stopped running
+// without ever going red, so the roster's membership is pinned here — and
+// so is the property that makes the two floors safe to differ: the opt-out
+// waives the EXPECTED-FAIL requirement and nothing else.
+
+test('the play-scripts roster names both Story testbeds (rf2-kttom)', () => {
+  const labels = TESTBEDS.map((t) => t.label);
+  assert.ok(
+    labels.includes('counter-with-stories'),
+    'the counter testbed must stay on the roster — it owns proof of the ' +
+      "runner's own pass/fail semantics.",
+  );
+  assert.ok(
+    labels.includes('hicasso-counter'),
+    'the hicasso testbed must be on the roster — it owns proof that a view ' +
+      'authored on the native substrate paints in Story (rf2-kttom).',
+  );
+  for (const t of TESTBEDS) {
+    assert.ok(t.build, `${t.label}: roster entry must carry a shadow-cljs build id`);
+    assert.ok(t.dirName, `${t.label}: roster entry must carry an output dir name`);
+    assert.ok(t.htmlSrc, `${t.label}: roster entry must carry an HTML source`);
+    assert.ok(t.outDir, `${t.label}: roster entry must carry an output dir`);
+    assert.ok(
+      t.vacuity && typeof t.vacuity.minRows === 'number',
+      `${t.label}: roster entry must carry its own non-vacuity floor`,
+    );
+  }
+});
+
+test("the counter entry's floor is UNCHANGED — four rows, both sides (rf2-kttom)", () => {
+  const counter = TESTBEDS.find((t) => t.label === 'counter-with-stories');
+  assert.equal(counter.vacuity.minRows, MIN_PLAY_ROWS);
+  assert.notEqual(
+    counter.vacuity.requireBothSides,
+    false,
+    'the counter entry must keep the both-sides invariant rf2-54xbp wrote.',
+  );
+});
+
+test('checkRowsNonVacuous: requireBothSides defaults TRUE, so no-opts callers keep the rf2-54xbp invariant', () => {
+  const oneSided = [
+    { 'variant-id': 'story.counter/a', 'play-key': null },
+    { 'variant-id': 'story.counter/b', 'play-key': null },
+    { 'variant-id': 'story.counter/c', 'play-key': null },
+    { 'variant-id': 'story.counter/d', 'play-key': null },
+  ];
+  assert.equal(checkRowsNonVacuous(oneSided).ok, false);
+  assert.equal(checkRowsNonVacuous(oneSided, {}).ok, false);
+  assert.equal(checkRowsNonVacuous(oneSided, { minRows: 4 }).ok, false);
+});
+
+test('checkRowsNonVacuous: an opted-out entry passes on ONE successful play (rf2-kttom)', () => {
+  const hicasso = TESTBEDS.find((t) => t.label === 'hicasso-counter');
+  const v = checkRowsNonVacuous(
+    [{ 'variant-id': 'story.hicasso-counter/tally', 'play-key': null }],
+    hicasso.vacuity,
+  );
+  assert.equal(v.ok, true);
+  assert.equal(v.passRows, 1);
+  assert.equal(v.failRows, 0);
+});
+
+test('checkRowsNonVacuous: an opted-out entry still fails CLOSED on zero rows (rf2-kttom)', () => {
+  const hicasso = TESTBEDS.find((t) => t.label === 'hicasso-counter');
+  const v = checkRowsNonVacuous([], hicasso.vacuity);
+  assert.equal(v.ok, false);
+  assert.match(v.diagnostic, /DRIFTED/);
+});
+
+test('checkRowsNonVacuous: the opt-out waives expected-fail ONLY — no successful play is still RED (rf2-kttom)', () => {
+  // Every discovered row classifies expected-fail. For an entry whose whole
+  // job is to prove one play succeeds, that is vacuous in the direction the
+  // opt-out does NOT cover.
+  const v = checkRowsNonVacuous(
+    [{ 'variant-id': 'story.hicasso-counter/failing-tally', 'play-key': null }],
+    { minRows: 1, requireBothSides: false },
+  );
+  assert.equal(v.ok, false);
+  assert.equal(v.passRows, 0);
+  assert.match(v.diagnostic, /no successful play/);
+});
+
+// Pin the per-testbed loop so a refactor cannot collapse the roster back
+// to a single hardcoded testbed while every assertion above still passes.
+test('play-scripts runner drives every roster entry (rf2-kttom)', () => {
+  const src = stripComments(fs.readFileSync(PLAY_SCRIPTS_RUNNER, 'utf8'));
+  assert.match(
+    src,
+    /for\s*\(\s*const\s+testbed\s+of\s+TESTBEDS\s*\)/,
+    'runAllVariants must iterate the whole TESTBEDS roster.',
+  );
+  assert.match(
+    src,
+    /runTestbed\(\s*browser\s*,\s*baseUrl\s*,\s*testbed\s*\)/,
+    'each roster entry must be driven through runTestbed(browser, baseUrl, testbed).',
   );
 });
 

--- a/implementation/scripts/dev-testbed.cjs
+++ b/implementation/scripts/dev-testbed.cjs
@@ -104,12 +104,15 @@ const { REPO_ROOT, IMPL_ROOT } = require('./_path-policy.cjs');
 //                                         up when the gate and a watch run at
 //                                         once. The next free Xray slot is
 //                                         8038.
-//   8040-8044   Story showcases +         :dev-http (shadow-cljs.edn):
+//   8040-8045   Story showcases +         :dev-http (shadow-cljs.edn):
 //               worked examples             8040 nine-states-with-stories
 //                                           8041 login-with-stories
 //                                           8042 counter-with-stories
 //                                           8043 login-form
 //                                           8044 linearlite (plain example)
+//                                           8045 hicasso-counter (rf2-kttom)
+//                                         The next free slot in this band is
+//                                         8046.
 //   805x        examples orchestrator     DEFAULT_PORT in
 //                                           examples/scripts/examples-port.cjs
 //                                           (8050; pre-flight + forward scan).
@@ -126,7 +129,7 @@ const { REPO_ROOT, IMPL_ROOT } = require('./_path-policy.cjs');
 //                                         must share an origin.
 //   8765        Xray panel-gallery        :dev-http (shadow-cljs.edn).
 //
-// The :dev-http bands (8030-8036 / 8040-8044 / 8765) are mirrored in the
+// The :dev-http bands (8030-8036 / 8040-8045 / 8765) are mirrored in the
 // DEV_HTTP map below (READ-only — shadow-cljs.edn is hot-zone). The 805x
 // examples band is NOT a :dev-http port — it is the test-orchestrator's
 // http-server default, resolved at runtime — so it lives only here + in
@@ -156,6 +159,11 @@ const DEV_HTTP = {
   // rf2-tideyl — Linearlite optimistic-board example (804x band, plain
   // build: no Story shell, so no `story: true`).
   ':examples/linearlite': { port: 8044 },
+  // rf2-kttom — the Hicasso Story testbed (804x band). Story shell at
+  // /#/stories, so `story: true` like its Reagent siblings; the difference
+  // is in the deck, which declares `:substrates #{:hicasso}` and paints
+  // through the host-registered `:hicasso` render fn.
+  ':examples/hicasso-counter': { port: 8045, story: true },
   // rf2-5e22yc — top-level tenant-switcher testbed (806x band).
   ':testbeds/tenant-switcher': { port: 8060 },
   // rf2-vsgq — the Hicasso HMR testbed (806x band). Unlike every other

--- a/implementation/shadow-cljs.edn
+++ b/implementation/shadow-cljs.edn
@@ -572,7 +572,7 @@
                             "out/examples/managed-http"]
                   :handler re-frame.testbed.open-in-editor-server/handler}
             ;; --- Story showcases (rf2-xz4zn) -------------------------
-            ;; The four Story-enabled builds, on the 804x band (the Xray
+            ;; The Story-enabled builds, on the 804x band (the Xray
             ;; testbeds own 803x + 8765). Each is hash-routed: `/#/` is
             ;; the live app, `/#/stories` mounts the Story shell; the Xray
             ;; preload is wired (Ctrl+Shift+C). Same source-dir-first
@@ -587,6 +587,7 @@
             ;;   http://localhost:8041/#/stories  login showcase (rf2-p8v0q)
             ;;   http://localhost:8042/#/stories  counter (canonical minimal)
             ;;   http://localhost:8043/#/stories  login-form (5-state)
+            ;;   http://localhost:8045/#/stories  hicasso-counter (native substrate)
             8040 {:roots   ["../examples/patterns/nine_states"
                             "out/examples/nine-states-with-stories"]
                   :handler re-frame.testbed.open-in-editor-server/handler}
@@ -606,6 +607,15 @@
             ;; free slot in the example/story 804x band.
             8044 {:roots   ["../examples/capabilities/resources/linearlite"
                             "out/examples/linearlite"]
+                  :handler re-frame.testbed.open-in-editor-server/handler}
+            ;; rf2-kttom — the HICASSO Story testbed. Same hash-routed shape
+            ;; and source-dir-first cascade as the four Story builds above:
+            ;;   http://localhost:8045/#/        the live tally
+            ;;   http://localhost:8045/#/stories the deck, :substrates #{:hicasso}
+            ;; Port 8045 is the next free slot in the example/story 804x band
+            ;; (8040-8043 the Story-enabled four, 8044 linearlite).
+            8045 {:roots   ["../tools/story/testbeds/hicasso_counter"
+                            "out/examples/hicasso-counter"]
                   :handler re-frame.testbed.open-in-editor-server/handler}
             ;; --- Top-level testbeds (rf2-5e22yc) ---------------------
             ;; The 806x band for top-level testbeds/<surface>/ dev-http
@@ -1936,6 +1946,36 @@
    :modules          {:main {:init-fn login-form.core/run}}
    ;; rf2-qhhxp — re-frame2-pair.runtime preload added so pair-MCP can
    ;; probe this Story showcase's live runtime alongside Xray.
+   :devtools         {:preloads [re-frame2-pair.runtime
+                                 day8.re-frame2-xray.preload]}}
+
+  ;; Hicasso Story testbed (rf2-kttom) — Phase D of rf2-5czki, and the
+  ;; proof that a boundary authored on the NATIVE substrate paints in
+  ;; Story's canvas. Hash-routed like the four Story builds above: `#/`
+  ;; renders the live tally (a Reagent root carrying the boundary through
+  ;; `h/as-component`), `#/stories` mounts the shell over a deck declaring
+  ;; `:substrates #{:hicasso}`. Sources under
+  ;; tools/story/testbeds/hicasso_counter/, which resolves via the
+  ;; `../tools/story/testbeds` :source-paths entry near the top of this
+  ;; file; `re-frame.hicasso.*` resolves via the "hicasso/src" entry.
+  ;;
+  ;; The `:hicasso` substrate render fn is HOST-registered (rf2-2dbpd) —
+  ;; Story ships no installer for it, so `hicasso-counter.core/run` calls
+  ;; `story/register-substrate!` at boot. Bundle isolation is unaffected:
+  ;; this is a testbed build, and nothing under implementation/ requires
+  ;; anything under tools/.
+  :examples/hicasso-counter
+  {:target           :browser
+   :output-dir       "out/examples/hicasso-counter"
+   :asset-path       "."
+   ;; rf2-5dphw — build-env project-root for open-in-editor (see
+   ;; :examples/login-form above for the mechanism).
+   :compiler-options {:closure-defines
+                      {re-frame.testbed.config/checkout-root
+                       #shadow/env ["RF2_TESTBED_PROJECT_ROOT" ""]}}
+   :modules          {:main {:init-fn hicasso-counter.core/run}}
+   ;; rf2-qhhxp — pair-MCP + inline Xray, matching the sibling Story
+   ;; testbed builds.
    :devtools         {:preloads [re-frame2-pair.runtime
                                  day8.re-frame2-xray.preload]}}
 

--- a/tools/story/README.md
+++ b/tools/story/README.md
@@ -151,6 +151,7 @@ Xray preload is wired — press `Ctrl+Shift+C`).
 | `:examples/login-with-stories` | 8041 | http://localhost:8041/#/stories | login showcase |
 | `:examples/counter-with-stories` | 8042 | http://localhost:8042/#/stories | canonical minimal testbed |
 | `:examples/login-form` | 8043 | http://localhost:8043/#/stories | five-state login-form testbed |
+| `:examples/hicasso-counter` | 8045 | http://localhost:8045/#/stories | the deck authored on the native substrate (`:substrates #{:hicasso}`) |
 
 Name the Story build(s) you want to watch and `npm run dev`
 (`implementation/scripts/dev-testbed.cjs`) prints each shell URL on start

--- a/tools/story/spec/001-Authoring.md
+++ b/tools/story/spec/001-Authoring.md
@@ -1501,7 +1501,24 @@ cells independently.
 ```clojure
 (story/reg-variant :story.ui.button/all-substrates
   {:substrates #{:reagent :uix}})
+
+(story/reg-variant :story.ui.card/native
+  {:substrates #{:hicasso}})
 ```
+
+A member of `:substrates` names **which registered render fn embeds the
+subject** — the authoring layer — and not which adapter `rf/init!`
+installed. The two axes coincided while the members were `:reagent` and
+`:uix`; `:hicasso` separates them, because Hicasso ships no adapter of its
+own and a Hicasso deck runs perfectly well under a Reagent-hosted shell.
+
+Story installs `:reagent` itself and leaves `:uix` and `:hicasso` to the
+host, for the same reason in both cases: the render fn's one dependency
+is the application's, so registering it in Story core would put that
+dependency on every consumer's classpath. Five lines at boot are the whole
+of the `:hicasso` recipe, written out in
+`re-frame.story.ui.multi-substrate`'s namespace docstring and worked in
+`tools/story/testbeds/hicasso_counter/`.
 
 The multi-substrate pane (render shell) renders each substrate
 side-by-side. Substrate-specific failures render inline; see

--- a/tools/story/testbeds/hicasso_counter/core.cljs
+++ b/tools/story/testbeds/hicasso_counter/core.cljs
@@ -1,0 +1,141 @@
+(ns hicasso-counter.core
+  "Hicasso story testbed entry — the proof that a Hicasso boundary paints
+  in Story's canvas (rf2-kttom, Phase D of rf2-5czki).
+
+  URL-hash-routed between two surfaces, like every other Story testbed:
+
+    `#/`        → the live tally, a Reagent root carrying the boundary
+                  through `h/as-component`.
+    `#/stories` → the Story shell. The deck's two variants declare
+                  `:substrates #{:hicasso}` and paint through the
+                  registered `:hicasso` render fn.
+
+  ## The host installs the `:hicasso` renderer — all five lines of it
+
+  Story ships no `install-hicasso-substrate!`, and that is a ruling
+  (rf2-1gy4e placement 1) rather than an omission: the renderer's one
+  dependency is the HOST's, so registering it here keeps Story core free
+  of Hicasso and `tools/story/deps.edn` untouched. `:uix` is host-registered
+  for the same reason. [[install-hicasso-substrate!]] below is byte-for-byte
+  the recipe written out in `re-frame.story.ui.multi-substrate`'s ns
+  docstring, which is also what
+  `re-frame.story.ui.hicasso-substrate-dom-cljs-test` drives.
+
+  ## Reagent is the SHELL's adapter, and that is not a contradiction
+
+  `rf/init!` installs ONE adapter and this testbed installs Reagent's,
+  because the Story shell and the hash-routing host are Reagent trees.
+  A substrate in Story names WHICH REGISTERED RENDER FN embeds the
+  subject — the authoring layer — and not the adapter `rf/init!` seated;
+  the two axes coincided while the members were `:reagent` and `:uix`,
+  and `:hicasso` is the member that separates them (Hicasso ships no
+  adapter at all). The canvas wraps every variant in
+  `[rf/frame-provider {:frame variant-id} …]`, whose provider is
+  `re-frame.adapter.context/frame-context` — the single React context
+  every React-shaped adapter reads — so a Hicasso boundary spliced into
+  that Reagent tree resolves the VARIANT's frame from it, with no second
+  root and no props ABI.
+
+  ## Elision
+
+  Per `001-Authoring.md` §Registration macros, under `:advanced` with
+  `:closure-defines {re-frame.story.config/enabled? false}` every `reg-*`
+  in `hicasso-counter.stories` elides to nil and `mount-shell!`
+  short-circuits. This build leaves Story enabled; the elision path is
+  gated elsewhere."
+  (:require [re-frame.core :as rf]
+            [re-frame.adapter.reagent :as reagent-adapter]
+            [re-frame.hicasso :as h]
+            [re-frame.story :as story]
+            [re-frame.story.play.ci-runner :as story-ci]
+            [day8.re-frame2-xray.config :as xray-config]
+            [hicasso-counter.events]
+            [hicasso-counter.subs]
+            [hicasso-counter.views :as views]
+            [hicasso-counter.stories]
+            ;; Shared Story-host helper: owns the live-app↔Story-shell hash
+            ;; router + React-root handle, and the open-in-editor project-root
+            ;; config via the `:source-subdir` opt.
+            [re-frame.testbed.story-host :as story-host])
+  (:require-macros [re-frame.core :refer [reg-view]]))
+
+;; ---------------------------------------------------------------------------
+;; The `:hicasso` substrate render fn — the consumer's five lines
+;; ---------------------------------------------------------------------------
+
+(defn install-hicasso-substrate!
+  "Register the `:hicasso` render fn with Story. Three decisions ride in
+  these lines and each is ruled on rf2-2dbpd:
+
+  - resolve LATE, per render, off `(rf/handler-meta :view id)`, so
+    re-evaluating a `defview` — which replaces the registrar entry behind
+    the same id — reaches the deck with no deck change;
+  - read `:hicasso/component`, because the alias entry deliberately
+    carries no `:handler-fn` and `rf/view` answers nil for it (rf2-5qaf4);
+  - mint the element with `h/as-element` rather than bridging through
+    `h/as-component`. `defview` already mints ONE `React.memo` wrapper per
+    head, so a fresh element per pass rides a stable TYPE and the boundary
+    re-renders instead of remounting."
+  []
+  (story/register-substrate! :hicasso
+    (fn [_variant-id view-id args]
+      (if-let [head (:hicasso/component (rf/handler-meta :view view-id))]
+        (h/as-element [head args])
+        [:div (str ":component " (pr-str view-id)
+                   " is not registered as a hicasso view")]))))
+
+;; ---------------------------------------------------------------------------
+;; Live-app root view — a Reagent tree carrying the boundary
+;; ---------------------------------------------------------------------------
+
+(reg-view tally-page []
+  [:div {:style {:padding "2em" :font-family "system-ui, sans-serif"
+                 :max-width "640px" :margin "0 auto"}}
+   [:h2 {:style {:margin "0 0 0.5em 0"}} "Hicasso tally (Story testbed)"]
+   [:p {:style {:font-size "13px" :color "#666" :margin "0 0 1.5em 0"}}
+    "Every element below this line was authored with "
+    [:code {:style {:background "#f5f5f5" :padding "1px 4px"}} "h/defview"]
+    ". Open "
+    [:a {:href "#/stories"} "#/stories"]
+    " for the same views as Story variants under "
+    [:code {:style {:background "#f5f5f5" :padding "1px 4px"}}
+     ":substrates #{:hicasso}"]
+    "."]
+   ;; `:>` places a real React component in Reagent's tree. The components
+   ;; themselves are minted ONCE, at the top level of `views` — minting one
+   ;; per render would hand React a fresh element type every pass, and React
+   ;; answers a fresh type by unmounting the subtree.
+   [:> views/tally-component {:heading "Tally"}]
+   [:> views/readout-component {:label "count"}]])
+
+;; EP-0002: the runtime never synthesises a frame from absence, so the
+;; live-app surface renders under an explicit frame scope. The Story shell
+;; side allocates its own per-variant frames; this wrapper scopes only the
+;; `#/` surface to the testbed's `:rf/default` frame. Mirrors
+;; login-form.core/live-app-root.
+(defn live-app-root []
+  [rf/frame-provider {:frame :rf/default} [tally-page]])
+
+;; ---------------------------------------------------------------------------
+;; Boot
+;; ---------------------------------------------------------------------------
+
+(defn ^:export run []
+  ;; Story owns this page's full-width browser-test canvas. Keep Xray's
+  ;; collectors and keybinding installed but skip the default panel launch.
+  (xray-config/configure! {:rf.xray/auto-open? false})
+  (rf/init! reagent-adapter/adapter)
+  (install-hicasso-substrate!)
+  (rf/make-frame {:id  :rf/default
+                  :doc "Hicasso-counter testbed default frame."})
+  ;; Seed the live page's frame. EP-0002: `init!` installs the adapter
+  ;; only, and a frameless `dispatch-sync` raises `:rf.error/no-frame-context`.
+  (rf/with-frame :rf/default
+    (rf/dispatch-sync [:hicasso-counter/initialise 0]))
+  ;; The `window.__rf2_story_ci` door the play-scripts runner enumerates
+  ;; and drives. Installed unconditionally — the fn body is itself gated on
+  ;; Story being enabled — and BEFORE the router mounts, so the global is
+  ;; present by the time the page has finished loading.
+  (story-ci/install-ci-hooks!)
+  (story-host/mount-with-hash-routing! live-app-root
+                                       {:source-subdir "tools/story/testbeds"}))

--- a/tools/story/testbeds/hicasso_counter/events.cljs
+++ b/tools/story/testbeds/hicasso_counter/events.cljs
@@ -1,0 +1,37 @@
+(ns hicasso-counter.events
+  "Model for the hicasso story testbed — plain re-frame2, with nothing
+  substrate-specific in it.
+
+  This is the point of the file being separate. A `h/defview` boundary
+  reads subscriptions and dispatches events through exactly the same
+  registrar every Reagent view uses, so the model an author writes for a
+  Hicasso app is the model they would have written anyway. Nothing here
+  names Hicasso, Story, or a substrate.
+
+  The tally is deliberately small — a count and the step it moves by —
+  because the claim under test is that a NATIVE-SUBSTRATE app can be
+  storied, not that Hicasso can express something elaborate. A bigger app
+  would put more between a red gate and its cause."
+  (:require [re-frame.core :as rf]))
+
+(rf/reg-event :hicasso-counter/initialise
+  {:doc "Seed the tally. Idempotent, so a play script that re-runs — the
+        Story shell auto-runs on a deep link AND on a watcher edge —
+        reaches the same terminal state either way."}
+  (fn [{:keys [db]} [_ n]]
+    {:db (assoc db :count (or n 0) :step (or (:step db) 1))}))
+
+(rf/reg-event :hicasso-counter/bump
+  {:doc "Advance the tally by the current step. The one interaction the
+        live page and the play script both drive."}
+  (fn [{:keys [db]} _]
+    {:db (update db :count + (or (:step db) 1))}))
+
+(rf/reg-event :hicasso-counter/set-step
+  {:doc "Set the step size. Reads its value off the field through the
+        `::h/value` marker at the call site, so the event handler takes
+        an ordinary string and coerces it here rather than in the view."}
+  (fn [{:keys [db]} [_ typed]]
+    {:db (assoc db :step (if (re-matches #"-?[0-9]+" (str typed))
+                           (js/parseInt typed 10)
+                           (:step db)))}))

--- a/tools/story/testbeds/hicasso_counter/index.html
+++ b/tools/story/testbeds/hicasso_counter/index.html
@@ -1,0 +1,11 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>re-frame2 testbed: hicasso-counter (Story on the native substrate)</title>
+</head>
+<body>
+  <div id="app"></div>
+  <script src="main.js"></script>
+</body>
+</html>

--- a/tools/story/testbeds/hicasso_counter/stories.cljs
+++ b/tools/story/testbeds/hicasso_counter/stories.cljs
@@ -1,0 +1,116 @@
+(ns hicasso-counter.stories
+  "The deck — Story variants over views authored in Hicasso.
+
+  This is Phase D of rf2-5czki, and its whole claim is one sentence: a
+  view a programmer wrote on the NATIVE substrate is storyable inside
+  Story, on the same PR-path gate every Reagent deck rides. Not \"a
+  Hicasso boundary can be embedded in a Reagent testbed\" — the deck below
+  declares `:substrates #{:hicasso}` and nothing here paints under
+  Reagent.
+
+  ## What each variant is for
+
+    :story.hicasso-counter/tally    the interaction, and the gate's row.
+                                    Its `:script` mounts the real
+                                    boundary, clicks a real button, and
+                                    asserts BOTH the resulting app-db and
+                                    the resulting DOM.
+    :story.hicasso-counter/readout  a second, read-only boundary — so the
+                                    deck says which Hicasso view painted
+                                    rather than merely that one did.
+
+  ## What is deliberately NOT here
+
+  No expected-fail fixture, and no four-row inventory. The counter
+  testbed owns proof of the runner's pass/fail semantics and keeps its
+  both-sides invariant unchanged; manufacturing a failing hicasso variant
+  would test the runner twice and the substrate no harder (ruled,
+  rf2-kttom). This deck's floor is ONE meaningful play, and the roster
+  entry in `examples/scripts/serve-and-run-story-play-scripts.cjs` says so.
+
+  No app image either. `login-form.stories` declares one because its
+  namespaces are CO-LOADED into the consolidated `:node-test` build by a
+  sibling `*_cljs_test.cljs`, where cross-app registrations of the same
+  `[kind id]` would collide in the default-image projection. This testbed
+  ships no such test, so nothing co-loads it and there is no collision to
+  scope away from.
+
+  ## The `:hicasso` substrate must be REGISTERED, and the host does it
+
+  Story ships no installer for `:hicasso`, exactly as it ships none for
+  `:uix` — the renderer's one dependency is the host's. `hicasso-counter.core`
+  registers it at boot. A variant below resolving to an unregistered
+  substrate paints a red cell naming the missing `register-substrate!`
+  call, which is what makes removing that registration a legible RED
+  rather than a silent fall-back to Reagent."
+  (:require [re-frame.story :as story]
+            ;; Sourcing these fires the registrations the variants name.
+            [hicasso-counter.events]
+            [hicasso-counter.subs]
+            [hicasso-counter.views]))
+
+(defn register-all!
+  "Register the testbed's Story artefacts. Idempotent; fired once at
+  namespace load. The canonical vocabulary auto-installs on the first
+  `reg-*` below, so there is no boot step to remember."
+  []
+  (story/reg-story :story.hicasso-counter
+    {:doc        "A tally authored in Hicasso — `h/defview`, `h/sub` and
+                 intent vectors, with no adapter call anywhere in the
+                 view source."
+     :component  :hicasso-counter.views/tally
+     :args       {:heading "Tally"}
+     :tags       #{:dev :docs}
+     :substrates #{:hicasso}})
+
+  ;; -------------------------------------------------------------------------
+  ;; The gate's row — one meaningful play through the live Story shell.
+  ;;
+  ;; Sleep-free by construction (rf2-n0sz4): the runner holds each step
+  ;; until its preconditions hold — the frame's event queue drained and
+  ;; the named node present — committing the substrate through the live
+  ;; adapter's `flush-render!` between attempts. `[:wait ms]` is spec/017's
+  ;; determinism OPT-OUT, and its absence here is the point.
+  ;;
+  ;; The script is IDEMPOTENT (initialise → one bump → assert), so the
+  ;; shell's deep-link auto-run and its watcher-edge auto-run reach the
+  ;; same terminal state.
+  ;; -------------------------------------------------------------------------
+
+  (story/reg-variant :story.hicasso-counter/tally
+    {:doc    "The interaction. Seeds the tally, reads it off the DOM the
+             boundary painted, clicks the boundary's own button, and
+             asserts that the click reached the frame (app-db) AND came
+             back out as a repaint (the DOM).
+
+             Three things have to be true for this to pass and each is
+             part of the claim: the `:hicasso` render fn resolved the
+             head off the view alias; the boundary read the VARIANT's
+             frame through React context rather than a default; and a
+             write into that frame re-ran the body."
+     :args   {:heading "Tally"}
+     :setup  [[:hicasso-counter/initialise 0]]
+     :script
+     {:name      "bump-reaches-the-frame-and-repaints-the-boundary"
+      :auto-run? true
+      :script    [[:dispatch-sync [:hicasso-counter/initialise 0]]
+                  [:assert-dom "[data-test=hic-count]" :text "0"]
+                  [:click      "[data-test=hic-bump]"]
+                  [:assert-db  [:count] 1]
+                  [:assert-dom "[data-test=hic-count]" :text "1"]]}
+     :tags   #{:dev :docs :test}
+     :substrates #{:hicasso}})
+
+  (story/reg-variant :story.hicasso-counter/readout
+    {:doc        "A second Hicasso boundary under the same substrate, so
+                 a green row names WHICH view painted. Read-only: it
+                 carries no script, and exists to keep the deck honest
+                 about resolution rather than to add gate coverage."
+     :component  :hicasso-counter.views/readout
+     :args       {:label "tally"}
+     :setup      [[:hicasso-counter/initialise 7]]
+     :tags       #{:dev :docs}
+     :substrates #{:hicasso}}))
+
+;; Fire the registrations once at namespace load.
+(register-all!)

--- a/tools/story/testbeds/hicasso_counter/subs.cljs
+++ b/tools/story/testbeds/hicasso_counter/subs.cljs
@@ -1,0 +1,15 @@
+(ns hicasso-counter.subs
+  "Subscriptions for the hicasso story testbed.
+
+  Ordinary `reg-sub`s. `h/sub` inside a boundary body resolves through
+  the same registrar and the same frame the Story canvas scoped, which is
+  why there is no Hicasso-flavoured subscription surface to declare here."
+  (:require [re-frame.core :as rf]))
+
+(rf/reg-sub :hicasso-counter/count
+  {:doc "The tally."}
+  (fn [db _] (or (:count db) 0)))
+
+(rf/reg-sub :hicasso-counter/step
+  {:doc "How far a bump moves the tally."}
+  (fn [db _] (or (:step db) 1)))

--- a/tools/story/testbeds/hicasso_counter/views.cljs
+++ b/tools/story/testbeds/hicasso_counter/views.cljs
@@ -1,0 +1,77 @@
+(ns hicasso-counter.views
+  "The subject — views authored in Hicasso, and nothing else.
+
+  `h/defview` is the whole authoring surface here: a boundary reads its
+  own subscriptions with `h/sub` and states its intent as a data vector at
+  `:on-click` / `:on-input`. There is no adapter call, no React import and
+  no props ABI in this file, which is what makes it a fair sample of what
+  a programmer on the native substrate actually writes.
+
+  ## What Story needs from a declaration here, and gets for free
+
+  Each `defview` publishes ONE registrar `:view` entry under
+  `(keyword \"hicasso-counter.views\" \"<sym>\")` carrying its minted head
+  at `:hicasso/component` (rf2-5qaf4). A variant in `stories.cljs`
+  therefore names `:hicasso-counter.views/tally` exactly as a Reagent
+  variant names a `reg-view` id, and the `:hicasso` render fn the shell
+  registers reads the head back out of that slot.
+
+  ## The `data-test` attributes are the play script's grip, not decoration
+
+  `[data-test=hic-count]`, `[data-test=hic-bump]` and
+  `[data-test=hic-step]` are what the deck's `:click` / `:type` /
+  `:assert-dom` steps address. They are ordinary attributes on ordinary
+  elements — nothing in this file is test-only behaviour, and removing
+  the deck would leave the views unchanged."
+  (:require [re-frame.core :as rf]
+            [re-frame.hicasso :as h]))
+
+(h/defview tally
+  "The stateful subject. Reads the tally and its step from the frame the
+  canvas scoped, and bumps the tally through an intent vector — so the
+  round trip a play script drives (click → event → app-db → repaint) is
+  entirely inside the boundary."
+  [{:keys [heading]}]
+  [:section {:class "hic-tally" :data-test "hic-tally"}
+   [:h3 (or heading "Tally")]
+   [:output {:data-test "hic-count"} (str (h/sub [:hicasso-counter/count]))]
+   [:button {:data-test "hic-bump"
+             :on-click  [:hicasso-counter/bump]}
+    (str "+" (h/sub [:hicasso-counter/step]))]
+   [:label "step "
+    [:input {:data-test "hic-step"
+             :type      "text"
+             :value     (str (h/sub [:hicasso-counter/step]))
+             :on-input  [:hicasso-counter/set-step ::h/value]}]]])
+
+(h/defview readout
+  "A SECOND boundary, so the deck can tell one Hicasso view from another
+  rather than merely from a Reagent one. Read-only: it proves the
+  substrate resolves the variant's frame even with no interaction of its
+  own to drive."
+  [{:keys [label]}]
+  [:p {:data-test "hic-readout"}
+   (str (or label "count") " = " (h/sub [:hicasso-counter/count]))])
+
+;; ---------------------------------------------------------------------------
+;; The live-page bridge — minted ONCE, at the top level
+;; ---------------------------------------------------------------------------
+;;
+;; The Story canvas needs none of this: its `:hicasso` render fn mints an
+;; element per render with `h/as-element`, riding the stable `React.memo`
+;; wrapper `defview` already made. The LIVE `#/` surface is the other
+;; case — a Reagent root whose hiccup has to carry the boundary — and
+;; `h/as-component` is the door for it.
+;;
+;; `def`, not a call inside a render: `as-component` ALLOCATES a component,
+;; so minting one per render hands React a fresh element type every pass
+;; and React answers a fresh type by unmounting the subtree. Once, here,
+;; and the live page re-renders the boundary instead of remounting it.
+
+(def tally-component
+  "`tally` as a component a Reagent parent can place in hiccup."
+  (h/as-component tally))
+
+(def readout-component
+  "`readout`, likewise."
+  (h/as-component readout))


### PR DESCRIPTION
Phase D of rf2-5czki — the proof that a Hicasso boundary paints in Story's canvas, and responds to writes once it has.

## What landed

`tools/story/testbeds/hicasso_counter/` is a compact app authored entirely with `h/defview`: app-db, events, subs, and two boundaries reading `h/sub` and stating intent as data vectors. No adapter call, no React import, no props ABI in the view source. Its deck declares `:substrates #{:hicasso}` and nothing in it paints under Reagent.

The host registers the `:hicasso` render fn — five lines, byte-for-byte the recipe in `re-frame.story.ui.multi-substrate`'s ns docstring and what `re-frame.story.ui.hicasso-substrate-dom-cljs-test` drives. Story ships no installer for it, exactly as it ships none for `:uix`, because the renderer's one dependency is the application's.

**Build id and port: `:examples/hicasso-counter` on `:dev-http` 8045**, the next free slot in the example/story 804x band (8040–8043 the Story-enabled four, 8044 linearlite; re-verified at dispatch — `git grep -c 8045 -- implementation/shadow-cljs.edn` exits 1). The next toucher of that band should start from 8046.

## The pattern followed from the two existing testbeds

`login_form` is the model, not `counter_with_stories`. Same file split (`core` / `events` / `subs` / `views` / `stories` / `index.html`), same `re-frame.testbed.story-host` hash router, same `live-app-root` `frame-provider` wrapper for the `#/` surface, same `:source-subdir "tools/story/testbeds"` open-in-editor wiring, same `#shadow/env` `checkout-root` closure-define and pair+Xray preloads in the build. The counter testbed's diagnostic zoo, workspace matrix, deliberately-broken panels and expected-failure fixtures are deliberately **not** copied (ruled).

Two deliberate departures from `login_form`, both stated in the deck's docstring: no app image (nothing co-loads this namespace — `login_form` needs one only because a sibling `*_cljs_test.cljs` puts it in the consolidated node-test build), and an explicit `story-ci/install-ci-hooks!` (the counter has one; `login_form` does not, because it carries no play scripts — its absence is what made the first run of this gate fail with `window.__rf2_story_ci did not install`).

## Proof the boundary actually paints

Not "it compiles". The play-scripts gate ran the deck's one play through the live Story shell:

```
OK   hicasso-counter  story.hicasso-counter/tally[bump-reaches-the-frame-and-repaints-the-boundary]  expected=pass actual=pass  steps=5
Ran 31 :play-script row(s). 0 unexpected outcomes.
```

The five steps are the whole claim, in order: seed the frame; **read "0" off the DOM the boundary painted**; **click the boundary's own button in a real browser**; assert the click reached the variant's frame (`[:count]` is 1); **assert the repaint** ("1" back out of the DOM). Three things must hold for that to pass — the render fn resolved the head off the `:hicasso/component` view alias, the boundary read the *variant's* frame through React context rather than a default, and a write into that frame re-ran the body.

The counter testbed's 30 rows are unchanged and green, both sides included.

## The negative control

Sabotage: `#_` the single `(install-hicasso-substrate!)` call in `core.cljs` — one line, anchored, nothing else touched. The runner clean-stages and recompiles every run, so the plant is provably in the served bundle rather than served from a stale watcher compile.

```
MISS hicasso-counter  story.hicasso-counter/tally[...]  expected=pass actual=fail  steps=5
     step 1 assert — step preconditions never settled within 2000ms — no node matches "[data-test=hic-count]"
     step 2 click  — step preconditions never settled within 2000ms — no node matches "[data-test=hic-bump]"
     step 3 assert — expected 1 at [:count] but got 0 expected=1 actual=0
     step 4 assert — step preconditions never settled within 2000ms — no node matches "[data-test=hic-count]"
Ran 31 :play-script row(s). 1 unexpected outcomes.
```

Captured exit code **1**. This is acceptance (3) exactly: removing the registration turns the gate RED and does **not** silently fall back to Reagent — the boundary's nodes are simply absent. The 30 counter rows stayed green through the sabotage run, so the red is attributable to this entry alone.

Restore verified by hashing the bytes with git's own content hash against the committed object, not by reading a diff:

```
pre-plant   git hash-object …/core.cljs   6d8a35891077e633a601ff6e130346351530163c
planted                                   9a4824b3ebcb42fc81341b6c79c404b233ca0e6f   (the plant provably applied)
restored    git hash-object …/core.cljs   6d8a35891077e633a601ff6e130346351530163c
committed   git rev-parse HEAD:…/core.cljs 6d8a35891077e633a601ff6e130346351530163c
```

## The runner became a roster

`examples/scripts/serve-and-run-story-play-scripts.cjs` drove one hardcoded testbed. It now carries `TESTBEDS`, modelled on the roster/clean/compile/stage loop its feature-load sibling already keeps. One `shadow-cljs compile` for both builds; one browser context per entry (so neither deck's localStorage or shell state can reach the other); the verdict computed once over the whole roster, after every entry has run, so a red in the first does not hide what the second would have said.

**Each entry carries its own non-vacuity floor, and they differ on purpose.** The counter keeps `MIN_PLAY_ROWS` = 4 and both sides — it owns proof of the runner's own pass/fail semantics, so its seeded expected-fail fixtures must stay discovered. The hicasso entry's floor is **one successful meaningful play**. `requireBothSides` defaults **true**, so every existing caller (including every existing unit case, which passes no opts) keeps the invariant rf2-54xbp wrote. The opt-out waives the expected-fail requirement **and nothing else**: an opted-out entry whose every row classifies expected-fail has no successful play at all, and is still a loud red.

## The classifier `.html` hole

Ruled in scope for this bead, and real. The browser runners **copy** each testbed's hand-written `index.html` into the served output dir and navigate to it (`stageTestbedHtml`, and the `:dev-http` roots resolve the same file), so the served document is a testbed source file — break its `<script src>` or its `#app` node and every play in that deck fails. `.html` was not in `is_story_xray_runtime_path`'s extension predicate, so an HTML-only regression classified as no-surface and skipped `story_xray_browser` entirely. Fixed, with three self-test rows: a Story testbed `.html` and an Xray testbed `.html` both arm the gate, and an `.html` under `tools/story/spec/**` still does not — the widening is one extension under the two existing trees, not a blanket arm.

## Docs and spec

`docs/story/09-multi-substrate-and-agent-loop.md` — the sentence this whole programme existed to change ("Today, the tutorial and scaffolded Story path are Reagent-focused. The broader contract leaves room for UIx as adapter coverage matures") is gone. It now says what is true: a member of `:substrates` names which registered render fn embeds the subject, `:hicasso` is the member that separates the authoring layer from the seated adapter, and there is a worked deck riding the same PR-path gate.

`tools/story/spec/001-Authoring.md` §Substrates — the `#{:reagent :uix}` example gains a `#{:hicasso}` sibling and the two-axes rule, plus why Story installs `:reagent` and leaves the other two to the host.

## Quality gates

| gate | how run | captured exit |
|---|---|---|
| `scripts/test-fast-pr.sh` attempt 1 | detached, polled to completion in-turn; absolute path | **1** — a real RED, see below |
| `scripts/test-fast-pr.sh` attempt 2 (after the fix) | same | **0** |
| `scripts/test-fast-pr.sh` attempt 3, **on the rebased base** | same | **0** |
| `npm run test:script-helpers` (the failing suite, alone) | foreground | **0** |
| `npm run test:story-play-scripts` (the whole roster, both testbeds) | foreground | **0** — 31 rows, 0 unexpected outcomes |
| the same gate, **sabotaged** | foreground | **1** — the negative control above |
| `node implementation/scripts/_story-script-runners-policy.test.cjs` | foreground | **0** — 24 passed (was 17; +7 roster/floor rows) |
| `node implementation/scripts/_changed-surfaces.test.cjs` | foreground | **0** — 292 passed (+3 `.html` rows) |
| `shadow-cljs compile :examples/hicasso-counter` | foreground | **0** — 701 files, 0 warnings |

**The spine's attempt-1 RED was real and is the reason to derive gate coverage rather than nominate it.** A new `:dev-http` entry arms a drift guard I had not anticipated: `dev-testbed.cjs`'s `DEV_HTTP` map must name every build `shadow-cljs.edn` serves, or `npm run dev` cannot print the new testbed's URL. It failed with `DEV_HTTP … is missing builds served on a :dev-http port …: :examples/hicasso-counter (served on 8045)`. Fixed in the second commit, along with the two build→port tables the guard's own message points at.

**That RED also settles which tree the spine read.** `gate root:` on line 1 printed `/c/Users/miket/code/re-frame2-worktrees/storytb-kttom` on every attempt — but the stronger evidence is the failure itself: it named a build id that exists in no other checkout, so a run that had wandered into a sibling worktree could not have produced it.

**Note on the harness-reported status.** For spine attempt 1 the harness reported the run as exit 0 while the number I captured with the redirect was **1** — the documented disagreement, and here it would have hidden a genuine one-test failure. Every number in the table is the captured one.

Every number above is the one captured from the runner itself with the redirect and the `echo $?` on one command line — never a harness-reported status for the same run.

**Which gates cover this surface, derived rather than nominated.** A top-level `implementation/shadow-cljs.edn` edit is a broad trigger and the spine classified all three tiers true, which is what I expected. The load-bearing gate for the new code is `story_xray_browser` → `npm run test:story-play-scripts`, which `.github/scripts/report-changed-surfaces.sh:274-279` already arms for `tools/story/testbeds/*` runtime extensions and for the runner script itself — **no new job, condition, package script or nightly split**. `tools/story/spec/**` is markdown and correctly arms nothing browser-side. `scripts/check_doc_slugs.py` covers the `docs/story/` edit and runs in the spine's docs tier and unconditionally in `verify-readme-links`.

**Rebased onto `origin/main` and the spine re-run on the final base** (attempt 3, captured **0**). Main had moved 24 commits; none of them touched any file on this branch, and the rebase was clean.

**Spine-versus-required-CI gap: `scripts/check_fast_pr_gap.py --list`, currently 94.** That is a fact about the SPINE, not a census of what I ran — what I ran is the table above, and the spine did run.

## What I deliberately did NOT do

**Gating the new testbed in a workflow file — deferred, as a follow-up.** `.github/workflows/*` was fenced away from me this round (a peer had `test.yml` transiently dirty for its own negative control). Nothing is actually missing for the gate to run: the classifier already arms `story_xray_browser` for `tools/story/testbeds/*` and for the runner script, and both `test.yml`'s step and `expensive-tests.yml` invoke the same `npm run test:story-play-scripts`, which now drives the roster. So the new testbed **is** gated on the PR path today, with no workflow edit. The follow-up is cosmetic-but-real: **`test.yml`'s prose still describes the play-scripts step as a single-testbed compile, and that sentence is now false.** It is a comment-only edit to a hot-zone file and wants its own sole-toucher slot.

## Fence notes for the mayor

- `implementation/shadow-cljs.edn` was verified free of live touchers at start-up and again before the first edit — **with one correction to the dispatch brief**: `worker/retire-delete` carries a committed change to it. That branch is 280 behind / 1 ahead, last committed 2026-08-15 20:07, has no open PR, and its change (deleting the `ui/*` source paths) is already on main via #8322 — a stale superseded branch, not a live toucher.
- `worker/ymlparse-cb7hs` no longer has `.github/workflows/test.yml` dirty (its planted parse break is restored); its file list is `scripts/check_workflow_yaml.py` + `scripts/test-fast-pr.sh`. `.github/scripts/report-changed-surfaces.sh` was therefore free, which is why the ruled classifier fix is in this PR. I touched no `.github/workflows/**` and no `scripts/**`.
- `examples/scripts/serve-and-run-story-play-scripts.cjs`, `implementation/scripts/_changed-surfaces.test.cjs` and `implementation/scripts/_story-script-runners-policy.test.cjs` were free of touchers at both checks.
- `origin/main...HEAD` read for reverts before pushing: 13 files, all additive or narrowing; nothing a sibling landed is undone.

**This PR's total check count: 87.** Expected near 88 after the retire removed twelve required jobs; adding a build id armed no job that was not already armed, since `story_xray_browser` fires on `tools/story/testbeds/*` and on the runner script regardless.

Closes rf2-kttom.
