### PR TITLE
fix(docs,ci): the Dynamic roster is ten tabs and the ninth is Frames; refresh the stale smoke-tier sizing (rf2-gbm4t)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4049,12 +4049,15 @@ jobs:
       #
       #   - Xray feature gate in --smoke mode: every scenario tagged
       #     `smoke: true` in tools/xray/testbeds/feature_matrix/
-      #     scenarios.cjs, a set the gate counts and prints on each run.
-      #     As at 2026-08-06 that is 5 scenarios (9-tab shell handoff,
-      #     freehand-views Views roster, deterministic exceptions →
-      #     inline/Trace surfacing, Cmd-K palette, panel-gallery theme
-      #     tokens) over 4 staged surfaces, compiling 4 testbed bundles
-      #     instead of 12 — ~80s warm (rf2-ano54).
+      #     scenarios.cjs, a set the gate counts and prints on each run —
+      #     read that live pair, not the snapshot below. As at 2026-08-17
+      #     that is 4 scenarios (ten-tab shell + panel handoff,
+      #     deterministic exceptions → inline/Trace surfacing, Cmd-K
+      #     palette, panel-gallery theme tokens) over 3 staged surfaces,
+      #     compiling 3 testbed bundles instead of 11 — ~80s warm as
+      #     measured at 4 bundles (rf2-ano54), so an upper bound now. The
+      #     freehand-views Views roster scenario and its staged surface
+      #     went with the rf2-0yp7w Freehand retirement (rf2-l86mm).
       #   - Story :play-script CI-as-test gate (rf2-3qcxk): drives the
       #     live Story shell over the runner's own testbed roster and
       #     runs every variant's :play-script. This is the gate that

--- a/skills/README.md
+++ b/skills/README.md
@@ -107,10 +107,12 @@ the situation they cover:
   **Xray**, the re-frame2 in-app devtools panel. Answers how to *launch*
   Xray (true-inline panel, pop-out, programmatic `init!`, wired hotkeys,
   the Dynamic ↔ Static mode toggle) and *which tab shows X* — across the
-  9 Dynamic event-spine tabs (Epoch (hero) / app-db / Views / Trace /
-  Machine / Routes / Resources / Graph / Modules — Graph being Xray's UI over the
-  EP-0014 derivation/process graph, and Modules its EP-0023
-  `image → frame → event stream` lens (which image loaded which frame, L4-only))
+  10 Dynamic event-spine tabs (Epoch (hero) / app-db / Views / Trace /
+  Machine / Routes / Resources / Graph / Frames / Hicasso — Graph being
+  Xray's UI over the EP-0014 derivation/process graph, Frames its EP-0023
+  `image → frame → event stream` lens (which image loaded which frame,
+  L4-only), and Hicasso the Hicasso view substrate's evidence lens — six
+  views over four evidence envelopes, L4-only)
   and the 5 Static registry-browse
   tabs (Machines / Routes / Schemas / Flows / Interceptors). There is no
   Issues tab — issues surface inline. Xray owns


### PR DESCRIPTION
Closes rf2-gbm4t. Sibling PR #8428 (rf2-22dl8) **merged** as `7ad556b7e1` while this was in flight; this branch is rebased onto it and the censuses below are re-derived at that tip. Nothing under `tools/xray/` is touched.

Both sites in the bead came back **positive**. Neither is a refusal.

## Site 1 — `skills/README.md:110` (the roster)

Re-derived at source: `tools/xray/src/day8/re_frame2_xray/focus.cljc` `valid-panels` is
`#{:epoch :app-db :views :trace :machines :routing :resources :derivation-graph :module-view :hicasso}` — **ten**, and `panels/module_view.cljs` registers `:label "Frames"` (`:mnem "u"`, `:order 9`), `panels/hicasso.cljs` registers `:label "Hicasso"` (`:mnem "h"`, `:order 10`). The bead's description matches the runtime exactly.

The roster gains its **tenth row** rather than a numeral swap, per the "worse than leaving it" test from rf2-xgi62 — a nine-item list relabelled "10" is worse than what it replaced. Wording carries #8428's convention and the already-corrected sibling `skills/re-frame2-xray/SKILL.md:70` (Hicasso = "the Hicasso view substrate's evidence lens: six views over four evidence envelopes"). The page's own `/` separator is kept; #8428's `·` belongs to the files that already used it.

