### PR TITLE
fix(bench): a collection INSIDE a leg is refused by a third gate (rf2-4ctls)

### DIFF
--- a/implementation/core/test/re_frame/bench/p0_ladder_structural.test.cjs
+++ b/implementation/core/test/re_frame/bench/p0_ladder_structural.test.cjs
@@ -64,6 +64,8 @@ const {
   allocSiteSplit,
   allocSiteWitness,
   allocSiteReport,
+  allocIntraLegRefusals,
+  allocWindowVerdict,
   ALLOC_SITES,
   ALLOC_SITE_NAMES,
 } = require('./p0_run.cjs');
@@ -1162,6 +1164,246 @@ test('THE REPORT RUNS — the mode is not merely defined', () => {
   assert.deepStrictEqual(allocSiteReport({ bySite: false, perRound: [] }), []);
 });
 
+// ===========================================================================
+// THE INTRA-LEG RECLAMATION GATE — rf2-4ctls
+// ===========================================================================
+//
+// THE DEFECT THIS PINS, and it was MEASURED rather than predicted. rf2-ojehu's
+// by-site window took 72 floor-arm windows over six runs on a quiet box. 24
+// carry at least one NEGATIVE site step — a reclamation inside a single leg —
+// and 21 of those are already refused by the falls gate. THREE have `falls` = 0
+// and TWO of those three ALSO CERTIFIED at τ.
+//
+// NEITHER OF THE TWO EXISTING GATES IS DEFECTIVE ON ITS OWN TERMS, which is
+// what makes this a gap between them rather than a bug in either. The falls
+// gate walks the COLLAPSED stride-2 stream, where such a leg is one
+// non-negative step. The leg tolerance — the gate written for exactly that
+// blind side — reads that leg's NET, which sits inside τ of the cohort median.
+// So the pins below assert BOTH halves on every replayed window: that the two
+// old gates pass it (the gap is real) and that the new one refuses it (the gap
+// is closed). Asserting only the second would pass just as well against a gate
+// that refuses everything.
+//
+// A REPLAY, NOT A FIXTURE. The three windows below are the site legs
+// rf2-ojehu's run actually recorded, to the byte, and each is driven through
+// the SAME four calls the driver makes — `allocSiteSplit`, `allocPrimeSplit`,
+// `allocSteps`, `allocWindowVerdict`. Nothing is reconstructed and no expected
+// verdict is asserted that the real code did not produce.
+
+// `[dispatch, drain]` per work unit, PRIME FIRST, exactly as `siteLegs` carries
+// them. The window's own leg numbering counts the prime as leg 1 — which is how
+// the measurement record quotes these — so the measured-cohort index the
+// refusals use is one lower.
+const OJEHU = {
+  // falls 0, CERTIFIED at τ: leg total +21,484 B against a 20,154 B median is
+  // +6.6%, comfortably inside 25%, while 178 KB was reclaimed inside the leg.
+  c6page_r0_uix: [
+    [25096, 80], [21824, 80], [199980, -178496], [18744, 80],
+    [18232, 80], [18232, 80], [23560, 80],
+  ],
+  // falls 0, CERTIFIED at τ: +20,100 B against 18,092 B is +11.1%, and 285 KB
+  // was reclaimed inside the leg. This is the window the bead leads with.
+  c6page_r2_uix: [
+    [24876, 80], [18012, 80], [18012, 80], [305392, -285292],
+    [17976, 80], [18012, 80], [18012, 80],
+  ],
+  // falls 0, and already refused — on two OTHER legs, at τ. The intra-leg
+  // reason is additional to those, never instead of them.
+  c24page_r0_reagent: [
+    [25000, 96], [279024, -259996], [18232, 80], [18196, 152],
+    [278416, 80], [18412, 80], [18948, 262148],
+  ],
+};
+
+// The driver's own four calls, in the driver's own order, over one window.
+const replay = (pairs) => {
+  const site = allocSiteSplit(siteStream(pairs), 3);
+  const { primeLegs, measured } = allocPrimeSplit(site.collapsed, 1);
+  const steps = allocSteps(measured);
+  return { site, primeLegs, steps, verdict: allocWindowVerdict(steps, site.siteLegs, 1) };
+};
+
+test('THE REPLAY — the two windows that CERTIFIED are refused, and both old gates are shown blind', () => {
+  for (const [name, pairs, reclaimed, legTotal, med] of [
+    ['c6page_r0_uix', OJEHU.c6page_r0_uix, 178496, 21484, 20154],
+    ['c6page_r2_uix', OJEHU.c6page_r2_uix, 285292, 20100, 18092],
+  ]) {
+    const { steps, verdict } = replay(pairs);
+
+    // HALF ONE: the gap is real. The falls gate saw nothing at all...
+    assert.strictEqual(steps.falls, 0, `${name}: no step fell — that IS the blind side`);
+    assert.strictEqual(steps.fall, 0, `${name}: and nothing was netted either`);
+    // ...and the leg tolerance, the gate written for that blind side, passed it
+    // because it reads the leg's NET.
+    assert.strictEqual(steps.legMedian, med, `${name}: the cohort median as measured`);
+    assert.deepStrictEqual(steps.refusals, [], `${name}: τ had nothing to say`);
+    assert.strictEqual(steps.certified, true, `${name}: which is how it got published`);
+    assert.ok(
+      Math.abs(steps.legWorstDeviation) < ALLOC_LEG_TOLERANCE,
+      `${name}: the net deviation is inside τ, so tightening τ is not the repair`
+    );
+
+    // HALF TWO: the third gate refuses it, and names what it found.
+    assert.strictEqual(verdict.certified, false, `${name}: the intra-leg gate must refuse it`);
+    assert.strictEqual(verdict.intraLegRefusals.length, 1, JSON.stringify(verdict.intraLegRefusals));
+    assert.match(verdict.intraLegRefusals[0], new RegExp(`reclaimed ${reclaimed} B inside its drain site`));
+    assert.match(verdict.intraLegRefusals[0], new RegExp(`leg total \\+${legTotal} B`));
+    assert.match(verdict.intraLegRefusals[0], /DO NOT WIDEN A GATE/);
+    // The refusal it carries is the intra-leg one and ONLY it: nothing was
+    // smuggled in from the tolerance, which passed this window.
+    assert.deepStrictEqual(verdict.legRefusals, []);
+    assert.deepStrictEqual(verdict.refusals, verdict.intraLegRefusals);
+  }
+});
+
+test('THE THIRD WINDOW was already refused, and the new reason is ADDITIONAL', () => {
+  // The gate never replaces a refusal. This window fails τ on two legs that ran
+  // an order of magnitude high, and carries an intra-leg reclamation as well.
+  const { steps, verdict } = replay(OJEHU.c24page_r0_reagent);
+  assert.strictEqual(steps.falls, 0, 'the falls gate is blind here too');
+  assert.strictEqual(steps.certified, false, 'but τ refused it on other legs');
+  assert.strictEqual(steps.refusals.length, 2);
+  assert.deepStrictEqual(verdict.legRefusals, steps.refusals, 'and those survive verbatim');
+  assert.strictEqual(verdict.intraLegRefusals.length, 1, 'with the intra-leg reason added');
+  assert.match(verdict.intraLegRefusals[0], /reclaimed 259996 B inside its drain site/);
+  assert.strictEqual(verdict.refusals.length, 3, 'the union is both gates, never one of them');
+  assert.strictEqual(verdict.certified, false);
+});
+
+test('THE GATE IS NOT VACUOUS — a clean window passes it, at every stride', () => {
+  // A gate that refuses everything would satisfy the replay above and be
+  // useless. rf2-ojehu's own numbers say 48 of the 72 windows carry no negative
+  // site step at all; this is that shape, through the same four calls.
+  const { steps, verdict } = replay([
+    [7988, 18056], [1200, 18056], [1200, 18056], [1200, 20696],
+    [1200, 18056], [1200, 18056], [1200, 18056],
+  ]);
+  assert.strictEqual(steps.certified, true, 'six alike legs are one work unit repeated');
+  assert.deepStrictEqual(verdict.intraLegRefusals, [], 'and nothing was reclaimed inside one');
+  assert.strictEqual(verdict.certified, true, 'so the gate must let it through');
+  assert.deepStrictEqual(verdict.refusals, []);
+  // A window that is merely LARGE is not a window that collected. Magnitude is
+  // not the test — the SIGN is — so there is no threshold here to drift.
+  const big = replay(Array.from({ length: 7 }, () => [900000, 900000]));
+  assert.deepStrictEqual(big.verdict.intraLegRefusals, []);
+  assert.strictEqual(big.verdict.certified, true);
+});
+
+test('INERT AT THE SHIPPED STRIDE — every published row is untouched', () => {
+  // The property that makes this bead additive, and the reason no published
+  // conclusion moves: every row ever published was taken at stride 2, where
+  // `allocSiteSplit` yields NO site legs, so there is no site step to be
+  // negative. Driven through the real collapse rather than asserted.
+  const s2 = allocSiteSplit(stream([19256, 19256, 19256, 19256]), 2);
+  assert.deepStrictEqual(s2.siteLegs, [], 'the shipped stride has no seam to read');
+  const steps = allocSteps(allocPrimeSplit(s2.collapsed, 1).measured);
+  const verdict = allocWindowVerdict(steps, s2.siteLegs, 1);
+  assert.deepStrictEqual(verdict.intraLegRefusals, []);
+  assert.deepStrictEqual(verdict.refusals, steps.refusals);
+  assert.strictEqual(verdict.certified, steps.certified);
+  // And the bare function, at the two ways a window can carry no site legs.
+  assert.deepStrictEqual(allocIntraLegRefusals([], 1), []);
+  assert.deepStrictEqual(allocIntraLegRefusals([{ dispatch: -9, drain: 1, leg: -8 }], 1), [],
+    'a single leg is the prime, and the prime is in no figure and no certificate');
+});
+
+test('THE FENCE HOLDS — `allocSteps` is untouched and no published quantity moves', () => {
+  // rf2-rs8q6's fence is load-bearing: the certificate is read off the
+  // COLLAPSED stream so that `rise`, `falls` and `maxStep` cannot move. Feeding
+  // the mid samples to `allocSteps` was the other available repair and would
+  // have split one step into two — on the second window below, `rise` would
+  // have gained the whole 285,292 B and `falls` would have gone to 1. This gate
+  // moves neither, on the windows where it fires hardest.
+  for (const pairs of Object.values(OJEHU)) {
+    const { steps, verdict } = replay(pairs);
+    for (const f of ['rise', 'fall', 'falls', 'maxStep', 'endpoints', 'legMedian',
+                     'legWorstDeviation', 'legTolerance']) {
+      assert.strictEqual(verdict[f], steps[f], `${f} must be the same number`);
+    }
+    for (const f of ['legs', 'gaps']) {
+      assert.deepStrictEqual(verdict[f], steps[f], `${f} must be the same array`);
+    }
+  }
+  // And the source says so: the driver still hands `allocSteps` the measured
+  // COLLAPSED region at both window sites, and the new gate reads `siteLegs`
+  // instead of reaching into the sample stream.
+  assert.strictEqual(
+    (SRC.match(/const verdict = allocWindowVerdict\(s, site\.siteLegs\);/g) || []).length,
+    2,
+    'both window sites apply the third gate, off the site legs'
+  );
+  lacks(
+    /allocSteps\(site\.siteLegs\)|allocSteps\(.*\.samples\)/,
+    'nothing hands a by-site stream to the certificate'
+  );
+});
+
+test('THE GATE HAS NO DIAL, AND τ IS NOT IT', () => {
+  // Every gate on this rig exists because something once passed that should
+  // not have, so widening one to admit today's run retro-admits that failure.
+  // This gate has nothing to widen: the test is a SIGN, not a threshold.
+  lacks(
+    /P0_ALLOC_INTRA|P0_ALLOC_SITE_STEP|P0_ALLOC_RECLAIM|P0_ALLOC_NEGATIVE/,
+    'a gate with an env dial on it is a gate that gets dialled off'
+  );
+  assert.strictEqual(
+    allocIntraLegRefusals.length,
+    1,
+    'site legs in, refusals out — there is no tolerance parameter on it to sweep or to dial'
+  );
+  // rf2-e9wr established that no honest τ calibration exists on the arms' data
+  // in either direction, and rf2-rs8q6 repeats the fence. Nothing in this bead
+  // is a reason to move it, and the placeholder marker stays.
+  assert.strictEqual(ALLOC_LEG_TOLERANCE, 0.25);
+  has(/THIS VALUE IS AN UNCALIBRATED PLACEHOLDER/, 'still not calibrated, still marked');
+  // The refusal it fires is independent of τ, because it never reads it: the
+  // two windows that certified refuse at every tolerance, exactly as the two
+  // audit probes at the foot of this file do.
+  for (const tolerance of [0.01, 0.25, 0.99]) {
+    const site = allocSiteSplit(siteStream(OJEHU.c6page_r2_uix), 3);
+    const steps = allocSteps(allocPrimeSplit(site.collapsed, 1).measured, tolerance);
+    assert.strictEqual(
+      allocWindowVerdict(steps, site.siteLegs, 1).intraLegRefusals.length,
+      1,
+      `τ = ${tolerance} does not move the intra-leg verdict`
+    );
+  }
+});
+
+test('THE SUMMARY REPORTS IT — the gate runs, and an operator can see it did', () => {
+  // "The gate is defined" and "the gate runs" are different claims, and this
+  // file makes that point about `summariseAlloc` and about `allocSiteReport`
+  // already. Drive a collected row through the real summary and read what an
+  // operator would have seen.
+  const site = allocSiteSplit(siteStream(OJEHU.c6page_r2_uix), 3);
+  const window = allocWindowVerdict(
+    allocSteps(allocPrimeSplit(site.collapsed, 1).measured),
+    site.siteLegs,
+    1
+  );
+  // Both floor arms, as the plan mounts them, with the reclamation in ONE of
+  // them: a summary that counted every window would read 4 rather than 2.
+  const arms = FLOOR_ARMS();
+  arms['uix-subs|grid/floor'] = { ...arms['uix-subs|grid/floor'], ...window };
+  const armed = allocSummaryFor('floor', arms, {
+    bySite: true,
+    sites: 3,
+    siteNames: ALLOC_SITE_NAMES,
+  });
+  assert.match(armed.out, /intra-leg reclamations: 2 negative site steps across 2 of 4 windows/);
+  assert.match(armed.out, /invisible to both the other gates, and REFUSED here/);
+  assert.strictEqual(armed.row.intraLegRefusalReasons, 2, 'two rounds of the same synthetic window');
+  // The refusal itself is printed under the summary, in full, as every other
+  // refusal on this row is.
+  assert.match(armed.out, /REFUSED round 1 uix-subs\|grid\/floor: leg 3 of 6 reclaimed 285292 B/);
+  // AND OFF THE MODE THE LINE IS ABSENT, so a published run's summary is
+  // unchanged to the byte. Off it there are no site legs at all, and a line
+  // reading "0 intra-leg reclamations" would claim the instrument looked when
+  // it could not.
+  const off = allocSummaryFor('floor', FLOOR_ARMS());
+  assert.doesNotMatch(off.out, /intra-leg reclamation/, 'silent at the shipped stride');
+});
+
 // --- the row-level witness the driver actually exits on --------------------
 
 const allocRowWith = (windows, rounds = 2) => ({
@@ -1205,6 +1447,33 @@ test('every REFUSED window is named, on every round, with its reason', () => {
   }
   assert.ok(fails.some((f) => f.startsWith('round 1 ')));
   assert.ok(fails.some((f) => f.startsWith('round 2 ')));
+});
+
+test('THE EXIT NAMES WHICH GATE FIRED — the two lists are read apart (rf2-4ctls)', () => {
+  // A failure line is what an operator repairs against, and the two gates send
+  // them to different places: a leg past τ is a question about the arm, an
+  // intra-leg reclamation is a question about the collector's schedule. A
+  // message claiming the tolerance fired when it did not would point at the one
+  // constant this row may not touch.
+  const site = allocSiteSplit(siteStream(OJEHU.c6page_r2_uix), 3);
+  const window = allocWindowVerdict(
+    allocSteps(allocPrimeSplit(site.collapsed, 1).measured),
+    site.siteLegs,
+    1
+  );
+  const row = { perRound: [{ round: 1, arms: { 'uix-subs|grid/floor': window } }] };
+  assert.deepStrictEqual(allocRefusedWindows(row, 'legRefusals'), [],
+    'the tolerance did NOT refuse this window, and the exit must not say it did');
+  const intra = allocRefusedWindows(row, 'intraLegRefusals');
+  assert.strictEqual(intra.length, 1);
+  assert.match(intra[0], /^round 1 uix-subs\|grid\/floor: leg 3 of 6 reclaimed 285292 B/);
+  // The default is still the union, which is what the summary prints.
+  assert.deepStrictEqual(allocRefusedWindows(row), intra);
+  // And a window from a stride-2 row, which carries no such list at all, is
+  // read as empty rather than throwing.
+  const plain = { perRound: [{ round: 1, arms: { a: allocSteps(SMALL) } }] };
+  assert.deepStrictEqual(allocRefusedWindows(plain, 'intraLegRefusals'), []);
+  assert.deepStrictEqual(allocRefusedWindows(plain, 'legRefusals'), []);
 });
 
 test('THE RATIO IS POSSIBLE — refusal REASONS are not counted against WINDOWS', () => {
@@ -1276,8 +1545,24 @@ test('THE RATIO IS POSSIBLE — refusal REASONS are not counted against WINDOWS'
 
 test('the driver exits on THIS function and does not re-derive the verdict', () => {
   has(/const refusedWindows = allocRefusedWindows\(out\.alloc\);/, 'the alloc gate calls it');
-  has(/if \(refusedWindows\.length > 0\) \{/, 'and its result is what pushes a failure');
+  // THE UNION IS WHAT THE SUMMARY PRINTS; THE EXIT READS THE TWO GATES APART
+  // (rf2-4ctls). `refusedWindows` above is still every reason on every refused
+  // window, and it is still what `summariseAlloc` is handed. What changed is
+  // that the exit no longer attributes all of them to the leg tolerance: a
+  // window refused for an intra-leg reclamation had no leg past τ, and a
+  // failure line naming the wrong gate points an operator at the one constant
+  // this row may not touch.
+  has(
+    /const legRefused = allocRefusedWindows\(out\.alloc, 'legRefusals'\);/,
+    'the leg tolerance reads its own list'
+  );
+  has(/if \(legRefused\.length > 0\) \{/, 'and its result is what pushes that failure');
   has(/DO NOT WIDEN THE TOLERANCE/, 'naming the repair, not the dial');
+  has(
+    /const intraRefused = allocRefusedWindows\(out\.alloc, 'intraLegRefusals'\);/,
+    'and the intra-leg gate reads its own'
+  );
+  has(/if \(intraRefused\.length > 0\) \{/, 'which is a separate exit, additional to both others');
   // The nine this file drives, in order. The trailing `};` came off in
   // rf2-gxrr: it made the pin a CLOSED list, which was never its content —
   // "so this file can drive it" is a claim about what is exported, not about
@@ -1785,8 +2070,10 @@ test('the narrow plans SUBTRACT arms — they add none, move none and reorder no
 // build, exactly as every other pin in this file.
 
 // The fields `summariseAlloc` reads, and no more. `arms` is what the plan
-// shape decides, so it is the parameter.
-function allocSummaryFor(planName, arms = {}) {
+// shape decides, so it is the parameter. `extra` overlays the row afterwards,
+// for the fields a MODE sets rather than a plan — `bySite` and its siblings
+// (rf2-4ctls) — so the by-site summary can be driven without a second harness.
+function allocSummaryFor(planName, arms = {}, extra = {}) {
   // The control windows carry a prime too and it costs them nothing — the
   // studio page records their worst leg deviation at <= 1% against the arms'
   // 26-46%, which is the contrast that located the term in the first place.
@@ -1821,6 +2108,7 @@ function allocSummaryFor(planName, arms = {}) {
       arms,
     })),
     allocFits: { perRound: {}, mean: {} },
+    ...extra,
   };
   const lines = [];
   const real = console.log;

--- a/implementation/core/test/re_frame/bench/p0_ladder_structural.test.cjs
+++ b/implementation/core/test/re_frame/bench/p0_ladder_structural.test.cjs
@@ -1402,6 +1402,11 @@ test('THE SUMMARY REPORTS IT — the gate runs, and an operator can see it did',
   // it could not.
   const off = allocSummaryFor('floor', FLOOR_ARMS());
   assert.doesNotMatch(off.out, /intra-leg reclamation/, 'silent at the shipped stride');
+  assert.strictEqual(
+    off.row.intraLegRefusalReasons,
+    undefined,
+    'and the RECORD gains no field either — a 0 there would claim the instrument looked'
+  );
 });
 
 // --- the row-level witness the driver actually exits on --------------------

--- a/implementation/core/test/re_frame/bench/p0_run.cjs
+++ b/implementation/core/test/re_frame/bench/p0_run.cjs
@@ -2692,13 +2692,14 @@ function summariseAlloc(row, refused) {
   // the leg's NET inside τ, so the certificate below reports clean. The by-site
   // stride sees it directly, and this counts what it saw.
   //
-  // PRINTED ONLY UNDER THE MODE, on `allocSiteReport`'s rule: off it there are
-  // no site legs, and a line reading "0 intra-leg reclamations" would claim the
-  // instrument looked when it could not. Every published row is a stride-2 row,
-  // so nothing above or below moves on one.
-  const intraLegReasons = allocRefusedWindows(row, 'intraLegRefusals');
-  row.intraLegRefusalReasons = intraLegReasons.length;
+  // RECORDED AND PRINTED ONLY UNDER THE MODE, on `allocSiteReport`'s rule and
+  // `siteWitness`'s: off it there are no site legs, so a 0 here — in the line
+  // or in the record — would claim the instrument looked when it could not.
+  // Every published row is a stride-2 row, so neither the summary nor the raw
+  // record's shape moves on one.
   if (row.bySite) {
+    const intraLegReasons = allocRefusedWindows(row, 'intraLegRefusals');
+    row.intraLegRefusalReasons = intraLegReasons.length;
     const intraWindows = row.perRound.reduce(
       (a, r) => a + Object.values(r.arms).filter((x) => (x.intraLegRefusals || []).length).length,
       0

--- a/implementation/core/test/re_frame/bench/p0_run.cjs
+++ b/implementation/core/test/re_frame/bench/p0_run.cjs
@@ -1716,6 +1716,121 @@ function allocSiteWitness(siteLegs, prime = ALLOC_PRIME_WRITES) {
   };
 }
 
+// ---------------------------------------------------------------------------
+// THE INTRA-LEG RECLAMATION GATE (rf2-4ctls) — the falls gate's own rule, at
+// the stride the by-site mode already opens
+// ---------------------------------------------------------------------------
+//
+// THE GAP, MEASURED RATHER THAN REASONED ABOUT. rf2-ojehu's by-site window took
+// 72 floor-arm windows on a quiet box across six runs. TWENTY-FOUR of them carry
+// at least one NEGATIVE site step — a reclamation inside a single leg.
+// Twenty-one are already refused by the falls gate. THREE have `falls` = 0, so
+// the falls gate saw nothing at all, and TWO of those three ALSO CERTIFIED at τ:
+//
+//   s3-c6-page  round 0 uix-subs     leg 3: dispatch +199,980 B,
+//     drain -178,496 B, leg total +21,484 B — falls 0, CERTIFIED
+//   s3-c6-page  round 2 uix-subs     leg 4: dispatch +305,392 B,
+//     drain -285,292 B, leg total +20,100 B — falls 0, CERTIFIED
+//   s3-c24-page round 0 reagent-subs leg 2: dispatch +279,024 B,
+//     drain -259,996 B, leg total +19,028 B — falls 0, refused on another leg
+//
+// (Those leg numbers are the WINDOW's, counting the prime as leg 1, which is how
+// the measurement record quotes them. The refusals below number the MEASURED
+// cohort from 1, exactly as the leg tolerance's do, so each is one lower.)
+//
+// NEITHER EXISTING GATE IS DEFECTIVE ON ITS OWN TERMS, and that is what decides
+// the shape of the repair. The falls gate walks the COLLAPSED stride-2 stream,
+// where the leg is ONE step: a reclamation bracketed by a larger allocation
+// inside that step turns nothing negative, so nothing falls. The leg tolerance
+// is the gate written for exactly that blind side — this file says so directly
+// above `allocSteps` — and it passes these because the leg's NET sits inside τ
+// of the cohort median, at +1,330 B and +2,008 B against medians of 20,154 B
+// and 18,092 B. So this is a gap BETWEEN two gates rather than a bug in either,
+// and TIGHTENING EITHER ONE WOULD BE THE WRONG SHAPE: it would retro-reject
+// legitimate windows to catch a fault neither gate is looking at.
+//
+// WHAT IT COSTS. A certified window asserts its measured legs are repetitions of
+// ONE work unit. A leg carrying a 285 KB collect-and-reallocate is not the same
+// work unit as its siblings, and the window under-reads its true allocation by
+// at least the reclaimed amount — the same failure mode the leg tolerance exists
+// to catch, arriving through the seam the tolerance cannot see, on a window that
+// looks clean by every published figure.
+//
+// SO THIS IS A THIRD GATE, READING WHAT IS ALREADY MEASURED. The by-site stream
+// SEES the reclamation — that is the whole of rf2-ojehu's finding — and
+// `siteLegs` has been on the window record since rf2-rs8q6 without adjudicating
+// anything. The rule is the falls gate's own, unaltered, applied one stride
+// finer:
+//
+//     REFUSE the window if any MEASURED site step is negative.
+//
+// Nothing in the work unit removes bytes; the collector does. That is the same
+// observation the falls gate rests on and the same one the leg tolerance's "a
+// leg BELOW its cohort" branch rests on, so no new premise is introduced and no
+// threshold is invented — there is nothing here to calibrate, because the test
+// is a SIGN.
+//
+// WHY THIS IS NOT A WIDENING, which is the fence this row holds every gate to.
+// It can only ever ADD refusals: `allocIntraLegRefusals` returns a list and
+// `allocWindowVerdict` unions it into the window's own. No window refused today
+// is admitted tomorrow, at any τ, on any page.
+//
+// AND τ IS UNTOUCHED, in either direction. rf2-e9wr established that no honest
+// calibration exists on the arms' data and rf2-rs8q6 repeats the fence. Nothing
+// here is a reason to move it, and this gate does not read it.
+//
+// WHY THE CERTIFICATE STILL NEVER SEES A BY-SITE STREAM. rf2-rs8q6's fence is
+// load-bearing and it STANDS: `allocSteps` is handed the COLLAPSED stride-2
+// stream and is not touched by this bead, so `rise`, `falls`, `maxStep`, `legs`,
+// `legMedian` and `legWorstDeviation` are byte-identical on every window at
+// every stride, and every one of that bead's pins stands unedited. Handing the
+// mid samples to `allocSteps` was the other available repair and it is REFUSED
+// for exactly that reason: it would split one step into two and move three
+// PUBLISHED quantities to catch a fault a separate list catches while moving
+// none.
+//
+// INERT AT THE SHIPPED STRIDE, BY CONSTRUCTION rather than by a switch.
+// `allocSiteSplit` returns an EMPTY `siteLegs` at stride 2, so there is no site
+// step to be negative and this returns `[]`. Every row ever published was taken
+// at stride 2, so no published figure and no published verdict moves.
+//
+// WHAT IT DOES NOT CLOSE, stated because a gate that oversells itself is worse
+// than none. A reclamation bracketed inside ONE SITE — collected and
+// re-allocated between the same two readings — is invisible here for the reason
+// it is invisible to the falls gate one stride up, and reaching it needs a seam
+// `p0-heap/alloc-window!` deliberately does not cut. This gate MOVES the blind
+// spot from the leg to the site; it does not remove it. The leg tolerance still
+// runs underneath, and a masked site that costs the leg more than τ·m is taken
+// there.
+//
+// THE PRIME IS OUT OF IT, on `allocSiteWitness`'s rule and clamped the same way.
+// The prime leg is in no published figure and in no certificate, so a collection
+// inside it refuses nothing — and a collection BETWEEN the prime and the
+// measured region lands in the boundary gap, which `allocSteps` already walks on
+// the collapsed stream.
+function allocIntraLegRefusals(siteLegs, prime = ALLOC_PRIME_WRITES) {
+  const p = Math.max(0, Math.min(prime, siteLegs.length));
+  const measured = siteLegs.slice(p);
+  const out = [];
+  for (const [k, l] of measured.entries()) {
+    for (const s of ALLOC_SITE_NAMES) {
+      if (l[s] >= 0) continue;
+      out.push(
+        `leg ${k + 1} of ${measured.length} reclaimed ${-l[s]} B inside its ${s} site ` +
+          `(${ALLOC_SITE_NAMES.map((n) => `${n} ${l[n] > 0 ? '+' : ''}${l[n]}`).join(', ')}; ` +
+          `leg total ${l.leg > 0 ? '+' : ''}${l.leg} B): a collection ran INSIDE this leg and a ` +
+          'larger allocation in the same leg bracketed it, so the collapsed step never turned ' +
+          'negative and the falls gate saw nothing, while the leg tolerance reads only the NET. ' +
+          'The window under-reads its true allocation by at least the reclaimed amount with both ' +
+          'the other gates silent, and under-reading is the direction that manufactures ' +
+          "HD-002's flat-at-zero. DO NOT WIDEN A GATE TO ADMIT IT: this is a THIRD gate and it " +
+          'refuses only what the other two cannot see'
+      );
+    }
+  }
+  return out;
+}
+
 // Rising and falling steps, accumulated separately, from one window's raw
 // samples — AND the leg cohort the certificate is read off.
 //
@@ -1807,6 +1922,32 @@ function allocSteps(samples, tolerance = ALLOC_LEG_TOLERANCE) {
   };
 }
 
+// THE WINDOW'S VERDICT — the two window gates' refusals, named apart and
+// unioned (rf2-4ctls). Pure, for `allocSteps`'s reason: the pin can DRIVE it
+// rather than read the source and hope.
+//
+// `refusals` and `certified` keep their meanings exactly — the union, and "none
+// of them", which is the one verdict shape this row has carried across the
+// preflight and the window gate since rf2-2rtt6.142, so `allocRefusedWindows`
+// and the summary read what they always read. `legRefusals` and
+// `intraLegRefusals` are the two gates' own lists, kept apart so the EXIT can
+// name WHICH gate fired: a failure claiming a leg strayed past the tolerance
+// when what happened was an intra-leg collection would send an operator to the
+// wrong instrument, and to the one constant this row may not touch.
+//
+// OFF THE MODE `siteLegs` IS EMPTY, so this is the identity on `steps`: the same
+// `certified`, the same `refusals`, and every published figure passed through.
+function allocWindowVerdict(steps, siteLegs = [], prime = ALLOC_PRIME_WRITES) {
+  const intraLegRefusals = allocIntraLegRefusals(siteLegs, prime);
+  return {
+    ...steps,
+    legRefusals: steps.refusals,
+    intraLegRefusals,
+    refusals: [...steps.refusals, ...intraLegRefusals],
+    certified: steps.certified && intraLegRefusals.length === 0,
+  };
+}
+
 // The witness over a whole collected row, as a PURE FUNCTION of it — the
 // same shape and for the same reason as `ladderStructuralFailures` below: it
 // needs neither a release build nor a Chromium to adjudicate, so it can be
@@ -1820,12 +1961,20 @@ function allocSteps(samples, tolerance = ALLOC_LEG_TOLERANCE) {
 //
 // EVERY REFUSED WINDOW IS NAMED WITH ITS REASON, on every round, because a
 // count of refusals tells an operator nothing about which leg misbehaved.
-function allocRefusedWindows(row) {
+//
+// `field` READS ONE GATE'S OWN LIST (rf2-4ctls), and the default is the union a
+// window was refused on. It exists so the EXIT can attribute a refusal to the
+// gate that made it — `legRefusals` for the leg tolerance, `intraLegRefusals`
+// for the intra-leg reclamation gate — while the SUMMARY goes on printing every
+// reason together, which is what a reader of a refused window wants. The guard
+// is the reason list rather than `certified` so that a named sub-list is read
+// correctly; for the union the two are the same test, since `certified` is
+// exactly "no refusals".
+function allocRefusedWindows(row, field = 'refusals') {
   const out = [];
   for (const r of row.perRound || []) {
     for (const [key, a] of Object.entries(r.arms || {})) {
-      if (a.certified) continue;
-      for (const reason of a.refusals || []) out.push(`round ${r.round} ${key}: ${reason}`);
+      for (const reason of a[field] || []) out.push(`round ${r.round} ${key}: ${reason}`);
     }
   }
   return out;
@@ -2008,10 +2157,16 @@ async function allocRow(chromium) {
       const site = allocSiteSplit(w.samples, w.sites);
       const { primeLegs, measured } = allocPrimeSplit(site.collapsed);
       const s = allocSteps(measured);
+      // AND THE THIRD GATE (rf2-4ctls), which reads the site legs the mode has
+      // already measured and adjudicates nothing `allocSteps` adjudicates. The
+      // identity off the mode, where there are no site legs to be negative.
+      // ONE WINDOW SHAPE, NOT TWO: the controls take this exactly as they take
+      // the prime, so a control refuses for the same reasons an arm does.
+      const verdict = allocWindowVerdict(s, site.siteLegs);
       return {
         kind,
         d,
-        ...s,
+        ...verdict,
         primeLegs,
         primeExcess: primeLegs.length ? primeLegs[0] - s.legMedian : null,
         perIter: s.rise / ALLOC_WRITES,
@@ -2112,6 +2267,12 @@ async function allocRow(chromium) {
         const site = allocSiteSplit(win.samples, win.sites);
         const { primeLegs, measured } = allocPrimeSplit(site.collapsed);
         const s = allocSteps(measured);
+        // AND THE THIRD GATE (rf2-4ctls), at the arm window exactly as at the
+        // control window above. It reads `site.siteLegs` — already measured,
+        // never adjudicated until now — and unions its refusals into the
+        // window's. `allocSteps` is handed the collapsed stream still, so
+        // `rise`, `falls` and `maxStep` are the same numbers on the same code.
+        const verdict = allocWindowVerdict(s, site.siteLegs);
         // THE WRITE READ-BACK, and the row exits on it. At R reads of a
         // page whose cells were all written to `v`, a ladder boundary's
         // text is `R·v`; the floor has no subscription and cannot move.
@@ -2133,7 +2294,7 @@ async function allocRow(chromium) {
           reads: R,
           boundaries: B,
           text: win.text,
-          ...s,
+          ...verdict,
           // THE PRIME LEG, RECORDED RATHER THAN DISCARDED (rf2-oiy1). It is
           // in no published quantity and in no certificate, and it is the
           // term that made every floor window uncertifiable, so the record
@@ -2236,7 +2397,9 @@ async function allocRow(chromium) {
       'in-page performance.memory.usedJSHeapSize sampled at every leg boundary, ' +
       'rising steps accumulated separately from falling ones; --enable-precise-memory-info. ' +
       'A falling step is a collection this counter SAW; a leg that deviates from its cohort ' +
-      'median by more than the leg tolerance is a work unit that is not one, and both refuse',
+      'median by more than the leg tolerance is a work unit that is not one; and under the ' +
+      'by-site stride a NEGATIVE SITE STEP is a collection inside one leg that neither of the ' +
+      'other two can see. All three refuse',
     fallThresholdB: ALLOC_FALL_THRESHOLD_B,
     legTolerance: ALLOC_LEG_TOLERANCE,
     verification: { unverified, detail: unverifiedDetail },
@@ -2274,7 +2437,13 @@ function allocSiteReport(row) {
     ';;   A leg is exactly `dispatch + drain`, over the same outer pair of readings the shipped'
   );
   out.push(
-    ';;   stride takes — so the certificate above is unchanged, and these figures adjudicate nothing.'
+    ';;   stride takes — so `rise`, `falls` and `maxStep` above are unchanged, and no median or'
+  );
+  out.push(
+    ';;   attribution below adjudicates anything. ONE THING HERE DOES (rf2-4ctls): a NEGATIVE site'
+  );
+  out.push(
+    ';;   step is a collection inside a leg, and it refuses the window through the intra-leg gate.'
   );
   out.push(
     ';;   EVERY FIGURE HERE CARRIES ONE EXTRA SAMPLER READ PER LEG. It is a constant per leg, so it'
@@ -2516,6 +2685,31 @@ function summariseAlloc(row, refused) {
   // that fault, which is the direction that flatters a candidate whose
   // predicted answer is zero.
   row.fallsInMeasuredWindows = falls;
+
+  // THE FALLS GATE'S OTHER BLIND SIDE, NOW READ (rf2-4ctls). A collection inside
+  // ONE LEG, bracketed by a larger allocation in the same leg, turns no step
+  // negative on the collapsed stream — so the line above reports 0 — and leaves
+  // the leg's NET inside τ, so the certificate below reports clean. The by-site
+  // stride sees it directly, and this counts what it saw.
+  //
+  // PRINTED ONLY UNDER THE MODE, on `allocSiteReport`'s rule: off it there are
+  // no site legs, and a line reading "0 intra-leg reclamations" would claim the
+  // instrument looked when it could not. Every published row is a stride-2 row,
+  // so nothing above or below moves on one.
+  const intraLegReasons = allocRefusedWindows(row, 'intraLegRefusals');
+  row.intraLegRefusalReasons = intraLegReasons.length;
+  if (row.bySite) {
+    const intraWindows = row.perRound.reduce(
+      (a, r) => a + Object.values(r.arms).filter((x) => (x.intraLegRefusals || []).length).length,
+      0
+    );
+    console.log(
+      `;;   intra-leg reclamations: ${intraLegReasons.length} negative site step` +
+        `${intraLegReasons.length === 1 ? '' : 's'} across ${intraWindows} of ${wins} windows ` +
+        '(a collection INSIDE a leg, which turns no step negative on the collapsed stream and ' +
+        'leaves the leg NET inside τ — invisible to both the other gates, and REFUSED here)'
+    );
+  }
 
   // THE OBSERVED-COLLECTION WITNESS (rf2-2rtt6.140), which is the fall gate's
   // blind side and a SECOND exit, not a softening of the first. A collection
@@ -3201,6 +3395,14 @@ module.exports = {
   ALLOC_BY_SITE,
   ALLOC_SITES,
   ALLOC_SITE_NAMES,
+  // The intra-leg reclamation gate (rf2-4ctls), exported on the same rule: both
+  // halves are pure, so the pin can REPLAY the three windows rf2-ojehu measured
+  // through the real gate rather than assert that it would refuse them. The
+  // property that matters most — that `allocSteps` is untouched and every
+  // published figure is byte-identical — is likewise something a pin can drive
+  // by running both functions over one window and comparing.
+  allocIntraLegRefusals,
+  allocWindowVerdict,
   // The measurement surface (rf2-gxrr), exported so the structural pin can
   // DRIVE it rather than read its source: the tables as values, the plan
   // filter as a pure function, and the two resolved selections so the env
@@ -3384,14 +3586,38 @@ if (require.main === module) (async () => {
       // OWN legs — W repetitions of one work unit — and refuses the window
       // where one of them does not look like the others. It is additional to
       // the falling-step gate and replaces none of it.
-      if (refusedWindows.length > 0) {
+      //
+      // THE TWO GATES ARE NAMED APART IN THE EXIT (rf2-4ctls), because a
+      // failure line is what an operator repairs against and the two send them
+      // to different places: one to the arm, one to the collector's schedule.
+      // The summary above still prints every reason together.
+      const legRefused = allocRefusedWindows(out.alloc, 'legRefusals');
+      if (legRefused.length > 0) {
         failures.push(
-          `alloc: ${refusedWindows.length} windows have a work leg that deviates from its own ` +
+          `alloc: ${legRefused.length} windows have a work leg that deviates from its own ` +
             'cohort median by more than the leg tolerance. A leg BELOW its cohort is a leg ' +
             'something removed bytes from and nothing in the work unit removes bytes; a leg ' +
             'ABOVE it is a window whose ONE WORK UNIT premise failed. Either way the window ' +
             "under-reads by an unknown amount, and under-reading manufactures HD-002's " +
-            `flat-at-zero. DO NOT WIDEN THE TOLERANCE. First: ${refusedWindows[0]}`
+            `flat-at-zero. DO NOT WIDEN THE TOLERANCE. First: ${legRefused[0]}`
+        );
+      }
+      // AND THE SEAM BETWEEN THEM (rf2-4ctls). rf2-ojehu measured 72 arm
+      // windows and found 24 carrying a reclamation INSIDE one leg; three were
+      // invisible to the falls gate and two of those certified at τ. The falls
+      // gate is defined on the collapsed stream, where such a leg is one
+      // non-negative step; the leg tolerance reads that leg's NET, which sits
+      // inside τ. Neither is defective — the fault lives in the gap, and this
+      // reads the by-site stream that already saw it. REPAIR NOTHING BY
+      // WIDENING: this gate only ever adds refusals, and τ is not its dial.
+      const intraRefused = allocRefusedWindows(out.alloc, 'intraLegRefusals');
+      if (intraRefused.length > 0) {
+        failures.push(
+          `alloc: ${intraRefused.length} intra-leg reclamations — a collection ran INSIDE a ` +
+            'measured leg and a larger allocation in the same leg bracketed it, so no step fell ' +
+            'and the leg NET stayed inside τ. The window under-reads by at least the reclaimed ' +
+            'amount with both other gates silent, which is exactly the direction that ' +
+            `manufactures HD-002's flat-at-zero. First: ${intraRefused[0]}`
         );
       }
     }


### PR DESCRIPTION
**Two of the 72 measured windows change classification, and no published conclusion moves.** The two are exactly the ones `rf2-4ctls` names — both currently `CERTIFIED` — and the run's certified count goes 39 → 37 of 72. Nothing else in the measurement changes verdict: 48 of the 72 windows carry no negative site step at all and are untouched, and the other 22 were already refused. `rf2-e9wr`'s window was taken entirely at stride 2, where this gate is inert by construction; `rf2-ojehu`'s page already excluded exactly these two windows by hand. One *count* on that page would read differently on a re-run and is named below rather than edited.

## The gap, and why tightening either gate would be the wrong shape

`rf2-ojehu` measured 72 floor-arm windows over six runs on a quiet box. 24 carry at least one **negative site step** — a reclamation inside a single leg. 21 are already refused by the falls gate. Three have `falls === 0`, and two of those also certified at τ.

Neither existing gate is defective on its own terms:

- The **falls gate** walks the collapsed stride-2 stream, where the leg is one step. A reclamation bracketed by a larger allocation inside that step turns nothing negative, so nothing falls.
- The **leg tolerance** is the gate written for exactly that blind side — and it passes these because the leg's *net* sits inside τ of the cohort median, at +1,330 B and +2,008 B against medians of 20,154 B and 18,092 B.

So the fault lives in the gap *between* two gates. Tightening either would retro-reject legitimate windows to catch something neither is looking at.

## What this does

A **third gate**, reading what the by-site mode already measures. `siteLegs` has been on the window record since `rf2-rs8q6` without adjudicating anything; `allocIntraLegRefusals` now refuses a window carrying a negative **measured** site step. That is the falls gate's own rule, one stride finer.

`allocWindowVerdict` unions the two gates' refusals and keeps each list named (`legRefusals`, `intraLegRefusals`) so the exit can attribute a failure to the gate that made it — a message claiming a leg strayed past τ when what happened was an intra-leg collection points an operator at the one constant this row may not touch.

**It is not a widening.** It can only ever *add* refusals. There is no threshold in it to calibrate or dial, because the test is a **sign** — pinned: the two windows refuse identically at τ = 0.01, 0.25 and 0.99.

**τ is untouched.** `ALLOC_LEG_TOLERANCE` stays 0.25 with its uncalibrated marker intact, and the gate never reads it.

**`rf2-rs8q6`'s fence holds.** `allocSteps` is still handed the *collapsed* stride-2 stream and is not touched by this bead, so `rise`, `fall`, `falls`, `maxStep`, `endpoints`, `legs`, `gaps`, `legMedian`, `legWorstDeviation` and `legTolerance` are byte-identical — pinned by driving both functions over all three named windows and comparing field by field. Feeding the mid samples to `allocSteps` was the other available repair and is refused for that reason: on the lead window it would have added the whole 285,292 B to `rise` and taken `falls` to 1.

The bead floated a cheaper shape — a diagnostic count reported *beside* the certificate, adjudicating nothing. That is rejected: it leaves the certificate still reading `CERTIFIED` on a window whose legs are not one work unit, which is the cost the bead itself names. The refusal list is the diagnostic that also adjudicates, and it moves no published quantity to do it.

## What changes on the 72 measured windows

Replayed through the new code against `rf2-ojehu`'s own raw record, whose `falls` / τ / certified counts (23 / 33 / 39) reproduce that window's published figures exactly:

| | windows |
|---|---|
| untouched — no measured negative site step | **48** of 72 |
| gain at least one intra-leg refusal *reason* | 24 of 72 |
| …of those, already refused (21 on falls + τ, 1 on τ alone) | 22 |
| **change classification, certified → refused** | **2** |
| certified count, before → after | **39 → 37** of 72 |

Of the 108 control windows in the by-site runs, one carries a negative measured site step and was already refused by the falls gate, so no control flips.

## Whether any published conclusion moves — no, and here is the one number that would re-read

- **`rf2-e9wr`'s window was taken entirely at stride 2.** `allocSiteSplit` yields no site legs there, so the gate has nothing to read. Verified against that run's own raw record: `siteLegs` is empty in all 12 arm windows and all 18 control windows, and `siteWitness` is `null` throughout.
- **`rf2-ojehu`'s page already excluded exactly these two windows by hand.** Its headline population is *"collection-free, no excursion, no intra-leg reclamation"* — 41 of 72 — and its own refusals section states the population *"additionally excludes … the two windows carrying an intra-leg reclamation"*. Every conclusion on that page is drawn on a population this gate does not touch.
- **One count on that page would read differently on a re-run**, named here rather than edited there: it reports *"39 of 72 certify"*; under this gate that is **37 of 72**. It is a count of what the driver refused, not a conclusion — the page quotes nothing from a refused window, and both newly-refused windows were already outside every figure it publishes. Neither published result page is touched by this PR.

## What it does not close

A reclamation bracketed inside **one site** — collected and re-allocated between the same two readings — is invisible here for the reason it is invisible to the falls gate one stride up. This gate **moves** the blind spot from the leg to the site; it does not remove it. The leg tolerance still runs underneath. Reaching further needs a seam `p0-heap/alloc-window!` deliberately does not cut. This is stated in the source beside the gate.

## `rf2-stals` not taken

The `worst-dev site` heading is in the same function this PR edits one clause of, but they are different claims and do not belong in one commit. The heading is untouched — `git diff` touches no line containing `worst-dev`. The one clause edited there is the report's *"these figures adjudicate nothing"*, which this change makes untrue: a negative site step now refuses the window.

## Quality gates

**The spine ran, to completion, and its verdict is a captured number.** `scripts/test-fast-pr.sh`, invoked by absolute path, detached and polled in-turn: `PASS fast PR spine`, captured **exit 0**, **0** `FAIL` lines across 378,273 bytes of log. The exit file is a single clean 7-byte write and the log contains no NUL bytes, so it is not spliced from a second writer. Classified `docs=false jvm=true node=true`.

| tier | result |
|---|---|
| static / drift (always-on) | all green |
| JVM — `implementation/core` | **2,243 tests, 11,681 assertions**, 0 failures |
| node — CLJS `:node-test` | **11,771 tests, 59,589 assertions**, 0 failures |
| node — per-namespace isolation | 16 namespaces standalone, 190 tests, 700 assertions |
| node — hicasso invariants | 149 namespaces, 0 warnings |
| node — JS harness self-tests | includes this PR's pin — see below |

**Which tree the gate read.** The spine's log names `C:\Users\miket\code\re-frame2-worktrees\legcollect-4ctls` throughout — the worktree this branch was built in, not a sibling.

**The targeted gate, run directly.** `node core/test/re_frame/bench/p0_ladder_structural.test.cjs` — the pin that owns this change — **82 passed, exit 0**. It also runs *inside* the spine via `npm run test:script-helpers`, and the spine's log carries `p0_ladder_structural.test.cjs: 82 passed`. Both files were verified byte-identical to their committed blobs (`git hash-object` vs `git rev-parse HEAD:<path>`) before that run.

**Sabotage, because a green suite proves little here by construction.** The gate's sign test was flipped to never fire; **4 pins went red** — the replay, the third window, the no-dial pin and the exit-attribution pin — naming exactly what was planted. Restored and verified by content hash (`2b92feef6717254f0ddd5d04381666f60a5d5e48`, unchanged), with a positive control confirming the residue search finds strings that are present.

**Test and assertion counts, before → after.** 74 → **82** tests, 353 → **403** assertions in `p0_ladder_structural.test.cjs` — verified by running the committed-at-`HEAD~` file in a scratch copy of the bench tree (74 passed) against this branch (82 passed). The +8 are deliberately added for this bead. **No pre-existing test was removed.** Two pre-existing surfaces were deliberately edited and are called out rather than left to a reviewer: the exit-wiring pin's assertions (the exit now attributes per gate, so it pins both `legRefusals` and `intraLegRefusals` wiring instead of the single old `refusedWindows` branch), and `allocSummaryFor` gained an optional third parameter so the by-site summary can be driven without a second harness.

**The discriminating test, both directions.** The replay refuses the two windows that certified — driven through `allocSiteSplit` → `allocPrimeSplit` → `allocSteps` → `allocWindowVerdict`, the driver's own four calls, over the site legs `rf2-ojehu` actually recorded — while asserting on each that `falls === 0` and the τ gate certified, so the gap is shown to be real rather than assumed. It does **not** refuse clean windows: 48 of the 72 measured windows carry no negative site step and are untouched, and there are explicit non-vacuity pins including a window of seven 1.8 MB legs, since magnitude is not the test.

**The spine-versus-required-CI gap**, derived rather than enumerated by hand: `python scripts/check_fast_pr_gap.py --list` reports **94 required checks this spine does not run**. That is a fact about the spine, not a census of this run. The spine's own `NOT RUN` block names three families: documentation gates (docs surface unchanged), the JVM artefact suites for the 20 artefacts this diff does not touch, and the CI-only lanes (browser, prod-elision / bundle-isolation / perf, adapter probes and smokes, Xray feature matrix, mcp-conformance, tool JVM suites).

**Skipped, with reasons.** Documentation gates — no file under `docs/` is touched by this PR. `mkdocs build --strict` — same reason. Browser lanes — this change is two `.cjs` files under `implementation/core/test/`, reached by no browser build; CI owns them regardless.
