### PR TITLE
docs(hicasso): the install chapter answers the template question (rf2-6i5kw)

### DIFF
--- a/docs/core/hicasso/00-installation.md
+++ b/docs/core/hicasso/00-installation.md
@@ -6,6 +6,11 @@ throughout the guide: [`h/defview`](glossary.md#defview) for a view,
 [`h/sub`](glossary.md#hsub) for a subscription read, and event vectors for
 ordinary handlers.
 
+There is no Hicasso variant of the re-frame2 app template — it scaffolds
+`:reagent` and `:uix`, and neither emits Hicasso views. Build by hand from this
+chapter instead: it names every file a Hicasso project needs, and the result
+boots.
+
 ## Add the dependencies
 
 !!! warning "Pre-alpha: no Clojars coordinate"


### PR DESCRIPTION
Closes rf2-6i5kw. One paragraph, prose only, in `docs/core/hicasso/00-installation.md`.

**The scaffolding question is not reopened here.** `tools/template/spec/001-Substrate-Variants.md:153-200` already refuses it and records why, and this PR does not restate that reasoning to the reader, add a scaffolding section, or take the open `:substrate` decision. What was missing was smaller and purely reader-facing: a newcomer asking *"is there a Hicasso template?"* found no answer anywhere they would look.

```
There is no Hicasso variant of the re-frame2 app template — it scaffolds
`:reagent` and `:uix`, and neither emits Hicasso views. Build by hand from this
chapter instead: it names every file a Hicasso project needs, and the result
boots.
```

It sits directly after the chapter's opening paragraph, which is where that reader lands, rather than inside the `Pre-alpha: no Clojars coordinate` admonition below — that box is tightly about the artefact coordinate and `:local/root`, and widening it would blunt it.

The template is named generically rather than by coordinate on purpose. `docs/release-process.md:147` says it ships as a git coordinate on a `template-v*` tag, and `git ls-remote --tags origin` returns **no tags of any kind**, so no coordinate spelling would resolve for a reader today. Naming one would have sent them chasing a 404.

## Every premise checked at source

| Premise | Verdict |
| --- | --- |
| `git ls-remote --tags origin` returns nothing | **Holds.** Zero lines. Positive control: `--heads` returns `main` + worker branches, so the remote is reachable and the empty result is real |
| Template menu is `:reagent` + `:uix`, no Hicasso variant | **Holds.** `docs/release-process.md:119`; `tools/template/README.md:55,65` |
| Hicasso mints no adapter; a Hicasso app installs UIx | **Holds.** `tools/template/spec/001-Substrate-Variants.md:175-181` |
| Whether Hicasso is a `:substrate` value at all wants an operator ruling | **Holds**, and is left untouched — `001-Substrate-Variants.md:181-188` |
| No docs page answers the template question | **Holds.** The only `template` hits under `docs/core/hicasso/` are a *string* template (`18-ssr-and-hydration.md:4`), a *macro* template (`20-migration-from-reagent.md:84`) and a *runtime* template (`troubleshooting.md:145`) — none about scaffolding. Positive control: the same fixed-string search finds 35 `scaffold` hits elsewhere under `docs/` |
| Chapter yields a project that boots | **Holds.** PR #8397 built it from an empty directory outside the repo: mount, click, hot reload, no console errors |
| Fence cleared by PR #8411 | **Holds.** MERGED `2026-08-16T09:47:02Z`, touching only 3 `docs/EP/` + 2 `docs/api/` files. Verified an ancestor of this branch's base |

## Quality gates

The spine **ran**, and printed `gate root: /c/Users/miket/code/re-frame2-worktrees/install-6i5kw` on line 1 — first of two independent confirmations it read this worktree. Classifier: `docs=true jvm=false node=false`.

| Gate | Captured exit | Note |
| --- | --- | --- |
| `scripts/test-fast-pr.sh` | **0** | `PASS fast PR spine`; 1092 log lines, **31 PASS lines, 0 failures** |
| `check_guide_samples.py --self-test` | 0 | all rules fire |
| `check_guide_samples.py` (live) | 0 | 223 blocks pinned across 29 pages — **no roster regen needed** |
| `scripts/check_doc_slugs.py` | 0 | green baseline |
| `scripts/check_doc_slugs.py` **with planted anchor** | **1** | red proof, see below |
| `scripts/check_doc_slugs.py` after restore | 0 | |
| `python -m mkdocs build --strict` | 0 | 19.78s |
| `scripts/check_fast_pr_gap.py --list` | 0 | reports **94** required checks the spine does not decide |

**Counts.** 31 pass, 0 fail. Nine log lines contain the substring `FAIL` and none is a failure — each is a self-test *negative-case label* carrying a `PASS` prefix, e.g. `PASS an unknown kind FAILS`. Counted and read rather than pattern-matched.

**Every number above was captured by `echo $? > …exit` on the same command line as the redirect**, never one reported about the run. No gate was piped through a filter. No gate was skipped.

**Spine-versus-CI gap.** `scripts/check_fast_pr_gap.py --list` derives **94** required checks the spine does not run (40 `test.yml`, 4 `lint.yml`, 1 `docs.yml`, plus the per-step remainder). That is a fact about the spine, not a census of this PR: the spine ran, and the six targeted gates above were additionally run directly.

**Digest-pinned blocks — the trap this file carries.** `implementation/hicasso/scripts/check_guide_samples.py` hashes every fenced block under `docs/core/hicasso/**`, so a fenced-block edit would have made this a two-file change against `samples_coverage_jvm_test.clj`. **This edit is prose only and touches no fenced block** — confirmed two ways. The live checker passes at 223 pinned blocks **with no roster regeneration**, which is the authoritative signal. And `git diff -U0 origin/main...HEAD | grep -cE '^[+-]\x60\x60\x60'` returns **0**.

That second check is a search returning zero, so it was controlled before being believed — and the first control chosen for it was **invalid**: commit `9cf8f2e54c` also returned 0, because it edits README prose without adding or removing a fence line. The valid control is `220cbcbb72`, the commit that added fenced blocks to *this same file*, where the identical regex returns **4**. Zero from a pattern proven to find 4 elsewhere is a real zero.

**Red proof and restore.** `check_doc_slugs.py` prints repository-relative paths, so its output cannot by itself distinguish two checkouts. The discrimination is the red: a broken anchor `#no-such-anchor-planted` was planted **on my own new line**, existing in no other tree. The gate went **exit 1**, naming `docs\core\hicasso\00-installation.md:9 -> #no-such-anchor-planted` — exactly the planted line. A run that had wandered into a sibling worktree would have come back green. Restored and verified by git's own content hash, not by reading a diff:

```
PRE_PLANT_HASH    = ca664154e502ec32fe6edb5f05f92c5401fe593f
POST_RESTORE_HASH = ca664154e502ec32fe6edb5f05f92c5401fe593f
```

Worth recording: `grep -F` over that gate log returned **empty** for strings demonstrably present in it — the known plain-grep false-empty on this Windows setup. The red was confirmed by reading the log directly. A worker trusting that grep would have concluded the plant never fired.

## Manual verification, since nothing gates it

- `mkdocs.yml`'s `exclude_docs` excludes `tools/playground/`, two `codemod/` trees, `design/freehand/`, `design/hicasso/`, `design/retirement/` — **not** `docs/core/`, so `mkdocs build --strict` genuinely reaches this page.
- The added paragraph introduces no link and no heading, so no anchor or nav row is created. The troubleshooting table is untouched and stays at three columns.
- Rendering: a plain paragraph between the intro and the first `##`, inside no admonition or list.

## Fence

Re-derived at start-up, before the first edit, and again before push. One open PR — **#8412** (`worker/pullabort-guyte`), which does not touch this file. `worker/bootdocs-ttmi9` surfaces in a three-dot scan only because #8397 was rebase-merged; its content is byte-identical to `origin/main` for this file, so it is a stale branch and not a live contender. Merge base is unmoved (`017b4f7f7e`), so no rebase was needed and the gates above ran on the final tree.

**Reverts nothing.** The three-dot diff against `origin/main` is 5 added lines and **zero deletions**, so PR #8397's rewrite of this chapter is fully preserved.