**Why this site survived two sweeps:** `scripts/check_skill_xray_tab_inventory_drift.py` sets `SKILL_DIR = REPO_ROOT / "skills" / "re-frame2-xray"` and rosters seven files under it. Top-level `skills/README.md` is in neither that roster nor the rf2-5atkk / rf2-xgi62 censuses, all of which scope to the subtree.

## Site 2 — `.github/workflows/test.yml:4053` (the smoke-tier sizing)

**The discriminator came back positive, so this is a repair, not the "accurate history" refusal.** The comment claimed `5 scenarios (9-tab shell handoff, freehand-views Views roster, …) over 4 staged surfaces, compiling 4 testbed bundles instead of 12`. Counted by replaying the gate's **own** filter (`smoke === true` plus `surfaceForScenario` from `implementation/scripts/serve-and-run-xray-feature-gate.cjs`) against `scenarios.cjs` at HEAD:

| | claimed | live |
|---|---|---|
| smoke scenarios | 5 | **4** |
| staged surfaces | 4 | **3** |
| testbed bundles | 4 | **3** |
| nightly bundles | 12 | **11** |

All four numbers are stale. The live four are `feature matrix shell and panel handoff` (`/counter/`), `deterministic exceptions and inline/trace surfacing` (`/testbeds/deliberate-throw/`), `command palette chord…` (`/counter/`, reuses the surface), and `panel-gallery theme-token CSS-variable resolution` (`/testbeds/panel-gallery/`). Nightly-full is 16 scenarios over 11 surfaces.

The fifth, `freehand-views Views roster`, was **deliberately deleted** — `tools/xray/spec/017-Test-Coverage-Matrix.md:316` records it and its `STAGED_SURFACES` entry going with the rf2-0yp7w Freehand retirement, per rf2-l86mm, precisely so the smoke run stays derived rather than fixed. The comment also carried `9-tab shell handoff`, which is defect (1) again.

The `As at <date>` dated-snapshot idiom is **kept and refreshed** rather than deleted — it is the file's own convention, and the sentence already points the reader at the live pair the gate prints. `~80s warm` is left attributed to rf2-ano54 and marked an upper bound, because it was measured at 4 bundles and **was not re-measured here**.

## Delta against the bead

- **"the last surviving instance of either" — half true.** The retired-**label** half HOLDS: after #8428, every remaining `Modules` hit over the tracked tree is correct — accurate history and illustrative examples in `check_skill_xray_tab_inventory_drift.py` (lines 12/14/16/46/53), its deliberate self-test fixtures (442/455/472, which must contain the string to prove the gate bites), and `skills/re-frame2-xray/evals/*`, which assert the label is retired.
- **The nine-tab-**roster** half does NOT hold.** Two live instances survive outside `tools/xray/`, both **numeral-free**, which is exactly why every numeric census missed them (`skills/re-frame2-xray/evals/README.md:178` names this failure mode: "a numeral is invisible to it"). Both are outside this bead's fence and are filed as **rf2-vuabu**:
  - `scripts/check_skill_xray_tab_inventory_drift.py:29-32` — "Ordered by `:order`, **that is today**:" then a nine-item roster ending `Graph · Frames`, mnemonics `e a v t m r s g u`, no Hicasso. Present tense, in the docstring of the gate that owns this class. Prose only — the gate's checks read the runtime, so it is green and stays green.
  - `implementation/scripts/serve-and-run-xray-feature-gate.cjs:64-65` — the same stale sizing as site 2: "the split is 5 scenarios over 4 surfaces against 17 over 12 nightly" (live: 4/3 vs 16/11).
- **Gate ownership corrected.** The bead says `skills/README.md` is covered "by `check_doc_slugs.py` … and by `check_readme_links.py`, so both gates apply." Only the first is true. `check_readme_links.py` `_is_excluded` returns True for any path whose first part is in `DOCS_GATE_ROOTS`, which contains `skills` — it deliberately skips the subtree the docs gate owns.

## Quality gates

Every exit code below is the one **captured** in the same shell as the run (`cmd > log 2>&1; echo $? > exit`), not one reported about it.

