### PR TITLE
docs(retire): R6b — the docs/ prose sweep, with docs/design/freehand/ refused and escalated (rf2-usulq)

### DIFF
--- a/docs/EP/EP-0034-re-frame-ui-production-ssr-testing.md
+++ b/docs/EP/EP-0034-re-frame-ui-production-ssr-testing.md
@@ -5,6 +5,18 @@ Type: standards-track
 Created: 2026-07-16
 Resolution: accepted 2026-07-11; component-library gates added 2026-07-16
 
+> **Historical record — 2026-08-16.** This EP's programme
+> ([EP-0030](EP-0030-the-compiled-view-substrate-program.md)) was absorbed into
+> Freehand, and Freehand
+> ([EP-0036](EP-0036-the-freehand-view-substrate-programme.md)) was **withdrawn**
+> on 2026-07-30. Both donor substrates were then **removed from the tree** on
+> 2026-08-16 under the operator ruling recorded as `rf2-0yp7w` —
+> `implementation/ui/` and `implementation/freehand/` return nothing from
+> `git ls-files`. The EP is kept as the record of the donor programme and no work
+> is in flight under it: the production, SSR and testing posture set out below,
+> and the G-1..G-18 gate roster that enforced it, describe surfaces that no
+> longer exist.
+
 > **Addendum — 2026-07-21 (rf2-n7jtp).** The `ui.test` surface was minimized to
 > six names — `render` / `attrs` / `text` on the JVM structural host, and
 > `with-root` / `flush!` / `flush-presence!` on the CLJS mounted host.

--- a/docs/EP/EP-0035-component-library-readiness.md
+++ b/docs/EP/EP-0035-component-library-readiness.md
@@ -5,6 +5,19 @@ Type: standards-track
 Created: 2026-07-16
 Resolution: accepted 2026-07-16 (directed); final 2026-07-20
 
+> **Historical record — 2026-08-16.** This EP's programme
+> ([EP-0030](EP-0030-the-compiled-view-substrate-program.md)) was absorbed into
+> Freehand, and Freehand
+> ([EP-0036](EP-0036-the-freehand-view-substrate-programme.md)) was **withdrawn**
+> on 2026-07-30. Both donor substrates were then **removed from the tree** on
+> 2026-08-16 under the operator ruling recorded as `rf2-0yp7w` —
+> `implementation/ui/` and `implementation/freehand/` return nothing from
+> `git ls-files`, and `spec/004D-Freehand-Compiled-Grammar.md`, named in
+> §References below, went with them. The EP is kept as the record of the donor
+> programme and no work is in flight under it: the re-com port this package
+> prepared for was never begun, and the readiness contracts below shipped into a
+> substrate that no longer exists.
+
 ## Abstract
 
 re-com is the first and most important consumer test for `re-frame.ui`; the

--- a/docs/EP/EP-0038-the-hicasso-view-layer-programme.md
+++ b/docs/EP/EP-0038-the-hicasso-view-layer-programme.md
@@ -445,6 +445,31 @@ record written by `rf2-2rtt6.144`: `docs/design/hicasso/decisions.md` HD-029,
 `product/decision-brief.md`, `production-server-arm.md`. This addendum answers
 `rf2-k6bv`.
 
