### PR TITLE
audit rf2-k9rzr: six orphan claims re-derived — three refused, three real (+ rf2-2vr35: the weak-node-record fixture's racy expunge)

### DIFF
--- a/implementation/core/src/re_frame/error_emit.cljc
+++ b/implementation/core/src/re_frame/error_emit.cljc
@@ -435,9 +435,19 @@
   successor's own `:observability :errors` sink. This is the event-centric
   mirror of the union-path `route-frame?` seam rf2-vxgfnd.118 added for the
   post-dissoc teardown report. Every ordinary live / address-directed caller
-  keeps the default, so normal frame-owned routing is untouched — and no
-  in-repo caller passes false today, the one that did having gone with the
-  retired view artefact's frame-bundle stale-op seam."
+  keeps the default, so normal frame-owned routing is untouched.
+
+  THE FALSE BRANCH IS LIVE, reached through [[emit-error-both!]], which threads
+  its own trailing `route-frame?` straight into this 9-arity. rf2-qjfrw carried
+  the seam from the retired view artefact's `(frame)` bundle into core's own
+  `capture-frame` primitive, and two production sites drive it:
+  `router/emit-frame-destroyed!` passes `(nil? op)`, so every captured-op
+  rejection suppresses the route, and `subs/emit-frame-destroyed-recovery!`
+  passes a literal false for a captured subscribe whose pinned incarnation was
+  superseded. `capture_frame_reincarnation_sink_route_cljs_test` pins both
+  branches. (This paragraph used to say no in-repo caller passed false — true
+  while the seam was UI-only, stale from rf2-qjfrw onward, and read by a later
+  audit as evidence the branch was unreachable. That is rf2-k9rzr.)"
   ([error-kw event event-id frame-id exception elapsed-ms time]
    (dispatch-on-error! error-kw event event-id frame-id exception elapsed-ms time nil true))
   ([error-kw event event-id frame-id exception elapsed-ms time attrs]

--- a/implementation/core/test/re_frame/observation_port_cljs_test.cljc
+++ b/implementation/core/test/re_frame/observation_port_cljs_test.cljc
@@ -2456,16 +2456,35 @@
      was. Allocates transient heap pressure between cycles to prod the
      collector. The bounded loop keeps the fixture deterministic — it never
      blocks unboundedly (a still-strong-reachable referent returns false, which
-     is the pre-fix failure signal)."
-     [^java.lang.ref.WeakReference wref]
-     (loop [i 0]
-       (cond
-         (nil? (.get wref)) true
-         (>= i 40)          false
-         :else              (do (System/gc)
-                                (System/runFinalization)
-                                (make-array Object 200000) ;; transient pressure
-                                (recur (inc i)))))))
+     is the pre-fix failure signal).
+
+     `poke` runs ONCE PER CYCLE, inside the loop, and is how a caller whose
+     referent is reachable only through a `java.util.WeakHashMap` VALUE keeps
+     this fixture honest. Such a value is released solely by
+     `expungeStaleEntries`, which runs on a MAP OPERATION and drains the map's
+     own ReferenceQueue. A Reference is CLEARED during the collection but
+     ENQUEUED afterwards, asynchronously, by the ReferenceHandler thread — the
+     same asymmetry `jvm-provenance-entry-is-weak-and-expunged-when-its-throwable-dies`
+     records below (rf2-8vvdo) — so there is a window in which the key reads
+     cleared and has not yet been enqueued. A single map operation performed
+     BEFORE this loop can land in that window: it expunges nothing, no later
+     cycle touches the map, and the value stays strongly reachable for the rest
+     of the run. That is not a slow test but a permanently red one, and it is
+     what reddened `jvm-core-prod-gate` on a branch whose diff could not reach
+     this namespace (rf2-2vr35). Poking every cycle relies on no happens-before
+     edge and needs none: whichever cycle follows the enqueue expunges."
+     ([^java.lang.ref.WeakReference wref]
+      (gc-until-cleared? wref (fn [])))
+     ([^java.lang.ref.WeakReference wref poke]
+      (loop [i 0]
+        (cond
+          (nil? (.get wref)) true
+          (>= i 40)          false
+          :else              (do (System/gc)
+                                 (System/runFinalization)
+                                 (make-array Object 200000) ;; transient pressure
+                                 (poke)
+                                 (recur (inc i))))))))
 
 #?(:clj
    (deftest jvm-weak-node-record-does-not-strong-pin-its-abandoned-reaction
@@ -2500,11 +2519,13 @@
              (str "the abandoned reaction is GC-collectable — the weak "
                   "node-records value no longer strong-references its own weak "
                   "key (this assertion FAILS on PR #5710's strong :reaction)"))
