### PR TITLE
docs(hicasso): the install chapter boots, and the three boot pages agree (rf2-ttmi9, rf2-ypct8)

### DIFF
--- a/docs/core/hicasso/00-installation.md
+++ b/docs/core/hicasso/00-installation.md
@@ -16,33 +16,70 @@ ordinary handlers.
     Treat the snippet below as the shape of the dependency, not as a
     coordinate you can paste into a fresh project.
 
-Add the Hicasso artifact and a [substrate
+`:local/root` is relative to *your* `deps.edn`, so clone the monorepo **beside**
+your project directory — the convention the rest of the docs use:
+
+```bash
+cd ..                                             # the folder holding your project
+git clone https://github.com/day8/re-frame2.git
+cd my-app
+```
+
+Then add the Hicasso artifact and a [substrate
 adapter](#hicasso-needs-a-substrate-adapter) to `deps.edn`:
 
 ```clojure
 ;; deps.edn — resolved from a re-frame2 checkout beside your project
-{:deps {day8/re-frame2-hicasso {:local/root "../re-frame2/implementation/hicasso"}
-        day8/re-frame2-uix     {:local/root "../re-frame2/implementation/adapters/uix"}}}
+{:paths ["src"]
+ :deps  {day8/re-frame2-hicasso {:local/root "../re-frame2/implementation/hicasso"}
+         day8/re-frame2-uix     {:local/root "../re-frame2/implementation/adapters/uix"}}
+
+ ;; shadow-cljs reads its classpath from this file, so the compiler is a
+ ;; dependency here as well as an npm package below.
+ :aliases
+ {:shadow {:extra-deps {thheller/shadow-cljs {:mvn/version "3.4.10"}}}}}
 ```
 
-The artifact brings `day8/re-frame2` with it. Install React from npm:
+The Hicasso artifact brings `day8/re-frame2` with it. React and the shadow-cljs
+launcher come from npm:
+
+```json
+{
+  "dependencies":    {"react": "19.2.0", "react-dom": "19.2.0"},
+  "devDependencies": {"shadow-cljs": "3.4.10"}
+}
+```
 
 ```bash
-npm install react react-dom
+npm install
 ```
+
+Both npm lines earn their place. **Pin React**: Hicasso needs 18 or newer — it
+mounts through `createRoot` and reads `useId` for `:identifier-prefix` — and
+19.2 is what the reference implementation runs and what this chapter is checked
+against, whereas a bare `npm install react react-dom` resolves to whatever is
+current that day. **And keep `shadow-cljs` in `devDependencies`** even though
+the JVM dependency above is what compiles: the npm package is where the
+`process` shim React's CommonJS build asks for comes from, and without it the
+build stops at `The required JS dependency "process" is not available`.
 
 Hicasso interprets Hiccup at runtime, so it needs no compiler hook, macro
 allow-list, or build flag. A normal shadow-cljs browser build is enough:
 
 ```clojure
 ;; shadow-cljs.edn
-{:deps     true
+{:deps     {:aliases [:shadow]}
  :dev-http {8080 "public"}
  :builds   {:app {:target     :browser
                   :output-dir "public/js"
                   :asset-path "/js"
-                  :modules    {:main {:entries [counter.core]}}}}}
+                  :modules    {:main {:init-fn counter.core/init}}}}}
 ```
+
+`{:deps {:aliases [:shadow]}}` is what puts the compiler on the classpath. A
+bare `{:deps true}` reads `deps.edn` without the alias, finds no
+`thheller/shadow-cljs` there, and dies before it compiles anything:
+`Could not locate shadow/cljs/devtools/cli`.
 
 ```html
 <!-- public/index.html -->
@@ -96,11 +133,13 @@ it notifies nothing.
 
 A production application normally separates registrations and views into
 several namespaces. This complete example keeps them together so the boot
-sequence is visible:
+sequence is visible — adapter first, then the root, inside the one `init` the
+build calls:
 
 ```clojure
 (ns counter.core
   (:require [re-frame.core :as rf]
+            [re-frame.adapter.uix :as uix-adapter]
             [re-frame.hicasso :as h]))
 
 (rf/reg-event :counter/initialise
@@ -120,15 +159,28 @@ sequence is visible:
    [:h1 "Clicked " (h/sub [:counter/count]) " times"]
    [:button {:on-click [:counter/increment]} "Click me"]])
 
-(defonce root
-  (h/mount! (js/document.getElementById "app")
-            {:frame          :rf/default
-             :initial-events [[:counter/initialise]]}
-            [counter]))
+(defonce !root (atom nil))
 
 (defn ^:dev/after-load rerender! []
-  (h/render! root [counter]))
+  (when-some [root @!root]
+    (h/render! root [counter])))
+
+(defn ^:export init []
+  (rf/init! uix-adapter/adapter)
+  (reset! !root
+          (h/mount! (js/document.getElementById "app")
+                    {:frame          :rf/default
+                     :initial-events [[:counter/initialise]]}
+                    [counter]))
+  nil)
 ```
+
+`init` is the build's `:init-fn`, wired in `shadow-cljs.edn` above. Namespace
+load registers handlers and defines views and touches no DOM, so a test host, a
+Story tool, or another namespace can require this one for its registrations
+alone — the rule [Boot and mount an
+app](../how-to/boot-and-mount-an-app.md#no-dom-work-at-namespace-load) states
+for every substrate.
 
 Start the build and open the page:
 
@@ -187,16 +239,21 @@ The first root creates and seeds the frame. A later root that names the same
 frame joins its current state and does not replay `:initial-events`:
 
 ```clojure
