### PR TITLE
docs(hicasso): three shipped-guide defects from the fresh-reader pass (rf2-mv7oh, rf2-bir0r, rf2-zu2rb)

### DIFF
--- a/docs/core/hicasso/03-events-as-data.md
+++ b/docs/core/hicasso/03-events-as-data.md
@@ -219,6 +219,19 @@ legal only during a boundary body (or a render callback that boundary
 supplied), that returns the current frame **id keyword**. It is not a tracked
 subscription.
 
+!!! warning "`h/frame` is exported today as `h/hframe`"
+
+    This is the one door this guide spells differently from the code, and the
+    difference is deliberate rather than a slip — [Status](index.md#status)
+    records the whole of it. The samples below teach `h/frame`; to run them
+    today, substitute `h/hframe` at each call site. Nothing else changes: same
+    arity, same return, same legality rule.
+
+    The recommendation on record is to retire the verb rather than respell it,
+    leaving `rf/current-frame-id` and `rf/capture-frame` as the frame doors
+    they already are. That is why the guide has not simply been rewritten to
+    `h/hframe`.
+
 The carry spelling is composition with core's capture primitive:
 
 ```clojure

--- a/docs/core/hicasso/16-diagnostics.md
+++ b/docs/core/hicasso/16-diagnostics.md
@@ -13,8 +13,26 @@ is removed from production builds.
    chapter](../../xray/01-installation.md) carries the dependency coordinate,
    the host element, and the preload namespace.
 2. Reproduce the click, keystroke, or update.
-3. Select the view occurrence that ran.
+3. Open Xray's **Hicasso** tab and select the view occurrence that ran.
 4. Read its cause, fan-out, and attribution.
+
+!!! warning "The Xray guide does not yet document the Hicasso tab"
+
+    Steps 3 and 4 — and the read topology, advisor, and explain-render sections
+    below — all live in one place: Xray's **Hicasso** tab, which appears
+    alongside Epoch, app-db, Views, Trace, Machine, and Routes whenever the
+    inspected app is running Hicasso. It carries six views: **Mounted** (which
+    boundaries are mounted, over which frames), **Reads** (which boundaries read
+    each subscription), **Intents** (what was dispatched, in order, inside the
+    retained window), **Why** (which reads changed, and what that can and cannot
+    prove), **Advisor**, and **Causal**.
+
+    The tab ships, but the [Xray guide](../../xray/index.md) describes none of
+    it — its panel tour still enumerates six tabs, and the Hicasso tab is the
+    seventh. So this chapter is the only prose description of it anywhere, which
+    is why the sections below are written out rather than linked. Closing that
+    gap is tracked as `rf2-3bwos`; until it lands, there is nothing in the Xray
+    corpus to link to.
 
 An **epoch** is one event pipeline run, from dispatch through its state commit.
 Xray organises its evidence around epochs.
@@ -62,8 +80,8 @@ When it cannot, it reports that limitation instead of guessing.
 
 ## Read topology and fan-out
 
-The standing view maps subscriptions to the currently committed views that
-read them. Four measurements usually identify the shape:
+The Hicasso tab's **Reads** view maps subscriptions to the currently committed
+views that read them. Four measurements usually identify the shape:
 
 | Measurement | What it reveals |
 | --- | --- |
@@ -86,8 +104,8 @@ windowed collection reads as described in
 
 ## Use attribution before choosing a fix
 
-The hot-view advisor ranks views by time, frequency, read churn, and fan-out.
-It first identifies where the time is going:
+The Hicasso tab's **Advisor** view ranks views by time, frequency, read churn,
+and fan-out. It first identifies where the time is going:
 
 | Pressure | Cost owner | Smallest credible fix |
 | --- | --- | --- |
@@ -97,12 +115,27 @@ It first identifies where the time is going:
 | React | Reconciliation, hooks, or vendor internals | Use a named native island or UIx component |
 | Layout and paint | Browser style, layout, and rendering | Reduce DOM, virtualise, or fix CSS; use browser tooling |
 
-The advisor recommends a native escape only when native code addresses the
-measured owner. If lowering is 4% of an interaction, a lowering escape cannot
-recover more than that 4%.
+Only the first two rows of that table are instrumented. The advisor measures
+computation from the retained subscription ring's elapsed times and derives
+topology from the cell table's fan-out and the entry cache's read orders.
+Hiccup lowering, React, and layout and paint it **names but cannot measure**,
+and it says so rather than ranking on a clock it does not have. That absence is
+a decision rather than a gap: Chrome clamps its timer to a 0.1 ms grain while a
+boundary body costs single-digit microseconds, so a ranking built on boundary
+self time would order noise; and commit, paint, and attempt outcome belong to
+React, which reports them as opaque every time.
 
-Xray recommends; it does not rewrite or promote code automatically. Any native
-escape must pass the benefit thresholds in [Performance](19-performance.md).
+One consequence is worth stating plainly, because it is the opposite of what a
+ranked list of durations suggests: **the advisor never recommends a native
+escape.** Not for the hottest boundary on the page. Every native rung addresses
+lowering, hooks, or reconciliation, and this evidence cannot say whether any of
+them owns the pressure — so recommending one would be an expensive,
+semantics-changing change made on evidence that cannot support it.
+
+Treat the last three rows as your own checklist instead, reached through React
+DevTools and browser performance tools. Xray recommends; it does not rewrite or
+promote code automatically, and any native escape must still pass the benefit
+thresholds in [Performance](19-performance.md).
 
 ## Incomplete evidence is reported explicitly
 
@@ -229,7 +262,11 @@ When the question is correctness rather than cause, write a test
 
 ### Explain-render envelope
 
-The panel, tests, and AI pair use the same versioned evidence envelope. A
+The Hicasso tab's **Why** view, tests, and an AI pair all read one versioned
+evidence envelope, produced by
+[`re-frame.hicasso.tool/explain-render`](api-reference.md#re-framehicassotool).
+Read it through the Why view; calling the reader yourself is for scripted
+diagnosis, and every read on that door answers `nil` in a release build. A
 representative occurrence:
 
 ```clojure

--- a/docs/core/hicasso/16-diagnostics.md
+++ b/docs/core/hicasso/16-diagnostics.md
@@ -23,11 +23,10 @@ is removed from production builds.
     Epoch, app-db, Views, Trace, Machine, and Routes in Dynamic mode. The tab is
     always present; when the inspected app is not running Hicasso it says so in
     those words, rather than showing you an empty table to interpret. It carries
-    six views: **Mounted** (which
-    boundaries are mounted, over which frames), **Reads** (which boundaries read
-    each subscription), **Intents** (what was dispatched, in order, inside the
-    retained window), **Why** (which reads changed, and what that can and cannot
-    prove), **Advisor**, and **Causal**.
+    six views: **Mounted** (which boundaries are mounted, over which frames),
+    **Reads** (which boundaries read each subscription), **Intents** (what was
+    dispatched, in order, inside the retained window), **Why** (which reads
+    changed, and what that can and cannot prove), **Advisor**, and **Causal**.
 
     The tab ships, but the [Xray guide](../../xray/index.md) describes none of
     it — its panel tour still enumerates six tabs, and the Hicasso tab is the

--- a/docs/core/hicasso/16-diagnostics.md
+++ b/docs/core/hicasso/16-diagnostics.md
@@ -19,9 +19,11 @@ is removed from production builds.
 !!! warning "The Xray guide does not yet document the Hicasso tab"
 
     Steps 3 and 4 — and the read topology, advisor, and explain-render sections
-    below — all live in one place: Xray's **Hicasso** tab, which appears
-    alongside Epoch, app-db, Views, Trace, Machine, and Routes whenever the
-    inspected app is running Hicasso. It carries six views: **Mounted** (which
+    below — all live in one place: Xray's **Hicasso** tab, which sits alongside
+    Epoch, app-db, Views, Trace, Machine, and Routes in Dynamic mode. The tab is
+    always present; when the inspected app is not running Hicasso it says so in
+    those words, rather than showing you an empty table to interpret. It carries
+    six views: **Mounted** (which
     boundaries are mounted, over which frames), **Reads** (which boundaries read
     each subscription), **Intents** (what was dispatched, in order, inside the
     retained window), **Why** (which reads changed, and what that can and cannot

--- a/docs/core/hicasso/19-performance.md
+++ b/docs/core/hicasso/19-performance.md
@@ -113,8 +113,27 @@ The runtime delivers entries to `PerformanceObserver` and browser DevTools but
 does not retain them for later polling. A subsequent `getEntriesByType` call
 may find nothing even though the live observer saw the entries.
 
+**`h/defview` boundaries are bracketed**, so your Hicasso views do appear in the
+stream. Each emits `rf:render:<view-id>`, where the id is the
+`"<namespace>/<name>"` of the declaration — the same string React DevTools shows
+as `displayName`, so a measure name and a DevTools node are one identifier. A
+typical entry reads `rf:render:app.todo/todo-row`. This holds for frame-fed
+boundaries too, and does not vary by adapter: Hicasso is the view substrate
+rather than a layer over one.
+
+The bracket sits on the boundary and nowhere else. A plain function inlined into
+a body is not a boundary and gets no measure of its own; its cost lands inside
+the enclosing boundary's entry.
+
 A view that bails out emits no measure because its body did not run.
-Development StrictMode emits twice when the body runs twice.
+Development StrictMode emits twice when the body runs twice. When the runtime
+re-runs a body internally to settle its reads, the bracket still emits once —
+the count is render passes React actually performed, and the duration is the
+wall-clock it actually paid, not a total inflated by an internal retry.
+
+A throwing body still emits, because the bracket is a `try`/`finally`. An
+`rf:render:` entry is evidence that a render was attempted, not that it
+completed.
 
 ## Keep an escape only when it earns its cost
 

--- a/docs/core/hicasso/glossary.md
+++ b/docs/core/hicasso/glossary.md
@@ -232,6 +232,9 @@ Returns the frame **id keyword** of the Hicasso boundary currently rendering.
 Legal only during a boundary body or a render callback that boundary supplied.
 Not a tracked subscription.
 
+Exported today as `h/hframe`; substitute that spelling to run the sample below.
+The difference is deliberate and is recorded under [Status](index.md#status).
+
 The taught carry spelling is composition with core:
 
 ```clojure

--- a/docs/core/how-to/fix-a-slow-view.md
+++ b/docs/core/how-to/fix-a-slow-view.md
@@ -209,9 +209,9 @@ Xray rides the dev [trace stream](../glossary.md#trace-stream), which is [elided
 | `event` | an event handler ran (the full interceptor chain for one event) | `rf:event:article/toggle-favorite` |
 | `sub` | a subscription recomputed its body | `rf:sub:feed/slugs` |
 | `fx` | one effect executed (including reserved fx like `:dispatch` and managed HTTP) | `rf:fx:rf.http/managed` |
-| `render` | a `reg-view` rendered | `rf:render:my.app/article-row` |
+| `render` | a `reg-view` (or a Hicasso `h/defview` boundary) rendered | `rf:render:my.app/article-row` |
 
-The id keeps its full namespace, so you can split on the second `:` for a per-bucket view. Note that only `reg-view` views show up under `rf:render:` — a plain `defn` view has no registered id to bracket, which is one more reason to register the views you care about measuring.
+The id keeps its full namespace, so you can split on the second `:` for a per-bucket view. Note that only *registered* views show up under `rf:render:` — a plain `defn` view has no registered id to bracket, which is one more reason to register the views you care about measuring. Hicasso's `h/defview` counts as registered here: every boundary it declares is bracketed under the same `rf:render:<namespace>/<name>` id, so a Hicasso screen needs no extra step. See [Performance](../hicasso/19-performance.md) in the Hicasso guide for what its counts and durations mean.
 
 !!! warning "Gotcha — a throwing path still leaves a measure"
 


### PR DESCRIPTION
Three shipped-guide defects from the same fresh-reader pass (`rf2-hic-069`), worked in the brief's order. All three premises held at source, though one of them held for a different reason than the brief gave.

## rf2-mv7oh — the export is `h/hframe`, and the guide's `h/frame` is deliberate

**Established from `implementation/hicasso/src/`, not from the docs.** The facade `re_frame/hicasso.cljc:555` reads `hframe impl-intent/hframe`, aliasing `re-frame.hicasso.impl.intent/hframe` (defined at `impl/intent.cljs:419`). No `frame` var exists on the facade — the only `frame`-named definitions in the package are `frame-of`, `frame-prop-head?`, `frame-row`, `frame-dispatch` and `frame-prop-shell`, none of them the authoring door. So the frame-carry recipe at `03-events-as-data.md` does not compile as written. **Premise holds.**

**The trap the brief warned about is real, and it cuts the other way.** The guide's `h/frame` spelling is not drift — it is a *declared, machine-enforced* divergence. `implementation/hicasso/scripts/check_guide_samples.py` carries exactly one `DIVERGENCES` row:

```
("re-frame.hicasso", "frame"): ("hframe", "a bare `frame` would shadow on a
`:refer`; naming-ledger row 18 retires the verb rather than respelling it…")
```

Its R3 rule reds the day the gap closes, and R4 requires the matching Status bullet on `index.md` — which is present. Respelling the chapter to `h/hframe` would therefore have broken two gate rules *and* pre-empted row 18, which retires the verb rather than renaming it.

`bd show rf2-mv7oh` is explicit on this and governs: *"NOT A REQUEST TO RESOLVE THE NAMING QUESTION… A pointer at the Status admonition from chapter 3 would close it without pre-empting the ruling."* The real defect is narrower and is what I fixed: the warning existed only on `index.md`, so a reader arriving at chapter 3 from the sidebar or a search never saw it. Chapter 3 now carries an admonition naming the substitution and linking `index.md#status`; the glossary entry behind the `#hframe` anchor says the same in one line.

**No fenced block was touched**, so no digest pin needed updating — the roster still reads 217 blocks across 29 pages, identical before and after.

## rf2-bir0r — the surfaces exist; only the Xray documentation is missing

The bead asked me to establish which of three remedies was true against `tools/xray/`. Source says a fourth: **the surfaces are real and shipped.**

`tools/xray/src/day8/re_frame2_xray/panels/hicasso.cljs:613` registers an L4 tab `{:id :hicasso :label "Hicasso" :mnem "h" :modes #{:dynamic} :order 10}` with six views (`hicasso_helpers.cljc:571-582`): Mounted, Reads, Intents, Why, Advisor, Causal — backed by `re-frame.hicasso.tool`'s four reads. So "the standing view" is the **Reads** view, "the hot-view advisor" is the **Advisor** view, and the explain-render envelope is what the **Why** view reads. All three now carry their shipped names in the chapter.

The bead's zero-grep over `docs/xray/**` reproduces. `git grep -inF hicasso -- docs/xray/` returns **nothing** across all 16 files, against a positive control of 2/5/3 for `machine` on the first three. No chapter describes the tab; `02-panel-tour.md` still enumerates six Dynamic tabs and Hicasso is the seventh.

Per the brief I said so plainly rather than linking to nothing, and **filed the Xray gap as `rf2-3bwos`** rather than writing that corpus myself.

**One accuracy fix beyond the bead.** The page implied the advisor might route a reader to a native escape. Reading `hicasso_advisor.cljc`, it never does — that refusal is the deliberate product. It measures computation (Spec 009 `:rf.sub/elapsed-ms`) and derives topology; lowering, React and layout/paint it names and cannot measure. Boundary self time was killed as a decision (Chrome clamps its timer to a 0.1 ms grain against single-digit-microsecond bodies, so the ranking would order noise); commit and paint are `:host-opaque` every time. The page said the opposite by omission.

**A claim I wrote and then retracted before shipping** (commit 4 in this branch): I first wrote that the tab appears "whenever the inspected app is running Hicasso", inferring the gating from the panel's own presence handling. Reading the caller, `registry.cljs:340` runs `hicasso/install!` inside schema 5 of the registration migration for any process below that schema — "gated" in its docstring means the umbrella no-ops for an already-registered process, not conditional on Hicasso. The tab is always present in Dynamic mode, and "not running Hicasso" is one of three named empties it renders in its own words. The page now says that.

## rf2-zu2rb — yes, they do, and here is the id

**Resolved from the implementation, not from the two prose lines. `h/defview` boundaries DO emit `rf:render:` measures.**

`impl/collector.cljs:1984` wraps `mint-view!`'s component fn in `(performance/mark-and-measure :render view-name (shell body-fn js-props))`, and `:2036` does the same for `mint-frame-prop-view!`. Those are the arm's two view-substrate wrappers, so a frame-fed boundary is bracketed alongside an ordinary one. The entry is `rf:render:<view-name>` where `view-name` is the `"<ns>/<sym>"` string also stamped as `displayName` — so the measure name and the React DevTools node are one identifier. Witnessed by `arm1.render-measure-cljs-test` (flag OFF) and `arm1.render-measure-emit-nightly-test` (ON).

**It does not depend on adapter** — Hicasso is the view substrate rather than a layer over one. **It depends on build mode only** through the `re-frame.performance/enabled?` closure-define that `19-performance.md` already documents: with the flag off under `:advanced` the macro constant-folds to `(shell body-fn js-props)`, byte-for-byte the call that preceded it.

So `19-performance.md:116-117` was right and merely incomplete. The page now states the bracket, the id shape, and three counting rules that follow from the bracket sitting on the component fn: an inlined helper is not separately measured, an internal read-settling retry still emits once per React render pass, and a throwing body still emits.

`docs/core/how-to/fix-a-slow-view.md:212-214` was the half that was actually wrong — its `rf:render:` table row and the sentence under it said only `reg-view` qualifies. Both now carry the Hicasso clause and a link to the Hicasso performance chapter.

## Quality gates

Docs-only diff; the spine classified it `docs=true jvm=false node=false`.

| Gate | Attempt | Captured exit | Result |
|---|---|---|---|
| `scripts/test-fast-pr.sh` (pre-rebase base `830e48ed92`) | 1 | `0` | pass |
| **`scripts/test-fast-pr.sh` (final base `dd026b4742`, post-rebase)** | **2** | **`0`** | **pass — this is the authoritative run** |
| `scripts/check_doc_slugs.py` (direct, after each bead and after the final reflow) | 2, 4, 5, 6 | `0`, `0`, `0`, `0` | pass |
| `implementation/hicasso/scripts/check_guide_samples.py` (direct, same points) | 2, 4, 5, 6 | `0`, `0`, `0`, `0` | pass |
| `scripts/check_doc_slugs.py` — **planted fault** | SABOTAGE-3 | `1` | **red as designed** |

Every number above is the exit code **I captured myself**, written to its own `.exit` file with the redirect and the `echo` on one command line — not a status the harness reported about the same run. Artefacts are named for this worktree and for the attempt (`gate-<name>-guidefix-mv7oh-<n>.log` / `.exit`).

Pass/fail counts: **11 green, 1 deliberately red** (the control), 0 unexplained failures, 0 skipped. The authoritative spine run is attempt 2, on the post-rebase base — the attempt-1 green is evidence about a tree that no longer exists and is listed only for completeness. Both spine runs logged exactly one `run pid:` line and one summary, so no orphaned predecessor was writing into either log.

**Which gate, derived rather than nominated.** `check_doc_slugs.py` walks `docs`, `spec`, `skills`, `migration`, so it covers all four files I touched and validates both link targets and heading anchors. `mkdocs build --strict` is the gate for anything nav-reachable and ran inside the spine's documentation tier. The digest-pin gate for this corpus is **not** the Freehand `samples_coverage_jvm_test.clj` the usual shorthand names — that suite's guide-dir is the literal `docs/core/freehand`. It is `implementation/hicasso/scripts/check_guide_samples.py`, whose `GUIDE_DIR` is `docs/core/hicasso`, chained into `npm run test:hicasso-invariants` and run in CI as `hicasso-guide-samples`. I ran it directly at every step. `docs/core/how-to/` is pinned by neither, so the `fix-a-slow-view.md` edit needed no roster row.

**Red proof, and a hash-verified restore.** I planted a broken heading anchor in `03-events-as-data.md` — `[Status](index.md#status)` → `[Status](index.md#status-block-that-does-not-exist)`, anchored to the single occurrence and asserted to be a single occurrence before writing, so a silent no-op could not fake it. `check_doc_slugs.py` came back **exit 1** and named the plant:

```
BROKEN ANCHOR: docs\core\hicasso\03-events-as-data.md:225 -> index.md#status-block-that-does-not-exist
```

That output also proves the gate read **my** worktree: the plant exists nowhere else, so a run that had wandered into a sibling checkout would have returned green. The spine independently prints `gate root: /c/Users/miket/code/re-frame2-worktrees/guidefix-mv7oh` on line 1. Restore verified by hashing the bytes, not by reading a diff — `git hash-object` reads `ad78225e8789a539fcee40025af89639d60b3edc` both before the plant and after the restore.

**Digest pins:** no fenced code block was added, edited, deleted or reordered in any of the four files, so no pin changed. `check_guide_samples.py` reports the identical roster before and after — 217 blocks across 29 pages, 104 verb use-sites resolved, 1 declared divergence still live.

**Spine-versus-CI gap:** `python scripts/check_fast_pr_gap.py --list` — it currently reads **94**. That is a fact about the spine, not a census of what I ran. **The spine did run**, to completion, twice, foreground-equivalent via detached execution with in-turn polling of both the log and the exit file. What I ran directly beyond it is the table above. Per the gap script's own note, `clj-kondo` is pinned to 2026.04.15 in CI and a local pass proves nothing there; my diff touches no Clojure source, so nothing in the lint tier is reachable from it.

**Total check count on this PR: 19** (18 reporting + 1 skipped), not the ~88 a code-touching PR draws. That is expected rather than a partial rollup: most of CI's matrix is surface-gated and creates no check row for a diff that does not reach it — the same property `check_fast_pr_gap.py --list` calls out, and the same classification the spine made (`docs=true jvm=false node=false`). This diff touches five markdown files and no Clojure, EDN, or workflow source.

**No revert of PR #8394.** `16-diagnostics.md` was edited by #8394 (merged 06:26 UTC) minutes before this work started. I read `git diff origin/main...HEAD` for deleted lines: every deletion is a line I intentionally replaced, and #8394's `../../xray/01-installation.md` cross-link survives at `:12-14`. Gates cannot catch that class of revert; the diff read is what catches it.

## Left for other beads, not fixed here

- **`rf2-3bwos`** (filed by this work, P2) — `docs/xray/` documents no Hicasso tab. Carries three concrete drifts: the "Six Dynamic Tabs" enumeration, whether `:hicasso` belongs in `valid-focus-panels` (`000-Vision.md:304` calls it an L4-only registry tab, which may mean it is correctly unfocusable — a question to answer, not assume), and the absent chapter. Until it lands, `16-diagnostics.md` is the only prose description of the tab anywhere in the published corpus, which is why this PR says so in-page instead of linking.
- Nothing found for `worker/bootdocs-ttmi9` — no boot defect surfaced in my files.
- The six other `[docs-defect]` beads from the same pass are untouched.

## Fence

Re-derived at start-up and again before the first edit, from `gh pr list --state open` plus per-worktree `git diff --name-only origin/main...HEAD` and `git status --porcelain` across all 12 live worker worktrees. No worktree touches any of my four files. The one contested path is `implementation/hicasso/scripts/check_guide_samples.py`, held uncommitted by `worker/bootdocs-ttmi9` — which is exactly why every edit here is prose and no roster row moved.
