### PR TITLE
fix(skills): the setup skill teaches the measured hot-reload lifecycle, and its guard enforces it (rf2-ms6r8)

### DIFF
--- a/scripts/check_skill_setup_counter_drift.py
+++ b/scripts/check_skill_setup_counter_drift.py
@@ -17,18 +17,40 @@ ids its substrate view snippets DISPATCH/SUBSCRIBE. Two prior drifts broke that:
     prevent. This guard pins ONE shared vocabulary across the setup leaves and the
     generator template's `_shared/events.cljs` + `_shared/subs.cljs`.
 
-  * HOT-RELOAD-LIFECYCLE drift (finding 2). The correct shadow-cljs `:browser`
-    lifecycle is: the module `:init-fn` is wired as BOTH the startup entry and the
-    default after-load hook, so it re-runs after EACH hot reload — no separate
-    `^:dev/after-load` hook is needed, and the explicit `dispatch-sync` seed in
-    `init` is the per-reload reset boundary. This matches the generator template's
-    README §Hot reload (CI-guarded by `tools/template/.../template_test.clj`) and
-    the implementation. `references/shadow-cljs.md` / `references/entry-namespace.md`
-    had previously taught the OPPOSITE (Camp B): that `:init-fn` is a "one-time
-    startup hook" that does NOT re-run on a bare code reload, recommending a
-    separate `^:dev/after-load render!` hook. That framing is wrong. This guard
-    fails if the retired one-time-startup / "add an `^:dev/after-load` hook to
-    re-render" framing reappears.
+  * HOT-RELOAD-LIFECYCLE drift (finding 2, INVERTED by rf2-ms6r8). This arm was
+    installed pointing the wrong way, on an unmeasured premise, and now points
+    the right way. MEASURED under rf2-r0kk7 (PR #8400) on shadow-cljs 3.4.10,
+    against a real deps-new scaffold driven by a live `shadow-cljs watch` and a
+    browser: a `:browser` build whose only entry point is a module `:init-fn`
+    does **not** re-render after a hot reload. shadow loads the new code (the
+    console logs `load JS … views.cljs`), logs
+
+        shadow-cljs: reloading code but no :after-load hooks are configured!
+
+    and the page keeps painting the OLD view — measured unchanged for a full 90
+    seconds. shadow calls the module `:init-fn` ONCE, when the bundle loads; a
+    reload loads the new code and then calls the build's `^:dev/after-load`
+    hooks. With a separate `^:dev/after-load` re-render hook the identical edit
+    landed in 1033 ms (Reagent) / 513 ms (UIx) with app-db intact.
+
+    So the CORRECT lifecycle — the one `tools/template`,
+    `docs/core/how-to/boot-and-mount-an-app.md` and every `examples/` entry ns
+    teach — is the two-function split: the one-time boot ceremony stays in
+    `init`, and a separate `^:dev/after-load` hook re-renders into the retained
+    React root. The RETIRED framing, which this guard now fails on, is the
+    mirror image: that `:init-fn` re-runs after each hot reload, that it is the
+    "default after-load hook", that `init` IS the re-render path, or that "no
+    separate `^:dev/after-load` hook" is needed.
+
+    The arm is INVERTED rather than retired, so the protection is kept and
+    merely pointed the right way: the same three leaves are still pinned, and a
+    page that teaches the false claim still fails the build. It additionally
+    asserts the AFFIRMATIVE half — every leaf that teaches the boot lifecycle
+    must NAME `^:dev/after-load` — which the pre-inversion arm never checked in
+    either direction (its patterns matched only the negated forms, so a bare
+    "add a `^:dev/after-load` hook" recommendation passed it silently). That
+    mirrors the sibling gate PR #8400 landed over the generator template
+    (`hot-reload-prose-is-accurate-test`).
 
 The COUNTER-KEYWORD check is a CONTAINMENT assertion, not a literal-text diff:
 
@@ -135,31 +157,71 @@ REG_SUB = re.compile(r"reg-sub\s+(:counter/[a-z0-9-]+)")
 DISPATCH = re.compile(r"dispatch\s+\[\s*(:counter/[a-z0-9-]+)")
 SUBSCRIBE = re.compile(r"(?:use-subscribe|subscribe)\s+\[\s*(:counter/[a-z0-9-]+)")
 
-# HOT-RELOAD-LIFECYCLE retired framing (finding 2). The CORRECT shadow-cljs
-# `:browser` lifecycle is: the module `:init-fn` re-runs after each hot reload (it is
-# both the startup entry and the default after-load hook). The RETIRED (Camp B)
-# framing asserted the opposite — that `:init-fn` is a "one-time startup hook" that
-# does NOT re-run on a bare code reload, and recommended adding a separate
-# `^:dev/after-load` render hook to get hot reload. This guard fails if that retired
+# HOT-RELOAD-LIFECYCLE retired framing (finding 2, INVERTED by rf2-ms6r8). The
+# CORRECT shadow-cljs `:browser` lifecycle — measured under rf2-r0kk7 / PR #8400 on
+# shadow-cljs 3.4.10 — is that the module `:init-fn` is called ONCE when the bundle
+# loads and is NOT re-run by a hot reload; a reload loads the new code and then calls
+# the build's `^:dev/after-load` hooks, so the entry ns carries one. The RETIRED
+# framing is the mirror image: that `:init-fn` re-runs after each reload, that it is
+# the "default after-load hook", that `init` IS the re-render path, or that "no
+# separate `^:dev/after-load` hook" is needed. This guard fails if that retired
 # framing reappears. Patterns are case-insensitive, whitespace-tolerant, and matched
 # per-line so an honest mention can't trip a neighbouring line.
+#
+# These first patterns are unambiguous: no correct sentence contains them, whatever
+# the surrounding polarity.
 HOT_RELOAD_DRIFT = [
-    # "the :init-fn is a one-time startup hook" (the load-bearing wrong claim).
-    re.compile(r":?init-fn[^.\n]{0,40}\bone-?time\b[^.\n]{0,30}startup", re.IGNORECASE),
-    re.compile(r"\bone-?time\b[^.\n]{0,30}startup[^.\n]{0,40}:?init-fn", re.IGNORECASE),
-    # ":init-fn is ... NOT the hot-reload hook".
-    re.compile(r":?init-fn[^.\n]{0,40}\bnot\b[^.\n]{0,20}(?:the\s+)?hot[\s-]?reload[^.\n]{0,10}hook", re.IGNORECASE),
-    # "does not re-run / re-invoke :init-fn / init [on/after a reload]". The
-    # trailing `\b` pins `:init` / `:init-fn` as a COMPLETE token so the pattern
-    # does not falsely fire on the longer, unrelated `:initial-events` keyword
-    # (the EP-0027 seed-event id) — a sentence like "the surgical update does
-    # not rerun any `:initial-events`" is correct re-frame2 semantics, not the
-    # retired one-time-startup `:init-fn` claim this guard catches. Without the
-    # boundary the `:?init(?:-fn)?` prefix matched the `:init` of
-    # `:initial-events` and produced a false HOT-RELOAD-LIFECYCLE drift.
-    re.compile(r"does\s+\*?\*?not\*?\*?[^.\n]{0,30}re-?(?:run|invoke)s?[^.\n]{0,30}:?init(?:-fn)?\b", re.IGNORECASE),
-    re.compile(r"does\s+\*?\*?not\*?\*?[^.\n]{0,30}re-?(?:run|invoke)s?\s+(?:the\s+)?:?init\b", re.IGNORECASE),
+    # "no separate `^:dev/after-load` hook" / "no `:after-load` hook needed" — the
+    # actionable harm, because it tells the author NOT to write the hook that is
+    # the only thing making a reload repaint.
+    #
+    # The qualifier ("separate", or a trailing needed/necessary/required) is what
+    # keeps this off shadow-cljs's OWN diagnostic, which the corrected prose quotes
+    # verbatim in all three leaves: "reloading code but no :after-load hooks are
+    # configured!". A bare `no … after-load … hook` matches that sentence too, and
+    # would red the very pages that teach the fix.
+    re.compile(r"\bno\s+separate\b[^.\n]{0,25}(?:\^\s*)?:?(?:dev/)?after-?load\b[^.\n]{0,25}\bhook", re.IGNORECASE),
+    re.compile(r"\bno\b[^.\n]{0,25}(?:\^\s*)?:?(?:dev/)?after-?load\b[^.\n]{0,25}\bhooks?\b[^.\n]{0,25}\b(?:needed|necessary|required)\b", re.IGNORECASE),
+    re.compile(r"(?:\^\s*)?:?(?:dev/)?after-?load\b[^.\n]{0,15}\bhooks?\b[^.\n]{0,20}\b(?:not needed|unnecessary|isn'?t needed|is not needed)", re.IGNORECASE),
+    # ":init-fn is ... the default after-load hook" (incl. "both the startup entry
+    # and the default after-load hook").
+    re.compile(r":?init(?:-fn)?\b[^.\n]{0,60}\bdefault\b[^.\n]{0,25}after-?load\b[^.\n]{0,10}hook", re.IGNORECASE),
+    # "init IS the re-render path" / "init is the hot-reload hook".
+    re.compile(r":?init(?:-fn)?\b[^.\n]{0,25}\bis\b[^.\n]{0,20}(?:the\s+)?(?:re-?render\s+path|hot[\s-]?reload\s+hook)", re.IGNORECASE),
+    # "the dispatch-sync seed ... per-reload reset boundary" / "re-seeds ... on every
+    # hot reload". Same false claim in different words: with `init` not re-running,
+    # nothing in it re-seeds, and the `:initial-events` seed runs ONCE at frame
+    # creation (`frame-root` REUSES a live frame without re-seeding).
+    re.compile(r"\bper-?reload\b[^.\n]{0,20}reset\s+boundary", re.IGNORECASE),
+    re.compile(r"re-?seeds?\b[^.\n]{0,40}\b(?:each|every)\b[^.\n]{0,15}hot[\s-]?reload", re.IGNORECASE),
 ]
+
+# The affirmative "`:init-fn` re-runs after each hot reload" claim. This one needs
+# polarity, because the CORRECT sentence is the same words negated ("shadow does NOT
+# re-run the module `:init-fn` after a reload"). We match the affirmative shape and
+# then reject the hit if the clause leading into it carries a negation — see
+# `_rerun_is_negated`.
+#
+# The trailing `\b` on `:init` pins it as a COMPLETE token so the patterns do not
+# fire on the longer, unrelated `:initial-events` keyword (the EP-0027 seed-event
+# id). Without the boundary the `:?init(?:-fn)?` prefix matches the `:init` of
+# `:initial-events` and produces a false HOT-RELOAD-LIFECYCLE drift.
+HOT_RELOAD_RERUN = [
+    re.compile(r":?init(?:-fn)?\b[^.\n]{0,50}\bre-?(?:runs?|invokes?|invoked)\b[^.\n]{0,50}(?:hot[\s-]?)?(?:reload|rebuild|save)", re.IGNORECASE),
+    re.compile(r"\bre-?(?:runs?|invokes?|invoked)\b[^.\n]{0,50}:?init(?:-fn)?\b[^.\n]{0,50}(?:hot[\s-]?)?(?:reload|rebuild|save)", re.IGNORECASE),
+]
+
+# A negation anywhere in the clause running into the match flips its meaning, so the
+# hit is not drift. We look at the text preceding the match on the same line, back to
+# the previous sentence boundary (or 80 chars, whichever is nearer), plus the matched
+# span itself — long enough to catch "shadow ... does **not** re-run", short enough
+# that a negation in an unrelated earlier sentence cannot launder a false claim.
+RERUN_NEGATION = re.compile(r"\*{0,2}\b(?:not|never|n't|cannot|can't|won'?t)\b\*{0,2}", re.IGNORECASE)
+
+# The AFFIRMATIVE half: a leaf that teaches the boot lifecycle must NAME the hook.
+# Catching the false claim is not enough on its own — prose can be silently stripped
+# of the wrong sentence and still leave the author with no hook and no hot reload.
+AFTER_LOAD_HOOK = re.compile(r"(?:\^\s*)?:dev/after-?load", re.IGNORECASE)
 
 # ADAPTER-KEY retired wording (finding 3). The current Spec 006 adapter contract
 # names `:make-state-container` and `:subscribe-container`. The retired wording
@@ -268,27 +330,72 @@ def find_counter_drift(
     return problems
 
 
+_LIFECYCLE_REMEDY = (
+    "That is the wrong shadow-cljs lifecycle, and it costs the author their inner "
+    "loop. MEASURED on shadow-cljs 3.4.10 (rf2-r0kk7 / PR #8400): for the :browser "
+    "target shadow calls the module :init-fn ONCE, when the bundle loads, and does "
+    "NOT re-run it after a hot reload — it loads the new code and calls the build's "
+    "^:dev/after-load hooks. With none configured it logs 'reloading code but no "
+    ":after-load hooks are configured!' and the page keeps painting the OLD view "
+    "(measured unchanged for 90s). Teach the two-function split the generator "
+    "template, docs/core/how-to/boot-and-mount-an-app.md and every examples/ entry "
+    "ns already use: the one-time boot ceremony stays in `init`, and a separate "
+    "`^:dev/after-load` hook re-renders into the retained React root."
+)
+
+
+def _rerun_is_negated(line: str, start: int, end: int) -> bool:
+    """True when the clause running into a `re-runs :init-fn` hit negates it.
+
+    The CORRECT sentence is the false one negated ("shadow does **not** re-run the
+    module `:init-fn` after a reload"), so polarity is what separates them. We read
+    back from the match to the previous sentence boundary — capped at 80 chars so a
+    negation in an unrelated earlier clause cannot launder a false claim — and
+    include the matched span itself.
+    """
+    window = line[max(0, start - 80):start]
+    window = re.split(r"[.;:—]", window)[-1]
+    return bool(RERUN_NEGATION.search(window + line[start:end]))
+
+
 def find_hot_reload_drift(*texts_with_names: tuple[str, str]) -> list[str]:
     """HOT-RELOAD-LIFECYCLE check. Returns drift messages (empty == clean)."""
     problems: list[str] = []
-    for name, text in ((n, t) for t, n in [(t, n) for n, t in texts_with_names]):
+    for name, text in texts_with_names:
         for lineno, line in enumerate(text.splitlines(), start=1):
-            for pat in HOT_RELOAD_DRIFT:
-                if pat.search(line):
-                    problems.append(
-                        f"HOT-RELOAD-LIFECYCLE: {name}:{lineno} teaches the retired "
-                        "Camp B framing — that :init-fn is a one-time startup hook "
-                        "that does NOT re-run on a hot reload (and that you must add a "
-                        "separate ^:dev/after-load hook). That is the wrong shadow-cljs "
-                        "lifecycle. For the :browser target the module :init-fn IS "
-                        "re-invoked after each hot reload by default (it is wired as "
-                        "both the startup entry and the default after-load hook), so no "
-                        "^:dev/after-load hook is needed and the dispatch-sync seed in "
-                        "init is the per-reload reset boundary. Rewrite the sentence to "
-                        f"match the template README §Hot reload: {line.strip()!r}"
-                    )
-                    break
+            hit = next((p for p in HOT_RELOAD_DRIFT if p.search(line)), None)
+            if hit is None:
+                for pat in HOT_RELOAD_RERUN:
+                    m = pat.search(line)
+                    if m and not _rerun_is_negated(line, m.start(), m.end()):
+                        hit = pat
+                        break
+            if hit is not None:
+                problems.append(
+                    f"HOT-RELOAD-LIFECYCLE: {name}:{lineno} teaches the retired "
+                    "framing — that the module :init-fn re-runs after each hot "
+                    "reload (that it is the 'default after-load hook', that `init` "
+                    "IS the re-render path, or that no separate ^:dev/after-load "
+                    f"hook is needed). {_LIFECYCLE_REMEDY} Offending line: "
+                    f"{line.strip()!r}"
+                )
     return problems
+
+
+def find_missing_after_load_hook(*texts_with_names: tuple[str, str]) -> list[str]:
+    """AFTER-LOAD-HOOK presence check. Returns drift messages (empty == clean).
+
+    The affirmative half of the lifecycle contract. Deleting the false sentence
+    without teaching the hook leaves the author exactly as stranded — a scaffold
+    that compiles, reloads, and never repaints.
+    """
+    return [
+        f"AFTER-LOAD-HOOK: {name} never names `^:dev/after-load`. This leaf teaches "
+        "the boot lifecycle, so it must show the hook that makes a hot reload "
+        f"repaint. {_LIFECYCLE_REMEDY}"
+        for name, text in texts_with_names
+        if not AFTER_LOAD_HOOK.search(text)
+    ]
 
 
 def find_adapter_key_drift(name: str, text: str) -> list[str]:
@@ -385,10 +492,20 @@ def run(*, verbose: bool, ci: bool) -> int:
         _slurp(TEMPLATE_EVENTS),
         _slurp(TEMPLATE_SUBS),
     )
-    problems += find_hot_reload_drift(
+    # The hot-reload arm scans all four setup leaves. Before rf2-ms6r8 it read only
+    # shadow-cljs.md + entry-namespace.md, which is why the same false claim sat
+    # unguarded inside first-counter.md's copy-complete `core.cljs` — the single
+    # most load-bearing site, because it is the file the author actually copies.
+    lifecycle_leaves = (
         (str(SHADOW_CLJS.relative_to(REPO_ROOT)), shadow_text),
         (str(ENTRY_NAMESPACE.relative_to(REPO_ROOT)), entry_namespace_text),
+        (str(FIRST_COUNTER.relative_to(REPO_ROOT)), first_counter_text),
+        (str(SKILL_MD.relative_to(REPO_ROOT)), skill_text),
     )
+    problems += find_hot_reload_drift(*lifecycle_leaves)
+    # SKILL.md is scanned for the false claim but is NOT required to name the hook:
+    # it is the router, and the lifecycle is the three reference leaves' territory.
+    problems += find_missing_after_load_hook(*lifecycle_leaves[:3])
     problems += find_adapter_key_drift(
         str(ENTRY_NAMESPACE.relative_to(REPO_ROOT)), entry_namespace_text
     )
@@ -404,7 +521,9 @@ def run(*, verbose: bool, ci: bool) -> int:
         print(
             "setup-counter guard: checked counter-keyword containment "
             "(first-counter.md + entry-namespace.md + template), hot-reload "
-            "lifecycle wording (shadow-cljs.md + entry-namespace.md), adapter-key "
+            "lifecycle wording (shadow-cljs.md + entry-namespace.md + "
+            "first-counter.md + SKILL.md) and ^:dev/after-load presence in the "
+            "three reference leaves, adapter-key "
             "vocabulary (entry-namespace.md), one-canonical-source "
             "(first-counter.md is the sole copy-complete core.cljs), and the "
             "schemas single-require contract (only re-frame.schemas; no separate "
@@ -491,42 +610,110 @@ def _self_test() -> int:
         print(f"SELF-TEST FAIL (C superset clean): unexpected {probs}")
         failures += 1
 
-    # Case D — hot-reload clean: the CORRECT (Camp A) framing.
+    # Case D — hot-reload clean: the CORRECT (measured) framing. Note it is the
+    # retired claim's own words, NEGATED — which is exactly why the affirmative
+    # `re-runs :init-fn` patterns must be polarity-aware.
     good_shadow = (
-        "The `:browser` target re-runs the module `:init-fn` after each hot "
-        "reload, so no `:after-load` hook is needed; the dispatch-sync seed in "
-        "init is the per-reload reset boundary.\n"
+        "shadow calls the module `:init-fn` ONCE, when the bundle loads. It does "
+        "NOT re-run it after a hot reload — a reload loads the new code and then "
+        "calls the build's `^:dev/after-load` hooks, so `core.cljs` carries one.\n"
+        "`^:dev/after-load` is shadow's cue to re-run `mount!` after each "
+        "successful hot reload, re-rendering your edited views into the retained "
+        "React root.\n"
     )
     probs = find_hot_reload_drift(("shadow-cljs.md", good_shadow))
     if probs:
         print(f"SELF-TEST FAIL (D hot-reload clean): unexpected {probs}")
         failures += 1
+    probs = find_missing_after_load_hook(("shadow-cljs.md", good_shadow))
+    if probs:
+        print(f"SELF-TEST FAIL (D after-load presence): unexpected {probs}")
+        failures += 1
 
-    # Case E — the retired Camp B drift (the one-time-startup framing).
-    drift_shadow = (
-        "`:init-fn` is a one-time startup hook — it is NOT the hot-reload hook. "
-        "A plain code reload does not re-run `:init-fn`; add a `^:dev/after-load` "
-        "hook for an explicit re-render.\n"
+    # Case E — the retired drift, in each of the shapes the setup skill actually
+    # carried before rf2-ms6r8. Every one must be caught on its own line.
+    for label, drift_shadow in [
+        ("re-runs after each reload",
+         "shadow-cljs's `:browser` target re-runs `:init-fn` (`init`) after "
+         "**each** hot reload, so `init` IS the re-render path.\n"),
+        ("default after-load hook",
+         "For the `:browser` target the module `:init-fn` is both the startup "
+         "entry and the default after-load hook.\n"),
+        ("no separate hook",
+         "A code reload re-invokes `init` — no separate `^:dev/after-load` "
+         "hook.\n"),
+        ("init re-runs every save",
+         "`init` re-runs on **every** hot reload, so `rf/init!` runs again each "
+         "save.\n"),
+        # The subject is load-bearing and the pattern requires it. A subject-LESS
+        # "re-invoked on each hot reload" is not decidable per-line: said of
+        # `mount!` it is correct prose, said of `init` it is the false claim. The
+        # template's own subject-less docstring shape (`_uix/core.cljs`, "Idempotent
+        # — re-invoked on each hot reload") is gated where it lives, by PR #8400's
+        # `entry-namespace-carries-after-load-hook-test`.
+        ("init re-invoked on each reload",
+         "`init` is idempotent — it is re-invoked on each hot reload.\n"),
+        ("per-reload reset boundary",
+         "The explicit `dispatch-sync` seed in `init` is the per-reload reset "
+         "boundary.\n"),
+        ("re-seeds every reload",
+         "The `dispatch-sync` seed re-seeds this counter on every hot reload.\n"),
+    ]:
+        probs = find_hot_reload_drift(("shadow-cljs.md", drift_shadow))
+        if not any("HOT-RELOAD-LIFECYCLE" in p for p in probs):
+            print(f"SELF-TEST FAIL (E hot-reload drift / {label}): expected drift, got {probs}")
+            failures += 1
+
+    # Case E2b — shadow-cljs's OWN diagnostic must not trip the guard. All three
+    # corrected leaves quote it verbatim to tell the author what a missing hook
+    # looks like, so a bare `no … after-load … hook` pattern would red exactly the
+    # pages that teach the fix. Pinned in both the quoted and the paraphrased form.
+    for label, quoted_diagnostic in [
+        ("verbatim",
+         ";; \"reloading code but no :after-load hooks are configured!\" and the "
+         "page keeps painting the OLD view.\n"),
+        ("paraphrased",
+         "With no hook configured shadow says so — `reloading code but no "
+         "`:after-load` hooks are configured!` — and the page keeps painting the "
+         "old view.\n"),
+    ]:
+        probs = find_hot_reload_drift(("first-counter.md", quoted_diagnostic))
+        if probs:
+            print(f"SELF-TEST FAIL (E2b shadow diagnostic / {label}): unexpected {probs}")
+            failures += 1
+
+    # Case E3 — the AFFIRMATIVE half. Prose stripped of the false sentence but
+    # never taught the hook is the same stranded author, so it must still fail.
+    silent_shadow = (
+        "The `:browser` target compiles your edit and pushes the new module to "
+        "the page. Hold the React root in a `defonce` so a save reuses it.\n"
     )
-    probs = find_hot_reload_drift(("shadow-cljs.md", drift_shadow))
-    if not any("HOT-RELOAD-LIFECYCLE" in p for p in probs):
-        print(f"SELF-TEST FAIL (E hot-reload drift): expected drift, got {probs}")
+    probs = find_missing_after_load_hook(("shadow-cljs.md", silent_shadow))
+    if not any("AFTER-LOAD-HOOK" in p for p in probs):
+        print(f"SELF-TEST FAIL (E3 after-load absent): expected drift, got {probs}")
         failures += 1
 
     # Case E2 — `:initial-events` must NOT trip the retired-framing patterns
     # (regression pin for the EP-0027 false positive). "the surgical update …
     # does not rerun any `:initial-events`" is correct re-frame2 semantics: the
-    # `:?init(?:-fn)?` prefix must match `:init` / `:init-fn` only as a complete
+    # `:?init(?:-fn)?` token must match `:init` / `:init-fn` only as a COMPLETE
     # token, never as the `:init` prefix of the longer `:initial-events` keyword.
-    initial_events_clean = (
-        "This explicit `dispatch-sync` is the reset boundary: it re-seeds the "
-        "demo state on every hot reload (the surgical update in step 2 does not "
-        "rerun any `:initial-events`). Some apps instead seed lazily.\n"
-    )
-    probs = find_hot_reload_drift(("entry-namespace.md", initial_events_clean))
-    if probs:
-        print(f"SELF-TEST FAIL (E2 :initial-events false positive): unexpected {probs}")
-        failures += 1
+    # Both polarities are pinned, because the affirmative `re-runs` patterns
+    # (HOT_RELOAD_RERUN) reach shapes the pre-inversion arm never matched.
+    for label, initial_events_clean in [
+        ("negated",
+         "`frame-root` REUSES the live frame, so the surgical update in step 2 "
+         "does not rerun any `:initial-events`.\n"),
+        ("affirmative",
+         "`frame-root` runs the `:initial-events` seed once, at frame creation; "
+         "a browser refresh re-runs it because the reload creates a fresh "
+         "frame.\n"),
+    ]:
+        probs = find_hot_reload_drift(("entry-namespace.md", initial_events_clean))
+        if probs:
+            print(f"SELF-TEST FAIL (E2 :initial-events false positive / {label}): "
+                  f"unexpected {probs}")
+            failures += 1
 
     # Case F — adapter-key clean: current names + the front-porch sentence.
     good_adapter = (

--- a/skills/re-frame2-setup/references/entry-namespace.md
+++ b/skills/re-frame2-setup/references/entry-namespace.md
@@ -16,13 +16,13 @@ The **boot lifecycle** of `your-app/core.cljs` — the entry namespace shadow-cl
 
 ## The entry-namespace lifecycle
 
-The entry namespace is the top of `core.cljs` — the `ns` form, a `defonce` React-root atom, and the exported `init` fn shadow-cljs calls. It is the mount half of the one copy-complete counter in [`first-counter.md`](first-counter.md) (§The whole file; counter-specific mount notes in §Mount), not a file you write separately. Reading that `init` top to bottom, it does four things, in order — full contract in §Order of operations below:
+The entry namespace is the top of `core.cljs` — the `ns` form, a `defonce` React-root atom, and **two** fns: the exported `init` shadow-cljs calls once, and a `^:dev/after-load mount!` the hot reload calls. It is the mount half of the one copy-complete counter in [`first-counter.md`](first-counter.md) (§The whole file; counter-specific mount notes in §Mount), not a file you write separately. Reading it top to bottom, it does three things, in order — full contract in §Order of operations below:
 
 1. `(rf/init! reagent-adapter/adapter)` — install the Reagent adapter (no frame yet).
 2. `(register-schema!)` — attach the frame-local schema, naming the app frame explicitly (`{:frame :rf/default}`), before the frame even exists.
-3. `(rdc/render …)` — mount the tree wrapped in `[rf/frame-root {:id :rf/default :initial-events [[:counter/initialise]]} …]`. `frame-root` is the ENSURE element: it **creates** `:rf/default` the first time (running the `:initial-events` seed synchronously, so the initial render sees the seeded app-db), **reuses** the live frame without re-seeding on every later mount, and provides it so every bare `dispatch` / `subscribe` under it resolves against `:rf/default`.
+3. `(mount!)` — whose body calls `(rdc/render …)` on the tree wrapped in `[rf/frame-root {:id :rf/default :initial-events [[:counter/initialise]]} …]`. `frame-root` is the ENSURE element: it **creates** `:rf/default` the first time (running the `:initial-events` seed synchronously, so the initial render sees the seeded app-db), **reuses** the live frame without re-seeding on every later mount, and provides it so every bare `dispatch` / `subscribe` under it resolves against `:rf/default`.
 
-`defonce` guards the React root so a save doesn't create a second one (§The Reagent root pattern). shadow-cljs's `:browser` target re-runs `:init-fn` (`init`) after **each** hot reload, so `init` IS the re-render path — no separate `^:dev/after-load` hook. The re-rendered `frame-root` finds `:rf/default` already live and leaves your state alone — a hot reload is a **no-op for app state**; the `:initial-events` seed runs once, at frame creation (refresh the tab to re-seed). Events / subs / views live above the mount point in `core.cljs`, or in their own namespaces for anything larger (§Where everything else goes).
+**Why the mount is its own fn: the `^:dev/after-load` metadata on `mount!` is what gives you hot reload.** shadow-cljs calls the module `:init-fn` once, at bundle load. A reload loads the new code and then calls the build's `^:dev/after-load` hooks — it does not call `:init-fn` again, and with no hook configured it says so (`reloading code but no :after-load hooks are configured!`) while the page goes on painting the old view. Splitting the entry keeps the one-time ceremony (`init!`, the schema attach) out of the reload path while `mount!` re-renders the edited views. `defonce` guards the React root so a save doesn't create a second one (§The Reagent root pattern), and the re-rendered `frame-root` finds `:rf/default` already live and leaves your state alone — a hot reload is a **no-op for app state**; the `:initial-events` seed runs once, at frame creation (refresh the tab to re-seed). Events / subs / views live above the mount point in `core.cljs`, or in their own namespaces for anything larger (§Where everything else goes).
 
 `counter-app` is the top-level registered view. `:rf/default` is the generator template's frame id — under EP-0002 (the carried-frame invariant) it is **not** auto-registered; the view's `frame-root` ENSURE element creates it at mount (§Order of operations). Any id works — keep it consistent between `frame-root`'s `:id` and the schema attach's `{:frame …}` target.
 
@@ -34,7 +34,7 @@ The entry symbol is `init`, matching the generator template's `:init-fn {{namesp
 
 1. **`(rf/init! reagent-adapter/adapter)`** — install the substrate adapter. (`init!` installs the adapter and runtime capabilities only; it creates **no** frame.)
 2. **`(register-schema!)`** — attach the frame-local schema. The registration names the app frame **explicitly** (`(rf/reg-app-schema [] {:frame :rf/default} CounterDb)`), so it runs at boot BEFORE the frame exists — the `:initial-events` seed in step 3 is then validated from its very first write. (A bare two-slot `reg-app-schema` with no frame scope raises `:rf.error/no-frame-context`; see [`first-counter.md` §Schema](first-counter.md).)
-3. **`(rdc/render react-root [rf/frame-root {:id :rf/default :initial-events [[:your-app/initialise]]} [counter-app]])`** — mount the React tree in `frame-root`'s `{:id …}` **ENSURE** shape. `frame-root` creates `:rf/default` the first time — running the `:initial-events` seed **synchronously at frame creation**, so the initial render sees the seeded app-db — then **reuses** the live frame without re-seeding on every later mount, and provides the frame so every bare `dispatch` / `subscribe` under it resolves against `:rf/default`. A hot reload therefore never clobbers state; the seed runs at frame **creation** (a browser refresh re-seeds), and editing what `:your-app/initialise` writes changes what a fresh mount seeds. (`frame-provider` is the SCOPE-only sibling — it provides an **already-created** frame, e.g. one your code built programmatically with `rf/make-frame`, and fails loud given `{:id …}`.)
+3. **`(mount!)`** — the `^:dev/after-load` fn whose body is `(rdc/render react-root [rf/frame-root {:id :rf/default :initial-events [[:your-app/initialise]]} [counter-app]])`, mounting the React tree in `frame-root`'s `{:id …}` **ENSURE** shape. Steps 1 and 2 are the one-time ceremony and stay in `init`; step 3 is the only one a hot reload re-runs. `frame-root` creates `:rf/default` the first time — running the `:initial-events` seed **synchronously at frame creation**, so the initial render sees the seeded app-db — then **reuses** the live frame without re-seeding on every later mount, and provides the frame so every bare `dispatch` / `subscribe` under it resolves against `:rf/default`. A hot reload therefore never clobbers state; the seed runs at frame **creation** (a browser refresh re-seeds), and editing what `:your-app/initialise` writes changes what a fresh mount seeds. (`frame-provider` is the SCOPE-only sibling — it provides an **already-created** frame, e.g. one your code built programmatically with `rf/make-frame`, and fails loud given `{:id …}`.)
 
 If you render *without* `frame-root` (or a `frame-provider` around an existing frame), every `subscribe` / `dispatch` in the tree raises `:rf.error/no-frame-context` — the runtime refuses to guess a frame. If you render before `rf/init!`, `frame-root`'s frame creation finds no substrate adapter and you get `:rf.error/no-adapter-installed`.
 
@@ -45,16 +45,16 @@ re-frame2 splits **the registry** (the process-wide handler / sub / fx map your 
 Three consequences:
 
 - **Adapters are values, not magic.** `re-frame.adapter.reagent/adapter` is a regular CLJS var holding a map. `rf/init!` takes that value directly — no global registration, no name-based lookup. Swap it for `re-frame.adapter.uix/adapter` and you have a UIx app.
-- **`rf/init!` is idempotent — safe to call more than once.** `init` re-runs on **every** hot reload, so `rf/init!` runs again each save; that is safe — a second `init!` re-installs the substrate config only when none is seated, and creates no frame. Leave it unguarded in `init` (don't wrap it in a `defonce`); the idempotence is what makes the per-reload re-run harmless. (`frame-root` re-mounting against the same `:id` likewise reuses the live frame — no re-seed, no state loss.)
+- **`rf/init!` is idempotent — safe to call more than once.** A hot reload re-runs `mount!`, not `init`, so in the ordinary loop `rf/init!` runs exactly once per page load. The idempotence still matters: a namespace reload that re-evaluates `init`, a REPL call, or a second entry point all re-enter it safely — a second `init!` re-installs the substrate config only when none is seated, and creates no frame. Leave it unguarded in `init` (don't wrap it in a `defonce`). (`frame-root` re-mounting against the same `:id` likewise reuses the live frame — no re-seed, no state loss.)
 - **No implicit boot.** No default adapter — multi-substrate support and the per-frame substrate-config model (Spec 006) mean the runtime must know *which* adapter you want before any subscription resolves, so you supply it at boot via the explicit `init!`.
 
 **You don't construct the adapter map — you require the namespace and pass its exported `adapter` var.** App authors never assemble it by hand; the map implements the reactive-substrate adapter contract of [Spec 006](../../../spec/006-ReactiveSubstrate.md), and constructing or extending it is the **`re-frame2-implementor`** skill's territory, not greenfield's.
 
 ## The Reagent root pattern (`defonce` + `rdc/create-root`)
 
-The entry ns holds the React root in a `defonce` atom, created lazily inside `init`. Two contractual bits:
+The entry ns holds the React root in a `defonce` atom, filled lazily the first time `mount!` runs. Two contractual bits:
 
-- **`defonce`** — `core.cljs` reloads on every save; without `defonce`, each reload calls `create-root` again on the same DOM node and React 19 complains loudly (or silently mounts two fighting roots). `defonce` creates the root exactly once per page load.
+- **`defonce` + the `when-not @react-root` guard** — `core.cljs` reloads on every save, and `mount!` runs again on each one; without both, a reload calls `create-root` a second time on the same DOM node and React 19 complains loudly (or silently mounts two fighting roots). Together they create the root exactly once per page load, and every later reload renders into that same retained root — which is why your app-db and your scroll position survive a save.
 - **`(js/document.getElementById "app")`** — must match the `id` in `index.html`. Mismatch here is the most common cause of a blank page with no console error.
 
 `rdc/render` is called against `react-root`, not the DOM node. Both `create-root` and `render` come from `reagent.dom.client` — the React 19 client-Root surface for Reagent 2.x.
@@ -163,18 +163,30 @@ This skill scaffolds against **Reagent** (the default reference substrate). For 
               [your-app.schema :as schema]   ;; CounterDb + register-schema! (shared-dataflow.md)
               [your-app.views  :as views]))
 
-  (defonce react-root (uix-dom/create-root (js/document.getElementById "app")))
+  ;; Namespace load does no DOM work — mount! creates the root lazily.
+  (defonce react-root (atom nil))
 
+  ;; ^:dev/after-load is what makes hot reload repaint: shadow does NOT re-run
+  ;; the module :init-fn after a reload — it loads the new code and calls these
+  ;; hooks. Without one the page keeps showing the OLD view.
+  (defn ^:dev/after-load mount! []
+    (when-let [el (and (exists? js/document)
+                       (js/document.getElementById "app"))]
+      (when-not @react-root
+        (reset! react-root (uix-dom/create-root el)))
+      (uix-dom/render-root
+        ($ uix-adapter/frame-root {:id             :rf/default
+                                   :initial-events [[:counter/initialise]]}
+          ($ views/counter-app))
+        @react-root)))
+
+  ;; Called ONCE by shadow-cljs when the bundle loads — boot ceremony only.
   (defn ^:export init []
     (rf/init! uix-adapter/adapter)
     (schema/register-schema!)   ;; names :rf/default explicitly — attach before the frame exists
-    (uix-dom/render-root
-      ($ uix-adapter/frame-root {:id             :rf/default
-                                 :initial-events [[:counter/initialise]]}
-        ($ views/counter-app))
-      react-root))
+    (mount!))
   ```
-  The adapter's `frame-root` ensures + provides the app frame for its subtree; rendering without it raises `:rf.error/no-frame-context` on the first subscribe. The entry namespace matches the generator template's `_uix/core.cljs`.
+  The adapter's `frame-root` ensures + provides the app frame for its subtree; rendering without it raises `:rf.error/no-frame-context` on the first subscribe. The entry namespace matches the generator template's `_uix/core.cljs` — including the `^:dev/after-load mount!` split, which this route needs exactly as much as the Reagent one.
 - **views** — the substitution `first-counter.md` does **not** cover. Reagent's `reg-view` auto-injects `dispatch`/`subscribe`; UIx has **no auto-injection** — components read subs through the adapter's `use-subscribe` hook and get `dispatch` off the adapter's `use-frame` hook (capture-frame in hook position), destructured once per render (the closed-over `dispatch` still targets that frame from an async callback). UIx uses `defui` + `$`. Copy the `views.cljs` below verbatim (identical to the template's `_uix/views.cljs`, reproduced here so the recipe is self-contained):
 
   ```clojure

--- a/skills/re-frame2-setup/references/first-counter.md
+++ b/skills/re-frame2-setup/references/first-counter.md
@@ -87,23 +87,35 @@ Use it as the body of `src/your_app/core.cljs`. When it mounts and clicks work, 
 ;; Namespace load does no DOM work — the root is created lazily inside init.
 (defonce react-root (atom nil))
 
-;; shadow-cljs's :browser target re-runs :init-fn (init) after EACH hot
-;; reload, so init IS the re-render path — no separate ^:dev/after-load hook.
-(defn ^:export init []
-  (rf/init! reagent-adapter/adapter)             ;; install the Reagent adapter (no frame yet)
-  (register-schema!)                              ;; attach the frame-local schema (names :rf/default explicitly)
+;; `mount!` is the browser half: create the root once, then render the tree.
+;; THE ^:dev/after-load HOOK IS WHAT MAKES HOT RELOAD WORK. shadow's :browser
+;; target does NOT re-run the module :init-fn after a reload — it loads the new
+;; code and calls the ^:dev/after-load hooks. With none configured it logs
+;; "reloading code but no :after-load hooks are configured!" and the page keeps
+;; painting the OLD view, however long you wait.
+;;
+;; frame-root's {:id …} ENSURE shape creates :rf/default the first time
+;; (running the :initial-events seed synchronously, so the initial render
+;; sees the seeded app-db) and REUSES the live frame WITHOUT re-seeding
+;; on every later render — so a reload leaves your app-db exactly as you
+;; left it.
+(defn ^:dev/after-load mount! []
   (when-let [el (and (exists? js/document)
                      (js/document.getElementById "app"))]
     (when-not @react-root
       (reset! react-root (rdc/create-root el)))
-    ;; frame-root's {:id …} ENSURE shape creates :rf/default the first time
-    ;; (running the :initial-events seed synchronously, so the initial render
-    ;; sees the seeded app-db) and REUSES the live frame WITHOUT re-seeding
-    ;; on every later mount — hot reload is a no-op for your state.
     (rdc/render @react-root
                 [rf/frame-root {:id             :rf/default
                                 :initial-events [[:counter/initialise]]}
                  [counter-app]])))
+
+;; Called ONCE by shadow-cljs (:init-fn in shadow-cljs.edn) when the bundle
+;; loads. One-time boot ceremony only — `mount!` above owns the browser side
+;; and is the fn a hot reload re-runs.
+(defn ^:export init []
+  (rf/init! reagent-adapter/adapter)             ;; install the Reagent adapter (no frame yet)
+  (register-schema!)                              ;; attach the frame-local schema (names :rf/default explicitly)
+  (mount!))
 ```
 
 That's the entire greenfield app. ~35 lines of substance, every re-frame2 primitive exercised once — including the typed-at-boundaries schema attach the generator ships.
@@ -143,10 +155,10 @@ One subscription, `[:counter/value]`, reads `(:counter/value db)`. Views deref i
 
 ### Mount
 
-`defonce` guards `react-root` against hot-reload. `init` runs three steps in order — `rf/init!` → `(register-schema!)` → `rdc/render` wrapped in `frame-root`'s `{:id … :initial-events …}` ENSURE shape — fully detailed in [`entry-namespace.md` §Order of operations](entry-namespace.md). Two counter-specific facts:
+`defonce` guards `react-root` against hot-reload. The mount is split across two fns — `init` runs the one-time boot ceremony (`rf/init!` → `(register-schema!)` → `(mount!)`), and `mount!` carries the `^:dev/after-load` metadata that makes it the fn shadow-cljs re-runs after each reload. Both are fully detailed in [`entry-namespace.md` §Order of operations](entry-namespace.md). Two counter-specific facts:
 
-- **Step 2 attaches the schema before the mount** (explicit `{:frame :rf/default}` target — §Schema), and `frame-root` runs the `:initial-events` seed synchronously at frame creation, so the initial render sees `{:counter/value 0}` already validated.
-- **The `dispatch-sync` seed re-seeds this counter on every hot reload** (the reset boundary — see entry-namespace.md), so a save mid-demo resets the count to `0` rather than leaving it where you'd clicked.
+- **The schema is attached before the mount** (explicit `{:frame :rf/default}` target — §Schema), and `frame-root` runs the `:initial-events` seed synchronously at frame creation, so the initial render sees `{:counter/value 0}` already validated.
+- **A hot reload leaves your count where you clicked it.** `mount!` re-renders into the retained root, and `frame-root` reuses the live `:rf/default` frame without re-running `:initial-events` — so a save mid-demo repaints the edited view over the state you had. Reload the browser tab to seed a fresh counter.
 
 ## Verifying it works
 

--- a/skills/re-frame2-setup/references/first-counter.md
+++ b/skills/re-frame2-setup/references/first-counter.md
@@ -84,7 +84,7 @@ Use it as the body of `src/your_app/core.cljs`. When it mounts and clicks work, 
 
 ;; -- Mount -----------------------------------------------------------------
 
-;; Namespace load does no DOM work — the root is created lazily inside init.
+;; Namespace load does no DOM work — the root is created lazily inside mount!.
 (defonce react-root (atom nil))
 
 ;; `mount!` is the browser half: create the root once, then render the tree.

--- a/skills/re-frame2-setup/references/shadow-cljs.md
+++ b/skills/re-frame2-setup/references/shadow-cljs.md
@@ -104,12 +104,12 @@ Six contractual bits:
 The day-one build (top of this file) already carries `:devtools {:preloads [day8.re-frame2-xray.preload]}`. What it wires:
 
 - **`:preloads [day8.re-frame2-xray.preload]`** — loads the Xray in-app devtools panel in dev/watch builds. `:preloads` (and the whole `:devtools` block) are cut from `release` builds automatically, so Xray never ships to production.
-- **`:init-fn` re-runs after each hot reload.** For shadow-cljs's `:browser` target the module `:init-fn` is both the startup entry and the default after-load hook, so a code reload re-invokes `init` — no separate `^:dev/after-load` hook. That is why the React root is held in a `defonce` and why the explicit `dispatch-sync` seed in `init` is the per-reload reset boundary. Full lifecycle → [`entry-namespace.md` §Order of operations](entry-namespace.md).
+- **`^:dev/after-load` is what makes a reload repaint — `:init-fn` is not.** shadow-cljs calls the module `:init-fn` **once**, when the bundle loads. A hot reload loads the new code and then calls the build's `^:dev/after-load` hooks; it does not call `:init-fn` again. So `core.cljs` splits the entry in two — the one-time boot ceremony in `init`, and a `^:dev/after-load mount!` that re-renders the edited views into the React root held in a `defonce`. Leave the hook out and shadow logs `reloading code but no :after-load hooks are configured!` while the page keeps painting the old view. Full lifecycle → [`entry-namespace.md` §Order of operations](entry-namespace.md).
 - The dev server comes from the top-level `:dev-http {8280 "resources/public"}`, not from a `:http-port`/`:http-root` inside `:devtools`. Use the top-level `:dev-http` form, matching the template.
 
 With this block in place, `npx shadow-cljs watch app` starts the dev server (use `npx` — or `npm run watch` — so the locally-installed `shadow-cljs` from `node_modules/.bin` resolves even with no global binary on PATH). Visit `http://localhost:8280/` and the browser auto-refreshes on every recompile.
 
-re-frame2's *core* does not need a preload for hot-reload — shadow-cljs's default behaviour is enough. **Xray is the one default preload**, wired here because it is a day-one dep; it auto-opens into the `index.html` `[data-rf-xray-host]` column after `rf/init!` seats the adapter (no lazy/manual-only launch step). The default day-one scaffold keeps it.
+re-frame2's *core* needs no preload for hot reload — shadow-cljs's own reload pipeline plus the entry ns's `^:dev/after-load` hook (above) is the whole mechanism. **Xray is the one default preload**, wired here because it is a day-one dep; it auto-opens into the `index.html` `[data-rf-xray-host]` column after `rf/init!` seats the adapter (no lazy/manual-only launch step). The default day-one scaffold keeps it.
 
 **Explicit Xray opt-out (the only no-Xray path).** If you genuinely want a Xray-free build, opt out by removing **all three** pieces together — they are one contract:
 

--- a/skills/re-frame2-setup/tests/setup_drift_test.clj
+++ b/skills/re-frame2-setup/tests/setup_drift_test.clj
@@ -725,9 +725,11 @@
     (let [body @shadow-cljs-md]
       ;; A ":devtools block (optional, for hot-reload)" TOC/section header
       ;; would imply the Xray preload is opt-in hot-reload tooling. It is the
-      ;; day-one default — not optional hot-reload material. (For the :browser
-      ;; target the module :init-fn re-runs after each hot reload by default,
-      ;; so no separate ^:dev/after-load hook is needed at all.)
+      ;; day-one default — not optional hot-reload material. (Nor is the preload
+      ;; what drives hot reload: for the :browser target shadow calls the module
+      ;; :init-fn ONCE at bundle load and does NOT re-run it on a reload, so the
+      ;; entry ns carries a ^:dev/after-load hook — rf2-ms6r8, measured under
+      ;; rf2-r0kk7 / PR #8400.)
       (is (not (str/includes? body "optional, for hot-reload"))
           (str "shadow-cljs.md still labels the `:devtools` section "
                "\"optional, for hot-reload\". The Xray preload is the day-one "

--- a/skills/re-frame2-setup/tests/setup_drift_test.clj
+++ b/skills/re-frame2-setup/tests/setup_drift_test.clj
@@ -1009,16 +1009,62 @@
                "the UIx core.cljs. The frame-local schema attach "
                "must run at boot on every substrate, matching the generator's "
                "_uix/core.cljs (rf2-3fc89f)."))
-      ;; …and it must run BEFORE the frame-root mount (the attach names
-      ;; :rf/default explicitly, so it precedes frame creation; the frame's
-      ;; :initial-events seed is then validated from its first write).
-      (is (re-find #"\(schema/register-schema!\)[^\n]*(?:\n[^\n]*){0,6}?frame-root\s+\{:id\s+:rf/default[\s\S]{0,80}?:initial-events\s+\[\[:counter/initialise\]\]"
+      ;; …and it must run BEFORE the mount (the attach names :rf/default
+      ;; explicitly, so it precedes frame creation; the frame's :initial-events
+      ;; seed is then validated from its first write).
+      ;;
+      ;; Since rf2-ms6r8 the entry ns is TWO fns — the boot ceremony in `init`,
+      ;; and a `^:dev/after-load mount!` carrying the frame-root, which is what
+      ;; shadow re-runs on a hot reload (`:init-fn` is NOT re-run; see the
+      ;; hot-reload lock below). So the ordering can no longer be read off the
+      ;; adjacency of `register-schema!` and `frame-root` — they are in
+      ;; different fns, and the frame-root now appears EARLIER in the file. The
+      ;; invariant is unchanged and is asserted where it actually lives: inside
+      ;; `init`, the schema attach precedes the `(mount!)` call.
+      (is (re-find #"\(schema/register-schema!\)[^\n]*(?:\n[^\n]*){0,3}?\(mount!\)"
                    body)
           (str "entry-namespace.md's substrate boot no longer attaches the schema "
-               "BEFORE the frame-root ENSURE mount. The explicit-frame "
-               "register-schema! must precede the mount so the "
+               "BEFORE the mount. The explicit-frame "
+               "register-schema! must precede the (mount!) call in `init` so the "
                ":counter/initialise seed is validated from its first write "
                "(rf2-3fc89f lineage; frame-root migration).")))))
+
+;; ---------------------------------------------------------------------------
+;; Lock 14b — the substrate entry ns carries the ^:dev/after-load re-render hook
+;; that gives the author hot reload (rf2-ms6r8, measured under rf2-r0kk7 /
+;; PR #8400).
+;;
+;; shadow's :browser target calls the module :init-fn ONCE, at bundle load, and
+;; does NOT re-run it after a hot reload — it loads the new code and calls the
+;; build's ^:dev/after-load hooks. With none configured it logs "reloading code
+;; but no :after-load hooks are configured!" and the page keeps painting the OLD
+;; view (measured unchanged for 90s on a real generated scaffold). This skill
+;; taught the opposite for both substrates, so an author following it built an
+;; app with no working inner loop.
+;;
+;; The prose wording is guarded repo-side by
+;; scripts/check_skill_setup_counter_drift.py; this lock guards the SHAPE of the
+;; copyable UIx code — the hook must exist, and it must be the fn that mounts,
+;; not a decoration on something that never renders.
+;; ---------------------------------------------------------------------------
+
+(deftest uix-core-carries-after-load-render-hook
+  (testing "entry-namespace.md's UIx core.cljs re-renders from a ^:dev/after-load hook"
+    (let [body @entry-namespace-md]
+      (is (re-find #"\(defn\s+\^:dev/after-load\s+mount!" body)
+          (str "entry-namespace.md's UIx core.cljs no longer defines "
+               "`(defn ^:dev/after-load mount! ...)`. shadow does NOT re-run the "
+               "module :init-fn after a hot reload — without this hook the "
+               "scaffolded app compiles, reloads, and never repaints "
+               "(rf2-ms6r8)."))
+      ;; The hook must be the fn that actually renders: the frame-root ENSURE
+      ;; mount has to sit inside `mount!`, not back in `init`.
+      (is (re-find #"\(defn\s+\^:dev/after-load\s+mount!(?:[\s\S]{0,600}?)frame-root\s+\{:id\s+:rf/default[\s\S]{0,120}?:initial-events\s+\[\[:counter/initialise\]\]"
+                   body)
+          (str "entry-namespace.md's `^:dev/after-load mount!` no longer "
+               "contains the frame-root ENSURE mount. The hook must be what "
+               "re-renders — a hook that does not mount leaves the reload just "
+               "as dead as no hook at all (rf2-ms6r8).")))))
 
 ;; ---------------------------------------------------------------------------
 ;; Lock 15 — the UIx route ships NO Xray (rf2-hki2j; rf2-p6f6u lineage).


### PR DESCRIPTION
Closes rf2-ms6r8.

An agent or human following `skills/re-frame2-setup` built an app with no hot reload
— and a required CI guard **enforced** the claim that made it so. Correcting the
prose alone could not merge, so this inverts the guard in the same change.

## The underlying fact — cited, not re-measured

Established by **rf2-r0kk7 / PR #8400** (merged 2026-08-16T07:58:15Z), which drove a
real deps-new scaffold with a live `shadow-cljs watch` plus Playwright: on
**shadow-cljs 3.4.10**, a `:browser` build whose only entry point is a module
`:init-fn` does **not** re-render after a hot reload. The DOM was unchanged for the
full 90 s while shadow logged `load JS … views.cljs` — which is what separates "the
bug is real" from "the edit missed the build". With a separate `^:dev/after-load`
hook the identical edit landed in **1033 ms (Reagent) / 513 ms (UIx), app-db
intact**. I re-measured nothing; #8400 also settled the fix *shape*, and this follows
it rather than inventing one.

Ordering note: the bead's mayor comment is stamped `2026-08-16 07:46` by the tracker
and `17:46 AUSEST` in its own prose — the same instant, not a disagreement. It said
"dispatch the tick after rf2-r0kk7's PR merges"; #8400 merged at 07:58Z, so that
condition is met.

## Which premises held at source

| bead claim | verdict |
| --- | --- |
| `references/entry-namespace.md:25` teaches the false claim | **HOLDS**, verbatim |
| `references/first-counter.md:90` teaches it inside the copy-complete `core.cljs` | **HOLDS** (lines 90–91) |
| `references/shadow-cljs.md:107` teaches it | **HOLDS** |
| `SKILL.md` repeats it | **DOES NOT HOLD** — SKILL.md names `:init-fn` three times, never the reload claim. No edit needed. |
| guard fails on prose saying `:init-fn` does not re-run | **HOLDS** — sabotage-verified, exit 1 |
| guard fails on prose that *recommends* `^:dev/after-load` | **DOES NOT HOLD** — see below |
| guard scans only `SHADOW_CLJS` + `ENTRY_NAMESPACE` | **HOLDS** (`run()`, the `find_hot_reload_drift` call site) |

**Two more sites the bead's grep missed**, the same claim in different words, corrected
here (this is why the inverted guard reports five, not three):

- `entry-namespace.md:48` — *"`init` re-runs on **every** hot reload, so `rf/init!` runs again each save"*.
- `first-counter.md:149` — *"The `dispatch-sync` seed re-seeds this counter on every hot reload (the reset boundary)"*. False twice over: `init` does not re-run, **and** there is no `dispatch-sync` in this counter — the seed is `:initial-events`, which `frame-root` runs once at frame creation. It already contradicted lines 99–102 of its own file.

### The premise that did not hold, and why it matters

Both the bead and #8400 state the guard fails "if a page recommends `^:dev/after-load`".
**It does not.** Read at source, no pattern in `HOT_RELOAD_DRIFT` matches a
recommendation — only the *negated* forms (`one-time startup`, `not the hot-reload
hook`, `does not re-run :init-fn`). The recommendation appears only in the guard's
error *message*. Sabotage-confirmed: a page saying "Add a `^:dev/after-load` hook that
re-renders your edited views" passed the pre-change guard with **captured exit 0**.

So the guard was weaker than believed in a way that matters here: it never checked the
affirmative half in either direction. The inversion adds it.

## The guard arm, inverted

`scripts/check_skill_setup_counter_drift.py` — the `HOT-RELOAD-LIFECYCLE` arm
(`HOT_RELOAD_DRIFT`, previously L146–162; `find_hot_reload_drift`, previously L271–291;
call site in `run()`, previously L388–391).

**Inverted, not retired — nothing stops being checked.** What it enforces now, as a
sentence: *the setup skill must not teach that shadow re-runs the module `:init-fn`
after a hot reload, and every leaf that teaches the boot lifecycle must name the
`^:dev/after-load` hook that actually makes a reload repaint.* Four changes:

1. **Polarity flipped.** The patterns now match the false claim's shapes — `:init-fn`
   re-running after a reload, being the "default after-load hook", `init` being "the
   re-render path", "no separate `^:dev/after-load` hook", the "per-reload reset
   boundary" / "re-seeds on every hot reload" wording.
2. **A polarity-aware re-run check** (`HOT_RELOAD_RERUN` + `_rerun_is_negated`). The
   correct sentence is the false one negated, so a bare `re-runs :init-fn … reload`
   pattern would red the corrected pages. The hit is rejected when the clause running
   into it carries a negation, read back to the previous sentence boundary (capped at
   80 chars so a negation in an earlier clause cannot launder a false claim).
3. **The affirmative half added** (`find_missing_after_load_hook`). Deleting the false
   sentence without teaching the hook strands the author identically. Mirrors the
   sibling gate #8400 landed over the template (`hot-reload-prose-is-accurate-test`).
4. **Scope widened from two leaves to four.** `first-counter.md` — the file the author
   actually copies, and the most load-bearing site — was previously **unscanned** by
   this arm. `SKILL.md` is scanned for the false claim but not required to name the
   hook (it is the router, not a lifecycle leaf).

Docstring, CI error message and `--verbose` summary rewritten to match. Self-test Case D
(clean) and E (drift) swapped, E expanded to **seven** shapes — every phrasing the skill
actually carried. Case E2 (the `:initial-events` false-positive regression pin) kept and
extended to both polarities, since the new affirmative patterns reach shapes the old arm
never matched.

**One documented limit.** A *subject-less* "re-invoked on each hot reload" is not
decidable per-line: said of `mount!` it is correct, said of `init` it is false. The
patterns therefore require the subject. The template's subject-less docstring is gated
where it lives, by #8400's `entry-namespace-carries-after-load-hook-test`.

**One false positive found and fixed by the controls.** The first inverted draft red the
corrected pages: all three leaves quote shadow's own diagnostic — `reloading code but no
:after-load hooks are configured!` — which a bare `no … after-load … hook` pattern
matches. The pattern now requires a qualifier (`separate`, or a trailing
needed/necessary/required), and **Case E2b** pins that shadow's diagnostic must never
trip the guard, in quoted and paraphrased form.

## Checker scope, verified at source

The hot-reload arm read **exactly** `SHADOW_CLJS` + `ENTRY_NAMESPACE` — matching the
bead, and the reason #8400's template-only fix did not red it. Confirmed by reading
`run()`, not inferred. It reaches no further: `TEMPLATE_EVENTS` / `TEMPLATE_SUBS` are
read only by the counter-keyword arm. No blast radius beyond this skill.

## The prose, corrected

Following #8400's shape, explicitly rather than by invention: **a separate
`^:dev/after-load` hook that re-renders, with the one-time boot ceremony left in
`init`.** #8400 rejected putting `^:dev/after-load` on `init` itself because it replays
the boot ceremony every save — and on the SSR variant that runs `ssr/hydrate!` twice.

- **`first-counter.md`** — the sole copy-complete `core.cljs` now defines
  `(defn ^:dev/after-load mount! [] …)` carrying the `frame-root` mount; `init` keeps
  `rf/init!` → `register-schema!` → `(mount!)`. §Mount rewritten: a hot reload now
  correctly leaves your count where you clicked it.
- **`entry-namespace.md`** — §lifecycle, §Order of operations step 3, the `rf/init!`
  idempotence bullet and §The Reagent root pattern rewritten. The **UIx** entry ns had
  **no hook at all** and created its root eagerly at ns-load; it now matches the
  template's lazy `defonce` + `^:dev/after-load mount!`.
- **`shadow-cljs.md`** — the `:devtools` §bullet rewritten; the "shadow-cljs's default
  behaviour is enough" line corrected (the default behaviour is *not* enough — the hook is).

Drive-by in a paragraph already being rewritten: §lifecycle said `init` "does four
things" above a list of three.

`tools/template/` untouched (#8400 owns it). No other skill touched.

## Test-lock repair

`skills/re-frame2-setup/tests/setup_drift_test.clj` Lock 14 read the schema-before-seed
ordering off the **textual adjacency** of `(schema/register-schema!)` and `frame-root`.
The two-fn split puts them in different fns — and the `frame-root` now appears *earlier*
in the file — so the proxy broke while the invariant it stood for did not. Re-expressed
where the invariant lives: inside `init`, the schema attach precedes `(mount!)`. Same
class of stale pin #8400 hit with the SSR emission assertions.

New **Lock 14b** replaces the coverage the old regex incidentally gave and adds the hook
pin: the UIx entry ns must define `(defn ^:dev/after-load mount! …)`, and that hook must
be the fn carrying the `frame-root` ENSURE mount — a hook that does not mount leaves the
reload as dead as no hook.

## Both sabotage verdicts

Every number below is the exit code the run itself wrote to its own `.exit` file, never
one reported about the run. Each restore is verified by `git hash-object` against the
committed blob — not by reading a diff.

| # | control | guard | captured exit | verdict |
| --- | --- | --- | --- | --- |
| 1 | **BEFORE** — plant the TRUE claim ("shadow does not re-run `:init-fn` … calls the `^:dev/after-load` hooks") | pre-change | **1** | RED. The bead's premise holds: the guard enforced the falsehood. |
| 2 | **BEFORE** — plant only a bare `^:dev/after-load` recommendation | pre-change | **0** | GREEN — **premise does not hold** (see above). |
| 3 | **AFTER** — restore the old FALSE claim verbatim | inverted | **1** | RED, naming `shadow-cljs.md:107` in **this** worktree. |
| 4 | **AFTER** — strip `^:dev/after-load` from the UIx entry ns | Lock 14b | **1** | RED, 2 failures. The new lock is not vacuous. |

Restore hashes: `shadow-cljs.md` `7222e836…` → planted `8023481a…` / `e3c9fa67…` →
restored `7222e836…` / `7552f791…` (each equal to the committed blob at that point);
`entry-namespace.md` `746e6e00…` → planted `5adf1265…` → restored `746e6e00…`.
Guard green again after every restore (exit 0), tree clean.

The guard is green on the corrected prose and red on the false claim — not green on
both, which is what a deleted guard looks like however the diff reads.

## Quality gates

| gate | how run | captured exit | result |
| --- | --- | --- | --- |
| `scripts/test-fast-pr.sh` | foreground, absolute path | **0** | PASS — 74 checks. `gate root:` line 1 read **this** worktree; classified `docs=true jvm=false node=false` |
| `check_skill_setup_counter_drift.py --self-test` | foreground | **0** | all cases pass, incl. 7 new drift shapes + E2b |
| `check_skill_setup_counter_drift.py --verbose --ci` | foreground | **0** | no drift |
| `bb tests/setup_drift_test.clj` (the `skills-structural` job) | foreground | **0** | 33 tests, 104 assertions, 0 failures |
| sabotage controls 1–4 | foreground | **1 / 0 / 1 / 1** | as tabled above |

All re-run on the **final rebased base** (`origin/main` `f7c4e5b4`), not a pre-rebase tree.

**Gate coverage derived, not taken on nomination.** `check_skill_setup_counter_drift.py`
is armed by the **`verify-skill-mcp-drift`** job in `test.yml` (self-test at L390–392,
live scan at L395–397), and is *also* in the fast-PR spine (`test-fast-pr.sh:1198–1202`)
— so the spine covers this bead's central gate directly. Of the other skill-drift
checkers, only **`check_skill_re_frame2_drift.py`** reaches `skills/re-frame2-setup/`, and
only as a bounded block anchored on `first-counter.md`'s `> **Reagent only.**` warning,
which this PR does not touch. `check_skill_package_refs.py`,
`check_skill_redirect_anchors.py`, `check_readme_inventories.py` and
`check_skill_eval_docs.py` do not reach this skill.

The **`skills-structural`** job (`bb tests/*_test.clj`) is armed by this change and is
**not** in the spine — hence run directly above. clj-kondo is *not* armed: `lint.yml`
gates it on `implementation/*|tools/*|examples/*|testbeds/*|.clj-kondo/*`, which excludes
`skills/`, so the spine's "no clj-kondo lint surface in the diff" skip is correct despite
the `.clj` edit.

**Spine gap: 94** — `python scripts/check_fast_pr_gap.py --list`. That is a fact about the
SPINE, not a census of what ran here: **the spine ran** (exit 0), and beyond it I ran the
setup-skill structural suite and the four sabotage controls directly.

**This PR reports 88 checks: 27 pass, 61 surface-gated skips, 0 failing** — read *after*
the `All required checks passed` rollup row appeared, not before. It sat at 19 rows and
then 87 for several minutes with no rollup; that row is not created until its `needs:`
resolve, so both earlier reads were partial. The three jobs that decide this change are
all green: **Repo invariant checks (skills, MCP, catalogues, namespaces)** — the job
running `check_skill_setup_counter_drift.py`, i.e. the inverted guard itself — plus
**Skills structural tests (changed skill paths only)** (the `bb` locks, 14 s) and
**Verify markdown link slugs**.

## Not widened

`.github/workflows/test.yml`'s comment above this job already describes the guard as
pinning the **true** framing ("`:init-fn` is the one-time startup hook, `^:dev/after-load`
is the reload re-render hook — not '`:init-fn` re-runs each hot reload'") — it had drifted
from the script it documents. This PR makes the script match its own CI description, so
**no hot-zone edit is needed**; `test.yml` is held by PR #8402 and is untouched here.

`skills/re-frame2-setup/README.md:73` and `spec/design.md:136` describe the guard as
checking "the `:init-fn` hot-reload lifecycle wording", which stays accurate after the
inversion — left alone.
