### PR TITLE
fix(xray): the Hicasso tab counts ten focusable tabs and six views, in the spec and in the guide (rf2-vnuph, rf2-p8eya)

### DIFF
--- a/docs/core/hicasso/16-diagnostics.md
+++ b/docs/core/hicasso/16-diagnostics.md
@@ -16,24 +16,13 @@ is removed from production builds.
 3. Open Xray's **Hicasso** tab and select the view occurrence that ran.
 4. Read its cause, fan-out, and attribution.
 
-!!! warning "The Xray guide does not yet document the Hicasso tab"
-
-    Steps 3 and 4 — and the read topology, advisor, and explain-render sections
-    below — all live in one place: Xray's **Hicasso** tab, which sits alongside
-    Epoch, app-db, Views, Trace, Machine, and Routes in Dynamic mode. The tab is
-    always present; when the inspected app is not running Hicasso it says so in
-    those words, rather than showing you an empty table to interpret. It carries
-    six views: **Mounted** (which boundaries are mounted, over which frames),
-    **Reads** (which boundaries read each subscription), **Intents** (what was
-    dispatched, in order, inside the retained window), **Why** (which reads
-    changed, and what that can and cannot prove), **Advisor**, and **Causal**.
-
-    The tab ships, but the [Xray guide](../../xray/index.md) describes none of
-    it — its panel tour still enumerates six tabs, and the Hicasso tab is the
-    seventh. So this chapter is the only prose description of it anywhere, which
-    is why the sections below are written out rather than linked. Closing that
-    gap is tracked as `rf2-3bwos`; until it lands, there is nothing in the Xray
-    corpus to link to.
+Steps 3 and 4 — and the read topology, advisor, and explain-render sections
+below — all happen in one place: Xray's **Hicasso** tab, in Dynamic mode. [11.
+The Hicasso tab](../../xray/11-hicasso-tab.md) is its reference chapter: what
+each of its views asks, how to read an empty one, and why the advisor refuses to
+recommend a native route. This chapter covers the same ground from the
+application side — which cause you are looking at, which pressure owns it, and
+what to change.
 
 An **epoch** is one event pipeline run, from dispatch through its state commit.
 Xray organises its evidence around epochs.

--- a/tools/xray/spec/000-Vision.md
+++ b/tools/xray/spec/000-Vision.md
@@ -260,13 +260,14 @@ Each row is "new in re-frame2 → new tooling story Xray tells."
 
 ## The tab inventory
 
-The legacy 16-panel sidebar is dead. Xray ships a **9-tab Dynamic detail
+The legacy 16-panel sidebar is dead. Xray ships a **10-tab Dynamic detail
 panel** (Layer 3 of the 4-layer chrome). Each tab is one projection of the
 focused event; selection in the L2 event list rebinds every tab. Cross-cutting
 concerns extend each tab — and where a sub-domain grows cohesive enough it
 earns its own lens tab (Mike's cohesive-sub-domain rule, 2026-05-18): Routing
-(rf2-nrbs9), Resources (EP-0016), Graph (EP-0014), and Modules (EP-0013) each
-landed as their own Dynamic L4 tab rather than overloading App-db.
+(rf2-nrbs9), Resources (EP-0016), Graph (EP-0014), Frames (EP-0023), and
+Hicasso (rf2-hic-023) each landed as their own Dynamic L4 tab rather than
+overloading App-db.
 
 **The Issues tab was removed per rf2-gbz39 (Mike RULED Option (c),
 2026-05-31).** Issues used to get a dedicated tab carrying a session-wide
@@ -278,7 +279,7 @@ epoch has an issue — rf2-b8guz), and via the always-on issues ribbon signal
 (the auto-open-on-error watcher — the cross-epoch "something is wrong" cue
 that Mike kept under (c)).
 