+### Addendum, 2026-08-16 — the donor trees are deleted, and the measurement lane moved with them
+
+Wave 3's HD-018 deletion executed on 2026-08-16 (`rf2-0yp7w`, PR #8322):
+`implementation/ui/` and `implementation/freehand/` return nothing from
+`git ls-files`, and `re-frame.freehand` and `re-frame.ui` are no longer public
+surfaces. Two rules above read against that, and this is what they resolve to
+rather than a rewrite of the frozen text:
+
+- **§Sequencing law's bench carve-out** names
+  `implementation/freehand/test/.../bench/` as the programme's measurement
+  apparatus. That lane moved to `implementation/hicasso/test/re_frame/bench/hicasso/`
+  ahead of the cut and is kept as evidence, so every
+  `implementation/freehand/test/…/bench/hicasso/…` path cited above reads
+  against the same tree at its new root.
+- **§Backwards Compatibility's freeze** — *"the Freehand and re-frame.ui trees
+  are frozen except the bench/test measurement lane"* — was a wave-0..2 rule.
+  The P2 "go" discharged it: the trees are gone, not frozen.
+
+§Graduation's other go-condition is **not** discharged, and should not be read
+as a plan in flight. `spec/004D` was ruled DELETED rather than re-aimed at
+Hicasso (`rf2-0yp7w.11`), precisely so donor-era normative text is not laundered
+into Hicasso's contract, and the disposition of `spec/004`, `spec/004C` and the
+S3/S4/S5 conformance profiles is an open operator question (`rf2-h89ri`). This
+EP therefore stays `accepted`.
+
 ## Open Issues
 
 1. The donor-gate ruling (delegated advisory; expected days after P0 publishes).