-         ;; The reaction (weak KEY) is gone; a WeakHashMap operation now expunges
-         ;; the stale entry, dropping the map's strong ref to the VALUE (record →
-         ;; :owners → handle), which the next GC reclaims.
-         (.size ^java.util.Map @#'obs/node-records)
-         (is (gc-until-cleared? handle-ref)
+         ;; The reaction (weak KEY) is gone; a WeakHashMap operation expunges the
+         ;; stale entry, dropping the map's strong ref to the VALUE (record →
+         ;; :owners → handle), which the next GC reclaims. That operation runs
+         ;; INSIDE the loop, never once before it: clearing the key and ENQUEUEING
+         ;; it are separate steps, so a single pre-loop `.size` can expunge nothing
+         ;; and pin the handle for the whole run (rf2-2vr35 — see gc-until-cleared?).
+         (is (gc-until-cleared? handle-ref #(.size ^java.util.Map @#'obs/node-records))
              "the abandoned handle was reclaimed once its node record's weak key died")))))
 
 ;; ===========================================================================

--- a/implementation/scripts/api-manifest/probe/src/re_frame/api_manifest/cljs_probe.cljc
+++ b/implementation/scripts/api-manifest/probe/src/re_frame/api_manifest/cljs_probe.cljc
@@ -48,10 +48,23 @@
   `:cljs-only` ADAPTER/Xray surfaces, which bind fn-valued value-defs the
   analyzer cannot tell from a plain `:var`. The host-signature
   reconciler below (`signature-problems`) DOES reconcile `:kind` (rf2-d7sso):
-  that surface is real `defn`s + `defmacro`s (no value-defs), so the analyzer
-  classifies it reliably, and the sidecar's declared kind is VALIDATED against
-  the live analyzer kind rather than trusted — closing the seam where the JVM
-  lane once ignored the sidecar kind while this lane trusted it to select checks.
+  it is written for surfaces of real `defn`s + `defmacro`s (no value-defs), which
+  the analyzer classifies reliably, so the sidecar's declared kind is VALIDATED
+  against the live analyzer kind rather than trusted — closing the seam where the
+  JVM lane once ignored the sidecar kind while this lane trusted it to select
+  checks.
+
+  NO SIDECAR BLOCK DRIVES `signature-problems` TODAY. It was written beside the
+  `:ui-test-signatures` block of the `re-frame.ui.test` surface, and that block
+  went with the retired donor view artefact (rf2-0yp7w.4). The reconciler itself
+  is host-agnostic and sidecar-key-agnostic — it takes `contract` and `surface`
+  as ARGUMENTS and reads no key — so it survives as the mechanism any future
+  host-aware signature block plugs into via `cljs-publics/emit-signature-contract`.
+  It is NOT silently passing in the meantime: eleven tests drive it directly on
+  synthetic fixtures, eight asserting a specific mutation goes RED and three
+  guarding against over-tightening. Its diagnostics no longer name the retired
+  namespace or key (rf2-k9rzr) — a real drift would have sent the reader looking
+  for both.
 
   ## Why the adapters are `:fully-rowed` but the Xray mount surface is not
 
