### PR TITLE
fix(hicasso): the codec-range count described the page as it was before the sentence existed (rf2-prvry)

### DIFF
--- a/docs/design/hicasso/studio/hd8-freehand-codec-donor-arm.md
+++ b/docs/design/hicasso/studio/hd8-freehand-codec-donor-arm.md
@@ -47,8 +47,8 @@
 > the same kind of thing. **The sentence was therefore not written, and nothing
 > is claimed in its place.** The same three ranges recur in the replication
 > table's sweep-1 column below, and `1.078 – 1.306` once more as the min–max
-> union of all six `mount-M` run-segments — seven lines on this page, every one
-> of them inside this frozen record.
+> union of all six `mount-M` run-segments — seven source-data rows below this
+> amendment, every one of them inside this frozen record.
 >
 > **`codecs-differ?` went with the arm rather than being re-pointed**, and its
 > absence is stated at source in `hd8_witnesses.cljs`'s closing section. It


### PR DESCRIPTION
Follow-up to the merged-PR audit of #8426, recorded on `rf2-prvry`. One narrow correctness defect, one file, two lines. **The main verdict of `rf2-prvry` is settled and is not re-opened here**, and the bead's separate item — Mike's assent to that verdict — is untouched and still outstanding.

## The defect

PR #8426 added a dated amendment to the retirement banner of `docs/design/hicasso/studio/hd8-freehand-codec-donor-arm.md`. Its closing sentence said the three per-run codec ranges appear on **"seven lines on this page"**.

That was true of the parent commit. It stopped being true at the instant it landed, because the amendment *itself* quotes all three ranges at `:36-37` and repeats `1.078 – 1.306` at `:49`. **The sentence described the tree as it was before the sentence existed** — it invalidated its own occurrence census by being written.

## Census, re-derived independently at `origin/main`

Counted as fixed strings over the three literal ranges `1.139 – 1.217`, `1.154 – 1.272`, `1.078 – 1.306` (en-dash, spaced, exactly as the page writes them):

| tree | hits | distinct lines | where |
|---|---|---|---|
| parent `02dbd35d99^` (= `f0856421ec`) | **7** | **7** | `:260 :264 :268` · `:343 :344 :345` · `:387` |
| landed `02dbd35d99` (= `origin/main` for this file) | **11** | **10** | source data `:285 :289 :293` · `:368 :369 :370` · `:412`; amendment `:36` (1) · `:37` (**2**) · `:49` (1) |
| this branch, after my edit | **11** | **10** | unchanged — the repair adds and removes no range literal |

**Delta against the audit: zero on both figures.** The audit's "7 hits on 7 lines" at the parent and "11 hits across 10 lines" at the landed commit both reproduce exactly. Line `:37` carries two of the eleven hits, which is why 11 hits sit on only 10 lines.

## The repair, and why this wording

Preserved: the **seven historical source-data rows**. They are the real subject, they have not changed, and none is touched.

```diff
-> union of all six `mount-M` run-segments — seven lines on this page, every one
-> of them inside this frozen record.
+> union of all six `mount-M` run-segments — seven source-data rows below this
+> amendment, every one of them inside this frozen record.
```

Of the two remedies the audit offered — qualify as *"seven source-data lines below"*, or state the actual total — **I took the qualification, not the total.** Stating the page-wide total (11 across 10) would be true today and brittle tomorrow: it is a census of the page *including its own prose*, so the next amendment that quotes a figure falsifies it again, which is precisely the failure being repaired. The qualified form counts only the historical rows, and prose can never enter that set.

Two deliberate departures from the audit's literal phrasing, both narrowing:

* **"rows" rather than "lines"** — all seven are markdown table rows (verified: every one begins `|`), and `docs/design/hicasso/product/correction-ledger.md:73` already uses "data rows" for exactly this. `source-data` as a hyphenated term appears nowhere else in `docs/` (`git grep -nF -- "source-data" -- 'docs/'` → exit 1), so it is new, but it is the audit's own coinage and it is doing real work.
* **"below this amendment" rather than bare "below"** — bare "below" is anchored to wherever the sentence sits, so a *future* amendment placed lower could re-quote a figure and falsify the seven all over again. Naming the boundary makes the region fixed.

## Is the sentence true of the tree that contains it?

Yes, and this is the point of the exercise, so it is checked against the file **including my own edit**, not against the file I started from:

* The amendment block runs `:33`–`:51`.
* Range-bearing lines at or above `:51`: `36, 37, 49` — the amendment's own quotations, deliberately outside the claim.
* Range-bearing lines **below** `:51`: `285, 289, 293, 368, 369, 370, 412` — **exactly seven**, and all seven are markdown table rows.

The claim is therefore self-consistent under its own count, which the sentence it replaces was not.

## Shape

Same shape the audit approved: a correction to prose inside the dated amendment. No table row added, altered or removed; no link added; no measured figure restated, moved or re-baselined; no anchor changed. `git diff origin/main...HEAD` is 1 file, +2/-2, entirely within the one sentence.