--- a/docs/api/re-frame.core.md
+++ b/docs/api/re-frame.core.md
@@ -358,7 +358,7 @@ The view layer is **substrate-agnostic**. The shared dataflow — frames, subscr
   (reg-view sym docstring [args] body+)
   (reg-view ^{:rf/id :explicit/id} sym [args] body+)
   ```
-- **Description**: The `defn`-shape view registration — the app-facing lane. It auto-defs the symbol, auto-derives the id from `(keyword *ns* sym)`, and auto-injects `dispatch` / `subscribe` as lexical bindings. It rejects non-defn-shape bodies at macroexpand. In all shapes the symbol is `def`-ed, so sibling code can write `[my-view item]`. Render an app-facing view by **Var reference** or `(rf/view id)`. Bare keyword-tagged hiccup `[:my-view "args"]` is rejected (see Spec 004D §Resolved decisions).
+- **Description**: The `defn`-shape view registration — the app-facing lane. It auto-defs the symbol, auto-derives the id from `(keyword *ns* sym)`, and auto-injects `dispatch` / `subscribe` as lexical bindings. It rejects non-defn-shape bodies at macroexpand. In all shapes the symbol is `def`-ed, so sibling code can write `[my-view item]`. Render an app-facing view by **Var reference** or `(rf/view id)`. Bare keyword-tagged hiccup `[:my-view "args"]` is rejected.
 - **Example**:
   ```clojure
   (rf/reg-view counter-buttons []
@@ -842,7 +842,7 @@ The surfaces that bring a re-frame2 process up and take it down. The one-line bo
   ```clojure
   (current-adapter) → discriminator keyword
   ```
-- **Description**: Which substrate is installed. Answers `:rf.adapter/freehand` / `:rf.adapter/reagent` / `:rf.adapter/reagent-slim` / `:rf.adapter/uix` / `:rf.adapter/plain-atom` / `:rf.adapter/ssr` / `:custom` — or `nil` when no adapter is installed. (`:rf.adapter/ui` is also reserved, but only donor in-tree code can produce it.) For predicate / branch code.
+- **Description**: Which substrate is installed. Answers `:rf.adapter/reagent` / `:rf.adapter/reagent-slim` / `:rf.adapter/uix` / `:rf.adapter/plain-atom` / `:rf.adapter/ssr` / `:custom` — or `nil` when no adapter is installed. (`:rf.adapter/ui` and `:rf.adapter/freehand` stay reserved and are never recycled, but the two donor view substrates were removed on 2026-08-16 and nothing produces either value now.) For predicate / branch code.
 - **Example**:
   ```clojure
   (rf/current-adapter)   ;; => :rf.adapter/reagent   (nil when no adapter is installed)

--- a/docs/api/re-frame.ssr.md
+++ b/docs/api/re-frame.ssr.md
@@ -51,7 +51,7 @@ The `re-frame.core` facade re-exports a curated set of render and head primitive
   (emit-ui-tree tree)
   (emit-ui-tree tree opts) → HTML string
   ```
-- **Description**: Serialises an **already-rendered** version-1 structural tree to a string. Where `render-to-string` consumes hiccup and renders it, this seam consumes the value `re-frame.ui.tree/render` already produced, and calls nothing: no view is invoked, no subscription is resolved, no frame is bound. Every dynamic value is already a literal in the tree. Pure, JVM-runnable, and deterministic to the byte.
+- **Description**: Serialises an **already-rendered** version-1 structural tree to a string. Where `render-to-string` consumes hiccup and renders it, this seam consumes a tree some other producer has already emitted — the version-1 tree ABI of [Spec 004B](../../spec/004B-UI-Tree-and-Conversion.md), which outlived the donor substrate that first emitted it — and calls nothing: no view is invoked, no subscription is resolved, no frame is bound. Every dynamic value is already a literal in the tree. Pure, JVM-runnable, and deterministic to the byte.
   - It emits the markup for one root's tree only. Manifests, payloads, root identity, and the HTTP response belong to the SSR artefact's other surfaces.
   - `opts` keys (all optional):
     - `:doctype?` — prefixes `<!DOCTYPE html>`.


### PR DESCRIPTION
R6b, the `docs/` half of the prose sweep closing out the retirement of `re-frame.ui` and `re-frame.freehand` (`rf2-usulq`, child of `rf2-0yp7w.9`).

Five files change. The rest of the surface is dispositioned below with reasons, and one 37-file row is **refused and escalated** rather than executed.

## The census, re-measured

The bead's 118 was measured at `3f58d0760e`. Re-measured at `origin/main` `b0f90a62`, with `git grep` over tracked files:

| pattern | files |
|---|---|
| `re-frame.ui` (fixed string) | 54 |
| `re-frame2-ui` **anchored** `re-frame2-ui($\|[^x])` | 9 |
| `freehand` / `Freehand` (case-insensitive) | 116 |
| `004D` (fixed string) | 15 |
| **union** | **120** |

**Both traps controlled.** The unanchored `re-frame2-ui` returns 14 files; anchoring drops 5 that name only `re-frame2-uix`, the live first-class UIx adapter. `:rf.ui/*`, `:rf.ui.compile/*` and `:rf.adapter/freehand` were checked for resolution before any row touched them — all three still resolve, and none was removed.

### Patterns 5 and 6 — bare aliases (added mid-run, from PR #8409's `spec/` measurement)

A require alias (`[re-frame.ui :as ui]`, `[re-frame.freehand :as v]`) severs the donor name from every call site, and documentation is *more* exposed than spec because guide prose quotes call sites without their require forms. Re-measured with alias-shaped patterns added:

| pattern | files |
|---|---|
| `ui.test` | 9 |
| `ui/` + known donor member (`mount`, `render!`, `hydrate-root`, `unmount`, `defview`, `slot`, `render-fn`, `spread`, `event`, `local`, `ref`, `effect`, `data`, `tree`) | 18 |
| `v/` + known Freehand member | 30 |
| **six-pattern union** | **122** |

**Delta: 120 → 122 raw files, and 0 genuine new rows.** The two files the four patterns missed are `docs/EP/EP-0017-recordable-coeffects.md` and `docs/core/coeffects.md`, and **both are false positives**: the hit is `:ui/local-theme`, an *app-authored* coeffect keyword in a worked example, in files carrying no donor require or alias at all. Exactly the collision the alias caution predicts.

No file already cleared changes disposition. The alias hits inside the cleared set are `:ui/local-theme` again (`docs/api/re-frame.core.md:135-143`), `:rf.ui/tree-version` in `docs/api/re-frame.ssr.md:59` — the *surviving* tree-ABI key, trap 2, correctly kept — and `ui.test` in `docs/EP/README.md:48-49`, index-row prose for the two EPs this PR banners.

**Controlled in both directions.** A broad probe for *any* `ui/` or `v/` symbol across the whole published and teaching corpus (`docs/core`, `docs/api`, `docs/xray`, `docs/story`, `docs/ssr`, `docs/routing`, `docs/async`, `docs/resources`) returns **two lines, both the same false positive** — while the same pattern fires **103 times in `docs/design/freehand/codex-design.md` alone** as the positive control. The published guide carries no bare donor aliases.

**The fifth spelling, generalised.** `004D` catches one deleted file. The class is *any* deleted file cited by name, so I ran the general form: every basename deleted since `efa0cdf770` (789 paths → 653 basenames that exist nowhere in the tree today), each `git grep -F`'d against `docs/`. Outside the design trees it returns exactly two, both false positives on inspection (`emit_cljs.cljc` inside EP-0034's frozen body, now covered by its new banner; `test.cljc` matching as a substring of live `*_cljs_test.cljc` paths). **No new dangling filename citations on the published `docs/` surface.**

