### PR TITLE
fix(docs): --strict fails on a directory-shaped link that escapes docs_dir (rf2-5exqc)

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -37,6 +37,32 @@ exclude_docs: |
   design/hicasso/
   design/retirement/
 
+# Link validation levels (rf2-5exqc).
+#
+# `--strict` fails the build on WARNING, not on INFO, so the DEFAULT levels
+# decide which broken links are gated and which ship silently.  MkDocs 1.6
+# grades a relative link it cannot resolve by whether the last path segment
+# carries a file extension (mkdocs/structure/pages.py, `_RelativePathTreeprocessor`):
+#
+#   * WITH an extension  -> `links.not_found`, default WARN  -> already gated.
+#   * WITHOUT one        -> `links.unrecognized_links`, default INFO -> NOT gated.
+#
+# So a *directory-shaped* link that escapes `docs_dir` — `](../examples)`,
+# `](../../../implementation/adapters)` — published as a 404 and `--strict`
+# stayed green.  mkdocs_hooks.py rewrites the cross-tree forms it knows to
+# absolute GitHub URLs, but any tree or depth missing from its table falls
+# through, and nothing said so.  Raising this one level makes the existing
+# `mkdocs build --strict` gate (scripts/test-fast-pr.sh's docs tier, and
+# docs.yml's "Build site (strict)" step) the permanent gate for the class.
+#
+# NOT raisable, and deliberately left alone: "contains a link to 'X' which is
+# excluded from the built site" is capped at INFO in MkDocs itself
+# (`min(logging.INFO, ...)` in pages.py), so no config value gates links into
+# `exclude_docs` trees.  That class is rf2-75q3l's, and it needs its own check.
+validation:
+  links:
+    unrecognized_links: warn
+
 # Build-time hooks. mkdocs_hooks.py rewrites core/* cross-references
 # from ../../spec/ (correct for GitHub source-tree browsing, where spec/
 # lives at the repo root) to ../spec/ (correct for the staged docs tree

--- a/mkdocs_hooks.py
+++ b/mkdocs_hooks.py
@@ -159,7 +159,13 @@ _GUIDE_XRAY_DIR = re.compile(r'\]\(\.\./\.\./xray/\)')
 # Case 3c: directory-style conformance/ from spec/SPEC-AUTHORING.md — the
 # conformance corpus is staged at docs/spec/conformance/, with README.md as
 # its index. MkDocs needs the explicit .md target.
-_SPEC_CONFORMANCE_DIR = re.compile(r'\]\(conformance/\)')
+#
+# The trailing slash is OPTIONAL (rf2-5exqc). GitHub renders `](conformance)`
+# and `](conformance/)` identically, so authors write both; before the `/?`
+# the slashless form fell through every rule and shipped as a 404, and only
+# at MkDocs INFO — see the `validation:` block in mkdocs.yml for why that was
+# silent. `--strict` now fails on it, and this rule means it does not have to.
+_SPEC_CONFORMANCE_DIR = re.compile(r'\]\(conformance/?\)')
 
 # Case 2: cross-tree refs that don't exist in the staged docs tree.
 # These rewrites apply to ALL pages (guide/, spec/, and docs/-root pages
