### PR TITLE
fix(template): the scaffolded app actually hot-reloads (rf2-r0kk7)

### DIFF
--- a/tools/template/resources/day8/re_frame2_template/_reagent/core.cljs
+++ b/tools/template/resources/day8/re_frame2_template/_reagent/core.cljs
@@ -15,20 +15,47 @@
             [{{namespace}}.schema    :as schema]
             [{{namespace}}.views     :as views]))
 
-(defonce ^:private root
-  (rdc/create-root (js/document.getElementById "app")))
+;; Namespace load does no DOM work — `mount!` creates the root lazily, so this
+;; namespace also loads cleanly in a test or Node host with no `js/document`.
+;; `defonce` keeps ONE React root for the life of the page: React must not get a
+;; second `create-root` for a live DOM node.
+(defonce ^:private react-root (atom nil))
+
+(def app-frame :rf/default)
+
+;; `mount!` is browser setup: create the root once, then render the view tree
+;; inside the frame-root. `^:dev/after-load` is shadow-cljs's cue to re-run it
+;; after each successful hot reload, so your edited views re-render into the
+;; same root and the same frame.
+;;
+;; THIS HOOK IS WHAT MAKES HOT RELOAD WORK. shadow's `:browser` target does NOT
+;; re-run the module `:init-fn` after a reload — it loads the new code and calls
+;; the `^:dev/after-load` hooks, and with none configured it says so in the
+;; console ("reloading code but no :after-load hooks are configured!") and the
+;; page keeps rendering the OLD view. See `docs/core/how-to/boot-and-mount-an-app.md`.
+;;
+;; `frame-root` ENSURES the app frame: it creates `:rf/default` the first time
+;; (running the `:initial-events` seed synchronously, so the initial render sees
+;; the seeded app-db), and REUSES the live frame WITHOUT re-seeding on every
+;; later render — so a reload leaves your app-db exactly as you left it.
+(defn ^:dev/after-load mount! []
+  (when-let [el (and (exists? js/document)
+                     (js/document.getElementById "app"))]
+    (when-not @react-root
+      (reset! react-root (rdc/create-root el)))
+    (rdc/render @react-root
+                [rf/frame-root {:id             app-frame
+                                :initial-events [[:counter/initialise]]}
+                 [views/counter-app]])))
 
 (defn ^:export init
-  "Called by shadow-cljs (see :init-fn in shadow-cljs.edn). Idempotent —
-   shadow's hot-reload pipeline re-invokes it on each rebuild."
+  "Called ONCE by shadow-cljs (see :init-fn in shadow-cljs.edn) when the
+   bundle loads. Process setup only — `mount!` above owns the browser side
+   and is what a hot reload re-runs."
   []
+  ;; `init!` installs the adapter but does not create a frame — the
+  ;; `rf/frame-root` element in `mount!` ensures it.
   (rf/init! reagent-adapter/adapter)
-  ;; `init!` installs the adapter but does not create a frame. The
-  ;; `rf/frame-root` element below ENSURES the app frame at mount: it creates
-  ;; `:rf/default` the first time (running the `:initial-events` seed
-  ;; synchronously, so the initial render sees the seeded app-db), and REUSES
-  ;; the live frame WITHOUT re-seeding on every hot-reload re-render.
-  ;;
   ;; Schemas validate shape; they do not classify durable app-db egress.
   ;; Classify a path from the event that writes it by returning `:sensitive`
   ;; or `:large` alongside `:db`:
@@ -40,9 +67,6 @@
   ;; See the README's privacy section for HTTP carriers and response bodies.
   ;;
   ;; Schema attachment is frame-local; it names the app frame explicitly so
-  ;; the `:initial-events` seed below is validated from the very first write.
+  ;; the `:initial-events` seed is validated from the very first write.
   (schema/register-schema!)
-  (rdc/render root
-              [rf/frame-root {:id             :rf/default
-                              :initial-events [[:counter/initialise]]}
-               [views/counter-app]]))
+  (mount!))

--- a/tools/template/resources/day8/re_frame2_template/_reagent/core_with_ssr.cljc
+++ b/tools/template/resources/day8/re_frame2_template/_reagent/core_with_ssr.cljc
@@ -139,59 +139,71 @@
 ;; Hydration and the view tree must target the same client frame.
 (def app-frame :rf/default)
 