## What changed

| file | row | disposition |
|---|---|---|
| `docs/EP/EP-0034-…md` | whole page | **banner added** |
| `docs/EP/EP-0035-…md` | whole page | **banner added** |
| `docs/EP/EP-0038-…md` | §Sequencing law, §Backwards Compatibility | **dated addendum** |
| `docs/api/re-frame.core.md` | `reg-view` :361 | de-addressed |
| `docs/api/re-frame.core.md` | `current-adapter` :845 | roster corrected |
| `docs/api/re-frame.ssr.md` | `emit-ui-tree` :54 | re-pointed at Spec 004B |

**EP-0034 and EP-0035 were the only two members of the EP-0030..EP-0036 donor family carrying no withdrawal banner.** Their four siblings each open with a `Historical record — 2026-07-30` block; these two do not, and both read `Status: accepted` / `final` with present-tense prose about a substrate deleted on 2026-08-16 (EP-0035's abstract: *"re-com is the first and most important consumer test for `re-frame.ui`; the substrate gets ready for it ahead of the port"*). That is the bead's own carve-out — *NAMES rather than TEACHES **unless a specific row presents a retired model as a live choice*** — so they now carry the sibling banner. Frozen body text is untouched, per the corpus's meaning-frozen-not-bytes convention (EP-0009).

**EP-0038 is the live Hicasso EP** and two of its rules read against trees that no longer exist: §Sequencing law's bench carve-out names `implementation/freehand/test/.../bench/` as the programme's measurement apparatus, and §Backwards Compatibility freezes the donor trees. A dated addendum in the page's own `### Addendum, YYYY-MM-DD` idiom records where the bench lane went (`implementation/hicasso/test/re_frame/bench/hicasso/`, 222 tracked files, kept as evidence per `donor-surfaces.md`) and that the freeze is discharged. It also says explicitly that §Graduation's `spec/004`-re-homing condition is **not** discharged and is `rf2-h89ri`'s open question — so a reader does not act on it.

**`docs/api` is hand-authored, not generated — a brief premise that does not hold.** Both the bead's parent and the dispatch brief say `docs/api/*.md` is "GENERATED by the api-manifest chain. Regenerate, never hand-edit." It is not. `implementation/scripts/api-manifest/src/re_frame/api_manifest/gen.clj` has exactly one `spit`, to `spec/api-manifest.edn`; nothing anywhere writes `docs/api/`. `doc_api_check.clj` *validates* the tree (call-position discipline + per-namespace member coverage) but does not emit it. So these two pages are hand-edited, correctly.

Their three rows: `reg-view`'s `(see Spec 004D §Resolved decisions)` pointed at a file `rf2-0yp7w.11` deleted, and the rule beside it stands on its own, so it is **de-addressed** — `rf2-g633h`'s ruled default. `current-adapter` promised `:rf.adapter/freehand` as an answer and called `:rf.adapter/ui` producible "by donor in-tree code" that no longer exists; the line now mirrors the posture R6a landed in `spec/API.md` and `spec/Conventions.md` on PR #8409 — both values stay reserved and never recycled, but nothing produces either. `emit-ui-tree` named the deleted `re-frame.ui.tree/render` as the producer of its input; it now points at the surviving **Spec 004B** tree ABI, which is exactly the posture R6a took on 004B itself (*"the tree ABI below outlives them as the input contract of `re-frame.ssr/emit-ui-tree`"*). `emit-ui-tree` is live and its contract is final, so this page had to be right.

## Refusal — `docs/design/freehand/` is NOT deleted here

`rf2-0yp7w.9`'s sub-surface list annotates *"`docs/design/freehand/` — 37 files. **Deletes.**"* I have not executed it, and have escalated it as **`rf2-0moc4` (P1, blocking `rf2-0yp7w.9`)**. Five sources contradict that one word:

1. **The plan page never says delete.** `docs/design/retirement/freehand-and-ui.md` — named by `donor-surfaces.md` as *"the authority"* — lists the tree at line 305 among R6's in-scope prose files, and nowhere says it is removed. Its very next paragraph rules that EP-0030..0036 and `docs/design/hicasso/` are **not** deleted.
2. **EP-0036, which that same paragraph keeps, says the tree remains.** §Design-record posture: *"`docs/design/freehand/` is a durable, frozen supporting record. It remains after spec graduation… It is excluded from the mkdocs site because its links are source-tree-oriented, not because it is temporary."* Deleting the tree makes a kept EP false.
3. **19 files cite it, across four fences.** `spec/004-Views.md` carries **14 mentions, 11 of them markdown links** that `check_doc_slugs.py` validates on every PR — independently re-measured at my own tip (R6a's "14 links" is 14 *mentions*; 11 are links, 3 are bare inline-code paths). `docs/design/hicasso/`, itself ruled kept, cites it in **8 files** as the frozen measurement base its numbers are anchored to. Outside `docs/` and `spec/`: `AGENTS.md`, `CLAUDE.md`, `mkdocs.yml:36`, `scripts/check_doc_slugs.py:1646`, `implementation/hicasso/src/re_frame/hicasso/forms.cljs:38`.
4. **It would falsify three documents W4 deliberately left standing.** `docs/AUTHORING.md:892`, `AGENTS.md:172` and `CLAUDE.md:114` each state that `exclude_docs` keeps `docs/design/freehand/` out of the site. W4 ruled AUTHORING.md:892 stays *because it is a live true fact*.
5. **The 004 coupling is already an open P1.** `rf2-h89ri` names this exact risk and says it *"IS LIVE TODAY AND NEEDS SEQUENCING WHATEVER IS RULED."*

A `docs/**`-fenced worker cannot execute this coherently: the repair set spans `spec/` (R6a), `implementation/` (R6c), and the hot-zone repo root. `rf2-0moc4` sets out three options and recommends keep-or-archive-in-place.

## Everything else on the surface, with reasons

| rows | disposition | why |
|---|---|---|
| `docs/design/hicasso/**` (67) | **leave** | `rf2-0yp7w.9` rules it explicitly: *"those are hicasso's record, not Freehand's."* Includes `decisions.md`, which the bead names as a conflict magnet. |
| `docs/design/freehand/**` (37) | **refused** | `rf2-0moc4` above. |
| `docs/design/retirement/**` (2) | **leave** | These *are* the retirement record; naming the donors is their entire function. Landed as PR #8390 today. |
| `docs/EP/EP-0030..0033`, `EP-0036` (5) | **leave** | Already carry withdrawal banners. History, not live direction. |
| `docs/EP/README.md`, `EP-template.md` (2) | **leave** | Index rows and a worked example of the `Status:`/`Resolution:` convention. NAMES. |
| `docs/AUTHORING.md:892` | **leave** | States a live true fact about `exclude_docs` — W4's ruled example. Cutting it would make the docs wrong. |
| `docs/release-process.md:17,162` | **leave** | Line 17 states the retirement as settled policy; line 162 is a closed historical note. `donor-surfaces.md` calls both *"the record working, not residue."* |

`docs/core/**` — the taught guide — carries **zero** hits on all four patterns, so no guide code block was touched and the `samples_coverage_jvm_test.clj` digest pin is not engaged.

**Held by another worker:** `docs/core/hicasso/16-diagnostics.md` (PR #8407). Not touched — and it carries no donor hits, so nothing is deferred on its account.

## Quality gates

Fence re-derived immediately before publishing: three open PRs (#8407, #8408, #8409). Only #8407 touches `docs/`, and only `docs/core/hicasso/16-diagnostics.md`. None of my five files is touched by any open PR or by any branch ahead of `origin/main`.

**Three-dot diff read for reverts** (`git diff origin/main...HEAD`): 53 insertions, 3 deletions. All three deletions are my own replaced `- **Description**:` lines in the two `docs/api` pages. Nothing a sibling landed is undone.

**Rebased, and the gates re-run on the final base.** `origin/main` moved four commits during the run (`d637812a73` plus three beads checkpoints, touching `.beads/issues.jsonl`, `scripts/check_skill_implementor_partition_drift.py` and `skills/re-frame2-implementor/references/phase-2-impl-order.md` — zero overlap with this PR). The branch was rebased onto the current tip anyway and **every gate below was re-run afterwards**, because a pre-rebase green is evidence about a tree that no longer exists. The six-pattern census re-measures at 122 on the new base, unchanged. Both runs are reported.

| gate | result |
|---|---|
| `scripts/test-fast-pr.sh` (fast pre-checkin spine) | **captured exit 0** pre-rebase (5m10s) and **captured exit 0** post-rebase (6m03s), both `PASS fast PR spine`. Documentation tier ran; JVM, node, clj-kondo and spine-self tiers skipped as unreached by a docs-only diff. |
| `scripts/check_doc_slugs.py` (run directly) | **captured exit 0** pre- and post-rebase |
| `mkdocs build --strict` (inside the spine, `==> mkdocs --strict build`) | **passed** in both runs |
| `scripts/check_readme_links.py --ci` (run directly) | **captured exit 0** pre- and post-rebase |
| `scripts/check_provenance_pins.py` | **skipped** — it gates changed pages under `docs/design/hicasso/`; this PR changes none. |
| `implementation/hicasso/scripts/check_guide_samples.py` | **skipped** — it hashes fenced blocks under `docs/core/`; this PR changes none. |

Every number above is the exit code **I captured** with `> log 2>&1; echo $? > exit` on one command line, not one reported about the run.

**The spine is not CI.** `python scripts/check_fast_pr_gap.py --list` derives, at step granularity, **94 required checks the spine does not run** — 40 `test.yml` jobs, 4 `lint.yml` jobs, 1 `docs.yml` job, plus steps inside jobs the spine does run. That is a fact about the spine's coverage, not a census of this PR: the spine *did* run, in full, and the targeted gates named above were run directly on top of it.

**`mkdocs build --strict` does NOT cover `docs/design/**`,** which is the fail-open case worth naming. `mkdocs.yml`'s `exclude_docs` block lists `tools/playground/`, `migration/*/codemod/`, `design/freehand/`, `design/hicasso/`, `design/retirement/`. **All five files this PR changes are outside every one of those**, so the gate reached all five — verified positively rather than assumed: `site/EP/EP-003{4,5,8}…/index.html` and `site/api/re-frame.{core,ssr}/index.html` all exist in the build output and the new EP-0034 banner is present in the rendered HTML, while `site/design/freehand/` does not exist (the negative control). This PR touches no excluded page, so no by-hand anchor/table verification was owed — but the class is real and is why the check was made rather than assumed.

**Negative control on the doc-slug gate,** because it prints no root banner and a silent green proves nothing. I planted a broken link target (`../../spec/004B-PLANTED-FAULT-rf2-usulq.md`) on a single line I was already editing in `docs/api/re-frame.ssr.md`, re-ran the gate, and it went **red with captured exit 1**, naming the plant exactly:

```
1 broken target file(s) found:
  BROKEN TARGET: docs\api\re-frame.ssr.md:54 -> ../../spec/004B-PLANTED-FAULT-rf2-usulq.md
```

The fault existed only in this worktree, so a run that had wandered into a sibling checkout would have come back green. Restore verified by content hash against the committed object, not by reading a diff: `git hash-object docs/api/re-frame.ssr.md` == `git rev-parse HEAD:docs/api/re-frame.ssr.md` == `d145d7d61fc53ad05b90fe6b1047a44df094786f`.