@@ -181,12 +187,21 @@ _REWRITES = (
     # how-to pages at docs/<cap>/<sub>/X.md) link ../../../examples/; depth-2
     # (docs/<tree>/X.md) link ../../examples/; depth-1 (docs/X.md) link
     # ../examples/. All resolve to the same GitHub blob URL.
-    (re.compile(r'\]\(\.\./\.\./\.\./examples/([^)\s]*)\)'),
-     rf']({GH_BLOB_BASE}/examples/\1)'),
-    (re.compile(r'\]\(\.\./\.\./examples/([^)\s]*)\)'),
-     rf']({GH_BLOB_BASE}/examples/\1)'),
-    (re.compile(r'\]\(\.\./examples/([^)\s]*)\)'),
-     rf']({GH_BLOB_BASE}/examples/\1)'),
+    #
+    # The path after the tree root is OPTIONAL, so a bare `](../examples)`
+    # naming the whole tree rewrites too (rf2-5exqc). It read as an oversight
+    # until `validation.links.unrecognized_links` was raised in mkdocs.yml,
+    # because MkDocs graded the resulting dead link INFO rather than WARNING:
+    # `spec/README.md` shipped three of them. Capturing the leading slash
+    # inside the group keeps every already-matching form byte-identical, and
+    # `examples-old/x` still does not match — after `examples` the regex needs
+    # either `/` or the closing paren.
+    (re.compile(r'\]\(\.\./\.\./\.\./examples(/[^)\s]*)?\)'),
+     rf']({GH_BLOB_BASE}/examples\1)'),
+    (re.compile(r'\]\(\.\./\.\./examples(/[^)\s]*)?\)'),
+     rf']({GH_BLOB_BASE}/examples\1)'),
+    (re.compile(r'\]\(\.\./examples(/[^)\s]*)?\)'),
+     rf']({GH_BLOB_BASE}/examples\1)'),
     # root README.md
     (re.compile(r'\]\(\.\./\.\./README\.md(#[^)\s]*)?\)'),
      rf']({GH_BLOB_BASE}/README.md\1)'),


### PR DESCRIPTION
Closes rf2-5exqc.

## The premise did not hold, and the gate gap did

The bead lists nine links across six published pages as live 404s. **All nine already publish correctly.** `mkdocs_hooks.py` rewrites cross-tree links to absolute GitHub blob URLs, and its table covers `examples/` and `implementation/` at all three depths — exactly the trees and depths the bead names. Rendering each page through the real hook shows every one of the nine becoming `https://github.com/day8/re-frame2/blob/main/…`. The fresh-reader run checked both ends **in the source tree**, which is the correct check for GitHub browsing and the wrong one for the site; it did not render through the hook.

The gate gap the bead describes is real, and it is sharper than "an excluded target reports at INFO". MkDocs 1.6 grades an unresolvable relative link by **whether its last path segment carries a file extension** (`mkdocs/structure/pages.py`, `_RelativePathTreeprocessor.path_to_url`, lines 456-471):

| link shape | knob | default | `--strict` |
|---|---|---|---|
| `](../../../foo/bar.cljs)` — has an extension | `links.not_found` | `warn` | **already fails** |
| `](../../../foo/bar)` — no extension | `links.unrecognized_links` | `info` | **passes, ships a 404** |

So the silent class is precisely the **directory-shaped** escaping link. Half the bead's own list (`…/core.cljs`, `…_test.cljs`) would have failed `--strict` on the day it was written, had the hook not already handled it; the other half (`…/todomvc`, `…/realworld_http`) is the class that really was invisible.

**How I established it.** `mkdocs build --strict` on the base commit: **exit 0**, 0 warnings, with four `unrecognized relative link` INFO lines present. Then the A/B below, which isolates the behaviour to one config value.

## Where the check belongs, and why there is no new script

**In `mkdocs.yml`, as one `validation:` level — not a new checker.** Deriving rather than assuming:

- `scripts/check_doc_slugs.py` cannot cover this and should not be widened to. It validates targets against the **working tree**, where every one of these files exists; it renders no hook and knows nothing of staging; and it validates **only `.md` links** by design, while this entire class is directories and `.cljs`/`.edn` files. Widening its link filter would change its existing contract for every root it scans.
- `scripts/check_readme_links.py` owns repo-root markdown, which mkdocs never publishes. Out of scope in both directions.
- `mkdocs build --strict` already runs in the spine's docs tier and in `docs.yml`'s "Build site (strict)" step, already resolves links against the **staged** tree with the hook applied, and already reports this class — at the wrong level. One line promotes it.

A standalone `scripts/check_docs_dir_escapes.py` would have had to re-implement MkDocs' staging, the hook pipeline and its link resolution to say something MkDocs was already saying. That is the general link checker the brief warns against, and it would drift from the real build. **Refused, with the config line in its place.**

**Tier placement.** The brief asks the `check_workflow_yaml.py` question — would a tier-gated lane miss the case? Here the answer comes out the other way, and the derivation is what makes it safe to say so. Exactly three inputs decide this verdict: a `docs/**` or `spec/**` link edit, `mkdocs.yml`, and `mkdocs_hooks.py`. `is_doc_surface_path` in `scripts/test-fast-pr.sh` matches `*.md`, `mkdocs.yml` and `mkdocs_hooks.py` — all three. A source-tree *move* cannot silently break it, because the predicate is resolution against the built site, not existence on disk. So the docs tier is complete for this check, and no always-on lane is warranted.

One honest limitation, pre-existing and unchanged: the spine **soft-skips** `mkdocs --strict` where mkdocs resolves neither as a console script nor as `python -m mkdocs`, and says so. `docs.yml` is the hard gate. This change inherits that posture rather than altering it.

## Gate-found count versus the bead's list

**Gate: 4. Bead: 9. Overlap: 0.**

Every instance the gate found is one the bead does not list, and every instance the bead lists is one the gate does not find. This is the reason to build from the gate's output rather than the list.

| found by the gate | fix | why this fix |
|---|---|---|
| `spec/README.md` ×3 → `](../examples)` | rewriter | Bare cross-tree directory link. `](../examples/core/counter)` on the same line rewrote fine; only the tree root, named without a trailing slash, fell through. That is an author trap, not three typos — fixed in the rule so the next one cannot recur. Source stays correct for GitHub browsing, which is the whole point of rewriting at build time. |
| `spec/SPEC-AUTHORING.md` → `](conformance)` | rewriter | Same trap, same shape: `_SPEC_CONFORMANCE_DIR` required a trailing slash. The target is staged in the site, so this rewrites to the in-tree `conformance/README.md` rather than off-site — a corpus the reader is meant to open, not evidence being cited. |

Rewriting the four links by hand was the alternative and I rejected it: it fixes four bytes and leaves the trap armed. Staging these targets into `docs_dir` was never on the table — `examples/` is CLJS apps, not pages.

The regex change captures the leading slash inside an optional group, so **every already-matching form is byte-identical**. Verified rather than asserted: 506 pages rendered through both the `HEAD` hook and the new one differ on **exactly the four reported lines**, and `](../examples-old/x)` still does not match.

## Left for other beads, not fixed here

- **rf2-ypct8 / `worker/bootdocs-ttmi9`** — `docs/core/how-to/boot-and-mount-an-app.md:259,261` is fenced to that worker and I did not touch it. The finding to carry over is that **both links are fine**: the hook rewrites them to GitHub blob URLs, and the gate does not flag the file.
- **rf2-75q3l** — measured, as its parent asked. `validation.links.not_found` **cannot** gate this class: MkDocs caps the "excluded from the built site" message at INFO in code (`min(logging.INFO, …)`, `pages.py:509`), so no config value reaches it and rf2-75q3l does need its own check. The full live census is 13 links from 3 pages: `spec/004-Views.md` ×11 into `design/freehand/decisions/`, plus `docs/core/25-from-re-frame-v1.md` and `migration/from-re-frame-v1/README.md` into `migration/from-re-frame-v1/codemod/README.md`. All are inside `docs_dir` and all 404, so they are a different mechanism from this bead's escapes.
- **`docs/design/**`** — 39 further escaping links (depth-4 `../../../../`). Not defects: those trees are in `exclude_docs` and are never published, and MkDocs caps warnings from an excluded page at INFO, so they cannot red this gate.

## Quality gates

| gate | command | captured exit |
|---|---|---|
| fast PR spine | `sh …/scripts/test-fast-pr.sh` | **0** |
| mkdocs `--strict`, base commit (premise check) | `python -m mkdocs build --strict` | **0** — the defect class present and green |
| mkdocs `--strict`, gate on, before fix | `python -m mkdocs build --strict` | **1** — `Aborted with 4 warnings` |
| mkdocs `--strict`, after fix | `python -m mkdocs build --strict` | **0**, 0 warnings |
| **sabotage** — gate on | `python -m mkdocs build --strict` | **1** |
| **sabotage** — knob back to `info` | `python -m mkdocs build --strict` | **0** |

Spine: **PASS**, 36 steps ok, `gate root: /c/Users/miket/code/re-frame2-worktrees/docsdirgate-5exqc`, classified `docs=true jvm=false node=false`. Four lanes NOT RUN, each surface-gated with a printed reason: clj-kondo (no lint root in the diff), JVM artefact suites (`implementation_jvm` unchanged), npm/CLJS/isolation (`cljs_node_test` unchanged), and the CI-only browser/bundle/conformance lanes. The diff is `mkdocs.yml` + `mkdocs_hooks.py`, so none of those surfaces is reachable from it.

Every number above is the exit code captured by the runner itself — redirect and `echo $?` on one command line — not a harness report about the run.

### The control

Planted one anchored line in `docs/core/views.md` (a file I own), replacing the TodoMVC target with `](../../testbeds/sabotage-rf2-5exqc)` — directory-shaped, escaping `docs_dir`, and in no rewrite rule. Confirmed the patch actually applied by hash before believing the run.

```
WARNING -  Doc file 'core/views.md' contains an unrecognized relative link
           '../../testbeds/sabotage-rf2-5exqc', it was left as is.
Aborted with 1 warnings in strict mode!            exit 1
```

It names the file and the offending link; MkDocs' message carries no line number, which is worth knowing before anyone nominates this gate expecting one.

Then the A/B that isolates the cause — same tree, same plant, one value changed: with `unrecognized_links: info` (the stock default this PR overrides) the identical build reports the identical line as `INFO` and exits **0**. The gate is the config line, not something incidental to the build.

Restore verified by content hash against the committed objects, not by reading a diff:

```
mkdocs.yml         committed=563ba7a4… worktree=563ba7a4…  MATCH
docs/core/views.md committed=aff73166… worktree=aff73166…  MATCH
```

### Spine-versus-CI gap

`python scripts/check_fast_pr_gap.py --list` — **94**, unchanged by this PR, which is correct: it adds no step to the spine. It raises the severity of a check the spine already runs, so the set of required CI checks with no local lane is untouched.

## Docs-tree verification

`mkdocs.yml` and `mkdocs_hooks.py` are build configuration, not pages, so there are no anchors or table column counts to hand-check. The site build itself is the verification and it is green.