+;; Re-render the current view into the RETAINED root. Tagged `^:dev/after-load`
+;; so shadow-cljs re-runs it after each successful hot reload — edited views
+;; re-render into the same root and the already-hydrated frame.
+;;
+;; THIS HOOK IS WHAT MAKES HOT RELOAD WORK. shadow's `:browser` target does NOT
+;; re-run the module `:init-fn` after a reload — it loads the new code and calls
+;; the `^:dev/after-load` hooks, and with none configured it says so in the
+;; console ("reloading code but no :after-load hooks are configured!") and the
+;; page keeps rendering the OLD view.
+;;
+;; It never creates a root and never re-hydrates: the root is established once
+;; in `init`, and HYDRATE happens once there too, so a reload cannot re-seed the
+;; server slice over live interactive state.
+#?(:cljs
+   (defn ^:dev/after-load render! []
+     (when-let [root @react-root]
+       ;; Render inside the app-frame's `frame-provider`, so every `dispatch`
+       ;; and `subscribe` down in the view tree resolves to the hydrated frame.
+       (rdc/render root
+                   [rf/frame-provider {:frame app-frame}
+                    [(rf/view :app/root)]]))))
+
 #?(:cljs
    (defn ^:export init
-     "Called by shadow-cljs (see :init-fn in shadow-cljs.edn). Idempotent —
-      shadow's `:browser` target re-invokes it on every hot reload, so the
-      boot ceremony (frame -> schema -> hydrate -> root) runs exactly ONCE and
-      later reruns only re-render the edited views into the one retained root."
+     "Called ONCE by shadow-cljs (see :init-fn in shadow-cljs.edn) when the
+      bundle loads. The boot ceremony (frame -> schema -> hydrate -> root) runs
+      exactly once here; `render!` above is what a hot reload re-runs."
      []
      (rf/init! reagent-adapter/adapter)
-     (if @react-root
-       ;; HOT RELOAD — the boot already ran (the frame exists). Re-render the
-       ;; edited views into the SAME retained root. Never re-hydrate (that would
-       ;; re-seed the server slice over live interactive state) and never create
-       ;; a second root over the container.
-       (rdc/render @react-root
-                   [rf/frame-provider {:frame app-frame}
-                    [(rf/view :app/root)]])
-       ;; FIRST BOOT — create the frame before attaching its schema or hydrating
-       ;; state. Programmatic `rf/make-frame` (not the view-owned
-       ;; `rf/frame-root`): `ssr/hydrate!` must run against the live frame BEFORE
-       ;; React touches the DOM.
-       (do
-         (rf/make-frame {:id       app-frame
-                         :doc      "{{name}} SSR client app-frame"
-                         :platform :client})
-         (register-schema! app-frame)
-         ;; hydrate! seeds STATE and verifies the render-tree hash against the
-         ;; server marker BEFORE the mount; it never touches the DOM. It hands
-         ;; back the payload it applied (nil on a plain client load), which is
-         ;; what lets the mount below adopt-or-create correctly.
-         (let [el      (and (exists? js/document) (js/document.getElementById "app"))
-               payload (ssr/hydrate!
-                         {:frame          app-frame
-                          ;; The verify step renders the view to hash it. The
-                          ;; view's injected `subscribe` is frame-scoped, and
-                          ;; hydrate! calls this fn OUTSIDE any frame scope — so
-                          ;; pin the ambient frame here, or the render raises
-                          ;; :rf.error/no-frame-context.
-                          :render-tree-fn (fn []
-                                            (rf/with-frame app-frame
-                                              ((rf/view :app/root))))})
-               tree    [rf/frame-provider {:frame app-frame}
-                        [(rf/view :app/root)]]]
-           (when el
-             (if payload
-               ;; SERVER-RENDERED — ADOPT the server-painted DOM. `hydrate-root`
-               ;; reconciles React against the existing markup: the same nodes,
-               ;; handlers wired live, no re-paint and no flash. `create-root` +
-               ;; `render` here would throw the server HTML away and mount a
-               ;; fresh tree — the bug this branch exists to avoid.
-               (reset! react-root (rdc/hydrate-root el tree))
-               ;; PLAIN CLIENT LOAD — no server payload to adopt. Seed the
-               ;; app-db, then mount a fresh root.
-               (do
-                 (rf/dispatch-sync [:counter/initialise] {:frame app-frame})
-                 (reset! react-root (rdc/create-root el))
-                 (rdc/render @react-root tree)))))))))
+     ;; Create the frame before attaching its schema or hydrating state.
+     ;; Programmatic `rf/make-frame` (not the view-owned `rf/frame-root`):
+     ;; `ssr/hydrate!` must run against the live frame BEFORE React touches the
+     ;; DOM.
+     (rf/make-frame {:id       app-frame
+                     :doc      "{{name}} SSR client app-frame"
+                     :platform :client})
+     (register-schema! app-frame)
+     ;; hydrate! seeds STATE and verifies the render-tree hash against the
+     ;; server marker BEFORE the mount; it never touches the DOM. It hands
+     ;; back the payload it applied (nil on a plain client load), which is
+     ;; what lets the mount below adopt-or-create correctly.
+     (let [el      (and (exists? js/document) (js/document.getElementById "app"))
+           payload (ssr/hydrate!
+                     {:frame          app-frame
+                      ;; The verify step renders the view to hash it. The
+                      ;; view's injected `subscribe` is frame-scoped, and
+                      ;; hydrate! calls this fn OUTSIDE any frame scope — so
+                      ;; pin the ambient frame here, or the render raises
+                      ;; :rf.error/no-frame-context.
+                      :render-tree-fn (fn []
+                                        (rf/with-frame app-frame
+                                          ((rf/view :app/root))))})
+           tree    [rf/frame-provider {:frame app-frame}
+                    [(rf/view :app/root)]]]
+       (when el
+         (if payload
+           ;; SERVER-RENDERED — ADOPT the server-painted DOM. `hydrate-root`
+           ;; reconciles React against the existing markup: the same nodes,
+           ;; handlers wired live, no re-paint and no flash. `create-root` +
+           ;; `render` here would throw the server HTML away and mount a
+           ;; fresh tree — the bug this branch exists to avoid.
+           (reset! react-root (rdc/hydrate-root el tree))
+           ;; PLAIN CLIENT LOAD — no server payload to adopt. Seed the
+           ;; app-db, then mount a fresh root.
+           (do
+             (rf/dispatch-sync [:counter/initialise] {:frame app-frame})
+             (reset! react-root (rdc/create-root el))
+             (rdc/render @react-root tree)))))))