-(defonce app-root
-  (h/mount! (js/document.getElementById "app")
-            {:frame          :app/main
-             :initial-events [[:app/initialise]]}
-            [main-screen]))
+(defonce !app-root (atom nil))
+(defonce !status-root (atom nil))
 
-(defonce status-root
-  (h/mount! (js/document.getElementById "status")
-            {:frame :app/main}
-            [connection-badge]))
+(defn ^:export init []
+  (rf/init! uix-adapter/adapter)
+  (reset! !app-root
+          (h/mount! (js/document.getElementById "app")
+                    {:frame          :app/main
+                     :initial-events [[:app/initialise]]}
+                    [main-screen]))
+  (reset! !status-root
+          (h/mount! (js/document.getElementById "status")
+                    {:frame :app/main}
+                    [connection-badge]))
+  nil)
 ```
 
 Both roots read the same app-db and dispatch into the same queue. Seed from the
@@ -219,6 +276,12 @@ same view code but must not share state.
 The `^:dev/after-load` hook calls `h/render!` with the redefined view. The root,
 frame, app-db, and subscriptions survive, so changing the view does not reset
 the counter or leak registrations.
+
+Boot and re-render are two functions rather than one because shadow calls
+`:init-fn` **once**, when the module loads, and not again after a reload — a
+build whose only entry point is `:init-fn` logs `reloading code but no
+:after-load hooks are configured!` and leaves the page showing the old view.
+Mount in `init`; re-render in the hook.
 
 Hot reload also means a changed initialisation handler does not re-seed an
 already live frame. Reload the page, destroy the frame, or dispatch an explicit

--- a/docs/core/hicasso/00-installation.md
+++ b/docs/core/hicasso/00-installation.md
@@ -13,8 +13,8 @@ ordinary handlers.
     `day8/re-frame2-hicasso` is **not published**, and there is no date at
     which it will be. It lives in the re-frame2 monorepo, so today you resolve
     it — and `day8/re-frame2` with it — from a checkout using `:local/root`.
-    Treat the snippet below as the shape of the dependency, not as a
-    coordinate you can paste into a fresh project.
+    The snippet below resolves against a clone on your own disk, and becomes
+    an ordinary Maven coordinate the day Hicasso publishes.
 
 `:local/root` is relative to *your* `deps.edn`, so clone the monorepo **beside**
 your project directory — the convention the rest of the docs use:
@@ -55,13 +55,13 @@ npm install
 ```
 
 Both npm lines earn their place. **Pin React**: Hicasso needs 18 or newer — it
