### PR TITLE
retire(config): cut two live config residues pointing at deleted Freehand artefacts (rf2-puwyb)

### DIFF
--- a/implementation/README.md
+++ b/implementation/README.md
@@ -404,7 +404,6 @@ preserving first-seen order.
 | `:examples/machine-epochs` | http://localhost:8033/ |
 | `:examples/edn-inspector` | http://localhost:8034/ |
 | `:examples/managed-http` | http://localhost:8035/ |
-| `:testbeds/freehand-views` | http://localhost:8036/ |
 | `:examples/two-frame-isolation` | http://localhost:8030/ |
 | `:testbeds/panel-gallery` | http://localhost:8765/ |
 | `:examples/nine-states-with-stories` | http://localhost:8040/ · `/#/stories` |

--- a/implementation/scripts/dev-testbed.cjs
+++ b/implementation/scripts/dev-testbed.cjs
@@ -83,16 +83,20 @@ const { REPO_ROOT, IMPL_ROOT } = require('./_path-policy.cjs');
 //
 //   Band        Owner                     Notes
 //   ----------  ------------------------  ----------------------------------
-//   8030-8036   Xray testbeds             :dev-http (shadow-cljs.edn):
+//   8030-8035   Xray testbeds             :dev-http (shadow-cljs.edn):
 //                                           8030 two-frame-isolation
 //                                           8031 standard-epochs
 //                                           8032 routes-epochs
 //                                           8033 machine-epochs
 //                                           8034 edn-inspector
 //                                           8035 managed-http
-//                                           8036 freehand-views (rf2-6pohj)
+//                                         8036 was the freehand-views deck
+//                                         and is FREE again (rf2-puwyb): the
+//                                         deck, its build id and its :dev-http
+//                                         entry all went with the Freehand
+//                                         retirement (rf2-0yp7w).
 //   8037        xray-feature-gate         NOT a :dev-http port, and the one
-//                                         hole inside the Xray band above:
+//                                         reserved slot in the Xray run above:
 //                                         PREFERRED_PORT in implementation/
 //                                         scripts/serve-and-run-xray-feature-
 //                                         gate.cjs (XRAY_FEATURE_GATE_PORT),
@@ -100,10 +104,11 @@ const { REPO_ROOT, IMPL_ROOT } = require('./_path-policy.cjs');
 //                                         out because "next slot after the
 //                                         last testbed" is the natural way to
 //                                         pick a new Xray port and would land
-//                                         here — a collision that only shows
-//                                         up when the gate and a watch run at
-//                                         once. The next free Xray slot is
-//                                         8038.
+//                                         here once 8036 is taken — a
+//                                         collision that only shows up when
+//                                         the gate and a watch run at once.
+//                                         The next free Xray slot is 8036,
+//                                         then 8038; 8037 is never free.
 //   8040-8045   Story showcases +         :dev-http (shadow-cljs.edn):
 //               worked examples             8040 nine-states-with-stories
 //                                           8041 login-with-stories
@@ -129,7 +134,7 @@ const { REPO_ROOT, IMPL_ROOT } = require('./_path-policy.cjs');
 //                                         must share an origin.
 //   8765        Xray panel-gallery        :dev-http (shadow-cljs.edn).
 //
-// The :dev-http bands (8030-8036 / 8040-8045 / 8765) are mirrored in the
+// The :dev-http bands (8030-8035 / 8040-8045 / 8765) are mirrored in the
 // DEV_HTTP map below (READ-only — shadow-cljs.edn is hot-zone). The 805x
 // examples band is NOT a :dev-http port — it is the test-orchestrator's
 // http-server default, resolved at runtime — so it lives only here + in
@@ -148,9 +153,6 @@ const DEV_HTTP = {
   ':examples/machine-epochs': { port: 8033 },
   ':examples/edn-inspector': { port: 8034 },
   ':examples/managed-http': { port: 8035 },
-  // rf2-6pohj — the Freehand-hosted Views deck, the only Xray testbed whose
-  // views are Freehand views (803x band).
-  ':testbeds/freehand-views': { port: 8036 },
   ':testbeds/panel-gallery': { port: 8765 },
   ':examples/nine-states-with-stories': { port: 8040, story: true },
   ':examples/login-with-stories': { port: 8041, story: true },

--- a/implementation/scripts/dev-testbed.test.cjs
+++ b/implementation/scripts/dev-testbed.test.cjs
@@ -325,6 +325,28 @@ it('DEV_HTTP covers every :dev-http-served build in shadow-cljs.edn (drift guard
   );
 });
 
