### PR TITLE
docs(hicasso): the three per-run codec ranges are one comparison, not three comparators (rf2-prvry)

### DIFF
--- a/docs/design/hicasso/studio/hd8-freehand-codec-donor-arm.md
+++ b/docs/design/hicasso/studio/hd8-freehand-codec-donor-arm.md
@@ -30,6 +30,26 @@
 > (`donor-r* / uix`). That is a smaller claim honestly stated, not the same claim
 > on fewer arms.
 >
+> **Amended 2026-08-17 (`rf2-prvry`) — the three per-run codec ranges are ONE
+> comparison measured three ways, not three comparators.** `rf2-m4rpa`'s ruling
+> proposed writing that the codec claim *"survives on THREE independent
+> comparators instead of four"*, reading UIx `1.139 – 1.217`, Reagent
+> `1.154 – 1.272` and slim `1.078 – 1.306` as three arms that outlive
+> `:donor-fh`. They do not, and the ruling's own condition — *"re-verify the
+> three surviving figures at source before writing anything"* — is what caught
+> it. All three are the sweep-1 `mount-M` rows below: that table's `run` and
+> `comparison` columns are separate, all three rows carry the same comparison
+> `donor-fh / donor-r1`, and the numerator of all three is `:donor-fh`, the arm
+> being retired. `uix` / `reagent` / `slim` name the three ADAPTER INSTALLS the
+> instrument runs under — Spec 006 allows exactly one installed adapter per
+> process — rather than arms; `arm-ids-for` in `hd8_rows.cljs` lists `:uix` as
+> an arm *inside* the `:reagent` and `:slim` runs, so the two labels cannot be
+> the same kind of thing. **The sentence was therefore not written, and nothing
+> is claimed in its place.** The same three ranges recur in the replication
+> table's sweep-1 column below, and `1.078 – 1.306` once more as the min–max
+> union of all six `mount-M` run-segments — seven lines on this page, every one
+> of them inside this frozen record.
+>
 > **`codecs-differ?` went with the arm rather than being re-pointed**, and its
 > absence is stated at source in `hd8_witnesses.cljs`'s closing section. It
 > guarded exactly one reading — a `donor-fh / donor-r1` of 1.0 being ambiguous
@@ -248,6 +268,11 @@ own fixed React cost dominates most. That is the shape predicted.
 **Arm count: 5 / 6 / 6 by run (uix / reagent / slim), seven distinct arms.**
 Every figure below rests on that plan, and on an instrument that no longer
 exists — see the retirement banner at the top of this page.
+
+**`run` and `comparison` are separate columns below.** The three
+`donor-fh / donor-r1` rows in each mount table are that one comparison measured
+under three adapter installs — not three comparisons, and not three arms. See
+the 2026-08-17 amendment in the banner.
 
 Every figure is a **range over 6 rounds**, formed within each round against that
 round's own p50s. **A range including 1.0 means the two arms are


### PR DESCRIPTION
## Verdict: the bead's refutation is CONFIRMED, independently and at source

`rf2-m4rpa`'s ruling, action 3, said *"LET THE THREE SURVIVING ARMS CARRY THE CLAIM …
the claim that hicasso's codec is competitive survives on THREE independent comparators
instead of four"*, and attached its own condition: *"RE-VERIFY THE THREE SURVIVING
FIGURES AT SOURCE before writing anything."* Re-verified. **The premise does not hold**,
so the sentence cannot be written as ruled, and this PR does not write it or anything
standing in for it.

### 1. What the three figures are comparisons OF, and on which row

All three are the **same comparison on the same row** — `donor-fh / donor-r1`, labelled
THE CODEC, on `mount-M` in the sweep-1 results — differing only in the `run` column. The
table header settles it, because `run` and `comparison` are **separate columns**:

`docs/design/hicasso/studio/hd8-freehand-codec-donor-arm.md:258` (at `origin/main`; `:283`
after this PR's insertion)

```
| run | comparison | range | per-round |
```

`:260`, `:264`, `:268` (→ `:285`, `:289`, `:293` after this PR):

```
| uix     | **`donor-fh / donor-r1` — THE CODEC** | **1.139 – 1.217** | …
| reagent | **`donor-fh / donor-r1` — THE CODEC** | **1.154 – 1.272** | …
| slim    | **`donor-fh / donor-r1` — THE CODEC** | **1.078 – 1.306** | …
```

**The numerator of all three is `:donor-fh` — the arm being retired.** They cannot outlive
it. Arithmetic re-checked against the per-round columns the same lines quote: `1.1392 …
1.2169 → 1.139 – 1.217`; `1.1538 … 1.2717 → 1.154 – 1.272`; `1.0784 … 1.3059 →
1.078 – 1.306`. Each is a **min–max range over 6 rounds of per-round p50 ratios** (stated
at `:252-254`) — not a mean and not a confidence interval, so "the same band" is an
overlap observation, not an agreement of estimators.

**The bead's list of sites is incomplete by four.** `git grep -F` for the three literal
ranges returns exactly **7 tracked lines, all in this one file**: `:260 :264 :268` (sweep-1
mount-M), `:343 :344 :345` (the replication table's sweep-1 column) and `:387`. `:387` is
**not** a fourth quotation of the slim figure — it is the min–max **union** of all six
`mount-M` run-segments across both sweeps, which happens to equal slim's sweep-1 band
because that band holds both extremes (min `1.078` slim sweep 1; max `1.306` slim sweep 1;
the other five segments are `1.139 – 1.217`, `1.154 – 1.272`, `1.139 – 1.229`,
`1.159 – 1.205`, `1.114 – 1.292`).

### 2. `uix` / `reagent` / `slim` are adapter installs, not arms — from the code and the spec

Not from the prose describing the instrument:

* `implementation/hicasso/test/re_frame/bench/hicasso/hd8_rows.cljs:37-48` — *"## One
  adapter per process, so three runs / Spec 006 allows exactly one installed adapter per
  process … `?adapter=uix`, `?adapter=reagent`, `?adapter=slim`"*, followed by a table
  whose columns are literally `run` / `arms` / `answers`.
* `hd8_rows.cljs:268-270` — `arm-ids-for`, the structural proof:
  ```clojure
  {:uix     [:floor :uix :donor-r1 :donor-r2]
   :reagent [:floor :reagent :uix :donor-r1 :donor-r2]
   :slim    [:floor :reagent-slim :uix :donor-r1 :donor-r2]}
  ```
  Run keys, arm vectors — and `:uix` appears as an **arm inside the `:reagent` and `:slim`
  runs**, so run and arm cannot be the same kind of label.
* `hd8_rows.cljs:50-54` — *"FOUR, FIVE AND FIVE ARMS. A fifth/sixth `donor-fh` rode each of
  these plans between `rf2-2rtt6.29` and `rf2-m4rpa`"* — matching the page's banner
  (`:23`): seven distinct arms before, six after.
* `spec/006-ReactiveSubstrate.md:2813-2815` — *"### Single adapter per process / One
  adapter per process. Frames within a process all use the same adapter."* (The bead cited
  `:2836-2838`; the section has drifted 23 lines since, and the citation resolves.)

### 3. Therefore

**Action 3's sentence is refuted.** Those three numbers are the retiring figure measured
three ways, so they do not survive `:donor-fh`'s retirement. Writing *"survives on three
independent comparators"* would have been the exact failure mode the ruling exists to
prevent.

**No replacement claim is made, and none is available.** After the retirement the
instrument has exactly one runtime hiccup codec door left, so no surviving comparison
prices one codec against another. The honest outcome is that the codec axis rests on **no**
surviving comparator — which the page already said, and now says at the point of meeting.

The overclaiming sentence was **never written anywhere in the tracked tree**:
`git grep -F "three independent comparators" -- ':!.beads'` → **exit 1, zero lines**.
Positive control on the same fixed-string pattern, `.beads` included → **exit 0, 2 lines**
(Mike's ruling and this bead's description, in the database export), so the zero is a real
absence and not a broken search. `git grep -F "surviving arm"` → exit 0, 10 lines, as a
second control that fixed-string matching works over this corpus. No tracked record carries
`rf2-m4rpa`'s ruling text, so this PR's fence resolves to the studio page alone.

## What changed

25 inserted lines, 0 deleted, one file.

1. A **dated amendment** in the retirement banner (`2026-08-17`, `rf2-prvry`) recording the
   refutation itself: what the three figures are, whose numerator they carry, that `run ≠
   arm`, that the sentence was not written, that nothing is claimed in its place, and where
   all seven occurrences live. Dated amendment rather than an in-place rewrite, because the
   page is a measurement account and it aged rather than being wrong.
2. A four-line note above the sweep-1 tables: `run` and `comparison` are separate columns.

**Deliberately NOT claimed:** that the codec is competitive on fewer comparators; that any
surviving figure stands in for the retired one; that the three ranges are replicates in the
strict sense (they are the same arm pair under three different installed adapters, which is
not an identical condition). No figure is moved, re-baselined or deleted.

## Quality gates

Every exit code below is the one **captured by the running shell** (`> log 2>&1; echo
"EXIT=$?"` on one command line), never a harness-reported one.

| gate | exit | note |
|---|---|---|
| `python scripts/check_doc_slugs.py` (clean, pre-plant) | **0** | covers my surface — verified at source: `DEFAULT_ROOTS` includes `docs`, `EXCLUDE_DIR_NAMES` does not exclude `design`, and `_iter_markdown` walks those roots |
| `python scripts/check_doc_slugs.py` (**planted fault**) | **1** | the control — see below |
| `python scripts/check_doc_slugs.py` (post-restore) | **0** | restore hash-verified |
| `python scripts/check_doc_slugs.py` (post-rebase, final base) | **0** | re-run after rebasing onto `26e93d0b30` |
| `python scripts/check_provenance_pins.py` (full corpus) | **0** | `115 pages inspected, 560 cited pins … 0 findings` |
| `python scripts/check_provenance_pins.py --self-test --verbose` | **0** | `all 68 self-tests passed` |
| `python scripts/check_provenance_pins.py --changed-since origin/main --verbose` | **0** | `1 page inspected … 0 findings` — and the page it names is mine, which is itself a which-tree check |
| same, re-run post-rebase | **0** | identical output |
| `sh scripts/test-fast-pr.sh` | **0** | **it ran, in full.** Log line 1: `gate root: /c/Users/miket/code/re-frame2-worktrees/donorarm-prvry` — it read this worktree |

**Planted-fault control (the deliverable).** `check_doc_slugs.py` is silent on success, so
the discrimination is the red. On a line this PR authors, the banner cross-reference was
temporarily turned into
`[2026-08-17 amendment](hd8-freehand-codec-donor-arm.md#planted-fault-donorarm-prvry-no-such-anchor)`.
The gate went **red, exit 1**, naming exactly what was planted:

```
BROKEN ANCHOR: docs\design\hicasso\studio\hd8-freehand-codec-donor-arm.md:275
  -> hd8-freehand-codec-donor-arm.md#planted-fault-donorarm-prvry-no-such-anchor
```

The plant is proven to have applied by the content hash moving
`287b06e7d2eeecfb1d3fdded7b1ae65b28361b98 → 0cf0481e4184e816dbb8ec1b5615eed009a52fc3`, so
this is not a green-because-nothing-broke. The fault existed only in this worktree, so a
run that had wandered into a sibling's would have come back green. **Restore verified by
hashing the bytes against the committed object**, not by reading a diff: working
`287b06e7d2eeecfb1d3fdded7b1ae65b28361b98` == `git rev-parse HEAD:<path>`
`287b06e7d2eeecfb1d3fdded7b1ae65b28361b98`, `git status --porcelain` empty, gate green
again. The hash is unchanged after the rebase as well.

**`mkdocs build --strict` is NOT the gate for this edit** and is not nominated as one:
`mkdocs.yml`'s `exclude_docs` keeps `design/hicasso/` out of the built site. It did run
green inside the fast-PR spine, on the rest of the corpus.

**Nothing validates this tree's tables, rendering or nav, so both were checked BY HAND, with
counts.** Column counts, all 12 tables in the file, each row's delimiter count compared
against its header's: `16-23` 2 cols (8 rows) · `103-112` 2 (10) · `122-131` 2 (10) ·
`161-169` 2 (9) · `171-173` 2 (3) · `226-234` 3 (9) · `283-296` 4 (14) · `303-315` 4 (13) ·
`325-329` 3 (5) · `336-341` 3 (6) · `366-375` 6 (10) · `408-413` 4 (6). **12 tables, 0
mismatches**; this PR adds no table rows and no table cells. Anchors: the file carries 6
markdown links, 2 of them anchored (`:67 ../validation.md#p1-gate--the-composed-donor-arm-hd-008`,
`:71 hd8-composed-donor-arm.md#mount--the-m-page-300-rows-markup-dominant`); all 6 are
green under `check_doc_slugs.py`, whose liveness on this exact file is proven by the red
above. This PR adds **no links**, deliberately — the amendment cross-references the banner
in prose so no new anchor surface is created.

**Gap between this spine and CI:** `python scripts/check_fast_pr_gap.py --list` → exit 0,
reporting **94 required checks the spine does not run** ("Green here is not green in CI"),
across `test.yml` / `lint.yml` / `docs.yml`. That is the one path that derives the gap; it
is cited rather than restated. Nothing was skipped silently: no gate applicable to a
`docs/design/**` prose insertion was left unrun.

**Merge-base diff read before push** (`git diff origin/main...HEAD`, three-dot): 25
insertions, **0 deletions**, one file. Nothing a sibling landed is reverted. Rebased once
onto `26e93d0b30`; the only trunk movement in the interval was `.beads/issues.jsonl`, and
the docs gates were re-run on the final base regardless.

## Left for Mike

The bead asks for **Mike's assent to the reading, not for work.** This PR settles the
factual question and puts the refutation in the tracked record; what it cannot settle is
whether Mike accepts that action 3 is unwritable as ruled. If he does not, the sentence he
wants still needs naming — and two independent passes now agree that no surviving
comparison in this instrument prices one runtime hiccup codec against another, because
after the retirement there is exactly one codec door left. `rf2-prvry` is therefore left
**OPEN** with the verdict recorded on it.

Bead: `rf2-prvry`. Refutes action 3 of the ruling on `rf2-m4rpa` (PR #8235).