-mounts through `createRoot` and reads `useId` for `:identifier-prefix` — and
-19.2 is what the reference implementation runs and what this chapter is checked
-against, whereas a bare `npm install react react-dom` resolves to whatever is
-current that day. **And keep `shadow-cljs` in `devDependencies`** even though
-the JVM dependency above is what compiles: the npm package is where the
-`process` shim React's CommonJS build asks for comes from, and without it the
-build stops at `The required JS dependency "process" is not available`.
+mounts through `createRoot`, and `:identifier-prefix` sets what `useId` answers
+— and 19.2 is what the reference implementation runs and what this chapter is
+checked against, whereas a bare `npm install react react-dom` resolves to
+whatever is current that day. **And keep `shadow-cljs` in `devDependencies`**
+even though the JVM dependency above is what compiles: the npm package is where
+the `process` shim React's CommonJS build asks for comes from, and without it
+the build stops at `The required JS dependency "process" is not available`.
 
 Hicasso interprets Hiccup at runtime, so it needs no compiler hook, macro
 allow-list, or build flag. A normal shadow-cljs browser build is enough:
@@ -122,7 +122,7 @@ ns and pass its `adapter` Var, e.g. (rf/init! reagent/adapter).
 
 *Which* adapter is your choice, and it is the only line that changes between
 substrates — see [Use UIx or reagent-slim](../how-to/use-uix-or-slim.md) for the
-three and their coordinates. This guide passes `uix-adapter/adapter` throughout,
+three and their coordinates. This guide's recipes pass `uix-adapter/adapter`,
 because that is what Hicasso's own test lane and witnesses run on. It buys
 plumbing, not notation: you write Hicasso views either way and never call the
 adapter yourself. The headless plain-atom adapter is not a substitute for a

--- a/docs/core/hicasso/00-installation.md
+++ b/docs/core/hicasso/00-installation.md
@@ -16,11 +16,13 @@ ordinary handlers.
     Treat the snippet below as the shape of the dependency, not as a
     coordinate you can paste into a fresh project.
 
