### PR TITLE
docs(hicasso): the three-null window ran, and the +0.022 offset did not reproduce (rf2-lo7uy)

### DIFF
--- a/docs/design/hicasso/studio/the-cold-read-mount-term.md
+++ b/docs/design/hicasso/studio/the-cold-read-mount-term.md
@@ -442,6 +442,113 @@ and settled between samples behind a residue equality gate that never fired):
 > one of its original terms still does not resolve, and a decomposition with
 > an unresolved term is not one.
 
+> **THE THREE-NULL WINDOW RAN, AND THE `+0.022` OFFSET DID NOT REPRODUCE**
+> (`rf2-lo7uy`, 2026-08-17, base `3be82b04bc` on `origin/main`; instrument
+> blob `c220a8c23c`, `:advanced`, Playwright HeadlessChrome 147.0.7727.15).
+> Three runs — the count fixed before run 1 started, so no stopping rule could
+> end the series on a convenient answer — `exit 0` on each, both arm-order
+> guards reportable on each, the phase-A positive control passing on each, the
+> phase-B residue gate never firing. **Nothing refused.** The window shape is
+> unchanged again: 32 frames, 8 × (2 + 8) = 64 kept samples per arm, grid
+> 0.0015625 ms/commit. Eleven arms rather than nine, because PR #8384 appended
+> two more nulls *before* the window opened and took no measurement itself, so
+> this is a new series and its absolutes are not arm-by-arm comparable with the
+> nine-arm runs above.
+>
+> **What the window was for.** One null is one pair of slots, so `rf2-3l6hf`'s
+> `c-null` could say the offset's SIZE and not its CAUSE. `c-null-twin` sits at
+> slot 9, on `c-local`'s kept-sample position footprint EXACTLY; `c-null-curve`
+> sits at slot 10, sharing `c-local`'s mean position on a different footprint;
+> `c-null` stays at slot 2 where the published window had it. All three are
+> `c-local` again through the same `mk-local`, so all three deltas have a true
+> cost of exactly zero and differ in nothing but slot.
+>
+> **The estimator, named as computed.** Every run-level figure below is a
+> difference of two **pooled medians**, each over an arm's 64 kept samples
+> divided by the 32-frame window — the mean of the 32nd and 33rd *order
+> statistics*, not an arithmetic mean of the samples. Where a figure is the
+> arithmetic mean of the three run-level deltas, or a within-round median, it
+> is called that.
+>
+> | null (`c-local −` the arm) | slot | footprint | run 1 | run 2 | run 3 | range |
+> |---|---|---|---|---|---|---|
+> | `c-null`, displaced in mean and shape | 2 | `[0 0 2 4 5 6 7 9]` | +0.0109 | −0.0188 | +0.0313 | 0.0501 |
+> | **`c-null-twin`, `c-local`'s footprint exactly** | 9 | `[1 3 4 5 6 7 8 10]` | **−0.0031** | **+0.0047** | **−0.0047** | **0.0094** |
+> | `c-null-curve`, same mean, other shape | 10 | `[2 3 4 5 6 7 8 9]` | −0.0281 | −0.0250 | +0.0203 | 0.0484 |
+>
+> **THE OFFSET WAS NOT THERE TO BE DIAGNOSED.** On the same arm pair, both arms
+> at the slots the predecessor published them at, this series read `+0.0109 /
+> −0.0188 / +0.0313` — sign-changing, spanning 32 grid steps. The predecessor
+> read `+0.0234 / +0.0219 / +0.0234`, spanning one. The stable positive offset
+> whose cause this bead exists to establish did not appear on `c-null`, on the
+> twin, or on the curve. **So its cause is still not established**, and the
+> honest reading is narrower than either outcome the bead anticipated: a
+> `+0.022` offset stable to one grid step is not a reproducible property of
+> this instrument across a change of layout.
+>
+> **One positive finding, with its caveats attached.** The twin is the only one
+> of the eight deltas whose run-level range is small — `0.0094` against
+> `0.0360`–`0.0515` for the other seven, which include both other nulls. The
+> raw pooled medians say why: `c-local` read `0.5922 / 0.5875 / 0.6406` and the
+> twin `0.5953 / 0.5828 / 0.6453`, rising together by `+0.0531` and `+0.0625`
+> between runs 2 and 3, while `c-null` moved `+0.0031` and the curve `+0.0078`
+> across the same transition. Arms sharing a position footprint co-moved; arms
+> not sharing one did not. That is a position-linked component in the
+> instrument's **run-level** error. But it rests on **one** of the two
+> transitions three runs afford; there is **no second null pair** to corroborate
+> it, because `c-local`'s footprint is shared only with the twin and every other
+> footprint-sharing pair puts two *different workloads* together; and it is
+> **absent at round granularity**, where the within-round p50 deltas' standard
+> deviations are `0.0415` (twin), `0.0447` (`c-null`) and `0.0460` (curve) over
+> the window's 24 rounds — ratios of 1.08 and 1.11, so position control removes
+> essentially nothing from the round-to-round scatter.
+>
+> **The window also found a limit in its own rig, and did not repair it.**
+> `c-null-curve`'s job is to cancel a *linear* drift by matching `c-local`'s
+> mean position. That cancellation is exact for an arithmetic mean and only
+> first-order true for the median this instrument actually reports: two arms
+> sharing a footprint exactly have identical pooled mixtures and therefore
+> identical medians for any drift whatever, but two arms sharing only the mean
+> differ at second order in a term carrying the *variance* of the position
+> multiset — 7.25 for `c-local` against 5.25 for the curve. **So a non-zero
+> curve reading does not establish curvature, and this window concludes nothing
+> about whether the drift is linear.** It is recorded rather than fixed:
+> `n` feeds `lane/slot-order`, so touching the roster moves every published
+> footprint and starts a third series.
+>
+> **What is NOT concluded.** Not that the offset is fixed or was an artefact of
+> nine arms. Not that any candidate is its cause — it was not observed. Not any
+> separation of a residual arm-position effect from a within-sweep thermal or
+> cache drift: the twin cancels **any** function of sweep position whatever its
+> physical cause, so both fall on the same side of it. Not any bound on any
+> term — no null was subtracted from any term, and both prohibitions carried
+> from `rf2-3l6hf` stand. Not any restatement of the terms above; the five
+> ablation figures this series recorded are its own and supersede nothing.
+>
+> **The box.** Processor Queue Length (`\System\Processor Queue Length`) was
+> sampled on its own, five samples at 1 s, immediately before the window and
+> between every pair of runs on a 24-core host: `0,0,0,0,0` at 00:42:46,
+> `0,0,0,0,1` at 00:45:40, `0,0,0,0,0` at 00:47:05, `0,0,0,0,0` at 00:48:32
+> (all +10:00). A second counter, `% Processor Utility`, was read in the same
+> brackets and never exceeded 32.3% including the sampler's own cost — two
+> sources rather than one, because a headline utilisation figure can be wrong
+> by a wide margin while the queue length says whether anything is actually
+> waiting for a core. **Nothing was sampled inside a run**, so the quietness
+> claim is a bracketing claim and nothing stronger. No open PRs and no other
+> worker were in flight.
+>
+> Raw driver output for all three runs is committed beside the instrument at
+> `implementation/hicasso/test/re_frame/bench/hicasso/data/readprofile-lo7uy/`
+> (`run1.txt`, `run2.txt`, `run3.txt`), verbatim except for the one
+> `shadow-cljs - config:` banner line per file, whose absolute path is replaced
+> by `<worktree>` and marked inline as redacted — the portability gate refuses
+> a tracked personal home path. No figure, guard verdict or exit line was
+> touched, and the line counts are unchanged. That directory's `README.md`
+> states the redaction and carries the full tables.
+>
+> **`rf2-07rnj` stays blocked.** It is blocked on the offset's cause being
+> established, and this window did not establish it.
+
 Micro table, over the page's own roster (ns/op): `subscribe-once` 5,284;
 `compute-sub` 1,170; the raw handler invoke 227; `registrar/lookup` 67;
 `frame-state-value` 266; the `call-with-frame-resolution` wrap 206; the

--- a/implementation/hicasso/test/re_frame/bench/hicasso/data/readprofile-lo7uy/README.md
+++ b/implementation/hicasso/test/re_frame/bench/hicasso/data/readprofile-lo7uy/README.md
@@ -1,0 +1,235 @@
+# `read_profile` phase-A/B transcripts — rf2-lo7uy's three-null window
+
+Raw driver output from the three runs of `rf2-lo7uy`'s measurement window
+(2026-08-17), one file per run, in run order. This is the first window taken on
+the instrument with **three** negative controls at three different sweep slots,
+the layout PR #8384 built so that the `+0.022 ms/commit` offset `rf2-3l6hf`
+reported could have its CAUSE read rather than only its size.
+
+**THE HEADLINE IS A NEGATIVE: THE OFFSET DID NOT REPRODUCE.** On the same arm
+pair `rf2-3l6hf` measured it on — `c-local` at slot 1 against `c-null` at slot
+2, both arms at the slots that window published them at — this series read
+`+0.0109 / −0.0188 / +0.0313` ms/commit. Sign-changing, range `0.0501` (32 grid
+steps). The predecessor read `+0.0234 / +0.0219 / +0.0234`, range `0.0015` — one
+grid step. **The stable offset this bead exists to explain was not present in
+this series to be diagnosed**, so its cause is still not established and
+`rf2-07rnj` stays blocked.
+
+What the window did establish is narrower and is set out under "The one
+positive finding" below.
+
+## What produced them
+
+| | |
+|---|---|
+| **Base commit** | `3be82b04bc` (`origin/main` at the time of the window) |
+| **Instrument blob** | `c220a8c23c44ca6e19f9cab90528d932f271a784` (`read_profile_app.cljs`, identical before and after the window — the working tree was clean at both ends and no tracked file was edited until after run 3) |
+| **Window shape** | 32 frames/window, 8 × (2 + 8) = 64 kept samples per arm, grid 0.0015625 ms/commit — **unchanged** from `rf2-3l6hf` and `rf2-07rnj` |
+| **Arms** | 11. Two more than the predecessor window: `c-null-twin` and `c-null-curve` were appended **before** the window opened, by PR #8384, which took no measurement |
+| **Build** | `:advanced`, `goog.DEBUG false` |
+| **Runtime** | HeadlessChrome 147.0.7727.15 (Playwright) |
+| **Outcome** | `exit 0` on all three; both arm-order guards reportable on each; phase-A positive control passing on each; phase-B residue gate never firing |
+
+**Eleven arms is a new series.** `n` is an input to `lane/slot-order`, so every
+arm's position footprint differs from the nine-arm layout even where its slot
+index does not. Absolutes here are **not arm-by-arm comparable** with
+`readprofile-3l6hf/` or `readprofile-07rnj/`, and nothing below reads them as if
+they were.
+
+**The run count was fixed at three before run 1 started**, so no stopping rule
+could end the series on a convenient answer. Three is what the bead's
+2026-08-16T04:55:51Z comment specified.
+
+## The estimator these files report, named as computed
+
+Each `p50` in the phase-B arm table is a **pooled median over the 64 kept
+samples of that arm**, each sample first divided by the 32-frame window; 64
+being even, that median is the mean of the 32nd and 33rd **order statistics**.
+That is the standard median — it is **not** an arithmetic mean of the samples,
+and it is **not** a mean of per-round medians. Verified at source:
+`lane.cljs`'s `summarise` sorts and indexes.
+
+Each **run-level delta** is the difference of two such pooled medians.
+
+Where a figure below is an **arithmetic mean of the three run-level deltas**, it
+says so in those words. Where it is a **within-round p50 delta** — the median of
+one round's 8 kept samples, differenced against `c-local`'s, as the rig records
+under `:read-profile-commit-per-round-deltas` — it says that instead.
+
+## The layout, and why it can discriminate
+
+`rounds-async!` hands `lane/slot-order` the SAMPLE index, not the round, so the
+schedule repeats identically every round and an arm's multiset of sweep
+positions is fixed for the whole run. The transcripts carry it under
+`:read-profile-slot-plan`. At `n = 11` and this window's `2 + 8` sampling:
+
+| slot | arm | kept-sample positions | mean | positional variance |
+|---|---|---|---|---|
+| 1 | `c-local` | `[1 3 4 5 6 7 8 10]` | 5.500 | 7.25 |
+| 2 | `c-null` | `[0 0 2 4 5 6 7 9]` | 4.125 | 9.359 |
+| 9 | `c-null-twin` | `[1 3 4 5 6 7 8 10]` | 5.500 | 7.25 |
+| 10 | `c-null-curve` | `[2 3 4 5 6 7 8 9]` | 5.500 | 5.25 |
+
+All four arms are `C-FULL` built from the same `mk-local`, so each of the three
+`c-local − null` deltas has a true cost of **exactly zero by construction** and
+the arms differ in nothing but their slot.
+
+`c-null-twin` occupies `c-local`'s footprint exactly. `c-null-curve` shares its
+mean position on a different footprint. `c-null` is displaced in both.
+
+## The three nulls
+
+Run-level deltas (`c-local −` the arm), in ms/commit, straight off each file's
+own `PHASE B DELTAS` block:
+
+| null | slot | run 1 | run 2 | run 3 | arith. mean of the three | range | range in grid steps |
+|---|---|---|---|---|---|---|---|
+| `c-null` (displaced) | 2 | +0.0109 | −0.0188 | +0.0313 | +0.0078 | 0.0501 | 32 |
+| **`c-null-twin`** (same footprint) | 9 | **−0.0031** | **+0.0047** | **−0.0047** | **−0.0010** | **0.0094** | **6** |
+| `c-null-curve` (same mean) | 10 | −0.0281 | −0.0250 | +0.0203 | −0.0109 | 0.0484 | 31 |
+
+For scale, the same three columns for the ablation terms, which are **not**
+nulls and whose true costs are unknown and positive:
+
+| term (`c-local −` the arm) | run 1 | run 2 | run 3 | range |
+|---|---|---|---|---|
+| reaction build + cache insert (`c-nosub`) | +0.3891 | +0.3859 | +0.4344 | 0.0485 |
+| watch wiring (`c-nowatch`) | +0.0344 | +0.0156 | +0.0641 | 0.0485 |
+| cell-map insert (`c-nomap`) | +0.0062 | +0.0375 | +0.0500 | 0.0438 |
+| activation capture (`c-noactivate`) | +0.0359 | −0.0109 | +0.0406 | 0.0515 |
+| reader membership (`c-noreaders`) | −0.0219 | −0.0125 | +0.0141 | 0.0360 |
+
+## The one positive finding
+
+**The twin is the only one of the eight deltas whose run-level range is small**
+— `0.0094` (6 grid steps) against `0.0360`–`0.0515` (23–33 steps) for the other
+seven, which include the two other nulls whose true cost is also exactly zero.
+
+The raw pooled medians show the mechanism directly. Across the three runs:
+
+| arm | footprint | run 1 | run 2 | run 3 | its own range |
+|---|---|---|---|---|---|
+| `c-local` | `[1 3 4 5 6 7 8 10]` | 0.5922 | 0.5875 | 0.6406 | 0.0531 |
+| `c-null-twin` | `[1 3 4 5 6 7 8 10]` | 0.5953 | 0.5828 | 0.6453 | 0.0625 |
+| `c-null` | `[0 0 2 4 5 6 7 9]` | 0.5812 | 0.6063 | 0.6094 | 0.0282 |
+| `c-null-curve` | `[2 3 4 5 6 7 8 9]` | 0.6203 | 0.6125 | 0.6203 | 0.0078 |
+
+Between run 2 and run 3 `c-local` rose `+0.0531` and the twin rose `+0.0625`,
+while `c-null` moved `+0.0031` and the curve `+0.0078`. The two arms sharing a
+position footprint moved together; the two that do not share it did not.
+
+That is a position-linked component in the instrument's **run-level** error —
+which is what the twin was placed to detect, and it detected something.
+
+**Three caveats travel with that finding and none of them is optional.**
+
+1. **It rests on ONE transition.** Three runs give two run-to-run transitions.
+   The co-movement is clean in run 2 → run 3 and weak in run 1 → run 2
+   (`c-local` −0.0047, twin −0.0125, `c-null` +0.0251, curve −0.0078).
+2. **There is no second null pair to corroborate it.** Of the five distinct
+   footprints in this layout, `c-local`'s is shared only with the twin, and the
+   other footprint-sharing pairs (`c-null`/`b-build`, `commit`/`c-null-curve`,
+   `c-noactivate`/`c-nomap`, `c-nowatch`/`c-noreaders`) each pair arms doing
+   **different work**, so none of them is a second null.
+3. **The effect is absent at round granularity.** Over the 24 rounds of the
+   window (3 runs × 8), the standard deviations of the within-round p50 deltas
+   are `0.0415` (twin), `0.0447` (`c-null`) and `0.0460` (curve) — ratios of
+   1.08 and 1.11 to the twin. Position control removes essentially nothing from
+   the round-to-round scatter. Whatever the twin cancels lives in the run-level
+   term only.
+
+## What this window found out about its own rig, and did not act on
+
+**`c-null-curve` cannot test linearity under a median estimator, and the rig's
+docstring says it can.** The claim is that an arm sharing `c-local`'s MEAN
+position cancels a linear within-sweep drift. That is exact for an arithmetic
+mean and only first-order true for a median, which is what `lane/summarise`
+actually computes.
+
+Write a kept sample as `Y + g(p)`, `Y` the noise and `g` the drift. An arm's
+pooled sample is the mixture `(1/8) Σ_p F(x − g(p))` over its footprint. When
+two arms share a footprint **exactly** the two mixtures are identical, so their
+medians are identical for **any** `g` — the twin's argument survives the
+estimator. When they share only the mean, the mixtures agree to first order in
+`g` and differ at second order by a term in the **variance** of the position
+multiset — and those variances are not equal here: 7.25 for `c-local`, 5.25 for
+the curve.
+
+So a non-zero curve reading does not establish curvature, and **this window
+therefore does not conclude anything about whether the drift is linear.**
+
+This is recorded, not repaired. `n` feeds `lane/slot-order`, so touching the
+roster moves every published footprint and starts a third series — the same
+rule that made PR #8384 a separate, measurement-free edit half.
+
+## The box
+
+`\System\Processor Queue Length` was sampled **on its own** and **outside every
+measured run** — five samples at 1 s, immediately before the window and between
+every pair of runs — on a 24-core host. All times +10:00.
+
+| bracket | time | PQL | `% Processor Utility` |
+|---|---|---|---|
+| before run 1 | 00:42:46–50 | `0,0,0,0,0` | not sampled |
+| after run 1 | 00:45:40–44 | `0,0,0,0,1` | 14.7, 12.2, 18.9, 15.2, 12.2 |
+| after run 2 | 00:47:05–09 | `0,0,0,0,0` | 12.2, 11.4, 9.3, 10.9, 9.6 |
+| after run 3 | 00:48:32–36 | `0,0,0,0,0` | 9.7, 17.2, 8.7, 32.3, 27.4 |
+
+Two counters rather than one, because a headline utilisation figure can be
+wrong by a wide margin; the queue length is the one that says whether anything
+is actually waiting for a core, and it read 0 in 19 of 20 samples. The single
+`1` and the 32.3% utility reading were both taken **between** runs, and the
+utility figures include the sampler itself.
+
+**Nothing was sampled inside a run**, deliberately — a counter read inside a
+measured window makes the sampler part of the measurement. **The quietness
+claim here is a bracketing claim and nothing stronger.** No open PRs and no
+other worker were in flight when the window was taken. Each run's own `run.cjs`
+rebuilds the `:advanced` bundle before measuring, and that compile saturates
+this box; the bracket readings sit outside those compiles.
+
+## What was NOT concluded
+
+- **NOT** that the offset is fixed, gone, or was an artefact of nine arms.
+  `n` changed, so the two series are not comparable arm by arm. What is
+  established is only that a `+0.022` offset stable to one grid step is **not a
+  reproducible property of this instrument across a change of layout**.
+- **NOT** that candidate (a) is the cause of that offset. The offset was not
+  observed here, so nothing here can be its cause.
+- **NOT** that the drift is linear or non-linear — see the estimator caveat
+  above.
+- **NOT** any separation of (a) from (b). The twin cancels **any** function of
+  sweep position whatever its physical cause, so a residual arm-position effect
+  and a within-sweep thermal or cache drift fall on the same side of it. This
+  rig cannot split them.
+- **NOT** any bound on any term. No null was subtracted from any term, and no
+  null spread is quoted as an upper or lower bound on anything. Both
+  prohibitions carried from `rf2-3l6hf` stand: `c-null` calibrates slot 1
+  against slot 2 while reader membership differences slot 1 against slot 6, and
+  a null is a measured property of the ESTIMATOR, not of a cost.
+- **NOT** any claim about within-run quietness beyond the bracketing above.
+- **NOT** a restatement of `rf2-07rnj`'s or `§1`'s published terms. The five
+  ablation figures in the second table are this eleven-arm series' own and
+  supersede nothing.
+
+## Reproduction
+
+```bash
+HICASSO_INIT_FN=re-frame.bench.hicasso.read-profile-app/-main \
+HICASSO_OUT_DIR=out/hicasso-readprof \
+  node implementation/hicasso/test/re_frame/bench/hicasso/run.cjs
+```
+
+## The one redaction, stated so nobody reads these as doctored
+
+Each file is the driver's output verbatim **except for exactly one line**, the
+`shadow-cljs - config:` banner, whose absolute path is replaced by `<worktree>`
+and marked inline as redacted. Nothing else was touched — no figure, no guard
+verdict, no exit line, and the line counts are unchanged (260 / 259 / 259).
+
+The path was the window's proof that every build read the worker's own worktree
+rather than the mayor checkout, which is why the line is kept rather than
+deleted. It cannot be committed as it stood: the portability gate
+(`scripts/check-no-hardcoded-paths.sh`) refuses any tracked file carrying a
+personal home path, correctly and with no escape hatch. Re-running the command
+above prints the same banner with the reader's own checkout in it.