--- a/tools/template/resources/day8/re_frame2_template/_reagent/core_with_stories.cljs
+++ b/tools/template/resources/day8/re_frame2_template/_reagent/core_with_stories.cljs
@@ -78,9 +78,27 @@
   (.addEventListener js/window "hashchange" on-hash-change!)
   (reset! hash-listener on-hash-change!))
 
+;; -- hot reload -----------------------------------------------------------
+;;
+;; `^:dev/after-load` is shadow-cljs's cue to re-run this after each successful
+;; reload. THIS HOOK IS WHAT MAKES HOT RELOAD WORK: shadow's `:browser` target
+;; does NOT re-run the module `:init-fn` after a reload — it loads the new code
+;; and calls the `^:dev/after-load` hooks, and with none configured it says so
+;; in the console ("reloading code but no :after-load hooks are configured!")
+;; and the page keeps rendering the OLD view.
+;;
+;; The hook reinstalls the listener (whose fn identity changed with the reload)
+;; and re-applies the current hash, which re-renders the live surface into the
+;; same root. `frame-root` reuses the already-live frame without re-seeding, so
+;; your app-db survives the save. See
+;; `docs/core/how-to/boot-and-mount-an-app.md` §Host listeners.
+(defn ^:dev/after-load reload! []
+  (install-hash-listener!)
+  (on-hash-change!))
+
 (defn ^:export init
-  "Called by shadow-cljs (see :init-fn in shadow-cljs.edn). Idempotent —
-   shadow's hot-reload pipeline re-invokes it on each rebuild."
+  "Called ONCE by shadow-cljs (see :init-fn in shadow-cljs.edn) when the
+   bundle loads. `reload!` above is what a hot reload re-runs."
   []
   (rf/init! reagent-adapter/adapter)
   ;; init! installs the adapter but does not create the app frame — the

--- a/tools/template/resources/day8/re_frame2_template/_shared/shadow-cljs.edn
+++ b/tools/template/resources/day8/re_frame2_template/_shared/shadow-cljs.edn
@@ -19,8 +19,12 @@
   {:target     :browser
    :output-dir "resources/public/js"
    :asset-path "/js"
-   ;; shadow's :browser target re-runs the module :init-fn after each
-   ;; hot reload by default — no :after-load hook needed.
+   ;; shadow calls the module :init-fn ONCE, when the bundle loads. It does
+   ;; NOT re-run it after a hot reload — a reload loads the new code and then
+   ;; calls the build's ^:dev/after-load hooks. core.cljs therefore carries
+   ;; one — the fn that re-renders the edited views into the retained React
+   ;; root. Without it shadow logs "reloading code but no :after-load hooks
+   ;; are configured!" and the page keeps showing the OLD view.
    :modules    {:main {:init-fn {{namespace}}.core/init}}{{xray-preload}}}
 
   :test

--- a/tools/template/resources/day8/re_frame2_template/_uix/core.cljs
+++ b/tools/template/resources/day8/re_frame2_template/_uix/core.cljs
@@ -10,19 +10,48 @@
             [{{namespace}}.schema :as schema]
             [{{namespace}}.views  :as views]))
 