+// --- Drift guard, the other direction (rf2-puwyb) --------------------------
+// The guard above is one-way: it catches a served build MISSING from DEV_HTTP.
+// It says nothing about an ORPHAN — a DEV_HTTP entry whose build and :dev-http
+// port are both gone — so `:testbeds/freehand-views` (port 8036) survived the
+// Freehand retirement here, mapping a port to something that cannot be served,
+// and every census missed it because it is executable config rather than prose.
+// An orphan is not merely untidy: `npm run dev :testbeds/freehand-views` prints
+// a live-looking URL for a build shadow-cljs will reject. Assert the mirror is
+// exact in BOTH directions so the next deletion cannot leave one behind.
+it('DEV_HTTP carries no build that shadow-cljs.edn no longer serves (orphan guard)', () => {
+  const served = servedBuildPorts(readShadowEdn());
+  const orphans = Object.keys(DEV_HTTP).filter((buildId) => !(buildId in served));
+  assert.deepStrictEqual(
+    orphans,
+    [],
+    `DEV_HTTP (dev-testbed.cjs) maps build(s) that no :dev-http port in ` +
+      `shadow-cljs.edn serves: ${orphans.join(', ')}. Delete each from ` +
+      `DEV_HTTP (and the README build->port table) — the launcher would ` +
+      `print a URL for a build that cannot be served.`,
+  );
+});
+
 if (failed > 0) {
   console.error(`\n${failed} test(s) failed.`);
   process.exit(1);

--- a/implementation/shadow-cljs.edn
+++ b/implementation/shadow-cljs.edn
@@ -973,7 +973,7 @@
   ;;
   :browser-test
   {:target    :browser-test
-   :ns-regexp "^(?!re-frame\\.freehand\\.bench\\.).*-dom-cljs-test$"
+   :ns-regexp ".*-dom-cljs-test$"
    :test-dir  "out/browser-test"
    :runner-ns shadow.test.browser
    :compiler-options


### PR DESCRIPTION
Closes rf2-puwyb (child of the rf2-0yp7w Freehand/UI retirement epic; listed in rf2-0yp7w.9's REMAINDER table as this bead's own).

Two **executable-configuration** residues pointing at deleted Freehand artefacts. Both survived every prose census because R6c's fence was comment-only and neither is prose.

## What changed

**(1) `implementation/shadow-cljs.edn` — the `:browser-test` `:ns-regexp`** (was line 976)

```
- :ns-regexp "^(?!re-frame\\.freehand\\.bench\\.).*-dom-cljs-test$"
+ :ns-regexp ".*-dom-cljs-test$"
```

A negative lookahead excluding a namespace prefix that no longer exists — inert, but it told a reader `re-frame.freehand.bench.*` was a live hazard to fence off. `TESTING.md` already states the intended end state: ":browser-test now selects every `*_dom_cljs_test` namespace outright and a partition has nothing left to be true about."

**(2) `implementation/scripts/dev-testbed.cjs` — the `:testbeds/freehand-views` port mapping** (was line 153), its comment, and the owned-range port-band comment.

**(3) `implementation/README.md`** — the matching build to port table row. This is the third mirrored surface, named by the drift guard's own failure message ("Add each to DEV_HTTP *and the README build->port table*"). Leaving it would advertise a URL serving nothing.

**(4) `implementation/scripts/dev-testbed.test.cjs`** — closed the drift guard's blind half. See "Beyond the bead" below.

## The control: namespace selection before vs after

The bead asks for enumeration, not reasoning. Enumerated all namespaces on the **69 declared `:source-paths`** (all present on disk; 1943 namespaces total), applying each candidate pattern under **both** `re-find` and `re-matches` semantics:

| pattern | re-find | re-matches |
|---|---|---|
| BEFORE `^(?!re-frame\.freehand\.bench\.).*-dom-cljs-test$` | **139** | **139** |
| AFTER `.*-dom-cljs-test$` | **139** | **139** |

**Diff is EMPTY in both directions, under both semantics** — `only-in-BEFORE: []`, `only-in-AFTER: []`.

Namespaces on the source paths under the excluded prefix `re-frame.freehand.bench.`: **0**. Namespaces containing `freehand` at all: **0**.

**Why `.*-dom-cljs-test$` and not the bare `-dom-cljs-test$`** that house style elsewhere in this file uses: bare selects the same 139 under `re-find` but **0 under `re-matches`**, so it is semantics-dependent. `.*-dom-cljs-test$` is identical under both, making the cut provably safe without depending on which engine semantics shadow-cljs applies. (In-repo evidence says `re-find`: `:node-test`'s bare `cljs-test$` runs ~3500 tests and would select zero under `re-matches`. The chosen form does not rely on that.)

## Dangling-reference checks

Searches use `git grep -nF` / `-nE`, each with a **positive control** run against something it should find.

**`:testbeds/freehand-views` / port 8036 in executable trees** (`implementation/ .github/ scripts/ examples/ tools/`, excluding `.beads/`):

- `implementation/shadow-cljs.edn`: build map **absent** (exit 1). Positive control `:testbeds/` in the same file gives 18 hits, exit 0.
- `implementation/shadow-cljs.edn` `:dev-http`: **no port 8036**. Positive control `8035` hits at `shadow-cljs.edn:571`, exit 0.
- `tools/xray/testbeds/freehand_views/`: **directory gone** (`ls tools/xray/testbeds/` lists 9 dirs, not among them).
- Remaining hits after this PR are **prose only**: `tools/xray/spec/017`, `021`, `027`, `docs/design/**`, `.github/workflows/test.yml:4054` (a comment). All are R6 (rf2-0yp7w.9) prose-sweep territory, explicitly not this bead's — see "Declined".

**Programmatic mirror check** (parsing `:dev-http` and every build's `:output-dir` out of `shadow-cljs.edn`, the same way the drift guard does):

- 15 served builds recovered; **exactly one orphan**: `:testbeds/freehand-views` at 8036; **zero missing**. After this PR: zero orphans, zero missing.

**Port-band comment coherence.** Deleting 8036 makes the old text wrong in a way a bare deletion would have left behind: the band header said `8030-8036`, and the 8037 note said "the next free Xray slot is 8038". With 8036 freed the next free Xray slot is **8036**, then 8038 — 8037 stays permanently reserved (`PREFERRED_PORT` in `scripts/serve-and-run-xray-feature-gate.cjs:43`, verified still live). The comment now says exactly that.

## Quality gates

**`scripts/test-fast-pr.sh` RAN, in full, to completion — captured exit `0`.** Classified `docs=true jvm=false node=true`. Zero `FAIL`/`ERROR` lines in 406KB of log. Run twice: once on base `076fc9f5`, and again on the final rebased base `53e14715`.

The spine **printed its own root**, naming this worktree — `shadow-cljs - config: C:\Users\miket\code\re-frame2-worktrees\cfgresidue-puwyb\implementation\shadow-cljs.edn` — so it read this tree, not a sibling's.

Targeted gates, run directly, each with its own captured exit code:

| gate | what it covers | captured exit |
|---|---|---|
| `node scripts/_browser-dom-lane-partition.test.cjs` | reads the live `:browser-test` `:ns-regexp` and asserts it selects **every** `*_dom_cljs_test` namespace — the gate for change (1) | `0` (2 passed) |
| `node scripts/dev-testbed.test.cjs` | `DEV_HTTP` against `shadow-cljs.edn :dev-http` mirror — the gate for changes (2)/(4) | `0` (13 passed, was 12) |

Both are wired into CI via `test:script-policy` / `test:script-helpers` (`test.yml:3292`) and both run inside the spine (log lines 3346 and 3753-3768).

### Planted-fault controls

**Control A — `shadow-cljs.edn`, at the exact line edited.** Replaced the deleted lookahead with one excluding a **live** prefix, `^(?!re-frame\.hicasso\.).*-dom-cljs-test$`.

The gate `_browser-dom-lane-partition.test.cjs` went **RED, captured exit 1**, naming the planted exclusion: "these DOM suites are selected by NO browser lane, so they compile nowhere: re-frame.hicasso.activity-suspense-dom-cljs-test ...". The plant exists only in this worktree, so the red is itself the proof the gate read this tree.

**Control B — `dev-testbed.cjs`, re-planting the exact residue** this PR deletes.

The **new** orphan guard went **RED, captured exit 1**: "DEV_HTTP maps build(s) that no :dev-http port in shadow-cljs.edn serves: :testbeds/freehand-views". The **pre-existing** drift guard **PASSED** against that same plant. That is the direct demonstration that the old guard was blind to this residue class, and the justification for (4).

Both restores verified by **content hash against the committed object** (`git hash-object` against `git rev-parse HEAD:<path>`), not by reading a diff:

- `shadow-cljs.edn`: planted `a663274a96d7...` restored to `b571794efeae...` = committed `b571794efeae...`
- `dev-testbed.cjs`: planted `1e7f775f0648...` restored to `8d8168311ccb...` = committed `8d8168311ccb...`

### Coverage the spine does not decide

Per `python scripts/check_fast_pr_gap.py --list` (captured exit `0`) — the one path that derives this — **94 required checks are not run by the spine**. The one that matters most here is **`cljs-browser`** (`npm run test:browser`, `shadow-cljs compile browser-test` plus headless Chromium): that is the only job that actually *compiles the build id whose `:ns-regexp` this PR edits*, and it runs in CI, not locally. Green locally is not green in CI.

No gate was skipped silently. Nothing was run that needed `implementation/node_modules` without it: it was junctioned at the mayor checkout's real one for the two spine runs and **the junction was removed with `cmd /c rmdir`** afterwards — mayor `node_modules` entry count 103 before, 103 after.

## Beyond the bead — flagged for review

Items (3) and (4) go past the bead's literal two residues. Both are one deletion's blast radius rather than new scope, but they are called out so they can be stripped if unwanted:

- **(3)** the README row is the third surface of the same three-way mirror, and the drift guard's own message treats it as such.
- **(4)** the orphan guard is ~20 lines. The existing guard asserts every *served* build appears in `DEV_HTTP` but nothing asserted the converse — which is precisely how this residue survived. Control B shows the old guard passing against the re-planted residue and the new one catching it. It makes recurrence impossible rather than leaving it to the next census.

## Declined

- **The prose residues in `shadow-cljs.edn`** — `:node-test-freehand` is referenced at lines 827 and 839 but **exists as no build def** (verified: comment-only hits; positive control `:node-test-hicasso` returns both a comment hit and its def at line 849), and lines 868-934 carry a block of `:freehand-release` prose. These are rf2-0yp7w.9's, which explicitly rosters "implementation/shadow-cljs.edn (3 sites)" among its **KNOWN PROSE-ONLY CARRIERS, verified at source and NOT actioned**. Touching them here would collide with that sweep in a hot-zone file.
- **`tools/xray/spec/017`, `021`, `027` and `docs/design/**`** — outside the file-ownership fence, and prose-sweep territory.
- **`.github/workflows/test.yml:4054`** — hot-zone and comment-only.

## Notes for the mayor

- **`rf2-6pohj` does not exist in the tracker.** The bead asks that it be read before deleting ("it may record why the port was reserved"); `bd show rf2-6pohj` returns *no issue found matching*. The id survives only in source comments and in `.beads/issues.jsonl` prose. So the "why was it reserved" question could not be answered from the bead — it was answered from the config instead, which is unambiguous: the build id, its `:dev-http` entry and the testbed tree are all gone.
- **The bead's pointer to `shadow-cljs.edn:827`** describes it as the sibling comment explaining *this* regexp's intent. It is actually the `:node-test-hicasso` comment, and the `:ns-regexp` it explains is that build's. The comment that documents the `:browser-test` selector is at **959-972**, and it describes the regexp as plain `-dom-cljs-test$` with **no mention of the lookahead** — further evidence the lookahead was residue rather than intent. That comment needed no change.