@@ -202,12 +215,12 @@
   (str/join
    "\n"
    (concat
-    ["CLJS ui.test host-signature DRIFT (rf2-5bcdi/rf2-d7sso): a re-frame.ui.test"
-     "public var's live CLJS classification/arity no longer matches the signature"
-     "contract in spec/api-manifest-metadata.edn (:ui-test-signatures). The"
-     "sidecar's declared :kind is reconciled against the live analyzer kind, so a"
-     "stale/flipped kind is rejected here. Reshape the source or reconcile the"
-     "contract until this is green. Problems:"]
+    ["CLJS host-signature DRIFT (rf2-5bcdi/rf2-d7sso): a public var's live CLJS"
+     "classification/arity no longer matches the signature contract its lane read"
+     "out of spec/api-manifest-metadata.edn (the block the caller passed to"
+     "`emit-signature-contract`). The sidecar's declared :kind is reconciled"
+     "against the live analyzer kind, so a stale/flipped kind is rejected here."
+     "Reshape the source or reconcile the contract until this is green. Problems:"]
     (map (fn [{:keys [kind var expected got declared live-kind]}]
            (case kind
              :kind-mismatch
@@ -219,7 +232,7 @@
              :macro-host-variance
              (str "    " var ": MACRO contract :clj " (pr-str expected)
                   " but :cljs " (pr-str got)
-                  " — a ui.test macro is ONE .cljc defmacro expanded on both"
+                  " — a macro is ONE .cljc defmacro expanded on both"
                   " hosts, so its call grammar cannot differ by host. Set :cljs"
                   " equal to :clj (" (pr-str expected) "); if the grammar really"
                   " changed, change BOTH.")
@@ -230,7 +243,7 @@
              (str "    " var ": the contract names it but the live CLJS surface "
                   "does not expose it")
              :uncontracted-var
-             (str "    " var ": live CLJS public var with no :ui-test-signatures "
+             (str "    " var ": live CLJS public var with no signature-contract "
                   "entry")))
          problems))))
 