- **`scripts/test-fast-pr.sh` — RAN, exit 1.** Its first line printed `gate root: /c/Users/miket/code/re-frame2-worktrees/tabresidue-gbm4t`, confirming it read this worktree and not a sibling's. Every lane covering this change passed: `workflow YAML well-formed (11 files)` plus its 5-case self-test, the docs-corpus anchor validator, the README link validator, the Xray tab-inventory drift gate, and `mkdocs build --strict`. **The single failure is the last lane, `CLJS node integration`: `compile-node-test: could not resolve shadow-cljs: Cannot find module 'shadow-cljs/cli/runner.js'`** — a fresh worktree with no `implementation/node_modules`. It is environment, not this change: the diff is one markdown paragraph and one YAML comment, reaches no ClojureScript, and the lane runs against installed deps in CI. Not repaired locally because linking a multi-GB dependency tree to green a lane with no bearing on the diff is the gold-plating the stance rejects — and the junction carries the known `node_modules`-deletion hazard.
- **`python scripts/check_doc_slugs.py` — exit 0**, re-run post-rebase, exit 0. This is the gate that owns `skills/` (`DEFAULT_ROOTS = ("docs", "spec", "skills", "migration")`, confirmed at source along with `_iter_markdown`).
- **`python scripts/check_workflow_yaml.py` — exit 0** (`PASS workflow YAML well-formed (11 files)`), re-run post-rebase, exit 0. This is the gate that owns the `test.yml` edit; its `--self-test` arm passed 5 cases inside the spine, so it has teeth. Independently, `yaml.safe_load` parses the edited file to 73 jobs — the changed lines are comment-only.
- **`python scripts/check_skill_xray_tab_inventory_drift.py --ci` — exit 0** post-rebase.
- **`python scripts/check_fast_pr_gap.py --list` — exit 0.** It is the one path that derives which required CI checks the spine does not run: **94**, under the three required contexts `All required checks passed`, `Lint required`, `Docs required`. Not enumerated by hand and `.github/workflows/*` was not read for this purpose.

### Planted-fault control

`check_doc_slugs.py` prints **nothing** on success, so its colour is unfalsifiable without a negative control.

- **First plant did NOT bite, and that was the witness's fault, not the gate's.** Retargeting the bullet's link to a missing *directory* left the gate green at exit 0 — the hash moved (`7b5975d0` → `c0d31248`), so the patch genuinely applied. Reading the source explains it: the gate validates **only links to `.md` files**. The plant was outside the checked class. Recorded rather than quietly retried, because a green sabotage run read as proof would have inverted the conclusion.
- **Second plant bit.** A broken `.md` target on line 112 — a line this PR edits — took the gate to **captured exit 1**, naming exactly what was planted:
  ```
  1 broken target file(s) found:
    BROKEN TARGET: skills\README.md:112 -> ../docs/EP/EP-0014-PLANTED-FAULT-gbm4t.md
  ```
  That red is the discrimination: the fault existed only in this worktree, so a run that had wandered into a sibling's would have come back green.
- **Restore verified by hashing against the committed object**, not by reading a diff: `git hash-object skills/README.md` == `git rev-parse HEAD:skills/README.md` == `7b5975d012722736266faefb5713460f1df58a79`.

### Checked by hand

Anchors and link targets in the edited `skills/README.md` bullet are unchanged apart from the roster prose; the paragraph adds no new links. The `test.yml` change is comment-only — no key, value, job, step or indentation level moved.

## Verification

- Worktree guard printed `WORKTREE_ROOT=/c/Users/miket/code/re-frame2-worktrees/tabresidue-gbm4t`; the mayor checkout was confirmed clean of both files after each edit.
- Hot zone: `.github/workflows/*` is one-toucher-at-a-time. `worker/ciarm-st1x5` holds unmerged commits to `test.yml`, but it is a **dead leftover** — `rf2-st1x5` is CLOSED, resolved by merged PR #8279, its `hicasso-naming-census` job is already on main at `test.yml:1288`, the branch was never pushed and has no PR. Its hunks sit at lines 1234 and 6732, nowhere near 4053. No live holder; no other open PR touches either file.
- Merge-base diff (`origin/main...HEAD`, three-dot) is exactly these two files, +15/-10 — nothing a sibling landed is reverted. `7ad556b7e1..` touched neither file.