-(The chrome surface measures in 9 Dynamic L3 tabs; the underlying
+(The chrome surface measures in 10 Dynamic L3 tabs; the underlying
 **panel-component inventory** totals mountable panels across four
 tiers — see [`007-UX-IA.md`](007-UX-IA.md) §Mountable panel contract
 and [`016-Auxiliary-Panels.md`](016-Auxiliary-Panels.md)
@@ -301,7 +302,7 @@ cohesive sub-domains earn their own lens tab rather than overloading App-db.
 | 7 | **Resources** | `s` | The declarative-server-state lens (Spec 016 §Xray + AI tooling) — for the focused event: the resource registry · live instances · in-flight work · invalidations · the route→resource graph. The cohesive-sub-domain L4 tab for managed server state (EP-0016). Read-only. | [`024-Resources-Panel.md`](024-Resources-Panel.md) + framework [`spec/016-Resources.md`](../../../spec/016-Resources.md) |
 | 8 | **Graph** | `g` | The unified derivation / process graph across every algebra-view family for the focused cascade (EP-0014, rf2-9ett2d). An **L4-only registry tab** — `reg-l4-tab!` only, no standalone `mount-*!` facade (it is shell-internal, focusable but not independently mountable). | [`025-Derivation-Graph-Panel.md`](025-Derivation-Graph-Panel.md) |
 | 9 | **Frames** | `u` | The EP-0023 **`image -> frame`** PUBLIC model: each live image-loaded frame as an execution context carrying its resolved image's `[kind id]` descriptors with per-descriptor provenance (rf2-32siq3.12); the same `(kind id)` resolves differently in frames running different images. A process not using image-loaded frames shows the honest no-image caption. (The retired EP-0013 realm / app-value / module substrate this tab once also surfaced — the (realm, frame) REALMS section and the per-module MODULES section — was **deleted in full**; there is no `re-frame.realm` namespace.) An **L4-only registry tab** — `reg-l4-tab!` only, no standalone `mount-*!` facade. | [`026-Module-View-Panel.md`](026-Module-View-Panel.md) |
-| 10 | **Hicasso** | `h` | Four views over the adapter-neutral Hicasso evidence surface (rf2-hic-023): **Mounted** boundaries and their frames · **Reads** attribution (sub → boundary, with fan-out) · the **Intents** stream folded from Spec 009's retained window · **Why**, which separates what the cells' epoch stamps PROVE from the causal link that cannot be made. Every envelope states schema, producer, scope, basis, completeness and loss, and unknown is never rendered as an empty list: the three empties (no Hicasso here / an unparseable schema / running with nothing mounted) and the five absences (`unknown` · `opaque` · `host-opaque` · `cap` · `uncorrelated`) each get their own testid and their own sentence. An **L4-only registry tab** — `reg-l4-tab!` only, no standalone `mount-*!` facade. | [`027-Hicasso-Evidence.md`](027-Hicasso-Evidence.md) |
+| 10 | **Hicasso** | `h` | Six views over the adapter-neutral Hicasso evidence surface (rf2-hic-023): **Mounted** boundaries and their frames · **Reads** attribution (sub → boundary, with fan-out) · the **Intents** stream folded from Spec 009's retained window · **Why**, which separates what the cells' epoch stamps PROVE from the causal link that cannot be made · **Advisor**, which ranks the mounted census, classifies what owns the pressure, and refuses the routes its evidence cannot support · **Causal**, which walks one dispatch link by link from event to paint and names every link it cannot evidence (rf2-hic-037). The last two are derivations over the same four envelopes as the first four, taken in one turn, which is why they are sub-views of this tab rather than tabs of their own. Every envelope states schema, producer, scope, basis, completeness and loss, and unknown is never rendered as an empty list: the three empties (no Hicasso here / an unparseable schema / running with nothing mounted) and the five absences (`unknown` · `opaque` · `host-opaque` · `cap` · `uncorrelated`) each get their own testid and their own sentence. An **L4-only registry tab** — `reg-l4-tab!` only, no standalone `mount-*!` facade. | [`027-Hicasso-Evidence.md`](027-Hicasso-Evidence.md) |
 
 The former **Issues** tab (`i`) — JS exceptions + schema violations +
 sensitive-data warnings + hydration mismatches + perf-budget overruns + app

--- a/tools/xray/spec/008-Embedding-Contract.md
+++ b/tools/xray/spec/008-Embedding-Contract.md
@@ -195,7 +195,7 @@ panel/beat/path is [the new surface]."
 
 ```clojure
 {:frame       <frame-id>   ; the HOST frame Xray should observe (optional)
- :panel       <tab-id>     ; which L4 tab to surface (one of the 6 below)
+ :panel       <tab-id>     ; which L4 tab to surface (one of the 10 below)
  :epoch-id    <epoch-id>   ; settling epoch to pin the spine to
  :dispatch-id <id>         ; cascade root to pin the spine to
  :path        [<k> ...]    ; app-db path to highlight in the App-db panel
@@ -215,15 +215,18 @@ ever drift):
 
 ```
 #{:epoch :app-db :views :trace :machines :routing
-  :resources :derivation-graph :module-view}
+  :resources :derivation-graph :module-view :hicasso}
 ```
 
-(Nine tabs — all nine Dynamic L4 tabs are focusable. The registry id for
+(Ten tabs — all ten Dynamic L4 tabs are focusable. The registry id for
 the Routes tab is `:routing` (it RENDERS as "Routes"); a host that prefers
 the visible display-noun can pass `:routes`, normalised to `:routing` via
 `focus/panel-aliases`. `:derivation-graph` renders as "Graph" and
-`:module-view` as "Modules". The `:issues` tab was removed per rf2-gbz39 —
-issues now surface inline in the Epoch panel + the L2 event-row pink-wash +
+`:module-view` as "Frames". Focusability and mountability are separate
+axes: all ten are focusable, and the three L4-only registry tabs — Graph,
+Frames and Hicasso — have no standalone `mount-*!` facade. The `:issues`
+tab was removed per rf2-gbz39 — issues now surface inline in the Epoch
+panel + the L2 event-row pink-wash +
 the always-on issues ribbon signal, so `:issues` is no longer a focusable
 panel. A host that validates a focus command against `:issues` gets
 `{:ok? false :reason :unknown-panel}` from `focus!`.)

--- a/tools/xray/spec/API.md
+++ b/tools/xray/spec/API.md
@@ -195,7 +195,7 @@ implementation reality — ~40 symbols across 6 namespaces).
               :path [:checkout :state]
               :source {:kind :story/assertion}})
 (xray/focus! :checkout {:panel :trace})   ;; positional host-frame form
-xray/valid-focus-panels                   ;; the 9 valid :panel ids (see 008 §Host-facing focus API; :issues removed rf2-gbz39)
+xray/valid-focus-panels                   ;; the 10 valid :panel ids (see 008 §Host-facing focus API; :issues removed rf2-gbz39)
 
 (xray/load-theme css-string)
 ;; Programmatically swap the palette: injects `css-string` as a dedicated
@@ -249,8 +249,8 @@ authoritative list.
 | Namespace | Source | Public surfaces |
 |---|---|---|
 | `day8.re-frame2-xray.core` | `core.cljs` | The canonical re-exports above (`init!`, `open!`, `open-overlay!`, `close!`, `toggle!`, `popout!`, `status`, `target-frame`, `set-target-frame!`, `focus!` + `valid-focus-panels` (the Story→Xray focus entry point, rf2-crtmq), `load-theme`, plus the four highest-traffic config setters re-exported for boot-time convenience: `configure!`, `set-auto-open!`, `set-editor!`, `set-egress-profile!`). |
-| `day8.re-frame2-xray.focus` | `focus.cljc` | The host-facing **focus command** API (rf2-crtmq): `focus!` (the entry point, re-exported through `core`), `focus-command->dispatches` (pure command→`:rf.xray/*`-events translation; JVM-runnable), `valid-panels` + `panel-aliases` + `normalize-panel`. **`valid-panels` mirrors the LIVE Dynamic L4 tab registry** (`#{:epoch :app-db :views :trace :machines :routing :resources :derivation-graph :module-view}` — one per shipped tab; rf2-1sddi6 / rf2-7ed9ms aligned it to the registry so a host can no longer focus `:routes` onto an unknown-tab stub or be denied the shipped `:resources` / `:derivation-graph` / `:module-view` tabs; `:routes` is accepted as a host-friendly alias normalising to `:routing`; rf2-gbz39 removed `:issues` with the Issues tab per Option (c)). The channel Story uses to focus an embedded Xray panel/epoch/path from a beat or assertion. Full contract in [`008-Embedding-Contract.md`](./008-Embedding-Contract.md) §Host-facing focus API. |
-| `day8.re-frame2-xray.panels.*` | `panels/*.cljs` | The 7 standalone-mountable Dynamic `Panel` reg-views — `epoch-panel/Panel`, `app-db-diff/Panel`, `reactive-panel/Panel`, `trace/Panel`, `machine-inspector/Panel`, `routing/Panel`, `resources/Panel` (per [`008-Embedding-Contract.md`](./008-Embedding-Contract.md) + [`018-Event-Spine.md`](./018-Event-Spine.md) §The 9 tabs). The two remaining Dynamic tabs — `derivation_graph/Panel` (Graph, EP-0014) and `module_view/Panel` (Modules, EP-0013) — are **L4-only registry tabs**: focusable via `focus!` but with no standalone `mount-*!` facade (shell-internal). rf2-gbz39 removed `issues-ribbon/Panel` + `mount-issues-ribbon!` per Mike's Option (c) ruling — the Issues tab + its aggregate panel were removed; issues surface inline in the Epoch panel + the L2 event-row pink-wash + the always-on issues ribbon signal (the `:rf.xray/issues-ribbon` projection survives in `registry.cljs` as the ribbon signal's data source). rf2-5gl5r removed `event-detail/Panel` — the Epoch panel supersedes the Event/Handler design as the canonical "what happened in this epoch" surface. rf2-4v67l removed `chrome-a11y.panel/Panel` — a11y dogfooding is Story's domain (rf2-18t6p · `tools/story/src/re_frame/story/ui/chrome_a11y.cljs`). rf2-ga16q removed `machines-canvas.panel/Panel` — its spine-INDEPENDENT browse-all canvas relocated to the Static Machines sub-tab (the Runtime Machines tab is the event-driven lens per rf2-y9xmf). |
+| `day8.re-frame2-xray.focus` | `focus.cljc` | The host-facing **focus command** API (rf2-crtmq): `focus!` (the entry point, re-exported through `core`), `focus-command->dispatches` (pure command→`:rf.xray/*`-events translation; JVM-runnable), `valid-panels` + `panel-aliases` + `normalize-panel`. **`valid-panels` mirrors the LIVE Dynamic L4 tab registry** (`#{:epoch :app-db :views :trace :machines :routing :resources :derivation-graph :module-view :hicasso}` — one per shipped tab; rf2-1sddi6 / rf2-7ed9ms aligned it to the registry so a host can no longer focus `:routes` onto an unknown-tab stub or be denied the shipped `:resources` / `:derivation-graph` / `:module-view` tabs, and rf2-hic-023's `:hicasso` tab is focusable on the same footing; `:routes` is accepted as a host-friendly alias normalising to `:routing`; rf2-gbz39 removed `:issues` with the Issues tab per Option (c)). The channel Story uses to focus an embedded Xray panel/epoch/path from a beat or assertion. Full contract in [`008-Embedding-Contract.md`](./008-Embedding-Contract.md) §Host-facing focus API. |
+| `day8.re-frame2-xray.panels.*` | `panels/*.cljs` | The 7 standalone-mountable Dynamic `Panel` reg-views — `epoch-panel/Panel`, `app-db-diff/Panel`, `reactive-panel/Panel`, `trace/Panel`, `machine-inspector/Panel`, `routing/Panel`, `resources/Panel` (per [`008-Embedding-Contract.md`](./008-Embedding-Contract.md) + [`018-Event-Spine.md`](./018-Event-Spine.md) §The 9 tabs — the heading predates the tenth tab). The three remaining Dynamic tabs — `derivation_graph/Panel` (Graph, EP-0014), `module_view/Panel` (Frames, EP-0023) and `hicasso/Panel` (Hicasso, rf2-hic-023) — are **L4-only registry tabs**: focusable via `focus!` but with no standalone `mount-*!` facade (shell-internal). rf2-gbz39 removed `issues-ribbon/Panel` + `mount-issues-ribbon!` per Mike's Option (c) ruling — the Issues tab + its aggregate panel were removed; issues surface inline in the Epoch panel + the L2 event-row pink-wash + the always-on issues ribbon signal (the `:rf.xray/issues-ribbon` projection survives in `registry.cljs` as the ribbon signal's data source). rf2-5gl5r removed `event-detail/Panel` — the Epoch panel supersedes the Event/Handler design as the canonical "what happened in this epoch" surface. rf2-4v67l removed `chrome-a11y.panel/Panel` — a11y dogfooding is Story's domain (rf2-18t6p · `tools/story/src/re_frame/story/ui/chrome_a11y.cljs`). rf2-ga16q removed `machines-canvas.panel/Panel` — its spine-INDEPENDENT browse-all canvas relocated to the Static Machines sub-tab (the Runtime Machines tab is the event-driven lens per rf2-y9xmf). |
 | `day8.re-frame2-xray.config` | `config.cljc` | The `configure!` map dispatcher, the per-key setters (`set-editor!`, `set-project-root!`, `set-layout-host-selector!`, `set-auto-open!`, `set-keybinding-enabled!`, `set-egress-profile!`, `set-filter-seed!`, `set-filters-storage-key!`, `update-setting!`, `reset-settings!`, `reset-suppressed-count!`) and the published constants enumerated in §Published layout-host constants above. The full normative key inventory lives in [`015-Configuration.md`](./015-Configuration.md); the **key-naming axis** (how authors navigate the key surface by topical cluster prefix — editor / launch / keybinding / settings / filters / render / trace / logging) is documented at [`015-Configuration.md` §Key-naming axis](./015-Configuration.md#key-naming-axis--navigation-map-rf2-dz35f--audit-of-audits-16) per `rf2-dz35f`. |
 | `day8.re-frame2-xray.keybinding` | `keybinding.cljs` | `attach!` / `detach!` — the symmetric, idempotent lifecycle pair for the `Ctrl+Shift+C` global listener. `detach!` is the embed-host escape hatch documented at [`015-Configuration.md`](./015-Configuration.md) §`keybinding/detach!` and [`008-Embedding-Contract.md`](./008-Embedding-Contract.md) §Full-shell embed contract — needed when an embed host's mount lifecycle runs after Xray's preload and wants to take the chord back. |
 | `day8.re-frame2-xray.runtime` | `runtime.cljs` | The Xray ↔ MCP read-and-mutate seam. The accessor surface this namespace exposes is enumerated normatively in §Runtime accessor surface below. Tool clients (`tools/re-frame2-pair-mcp/` today) evaluate forms addressed at this namespace via `eval-cljs`. |
@@ -305,10 +305,11 @@ day8.re-frame2-xray.panels.resources/Panel
 ;; the L2 event-row pink-wash + the always-on issues ribbon signal.)
 ;; (Resources/Panel — the declarative-server-state lens, Spec 016 §Xray
 ;; and AI tooling — is the Dynamic L3 tab after Routing; read-only.)
-;; The remaining two Dynamic tabs — derivation_graph/Panel (Graph,
-;; EP-0014) and module_view/Panel (Modules, EP-0013) — are L4-only
-;; registry tabs: focusable via focus!, but NOT independently mountable
-;; (no mount-*! facade), so they are not part of this mountable list.
+;; The remaining three Dynamic tabs — derivation_graph/Panel (Graph,
+;; EP-0014), module_view/Panel (Frames, EP-0023) and hicasso/Panel
+;; (Hicasso, rf2-hic-023) — are L4-only registry tabs: focusable via
+;; focus!, but NOT independently mountable (no mount-*! facade), so they
+;; are not part of this mountable list.
 ```
 
 (rf2-qy0nu — the 8-panel dead-code sweep removed `causality-graph`,
@@ -319,8 +320,8 @@ supersedes it. rf2-gbz39 removed `issues-ribbon/Panel` with the Issues
 tab per Mike's Option (c) ruling. The 4-layer shell switches over the
 L3 tab ids in
 [`018-Event-Spine.md`](./018-Event-Spine.md) §The 9 tabs — these
-seven are the surviving standalone-mountable `Panel` exports (the
-ninth/eighth Dynamic tabs, Graph + Modules, are L4-only registry tabs
+seven are the surviving standalone-mountable `Panel` exports (the other
+three Dynamic tabs — Graph, Frames and Hicasso — are L4-only registry tabs
 with no `mount-*!` facade — see the code comment above). The L4 display label for
 `reactive-panel/Panel` is **Views** (per `spec/021 §11.5`); the
 panel-registry key stays `:views` for the smaller diff — the
@@ -351,7 +352,7 @@ one `opts` key — `:frame` — defaulting to `:rf/xray`.
 
 ### Static-mode Panel reg-views
 
-The nine Dynamic tabs above are the **Dynamic-mode** L4 tabs (the
+The ten Dynamic tabs above are the **Dynamic-mode** L4 tabs (the
 event-coupled spine — every panel narrates against the focused
 event). Xray's Static mode (per §Static mode above and
 [`007-UX-IA.md`](./007-UX-IA.md) §Static mode) ships a parallel set

--- a/tools/xray/src/day8/re_frame2_xray/core.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/core.cljs
@@ -239,9 +239,10 @@
 (def valid-focus-panels
   "The canonical host-facing Xray panel ids a focus command may target
   — one per LIVE Dynamic L4 tab: `#{:epoch :app-db :views :trace
-  :machines :routing :resources :derivation-graph :module-view}`. A host
-  validates a panel selector against this set before sending a focus
-  command (the host-friendly alias `:routes` normalises to `:routing`).
+  :machines :routing :resources :derivation-graph :module-view
+  :hicasso}`. A host validates a panel selector against this set before
+  sending a focus command (the host-friendly alias `:routes` normalises
+  to `:routing`).
   This MIRRORS the live L4 tab registry
   (`panel-registry/tab-ids-for-mode :dynamic`) — the set tracks the
   shipped inventory. See `day8.re-frame2-xray.focus/valid-panels`."

--- a/tools/xray/src/day8/re_frame2_xray/focus.cljc
+++ b/tools/xray/src/day8/re_frame2_xray/focus.cljc
@@ -112,11 +112,11 @@
   `panel-registry/reg-l4-tab!`:
 
       Epoch · app-db · Views · Trace · Machines · Routing · Resources ·
-      Graph (derivation-graph) · Modules (module-view) · Hicasso
+      Graph (derivation-graph) · Frames (module-view) · Hicasso
 
   Internal registry ids (`:views` renders as \"Views\", `:routing`
   renders as \"Routes\", `:derivation-graph` as \"Graph\",
-  `:module-view` as \"Modules\") — the id is not a user contract, the
+  `:module-view` as \"Frames\") — the id is not a user contract, the
   label is. Host callers who prefer the display-noun spelling can pass
   `:routes` (normalised to `:routing` via `panel-aliases`).
 

--- a/tools/xray/src/day8/re_frame2_xray/panels/hicasso.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/hicasso.cljs
@@ -495,7 +495,7 @@
 ;; the surrounding Xray instance's frame. A bare global `rf/dispatch` would
 ;; fire after render unwinds, when the ambient frame is gone, and leak to
 ;; `:rf/default` — the click would silently switch some other shell's
-;; sub-view, or none. This is the tab's only dispatch: the four views read.
+;; sub-view, or none. This is the tab's only dispatch: the six views read.
 (defn- sub-strip
   [dispatch selected]
   (into [:div {:data-testid (str "rf-xray-" panel-id "-sub-strip")
@@ -512,12 +512,14 @@
            label])))
 
 (rf/reg-view Panel
-  "The Hicasso tab: a sub-strip over four views of one evidence surface.
+  "The Hicasso tab: a sub-strip over six views of one evidence surface.
 
   Every view derefs `:rf.xray.hicasso/data`, which takes all four
   envelopes in one turn — the four rosters are projections of ONE runtime
   state, and reading them across two turns would let a mount land between
-  the census and the edges."
+  the census and the edges. Six views over four envelopes because Advisor
+  and Causal are derivations over the same take rather than reads of their
+  own: the four are the rosters, the six are the projections of them."
   []
   (let [selected (hh/normalise-sub-mode @(rf/subscribe [:rf.xray.hicasso/view]))
         {:keys [envelopes] :as data} @(rf/subscribe [:rf.xray.hicasso/data])

--- a/tools/xray/src/day8/re_frame2_xray/registry.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/registry.cljs
@@ -1304,9 +1304,11 @@
     ;; descriptors. Read-only: enumerating live frames + reading sealed
     ;; generations pins nothing, dispatches nothing.
     (module-view/install!)
-    ;; Hicasso tab — Dynamic L4 tab: four views over the adapter-neutral
+    ;; Hicasso tab — Dynamic L4 tab: six views over the adapter-neutral
     ;; Hicasso evidence surface (`re-frame.hicasso.tool`) — mounted
-    ;; boundaries, read attribution, the intent stream, and explain-render.
+    ;; boundaries, read attribution, the intent stream, and explain-render,
+    ;; plus the advisor and the causal slice (rf2-hic-037), which are
+    ;; derivations over those same four envelopes taken in one turn.
     ;; A pure reader like the Freehand door above it: the Hicasso tier has
     ;; no registry and no ownership plane, so there is nothing to acquire,
     ;; nothing to release and nothing another tool can lock us out of.


### PR DESCRIPTION
Two beads, both count/prose drift about the Hicasso tab, both made actionable by
PR #8401 (rf2-3bwos) merging at 2026-08-16 18:02 AUSEST.

## rf2-p8eya — 16-diagnostics links the Xray chapter instead of substituting for it

PR #8398 added an admonition to `docs/core/hicasso/16-diagnostics.md` saying
"The Xray guide does not yet document the Hicasso tab", and it wrote the tab's
six views out in full precisely because there was nothing to link to. #8401
added `docs/xray/11-hicasso-tab.md`, so both sentences the block rests on are
now false.

Read side by side, the enumeration goes rather than being corrected in place —
the mayor's reading, and mine with the two pages open. Every fact in the block
now lives in the Xray chapter and is stated there better: the always-present
tab (§The Tab Is Always There), and the six views with the question each answers
(§One Read, Six Views). Keeping a second copy buys a page that drifts against
the one that owns the subject. What replaces it is a link and one sentence
naming the split — the Xray chapter is the tab reference, this chapter is the
application-side view. Steps 3-4 of the "Diagnose an interaction" list stay, as
the bead directs, and so do the cause table, the pressure table and the
remedies, which are this chapter's own.

**The tab count the bead told me to check was wrong, and it was inside the
block.** Twice: "sits alongside Epoch, app-db, Views, Trace, Machine, and Routes
in Dynamic mode" (seven) and "its panel tour still enumerates six tabs, and the
Hicasso tab is the seventh". Ten Dynamic tabs ship. No count replaces them — the
chapter never needed one, and a count restated on a second page is how this bead
came to exist. The rest of the file states no tab count; "Four measurements
usually identify the shape" at :74 is the four-row table beneath it.

## rf2-vnuph — the spec counts ten focusable tabs and six Hicasso views

Comment- and prose-only. No behaviour change, and the cross-check tests the bead
names passed before and after.

**Ten focusable panels, not nine.** `focus.cljc:125-126` ships ten ids and
`:hicasso` is one of them, test-enforced in two places:
`registry_cljs_test.cljs:108-115` and `panels/hicasso_cljs_test.cljs:198-199`
both assert `focus/valid-panels` equals `(panel-registry/tab-ids-for-mode
:dynamic)`, and the second names `:hicasso`. `008-Embedding-Contract.md:217-221`
restated the set without `:hicasso` and called it nine — the exact
hand-restatement its own :207-211 forbids — and `API.md` restated it twice, at
:198 as a count and at :252 as a set literal. **That second one is not in the
bead**: it uses no count word, so the count-word grep that found the others
misses it. `000-Vision.md`'s "9-tab Dynamic detail panel" (:263) and "9 Dynamic
L3 tabs" (:281) contradicted the ten-row table directly below them; both
corrected.

**Six Hicasso views, not four.** `hicasso_helpers.cljc:571-582` defines six
sub-modes; Advisor and Causal arrived with rf2-hic-037. `000-Vision.md:304`,
`registry.cljs:1307` and the `Panel` docstring all still said four.

**One line of the bead I did not do as written, having checked it at source.**
The bead names `hicasso.cljs:519` "the four rosters" as drift. It is not: the
tab takes FOUR envelopes in one turn and projects SIX views over them, and both
the shipped code (`hicasso.cljs:524-535`, where `:advisor` and `:causal` both
read `:mounted-boundaries`) and the new Xray chapter (`11-hicasso-tab.md:47-49`)
say so. So :515 changes ("four views" → six) and :517-518 stands, with the
distinction now stated rather than left to be inferred — which is what made it
look like drift in the first place. The same wording is carried to
`000-Vision.md` and `registry.cljs`.

**Two source-located findings beyond the bead, both verified at the registration
site, both the same drift family:**

- `module_view.cljs:218-219` registers `:label "Frames"`. `008`, `API.md`,
  `000-Vision.md:268` and `focus.cljc`'s docstring all called it "Modules".
  Corrected wherever this change already touched the sentence — publishing a
  known-wrong label in a paragraph being rewritten for correctness is not an
  option, and `docs/xray/api/reference.md:25` already says "Frames". `API.md`
  also carried "EP-0013" for that tab; `000-Vision.md:304` records EP-0013 as
  deleted in full and the tab as EP-0023.
- `core.cljs:239-248` — the published `valid-focus-panels` facade docstring —
  restated the set without `:hicasso` too, so the facade, the spec and
  `docs/xray/api/reference.md` were three-way inconsistent.

**Rejected, and left exactly as it stands:** the Hicasso tab has no standalone
`mount-*!` facade. The bead records this as checked-and-not-a-defect and it is
right — `panels.cljs:27-33` lists seven Dynamic-tab `mount-*!` fns, and Graph,
Frames and Hicasso have none. `008` and `API.md` now state that focusability and
mountability are separate axes rather than leaving it to be inferred; that is the
whole of the change there.

**Deliberately out of scope, filed as `rf2-iosuo` (P3).**
`018-Event-Spine.md:510` is now a stale heading, `### The 9 tabs`, referenced by
title from `007-UX-IA.md`, `API.md` (four times) and a testbed — a rename across
three files this bead does not own. `API.md`'s first reference notes the heading
predates the tenth tab, and that note comes out with the rename. The same bead
carries the "four views" residue at eleven sites outside this bead's surface
(`tools/xray/README.md`, `tools/xray/deps.edn`, `spec/027`, `spec/README.md`,
`hicasso_helpers.cljc`, four test files, a testbed scenario), with the warning
that four is sometimes CORRECT and each site must be judged at source.

Per CLAUDE.md, a `tools/xray/` dispatch updates `tools/xray/spec/*` in the same
PR. That is the whole of rf2-vnuph, so it is satisfied by construction.

## Quality gates

**The spine ran, in full, twice — the second time on the final rebased base**
(`origin/main` moved to `84c6598748` mid-run; the rebase was clean and the
three-dot diff against the new merge base reverts nothing). Every number below
is the one the running shell captured with `echo $?` on the same command line as
the redirect, not one reported about the run.

| Gate | Result | Captured exit |
|---|---|---|
| `scripts/test-fast-pr.sh` (attempt 1, base `f7c4e5b415`) | `PASS fast PR spine` | 0 |
| `scripts/test-fast-pr.sh` (attempt 2, base `84c6598748`) | `PASS fast PR spine` | 0 |
| — `mkdocs build --strict` (docs tier) | built, 18.61s, 0 warnings | in spine |
| — `python scripts/check_doc_slugs.py` (docs tier) | 0 broken targets | in spine |
| — CLJS `:node-test` (node tier) | **11771 tests, 59589 assertions, 0 failures, 0 errors** | in spine |
| — per-namespace isolation (node tier) | 16 namespaces standalone, 190 tests, 700 assertions, 0 failures | in spine |
| — hicasso bench-lane compile (node tier) | 149 namespaces, 0 warnings | in spine |
| — clj-kondo (CI's pinned command) | clean | in spine |
| `python scripts/check_doc_slugs.py` (direct, final tree) | 0 broken targets | 0 |
| `cd tools/xray && clojure -M:test` | **1320 tests, 6246 assertions, 0 failures, 0 errors** (re-run identical on the rebased base) | 0 |
| `npm run test:xray-feature-gate:smoke` | **4 scenarios over 3 surfaces, 0 failures, 9 matrix rows** (re-run identical on the rebased base) | 0 |

**Every gate was verified to have read THIS worktree, and two were proved to
have teeth by a planted fault.**

- `test-fast-pr.sh` and the feature gate both print their root: `gate root:
  /c/Users/miket/code/re-frame2-worktrees/xraycounts-vnuph` and `shadow-cljs -
  config: C:\Users\miket\code\re-frame2-worktrees\xraycounts-vnuph\
  implementation\shadow-cljs.edn`.
- `check_doc_slugs.py` is silent, so: planted
  `../../xray/99-sabotage-control-no-such-page.md` at the line this PR edits →
  exit **1**, naming `docs\core\hicasso\16-diagnostics.md:21` and the missing
  target. Restored; git content hash back to `ba76cb9e45` exactly.
- `tools/xray`'s JVM runner is quiet (totals only), so: appended a scoped
  `(deftest zz-sabotage-control-remove-me (is (= 4 (count hh/sub-modes))))` →
  exit **1**, `FAIL in (zz-sabotage-control-remove-me)
  (hicasso_helpers_cljs_test.cljc:613)`, 1321 tests / 1 failure — one test more
  and one failure more than the control, so the plant did not abort the lane.
  Restored; hash back to `9a1ad3dea0` exactly.
- Both logs carry 0 NUL bytes and exactly one `run pid:` line, so no orphan
  spliced into them.

**The spine-versus-CI gap.** `python scripts/check_fast_pr_gap.py --list`
derives it at step granularity: **94 required checks this spine does not run**,
across `All required checks passed` (test.yml), `Lint required` (lint.yml) and
`Docs required` (docs.yml). That is a fact about the SPINE, not a census of this
run — what I ran directly beyond it is the three targeted gates in the table
above.

**Skipped, with reasons:**

- **The full `npm run test:xray-feature-gate`** (17 scenarios over 12 surfaces).
  TESTING.md §The Story/Xray two-tier split reserves the local full run for
  adding or materially changing a NON-SMOKE scenario. This PR adds none and
  changes none — `tools/xray/testbeds/feature_matrix/scenarios.cjs` is untouched
  — so `:smoke`, the command the PR job itself runs, is the surface-correct
  tier. The full sweep remains the nightly system of record.
- **The JVM tier / `scripts/test-jvm-implementation.sh`.** The spine classified
  `implementation_jvm` unchanged, correctly: the diff touches no
  `implementation/` path.
- **Browser lanes, prod-elision, bundle-isolation, perf-bundle, adapter probes
  and smokes, mcp-conformance.** No tier in the spine, and none reaches this
  diff's surface. `story-xray-browser` is the one CI job this diff *does* arm
  (TESTING.md: `tools/xray/src` changed), and its PR-smoke step is
  `test:xray-feature-gate:smoke` — run above.

One cosmetic note: the feature gate's first run printed `http-server exited
unexpectedly (code=1, signal=null)` during teardown, *after* reporting
`0 failures`. The captured exit was 0 both runs; it is a teardown race in the
harness, not a scenario result.