-(defonce ^:private root
-  (uix-dom/create-root (js/document.getElementById "app")))
+;; Namespace load does no DOM work — `mount!` creates the root lazily, so this
+;; namespace also loads cleanly in a test or Node host with no `js/document`.
+;; `defonce` keeps ONE React root for the life of the page: React must not get a
+;; second `create-root` for a live DOM node.
+(defonce ^:private react-root (atom nil))
+
+(def app-frame :rf/default)
+
+;; `mount!` is browser setup: create the root once, then render the view tree
+;; inside the frame-root. `^:dev/after-load` is shadow-cljs's cue to re-run it
+;; after each successful hot reload, so your edited views re-render into the
+;; same root and the same frame.
+;;
+;; THIS HOOK IS WHAT MAKES HOT RELOAD WORK. shadow's `:browser` target does NOT
+;; re-run the module `:init-fn` after a reload — it loads the new code and calls
+;; the `^:dev/after-load` hooks, and with none configured it says so in the
+;; console ("reloading code but no :after-load hooks are configured!") and the
+;; page keeps rendering the OLD view. See `docs/core/how-to/boot-and-mount-an-app.md`.
+;;
+;; `frame-root` ENSURES the app frame: it creates `:rf/default` the first time
+;; (running the `:initial-events` seed synchronously, so the initial render sees
+;; the seeded app-db), and REUSES the live frame WITHOUT re-seeding on every
+;; later render — so a reload leaves your app-db exactly as you left it.
+(defn ^:dev/after-load mount! []
+  (when-let [el (and (exists? js/document)
+                     (js/document.getElementById "app"))]
+    (when-not @react-root
+      (reset! react-root (uix-dom/create-root el)))
+    (uix-dom/render-root
+      ($ uix-adapter/frame-root {:id             app-frame
+                                 :initial-events [[:counter/initialise]]}
+         ($ views/counter-app))
+      @react-root)))
 
 (defn ^:export init
-  "Called by shadow-cljs. Idempotent — re-invoked on each hot reload."
+  "Called ONCE by shadow-cljs (see :init-fn in shadow-cljs.edn) when the
+   bundle loads. Process setup only — `mount!` above owns the browser side
+   and is what a hot reload re-runs."
   []
+  ;; `init!` installs the adapter but does not create a frame — the
+  ;; `frame-root` element in `mount!` ensures it.
   (rf/init! uix-adapter/adapter)
-  ;; `init!` installs the adapter but does not create a frame. The
-  ;; `frame-root` element below ENSURES the app frame at mount: it creates
-  ;; `:rf/default` the first time (running the `:initial-events` seed
-  ;; synchronously, so the initial render sees the seeded app-db), and REUSES
-  ;; the live frame WITHOUT re-seeding on every hot-reload re-render.
-  ;;
   ;; Schemas validate shape; they do not classify durable app-db egress.
   ;; Classify a path from the event that writes it by returning `:sensitive`
   ;; or `:large` alongside `:db`:
@@ -34,10 +63,6 @@
   ;; See the README's privacy section for HTTP carriers and response bodies.
   ;;
   ;; Schema attachment is frame-local; it names the app frame explicitly so
-  ;; the `:initial-events` seed below is validated from the very first write.
+  ;; the `:initial-events` seed is validated from the very first write.
   (schema/register-schema!)
-  (uix-dom/render-root
-    ($ uix-adapter/frame-root {:id             :rf/default
-                               :initial-events [[:counter/initialise]]}
-       ($ views/counter-app))
-    root))
+  (mount!))

--- a/tools/template/resources/day8/re_frame2_template/root/README.md
+++ b/tools/template/resources/day8/re_frame2_template/root/README.md
@@ -24,13 +24,27 @@ file save) are fast.
 
 ## Hot reload
 
-`shadow-cljs watch` rebuilds on every file save and re-invokes
-`{{namespace}}.core/init` — shadow's `:browser` target re-runs the
-module's `:init-fn` automatically after each hot reload, so no
-`:after-load` hook is needed. Two distinct mechanisms combine to give
-you a clean reload:
+`shadow-cljs watch` rebuilds on every file save, pushes the new code into
+the running page, and then calls the build's `^:dev/after-load` hooks.
+`core.cljs` carries one — `mount!` (named `reload!` in the Story scaffold,
+where it also reinstalls the hash listener) — and **that hook is what
+re-renders your edited views**. shadow calls the module's `:init-fn`
+(`{{namespace}}.core/init`) exactly **once**, when the bundle first loads;
+it does *not* re-run it on a reload. Drop the hook and shadow says so in
+the browser console — *"reloading code but no `:after-load` hooks are
+configured!"* — while the page goes on painting the OLD view.
 
-1. **Namespace reload re-runs your registrations.** Reloading
+Three mechanisms combine to give you a clean reload:
+
+1. **The `^:dev/after-load` hook re-renders into the same root and the
+   same frame.** The React root lives in a `defonce` cell, so a reload
+   renders into the root that already owns `#app` instead of creating a
+   second one over a live DOM node. The `rf/frame-root` element finds
+   `:rf/default` already alive and REUSES it **without re-seeding**, so
+   your app-db is exactly as you left it: click the counter to 7, save a
+   view, and it still reads 7 with your edit on screen.
+
+2. **Namespace reload re-runs your registrations.** Reloading
    `events.cljs` / `subs.cljs` / `views.cljs` re-evaluates the
    `reg-event` / `reg-sub` / `reg-view` forms at the top level, so
    each handler / sub / view re-registers in place against the new
@@ -46,7 +60,7 @@ you a clean reload:
    add: the new `id` shows up live, but the old `id` stays registered
    until that refresh.)
 
-2. **`rf/init!` is safe to re-call but does NOT reset anything by
+3. **`rf/init!` runs once, in `init`, and does NOT reset anything by
    itself.** It is idempotent and installs the substrate adapter
    **only when none is already seated**. Per EP-0002 (Spec 002 §Frame
    target resolution) `init!` does **not** create the `:rf/default`