--- a/implementation/hicasso/test/re_frame/bench/hicasso/data/readprofile-lo7uy/run1.txt
+++ b/implementation/hicasso/test/re_frame/bench/hicasso/data/readprofile-lo7uy/run1.txt
@@ -1,0 +1,260 @@
+[hicasso] building :advanced bundle — re-frame.bench.hicasso.read-profile-app/-main -> out/hicasso-readprof
+shadow-cljs - updating dependencies
+shadow-cljs - dependencies updated
+[:hicasso-bench] Compiling ...
+[:hicasso-bench] Build completed. (187 files, 132 compiled, 0 warnings, 17.71s)
+shadow-cljs - config: <worktree>/implementation/shadow-cljs.edn   [PATH REDACTED — see README.md]
+;; order-guard ok   the recorded 2.01x is REFUSED  — ratio 2.0125
+;; order-guard ok   the same study's uncontaminated slope passes  — forward 2830.7 / reversed 2842.8
+;; order-guard ok   a single-order result is refused as UNCHECKED  — only 1 stratum — the question was never asked
+;; order-guard ok   overlapping ranges are indistinguishable even 20% apart in median  — medians 1.2000x apart but the ranges OVERLAP — indistinguishable
+;; order-guard ok   the measured warm-up step is caught by PHASE, which no reversal would show  — phase: FIRST-THIRD reads 1.2633x LAST-THIRD, ranges disjoint
+;; order-guard ok   an arm that reads exactly zero in both strata is indistinguishable, not infinite  — within 10%
+;; order-guard ok   cyclic rotation gives every arm exactly ONE within-round predecessor  — rotation over 6 rounds: distinct predecessors per arm 1,1,1,1 (only the round seam ever differs, and that is one sample in R)
+;; order-guard ok   the reflecting schedule gives every arm TWO, in balance  — reflected: 2,2,2,2 predecessors per arm, largest modal share 50%
+;; order-guard ok   at k=2 an ALWAYS-reflecting schedule runs one order for ever and is UNCHECKED  — always-reflect over 6 rounds of 2 arms: 1 distinct order(s), predecessors per arm 2,1 — rotating a pair by one IS reversing it, so the two cancel
+;; order-guard ok   at k=2 slot-order alternates, and every arm gets TWO predecessors in balance  — slot-order: 2 distinct orders, predecessors per arm 3,2, largest modal share 50%
+;; order-guard ok   samples whose :position went NON-FINITE refuse instead of narrowing the question  — 18 of 24 samples have NO USABLE :position (nil, absent or non-finite) in a run that records them — the harness lost them, so this contrast is over the rest and the sample count above is not it
+;; order-guard ok   a present-but-NIL :position is the same loss, and recording NONE is still excused  — 18 of 24 samples have NO USABLE :position (nil, absent or non-finite) in a run that records them — the harness lost them, so this contrast is over the rest and the sample count above is not it — and a run offering no position at all is excused, not refused
+;; harvest OK — 1202 elements, 141 reads (141 distinct), from the real page's own entry
+;; ==== ARM-ORDER GUARD — read-profile phase A (in-page ms, diagnostic) ====
+;;   every arm partitioned by WHAT RAN BEFORE IT and by WHERE IN THE RUN it was measured; tolerance 10%, overlapping ranges are indistinguishable
+;;   ctl2  (60 samples)
+;;     [ok  ] by predecessor  within 10%
+;;              ship                     n=30  p50       7.8000  [6.6000–10.3000]
+;;              warm                     n=30  p50       8.0000  [7.5000–9.8000]
+;;     [ok  ] by phase        within 10%
+;;              LAST-THIRD               n=20  p50       7.9000  [6.6000–10.3000]
+;;              FIRST-THIRD              n=20  p50       7.9500  [7.5000–9.5000]
+;;   floor  (60 samples)
+;;     [ok  ] by predecessor  within 10%
+;;              probe-fresh              n=30  p50       0.2000  [0.1000–0.4000]
+;;              warm                     n=30  p50       0.2000  [0.1000–0.3000]
+;;     [ok  ] by phase        within 10%
+;;              FIRST-THIRD              n=20  p50       0.2000  [0.1000–0.3000]
+;;              LAST-THIRD               n=20  p50       0.2000  [0.1000–0.4000]
+;;   local  (60 samples)
+;;     [ok  ] by predecessor  within 10%
+;;              ship                     n=30  p50       4.0000  [3.7000–5.7000]
+;;              no-shell                 n=30  p50       4.2000  [3.6000–5.1000]
+;;     [ok  ] by phase        within 10%
+;;              LAST-THIRD               n=20  p50       4.0000  [3.6000–5.7000]
+;;              FIRST-THIRD              n=20  p50       4.2000  [3.7000–4.6000]
+;;   no-shell  (60 samples)
+;;     [ok  ] by predecessor  within 10%
+;;              probe                    n=24  p50       3.8500  [3.2000–5.0000]
+;;              local                    n=36  p50       4.0000  [3.4000–6.8000]
+;;     [ok  ] by phase        within 10%
+;;              LAST-THIRD               n=20  p50       3.8500  [3.2000–4.5000]
+;;              FIRST-THIRD              n=20  p50       4.0000  [3.4000–6.6000]
+;;   probe  (60 samples)
+;;     [ok  ] by predecessor  within 10%
+;;              probe-fresh              n=30  p50       1.8000  [1.5000–3.1000]
+;;              no-shell                 n=30  p50       1.9000  [1.6000–2.9000]
+;;     [ok  ] by phase        within 10%
+;;              LAST-THIRD               n=20  p50       1.8000  [1.6000–2.9000]
+;;              FIRST-THIRD              n=20  p50       1.9000  [1.7000–3.1000]
+;;   probe-fresh  (60 samples)
+;;     [ok  ] by predecessor  within 10%
+;;              floor                    n=18  p50       0.9000  [0.7000–1.3000]
+;;              probe                    n=42  p50       0.9500  [0.7000–1.4000]
+;;     [ok  ] by phase        medians 1.1111x apart but the ranges OVERLAP — indistinguishable
+;;              LAST-THIRD               n=20  p50       0.9000  [0.7000–1.3000]
+;;              FIRST-THIRD              n=20  p50       1.0000  [0.8000–1.3000]
+;;   ship  (60 samples)
+;;     [ok  ] by predecessor  within 10%
+;;              local                    n=24  p50       2.0500  [1.7000–2.5000]
+;;              ctl2                     n=36  p50       2.1000  [1.7000–3.3000]
+;;     [ok  ] by phase        medians 1.1000x apart but the ranges OVERLAP — indistinguishable
+;;              LAST-THIRD               n=20  p50       2.0000  [1.7000–2.4000]
+;;              FIRST-THIRD              n=20  p50       2.2000  [1.9000–3.3000]
+;;   warm  (60 samples)
+;;     [ok  ] by predecessor  within 10%
+;;              floor                    n=36  p50       0.4000  [0.2000–0.8000]
+;;              ctl2                     n=24  p50       0.4000  [0.2000–0.6000]
+;;     [ok  ] by phase        within 10%
+;;              LAST-THIRD               n=20  p50       0.4000  [0.2000–0.8000]
+;;              FIRST-THIRD              n=20  p50       0.4000  [0.3000–0.5000]
+;;   VERDICT: reportable — no arm reads differently for its position in the plan
+;; HICASSO read-profile-census
+{:reads 141, :distinct 141, :by-sub-id {:conduit/your-feed? 1, :conduit/slugs 1, :conduit/tags 1, :conduit/article 69, :conduit/favorite-pending? 69}, :input-kinds {:db 141}}
+;; HICASSO read-profile-arms
+{:ship {:n 60, :min 0.2125, :max 0.4125, :p50 0.2625}, :local {:n 60, :min 0.45, :max 0.7125, :p50 0.5125}, :no-shell {:n 60, :min 0.4, :max 0.85, :p50 0.5}, :probe {:n 60, :min 0.1875, :max 0.3875, :p50 0.225}, :probe-fresh {:n 60, :min 0.0875, :max 0.175, :p50 0.1125}, :floor {:n 60, :min 0.0125, :max 0.05, :p50 0.025}, :warm {:n 60, :min 0.025, :max 0.1, :p50 0.05}, :ctl2 {:n 60, :min 0.825, :max 1.2875, :p50 0.9875}}
+;; ==== READ PROFILE, PHASE A (ms per 141-read pass; diagnostic in-page clock) ====
+;;   reads/pass 141  passes/sample 8  design 6x(4+10)
+;;   ship: p50 0.2625 [0.2125 - 0.4125] ms/pass  (1.86 us/read)
+;;   local: p50 0.5125 [0.4500 - 0.7125] ms/pass  (3.63 us/read)
+;;   no-shell: p50 0.5000 [0.4000 - 0.8500] ms/pass  (3.55 us/read)
+;;   probe: p50 0.2250 [0.1875 - 0.3875] ms/pass  (1.60 us/read)
+;;   probe-fresh: p50 0.1125 [0.0875 - 0.1750] ms/pass  (0.80 us/read)
+;;   floor: p50 0.0250 [0.0125 - 0.0500] ms/pass  (0.18 us/read)
+;;   warm: p50 0.0500 [0.0250 - 0.1000] ms/pass  (0.35 us/read)
+;;   ctl2: p50 0.9875 [0.8250 - 1.2875] ms/pass  (7.00 us/read)
+;; ==== PHASE A DELTAS (floors; stubs stated in the ns docstring) ====
+;;   copy fidelity: local/ship = 1.9524  (local is the FROZEN subscribe-once path)
+;;   the-hicasso-shell (local - no-shell): delta 0.0125 ms/pass (0.09 us/read, 2.4% of the baseline)
+;;   churn-vs-probe (local - probe, the candidate's saving): delta 0.2875 ms/pass (2.04 us/read, 56.1% of the baseline)
+;;   memo-economy (probe-fresh - probe): delta -0.1125 ms/pass (-0.80 us/read, -100.0% of the baseline)
+;;   probe-overhead (probe - floor): delta 0.2000 ms/pass (1.42 us/read, 88.9% of the baseline)
+;;   warm steady-state: 0.0500 ms/pass (0.35 us/read)
+;;   control: predicted 1.000x, measured 0.988x [0.825–1.288] — the range meets the prediction within ±25%
+;; ==== ARM-ORDER GUARD — read-profile phase B (in-page ms, diagnostic) ====
+;;   every arm partitioned by WHAT RAN BEFORE IT and by WHERE IN THE RUN it was measured; tolerance 10%, overlapping ranges are indistinguishable
+;;   b-build  (64 samples)
+;;     [ok  ] by predecessor  within 10%
+;;              c-null-twin              n=24  p50      14.8500  [12.2000–18.9000]
+;;              c-nomap                  n=40  p50      15.8000  [11.5000–22.2000]
+;;     [ok  ] by phase        within 10%
+;;              FIRST-THIRD              n=21  p50      15.2000  [11.9000–18.5000]
+;;              LAST-THIRD               n=21  p50      15.9000  [12.2000–22.2000]
+;;   c-local  (64 samples)
+;;     [ok  ] by predecessor  within 10%
+;;              commit                   n=32  p50      18.6000  [15.4000–26.5000]
+;;              c-null                   n=32  p50      19.0500  [14.9000–24.9000]
+;;     [ok  ] by phase        medians 1.1445x apart but the ranges OVERLAP — indistinguishable
+;;              FIRST-THIRD              n=21  p50      17.3000  [15.2000–23.7000]
+;;              LAST-THIRD               n=21  p50      19.8000  [14.9000–26.5000]
+;;   c-noactivate  (64 samples)
+;;     [ok  ] by predecessor  within 10%
+;;              c-nowatch                n=32  p50      17.3000  [14.4000–29.1000]
+;;              c-null                   n=32  p50      18.4000  [14.2000–25.2000]
+;;     [ok  ] by phase        medians 1.1273x apart but the ranges OVERLAP — indistinguishable
+;;              FIRST-THIRD              n=21  p50      16.5000  [14.2000–24.0000]
+;;              LAST-THIRD               n=21  p50      18.6000  [14.6000–29.1000]
+;;   c-nomap  (64 samples)
+;;     [ok  ] by predecessor  within 10%
+;;              c-noreaders              n=32  p50      18.6000  [13.5000–31.9000]
+;;              b-build                  n=32  p50      19.0500  [13.8000–24.0000]
+;;     [ok  ] by phase        within 10%
+;;              FIRST-THIRD              n=21  p50      18.3000  [13.8000–24.0000]
+;;              LAST-THIRD               n=21  p50      18.8000  [14.6000–22.0000]
+;;   c-noreaders  (64 samples)
+;;     [ok  ] by predecessor  within 10%
+;;              c-nosub                  n=40  p50      19.1000  [14.2000–22.9000]
+;;              c-nomap                  n=24  p50      20.2000  [14.9000–26.2000]
+;;     [ok  ] by phase        within 10%
+;;              FIRST-THIRD              n=21  p50      18.6000  [14.6000–26.2000]
+;;              LAST-THIRD               n=21  p50      20.4000  [15.2000–25.8000]
+;;   c-nosub  (64 samples)
+;;     [ok  ] by predecessor  within 10%
+;;              c-nowatch                n=32  p50       6.4000  [4.9000–8.4000]
+;;              c-noreaders              n=32  p50       6.5000  [5.0000–10.0000]
+;;     [ok  ] by phase        medians 1.1639x apart but the ranges OVERLAP — indistinguishable
+;;              FIRST-THIRD              n=21  p50       6.1000  [5.1000–8.4000]
+;;              LAST-THIRD               n=21  p50       7.1000  [5.5000–10.0000]
+;;   c-nowatch  (64 samples)
+;;     [ok  ] by predecessor  within 10%
+;;              c-nosub                  n=24  p50      17.7500  [13.6000–23.8000]
+;;              c-noactivate             n=40  p50      17.9500  [14.0000–23.3000]
+;;     [ok  ] by phase        within 10%
+;;              FIRST-THIRD              n=21  p50      17.4000  [14.0000–22.4000]
+;;              LAST-THIRD               n=21  p50      18.6000  [13.6000–23.3000]
+;;   c-null  (64 samples)
+;;     [ok  ] by predecessor  medians 1.2355x apart but the ranges OVERLAP — indistinguishable
+;;              c-local                  n=32  p50      16.3500  [14.5000–28.0000]
+;;              c-null-twin              n= 7  p50      20.1000  [14.6000–22.6000]
+;;              c-noactivate             n=24  p50      20.2000  [14.7000–24.8000]
+;;              <none>                   n= 1  p50      20.3000  [20.3000–20.3000]
+;;     [ok  ] by phase        medians 1.2331x apart but the ranges OVERLAP — indistinguishable
+;;              FIRST-THIRD              n=21  p50      16.3000  [14.5000–23.1000]
+;;              LAST-THIRD               n=21  p50      20.1000  [14.6000–28.0000]
+;;   c-null-curve  (64 samples)
+;;     [ok  ] by predecessor  within 10%
+;;              commit                   n=32  p50      19.7500  [15.4000–31.0000]
+;;              c-null-twin              n=32  p50      20.0000  [14.9000–33.1000]
+;;     [ok  ] by phase        medians 1.1444x apart but the ranges OVERLAP — indistinguishable
+;;              FIRST-THIRD              n=21  p50      18.0000  [15.4000–33.1000]
+;;              LAST-THIRD               n=21  p50      20.6000  [14.9000–26.0000]
+;;   c-null-twin  (64 samples)
+;;     [ok  ] by predecessor  within 10%
+;;              c-null-curve             n=32  p50      18.1000  [14.8000–25.3000]
+;;              b-build                  n=32  p50      19.8500  [15.6000–30.8000]
+;;     [ok  ] by phase        medians 1.1099x apart but the ranges OVERLAP — indistinguishable
+;;              FIRST-THIRD              n=21  p50      18.2000  [14.9000–24.1000]
+;;              LAST-THIRD               n=21  p50      20.2000  [15.4000–23.9000]
+;;   commit  (64 samples)
+;;     [ok  ] by predecessor  medians 1.1066x apart but the ranges OVERLAP — indistinguishable
+;;              c-null-curve             n=32  p50      18.3000  [15.4000–24.7000]
+;;              c-local                  n=32  p50      20.2500  [15.8000–27.6000]
+;;     [ok  ] by phase        medians 1.1467x apart but the ranges OVERLAP — indistinguishable
+;;              FIRST-THIRD              n=21  p50      18.4000  [15.4000–26.6000]
+;;              LAST-THIRD               n=21  p50      21.1000  [16.0000–24.7000]
+;;   VERDICT: reportable — no arm reads differently for its position in the plan
+;; HICASSO read-profile-commit
+{:c-null-twin {:n 64, :min 0.4625, :max 0.9625, :p50 0.5953}, :c-local {:n 64, :min 0.4656, :max 0.8281, :p50 0.5922}, :c-noreaders {:n 64, :min 0.4438, :max 0.8188, :p50 0.6141}, :c-noactivate {:n 64, :min 0.4437, :max 0.9094, :p50 0.5563}, :c-null {:n 64, :min 0.4531, :max 0.875, :p50 0.5812}, :c-nowatch {:n 64, :min 0.425, :max 0.7438, :p50 0.5578}, :commit {:n 64, :min 0.4813, :max 0.8625, :p50 0.6063}, :c-nomap {:n 64, :min 0.4219, :max 0.9969, :p50 0.5859}, :b-build {:n 64, :min 0.3594, :max 0.6937, :p50 0.4891}, :c-null-curve {:n 64, :min 0.4656, :max 1.0344, :p50 0.6203}, :c-nosub {:n 64, :min 0.1531, :max 0.3125, :p50 0.2031}}
+;; HICASSO read-profile-commit-per-round
+{:c-null-twin [0.6234 0.5344 0.5313 0.6328 0.5469 0.6453 0.6141 0.5844], :c-local [0.6187 0.5203 0.5187 0.6266 0.5594 0.6453 0.6516 0.525], :c-noreaders [0.6281 0.5422 0.5828 0.6266 0.5703 0.6531 0.6062 0.6109], :c-noactivate [0.5172 0.4938 0.5203 0.6078 0.5172 0.6578 0.6188 0.4984], :c-null [0.5578 0.4703 0.5844 0.6219 0.5516 0.6359 0.6375 0.5641], :c-nowatch [0.5531 0.5375 0.4937 0.5922 0.5344 0.5891 0.6172 0.5125], :commit [0.6031 0.5594 0.575 0.6234 0.5547 0.6703 0.6563 0.5859], :c-nomap [0.6609 0.5344 0.5 0.6063 0.5484 0.6516 0.5672 0.5828], :b-build [0.4688 0.4578 0.4797 0.4906 0.4078 0.5094 0.4984 0.4891], :c-null-curve [0.6406 0.5625 0.5313 0.6203 0.5484 0.6516 0.7578 0.5172], :c-nosub [0.1953 0.2141 0.1672 0.1984 0.1625 0.2063 0.2219 0.2078]}
+;; HICASSO read-profile-commit-per-round-deltas
+{:c-null [0.0609 0.05 -0.0657 0.0047 0.0078 0.0094 0.0141 -0.0391], :c-noactivate [0.1015 0.0265 -0.0016 0.0188 0.0422 -0.0125 0.0328 0.0266], :c-nowatch [0.0656 -0.0172 0.025 0.0344 0.025 0.0562 0.0344 0.0125], :c-nosub [0.4234 0.3062 0.3515 0.4282 0.3969 0.439 0.4297 0.3172], :c-noreaders [-0.0094 -0.0219 -0.0641 0 -0.0109 -0.0078 0.0454 -0.0859], :c-nomap [-0.0422 -0.0141 0.0187 0.0203 0.011 -0.0063 0.0844 -0.0578], :c-null-twin [-0.0047 -0.0141 -0.0126 -0.0062 0.0125 0 0.0375 -0.0594], :c-null-curve [-0.0219 -0.0422 -0.0126 0.0063 0.011 -0.0063 -0.1062 0.0078]}
+;; HICASSO read-profile-slot-plan
+[{:positions [2 3 4 5 6 7 8 9], :mean-position 5.5, :id :commit, :slot 0} {:positions [1 3 4 5 6 7 8 10], :mean-position 5.5, :id :c-local, :slot 1} {:positions [0 0 2 4 5 6 7 9], :mean-position 4.125, :id :c-null, :slot 2} {:positions [1 1 3 5 6 8 10 10], :mean-position 5.5, :id :c-noactivate, :slot 3} {:positions [0 0 2 2 4 7 9 9], :mean-position 4.125, :id :c-nowatch, :slot 4} {:positions [1 1 3 3 8 8 10 10], :mean-position 5.5, :id :c-nosub, :slot 5} {:positions [0 0 2 2 4 7 9 9], :mean-position 4.125, :id :c-noreaders, :slot 6} {:positions [1 1 3 5 6 8 10 10], :mean-position 5.5, :id :c-nomap, :slot 7} {:positions [0 0 2 4 5 6 7 9], :mean-position 4.125, :id :b-build, :slot 8} {:positions [1 3 4 5 6 7 8 10], :mean-position 5.5, :id :c-null-twin, :slot 9} {:positions [2 3 4 5 6 7 8 9], :mean-position 5.5, :id :c-null-curve, :slot 10}]
+;; ==== READ PROFILE, PHASE B — THE COMMIT HALF (ms per 141-key boundary commit) ====
+;;   design 8x(2+8)  window = 32 frames/commit each  kept = 64 samples/arm (EVEN — p50 is the mean of two middle clock readings)  grid = 0.001563 ms/commit
+;;   slot plan (each arm's kept-sample sweep positions — the schedule is indexed by SAMPLE, so this footprint repeats identically every round; rf2-lo7uy):
+;;     slot 0 commit: [2 3 4 5 6 7 8 9]  mean 5.500
+;;     slot 1 c-local: [1 3 4 5 6 7 8 10]  mean 5.500
+;;     slot 2 c-null: [0 0 2 4 5 6 7 9]  mean 4.125
+;;     slot 3 c-noactivate: [1 1 3 5 6 8 10 10]  mean 5.500
+;;     slot 4 c-nowatch: [0 0 2 2 4 7 9 9]  mean 4.125
+;;     slot 5 c-nosub: [1 1 3 3 8 8 10 10]  mean 5.500
+;;     slot 6 c-noreaders: [0 0 2 2 4 7 9 9]  mean 4.125
+;;     slot 7 c-nomap: [1 1 3 5 6 8 10 10]  mean 5.500
+;;     slot 8 b-build: [0 0 2 4 5 6 7 9]  mean 4.125
+;;     slot 9 c-null-twin: [1 3 4 5 6 7 8 10]  mean 5.500
+;;     slot 10 c-null-curve: [2 3 4 5 6 7 8 9]  mean 5.500
+;;   commit: p50 0.6063 [0.4813 - 0.8625] ms/pass  (4.30 us/read)
+;;   c-local: p50 0.5922 [0.4656 - 0.8281] ms/pass  (4.20 us/read)
+;;   c-null: p50 0.5812 [0.4531 - 0.8750] ms/pass  (4.12 us/read)
+;;   c-noactivate: p50 0.5563 [0.4437 - 0.9094] ms/pass  (3.95 us/read)
+;;   c-nowatch: p50 0.5578 [0.4250 - 0.7438] ms/pass  (3.96 us/read)
+;;   c-nosub: p50 0.2031 [0.1531 - 0.3125] ms/pass  (1.44 us/read)
+;;   c-noreaders: p50 0.6141 [0.4438 - 0.8188] ms/pass  (4.36 us/read)
+;;   c-nomap: p50 0.5859 [0.4219 - 0.9969] ms/pass  (4.16 us/read)
+;;   b-build: p50 0.4891 [0.3594 - 0.6937] ms/pass  (3.47 us/read)
+;;   c-null-twin: p50 0.5953 [0.4625 - 0.9625] ms/pass  (4.22 us/read)
+;;   c-null-curve: p50 0.6203 [0.4656 - 1.0344] ms/pass  (4.40 us/read)
+;; ==== PHASE B DELTAS (c-local minus ablation; floors) ====
+;;   copy fidelity: c-local/commit = 0.9768
+;;   NULL CONTROL (c-local - c-null): delta 0.0109 ms/pass (0.08 us/read, 1.8% of the baseline)
+;;     ^ true cost EXACTLY ZERO by construction — both arms are C-FULL. What it reads is this instrument's own error at this shape, and it is what the terms below are adjudicated against (rf2-3l6hf). It bounds no term's cost: a delta inside this spread is a term the window cannot SEE, which leaves its size open in both directions
+;;     ^ slot 1 against slot 2, on footprints that differ in BOTH mean position and shape. The two nulls below hold that zero and move the SLOT, which is what makes the offset's cause readable rather than only its size (rf2-lo7uy)
+;;   NULL CONTROL, position TWIN (c-local - c-null-twin): delta -0.0031 ms/pass (-0.02 us/read, -0.5% of the baseline)
+;;     ^ same zero, and this arm's kept-sample position footprint IS c-local's, so ANY cost that is a function of sweep position cancels term by term. A reading here is error sweep position cannot explain; a reading of zero here beside a non-zero c-null puts the offset ON position
+;;   NULL CONTROL, equal MEAN position (c-local - c-null-curve): delta -0.0281 ms/pass (-0.20 us/read, -4.7% of the baseline)
+;;     ^ same zero, c-local's MEAN position on a DIFFERENT footprint: a linear within-sweep drift cancels here, a curved one does not. Read the three nulls together — alike means the offset is not positional; c-null alone means it is; c-null and this one means it is and is not linear
+;;   activation-capture (c-local - c-noactivate): delta 0.0359 ms/pass (0.25 us/read, 6.1% of the baseline)
+;;     ^ a REAL term here, NOT a floor and not an arbiter: nothing activates on this UIx host, but the hook key is never published and so never cached, and this prices that lookup (rf2-tcffa, rf2-19usn). The capture itself is real only under the ratom family (rf2-lzpfj)
+;;   watch-wiring (c-local - c-nowatch): delta 0.0344 ms/pass (0.24 us/read, 5.8% of the baseline)
+;;   reaction-build+cache-insert (c-local - c-nosub): delta 0.3891 ms/pass (2.76 us/read, 65.7% of the baseline)
+;;   reader-membership (c-local - c-noreaders): delta -0.0219 ms/pass (-0.16 us/read, -3.7% of the baseline)
+;;   cell-map-insert (c-local - c-nomap): delta 0.0062 ms/pass (0.04 us/read, 1.1% of the baseline)
+;;   b-build (build+compute, no in-window dispose): 0.4891 ms/pass (3.47 us/read)
+;; HICASSO read-profile-micro
+{:subscribe-once 4397.1631, :compute-sub 921.9858, :handler-invoke 241.1348, :registrar-lookup 78.0142, :frame-state-value 294.3262, :resolution-wrap 265.9574, :cache-peek-miss 31.9149, :sub-key-mint 10.6383}
+;; ==== MICRO (ns/op over the page's own roster) ====
+;;   subscribe-once: 4397.2 ns
+;;   compute-sub: 922.0 ns
+;;   handler-invoke: 241.1 ns
+;;   registrar-lookup: 78.0 ns
+;;   frame-state-value: 294.3 ns
+;;   resolution-wrap: 266.0 ns
+;;   cache-peek-miss: 31.9 ns
+;;   sub-key-mint: 10.6 ns
+;; HICASSO DONE
+;; ==== HICASSO RUNTIME ====
+;; chromium 147.0.7727.15 (playwright), :advanced, goog.DEBUG false
+;; ==== HICASSO read-profile-census ====
+{:reads 141, :distinct 141, :by-sub-id {:conduit/your-feed? 1, :conduit/slugs 1, :conduit/tags 1, :conduit/article 69, :conduit/favorite-pending? 69}, :input-kinds {:db 141}}
+;; ==== HICASSO read-profile-arms ====
+{:ship {:n 60, :min 0.2125, :max 0.4125, :p50 0.2625}, :local {:n 60, :min 0.45, :max 0.7125, :p50 0.5125}, :no-shell {:n 60, :min 0.4, :max 0.85, :p50 0.5}, :probe {:n 60, :min 0.1875, :max 0.3875, :p50 0.225}, :probe-fresh {:n 60, :min 0.0875, :max 0.175, :p50 0.1125}, :floor {:n 60, :min 0.0125, :max 0.05, :p50 0.025}, :warm {:n 60, :min 0.025, :max 0.1, :p50 0.05}, :ctl2 {:n 60, :min 0.825, :max 1.2875, :p50 0.9875}}
+;; ==== HICASSO read-profile-commit ====
+{:c-null-twin {:n 64, :min 0.4625, :max 0.9625, :p50 0.5953}, :c-local {:n 64, :min 0.4656, :max 0.8281, :p50 0.5922}, :c-noreaders {:n 64, :min 0.4438, :max 0.8188, :p50 0.6141}, :c-noactivate {:n 64, :min 0.4437, :max 0.9094, :p50 0.5563}, :c-null {:n 64, :min 0.4531, :max 0.875, :p50 0.5812}, :c-nowatch {:n 64, :min 0.425, :max 0.7438, :p50 0.5578}, :commit {:n 64, :min 0.4813, :max 0.8625, :p50 0.6063}, :c-nomap {:n 64, :min 0.4219, :max 0.9969, :p50 0.5859}, :b-build {:n 64, :min 0.3594, :max 0.6937, :p50 0.4891}, :c-null-curve {:n 64, :min 0.4656, :max 1.0344, :p50 0.6203}, :c-nosub {:n 64, :min 0.1531, :max 0.3125, :p50 0.2031}}
+;; ==== HICASSO read-profile-commit-per-round ====
+{:c-null-twin [0.6234 0.5344 0.5313 0.6328 0.5469 0.6453 0.6141 0.5844], :c-local [0.6187 0.5203 0.5187 0.6266 0.5594 0.6453 0.6516 0.525], :c-noreaders [0.6281 0.5422 0.5828 0.6266 0.5703 0.6531 0.6062 0.6109], :c-noactivate [0.5172 0.4938 0.5203 0.6078 0.5172 0.6578 0.6188 0.4984], :c-null [0.5578 0.4703 0.5844 0.6219 0.5516 0.6359 0.6375 0.5641], :c-nowatch [0.5531 0.5375 0.4937 0.5922 0.5344 0.5891 0.6172 0.5125], :commit [0.6031 0.5594 0.575 0.6234 0.5547 0.6703 0.6563 0.5859], :c-nomap [0.6609 0.5344 0.5 0.6063 0.5484 0.6516 0.5672 0.5828], :b-build [0.4688 0.4578 0.4797 0.4906 0.4078 0.5094 0.4984 0.4891], :c-null-curve [0.6406 0.5625 0.5313 0.6203 0.5484 0.6516 0.7578 0.5172], :c-nosub [0.1953 0.2141 0.1672 0.1984 0.1625 0.2063 0.2219 0.2078]}
+;; ==== HICASSO read-profile-commit-per-round-deltas ====
+{:c-null [0.0609 0.05 -0.0657 0.0047 0.0078 0.0094 0.0141 -0.0391], :c-noactivate [0.1015 0.0265 -0.0016 0.0188 0.0422 -0.0125 0.0328 0.0266], :c-nowatch [0.0656 -0.0172 0.025 0.0344 0.025 0.0562 0.0344 0.0125], :c-nosub [0.4234 0.3062 0.3515 0.4282 0.3969 0.439 0.4297 0.3172], :c-noreaders [-0.0094 -0.0219 -0.0641 0 -0.0109 -0.0078 0.0454 -0.0859], :c-nomap [-0.0422 -0.0141 0.0187 0.0203 0.011 -0.0063 0.0844 -0.0578], :c-null-twin [-0.0047 -0.0141 -0.0126 -0.0062 0.0125 0 0.0375 -0.0594], :c-null-curve [-0.0219 -0.0422 -0.0126 0.0063 0.011 -0.0063 -0.1062 0.0078]}
+;; ==== HICASSO read-profile-slot-plan ====
+[{:positions [2 3 4 5 6 7 8 9], :mean-position 5.5, :id :commit, :slot 0} {:positions [1 3 4 5 6 7 8 10], :mean-position 5.5, :id :c-local, :slot 1} {:positions [0 0 2 4 5 6 7 9], :mean-position 4.125, :id :c-null, :slot 2} {:positions [1 1 3 5 6 8 10 10], :mean-position 5.5, :id :c-noactivate, :slot 3} {:positions [0 0 2 2 4 7 9 9], :mean-position 4.125, :id :c-nowatch, :slot 4} {:positions [1 1 3 3 8 8 10 10], :mean-position 5.5, :id :c-nosub, :slot 5} {:positions [0 0 2 2 4 7 9 9], :mean-position 4.125, :id :c-noreaders, :slot 6} {:positions [1 1 3 5 6 8 10 10], :mean-position 5.5, :id :c-nomap, :slot 7} {:positions [0 0 2 4 5 6 7 9], :mean-position 4.125, :id :b-build, :slot 8} {:positions [1 3 4 5 6 7 8 10], :mean-position 5.5, :id :c-null-twin, :slot 9} {:positions [2 3 4 5 6 7 8 9], :mean-position 5.5, :id :c-null-curve, :slot 10}]
+;; ==== HICASSO read-profile-micro ====
+{:subscribe-once 4397.1631, :compute-sub 921.9858, :handler-invoke 241.1348, :registrar-lookup 78.0142, :frame-state-value 294.3262, :resolution-wrap 265.9574, :cache-peek-miss 31.9149, :sub-key-mint 10.6383}
+[hicasso] ok

--- a/implementation/hicasso/test/re_frame/bench/hicasso/data/readprofile-lo7uy/run2.txt
+++ b/implementation/hicasso/test/re_frame/bench/hicasso/data/readprofile-lo7uy/run2.txt
@@ -1,0 +1,259 @@
+[hicasso] cleared .shadow-cljs/builds/hicasso-bench — one build id, N arms (rf2-2rtt6.20)
+[hicasso] building :advanced bundle — re-frame.bench.hicasso.read-profile-app/-main -> out/hicasso-readprof
+[:hicasso-bench] Compiling ...
+[:hicasso-bench] Build completed. (187 files, 132 compiled, 0 warnings, 19.36s)
+shadow-cljs - config: <worktree>/implementation/shadow-cljs.edn   [PATH REDACTED — see README.md]
+;; order-guard ok   the recorded 2.01x is REFUSED  — ratio 2.0125
+;; order-guard ok   the same study's uncontaminated slope passes  — forward 2830.7 / reversed 2842.8
+;; order-guard ok   a single-order result is refused as UNCHECKED  — only 1 stratum — the question was never asked
+;; order-guard ok   overlapping ranges are indistinguishable even 20% apart in median  — medians 1.2000x apart but the ranges OVERLAP — indistinguishable
+;; order-guard ok   the measured warm-up step is caught by PHASE, which no reversal would show  — phase: FIRST-THIRD reads 1.2633x LAST-THIRD, ranges disjoint
+;; order-guard ok   an arm that reads exactly zero in both strata is indistinguishable, not infinite  — within 10%
+;; order-guard ok   cyclic rotation gives every arm exactly ONE within-round predecessor  — rotation over 6 rounds: distinct predecessors per arm 1,1,1,1 (only the round seam ever differs, and that is one sample in R)
+;; order-guard ok   the reflecting schedule gives every arm TWO, in balance  — reflected: 2,2,2,2 predecessors per arm, largest modal share 50%
+;; order-guard ok   at k=2 an ALWAYS-reflecting schedule runs one order for ever and is UNCHECKED  — always-reflect over 6 rounds of 2 arms: 1 distinct order(s), predecessors per arm 2,1 — rotating a pair by one IS reversing it, so the two cancel
+;; order-guard ok   at k=2 slot-order alternates, and every arm gets TWO predecessors in balance  — slot-order: 2 distinct orders, predecessors per arm 3,2, largest modal share 50%
+;; order-guard ok   samples whose :position went NON-FINITE refuse instead of narrowing the question  — 18 of 24 samples have NO USABLE :position (nil, absent or non-finite) in a run that records them — the harness lost them, so this contrast is over the rest and the sample count above is not it
+;; order-guard ok   a present-but-NIL :position is the same loss, and recording NONE is still excused  — 18 of 24 samples have NO USABLE :position (nil, absent or non-finite) in a run that records them — the harness lost them, so this contrast is over the rest and the sample count above is not it — and a run offering no position at all is excused, not refused
+;; harvest OK — 1202 elements, 141 reads (141 distinct), from the real page's own entry
+;; ==== ARM-ORDER GUARD — read-profile phase A (in-page ms, diagnostic) ====
+;;   every arm partitioned by WHAT RAN BEFORE IT and by WHERE IN THE RUN it was measured; tolerance 10%, overlapping ranges are indistinguishable
+;;   ctl2  (60 samples)
+;;     [ok  ] by predecessor  within 10%
+;;              warm                     n=30  p50       7.3500  [6.9000–8.5000]
+;;              ship                     n=30  p50       7.4500  [7.0000–10.3000]
+;;     [ok  ] by phase        within 10%
+;;              LAST-THIRD               n=20  p50       7.4000  [7.0000–8.5000]
+;;              FIRST-THIRD              n=20  p50       7.5000  [7.1000–8.4000]
+;;   floor  (60 samples)
+;;     [ok  ] by predecessor  within 10%
+;;              probe-fresh              n=30  p50       0.2000  [0.1000–0.4000]
+;;              warm                     n=30  p50       0.2000  [0.1000–0.3000]
+;;     [ok  ] by phase        within 10%
+;;              FIRST-THIRD              n=20  p50       0.2000  [0.1000–0.3000]
+;;              LAST-THIRD               n=20  p50       0.2000  [0.1000–0.4000]
+;;   local  (60 samples)
+;;     [ok  ] by predecessor  within 10%
+;;              no-shell                 n=30  p50       3.9000  [3.5000–4.7000]
+;;              ship                     n=30  p50       4.0000  [3.6000–6.2000]
+;;     [ok  ] by phase        within 10%
+;;              FIRST-THIRD              n=20  p50       3.9500  [3.6000–5.0000]
+;;              LAST-THIRD               n=20  p50       4.1000  [3.5000–6.2000]
+;;   no-shell  (60 samples)
+;;     [ok  ] by predecessor  within 10%
+;;              probe                    n=24  p50       3.6500  [3.3000–4.6000]
+;;              local                    n=36  p50       3.7000  [3.1000–5.8000]
+;;     [ok  ] by phase        within 10%
+;;              FIRST-THIRD              n=20  p50       3.7000  [3.5000–4.5000]
+;;              LAST-THIRD               n=20  p50       3.7500  [3.1000–4.6000]
+;;   probe  (60 samples)
+;;     [ok  ] by predecessor  within 10%
+;;              no-shell                 n=30  p50       1.7000  [1.5000–2.4000]
+;;              probe-fresh              n=30  p50       1.7500  [1.5000–2.5000]
+;;     [ok  ] by phase        within 10%
+;;              FIRST-THIRD              n=20  p50       1.8000  [1.5000–2.4000]
+;;              LAST-THIRD               n=20  p50       1.8000  [1.6000–2.3000]
+;;   probe-fresh  (60 samples)
+;;     [ok  ] by predecessor  within 10%
+;;              probe                    n=42  p50       0.9000  [0.7000–2.2000]
+;;              floor                    n=18  p50       0.9000  [0.8000–1.4000]
+;;     [ok  ] by phase        within 10%
+;;              FIRST-THIRD              n=20  p50       0.9000  [0.7000–1.2000]
+;;              LAST-THIRD               n=20  p50       0.9000  [0.8000–1.2000]
+;;   ship  (60 samples)
+;;     [ok  ] by predecessor  within 10%
+;;              ctl2                     n=36  p50       1.9000  [1.7000–3.3000]
+;;              local                    n=24  p50       1.9000  [1.7000–3.7000]
+;;     [ok  ] by phase        within 10%
+;;              FIRST-THIRD              n=20  p50       1.9500  [1.7000–3.7000]
+;;              LAST-THIRD               n=20  p50       2.0000  [1.7000–2.3000]
+;;   warm  (60 samples)
+;;     [ok  ] by predecessor  within 10%
+;;              floor                    n=36  p50       0.4000  [0.2000–0.8000]
+;;              ctl2                     n=24  p50       0.4000  [0.2000–0.6000]
+;;     [ok  ] by phase        within 10%
+;;              FIRST-THIRD              n=20  p50       0.4000  [0.3000–0.5000]
+;;              LAST-THIRD               n=20  p50       0.4000  [0.2000–0.8000]
+;;   VERDICT: reportable — no arm reads differently for its position in the plan
+;; HICASSO read-profile-census
+{:reads 141, :distinct 141, :by-sub-id {:conduit/your-feed? 1, :conduit/slugs 1, :conduit/tags 1, :conduit/article 69, :conduit/favorite-pending? 69}, :input-kinds {:db 141}}
+;; HICASSO read-profile-arms
+{:ship {:n 60, :min 0.2125, :max 0.4625, :p50 0.2375}, :local {:n 60, :min 0.4375, :max 0.775, :p50 0.4875}, :no-shell {:n 60, :min 0.3875, :max 0.725, :p50 0.4625}, :probe {:n 60, :min 0.1875, :max 0.3125, :p50 0.2125}, :probe-fresh {:n 60, :min 0.0875, :max 0.275, :p50 0.1125}, :floor {:n 60, :min 0.0125, :max 0.05, :p50 0.025}, :warm {:n 60, :min 0.025, :max 0.1, :p50 0.05}, :ctl2 {:n 60, :min 0.8625, :max 1.2875, :p50 0.925}}
+;; ==== READ PROFILE, PHASE A (ms per 141-read pass; diagnostic in-page clock) ====
+;;   reads/pass 141  passes/sample 8  design 6x(4+10)
+;;   ship: p50 0.2375 [0.2125 - 0.4625] ms/pass  (1.68 us/read)
+;;   local: p50 0.4875 [0.4375 - 0.7750] ms/pass  (3.46 us/read)
+;;   no-shell: p50 0.4625 [0.3875 - 0.7250] ms/pass  (3.28 us/read)
+;;   probe: p50 0.2125 [0.1875 - 0.3125] ms/pass  (1.51 us/read)
+;;   probe-fresh: p50 0.1125 [0.0875 - 0.2750] ms/pass  (0.80 us/read)
+;;   floor: p50 0.0250 [0.0125 - 0.0500] ms/pass  (0.18 us/read)
+;;   warm: p50 0.0500 [0.0250 - 0.1000] ms/pass  (0.35 us/read)
+;;   ctl2: p50 0.9250 [0.8625 - 1.2875] ms/pass  (6.56 us/read)
+;; ==== PHASE A DELTAS (floors; stubs stated in the ns docstring) ====
+;;   copy fidelity: local/ship = 2.0526  (local is the FROZEN subscribe-once path)
+;;   the-hicasso-shell (local - no-shell): delta 0.0250 ms/pass (0.18 us/read, 5.1% of the baseline)
+;;   churn-vs-probe (local - probe, the candidate's saving): delta 0.2750 ms/pass (1.95 us/read, 56.4% of the baseline)
+;;   memo-economy (probe-fresh - probe): delta -0.1000 ms/pass (-0.71 us/read, -88.9% of the baseline)
+;;   probe-overhead (probe - floor): delta 0.1875 ms/pass (1.33 us/read, 88.2% of the baseline)
+;;   warm steady-state: 0.0500 ms/pass (0.35 us/read)
+;;   control: predicted 0.925x, measured 0.925x [0.863–1.288] — the range meets the prediction within ±25%
+;; ==== ARM-ORDER GUARD — read-profile phase B (in-page ms, diagnostic) ====
+;;   every arm partitioned by WHAT RAN BEFORE IT and by WHERE IN THE RUN it was measured; tolerance 10%, overlapping ranges are indistinguishable
+;;   b-build  (64 samples)
+;;     [ok  ] by predecessor  within 10%
+;;              c-null-twin              n=24  p50      15.3000  [12.5000–19.2000]
+;;              c-nomap                  n=40  p50      15.5000  [11.4000–20.4000]
+;;     [ok  ] by phase        within 10%
+;;              FIRST-THIRD              n=21  p50      15.0000  [12.5000–18.7000]
+;;              LAST-THIRD               n=21  p50      15.4000  [11.4000–19.9000]
+;;   c-local  (64 samples)
+;;     [ok  ] by predecessor  within 10%
+;;              commit                   n=32  p50      18.7000  [15.5000–29.3000]
+;;              c-null                   n=32  p50      19.8000  [15.3000–22.2000]
+;;     [ok  ] by phase        within 10%
+;;              FIRST-THIRD              n=21  p50      18.1000  [16.1000–29.3000]
+;;              LAST-THIRD               n=21  p50      18.6000  [15.3000–22.8000]
+;;   c-noactivate  (64 samples)
+;;     [ok  ] by predecessor  within 10%
+;;              c-nowatch                n=32  p50      18.9500  [14.4000–25.4000]
+;;              c-null                   n=32  p50      19.1500  [14.0000–24.9000]
+;;     [ok  ] by phase        medians 1.1012x apart but the ranges OVERLAP — indistinguishable
+;;              FIRST-THIRD              n=21  p50      16.8000  [14.4000–25.4000]
+;;              LAST-THIRD               n=21  p50      18.5000  [14.0000–22.2000]
+;;   c-nomap  (64 samples)
+;;     [ok  ] by predecessor  within 10%
+;;              b-build                  n=32  p50      17.4500  [13.2000–27.1000]
+;;              c-noreaders              n=32  p50      17.7000  [13.4000–24.4000]
+;;     [ok  ] by phase        medians 1.1290x apart but the ranges OVERLAP — indistinguishable
+;;              LAST-THIRD               n=21  p50      15.5000  [13.2000–23.0000]
+;;              FIRST-THIRD              n=21  p50      17.5000  [13.4000–20.8000]
+;;   c-noreaders  (64 samples)
+;;     [ok  ] by predecessor  within 10%
+;;              c-nomap                  n=24  p50      18.6000  [15.4000–22.1000]
+;;              c-nosub                  n=40  p50      19.4000  [14.0000–24.1000]
+;;     [ok  ] by phase        medians 1.1149x apart but the ranges OVERLAP — indistinguishable
+;;              LAST-THIRD               n=21  p50      17.4000  [14.0000–23.5000]
+;;              FIRST-THIRD              n=21  p50      19.4000  [14.3000–23.0000]
+;;   c-nosub  (64 samples)
+;;     [ok  ] by predecessor  within 10%
+;;              c-noreaders              n=32  p50       6.2500  [5.0000–10.0000]
+;;              c-nowatch                n=32  p50       6.5000  [4.8000–11.7000]
+;;     [ok  ] by phase        within 10%
+;;              LAST-THIRD               n=21  p50       5.8000  [4.8000–9.1000]
+;;              FIRST-THIRD              n=21  p50       6.1000  [5.2000–11.7000]
+;;   c-nowatch  (64 samples)
+;;     [ok  ] by predecessor  within 10%
+;;              c-noactivate             n=40  p50      18.2000  [13.6000–26.7000]
+;;              c-nosub                  n=24  p50      18.3000  [13.4000–25.2000]
+;;     [ok  ] by phase        within 10%
+;;              FIRST-THIRD              n=21  p50      16.9000  [13.7000–26.7000]
+;;              LAST-THIRD               n=21  p50      16.9000  [13.4000–22.6000]
+;;   c-null  (64 samples)
+;;     [ok  ] by predecessor  medians 1.1358x apart but the ranges OVERLAP — indistinguishable
+;;              c-noactivate             n=24  p50      17.3000  [14.5000–22.0000]
+;;              c-null-twin              n= 7  p50      18.7000  [15.8000–20.3000]
+;;              c-local                  n=32  p50      19.6500  [14.8000–24.0000]
+;;              <none>                   n= 1  p50      21.3000  [21.3000–21.3000]
+;;     [ok  ] by phase        within 10%
+;;              LAST-THIRD               n=21  p50      17.0000  [14.8000–21.5000]
+;;              FIRST-THIRD              n=21  p50      17.1000  [14.5000–24.0000]
+;;   c-null-curve  (64 samples)
+;;     [ok  ] by predecessor  within 10%
+;;              commit                   n=32  p50      19.3000  [14.4000–25.6000]
+;;              c-null-twin              n=32  p50      20.3000  [14.7000–26.2000]
+;;     [ok  ] by phase        within 10%
+;;              FIRST-THIRD              n=21  p50      18.5000  [15.2000–26.2000]
+;;              LAST-THIRD               n=21  p50      19.4000  [14.7000–25.3000]
+;;   c-null-twin  (64 samples)
+;;     [ok  ] by predecessor  medians 1.1609x apart but the ranges OVERLAP — indistinguishable
+;;              c-null-curve             n=32  p50      17.4000  [14.4000–27.1000]
+;;              b-build                  n=32  p50      20.2000  [15.5000–28.6000]
+;;     [ok  ] by phase        within 10%
+;;              LAST-THIRD               n=21  p50      17.1000  [14.4000–28.6000]
+;;              FIRST-THIRD              n=21  p50      18.5000  [15.8000–27.1000]
+;;   commit  (64 samples)
+;;     [ok  ] by predecessor  medians 1.1811x apart but the ranges OVERLAP — indistinguishable
+;;              c-local                  n=32  p50      18.5000  [15.5000–27.1000]
+;;              c-null-curve             n=32  p50      21.8500  [16.2000–24.4000]
+;;     [ok  ] by phase        within 10%
+;;              FIRST-THIRD              n=21  p50      18.2000  [15.6000–24.4000]
+;;              LAST-THIRD               n=21  p50      18.6000  [15.5000–23.6000]
+;;   VERDICT: reportable — no arm reads differently for its position in the plan
+;; HICASSO read-profile-commit
+{:c-null-twin {:n 64, :min 0.45, :max 0.8937, :p50 0.5828}, :c-local {:n 64, :min 0.4781, :max 0.9156, :p50 0.5875}, :c-noreaders {:n 64, :min 0.4375, :max 0.7531, :p50 0.6}, :c-noactivate {:n 64, :min 0.4375, :max 0.7937, :p50 0.5984}, :c-null {:n 64, :min 0.4531, :max 0.75, :p50 0.6063}, :c-nowatch {:n 64, :min 0.4187, :max 0.8344, :p50 0.5719}, :commit {:n 64, :min 0.4844, :max 0.8469, :p50 0.6328}, :c-nomap {:n 64, :min 0.4125, :max 0.8469, :p50 0.55}, :b-build {:n 64, :min 0.3563, :max 0.6375, :p50 0.4828}, :c-null-curve {:n 64, :min 0.45, :max 0.8187, :p50 0.6125}, :c-nosub {:n 64, :min 0.15, :max 0.3656, :p50 0.2016}}
+;; HICASSO read-profile-commit-per-round
+{:c-null-twin [0.5641 0.5719 0.6516 0.6391 0.5781 0.6328 0.5297 0.5125], :c-local [0.5703 0.5594 0.5953 0.5906 0.6672 0.6484 0.5828 0.5688], :c-noreaders [0.5813 0.5891 0.6391 0.5516 0.6344 0.6047 0.5562 0.4953], :c-noactivate [0.4719 0.6047 0.6031 0.5625 0.6016 0.6 0.5938 0.5016], :c-null [0.5078 0.5719 0.5594 0.6375 0.6234 0.6203 0.4844 0.5328], :c-nowatch [0.4813 0.5391 0.6797 0.5766 0.5734 0.5734 0.6312 0.4812], :commit [0.5734 0.5453 0.7141 0.6937 0.7094 0.6891 0.5781 0.5656], :c-nomap [0.5562 0.5109 0.5953 0.5234 0.6219 0.6047 0.4922 0.4594], :b-build [0.4766 0.4469 0.4922 0.4609 0.5172 0.4828 0.5031 0.4047], :c-null-curve [0.5875 0.5375 0.6562 0.6266 0.6391 0.6469 0.6125 0.5406], :c-nosub [0.1891 0.1813 0.2156 0.2109 0.2125 0.2094 0.1875 0.1766]}
+;; HICASSO read-profile-commit-per-round-deltas
+{:c-null [0.0625 -0.0125 0.0359 -0.0469 0.0438 0.0281 0.0984 0.036], :c-noactivate [0.0984 -0.0453 -0.0078 0.0281 0.0656 0.0484 -0.011 0.0672], :c-nowatch [0.089 0.0203 -0.0844 0.014 0.0938 0.075 -0.0484 0.0876], :c-nosub [0.3812 0.3781 0.3797 0.3797 0.4547 0.439 0.3953 0.3922], :c-noreaders [-0.011 -0.0297 -0.0438 0.039 0.0328 0.0437 0.0266 0.0735], :c-nomap [0.0141 0.0485 0 0.0672 0.0453 0.0437 0.0906 0.1094], :c-null-twin [0.0062 -0.0125 -0.0563 -0.0485 0.0891 0.0156 0.0531 0.0563], :c-null-curve [-0.0172 0.0219 -0.0609 -0.036 0.0281 0.0015 -0.0297 0.0282]}
+;; HICASSO read-profile-slot-plan
+[{:positions [2 3 4 5 6 7 8 9], :mean-position 5.5, :id :commit, :slot 0} {:positions [1 3 4 5 6 7 8 10], :mean-position 5.5, :id :c-local, :slot 1} {:positions [0 0 2 4 5 6 7 9], :mean-position 4.125, :id :c-null, :slot 2} {:positions [1 1 3 5 6 8 10 10], :mean-position 5.5, :id :c-noactivate, :slot 3} {:positions [0 0 2 2 4 7 9 9], :mean-position 4.125, :id :c-nowatch, :slot 4} {:positions [1 1 3 3 8 8 10 10], :mean-position 5.5, :id :c-nosub, :slot 5} {:positions [0 0 2 2 4 7 9 9], :mean-position 4.125, :id :c-noreaders, :slot 6} {:positions [1 1 3 5 6 8 10 10], :mean-position 5.5, :id :c-nomap, :slot 7} {:positions [0 0 2 4 5 6 7 9], :mean-position 4.125, :id :b-build, :slot 8} {:positions [1 3 4 5 6 7 8 10], :mean-position 5.5, :id :c-null-twin, :slot 9} {:positions [2 3 4 5 6 7 8 9], :mean-position 5.5, :id :c-null-curve, :slot 10}]
+;; ==== READ PROFILE, PHASE B — THE COMMIT HALF (ms per 141-key boundary commit) ====
+;;   design 8x(2+8)  window = 32 frames/commit each  kept = 64 samples/arm (EVEN — p50 is the mean of two middle clock readings)  grid = 0.001563 ms/commit
+;;   slot plan (each arm's kept-sample sweep positions — the schedule is indexed by SAMPLE, so this footprint repeats identically every round; rf2-lo7uy):
+;;     slot 0 commit: [2 3 4 5 6 7 8 9]  mean 5.500
+;;     slot 1 c-local: [1 3 4 5 6 7 8 10]  mean 5.500
+;;     slot 2 c-null: [0 0 2 4 5 6 7 9]  mean 4.125
+;;     slot 3 c-noactivate: [1 1 3 5 6 8 10 10]  mean 5.500
+;;     slot 4 c-nowatch: [0 0 2 2 4 7 9 9]  mean 4.125
+;;     slot 5 c-nosub: [1 1 3 3 8 8 10 10]  mean 5.500
+;;     slot 6 c-noreaders: [0 0 2 2 4 7 9 9]  mean 4.125
+;;     slot 7 c-nomap: [1 1 3 5 6 8 10 10]  mean 5.500
+;;     slot 8 b-build: [0 0 2 4 5 6 7 9]  mean 4.125
+;;     slot 9 c-null-twin: [1 3 4 5 6 7 8 10]  mean 5.500
+;;     slot 10 c-null-curve: [2 3 4 5 6 7 8 9]  mean 5.500
+;;   commit: p50 0.6328 [0.4844 - 0.8469] ms/pass  (4.49 us/read)
+;;   c-local: p50 0.5875 [0.4781 - 0.9156] ms/pass  (4.17 us/read)
+;;   c-null: p50 0.6063 [0.4531 - 0.7500] ms/pass  (4.30 us/read)
+;;   c-noactivate: p50 0.5984 [0.4375 - 0.7937] ms/pass  (4.24 us/read)
+;;   c-nowatch: p50 0.5719 [0.4187 - 0.8344] ms/pass  (4.06 us/read)
+;;   c-nosub: p50 0.2016 [0.1500 - 0.3656] ms/pass  (1.43 us/read)
+;;   c-noreaders: p50 0.6000 [0.4375 - 0.7531] ms/pass  (4.26 us/read)
+;;   c-nomap: p50 0.5500 [0.4125 - 0.8469] ms/pass  (3.90 us/read)
+;;   b-build: p50 0.4828 [0.3563 - 0.6375] ms/pass  (3.42 us/read)
+;;   c-null-twin: p50 0.5828 [0.4500 - 0.8937] ms/pass  (4.13 us/read)
+;;   c-null-curve: p50 0.6125 [0.4500 - 0.8187] ms/pass  (4.34 us/read)
+;; ==== PHASE B DELTAS (c-local minus ablation; floors) ====
+;;   copy fidelity: c-local/commit = 0.9284
+;;   NULL CONTROL (c-local - c-null): delta -0.0188 ms/pass (-0.13 us/read, -3.2% of the baseline)
+;;     ^ true cost EXACTLY ZERO by construction — both arms are C-FULL. What it reads is this instrument's own error at this shape, and it is what the terms below are adjudicated against (rf2-3l6hf). It bounds no term's cost: a delta inside this spread is a term the window cannot SEE, which leaves its size open in both directions
+;;     ^ slot 1 against slot 2, on footprints that differ in BOTH mean position and shape. The two nulls below hold that zero and move the SLOT, which is what makes the offset's cause readable rather than only its size (rf2-lo7uy)
+;;   NULL CONTROL, position TWIN (c-local - c-null-twin): delta 0.0047 ms/pass (0.03 us/read, 0.8% of the baseline)
+;;     ^ same zero, and this arm's kept-sample position footprint IS c-local's, so ANY cost that is a function of sweep position cancels term by term. A reading here is error sweep position cannot explain; a reading of zero here beside a non-zero c-null puts the offset ON position
+;;   NULL CONTROL, equal MEAN position (c-local - c-null-curve): delta -0.0250 ms/pass (-0.18 us/read, -4.3% of the baseline)
+;;     ^ same zero, c-local's MEAN position on a DIFFERENT footprint: a linear within-sweep drift cancels here, a curved one does not. Read the three nulls together — alike means the offset is not positional; c-null alone means it is; c-null and this one means it is and is not linear
+;;   activation-capture (c-local - c-noactivate): delta -0.0109 ms/pass (-0.08 us/read, -1.9% of the baseline)
+;;     ^ a REAL term here, NOT a floor and not an arbiter: nothing activates on this UIx host, but the hook key is never published and so never cached, and this prices that lookup (rf2-tcffa, rf2-19usn). The capture itself is real only under the ratom family (rf2-lzpfj)
+;;   watch-wiring (c-local - c-nowatch): delta 0.0156 ms/pass (0.11 us/read, 2.7% of the baseline)
+;;   reaction-build+cache-insert (c-local - c-nosub): delta 0.3859 ms/pass (2.74 us/read, 65.7% of the baseline)
+;;   reader-membership (c-local - c-noreaders): delta -0.0125 ms/pass (-0.09 us/read, -2.1% of the baseline)
+;;   cell-map-insert (c-local - c-nomap): delta 0.0375 ms/pass (0.27 us/read, 6.4% of the baseline)
+;;   b-build (build+compute, no in-window dispose): 0.4828 ms/pass (3.42 us/read)
+;; HICASSO read-profile-micro
+{:subscribe-once 5815.6028, :compute-sub 957.4468, :handler-invoke 273.0496, :registrar-lookup 53.1915, :frame-state-value 212.766, :resolution-wrap 177.305, :cache-peek-miss 21.2766, :sub-key-mint 17.7305}
+;; ==== MICRO (ns/op over the page's own roster) ====
+;;   subscribe-once: 5815.6 ns
+;;   compute-sub: 957.4 ns
+;;   handler-invoke: 273.0 ns
+;;   registrar-lookup: 53.2 ns
+;;   frame-state-value: 212.8 ns
+;;   resolution-wrap: 177.3 ns
+;;   cache-peek-miss: 21.3 ns
+;;   sub-key-mint: 17.7 ns
+;; HICASSO DONE
+;; ==== HICASSO RUNTIME ====
+;; chromium 147.0.7727.15 (playwright), :advanced, goog.DEBUG false
+;; ==== HICASSO read-profile-census ====
+{:reads 141, :distinct 141, :by-sub-id {:conduit/your-feed? 1, :conduit/slugs 1, :conduit/tags 1, :conduit/article 69, :conduit/favorite-pending? 69}, :input-kinds {:db 141}}
+;; ==== HICASSO read-profile-arms ====
+{:ship {:n 60, :min 0.2125, :max 0.4625, :p50 0.2375}, :local {:n 60, :min 0.4375, :max 0.775, :p50 0.4875}, :no-shell {:n 60, :min 0.3875, :max 0.725, :p50 0.4625}, :probe {:n 60, :min 0.1875, :max 0.3125, :p50 0.2125}, :probe-fresh {:n 60, :min 0.0875, :max 0.275, :p50 0.1125}, :floor {:n 60, :min 0.0125, :max 0.05, :p50 0.025}, :warm {:n 60, :min 0.025, :max 0.1, :p50 0.05}, :ctl2 {:n 60, :min 0.8625, :max 1.2875, :p50 0.925}}
+;; ==== HICASSO read-profile-commit ====
+{:c-null-twin {:n 64, :min 0.45, :max 0.8937, :p50 0.5828}, :c-local {:n 64, :min 0.4781, :max 0.9156, :p50 0.5875}, :c-noreaders {:n 64, :min 0.4375, :max 0.7531, :p50 0.6}, :c-noactivate {:n 64, :min 0.4375, :max 0.7937, :p50 0.5984}, :c-null {:n 64, :min 0.4531, :max 0.75, :p50 0.6063}, :c-nowatch {:n 64, :min 0.4187, :max 0.8344, :p50 0.5719}, :commit {:n 64, :min 0.4844, :max 0.8469, :p50 0.6328}, :c-nomap {:n 64, :min 0.4125, :max 0.8469, :p50 0.55}, :b-build {:n 64, :min 0.3563, :max 0.6375, :p50 0.4828}, :c-null-curve {:n 64, :min 0.45, :max 0.8187, :p50 0.6125}, :c-nosub {:n 64, :min 0.15, :max 0.3656, :p50 0.2016}}
+;; ==== HICASSO read-profile-commit-per-round ====
+{:c-null-twin [0.5641 0.5719 0.6516 0.6391 0.5781 0.6328 0.5297 0.5125], :c-local [0.5703 0.5594 0.5953 0.5906 0.6672 0.6484 0.5828 0.5688], :c-noreaders [0.5813 0.5891 0.6391 0.5516 0.6344 0.6047 0.5562 0.4953], :c-noactivate [0.4719 0.6047 0.6031 0.5625 0.6016 0.6 0.5938 0.5016], :c-null [0.5078 0.5719 0.5594 0.6375 0.6234 0.6203 0.4844 0.5328], :c-nowatch [0.4813 0.5391 0.6797 0.5766 0.5734 0.5734 0.6312 0.4812], :commit [0.5734 0.5453 0.7141 0.6937 0.7094 0.6891 0.5781 0.5656], :c-nomap [0.5562 0.5109 0.5953 0.5234 0.6219 0.6047 0.4922 0.4594], :b-build [0.4766 0.4469 0.4922 0.4609 0.5172 0.4828 0.5031 0.4047], :c-null-curve [0.5875 0.5375 0.6562 0.6266 0.6391 0.6469 0.6125 0.5406], :c-nosub [0.1891 0.1813 0.2156 0.2109 0.2125 0.2094 0.1875 0.1766]}
+;; ==== HICASSO read-profile-commit-per-round-deltas ====
+{:c-null [0.0625 -0.0125 0.0359 -0.0469 0.0438 0.0281 0.0984 0.036], :c-noactivate [0.0984 -0.0453 -0.0078 0.0281 0.0656 0.0484 -0.011 0.0672], :c-nowatch [0.089 0.0203 -0.0844 0.014 0.0938 0.075 -0.0484 0.0876], :c-nosub [0.3812 0.3781 0.3797 0.3797 0.4547 0.439 0.3953 0.3922], :c-noreaders [-0.011 -0.0297 -0.0438 0.039 0.0328 0.0437 0.0266 0.0735], :c-nomap [0.0141 0.0485 0 0.0672 0.0453 0.0437 0.0906 0.1094], :c-null-twin [0.0062 -0.0125 -0.0563 -0.0485 0.0891 0.0156 0.0531 0.0563], :c-null-curve [-0.0172 0.0219 -0.0609 -0.036 0.0281 0.0015 -0.0297 0.0282]}
+;; ==== HICASSO read-profile-slot-plan ====
+[{:positions [2 3 4 5 6 7 8 9], :mean-position 5.5, :id :commit, :slot 0} {:positions [1 3 4 5 6 7 8 10], :mean-position 5.5, :id :c-local, :slot 1} {:positions [0 0 2 4 5 6 7 9], :mean-position 4.125, :id :c-null, :slot 2} {:positions [1 1 3 5 6 8 10 10], :mean-position 5.5, :id :c-noactivate, :slot 3} {:positions [0 0 2 2 4 7 9 9], :mean-position 4.125, :id :c-nowatch, :slot 4} {:positions [1 1 3 3 8 8 10 10], :mean-position 5.5, :id :c-nosub, :slot 5} {:positions [0 0 2 2 4 7 9 9], :mean-position 4.125, :id :c-noreaders, :slot 6} {:positions [1 1 3 5 6 8 10 10], :mean-position 5.5, :id :c-nomap, :slot 7} {:positions [0 0 2 4 5 6 7 9], :mean-position 4.125, :id :b-build, :slot 8} {:positions [1 3 4 5 6 7 8 10], :mean-position 5.5, :id :c-null-twin, :slot 9} {:positions [2 3 4 5 6 7 8 9], :mean-position 5.5, :id :c-null-curve, :slot 10}]
+;; ==== HICASSO read-profile-micro ====
+{:subscribe-once 5815.6028, :compute-sub 957.4468, :handler-invoke 273.0496, :registrar-lookup 53.1915, :frame-state-value 212.766, :resolution-wrap 177.305, :cache-peek-miss 21.2766, :sub-key-mint 17.7305}
+[hicasso] ok

--- a/implementation/hicasso/test/re_frame/bench/hicasso/data/readprofile-lo7uy/run3.txt
+++ b/implementation/hicasso/test/re_frame/bench/hicasso/data/readprofile-lo7uy/run3.txt
@@ -1,0 +1,259 @@
+[hicasso] cleared .shadow-cljs/builds/hicasso-bench — one build id, N arms (rf2-2rtt6.20)
+[hicasso] building :advanced bundle — re-frame.bench.hicasso.read-profile-app/-main -> out/hicasso-readprof
+[:hicasso-bench] Compiling ...
+[:hicasso-bench] Build completed. (187 files, 132 compiled, 0 warnings, 19.03s)
+shadow-cljs - config: <worktree>/implementation/shadow-cljs.edn   [PATH REDACTED — see README.md]
+;; order-guard ok   the recorded 2.01x is REFUSED  — ratio 2.0125
+;; order-guard ok   the same study's uncontaminated slope passes  — forward 2830.7 / reversed 2842.8
+;; order-guard ok   a single-order result is refused as UNCHECKED  — only 1 stratum — the question was never asked
+;; order-guard ok   overlapping ranges are indistinguishable even 20% apart in median  — medians 1.2000x apart but the ranges OVERLAP — indistinguishable
+;; order-guard ok   the measured warm-up step is caught by PHASE, which no reversal would show  — phase: FIRST-THIRD reads 1.2633x LAST-THIRD, ranges disjoint
+;; order-guard ok   an arm that reads exactly zero in both strata is indistinguishable, not infinite  — within 10%
+;; order-guard ok   cyclic rotation gives every arm exactly ONE within-round predecessor  — rotation over 6 rounds: distinct predecessors per arm 1,1,1,1 (only the round seam ever differs, and that is one sample in R)
+;; order-guard ok   the reflecting schedule gives every arm TWO, in balance  — reflected: 2,2,2,2 predecessors per arm, largest modal share 50%
+;; order-guard ok   at k=2 an ALWAYS-reflecting schedule runs one order for ever and is UNCHECKED  — always-reflect over 6 rounds of 2 arms: 1 distinct order(s), predecessors per arm 2,1 — rotating a pair by one IS reversing it, so the two cancel
+;; order-guard ok   at k=2 slot-order alternates, and every arm gets TWO predecessors in balance  — slot-order: 2 distinct orders, predecessors per arm 3,2, largest modal share 50%
+;; order-guard ok   samples whose :position went NON-FINITE refuse instead of narrowing the question  — 18 of 24 samples have NO USABLE :position (nil, absent or non-finite) in a run that records them — the harness lost them, so this contrast is over the rest and the sample count above is not it
+;; order-guard ok   a present-but-NIL :position is the same loss, and recording NONE is still excused  — 18 of 24 samples have NO USABLE :position (nil, absent or non-finite) in a run that records them — the harness lost them, so this contrast is over the rest and the sample count above is not it — and a run offering no position at all is excused, not refused
+;; harvest OK — 1202 elements, 141 reads (141 distinct), from the real page's own entry
+;; ==== ARM-ORDER GUARD — read-profile phase A (in-page ms, diagnostic) ====
+;;   every arm partitioned by WHAT RAN BEFORE IT and by WHERE IN THE RUN it was measured; tolerance 10%, overlapping ranges are indistinguishable
+;;   ctl2  (60 samples)
+;;     [ok  ] by predecessor  within 10%
+;;              ship                     n=30  p50       7.5000  [6.7000–9.7000]
+;;              warm                     n=30  p50       7.6000  [6.7000–11.6000]
+;;     [ok  ] by phase        within 10%
+;;              LAST-THIRD               n=20  p50       7.6500  [6.9000–9.7000]
+;;              FIRST-THIRD              n=20  p50       7.6500  [6.7000–11.6000]
+;;   floor  (60 samples)
+;;     [ok  ] by predecessor  within 10%
+;;              probe-fresh              n=30  p50       0.2000  [0.1000–0.3000]
+;;              warm                     n=30  p50       0.2000  [0.1000–0.4000]
+;;     [ok  ] by phase        within 10%
+;;              FIRST-THIRD              n=20  p50       0.2000  [0.1000–0.4000]
+;;              LAST-THIRD               n=20  p50       0.2000  [0.1000–0.2000]
+;;   local  (60 samples)
+;;     [ok  ] by predecessor  within 10%
+;;              ship                     n=30  p50       3.9000  [3.4000–4.5000]
+;;              no-shell                 n=30  p50       4.0000  [3.7000–4.9000]
+;;     [ok  ] by phase        within 10%
+;;              FIRST-THIRD              n=20  p50       4.0000  [3.7000–4.9000]
+;;              LAST-THIRD               n=20  p50       4.1000  [3.4000–4.8000]
+;;   no-shell  (60 samples)
+;;     [ok  ] by predecessor  within 10%
+;;              probe                    n=24  p50       3.7000  [3.4000–5.0000]
+;;              local                    n=36  p50       3.7500  [3.5000–5.9000]
+;;     [ok  ] by phase        within 10%
+;;              LAST-THIRD               n=20  p50       3.7000  [3.4000–4.9000]
+;;              FIRST-THIRD              n=20  p50       3.8500  [3.5000–5.0000]
+;;   probe  (60 samples)
+;;     [ok  ] by predecessor  within 10%
+;;              probe-fresh              n=30  p50       1.7000  [1.5000–2.6000]
+;;              no-shell                 n=30  p50       1.8000  [1.6000–3.6000]
+;;     [ok  ] by phase        within 10%
+;;              LAST-THIRD               n=20  p50       1.8000  [1.6000–3.6000]
+;;              FIRST-THIRD              n=20  p50       1.8500  [1.5000–3.1000]
+;;   probe-fresh  (60 samples)
+;;     [ok  ] by predecessor  within 10%
+;;              probe                    n=42  p50       0.9000  [0.8000–1.7000]
+;;              floor                    n=18  p50       0.9000  [0.8000–1.7000]
+;;     [ok  ] by phase        within 10%
+;;              LAST-THIRD               n=20  p50       0.9000  [0.8000–1.7000]
+;;              FIRST-THIRD              n=20  p50       0.9000  [0.8000–1.7000]
+;;   ship  (60 samples)
+;;     [ok  ] by predecessor  within 10%
+;;              ctl2                     n=36  p50       2.0000  [1.7000–2.8000]
+;;              local                    n=24  p50       2.0000  [1.8000–3.2000]
+;;     [ok  ] by phase        within 10%
+;;              LAST-THIRD               n=20  p50       2.0000  [1.7000–2.4000]
+;;              FIRST-THIRD              n=20  p50       2.1500  [1.8000–3.2000]
+;;   warm  (60 samples)
+;;     [ok  ] by predecessor  within 10%
+;;              floor                    n=36  p50       0.4000  [0.2000–0.8000]
+;;              ctl2                     n=24  p50       0.4000  [0.3000–0.6000]
+;;     [ok  ] by phase        within 10%
+;;              FIRST-THIRD              n=20  p50       0.4000  [0.3000–0.8000]
+;;              LAST-THIRD               n=20  p50       0.4000  [0.3000–0.5000]
+;;   VERDICT: reportable — no arm reads differently for its position in the plan
+;; HICASSO read-profile-census
+{:reads 141, :distinct 141, :by-sub-id {:conduit/your-feed? 1, :conduit/slugs 1, :conduit/tags 1, :conduit/article 69, :conduit/favorite-pending? 69}, :input-kinds {:db 141}}
+;; HICASSO read-profile-arms
+{:ship {:n 60, :min 0.2125, :max 0.4, :p50 0.25}, :local {:n 60, :min 0.425, :max 0.6125, :p50 0.5}, :no-shell {:n 60, :min 0.425, :max 0.7375, :p50 0.4625}, :probe {:n 60, :min 0.1875, :max 0.45, :p50 0.225}, :probe-fresh {:n 60, :min 0.1, :max 0.2125, :p50 0.1125}, :floor {:n 60, :min 0.0125, :max 0.05, :p50 0.025}, :warm {:n 60, :min 0.025, :max 0.1, :p50 0.05}, :ctl2 {:n 60, :min 0.8375, :max 1.45, :p50 0.9437}}
+;; ==== READ PROFILE, PHASE A (ms per 141-read pass; diagnostic in-page clock) ====
+;;   reads/pass 141  passes/sample 8  design 6x(4+10)
+;;   ship: p50 0.2500 [0.2125 - 0.4000] ms/pass  (1.77 us/read)
+;;   local: p50 0.5000 [0.4250 - 0.6125] ms/pass  (3.55 us/read)
+;;   no-shell: p50 0.4625 [0.4250 - 0.7375] ms/pass  (3.28 us/read)
+;;   probe: p50 0.2250 [0.1875 - 0.4500] ms/pass  (1.60 us/read)
+;;   probe-fresh: p50 0.1125 [0.1000 - 0.2125] ms/pass  (0.80 us/read)
+;;   floor: p50 0.0250 [0.0125 - 0.0500] ms/pass  (0.18 us/read)
+;;   warm: p50 0.0500 [0.0250 - 0.1000] ms/pass  (0.35 us/read)
+;;   ctl2: p50 0.9437 [0.8375 - 1.4500] ms/pass  (6.69 us/read)
+;; ==== PHASE A DELTAS (floors; stubs stated in the ns docstring) ====
+;;   copy fidelity: local/ship = 2.0000  (local is the FROZEN subscribe-once path)
+;;   the-hicasso-shell (local - no-shell): delta 0.0375 ms/pass (0.27 us/read, 7.5% of the baseline)
+;;   churn-vs-probe (local - probe, the candidate's saving): delta 0.2750 ms/pass (1.95 us/read, 55.0% of the baseline)
+;;   memo-economy (probe-fresh - probe): delta -0.1125 ms/pass (-0.80 us/read, -100.0% of the baseline)
+;;   probe-overhead (probe - floor): delta 0.2000 ms/pass (1.42 us/read, 88.9% of the baseline)
+;;   warm steady-state: 0.0500 ms/pass (0.35 us/read)
+;;   control: predicted 0.925x, measured 0.944x [0.837–1.450] — the range meets the prediction within ±25%
+;; ==== ARM-ORDER GUARD — read-profile phase B (in-page ms, diagnostic) ====
+;;   every arm partitioned by WHAT RAN BEFORE IT and by WHERE IN THE RUN it was measured; tolerance 10%, overlapping ranges are indistinguishable
+;;   b-build  (64 samples)
+;;     [ok  ] by predecessor  within 10%
+;;              c-null-twin              n=24  p50      15.6500  [12.0000–21.3000]
+;;              c-nomap                  n=40  p50      15.7500  [11.6000–18.6000]
+;;     [ok  ] by phase        within 10%
+;;              FIRST-THIRD              n=21  p50      15.6000  [12.1000–19.8000]
+;;              LAST-THIRD               n=21  p50      16.4000  [12.1000–21.3000]
+;;   c-local  (64 samples)
+;;     [ok  ] by predecessor  within 10%
+;;              commit                   n=32  p50      20.2500  [16.1000–27.6000]
+;;              c-null                   n=32  p50      21.0500  [15.4000–30.0000]
+;;     [ok  ] by phase        within 10%
+;;              FIRST-THIRD              n=21  p50      20.3000  [16.4000–27.6000]
+;;              LAST-THIRD               n=21  p50      20.6000  [15.4000–27.3000]
+;;   c-noactivate  (64 samples)
+;;     [ok  ] by predecessor  within 10%
+;;              c-null                   n=32  p50      19.2000  [15.2000–25.5000]
+;;              c-nowatch                n=32  p50      19.2500  [14.4000–28.3000]
+;;     [ok  ] by phase        within 10%
+;;              FIRST-THIRD              n=21  p50      18.3000  [14.4000–26.3000]
+;;              LAST-THIRD               n=21  p50      19.8000  [14.9000–23.3000]
+;;   c-nomap  (64 samples)
+;;     [ok  ] by predecessor  within 10%
+;;              c-noreaders              n=32  p50      18.4500  [14.1000–27.1000]
+;;              b-build                  n=32  p50      18.9500  [14.4000–24.2000]
+;;     [ok  ] by phase        within 10%
+;;              LAST-THIRD               n=21  p50      18.6000  [14.1000–24.2000]
+;;              FIRST-THIRD              n=21  p50      19.2000  [14.4000–27.1000]
+;;   c-noreaders  (64 samples)
+;;     [ok  ] by predecessor  within 10%
+;;              c-nosub                  n=40  p50      19.7000  [15.3000–27.9000]
+;;              c-nomap                  n=24  p50      20.9500  [18.1000–25.4000]
+;;     [ok  ] by phase        within 10%
+;;              FIRST-THIRD              n=21  p50      19.2000  [15.3000–25.4000]
+;;              LAST-THIRD               n=21  p50      20.1000  [15.3000–27.9000]
+;;   c-nosub  (64 samples)
+;;     [ok  ] by predecessor  within 10%
+;;              c-noreaders              n=32  p50       6.5000  [5.1000–11.6000]
+;;              c-nowatch                n=32  p50       6.6500  [5.1000–10.4000]
+;;     [ok  ] by phase        within 10%
+;;              FIRST-THIRD              n=21  p50       6.5000  [5.1000–11.6000]
+;;              LAST-THIRD               n=21  p50       6.6000  [5.1000–11.4000]
+;;   c-nowatch  (64 samples)
+;;     [ok  ] by predecessor  within 10%
+;;              c-nosub                  n=24  p50      18.3500  [15.2000–23.1000]
+;;              c-noactivate             n=40  p50      18.5500  [14.1000–22.3000]
+;;     [ok  ] by phase        within 10%
+;;              LAST-THIRD               n=21  p50      18.0000  [14.1000–20.1000]
+;;              FIRST-THIRD              n=21  p50      18.2000  [15.0000–23.1000]
+;;   c-null  (64 samples)
+;;     [ok  ] by predecessor  within 10%
+;;              c-null-twin              n= 7  p50      18.6000  [15.6000–21.1000]
+;;              <none>                   n= 1  p50      19.0000  [19.0000–19.0000]
+;;              c-local                  n=32  p50      19.4000  [15.1000–27.3000]
+;;              c-noactivate             n=24  p50      19.8000  [16.3000–30.8000]
+;;     [ok  ] by phase        within 10%
+;;              FIRST-THIRD              n=21  p50      18.1000  [15.6000–30.8000]
+;;              LAST-THIRD               n=21  p50      19.7000  [15.1000–24.0000]
+;;   c-null-curve  (64 samples)
+;;     [ok  ] by predecessor  within 10%
+;;              c-null-twin              n=32  p50      19.7500  [15.9000–26.1000]
+;;              commit                   n=32  p50      20.0500  [15.7000–25.7000]
+;;     [ok  ] by phase        within 10%
+;;              FIRST-THIRD              n=21  p50      19.9000  [16.0000–23.2000]
+;;              LAST-THIRD               n=21  p50      20.1000  [15.7000–26.1000]
+;;   c-null-twin  (64 samples)
+;;     [ok  ] by predecessor  within 10%
+;;              c-null-curve             n=32  p50      19.5500  [15.5000–24.7000]
+;;              b-build                  n=32  p50      21.4000  [16.4000–24.6000]
+;;     [ok  ] by phase        within 10%
+;;              FIRST-THIRD              n=21  p50      19.7000  [15.9000–24.6000]
+;;              LAST-THIRD               n=21  p50      21.5000  [15.5000–24.6000]
+;;   commit  (64 samples)
+;;     [ok  ] by predecessor  within 10%
+;;              c-local                  n=32  p50      19.6500  [16.5000–27.5000]
+;;              c-null-curve             n=32  p50      21.4500  [16.8000–24.4000]
+;;     [ok  ] by phase        within 10%
+;;              FIRST-THIRD              n=21  p50      21.5000  [16.5000–24.2000]
+;;              LAST-THIRD               n=21  p50      22.2000  [16.8000–27.5000]
+;;   VERDICT: reportable — no arm reads differently for its position in the plan
+;; HICASSO read-profile-commit
+{:c-null-twin {:n 64, :min 0.4844, :max 0.7719, :p50 0.6453}, :c-local {:n 64, :min 0.4812, :max 0.9375, :p50 0.6406}, :c-noreaders {:n 64, :min 0.4781, :max 0.8719, :p50 0.6266}, :c-noactivate {:n 64, :min 0.45, :max 0.8844, :p50 0.6}, :c-null {:n 64, :min 0.4719, :max 0.9625, :p50 0.6094}, :c-nowatch {:n 64, :min 0.4406, :max 0.7219, :p50 0.5766}, :commit {:n 64, :min 0.5156, :max 0.8594, :p50 0.6609}, :c-nomap {:n 64, :min 0.4406, :max 0.8469, :p50 0.5906}, :b-build {:n 64, :min 0.3625, :max 0.6656, :p50 0.4906}, :c-null-curve {:n 64, :min 0.4906, :max 0.8156, :p50 0.6203}, :c-nosub {:n 64, :min 0.1594, :max 0.3625, :p50 0.2062}}
+;; HICASSO read-profile-commit-per-round
+{:c-null-twin [0.6719 0.5703 0.6109 0.6594 0.5703 0.6469 0.6734 0.6422], :c-local [0.6797 0.6578 0.5984 0.6578 0.6328 0.6359 0.6594 0.5906], :c-noreaders [0.65 0.5984 0.6109 0.6375 0.5969 0.65 0.6328 0.6063], :c-noactivate [0.6172 0.5281 0.5687 0.5953 0.5891 0.6297 0.6297 0.5969], :c-null [0.6016 0.5469 0.5406 0.5609 0.6125 0.6328 0.6422 0.5641], :c-nowatch [0.5734 0.5625 0.5422 0.5531 0.6281 0.5984 0.5812 0.4719], :commit [0.7125 0.6141 0.5891 0.6141 0.6906 0.7047 0.6984 0.5391], :c-nomap [0.6734 0.5906 0.5125 0.6031 0.5703 0.5672 0.5906 0.5047], :b-build [0.5156 0.4828 0.425 0.4875 0.4547 0.5 0.5031 0.5266], :c-null-curve [0.6891 0.5297 0.6266 0.6031 0.5625 0.6344 0.6359 0.5625], :c-nosub [0.2219 0.1797 0.2125 0.2016 0.1813 0.2078 0.2047 0.2344]}
+;; HICASSO read-profile-commit-per-round-deltas
+{:c-null [0.0781 0.1109 0.0578 0.0969 0.0203 0.0031 0.0172 0.0265], :c-noactivate [0.0625 0.1297 0.0297 0.0625 0.0437 0.0062 0.0297 -0.0063], :c-nowatch [0.1063 0.0953 0.0562 0.1047 0.0047 0.0375 0.0782 0.1187], :c-nosub [0.4578 0.4781 0.3859 0.4562 0.4515 0.4281 0.4547 0.3562], :c-noreaders [0.0297 0.0594 -0.0125 0.0203 0.0359 -0.0141 0.0266 -0.0157], :c-nomap [0.0063 0.0672 0.0859 0.0547 0.0625 0.0687 0.0688 0.0859], :c-null-twin [0.0078 0.0875 -0.0125 -0.0016 0.0625 -0.011 -0.014 -0.0516], :c-null-curve [-0.0094 0.1281 -0.0282 0.0547 0.0703 0.0015 0.0235 0.0281]}
+;; HICASSO read-profile-slot-plan
+[{:positions [2 3 4 5 6 7 8 9], :mean-position 5.5, :id :commit, :slot 0} {:positions [1 3 4 5 6 7 8 10], :mean-position 5.5, :id :c-local, :slot 1} {:positions [0 0 2 4 5 6 7 9], :mean-position 4.125, :id :c-null, :slot 2} {:positions [1 1 3 5 6 8 10 10], :mean-position 5.5, :id :c-noactivate, :slot 3} {:positions [0 0 2 2 4 7 9 9], :mean-position 4.125, :id :c-nowatch, :slot 4} {:positions [1 1 3 3 8 8 10 10], :mean-position 5.5, :id :c-nosub, :slot 5} {:positions [0 0 2 2 4 7 9 9], :mean-position 4.125, :id :c-noreaders, :slot 6} {:positions [1 1 3 5 6 8 10 10], :mean-position 5.5, :id :c-nomap, :slot 7} {:positions [0 0 2 4 5 6 7 9], :mean-position 4.125, :id :b-build, :slot 8} {:positions [1 3 4 5 6 7 8 10], :mean-position 5.5, :id :c-null-twin, :slot 9} {:positions [2 3 4 5 6 7 8 9], :mean-position 5.5, :id :c-null-curve, :slot 10}]
+;; ==== READ PROFILE, PHASE B — THE COMMIT HALF (ms per 141-key boundary commit) ====
+;;   design 8x(2+8)  window = 32 frames/commit each  kept = 64 samples/arm (EVEN — p50 is the mean of two middle clock readings)  grid = 0.001563 ms/commit
+;;   slot plan (each arm's kept-sample sweep positions — the schedule is indexed by SAMPLE, so this footprint repeats identically every round; rf2-lo7uy):
+;;     slot 0 commit: [2 3 4 5 6 7 8 9]  mean 5.500
+;;     slot 1 c-local: [1 3 4 5 6 7 8 10]  mean 5.500
+;;     slot 2 c-null: [0 0 2 4 5 6 7 9]  mean 4.125
+;;     slot 3 c-noactivate: [1 1 3 5 6 8 10 10]  mean 5.500
+;;     slot 4 c-nowatch: [0 0 2 2 4 7 9 9]  mean 4.125
+;;     slot 5 c-nosub: [1 1 3 3 8 8 10 10]  mean 5.500
+;;     slot 6 c-noreaders: [0 0 2 2 4 7 9 9]  mean 4.125
+;;     slot 7 c-nomap: [1 1 3 5 6 8 10 10]  mean 5.500
+;;     slot 8 b-build: [0 0 2 4 5 6 7 9]  mean 4.125
+;;     slot 9 c-null-twin: [1 3 4 5 6 7 8 10]  mean 5.500
+;;     slot 10 c-null-curve: [2 3 4 5 6 7 8 9]  mean 5.500
+;;   commit: p50 0.6609 [0.5156 - 0.8594] ms/pass  (4.69 us/read)
+;;   c-local: p50 0.6406 [0.4812 - 0.9375] ms/pass  (4.54 us/read)
+;;   c-null: p50 0.6094 [0.4719 - 0.9625] ms/pass  (4.32 us/read)
+;;   c-noactivate: p50 0.6000 [0.4500 - 0.8844] ms/pass  (4.26 us/read)
+;;   c-nowatch: p50 0.5766 [0.4406 - 0.7219] ms/pass  (4.09 us/read)
+;;   c-nosub: p50 0.2062 [0.1594 - 0.3625] ms/pass  (1.46 us/read)
+;;   c-noreaders: p50 0.6266 [0.4781 - 0.8719] ms/pass  (4.44 us/read)
+;;   c-nomap: p50 0.5906 [0.4406 - 0.8469] ms/pass  (4.19 us/read)
+;;   b-build: p50 0.4906 [0.3625 - 0.6656] ms/pass  (3.48 us/read)
+;;   c-null-twin: p50 0.6453 [0.4844 - 0.7719] ms/pass  (4.58 us/read)
+;;   c-null-curve: p50 0.6203 [0.4906 - 0.8156] ms/pass  (4.40 us/read)
+;; ==== PHASE B DELTAS (c-local minus ablation; floors) ====
+;;   copy fidelity: c-local/commit = 0.9693
+;;   NULL CONTROL (c-local - c-null): delta 0.0313 ms/pass (0.22 us/read, 4.9% of the baseline)
+;;     ^ true cost EXACTLY ZERO by construction — both arms are C-FULL. What it reads is this instrument's own error at this shape, and it is what the terms below are adjudicated against (rf2-3l6hf). It bounds no term's cost: a delta inside this spread is a term the window cannot SEE, which leaves its size open in both directions
+;;     ^ slot 1 against slot 2, on footprints that differ in BOTH mean position and shape. The two nulls below hold that zero and move the SLOT, which is what makes the offset's cause readable rather than only its size (rf2-lo7uy)
+;;   NULL CONTROL, position TWIN (c-local - c-null-twin): delta -0.0047 ms/pass (-0.03 us/read, -0.7% of the baseline)
+;;     ^ same zero, and this arm's kept-sample position footprint IS c-local's, so ANY cost that is a function of sweep position cancels term by term. A reading here is error sweep position cannot explain; a reading of zero here beside a non-zero c-null puts the offset ON position
+;;   NULL CONTROL, equal MEAN position (c-local - c-null-curve): delta 0.0203 ms/pass (0.14 us/read, 3.2% of the baseline)
+;;     ^ same zero, c-local's MEAN position on a DIFFERENT footprint: a linear within-sweep drift cancels here, a curved one does not. Read the three nulls together — alike means the offset is not positional; c-null alone means it is; c-null and this one means it is and is not linear
+;;   activation-capture (c-local - c-noactivate): delta 0.0406 ms/pass (0.29 us/read, 6.3% of the baseline)
+;;     ^ a REAL term here, NOT a floor and not an arbiter: nothing activates on this UIx host, but the hook key is never published and so never cached, and this prices that lookup (rf2-tcffa, rf2-19usn). The capture itself is real only under the ratom family (rf2-lzpfj)
+;;   watch-wiring (c-local - c-nowatch): delta 0.0641 ms/pass (0.45 us/read, 10.0% of the baseline)
+;;   reaction-build+cache-insert (c-local - c-nosub): delta 0.4344 ms/pass (3.08 us/read, 67.8% of the baseline)
+;;   reader-membership (c-local - c-noreaders): delta 0.0141 ms/pass (0.10 us/read, 2.2% of the baseline)
+;;   cell-map-insert (c-local - c-nomap): delta 0.0500 ms/pass (0.35 us/read, 7.8% of the baseline)
+;;   b-build (build+compute, no in-window dispose): 0.4906 ms/pass (3.48 us/read)
+;; HICASSO read-profile-micro
+{:subscribe-once 4609.9291, :compute-sub 886.5248, :handler-invoke 191.4894, :registrar-lookup 85.1064, :frame-state-value 351.0638, :resolution-wrap 219.8582, :cache-peek-miss 21.2766, :sub-key-mint 17.7305}
+;; ==== MICRO (ns/op over the page's own roster) ====
+;;   subscribe-once: 4609.9 ns
+;;   compute-sub: 886.5 ns
+;;   handler-invoke: 191.5 ns
+;;   registrar-lookup: 85.1 ns
+;;   frame-state-value: 351.1 ns
+;;   resolution-wrap: 219.9 ns
+;;   cache-peek-miss: 21.3 ns
+;;   sub-key-mint: 17.7 ns
+;; HICASSO DONE
+;; ==== HICASSO RUNTIME ====
+;; chromium 147.0.7727.15 (playwright), :advanced, goog.DEBUG false
+;; ==== HICASSO read-profile-census ====
+{:reads 141, :distinct 141, :by-sub-id {:conduit/your-feed? 1, :conduit/slugs 1, :conduit/tags 1, :conduit/article 69, :conduit/favorite-pending? 69}, :input-kinds {:db 141}}
+;; ==== HICASSO read-profile-arms ====
+{:ship {:n 60, :min 0.2125, :max 0.4, :p50 0.25}, :local {:n 60, :min 0.425, :max 0.6125, :p50 0.5}, :no-shell {:n 60, :min 0.425, :max 0.7375, :p50 0.4625}, :probe {:n 60, :min 0.1875, :max 0.45, :p50 0.225}, :probe-fresh {:n 60, :min 0.1, :max 0.2125, :p50 0.1125}, :floor {:n 60, :min 0.0125, :max 0.05, :p50 0.025}, :warm {:n 60, :min 0.025, :max 0.1, :p50 0.05}, :ctl2 {:n 60, :min 0.8375, :max 1.45, :p50 0.9437}}
+;; ==== HICASSO read-profile-commit ====
+{:c-null-twin {:n 64, :min 0.4844, :max 0.7719, :p50 0.6453}, :c-local {:n 64, :min 0.4812, :max 0.9375, :p50 0.6406}, :c-noreaders {:n 64, :min 0.4781, :max 0.8719, :p50 0.6266}, :c-noactivate {:n 64, :min 0.45, :max 0.8844, :p50 0.6}, :c-null {:n 64, :min 0.4719, :max 0.9625, :p50 0.6094}, :c-nowatch {:n 64, :min 0.4406, :max 0.7219, :p50 0.5766}, :commit {:n 64, :min 0.5156, :max 0.8594, :p50 0.6609}, :c-nomap {:n 64, :min 0.4406, :max 0.8469, :p50 0.5906}, :b-build {:n 64, :min 0.3625, :max 0.6656, :p50 0.4906}, :c-null-curve {:n 64, :min 0.4906, :max 0.8156, :p50 0.6203}, :c-nosub {:n 64, :min 0.1594, :max 0.3625, :p50 0.2062}}
+;; ==== HICASSO read-profile-commit-per-round ====
+{:c-null-twin [0.6719 0.5703 0.6109 0.6594 0.5703 0.6469 0.6734 0.6422], :c-local [0.6797 0.6578 0.5984 0.6578 0.6328 0.6359 0.6594 0.5906], :c-noreaders [0.65 0.5984 0.6109 0.6375 0.5969 0.65 0.6328 0.6063], :c-noactivate [0.6172 0.5281 0.5687 0.5953 0.5891 0.6297 0.6297 0.5969], :c-null [0.6016 0.5469 0.5406 0.5609 0.6125 0.6328 0.6422 0.5641], :c-nowatch [0.5734 0.5625 0.5422 0.5531 0.6281 0.5984 0.5812 0.4719], :commit [0.7125 0.6141 0.5891 0.6141 0.6906 0.7047 0.6984 0.5391], :c-nomap [0.6734 0.5906 0.5125 0.6031 0.5703 0.5672 0.5906 0.5047], :b-build [0.5156 0.4828 0.425 0.4875 0.4547 0.5 0.5031 0.5266], :c-null-curve [0.6891 0.5297 0.6266 0.6031 0.5625 0.6344 0.6359 0.5625], :c-nosub [0.2219 0.1797 0.2125 0.2016 0.1813 0.2078 0.2047 0.2344]}
+;; ==== HICASSO read-profile-commit-per-round-deltas ====
+{:c-null [0.0781 0.1109 0.0578 0.0969 0.0203 0.0031 0.0172 0.0265], :c-noactivate [0.0625 0.1297 0.0297 0.0625 0.0437 0.0062 0.0297 -0.0063], :c-nowatch [0.1063 0.0953 0.0562 0.1047 0.0047 0.0375 0.0782 0.1187], :c-nosub [0.4578 0.4781 0.3859 0.4562 0.4515 0.4281 0.4547 0.3562], :c-noreaders [0.0297 0.0594 -0.0125 0.0203 0.0359 -0.0141 0.0266 -0.0157], :c-nomap [0.0063 0.0672 0.0859 0.0547 0.0625 0.0687 0.0688 0.0859], :c-null-twin [0.0078 0.0875 -0.0125 -0.0016 0.0625 -0.011 -0.014 -0.0516], :c-null-curve [-0.0094 0.1281 -0.0282 0.0547 0.0703 0.0015 0.0235 0.0281]}
+;; ==== HICASSO read-profile-slot-plan ====
+[{:positions [2 3 4 5 6 7 8 9], :mean-position 5.5, :id :commit, :slot 0} {:positions [1 3 4 5 6 7 8 10], :mean-position 5.5, :id :c-local, :slot 1} {:positions [0 0 2 4 5 6 7 9], :mean-position 4.125, :id :c-null, :slot 2} {:positions [1 1 3 5 6 8 10 10], :mean-position 5.5, :id :c-noactivate, :slot 3} {:positions [0 0 2 2 4 7 9 9], :mean-position 4.125, :id :c-nowatch, :slot 4} {:positions [1 1 3 3 8 8 10 10], :mean-position 5.5, :id :c-nosub, :slot 5} {:positions [0 0 2 2 4 7 9 9], :mean-position 4.125, :id :c-noreaders, :slot 6} {:positions [1 1 3 5 6 8 10 10], :mean-position 5.5, :id :c-nomap, :slot 7} {:positions [0 0 2 4 5 6 7 9], :mean-position 4.125, :id :b-build, :slot 8} {:positions [1 3 4 5 6 7 8 10], :mean-position 5.5, :id :c-null-twin, :slot 9} {:positions [2 3 4 5 6 7 8 9], :mean-position 5.5, :id :c-null-curve, :slot 10}]
+;; ==== HICASSO read-profile-micro ====
+{:subscribe-once 4609.9291, :compute-sub 886.5248, :handler-invoke 191.4894, :registrar-lookup 85.1064, :frame-state-value 351.0638, :resolution-wrap 219.8582, :cache-peek-miss 21.2766, :sub-key-mint 17.7305}
+[hicasso] ok


### PR DESCRIPTION
**Measurement window (Shape 6). No rig was edited.** This is the window half of
rf2-lo7uy, reading the discriminating arms PR #8384 appended. Two files land: a
result record under `data/readprofile-lo7uy/`, and one appended blockquote in
the studio page.

## What ran, and what refused

Three runs of `run.cjs` with
`HICASSO_INIT_FN=re-frame.bench.hicasso.read-profile-app/-main` on a drained
box. **The run count was fixed at three before run 1 started** — the count the
bead's 2026-08-16T04:55:51Z comment specified — so no stopping rule could end
the series on a convenient answer.

**Nothing refused.** All three: `exit 0`, both arm-order guards *reportable*,
phase-A positive control passing, phase-B residue gate never firing. Instrument
blob `c220a8c23c` on base `3be82b04bc`, `:advanced`, HeadlessChrome
147.0.7727.15.

## The result: the offset did not reproduce

On the same arm pair rf2-3l6hf measured it on — `c-local` slot 1 against
`c-null` slot 2, both at their published slots:

| null | slot | run 1 | run 2 | run 3 | range | grid steps |
|---|---|---|---|---|---|---|
| `c-null` | 2 | +0.0109 | −0.0188 | +0.0313 | 0.0501 | 32 |
| **`c-null-twin`** | 9 | **−0.0031** | **+0.0047** | **−0.0047** | **0.0094** | **6** |
| `c-null-curve` | 10 | −0.0281 | −0.0250 | +0.0203 | 0.0484 | 31 |

rf2-3l6hf read `+0.0234 / +0.0219 / +0.0234` on that first row — one grid step.
**The stable offset this bead exists to explain was not present to be
diagnosed**, so its cause is still not established.

`n` went 9 → 11, so the two series are not arm-by-arm comparable. What is
established is only that a `+0.022` offset stable to one grid step is not a
reproducible property of this instrument across a change of layout.

## Where (a), (b) and (c) stand

- **(a) residual arm-position effect** — *supported as a component of the
  run-level error, not established as the cause of the offset.* The twin is the
  only one of eight deltas with a small run-level range. Raw pooled medians:
  `c-local` 0.5922/0.5875/0.6406 and the twin 0.5953/0.5828/0.6453 rose together
  by +0.0531 and +0.0625 between runs 2 and 3, while `c-null` moved +0.0031 and
  the curve +0.0078.
- **(b) within-sweep thermal/cache drift** — *left open, and not separable from
  (a) by this rig.* The twin cancels any function of sweep position whatever its
  physical cause, so both fall on the same side of it.
- **(c) pooled median on a right-tailed arm** — *disfavoured as a cause of a
  systematic offset*, on a source-level argument the data does not need: two
  arms with identical true distributions have the same expected median under any
  estimator, so an estimator can produce variance between them but not bias. Not
  excluded as a contributor to run-level variance.

**Three caveats, all in the record.** The co-movement rests on one of the two
transitions three runs afford; there is no second null pair to corroborate it
(every other footprint-sharing pair puts two *different* workloads together);
and it is absent at round granularity, where the three nulls' within-round p50
delta standard deviations are 0.0415 / 0.0447 / 0.0460 — ratios of 1.08 and
1.11.

## A limit found in the rig, recorded and NOT repaired

`c-null-curve`'s job is to cancel a linear drift by matching `c-local`'s mean
position. That is exact for an arithmetic mean and only first-order true for the
**median** this instrument reports: two arms sharing a footprint exactly have
identical pooled mixtures and identical medians for any drift, but two arms
sharing only the mean differ at second order in the *variance* of the position
multiset — 7.25 for `c-local` against 5.25 for the curve. **So a non-zero curve
reading does not establish curvature, and this window concludes nothing about
linearity.** Not repaired: `n` feeds `lane/slot-order`, so touching the roster
moves every published footprint and starts a third series.

## rf2-07rnj

**Stays blocked.** It is blocked on the offset's cause being established, and
this window did not establish it.

## The estimator, named as computed

Every run-level figure is a difference of two **pooled medians** — `lane/summarise`'s
`:p50`, an order statistic; on an even kept count the mean of the two middle
*order statistics*, which is the standard median, **not** an arithmetic mean of
the samples. Verified at source. Where a figure is the arithmetic mean of three
run-level deltas, or a within-round median, the record calls it that.

## What was NOT concluded

Not that the offset is fixed or was an artefact of nine arms. Not that any
candidate is its cause. Not any separation of (a) from (b). Not whether the
drift is linear. **No bound on any term** — no null was subtracted from any
term and no null spread is quoted as a bound; both rf2-3l6hf prohibitions
stand. Nothing about within-run quietness beyond the bracketing. The five
ablation figures this series recorded supersede nothing.

## The box

`\System\Processor Queue Length` sampled **on its own and outside every measured
run**, five samples at 1 s, on a 24-core host: `0,0,0,0,0` before run 1;
`0,0,0,0,1` after run 1; `0,0,0,0,0` after run 2; `0,0,0,0,0` after run 3. A
second counter (`% Processor Utility`) read in the same brackets, never above
32.3% including the sampler's own cost — two sources, because a headline
utilisation figure can be wrong while the queue length says whether anything is
actually waiting for a core. Nothing sampled inside a run; the quietness claim
is a bracketing claim and nothing stronger. Zero open PRs and no other worker in
flight, verified at start-up and re-derived before the edit.

## Quality gates

`scripts/test-fast-pr.sh` — **exit 0**, captured by me via `; echo $? >` on one
command line in one shell, not reported by the harness. Verdict line `PASS fast
PR spine` appears exactly once; the exit artefact is 2 bytes with no NUL runs;
the log names this worktree 14 times.

- `scripts/check-no-hardcoded-paths.sh` — exit 0. **Fault-planted to prove it
  reads this worktree**: re-inserting the raw `config:` banner into `run1.txt`
  turned it red (exit 1) naming that exact path; restored and re-verified green.
- `scripts/check_doc_slugs.py` — exit 0.
- `scripts/check_provenance_pins.py` — exit 0, 0 findings.

`docs/design/hicasso/**` is outside `mkdocs build --strict`, so per CLAUDE.md I
checked by hand: **all 14 tables in the studio page and all 6 in the record have
consistent column counts** (verified programmatically across header, separator
and every row), and the page adds no new links or anchors.

## Redaction

Each transcript is verbatim except **one line** — the `shadow-cljs - config:`
banner, whose absolute path is replaced by `<worktree>` and marked inline as
redacted, because the portability gate refuses a tracked personal home path.
Diffed against the raw driver output: exactly that line differs and the other
259 / 258 / 258 lines are byte-identical. Line counts unchanged (260/259/259).
