### PR TITLE
refactor(core): remove frame-closing?, the bare-id read the spec rules against (rf2-0yp7w.13)

### DIFF
--- a/implementation/core/src/re_frame/frame.cljc
+++ b/implementation/core/src/re_frame/frame.cljc
@@ -433,8 +433,9 @@
 ;;
 ;; Keyed by the bare frame-id. Each value carries the DESTROYING incarnation's
 ;; token (its `:drain-lock`, captured while still live):
-;; `{id {:token drain-lock}}`. The bare id is what `frame-closing?` consults;
-;; the token is what the duplicate guard and
+;; `{id {:token drain-lock}}`. The bare id is what the re-entrancy guard above
+;; consults — "is a destroy for this id in flight at all"; the token is what
+;; the duplicate guard and
 ;; `frame-incarnation-closing?` consults so a stale close marker of an
 ;; already-torn-down incarnation A cannot be mistaken for a fresh same-id
 ;; REPLACEMENT incarnation B being in-flight. A new B claim REPLACES A's stale
@@ -1361,46 +1362,20 @@
     ;; arise from that seam.
     true))
 
-(defn frame-closing?
-  "True when `id` is anywhere in its CLOSE lifecycle: a `destroy-frame!` for it
-  is IN FLIGHT (its teardown recipe is running) OR the frame is already
-  destroyed / dissoc'd. False for a live, not-being-destroyed frame — including
-  a FRESH same-id incarnation created after a prior destroy fully completed.
-
-  The linearization read a substrate's cell-commit path consults so a cell that
-  acquires handles + enrols while a frame is being torn down does not publish
-  ownership onto a dying frame (rf2-vxgfnd.61). `destroying-frames` is populated
-  at the TOP of `destroy-frame!` — BEFORE any teardown step observes the live
-  cells — and cleared only in `destroy-frame!`'s terminal `finally`, AFTER
-  `mark-frame-destroyed!` flips liveness and `dissoc-frame!` forgets the record.
-  So `frame-closing?` is CONTINUOUSLY true across the entire teardown window (the
-  in-flight-but-not-yet-flipped sub-window the destroyed?/absent test alone
-  MISSES). A commit that enrols into a live-cell registry and THEN reads this
-  predicate therefore linearizes its own enrolment against the frame's CLOSURE:
-  if the enrolment was too late for a teardown sweep to see, the frame was
-  necessarily already in `destroying-frames` when the commit read it, so it
-  observes the close and joins the teardown instead of stranding `:connected`.
-  Keyed by the bare frame-id.
-
-  BARE-ID: this predicate cannot distinguish WHICH incarnation is closing. In the
-  JVM window where an old incarnation A's marker is still set (post-`dissoc-frame!`,
-  pre-`finally`) while a fresh same-id REPLACEMENT incarnation B is already live,
-  this reads true for the id — which would wrongly tear down a cell that owns B.
-  A commit that must resolve against the EXACT incarnation it acquired consults the
-  incarnation-scoped `frame-incarnation-closing?` instead (rf2-vxgfnd.94)."
-  [id]
-  (or (contains? @destroying-frames id)
-      (frame-disposed-for-drain? id)))
-
 (defn frame-incarnation-closing?
   "True when `id`'s in-flight `destroy-frame!` is tearing down EXACTLY the
   incarnation identified by `token` (its `:drain-lock` — see
   `frame-incarnation-token`), false otherwise.
 
-  The incarnation-scoped counterpart to `frame-closing?`: where `frame-closing?`
-  answers 'is this id anywhere in its close lifecycle' by BARE id,
-  `frame-incarnation-closing?` answers 'is the destroy that is in flight for this
-  id the one destroying the incarnation I acquired'. `destroying-frames` records
+  The close-lifecycle read, and deliberately the only one: it answers 'is the
+  destroy that is in flight for this id the one destroying the incarnation I
+  acquired'. There is no bare-id counterpart asking merely 'is this id anywhere
+  in its close lifecycle', because Spec 002's destroy recipe linearizes on the
+  EXACT-incarnation claim and states that a stale claim for incarnation A does
+  not fence a fresh same-id incarnation B — a bare-id answer contradicts that
+  invariant in exactly the post-dissoc window described below. Callers outside
+  this namespace acquire a token first (`frame-incarnation-token`) and ask this.
+  `destroying-frames` records
   `{id {:token destroying-incarnation-token}}`, so this
   compares the caller's acquire-time token against the token the marker carries
   by identity.
@@ -4396,7 +4371,7 @@
       ;; this teardown apart from a fresh same-id replacement that goes live
       ;; under the reused id before this destroy's `finally` clears the marker
       ;; (rf2-vxgfnd.94). `contains?`/keys keep the bare-id semantics the
-      ;; re-entrant guard + `frame-closing?` rely on.
+      ;; re-entrant guard relies on.
       ;; Capture the DESTROY-TIME frame-state value AFTER the exact-incarnation
       ;; claim / ordinary-queue cutoff and BEFORE cleanup or lifecycle mutation.
       ;; After `mark-frame-destroyed!` (step 4) flips :destroyed?,


### PR DESCRIPTION
Closes rf2-0yp7w.13 — the retire epic's last code-side child.

## The decision: CUT `frame-closing?`, KEEP `destroying-frames`

The bead offered "delete `frame-closing?` + `destroying-frames` outright, or keep them
as the substrate-neutral seam any future cell-commit path would consult". Neither option
survives contact with the source: the two have different answers.

**`destroying-frames` is load-bearing three ways and is not cuttable.** The bead flagged
this as a thing to check before cutting, and the check comes back positive:

| consumer | where | status |
| --- | --- | --- |
| re-entrancy guard (`claim-frame-destroy!`) | `frame.cljc` — bare-id `contains?` | spec-mandated |
| `frame-incarnation-closing?` | 5 call sites in `router.cljc` | live |
| `frame-disposed-for-drain?` | `router.cljc`, plus the `drain!` recipe in `spec/002-Frames.md:1962` | live + normative |

Spec 002 §Destroy states the guard outright: "the re-entrancy guard closes the window
BEFORE `:destroyed?` flips to true". So that half of the bead's first option is refused
on evidence.

**`frame-closing?` is cut — and not merely because it is uncalled.** It is a predicate
whose semantics the spec has since ruled against for the one job it was written for.
Spec 002's teardown recipe says the linearization point is the *exact-incarnation claim*,
and step 1 states plainly that "a stale claim for incarnation A does not fence a fresh
same-id incarnation B". `frame-closing?` is bare-id, and its own docstring recorded that
it therefore "reads true for the id — which would wrongly tear down a cell that owns B",
directing callers to `frame-incarnation-closing?` instead (rf2-vxgfnd.94).

That is the whole case. Keeping it as a reserved seam would be reserving the reading the
spec forbids, in the codebase's largest core file, for a substrate that already exists and
already chose otherwise — Hicasso, the re-frame-native view layer and the live cell-commit
path, consults `frame-incarnation-token` (`impl/collector.cljs:773`, `impl/frames.cljs:133`,
`impl/mount.cljs:269`), never a bare-id read. The "future substrate will need it" argument
is not speculative-and-untestable here; it is already answered, in the negative, by the
substrate that shipped.

Reading taken: **"no back-compat shims / minimal API"**, not "close minutiae". The stance's
anti-gold-plating clause guards against *inventing* work; it does not argue for keeping a
public var that contradicts a normative invariant. A one-line "reserved" comment would
have been the gold-plating here — it would preserve a footgun and cost the next reader the
same investigation this bead just paid for.

### Does any spec mandate the property?

**No.** `git grep -n -i -E "frame-closing|closing\?|close lifecycle|destroying-frames|frame-incarnation-closing" -- spec/ docs/` returns **zero**. Controlled: the same
invocation shape over the same paths returns `spec/002-Frames.md:1962` for
`frame-disposed-for-drain` and four hits for `destroy recipe`, so the zero is a real
absence, not a broken search. Spec 002's destroy recipe was read at current text
(post-R4 renumbering, `spec/002-Frames.md:669`), not from memory.

## Caller census, re-run at tip with controls

`git grep -n -F "frame-closing?" -- . ':!.beads/'` — **5 lines, one file**, all inside
`implementation/core/src/re_frame/frame.cljc` (2 comments at 436 and 4399, the `defn` at
1364, 2 docstring mentions at 1376 and 1400). **Zero callers anywhere in the tree.**
`.beads/issues.jsonl` is excluded because it is a database export that quotes the bead
text itself.

The premise is a near-zero, so it is controlled in both directions:

- **positive control** — `git grep -l -F "destroy-frame!"` over the same paths: 274 files.
- **negative control** — `git grep -c -F "zzzz-no-such-symbol"`: exit 1, no output.
- **after the cut** — `git grep -n -F "frame-closing?"` exits **1** (zero hits), while the
  identical invocation for `frame-incarnation-closing?` still exits 0 with hits in
  `frame.cljc` and `router.cljc`. A zero that a live positive control brackets.

One correction to the bead's own count, which said "its defn, two docstring mentions, one
comment" (4): there are **two** comments, not one — line 436 in the `destroying-frames`
header block and line 4399 in `claim-frame-destroy!`. Both are reworded here.

## What changed

Three hunks, one file, 13 insertions / 38 deletions.

1. The `defn frame-closing?` and its docstring — removed.
2. `frame-incarnation-closing?`'s docstring no longer opens by defining itself as "the
   counterpart to `frame-closing?`". It now states the positive rule — this is the
   close-lifecycle read and deliberately the only one — and says *why* no bare-id
   counterpart exists, so the next reader does not re-derive one.
3. The two comments naming the deleted var now name the real consumer (the re-entrancy
   guard) instead.

The `rf2-l260n` resolution-cost table at `frame.cljc:1226` counts
`frame-incarnation-closing?`, not `frame-closing?`, and is still accurate — checked, not
assumed.

## Test and assertion counts, before and after

A green suite proves nothing here by construction: nothing called the removed function, so
nothing could fail. The counts are the control that matters — a **drop** would mean
something reached was removed.

| tier | before | after | delta |
| --- | --- | --- | --- |
| JVM `implementation/core` (`clojure -M:test`) | 2243 tests / 11681 assertions | 2243 / 11681 | **0** |
| CLJS `npm run test:cljs` (`:node-test`) | 11771 tests / 59589 assertions | 11771 / 59589 | **0** |
| `:node-test` compile roster | 1985 files, 0 warnings | 1985 files, 0 warnings | **0** |

The CLJS "before" was taken by swapping `origin/main`'s `frame.cljc` back into this
worktree (verified in at blob `4a6cbe8fd6`) and running the node tier against it, then
restoring — not inferred. The compile roster is the namespace-count control: 1985 files
either side, so no namespace dropped out of the build. No `Use of undeclared Var` warning
appears in either run.

## The red proof — planted in the SURVIVING path

The fault is planted in what the change *keeps*, not in what it removed, because only that
can show the covering suite is real.

Plant: `frame-incarnation-closing?`'s body, anchored to a single line —
`(and (some? closing-token) (identical? token closing-token))` → `(and false (some? closing-token) (identical? token closing-token))`.

```
$ clojure -M:test -n re-frame.frame-destroy-incarnation-jvm-test
FAIL in (concurrent-duplicate-destroy-is-a-non-blocking-no-op)      frame_destroy_incarnation_jvm_test.clj:164
FAIL in (fresh-same-id-destroy-replaces-stale-marker-token-safely)  frame_destroy_incarnation_jvm_test.clj:271
Ran 29 tests containing 218 assertions.
2 failures, 0 errors.
captured exit = 1
```

Both failures name the exact `destroying-frames` teardown semantics this change argues are
load-bearing — the duplicate guard and the stale-marker/replacement window. That is the
evidence for the KEEP half of the decision, not just a liveness check on the gate.

**The harness reported this run as exit 0. The captured `.exit` file holds 1.** Recording
that here because the census of that discrepancy is load-bearing for how these runs are
read: it is another instance, and again it surfaced as a spurious zero on a deliberately
sabotaged run. Every number quoted in this PR is the captured one.

The red also proves the gate read *this* worktree: the fault existed only here, so a run
that had wandered into a sibling checkout would have come back green.

Restore verified by content hash, not by reading a diff:
`git hash-object` → `b3ecad4c0223f1da68f88cd4666040c4f2e0d42e`, byte-identical to
`git rev-parse HEAD:implementation/core/src/re_frame/frame.cljc`.

## Quality gates

Gate coverage was derived rather than assumed: `frame.cljc` is `.cljc`, so it compiles in
both the JVM core suite and the `:node-test` CLJS build, and the spine's classifier armed
`jvm=true node=true docs=false` for this diff — printed on the spine's own tier line.

| gate | result | captured exit |
| --- | --- | --- |
| `scripts/test-fast-pr.sh` (fast pre-checkin spine) | `PASS fast PR spine` | **0** |
| ↳ JVM `implementation/core` | 2243 tests, 11681 assertions, 0 failures, 0 errors | 0 |
| ↳ CLJS `:node-test` | 11771 tests, 59589 assertions, 0 failures, 0 errors | 0 |
| ↳ clj-kondo 2026.04.15 (the CI pin) | errors: 0, warnings: 2113 | 0 |
| `clojure -M:test` — core JVM, baseline before the edit | 2243 / 11681, 0 failures | 0 |
| `npm run test:cljs` — CLJS baseline on `origin/main`'s `frame.cljc` | 11771 / 59589, 0 failures | 0 |
| `clojure -M:test -n re-frame.frame-destroy-incarnation-jvm-test` — **sabotage** | 2 failures (expected) | **1** |
| `clojure -M:test` — core JVM re-run on the post-rebase base | 2243 / 11681, 0 failures, 0 errors | **0** |

The spine printed `gate root: /c/Users/miket/code/re-frame2-worktrees/closing-0yp7w13` on
line 1, and shadow-cljs resolved its config from the same root — both checked, so both
tiers demonstrably read this worktree.

**Not run, with reasons.** The browser lanes, production-elision / bundle-isolation /
perf-bundle gates, adapter smokes, the Xray feature matrix, mcp-conformance and
`scripts/test-jvm-tools.sh` are outside the spine and outside this diff's surface: the
change is confined to `implementation/core/src`, and `tools/` may not `:require` from
`implementation/`. CI runs them.

### The spine-versus-CI gap

`python scripts/check_fast_pr_gap.py --list` — the single authority for this, cited as a
path rather than enumerated by hand. It currently reads **94** required checks the spine
does not run. That is a fact about the SPINE, not a census of what this PR ran: the spine
*did* run here, to completion, plus the four direct runs tabled above.

### Rebase

Rebased onto `origin/main` at `132e5578c0`; trunk moved 10 commits under this branch. The
rebase left the blob byte-identical (`b3ecad4c02` before and after), and none of those 10
commits touches `implementation/core/src` — the only `implementation/` file among them is
`hicasso/scripts/check_guide_samples.py`, a Python checker, and the moved Clojure sources
are all `tools/template/` scaffolding resources, which the `:node-test` build does not
compile. The core JVM tier was re-run on the final base regardless; the node tier was not
re-run, because its compile roster is provably unchanged by that file list.

### Diff read for reverts

`git diff origin/main...HEAD` read hunk by hunk. R4 (`2c3c4341f9`, rf2-0yp7w.7) edited this
file hours earlier to remove the two donor-keyed `on-frame-destroyed!` hooks and renumber
Spec 002's destroy recipe; that commit is an ancestor of this branch's base (verified with
`git merge-base --is-ancestor`), and none of the three hunks here touches the region it
changed. Nothing is reverted.

## Scope held

Not widened. `destroying-frames` stays for the reasons above rather than being absorbed
into this change. One adjacent item is left for the prose sweep rather than fixed here:
`spec/009-Instrumentation.md:300` still documents the S6 committed-instance evidence schema
against `re-frame.ui.reactive` / `re-frame.ui.tool`, both of which are gone — that is
rf2-0yp7w.9 territory, and it is prose, not a surface this change can reach.