--- a/implementation/scripts/api-manifest/probe/test/re_frame/api_manifest/cljs_manifest_probe_cljs_test.cljs
+++ b/implementation/scripts/api-manifest/probe/test/re_frame/api_manifest/cljs_manifest_probe_cljs_test.cljs
@@ -233,7 +233,7 @@
       (is (= :fn (:live-kind (first problems)))))))
 
 (deftest cljs-classified-var-without-signature-goes-red
-  (testing "a live blessed var with no :ui-test-signatures entry (an omitted
+  (testing "a live blessed var with no signature-contract entry (an omitted
             contract entry, or a classified CLJS-only function added without a
             host-arity contract) is :uncontracted-var — cannot escape coverage"
     (let [problems (probe/signature-problems

--- a/implementation/scripts/check-bundle-isolation.test.cjs
+++ b/implementation/scripts/check-bundle-isolation.test.cjs
@@ -504,24 +504,26 @@ for (const relPath of Object.keys(DEDICATED_ISOLATION_GATES)) {
   assert(rt && rt.via === 'dedicated' && rt.relPath.startsWith('adapters/'),
     `${relPath}: must be discovered under adapters/ and covered by its validated dedicated gate`);
 }
-// rf2-a32r7 — `ui` was never publishable, so it was never discovered as a
-// required browser-optional runtime. The artefact itself is now RETIRED and the
-// directory is gone, so this assertion is vacuous rather than load-bearing; it is
-// kept only until somebody decides whether the retired-path guard is worth
-// generalising.
-assert(!realCoverage.required.some((rt) => rt.relPath === 'ui'),
-  'ui must NOT be in the required browser-optional set — it declares no :clein/build (rf2-a32r7)');
-
-// Every generic-coverage path must be a real implementation/ runtime on disk (so
-// a stale relPath can't paper over a missing runtime). Publishable ones are held
-// to the stronger structural test; `ui` is the one in-tree-only entry.
-const NON_PUBLISHABLE_GENERIC = new Set(['ui']);
+// rf2-k9rzr — the decision the retired-`ui` guard was left waiting on. Two
+// `ui`-shaped remnants stood here, and BOTH were unreachable once the artefact
+// was retired and its directory deleted:
+//
+//   - `assert(!realCoverage.required.some((rt) => rt.relPath === 'ui'))`. The
+//     required set is derived by READING each candidate's deps.edn off disk, so
+//     a path with no directory can never enter it. Measured: substituting any
+//     never-present string for 'ui' left the self-test green, which is the
+//     definition of an assertion proving nothing.
+//   - a `NON_PUBLISHABLE_GENERIC = new Set(['ui'])` waiver that let a named
+//     generic-coverage path settle for mere directory existence instead of the
+//     structural publishable test. `genericCoveragePaths()` has not yielded 'ui'
+//     since the retire, so the branch never ran.
+//
+// Generalising the first into a retired-path guard was considered and REJECTED:
+// discovery cannot manufacture a path that is not on disk, so the generalised
+// form would be vacuous by construction too. Both are deleted rather than
+// patched, and the waiver goes with them — an exemption nothing claims can only
+// ever weaken this check for whatever claims it next.
 for (const relPath of genericCoveragePaths()) {
-  if (NON_PUBLISHABLE_GENERIC.has(relPath)) {
-    assert(fs.existsSync(path.join(REPO_ROOT, 'implementation', relPath, 'deps.edn')),
-      `generic-coverage relPath '${relPath}' must be a real implementation/ artefact directory`);
-    continue;
-  }
   assert(pathDeclaresBuildAlias(path.join(REPO_ROOT, 'implementation'), relPath),
     `generic-coverage relPath '${relPath}' must be a real publishable implementation/ artefact`);
 }
@@ -544,7 +546,7 @@ console.log(
   `${sentinelMutations} deliberate production leaks; ` +
   `${thirdParty.size} emitted third-party owners; ` +
   `${coverageMutations} structural+causal enrollment mutations ` +
-  '(publishable ui + new adapter + nested non-adapter fail closed; leaf-collision, ' +
+  '(new flat publishable + new adapter + nested non-adapter fail closed; leaf-collision, ' +
   'EDN string/comment/discard rejected; dedicated gate bound to exact runtime + ' +
   'executable — prose/absent/uninvoked/echo/false-and/arg-only/substring command + ' +
   'unrelated-checker-for-new-runtime all rejected; nonexistent-root / subtree-EACCES / ' +


### PR DESCRIPTION
Closes rf2-k9rzr.

R6c reported five live-code orphans and one vacuous assertion under a comment-only fence, and deliberately did not action them. Every one is a **claim of absence**, which is the weakest kind, so all six were re-derived at `origin/main` with `git grep -nF`, each zero reported with a positive control. **Three did not survive re-derivation and are refused. Three were real and are fixed.** Two of the refusals are refused *for a reason different in kind from "the search came back empty"*, which is what the bead asked for.

The `.beads/issues.jsonl` export contains the bead text itself and matched every pattern, so all searches below exclude it (`':!.beads/'`).

---

## Verdicts

### 1. `guard-open-drain!` — REFUSED (deliberate, documented, ruled)

```
$ git grep -nF 'guard-open-drain' -- . ':!.beads/'
implementation/core/src/re_frame/frame.cljc:3521:(defn guard-open-drain!
spec/009-Instrumentation.md:2413: … the SHARED open-drain guard is `re-frame.frame/guard-open-drain!` in CORE …
```
Positive control (same file, adjacent symbol) — `git grep -nF 'run-frame-state-before'` returns 17 hits across `frame.cljc`, `router.cljc`, a test and the spec. The search works; the zero is real.

The claim "no caller anywhere" is TRUE and is **not news**. The function's own docstring says so: *"No in-repo substrate calls it today — both callers went with the retired donor view artefacts, and the guard stayed because the law is core's rather than theirs."* It is retained normative surface: `spec/009-Instrumentation.md` catalogues `:rf.error/flush-in-open-epoch` as enforced by this one function (ruling rf2-vxgfnd.207; moved into core by rf2-87ouj). Deleting it needs a `spec/009` edit — repo hot-zone, and outside this worker's fence.

Incidental observation, **not actioned** (spec is hot-zone): 009 says "EVERY substrate whose synchronous flush can publish a render phase calls it". That set is currently **empty** — the surviving substrates' only `flush!` (`hicasso/impl/collector.cljs:1005`) is an internal commit-time notifier that defers to a macrotask during a render body, not a user-forced registry flush. The sentence is vacuously true rather than false. Flagged for the mayor.

### 2. `dispatch-on-error!`'s `route-frame?` 9-arity — CLAIM FALSIFIED; the stale prose that caused it is fixed

The claim was that the 9-arity has no false-passer, so one branch is unreachable. **It has two, both production:**

- `implementation/core/src/re_frame/router.cljc:2236` passes `(nil? op)` to `emit-error-both!`, which threads its trailing `route-frame?` straight into the 9-arity (`error_emit.cljc:638`). Any captured-op rejection makes it **false**.
- `implementation/core/src/re_frame/subs.cljc:1087` passes a literal `false` via `emit-frame-destroyed-recovery!` for a captured subscribe whose pinned incarnation was superseded.

Both are rf2-qjfrw, and `capture_frame_reincarnation_sink_route_cljs_test.cljc` pins both branches.

**Why R6c got this wrong is itself the defect.** The docstring asserted *"no in-repo caller passes false today, the one that did having gone with the retired view artefact"* — true while the seam was UI-only, stale from rf2-qjfrw onward. An auditor read a stale absence claim as evidence of unreachability. The sentence is corrected to describe the live branch and to record that it was stale, so the next reader is not sent down the same path.

### 3. `:ssr/discover-root-manifest` — REFUSED (published conformance surface)

```
$ git grep -nF 'discover-root-manifest' -- . ':!.beads/'
implementation/core/src/re_frame/late_bind/directory.cljc:742    (the published hook declaration)
implementation/ssr/src/re_frame/ssr/manifest.cljc:770            (late-bind/set-fn!)
spec/011-SSR.md:606                                              (published API)
spec/conformance/S5-view-conformance-profile.md:66               (CONFORMANCE requirement)
```

The bead was right that "no consumer" cannot be the reasoning here, and the different-in-kind reason is this: it is a **conformance obligation on view substrates**, not an internal seam. `S5-view-conformance-profile.md` requires any view substrate's `hydrate-root` to find its manifest through this hook, precisely because a `view → ssr` require is forbidden by the Independence rule. The absent consumer is the *point* — a third-party substrate is the consumer, and there is no in-repo substrate implementing `hydrate-root` since the donor artefacts were retired.

The directory entry already states this in terms (`directory.cljc:742`): *"NO in-repo consumer resolves it today: both original consumers went with the retired donor view artefacts."* No edit needed; deletion would require editing two hot-zone spec files and would revoke a published contract.

### 4. `:rf.frame/must-create?` — REFUSED (live production reader; only the producer was retired)

The claim was "no consumer outside core's own tests". The **producer** is test-only; the **consumer is live production code**:

```
implementation/core/src/re_frame/frame.cljc:3097  must-create? (true? (:rf.frame/must-create? config))
implementation/core/src/re_frame/frame.cljc:3098  config (dissoc config :rf.frame/must-create?)
implementation/core/src/re_frame/frame.cljc:3325  (if must-create? …)
implementation/core/src/re_frame/frame.cljc:3350  must-create?
```

It is the create-exclusive mode behind the catalogued `:rf.error/frame-id-taken` (spec/009:2116), and three JVM tests pin it including a linearization race and a production-gate test. The bead suggested the keyword-catalogue check might have an opinion — **it does, and it is green**: `python scripts/check_keyword_catalogue_drift.py` → exit 0 with the keyword present.

What was lost is the `ui.test` Tier-1 plan-frame *producer*, retired with the substrate. Deleting the keyword would delete a catalogued error category and need a `spec/009` edit (hot-zone).

### 5. `cljs-probe` / `:ui-test-signatures` — HALF FALSIFIED; the real half fixed

The sharp part of the claim — *"may be silently passing"* — is **false**. `signature-problems` takes `contract` and `surface` as **arguments** and reads no sidecar key at all, and eleven tests drive it directly on synthetic fixtures: eight assert a specific mutation goes RED, three are positive controls against over-tightening. The test file already says so at lines 163-174. It is retained *mechanism*, generic over any host-aware signature block.

The real half: its **diagnostics** named `re-frame.ui.test` and the `:ui-test-signatures` sidecar key, neither of which has existed since rf2-0yp7w.4. That is the message a genuine drift prints, so it would have sent a developer looking for a namespace and a key that are gone. Fixed to name the mechanism instead, with the ns docstring now recording plainly that no sidecar block drives it today and that the synthetic fixtures keep it honest meanwhile.

Observed and **declined** as minutiae: `emit-ns-surface` and `emit-signature-contract` are `:refer`ed by the probe test but never invoked. They are the paired mechanism for the surviving reconciler; churning them buys nothing.

### 6. Vacuous assertion in `check-bundle-isolation.test.cjs` — CONFIRMED, plus a second one beside it

The file documented its own vacuity and left the decision open: *"this assertion is vacuous rather than load-bearing; it is kept only until somebody decides whether the retired-path guard is worth generalising."*

**The mechanical test the bead asked for — delete the signal, keep the fault.** Substituting a never-present string for `'ui'` in

```js
assert(!realCoverage.required.some((rt) => rt.relPath === 'ui'), …)
```

left the self-test **green at exit 0**. Any string passes: the required set is derived by *reading each candidate's `deps.edn` off disk*, and `implementation/ui` is gone (`git ls-files implementation/ui` → 0).

A **second**, worse remnant sat immediately below it and was not in the report: `NON_PUBLISHABLE_GENERIC = new Set(['ui'])`, a waiver letting a named generic-coverage path settle for mere directory existence instead of the structural publishable test. `genericCoveragePaths()` returns `["epoch","flows","hicasso","http","machines","resources","routing","schemas","ssr"]` — no `'ui'` — so the branch never ran. An exemption nothing claims can only weaken the check for whatever claims it next.

**Replaced, not patched**, per the bead. Generalising the first into a retired-path guard was considered and **rejected on the merits**: discovery cannot manufacture a path that is not on disk, so the generalised form would be vacuous by construction too. Both are deleted and the surviving loop is now unconditional — strictly stronger than what it replaced. The stale summary-line prose ("publishable ui") is corrected to `newpub`, the fictional path mutation 1 has actually used since the real case stopped existing.

### 7. `jvm-core-prod-gate` reddened — NOT by this diff. Diagnosed and fixed at source (rf2-2vr35)

The first push of this branch failed one required check, `JVM core under the production gate (-Dre-frame.debug=false)` (run 32027783986, job 95381750435):

```
FAIL in (jvm-weak-node-record-does-not-strong-pin-its-abandoned-reaction)
     (observation_port_cljs_test.cljc:2507)
the abandoned handle was reclaimed once its node record's weak key died
expected: (gc-until-cleared? handle-ref)
  actual: (not (gc-until-cleared? #object[java.lang.ref.WeakReference ...]))
```

**The failure was real, but it is not this diff's.** Three independent lines establish that before anything was changed:

1. **The diff cannot reach the lane.** Core's classpath is `:paths ["src"]` plus `:test`'s `["test" …examples]` (`implementation/core/deps.edn`), so neither `implementation/scripts/api-manifest/**` nor `check-bundle-isolation.test.cjs` is loaded by this gate at all. The one in-lane file, `error_emit.cljc`, changes only text **inside** the `dispatch-on-error!` docstring string literal — no form is touched.
2. **The gate is green on the branch head.** `bash scripts/test-core-prod-gate.sh` run three times on the unmodified head: exit 0 each time, 1986 tests / 8696 assertions — the same counts the failing CI run reported.
3. **Re-running the identical CI job on the identical commit went green.** Same SHA `e93fc922b1`, same job, `success` on the re-roll. A test whose verdict changes with nothing else changing is non-deterministic by definition.

**MECHANISM — clearing and ENQUEUEING are two separate steps.** The split in the failure is the whole diagnosis: the **first** assertion (line 2499 — the abandoned reaction is collectable, which is the property rf2-vxgfnd.37 is actually about) **passed**; only the **second** (line 2507 — the handle is reclaimed once the weak key dies) failed.

`node-records` is a `java.util.Collections/synchronizedMap (java.util.WeakHashMap.)` (`substrate/observation.cljc:716`). A WeakHashMap releases an entry's **VALUE** only in `expungeStaleEntries`, which is driven by the map's own ReferenceQueue and runs **only on a map operation**. A Reference is CLEARED during the collection but ENQUEUED afterwards, asynchronously, by the ReferenceHandler thread. `gc-until-cleared?` returns the moment `.get` reads nil — so it can return while the key has not yet been enqueued, and the test's single pre-loop

```clojure
(.size ^java.util.Map @#'obs/node-records)
```

then sat in exactly that window: it expunged nothing, the following 40-cycle `gc-until-cleared?` performed **no further map operation**, and the record VALUE went on strongly holding the handle for the rest of the run. That is not a slow test but a **permanently red one**, for that run — and a loaded runner widens the window, which is why it surfaced in CI and never locally.

**The fix is the discipline the file already uses elsewhere.** The two provenance proofs below it (rf2-8vvdo, lines 3540 and 3664) each poll with the map operation **inside** the loop, and rf2-8vvdo's own comment records this same clear-versus-enqueue asymmetry in terms. This fixture was the one site never brought up to that pattern. `gc-until-cleared?` gains a `poke` arity that runs once per cycle inside the loop, and the enrolled leg passes the `.size` through it. It relies on no happens-before edge and needs none: whichever cycle follows the enqueue expunges.

**The assertion is unchanged.** Nothing is relaxed, deleted, or added to the prod-gate known-red roster — the property is real and was never in doubt; only the fixture's timing was wrong.

---

## Quality gates

**Every number below is the one my own shell captured**, never one the harness reported, and the failing gate was re-run on the **final rebased base** (`582cc52c7e`) — the trunk moved repeatedly during this work.

| Gate | Captured exit |
|---|---|
| `bash scripts/test-core-prod-gate.sh` — **the check that failed**; 1986 tests / 8696 assertions, 0 failures | **0** |
| `scripts/test-fast-pr.sh` (fast PR spine) — printed `PASS fast PR spine`; classifier line `docs=false jvm=true node=true (classified)` | **0** |
| `implementation/` `npm run test:cljs`, split into its two phases — 11771 tests / 59589 assertions, 0 failures | **0** |
| `implementation/scripts/api-manifest` `clojure -M:test` — 84 tests / 183 assertions | **0** |
| `implementation/core` `clojure -M:test -n …error-catalogue-channel-conformance-test -n …late-bind-drift-test` — 35 tests / 801 assertions | **0** |
| `node implementation/scripts/check-bundle-isolation.test.cjs` | **0** |
| `python scripts/check_keyword_catalogue_drift.py` (item 4 evidence) | **0** |

**Where the failing gate's command comes from.** `.github/workflows/test.yml:1525`, job `jvm-core-prod-gate`, step *"Run the core suite under `-Dre-frame.debug=false`"*: `bash scripts/test-core-prod-gate.sh`. `python scripts/check_fast_pr_gap.py --list` derives the same command independently at its lines 82-84, where this job is one of the **94** required checks the spine does not run. The prod gate was run **six** times over this branch in total — three on the unmodified head as diagnosis, one on the fix, one sabotaged, one on the final base.

**Which tree the gates read.** `test-core-prod-gate.sh` prints `gate root: /c/Users/miket/code/re-frame2-worktrees/fixprodgate-8429` and the spine prints the same root — this worktree, on every run quoted.

**Controls (the deliverable).**

*Item 7, the fixture fix.* A green here proves nothing on its own, since the race does not reproduce on this machine — so the control is a planted fault proving the runtime **executed the new code path**. Replacing the poke with `#(throw (ex-info "PLANTED-FAULT-2vr35" {}))` (single-line anchor) reddened the gate at **exit 1**, and the failure output printed the planted text **verbatim**, which rules out a cached pre-plant compile. It also proves the poke runs **inside the loop**: the throw is reachable only from the `:else` branch, i.e. only after the first `.get` found the referent still live. Test and assertion counts were **identical** across the clean and planted runs (1986 / 8696, one error), so the plant aborted nothing downstream. Restore verified by `git hash-object` against the pre-plant digest — `c3802880c0` before, planted `55832a5d20`, `c3802880c0` after — not by reading a diff.

*Item 6, the deletion.* Before/after counts **identical**: 23 artefacts; 40 sentinel-removal mutations; 40 deliberate production leaks; 4 emitted third-party owners; 7 structural+causal enrollment mutations — exit 0 either side. Planting a fault in the **surviving** generic-coverage loop (`'implementation'` → `'PLANTED-FAULT-k9rzr'`) reddened it at **exit 1** naming `generic-coverage relPath 'schemas'`. Restore verified by `git hash-object`.

*Item 5, the probe.* Planting a fault in `signature-report`'s remedy phrase reddened the suite at **exit 1** with exactly one failure, in `cljs-macro-cljs-only-mutation-goes-red`, and the failure output printed the new header text verbatim. Namespace and assertion counts identical across clean and planted runs. Restore verified by `git hash-object`.

**Nothing was restored to make the gate green.** The vacuous `'ui'` assertion and the dead `NON_PUBLISHABLE_GENERIC` waiver stay deleted, the surviving loop stays unconditional, and none of the four refusals in items 1, 3 and 4 was undone. The prod-gate known-red roster is untouched.

**Skipped, with reason.** `npm run test:bundle-isolation` was not run whole: its first phase is a shadow-cljs `release` build of six example builds, and this diff touches only the **self-test** file, which reads synthetic fixtures and the real `deps.edn` tree rather than any release bundle. The self-test step itself was run directly (above). `mkdocs build --strict` was not run — no documentation surface is touched, and the spine's own classifier line (`docs=false`) confirms the docs tier did not arm. The spine ran on base `1b23cf473d`; the trunk delta between that and the final base `582cc52c7e` touches only `.beads/`, two xray files and `spec/009` — no file under `implementation/core/**`. The failing gate itself **was** re-run on the final base.

**Rebase discipline.** Rebased twice during this work, and the failing gate was re-run after the last one. The three-dot merge-base diff (`git diff origin/main...HEAD`) was read before pushing and contains exactly the five files below — nothing a sibling landed is reverted.

**Changed files (5).**
- `implementation/core/test/re_frame/observation_port_cljs_test.cljc` — item 7 (rf2-2vr35)
- `implementation/scripts/check-bundle-isolation.test.cjs` — item 6
- `implementation/core/src/re_frame/error_emit.cljc` — item 2 (prose only)
- `implementation/scripts/api-manifest/probe/src/re_frame/api_manifest/cljs_probe.cljc` — item 5 (prose/message only)
- `implementation/scripts/api-manifest/probe/test/re_frame/api_manifest/cljs_manifest_probe_cljs_test.cljs` — item 5 (one `testing` string)

No behaviour changes outside item 6's deletion and item 7's test-only fixture fix. No hot-zone file touched.