-Add the Hicasso artifact to `deps.edn`:
+Add the Hicasso artifact and a [substrate
+adapter](#hicasso-needs-a-substrate-adapter) to `deps.edn`:
 
 ```clojure
 ;; deps.edn — resolved from a re-frame2 checkout beside your project
-{:deps {day8/re-frame2-hicasso {:local/root "../re-frame2/implementation/hicasso"}}}
+{:deps {day8/re-frame2-hicasso {:local/root "../re-frame2/implementation/hicasso"}
+        day8/re-frame2-uix     {:local/root "../re-frame2/implementation/adapters/uix"}}}
 ```
 
 The artifact brings `day8/re-frame2` with it. Install React from npm:
@@ -57,6 +59,38 @@ The main namespace is `re-frame.hicasso`, conventionally required as `h`.
 Forms, overlays, motion, routing, the native tier, and the test kit use separate
 namespaces. A build that does not require an optional module does not include
 its code.
+
+## Hicasso needs a substrate adapter
+
+Hicasso is a view layer, not a [substrate](../glossary.md#substrate). It owns
+Hiccup interpretation and the render boundary; the reactive container app-db
+lives in comes from an [adapter](../glossary.md#adapter), and re-frame2 installs
+none for you. **So every Hicasso application calls
+[`rf/init!`](../glossary.md#init) with an adapter before it mounts anything** —
+one line, on the first line of boot:
+
+```clojure
+(rf/init! uix-adapter/adapter)
+```
+
+It is not optional and it does not fail quietly. `h/mount!` ensures its frame,
+creating a frame asks the adapter for a state container, and a container asked
+for before `init!` throws:
+
+```text
+rf/make-state-container was called before (rf/init! ...); require an adapter
+ns and pass its `adapter` Var, e.g. (rf/init! reagent/adapter).
+[:rf.error/no-adapter-installed]
+```
+
+*Which* adapter is your choice, and it is the only line that changes between
+substrates — see [Use UIx or reagent-slim](../how-to/use-uix-or-slim.md) for the
+three and their coordinates. This guide passes `uix-adapter/adapter` throughout,
+because that is what Hicasso's own test lane and witnesses run on. It buys
+plumbing, not notation: you write Hicasso views either way and never call the
+adapter yourself. The headless plain-atom adapter is not a substitute for a
+browser app — its derived values are not `IWatchable`, so a subscription under
+it notifies nothing.
 
 ## Mount a first screen
 
@@ -207,6 +241,7 @@ production; there is no production-only view mode.
 
 | Symptom | Cause | Fix |
 | --- | --- | --- |
+| A mount throws `:rf.error/no-adapter-installed`, naming `rf/make-state-container` | No [adapter](#hicasso-needs-a-substrate-adapter) is installed: `rf/init!` never ran, or ran after the mount | Make `(rf/init! uix-adapter/adapter)` the first line of boot |
 | `(counter {})` throws and names the view | A `defview` is a Hiccup head, not a directly callable helper | Render `[counter {}]`. Use a plain `defn` for inline markup |
 | `h/sub` in a callback, timer, or promise throws | `:rf.error/hicasso-sub-outside-render`: the read happened outside a synchronous view body | Read during the body and close over the value. Async work should read state through events and coeffects |
 | The first paint is empty and then fills in | Initial state was dispatched after mounting | Put the seed events in `:initial-events` so they finish before the first paint |

--- a/docs/core/hicasso/cookbook.md
+++ b/docs/core/hicasso/cookbook.md
@@ -42,7 +42,18 @@ Everything below assumes a mounted root, so start here.
   nil)
 ```
 
-Three things about this shape are load-bearing.
+Four things about this shape are load-bearing.
+
+**`rf/init!` comes first, and it is not optional.** Hicasso is a view layer, not
+a [substrate](../glossary.md#substrate): the reactive container app-db lives in
+comes from an [adapter](../glossary.md#adapter), and nothing installs one for
+you. `h/mount!` ensures its frame, creating a frame asks the adapter for a state
+container, and a mount that beats `init!` throws
+`:rf.error/no-adapter-installed`. `re-frame.adapter.uix` is its own artefact —
+[Installation](00-installation.md#add-the-dependencies) declares the
+`day8/re-frame2-uix` coordinate it comes from alongside Hicasso's, and
+[Use UIx or reagent-slim](../how-to/use-uix-or-slim.md) covers the other two
+substrates.
 
 **Keep the handle.** `h/render!`, `h/unmount!` and every teardown path take it,
 and a reload hook that calls `h/mount!` a second time would `createRoot` again —

--- a/docs/core/how-to/boot-and-mount-an-app.md
+++ b/docs/core/how-to/boot-and-mount-an-app.md
@@ -17,6 +17,18 @@ UIx. The frame is created later by the rendered
 The whole recipe serves two moments. First page load should create and seed the
 app. Hot reload should re-render changed views without losing app-db.
 
+!!! note "Hicasso apps boot the same way"
+
+    The three jobs are the substrate's, not Reagent's, and
+    [Hicasso](../hicasso/00-installation.md#hicasso-needs-a-substrate-adapter)
+    does not exempt itself from the second: it interprets Hiccup and owns the
+    render boundary, but the reactive container still comes from an adapter, so
+    a Hicasso app opens with the same `(rf/init! …)` line. Only the third job is
+    spelled differently. `h/mount!` is a function that *ensures* its frame
+    before it renders, rather than a `frame-root` element that ensures one
+    during the first commit — so a Hicasso tree has no frame component in it,
+    and `:initial-events` are already drained when the first paint happens.
+
 ## The small shape
 
 For an app with no browser listeners, you don't need a separate `boot!`

--- a/implementation/hicasso/scripts/check_guide_samples.py
+++ b/implementation/hicasso/scripts/check_guide_samples.py
@@ -1175,9 +1175,10 @@ def r6_unreadable_discard(corp: dict[str, list[dict]]) -> list[str]:
 
 ROSTER = {
     "00-installation.md": [
-        (1, "54792899937f"), (2, "4d3af42a62ba"), (3, "af13cef73d9f"),
-        (4, "34a2229c1f65"), (5, "5f9f8f55cfab"), (6, "e273338344de"),
-        (7, "caa27172a376"), (8, "daeb4bc56afc"), (9, "d85146b3bb90"),
+        (1, "82b96c1dfead"), (2, "4d3af42a62ba"), (3, "af13cef73d9f"),
+        (4, "34a2229c1f65"), (5, "2d389a8f20ce"), (6, "0bfa30966c57"),
+        (7, "5f9f8f55cfab"), (8, "e273338344de"), (9, "caa27172a376"),
+        (10, "daeb4bc56afc"), (11, "d85146b3bb90"),
     ],
     "01-getting-started.md": [
         (1, "dc6634f5c3ae"), (2, "603c4568fa1d"),

--- a/implementation/hicasso/scripts/check_guide_samples.py
+++ b/implementation/hicasso/scripts/check_guide_samples.py
@@ -1175,10 +1175,11 @@ def r6_unreadable_discard(corp: dict[str, list[dict]]) -> list[str]:
 
 ROSTER = {
     "00-installation.md": [
-        (1, "82b96c1dfead"), (2, "4d3af42a62ba"), (3, "af13cef73d9f"),
-        (4, "34a2229c1f65"), (5, "2d389a8f20ce"), (6, "0bfa30966c57"),
-        (7, "5f9f8f55cfab"), (8, "e273338344de"), (9, "caa27172a376"),
-        (10, "daeb4bc56afc"), (11, "d85146b3bb90"),
+        (1, "58a74f5bab9d"), (2, "6f09d655927e"), (3, "08dacefb6313"),
+        (4, "3a2dc0ae21eb"), (5, "550f961b9370"), (6, "34a2229c1f65"),
+        (7, "2d389a8f20ce"), (8, "0bfa30966c57"), (9, "43cfb5c82dc6"),
+        (10, "e273338344de"), (11, "caa27172a376"), (12, "6dde20a4d272"),
+        (13, "d85146b3bb90"),
     ],
     "01-getting-started.md": [
         (1, "dc6634f5c3ae"), (2, "603c4568fa1d"),


### PR DESCRIPTION
Closes rf2-ttmi9 (P1) and rf2-ypct8 (P2) — two halves of one journey: a reader
installs Hicasso and gets a screen on the page. Both were filed by the
no-context fresh-reader run under rf2-hic-069, which came back *install: partial
failure, diagnosis: failed*.

**Every premise in both beads held at source.** Line numbers had drifted by one
in two places (`:41` for the `:modules` line is `:42`; the boot how-to's throw
sentence spans `:235-240`, not `:236-238`); nothing else moved.

## How the true `rf/init!` answer was established

Not by reading — by building the install chapter's own example outside the repo
and deleting one line.

`h/mount!` → `impl.mount/root!` → `ensure-frame!`
(`implementation/hicasso/src/re_frame/hicasso/impl/mount.cljs:219-296`) →
`rf/make-frame` → the adapter's `make-state-container`. Remove
`(rf/init! uix-adapter/adapter)` and the page throws, in headless Chromium:

```
rf/make-state-container was called before (rf/init! ...); require an adapter
ns and pass its `adapter` Var, e.g. (rf/init! reagent/adapter).
[:rf.error/no-adapter-installed]
```

with `:where rf/make-state-container`. Restoring the line turns it green again.
So **Hicasso is not an exception**: it is a view layer, not a substrate, and the
reactive container still comes from an adapter. The repository says the same
thing in two places the guide never pointed at —
`implementation/hicasso/test/re_frame/hicasso/consumer_app.cljs:147-162` and
`.../examples/editor/app.cljs:71-77`, both citing Spec 006 §Adapter selection at
boot — and `implementation/hicasso/deps.edn` confirms the artefact ships no
adapter of its own ("Test-only: shipping source names no adapter at all").

The three pages now give that one answer, and each says *why* rather than only
*what*: the install chapter in its own section, the cookbook as the first of its
recipe's load-bearing points, and the boot how-to in a note saying the three
jobs are the substrate's and only the third is spelled differently under
Hicasso.

That also closes the bead's second half. `cookbook.md:22` required
`re-frame.adapter.uix` while nothing in the guide had ever declared
`day8/re-frame2-uix`; the install chapter declares it now, so the cookbook's
start-here block resolves in the project this chapter builds.

## Does a reader following the chapter get a booting project?

Yes — verified by doing it, from an empty directory outside the repository, with
the monorepo reachable as a sibling exactly as the page describes.

| Step | Before | After |
| --- | --- | --- |
| `npx shadow-cljs compile app` | **exit 1** — `Could not locate shadow/cljs/devtools/cli` | exit 0, 163 files |
| React resolution | **exit 1** — `The required JS dependency "process" is not available` | exit 0 |
| Browser boot | never reached | mounts, `Clicked 0 times`, click → `Clicked 1 times`, no console errors |
| Hot reload | not tested by the chapter | edit → `Tapped 2 times`, i.e. view reloaded *and* app-db survived |

Four gaps were real and are fixed; two were partly overstated and are handled
proportionately rather than expanded into sections:

- **`{:deps true}` cannot build.** It reads the classpath from `deps.edn`,
  which declared no `thheller/shadow-cljs`. Now `{:deps {:aliases [:shadow]}}`
  over a `:shadow` alias, matching the repo's own consumer template
  (`tools/template/resources/day8/re_frame2_template/_shared/shadow-cljs.edn`).
- **`shadow-cljs` is also an npm devDependency, and not only to run the
  launcher** — that package is where the `process` shim React's CommonJS build
  requires comes from (`npm ls process` → `shadow-cljs@3.4.10 → process@0.11.10`).
  Without it the build fails on React 19.2.0 *and* on whatever
  `npm install react react-dom` resolves to today. This is the finding the bead
  did not have.
- **No clone instructions, and the sibling requirement was never stated** — only
  implied by the `../` in the path. Both now present.
- **`(defonce root (h/mount! …))` at namespace top level** is the DOM work
  `boot-and-mount-an-app.md` forbids for every substrate, and there was no
  `:init-fn` for it to move into. Fixed, and the two-root example further down
  the page — which taught the same anti-pattern — follows the same shape now.
- *Overstated:* "no `package.json`". `npm install react react-dom` does write
  one (npm 11). The real defect is that it is **unpinned**, so the chapter shows
  a pinned one and says why in two sentences rather than adding a section.
- *Overstated:* "no React version". React 18 is the floor and today's `latest`
  satisfies it; the chapter pins 19.2.0 because that is what the reference
  implementation runs and what this chapter is checked against.

## Library defects found rather than papered over

Two, both filed, neither routed around in prose.

**`rf2-r0kk7` (P1) — the project template's hot-reload claim is false.** Three
sites say shadow's `:browser` target re-runs a module `:init-fn` after each hot
reload "so no `:after-load` hook is needed"
(`_shared/shadow-cljs.edn:22`, `_uix/core.cljs:17`, `root/README.md:29`).
Measured under `shadow-cljs watch` on shadow-cljs 3.4.10, it does not: the page
console logs `reloading code but no :after-load hooks are configured!` and keeps
rendering the old view for as long as you wait. An app scaffolded from the UIx
template therefore appears to hot-reload and silently does not re-render. Not
fixed here — `tools/` was fenced to `worker/r6dtail-mgrsl` — but this chapter no
longer repeats the claim: it teaches `:init-fn` to mount, `^:dev/after-load` to
re-render, and says why they are two functions.

**`rf2-hvr5h` (P3) — a Hicasso-only app still depends on UIx or Reagent.** The
install chapter now asks for `day8/re-frame2-uix` purely to supply an adapter,
in an app that writes no UIx notation. That is a packaging call for Mike, not a
bug: everything works and is now documented. Raised rather than designed around.

## Quality gates

`scripts/test-fast-pr.sh` ran to completion — **captured exit 0**, `PASS fast PR
spine`, 82 gate sections, 0 failures. Invoked by absolute path and detached with
in-turn polling of both its log and its exit-code file, because the node tier
(a 1985-file `:node-test` compile) does not fit the harness ceiling; the turn
never ended waiting on it. Two independent confirmations it read THIS worktree:
it printed `gate root: /c/Users/miket/code/re-frame2-worktrees/bootdocs-ttmi9`
on line 1, and every shadow-cljs build path in its output is under
`re-frame2-worktrees/bootdocs-ttmi9/implementation/.shadow-cljs`.

| Gate | Captured exit | Note |
| --- | --- | --- |
| `scripts/test-fast-pr.sh` (docs + node/CLJS + clj-kondo tiers) | **0** | classifier: `docs=true jvm=false node=true` |
| `check_guide_samples.py --self-test` | 0 | |
| `check_guide_samples.py` (live) | 0 | 221 blocks pinned across 29 pages, roster regenerated |
| `scripts/check_doc_slugs.py` | 0 | |
| `python -m mkdocs build --strict` | 0 | 17.1s, re-run on the final tree |
| `check_guide_samples.py` before the roster regen | **1** | R1 named all 13 blocks — proof the pin fires |
| `scripts/check_doc_slugs.py` with a planted anchor | **1** | see below |
| probe: `npx shadow-cljs compile app` (documented shape) | 0 | |
| probe: headless-Chromium boot proof | 0 | |
| probe: same, with `rf/init!` removed | **1** | `:rf.error/no-adapter-installed` |
| probe: hot-reload proof (`:init-fn` only) | **1** | `no :after-load hooks are configured!` |
| probe: hot-reload proof (`:init-fn` + `^:dev/after-load`) | 0 | `Tapped 2 times` — state survived |

Every number above is the one captured by `echo $? > …exit` on the same command
line as the redirect, not one reported about the run. The spine's captured 0 and
the harness's reported 0 agree here; the captured one is what is quoted.

Three prose-only corrections landed in `d2f48b5a22` after the spine started, so
the four documentation gates above (`check_guide_samples.py` self-test and live,
`check_doc_slugs.py`, `mkdocs build --strict`) were re-run on the final tree and
are the numbers quoted. None touched a fenced block, a link or an anchor.

**Digest-pinned blocks.** `implementation/hicasso/scripts/check_guide_samples.py`
R1 pins every fenced block in `docs/core/hicasso/**` by digest, so this is a
two-file change by construction; the roster is regenerated with `--emit-roster`
and the diff is the four added rows and nothing else.

**Red proof and restore.** Planted a single-line anchor typo
(`#hicasso-needs-a-substrate-adaptor`) in `00-installation.md`.
`scripts/check_doc_slugs.py` went **exit 1**, naming the plant by file, line and
target — and by a path inside my worktree, which is what proves the gate read my
tree rather than a sibling's. Restored, and verified with git's own content hash
rather than a diff:

```
PRE_PLANT_HASH   = 49b68d198127199127cea0721ef622449ad2d213
POST_RESTORE_HASH = 49b68d198127199127cea0721ef622449ad2d213
```

Gate green again at exit 0.

**Spine-versus-CI gap:** `scripts/check_fast_pr_gap.py --list` reads **94**
required checks the spine does not decide. That is a fact about the spine, not a
census of this PR: the spine ran, and `check_guide_samples.py` (self-test and
live), `check_doc_slugs.py` and the four probe gates above were additionally run
directly.

**Check count.** This PR posts **86** checks — 25 pass, 57 skipping, 4 pending,
0 fail on the first full pass. That is the expected band after the retire took
twelve required jobs out, not a partial rollup: 57 of the 86 skip because a
documentation diff arms no code surface.

**Nothing skipped without a reason.** No gate was skipped. The JVM tier was
classified out by the spine's own changed-surface classifier (`jvm=false`), not
by me.

## Fence

Re-derived at start-up and again before the first edit from `gh pr list --state
open` plus three-dot diffs. Neither open branch (`worker/r6dtail-mgrsl`,
`worker/storytb-kttom`) touches any file here. `worker/storytb-kttom` adds
`tools/story/testbeds/hicasso_counter/core.cljs`, which is a Hicasso boot
namespace and therefore adjacent — left alone. The merge-base diff
(`origin/main...HEAD`) reverts nothing: PR #8394's `index.md` and
`16-diagnostics.md` fixes are untouched.

**Manual verification, since nothing gates it:** the troubleshooting table gains
one row and stays at three columns; every link added here resolves
(`check_doc_slugs.py` covers this and is green); no `mkdocs.yml` nav row is
needed, so `worker/r6dtail-mgrsl` was not raced.