@@ -55,10 +69,8 @@ you a clean reload:
    element in `core.cljs` ENSURES `:rf/default` at mount — it creates
    the frame the first time (running the `:initial-events` seed
    synchronously) and REUSES the already-live frame **without
-   re-seeding** on every later mount. A second `init!` call (which
-   every hot reload makes) does **not** re-install the adapter, does
-   **not** snapshot the registrar, and does **not** touch app-db; the
-   re-rendered `frame-root` finds the frame already live and leaves
+   re-seeding** on every later mount. A reload never touches app-db;
+   the re-rendered `frame-root` finds the frame already live and leaves
    your state alone. So the reload is a no-op for your state.
 
 The thing that seeds the demo state is the `frame-root` element's

--- a/tools/template/test/day8/re_frame2_template/template_emission_test.clj
+++ b/tools/template/test/day8/re_frame2_template/template_emission_test.clj
@@ -1083,14 +1083,127 @@
           (is (.contains core "defonce")
               "the React root is held in a defonce atom so it is retained across
                hot reloads (one root owns the container)")
-          (is (re-find #"(?s)\(if\s+@react-root" core)
-              "init GUARDS on the retained root: a hot-reload rerun re-renders
-               into the same root rather than re-hydrating or creating a second
-               root (rf2-w1k3i)")
-          (is (re-find #"(?s)\(if\s+@react-root[\s\S]*?\(rdc/render\s+@react-root[\s\S]*?ssr/hydrate!" core)
-              "the retained-root rerun path re-renders into @react-root and does
-               NOT re-run ssr/hydrate! — a rerun must not re-seed the server
-               slice over live interactive state (rf2-w1k3i)"))
+          ;; -- the hot-reload path is a ^:dev/after-load hook, and it is the
+          ;;    ONLY thing a reload re-runs. shadow's :browser target does NOT
+          ;;    re-invoke the module :init-fn after a reload (measured on
+          ;;    shadow-cljs 3.4.10, rf2-r0kk7), so a scaffold whose re-render
+          ;;    lives inside `init` never repaints an edited view. --
+          (is (re-find #"\^:dev/after-load\s+render!" core)
+              "core.cljc carries a ^:dev/after-load render! hook — WITHOUT it
+               shadow loads the new code, logs \"reloading code but no
+               :after-load hooks are configured!\" and the page keeps painting
+               the OLD view (rf2-r0kk7)")
+          (is (re-find #"(?s)\^:dev/after-load\s+render!\s*\[\][\s\S]{0,400}?\(rdc/render\s+root" core)
+              "the after-load hook re-renders into the RETAINED root rather than
+               creating a second one (rf2-w1k3i / rf2-r0kk7)")
+          (is (not (re-find #"(?s)\^:dev/after-load\s+render!\s*\[\][\s\S]*?ssr/hydrate!\b[\s\S]*?\^:export\s+init" core))
+              "the after-load hook does NOT re-run ssr/hydrate! — a reload must
+               not re-seed the server slice over live interactive state
+               (rf2-w1k3i)")
+          (is (re-find #"(?s)\^:export\s+init[\s\S]*?ssr/hydrate!" core)
+              "the one-time boot ceremony (frame -> schema -> hydrate -> root)
+               stays in the :init-fn entry point (rf2-w1k3i)"))
+        (finally
+          (delete-recursively tmp))))))
+
+;; --- the hot-reload hook ---------------------------------------------------
+;;
+;; MEASURED on shadow-cljs 3.4.10 (rf2-r0kk7): a `:browser` build whose only
+;; entry point is a module `:init-fn` does NOT re-render after a hot reload.
+;; shadow compiles the change, pushes the module and evaluates it — the console
+;; even says `load JS … views.cljs` — and then logs
+;;
+;;   shadow-cljs: reloading code but no :after-load hooks are configured!
+;;
+;; while `#app` goes on painting the OLD view, indefinitely. The `:init-fn` is
+;; called ONCE, when the bundle loads; nothing re-invokes it. So EVERY emitted
+;; entry namespace must carry a `^:dev/after-load` hook that re-renders, and
+;; `init` must delegate to it rather than owning the render itself.
+;;
+;; This is the gate that was missing when the defect shipped: nothing anywhere
+;; asserted a hot reload reached the browser, and three documentation sites
+;; stated the opposite of what shadow does. The prose greps below are as
+;; load-bearing as the code ones — the next reader "corrects" a template back to
+;; whatever its own comments claim.
+
+(deftest entry-namespace-carries-after-load-hook-test
+  (testing "every emitted entry namespace carries a ^:dev/after-load re-render
+            hook, because shadow does NOT re-run the module :init-fn after a
+            hot reload (rf2-r0kk7)"
+    ;; `hook` is the ^:dev/after-load fn. `renders` is the call its body must
+    ;; make — the thing that actually repaints. `render-entry` is the fn BOTH
+    ;; the first load and the reload go through, so the two paths cannot drift
+    ;; apart: `mount!` on the plain scaffolds, and on the Story scaffold (whose
+    ;; hook additionally reinstalls its hash listener) the router's
+    ;; `on-hash-change!`.
+    (doseq [[label opts rel hook renders render-entry]
+            [["reagent" {:substrate :reagent}
+              "src/acme/my_app/core.cljs" "mount!" "rdc/render" "mount!"]
+             ["uix" {:substrate :uix}
+              "src/acme/my_app/core.cljs" "mount!" "uix-dom/render-root" "mount!"]
+             ["reagent+story" {:substrate      :reagent
+                               :include-story? true}
+              "src/acme/my_app/core.cljs" "reload!" "on-hash-change!" "on-hash-change!"]]]
+      (let [tmp (tmp-dir "rf2-emission-after-load-")]
+        (try
+          (let [proj (run-template-opts! tmp "acme/my-app" opts)
+                core (slurp (io/file proj rel))
+                ;; The hook's own body: from its header to the next top-level
+                ;; `(def`, so a later fn's render call cannot satisfy this.
+                hook-body (when-let [i (.indexOf core (str "^:dev/after-load " hook))]
+                            (when-not (neg? i)
+                              (let [rest- (subs core i)
+                                    j     (.indexOf rest- "\n(def")]
+                                (if (neg? j) rest- (subs rest- 0 j)))))]
+            (is (re-find (re-pattern (str "\\^:dev/after-load\\s+" hook)) core)
+                (str label ": core.cljs must define `^:dev/after-load " hook
+                     "` — shadow's :browser target does NOT re-invoke the "
+                     "module :init-fn after a hot reload, so without this hook "
+                     "an edited view never repaints (rf2-r0kk7)"))
+            (is (and hook-body (.contains hook-body renders))
+                (str label ": the `^:dev/after-load " hook "` body must call `"
+                     renders "` — the hook is what repaints an edited view"))
+            (is (re-find (re-pattern (str "\\^:export\\s+init[\\s\\S]*?\\("
+                                          render-entry "\\)")) core)
+                (str label ": `init` must call `" render-entry "` so the first "
+                     "load and every reload go through the same render path"))
+            (is (.contains core "defonce")
+                (str label ": the React root is held in a defonce cell so one "
+                     "root owns #app across reloads")))
+          (finally
+            (delete-recursively tmp)))))))
+
+(deftest hot-reload-prose-is-accurate-test
+  (testing "the emitted shadow-cljs.edn + README do NOT claim shadow re-runs the
+            module :init-fn after a hot reload — measured false on shadow-cljs
+            3.4.10 (rf2-r0kk7)"
+    (let [tmp (tmp-dir "rf2-emission-hot-reload-prose-")]
+      (try
+        (let [proj   (run-template! tmp "acme/my-app" :reagent)
+              shadow (slurp (io/file proj "shadow-cljs.edn"))
+              readme (slurp (io/file proj "README.md"))
+              norm   #(string/replace % #"\s+" " ")]
+          (doseq [[name text] [["shadow-cljs.edn" (norm shadow)]
+                               ["README.md" (norm readme)]]]
+            (is (not (re-find #"(?i)re-runs? the module :init-fn after" text))
+                (str name " must NOT claim shadow re-runs the module :init-fn "
+                     "after a hot reload — it does not (rf2-r0kk7)"))
+            (is (not (re-find #"(?i)no :?after-load hook (?:is )?(?:needed|required)" text))
+                (str name " must NOT claim an :after-load hook is unnecessary — "
+                     "the hook is the ONLY thing that repaints an edited view "
+                     "(rf2-r0kk7)"))
+            (is (not (re-find #"(?i)re-invokes? [^.]{0,40}\.core/init" text))
+                (str name " must NOT claim a reload re-invokes core/init — "
+                     "shadow calls the :init-fn once, at bundle load "
+                     "(rf2-r0kk7)")))
+          ;; Positively require the corrected teaching, so the section cannot be
+          ;; emptied instead of fixed.
+          (is (.contains readme "^:dev/after-load")
+              "README §Hot reload must name the ^:dev/after-load hook as what
+               re-renders edited views (rf2-r0kk7)")
+          (is (.contains shadow "^:dev/after-load")
+              "shadow-cljs.edn's :init-fn comment must point at the
+               ^:dev/after-load hook (rf2-r0kk7)"))
         (finally
           (delete-recursively tmp))))))
 


### PR DESCRIPTION
Closes rf2-r0kk7.

A developer who scaffolds an app from `tools/template` gets no hot reload. The page
keeps rendering the old view, forever, and three documented sites tell them that is
impossible. This restores the inner loop and corrects the prose that would otherwise
"correct" the template back.

## The defect, reproduced here

Measured in this worktree against **shadow-cljs 3.4.10** (the version
`tools/template/src/day8/re_frame2_template/hooks.clj` pins, matching
`implementation/package.json`), on a scaffold generated by the real deps-new
generator (`clojure -Tnew create :template day8/re-frame2-template :name
acme/hotreload-probe :substrate :reagent`), with the framework coords rewritten to
`:local/root` into this branch and `implementation/node_modules` junctioned in.

The probe runs a real `shadow-cljs watch app`, drives the page with Playwright,
clicks the counter to 2, rewrites one line of `views.cljs`, and polls the DOM.

**Before (template as it stands on `main`, `:init-fn` the only entry point):**

```
"reloadLanded": false,
"elapsedMs": 90175,
"counterAfterReload": "2",
"domAfter": "acme/hotreload-probe +12",       <- the OLD view, after 90s
"beforeHash":  "2b45b57e678102d156d0a5af719e7fec3377cf50e5f511dd18fb42d2cf242962",
"plantedHash": "49a71908fcdf94719ce6d9d8c5ece20d3bacbc80ec84a8c75c8189d69883a9e4",
"restoredHash":"2b45b57e678102d156d0a5af719e7fec3377cf50e5f511dd18fb42d2cf242962"

[log] shadow-cljs: reloading code but no :after-load hooks are configured!
[log] shadow-cljs: load JS  acme/hotreload_probe/views.cljs
[log] shadow-cljs: load JS  acme/hotreload_probe/core.cljs
```

The two `load JS` lines matter: this is **not** an edit that missed the build. The
plant changed the file (the hashes differ), shadow compiled it, pushed the module and
evaluated it — including `core.cljs`, the namespace holding `init` — and the view
still never repainted. shadow does not re-invoke the module `:init-fn` after a
reload; it calls the `^:dev/after-load` hooks, and there were none.

**After (this branch), same probe, same ports, freshly generated scaffold:**

```
"reloadLanded": true,
"elapsedMs": 1033,
"counterAfterReload": "2",     <- app-db intact
"domAfter": "HOTRELOAD-MARKER-1786865272586 +12"
```

and on the **UIx** scaffold — the variant the bead named as carrying no hook at all:

```
"reloadLanded": true,
"elapsedMs": 513,
"counterAfterReload": "2",     <- app-db intact
"domAfter": "HOTRELOAD-MARKER-1786865357308 +12"
```

`views.cljs` is restored byte-for-byte after every run and the restore is verified by
SHA-256 (`restoredHash == beforeHash` in all three runs, shown above for the first).

**app-db survives.** The counter was clicked to 2 before each edit and read `2`
afterwards, on both substrates. The `:initial-events` seed does not replay: `mount!`
renders into the retained root and `rf/frame-root` reuses the already-live frame.

## The fix, and why this one

A separate `^:dev/after-load` hook that re-renders, with the one-time boot ceremony
left in `init` — **the shape this repo already teaches** in
`docs/core/how-to/boot-and-mount-an-app.md` ("`^:dev/after-load` tells shadow-cljs to
call `mount!` after a successful reload… It does not re-run `run`") and in every
entry namespace under `examples/`. The template was the only place spelling it
differently.

Per variant: `mount!` on the plain Reagent and UIx scaffolds, `reload!` on the Story
one (it also reinstalls the hash listener, per that how-to's §Host listeners), and
`render!` on the SSR one (matching `examples/capabilities/ssr/ssr/core.cljc`). The
React root moves into a lazily-filled `defonce` cell, so namespace load does no DOM
work.

The alternative — putting `^:dev/after-load` on `init` itself, which is what the
bead's original probe demonstrated — also repaints, and is a smaller diff. It was
rejected because it replays the whole boot ceremony on every save, and on the SSR
variant that ceremony contains `ssr/hydrate!`, which must never run twice: a second
hydrate re-seeds the server slice over live interactive state. One shape that is
correct on all four variants beats a shape that needs an exception on one, and the
two-function split is the one already documented and already used everywhere else.

## The three sites, corrected

All three named on the bead are inside `tools/template/`, which no open PR contends,
so none was deferred:

1. `_shared/shadow-cljs.edn:22` — *"shadow's :browser target re-runs the module
   :init-fn after each hot reload by default — no :after-load hook needed."*
2. `_uix/core.cljs:17` — *"Idempotent — re-invoked on each hot reload."*
3. `root/README.md:29` — *"module's `:init-fn` automatically after each hot reload,
   so no…"* — §Hot reload rewritten.

Two more sites the bead's grep missed, same claim in different words, corrected in
the same pass: `_reagent/core.cljs:22-23` (*"shadow's hot-reload pipeline re-invokes
it on each rebuild"*) and `_reagent/core_with_stories.cljs:82-83` (identical
wording). `_reagent/core_with_ssr.cljc:144-147` said it too and additionally carried
a hand-rolled `(if @react-root …)` re-render branch inside `init` that nothing could
ever reach.

None of these files is held by PR #8397 / #8398 / #8393 / `worker/docsdirgate-5exqc`
— re-derived from `gh pr list` plus three-dot `git diff --name-only` per branch at
start-up and again before the first edit; `tools/template/` appears in none of them.

## What gates `tools/template/` (derived, not taken on nomination)

`.github/scripts/report-changed-surfaces.sh:1816` maps `tools/template/*` to
`template_expensive=true`, which arms exactly one PR-time job: **`jvm-tools-template`**
(`test.yml:4908`, `clojure -M:test` in `tools/template`, with
`RF2_TEMPLATE_RUN_EMITTED_TESTS=1`, Node 24 and a provisioned Chromium). `lint.yml`
additionally lints `tools/template/{src,test}` with clj-kondo — `resources/` is
excluded there by design, so the emitted `.cljs` files are linted only through the
emission tests.

**The fast-PR spine does not cover this surface at all**, and says so:
`jvm-tools-template` is named in its own §(B) "REQUIRED JOBS WITH NO LANE IN THIS
SPINE AT ALL". That is how this shipped. Nothing anywhere asserted that a hot reload
reached a browser, and the emission tests pinned the *wrong* shape — the SSR
assertions positively required the unreachable `(if @react-root …)` branch. Two new
gates close it (`template_emission_test.clj`):

- `entry-namespace-carries-after-load-hook-test` — every emitted entry namespace must
  define the `^:dev/after-load` hook, its body must make the render call, and `init`
  must route through the same render entry, across Reagent / UIx / Reagent+Story.
- `hot-reload-prose-is-accurate-test` — the emitted `shadow-cljs.edn` and `README.md`
  must not re-assert any of the three false claims, and must positively name
  `^:dev/after-load`.

Both were shown to bite: removing `^:dev/after-load` from `_reagent/core.cljs` reds
the suite with 2 failures naming exactly that hook (exit 1), and the file was restored
and verified by content hash (`fb2e65373b8693a99580307d4ea38fda11e0a630` before the
plant, `13a553d0…` planted, `fb2e6537…` after restore).

## Quality gates

Exit codes below are the numbers captured into `.exit` files by the runs themselves,
not numbers reported about them.

| gate | how run | captured exit | result |
| --- | --- | --- | --- |
| `scripts/test-fast-pr.sh` | foreground, absolute path | **0** | PASS; `gate root:` line 1 read this worktree; classified `docs=true jvm=false node=false` |
| `tools/template` `clojure -M:test` | foreground | **0** | 66 tests, 699 assertions, 0 failures, 0 errors |
| same, with `^:dev/after-load` removed (sabotage control) | foreground | **1** | 2 failures, both naming the missing hook — proves the gate read this worktree |
| `tools/template` `RF2_TEMPLATE_RUN_EMITTED_TESTS=1 clojure -M:test` | detached, log+exit polled in-turn | **0** | 66 tests, 784 assertions, 0 failures. The CI `jvm-tools-template` tier: compiles every emitted variant's `:app` build and runs the Chromium proofs — `dev-page boot proof PASS` for uix, reagent and reagent-with-story, `SSR hydration DOM proof PASS` for the SSR variant |
| live hot-reload probe, Reagent, before fix | foreground | **1** | reload did NOT land in 90s — the defect |
| live hot-reload probe, Reagent, after fix | foreground | **0** | reload landed in 1033 ms, app-db intact |
| live hot-reload probe, UIx, after fix | foreground | **0** | reload landed in 513 ms, app-db intact |

**The spine ran** (exit 0) and its gap is 94 — `python scripts/check_fast_pr_gap.py
--list`, which is a fact about the SPINE, not a census of what was run here. What was
run directly, beyond the spine, is the `tools/template` JVM suite in both its cheap
and its `RF2_TEMPLATE_RUN_EMITTED_TESTS=1` form, plus the three live browser probes.

This PR reports **88 checks**: 25 pass, 63 surface-gated skips, 0 failing. Among the
passes is `JVM tools/template (clojure -M:test)` — the one job `tools/template/*`
arms, and the one that decides this change.

Ports used, isolated from the other watch on this machine: dev-http **8791**, shadow
server **9691**, nREPL **9692**. Every watch was ended by `Stop-Process` on the pid in
that project's own `.shadow-cljs/server.pid`, verified gone. The
`implementation/node_modules` junction was removed as a link (`cmd /c rmdir`), never
its target; the mayor checkout reads 101 by `ls | wc -l` and 103 by
`Get-ChildItem -Force` both before and after.

## Not widened

`skills/re-frame2-setup/` teaches the same false claim in three more places
(`references/entry-namespace.md:25`, `references/first-counter.md:90`,
`references/shadow-cljs.md:107`), and `scripts/check_skill_setup_counter_drift.py`
**enforces** it: its `HOT_RELOAD_DRIFT` patterns fail the build if any of those pages
says `:init-fn` does not re-run on a reload, or recommends a `^:dev/after-load` hook.
That guard scans only the two skill leaves, so it does not red this PR — verified.
Filed as **rf2-ms6r8** (P1) rather than absorbed here; it is a different surface with its own
CI arm.
