### PR TITLE
docs(hicasso): the integration pass — cross-links and the fresh-reader run (rf2-hic-069)

### DIFF
--- a/docs/core/hicasso/16-diagnostics.md
+++ b/docs/core/hicasso/16-diagnostics.md
@@ -9,7 +9,9 @@ is removed from production builds.
 
 ## Diagnose an interaction
 
-1. Load Xray through the development preload.
+1. Load Xray through the development preload. [Xray's installation
+   chapter](../../xray/01-installation.md) carries the dependency coordinate,
+   the host element, and the preload namespace.
 2. Reproduce the click, keystroke, or update.
 3. Select the view occurrence that ran.
 4. Read its cause, fan-out, and attribution.

--- a/docs/core/hicasso/index.md
+++ b/docs/core/hicasso/index.md
@@ -13,10 +13,13 @@ and accessibility. Numbered pages run from
 [`22-accessibility`](22-accessibility.md), and the sidebar carries that order —
 each chapter leans only on what came before it.
 
-Three lookup surfaces follow the chapters. The [API
+Five lookup surfaces follow the chapters. The [API
 reference](api-reference.md) carries every public name with the signature it
-ships with; the [Cookbook](cookbook.md) carries whole recipes you can copy; and
-[Troubleshooting](troubleshooting.md) starts from a symptom or a complaint id.
+ships with; the [Cookbook](cookbook.md) carries whole recipes you can copy;
+[Troubleshooting](troubleshooting.md) starts from a symptom or a complaint id;
+[The escape ladder](escape-ladder.md) gives the criteria for going outside the
+interpreted model and what each rung costs; and the [Glossary](glossary.md)
+defines the Hicasso-specific terms the chapters use.
 
 ## Prerequisites
 

--- a/docs/core/how-to/index.md
+++ b/docs/core/how-to/index.md
@@ -8,6 +8,10 @@ These recipes assume you've already built something — the [introduction](../in
 
 The recipes are grouped by where they sit in the life of an app — **build it**, then, when something's off, **debug it**, and finally **ship it**. (Testing has grown into [its own section](../testing/index.md) — handlers, subscriptions, views, and whole pipeline runs, one page each.) You don't read the recipes in order; drop into the group that matches what's in front of you. Each is self-contained, so jumping straight to "Report errors in production" without having read "Build a form" costs you nothing.
 
+!!! note "If your views are Hicasso"
+
+    The view code in these recipes is written on a React substrate adapter and registered `reg-view` views — `rdc/create-root` to mount, `@(subscribe …)` to read, `^{:key}` metadata on list items, and Form-2 views where a value has to stay stable across renders. [Hicasso](../hicasso/index.md) accepts none of those spellings, so a recipe's view code will not run as written. What does carry over is everything below the view: the events, effects, subscriptions and frames are ordinary re-frame2 on either. For the view and the mount, read [Installation](../hicasso/00-installation.md) and [Views and reads](../hicasso/02-views-and-reads.md); for the debugging recipes, [Diagnostics](../hicasso/16-diagnostics.md) and [Performance](../hicasso/19-performance.md).
+
 ## Build it
 
 This is where most of your time goes: turning a feature request into stages of the event pipeline. Each recipe takes one common feature — a form, a paginated feed, a write that has to refresh the right reads — and shows the complete slice: the [events](../glossary.md#event), the [subscriptions](../glossary.md#subscription), the [effects](../glossary.md#effect), and the [view](../glossary.md#view), with nothing left as an exercise.


### PR DESCRIPTION
Closes the integration pass for `rf2-hic-069`: navigation, cross-links, and the named fresh-reader protocol.

## The premise that did not hold: the nav deliverable was already landed

The bead asks for "nav wiring for reference, cookbook, troubleshooting, performance method, escape ladder". **All of it is already on `main`, and I changed no nav row.** Derived at source rather than inherited:

- `docs/core/hicasso/` carries 29 tracked pages. `mkdocs.yml`'s nav carries all 29 — `index.md`, chapters `00`–`22`, plus `api-reference`, `cookbook`, `troubleshooting`, `escape-ladder`, `glossary`. Zero orphans. The "performance method" deliverable is `19-performance.md`, in the nav at line 249.
- It landed in `c0a7223804` (2026-08-14, "ship the Hicasso guide, retire the Freehand guide", rf2-0yp7w phase 5), with `aa29ea6767` (rf2-hic-060) adding the two lookup pages.
- `mkdocs build --strict` was **already exit 0 on the base commit** before I touched anything.

Mike's binding steer — the hicasso docs as a first-class section of the main published guide, in `docs/` proper and in the nav, not under `docs/design` — is therefore **already satisfied by `docs/core/hicasso/`**. The other candidate, `docs/design/hicasso/`, is the working design record, is excluded by `exclude_docs`, and its relocation is `rf2-ps7ia`'s — which explicitly reserves the destination split for Mike ("do not invent the destination"). I did not move it.

So this PR is the half that was genuinely missing: the cross-links, and the fresh-reader run.

## What I integrated

**1. `docs/core/hicasso/index.md` — the guide index promised three lookup surfaces where the nav carries five.** It named `api-reference`, `cookbook` and `troubleshooting`; `escape-ladder` and `glossary` went unnamed. Measured inbound prose links before the change: `escape-ladder.md` had 2 (`10-native-tier.md:31`, `19-performance.md:137`), `glossary.md` had **0** — reachable only from the sidebar. Now all five are named.

**2. `docs/core/hicasso/16-diagnostics.md` — "Load Xray through the development preload" was a step with no way to perform it.** 15 pages of the Hicasso guide name Xray in prose; `git grep -F` for any link into the Xray corpus across `docs/core/hicasso/` returned **zero** (positive control: 15 files match `Xray`). The coordinate, host element and preload namespace all live in `docs/xray/01-installation.md`, verified present at lines 14, 26 and 71. Step 1 now links there.

**3. `docs/core/how-to/index.md` — the Core how-to shelf routed a Hicasso reader into recipes whose view code cannot run for them.** Measured at source: `boot-and-mount-an-app.md` mounts with `rdc/create-root` (2 occurrences); `build-a-form.md`, `fix-a-slow-view.md`, `validate-with-schemas.md` and `use-uix-or-slim.md` all use `reg-view` and `@(subscribe …)`; `fix-a-slow-view.md` additionally uses `^{:key}` metadata (3) and Form-2 views (177, 191–193). **None of the five mentions Hicasso** (`git grep -ciF hicasso` = 0 on the slow-view recipe). `docs/core/hicasso/02-views-and-reads.md:93` confirms Hicasso does not read `^{:key}` metadata. Added one routing note saying which half carries over (events, effects, subscriptions, frames are ordinary re-frame2 — per `docs/core/hicasso/index.md:5-6`) and where the Hicasso equivalents are.

## Fresh-reader protocol — run, and how I controlled the zero

A genuinely fresh agent with no session context walked only nav-reachable pages under `docs/`, fenced out of `spec/`, `implementation/`, `docs/design/` and `docs/EP/`, and attempted the bead's three tasks: install → build one screen → diagnose one hot path.

| Task | Result |
|---|---|
| Install | **Partial failure** — produces a tree that compiles, but cannot establish that it boots |
| Build one screen | **Succeeded** — every view-layer form is documented and consistent; the corpus is genuinely strong here |
| Diagnose one hot path | **Failed** at "what do I look at" |

**The list is not empty**, so the bead's "an empty list from a first run is suspect" caveat does not apply. 23 defects, filed as beads below.

**Controlling the zero.** The bead's retirement question — does any nav path reach a retired model? — answers zero, and a zero from a search is not a check that passed. Two independent runs, each with a positive control:

- My own census (`git grep -lF`, fixed strings, over the 184 nav-reachable pages resolved from the `nav:` block): `re-frame.freehand` 0, `Freehand` 0, `defbehavior` 0, `compiled-view` 0, `compiled view` 0. **Positive control fires: `Hicasso` matches 30 files.** Two hits remain — `docs/api/re-frame.ssr.md` (`re-frame.ui`) and `docs/api/re-frame.core.md` (`freehand`) — and both are exactly the pages `rf2-hic-062`'s note fences to `rf2-0yp7w.9`, whose description confirms `docs/api/*.md` are **generated** and must be regenerated, never hand-edited. Not repaired from the nav side.
- The fresh reader's independent grep over the same corpus agreed: zero across `docs/core/**`, `docs/xray/**`, `docs/story/**`, `docs/skills/**`, `docs/machines/**`, `docs/resources/**`, `docs/routing/**`, `docs/ssr/**`, `docs/async/**`, `docs/migration/**` and `docs/index.md`, and it independently reached the same two API-page hits.

**`docs/EP/` behaved as `rf2-hic-062`'s note said it would.** All 39 EP pages are orphans from the nav — confirmed by resolving every `.md` in the `nav:` block against the tracked tree — so the fresh reader never landed on one. Deliberately-kept history that no nav path reaches, not a nav failure.

One caveat the fresh reader raised and I am recording rather than acting on: no nav-reachable page frames the retired substrates as history either. That is by design here — the withdrawal is legible in `docs/design/retirement/` and the EPs.

## A false positive worth naming

Resolving every `.md` string in the `nav:` block turns up three targets that do not exist: `13-overlays-and-focus.md`, `api/re-frame.ui.react.md`, `core/how-to/measure-before-paint.md`. **All three are prose inside mkdocs.yml comments**, not nav rows — the comment block at lines 200–227 discussing the retired `measure-before-paint` recipe. `mkdocs build --strict` exit 0 confirms no real nav row is broken. Naming it so the next census does not re-raise it.

## Quality gates

| Gate | Command | Captured exit |
|---|---|---|
| Fast pre-checkin spine (final content) | `sh scripts/test-fast-pr.sh` | **0** |
| Fast pre-checkin spine (post-rebase re-run) | `sh scripts/test-fast-pr.sh` | **0** |
| `mkdocs build --strict` (baseline, before edits) | `python -m mkdocs build --strict` | **0** |
| `scripts/check_doc_slugs.py` (baseline) | `python scripts/check_doc_slugs.py` | **0** |
| `mkdocs build --strict` (**sabotage**) | planted fault | **1** |
| `scripts/check_doc_slugs.py` (**sabotage**) | planted fault | **1** |

Pass 4, fail 0, deliberate-red 2, skipped 0.

Every number above is the runner's own exit code, captured with the redirect and the `echo` on one command line in one shell, never a harness-reported status.

**Which tree the gates read.** `scripts/test-fast-pr.sh` prints its root on line 1: `gate root: /c/Users/miket/code/re-frame2-worktrees/docsnav-hic069`. It was invoked by absolute path. The spine ran its documentation tier (`mkdocs build --strict`, 20.89s) and correctly skipped the JVM, node and lint tiers — a docs-only diff does not reach them; the PASS line enumerates all four skips.

**Spine-versus-CI gap: `python scripts/check_fast_pr_gap.py --list` reads 94.** That is a fact about the spine, not a census of what I ran. What I ran directly, beyond the spine: `mkdocs build --strict` and `check_doc_slugs.py`, both standalone, both in baseline and sabotage form.

## The control: red proof and hash-verified restore

A nav edit's characteristic failure is a link or anchor that no longer resolves, so I planted one of each in `docs/core/hicasso/index.md` — a page this PR already edits — anchored to single lines.

Both gates went red and **both named the plant**:

- `mkdocs build --strict`, exit **1**, `Aborted with 1 warnings in strict mode!` — `WARNING - Doc file 'core/hicasso/index.md' contains a link 'escape-ladder-PLANTED-BROKEN.md', but the target 'core/hicasso/escape-ladder-PLANTED-BROKEN.md' is not found among documentation files.`
- `scripts/check_doc_slugs.py`, exit **1** — `BROKEN TARGET: docs\core\hicasso\index.md:20 -> escape-ladder-PLANTED-BROKEN.md` and `BROKEN ANCHOR: docs\core\hicasso\index.md:23 -> glossary.md#planted-stale-anchor-does-not-exist`.

**The red is the discrimination.** The plant existed only in this worktree, so a run that had wandered into a sibling checkout would have come back green. Both came back red, which is what proves each gate read this tree.

**Restore verified by content hash, not by reading a diff.** `git hash-object docs/core/hicasso/index.md` before the plant and after the restore: `6e21c92d3e2ca24aa89a64bf81a83fe89c68cad7` both times — byte-identical, using version control's own hash against the committed object rather than a plain byte digest, because this checkout translates line endings. The committed blob id in the diff is the same `6e21c92d3e`.

## Manual verification

The doc-surface note in the worker protocol asks for hand-verification where nothing automated covers rendering. This PR adds no table and no heading, so there are no column counts or anchors to check. The three anchors it does introduce — `../../xray/01-installation.md`, `../hicasso/*.md` and the five sibling lookup links — are all plain file targets with no fragment, and `check_doc_slugs.py` resolves every one. The one admonition added (`!!! note "If your views are Hicasso"`) uses the `admonition` extension already enabled in `mkdocs.yml`, and `mkdocs build --strict` renders it without warning.

## Fenced out, deliberately

- `spec/` prose residue — `rf2-rzf0q`, held behind a live worker.
- `docs/api/re-frame.core.md` and `docs/api/re-frame.ssr.md` — `rf2-0yp7w.9`, and generated besides.
- `docs/design/hicasso/decisions.md` — declared conflict magnet, untouched.
- Relocating `docs/design/hicasso/product/**` — `rf2-ps7ia`, and Mike's split ruling comes first.
- I rewrote no hicasso guide content; the fresh reader's content defects are beads, not edits.

## Base

Rebased onto `origin/main` mid-flight. The only commits that landed underneath were three `chore(beads): checkpoint` touching `.beads/issues.jsonl` alone, so nothing this PR claims was invalidated — and the spine was re-run on the final base regardless. The three-dot diff (`origin/main...HEAD`) is three files, all additive; it reverts nothing a sibling landed.

## Check count

**85 checks**, polled until settled (the count sits at 21 for the first minute while jobs register, so an early read is misleading). That is in the expected band below 100 — the retirement removed twelve required jobs, so a lower count is correct here and is not a partial rollup.

## Fresh-reader defects, filed as beads

The bead asks that every point where the fresh reader needed outside knowledge be filed. Twenty-three defects, clustered into eight beads by shared surface and root cause:

| Bead | P | Defect |
|---|---|---|
| `rf2-ttmi9` | P1 | Whether a Hicasso app calls `rf/init!`, and with what, is unanswerable — three pages, three incompatible answers; the cookbook's "start here" also pulls an undeclared UIx dependency |
| `rf2-bir0r` | P2 | `16-diagnostics.md` sends readers to a hot-view advisor, standing view and `explain-render` that return **zero** matches across all of `docs/xray/**` |
| `rf2-ypct8` | P2 | The install chapter does not yield a project that boots — no shadow-cljs dep, no clone URL or sibling statement, a top-level `defonce` mount the boot recipe forbids, no `:init-fn`, no `package.json` or React version |
| `rf2-mv7oh` | P2 | `03-events-as-data.md` teaches `h/frame` in runnable code 8 times; the export is `h/hframe` |
| `rf2-75q3l` | P2 | Three published pages route authoritative answers into the excluded `docs/design/` tree (depends on `rf2-ps7ia`) |
| `rf2-wf1ey` | P3 | `docs/api/` claims completeness and omits Hicasso; `current-adapter` has no Hicasso discriminator |
| `rf2-5exqc` | P3 | Published pages link outside `docs_dir` and 404 on the site — and neither gate catches the class |
| `rf2-zu2rb` | P3 | Unresolved whether `h/defview` boundaries emit `rf:render:` measures |
| `rf2-0ircf` | P3 | Three onboarding gaps: no scaffolded Hicasso project, undocumented test-kit classpath, Hicasso hidden in a fold on the main Views chapter |

**Rejected rather than filed**, per the project's stance on minutiae: tracker ids appearing in published prose (`index.md:64,68` cite `rf2-hic-066` and `rf2-7mtcf`). That is this repo's deliberate provenance convention, not a defect.

Two of these are worth an operator eye rather than a worker: `rf2-0ircf`'s third part (whether Hicasso is promoted out of the `views.md` fold) and the related observation that `docs/index.md`'s "Batteries included" list names Machines, Routing, SSR and Resources but not the view layer. Both are framing calls in Mike's voice, so I recorded them rather than inventing an answer.

## Note left on rf2-ps7ia

Its fence reads "interim custody ends when the main-guide section lands", which nothing in the tracker would announce. I recorded that the trigger has **fired** — naming `c0a7223804` as the commit that landed it — while being explicit that this does **not** license the move: that bead reserves the destination split to Mike, so it is now ready to be surfaced for the ruling, not dispatched. I also carried across the new evidence (`rf2-75q3l`) and flagged that the `tool-consumer-census.md:160` correction its mayor-reread note asks for is still outstanding, since that file sits inside the design tree this bead owns and outside `rf2-hic-069`'s fence.