Not done here, and flagged rather than actioned: **#8426's merged PR body carries the same false post-change count**, for the same reason. It is a merged record and the audit's named remedy covers the page prose only, so I left it and recorded the fact on `rf2-prvry` instead.

## Quality gates

Every exit code below was captured by the running shell on the same command line as the redirect (`cmd > log 2>&1; ec=$?`) and quoted from that capture — never from a harness report, never through a pipe. Artefacts are named for this worktree and attempt.

| gate | captured exit | note |
|---|---|---|
| `python scripts/check_doc_slugs.py` | **0** | clean, pre-rebase. `DEFAULT_ROOTS` confirmed at source (`scripts/check_doc_slugs.py:93-98`) = `("docs","spec","skills","migration")` plus `tools/*/spec`, so `docs/**` is covered |
| `python scripts/check_doc_slugs.py` **(sabotaged)** | **1** | the control — see below |
| `python scripts/check_doc_slugs.py` (restored) | **0** | |
| `python scripts/check_doc_slugs.py` (post-rebase) | **0** | |
| `python scripts/check_provenance_pins.py --changed-since origin/main` | **0** | `1 page inspected, 10 cited pins — 8 landed, 1 stranded, 1 unresolvable, 0 foreign; 2 accompanied in scope; 0 findings` |
| `python scripts/check_provenance_pins.py --self-test` | **0** | |
| `python scripts/check_provenance_pins.py --changed-since origin/main` (post-rebase) | **0** | identical summary |
| `scripts/test-fast-pr.sh` | **0** | **it RAN, in full, in the foreground, to completion.** Classified `docs=true jvm=false node=false`; `PASS fast PR spine` at log line 1030 |
| `scripts/test-fast-pr.sh` (post-rebase) | **0** | re-run on the final base |
| `python scripts/check_fast_pr_gap.py --list` | **0** | the one path that derives what the spine does not decide: **94** required CI checks |

**The spine did not hit the expected `node_modules` failure**, and the reason is the classifier, not luck: `implementation/node_modules` is genuinely absent from this worktree, but a docs-only diff classifies to `node=false`, so the CLJS node integration lane was never in the plan. No junction into the mayor's `node_modules` was created — this repo has two recorded incidents of that cleanup emptying the real tree.

**Which tree the gates read.** `test-fast-pr.sh` prints its root, and line 1 of both runs reads `gate root: /c/Users/miket/code/re-frame2-worktrees/prvrycount-8426`. `check_doc_slugs.py` prints no root and is silent on success, so for that one the discrimination is the red.

**Planted-fault control.** A bogus cross-page anchor was planted at `:51` — a line this PR authors — and the gate went **RED, captured exit 1**, naming what was planted:

```
1 broken anchor link(s) found:
  BROKEN ANCHOR: docs\design\hicasso\studio\hd8-freehand-codec-donor-arm.md:51
      -> hd8-composed-donor-arm.md#planted-fault-prvrycount-8426-no-such-anchor
```

The plant is *proven to have applied* by the content hash moving `5573b37eae` → `d16c7bf380`, so this is not a patch that silently no-opped. The restore is verified by git's own content hash, not by reading a diff: back to `5573b37eae`, byte-identical to pre-plant. The fault existed only in this worktree, so a run that had strayed into a sibling's checkout would have come back green.

**Not nominated:** `mkdocs build --strict`. `mkdocs.yml`'s `exclude_docs` keeps `design/hicasso/` out of the built site, so it does not reach this file and a green from it would verify nothing.

**Hand checks** (nothing validates this tree's tables, rendering or nav):

* **Tables: 12 on the page, 0 column mismatches.** Every contiguous table block re-parsed cell by cell — banner 2-col; `:283-296` and `:303-315` 4-col; `:325-329` and `:336-341` 3-col; `:366-375` 6-col; `:408-413` 4-col; all internally uniform. This PR adds no table cell.
* **Anchors: 6 link targets, 5 unique, 2 anchored**, both cross-page (`../validation.md#p1-gate--the-composed-donor-arm-hd-008`, `hd8-composed-donor-arm.md#mount--the-m-page-300-rows-markup-dominant`). 14 headings. This PR adds no link. Both anchors resolve under `check_doc_slugs.py`, whose bite on this exact class is demonstrated by the planted-fault red above.

**Rebased once**, onto `origin/main` `98a35fece5` (which had gained 22 changed files, including #8425 and #8428). Every gate above was re-run on the final base, and the census was re-derived on it: unchanged at 11/10. My file was untouched on main across that move (`git diff --name-only b1a4726b4b..origin/main | grep -F hd8-freehand-codec-donor-arm.md` → exit 1, with the 22 files that *did* change as the positive control).

**Merge-base diff read for reverts.** `git diff origin/main...HEAD` (three-dot, against the merge base — not the tip) is the two-line hunk above and nothing else. This push reverts nothing a sibling landed.
