### PR TITLE
fix(scripts): the drift gate's own roster is ten tabs; refresh the feature-gate smoke sizing (rf2-vuabu)

### DIFF
--- a/implementation/scripts/serve-and-run-xray-feature-gate.cjs
+++ b/implementation/scripts/serve-and-run-xray-feature-gate.cjs
@@ -61,8 +61,10 @@ const VERBOSE_TESTS = isVerboseTests();
 // actually load — cutting the nightly sweep down to the high-signal
 // subset on the PR critical path. Both counts are DERIVED from
 // scenarios.cjs and main() prints the live pair every run, so read that
-// rather than a number frozen here (rf2-ano54). As at 2026-08-06 the
-// split is 5 scenarios over 4 surfaces against 17 over 12 nightly. The
+// rather than a number frozen here (rf2-ano54). As at 2026-08-17 the
+// split is 4 scenarios over 3 staged surfaces against 16 over 11
+// nightly — the freehand-views Views roster scenario and its staged
+// surface went with the rf2-0yp7w Freehand retirement (rf2-l86mm). The
 // full sweep keeps running nightly in expensive-tests.yml. The CLI flag
 // is the cross-platform entry point (no cross-env dependency); the env
 // var stays supported for harness composition.

--- a/scripts/check_skill_xray_tab_inventory_drift.py
+++ b/scripts/check_skill_xray_tab_inventory_drift.py
@@ -28,8 +28,11 @@ whose `:modes` include `:dynamic`, under
 `panel-registry/tab-ids-for-mode :dynamic`, guarded by an Xray-side build
 test). Ordered by `:order`, that is today:
 
-    Epoch · app-db · Views · Trace · Machine · Routes · Resources · Graph · Frames
-    (mnemonics  e     a       v       t       m         r        s          g       u)
+    Epoch · app-db · Views · Trace · Machine · Routes · Resources · Graph ·
+    Frames · Hicasso   (mnemonics: e a v t m r s g u h)
+
+That roster is a SNAPSHOT, and no check reads it — see the note below the
+checks for why that matters.
 
 The gate is behaviour-neutral: it reads the runtime, it never edits it.
 
@@ -53,15 +56,23 @@ Checks (all against the runtime inventory parsed fresh each run):
       reorder in the primary inventory prose (e.g. "… Graph · Modules").
 
   A3  MNEMONIC SEQUENCE — the runtime mnemonics, joined in `:order` order
-      (space-separated, e.g. `e a v t m r s g u`), must appear in SKILL.md,
+      (space-separated, e.g. `e a v t m r s g u h`), must appear in SKILL.md,
       references/panels.md, and evals/evals.json.
 
   A4  LABEL PRESENCE — every runtime Dynamic label appears at least once in
       SKILL.md (so a newly-added tab's user-visible name is actually taught).
 
-  A5  EVAL NINTH-TAB LABEL — evals.json names the highest-`:order` tab by its
-      shipped visible label (today "Frames"), so the answer-quality fixtures
-      pin the currently-shipped label rather than a stale one.
+  A5  EVAL HIGHEST-ORDER TAB LABEL — evals.json names the highest-`:order` tab
+      by its shipped visible label (today "Hicasso", `:order 10`), so the
+      answer-quality fixtures pin the currently-shipped label rather than a
+      stale one.
+
+THE GATE DOES NOT READ THIS FILE. Its inputs are the Xray runtime and
+`skills/re-frame2-xray/**` — nothing else. So the roster above is prose no
+check covers, and it drifted exactly the way the drift this gate exists to
+catch does: it sat at nine tabs ending "Frames", naming the retired ninth-tab
+framing, while the gate itself printed "10 Dynamic tabs verified" on every run
+(rf2-vuabu). Re-derive it from `focus.cljc` `valid-panels` when you touch it.
 
 Pure-Python-stdlib (no PyYAML / Node) to stay fast + CI-portable, mirroring the
 sibling `scripts/check_skill_*.py` gates.
@@ -118,7 +129,7 @@ SKILL_FILES = {
 ORDERED_LABEL_FILES = ("SKILL.md", "README.md", "references/panels.md", "evals/evals.json")
 MNEM_FILES = ("SKILL.md", "references/panels.md", "evals/evals.json")
 LABEL_PRESENCE_FILE = "SKILL.md"
-EVAL_NINTH_LABEL_FILE = "evals/evals.json"
+EVAL_HIGHEST_LABEL_FILE = "evals/evals.json"
 
 _MIDDOT = "·"  # "·"
 
@@ -342,13 +353,15 @@ def check(
             )
 
     # A5 — evals name the highest-:order tab by its shipped visible label.
-    ninth = max(runtime_tabs, key=lambda t: t.get("order", 0))
-    ninth_label = ninth.get("label")
-    eval_text = skill_files.get(EVAL_NINTH_LABEL_FILE, "")
-    if ninth_label and ninth_label not in eval_text:
+    # Derived, never hard-coded: the last tab was :module-view ("Frames") until
+    # rf2-hic-023 appended :hicasso at :order 10, and it will move again.
+    highest = max(runtime_tabs, key=lambda t: t.get("order", 0))
+    highest_label = highest.get("label")
+    eval_text = skill_files.get(EVAL_HIGHEST_LABEL_FILE, "")
+    if highest_label and highest_label not in eval_text:
         findings.append(
-            f"A5 eval-label [{EVAL_NINTH_LABEL_FILE}]: the shipped label for the "
-            f"highest-:order tab (:{ninth['id']}) is {ninth_label!r} but the eval "
+            f"A5 eval-label [{EVAL_HIGHEST_LABEL_FILE}]: the shipped label for the "
+            f"highest-:order tab (:{highest['id']}) is {highest_label!r} but the eval "
             f"fixtures never name it — the answer-quality layer would pass a "
             f"stale label."
         )
@@ -467,8 +480,8 @@ def _run_self_test() -> int:
          files(**{"SKILL.md": f"Tabs: Epoch {_MIDDOT} Machine {_MIDDOT} Frames (mnemonics {mnem})."
                               .replace("Frames", "Frms")}),
          False),
-        # A5: evals never name the ninth label.
-        ("eval ninth label absent", rt, vp,
+        # A5: evals never name the highest-:order tab's label.
+        ("eval highest-order label absent", rt, vp,
          files(**{"evals/evals.json": f'"list Epoch {_MIDDOT} Machine {_MIDDOT} Modules (mnemonics {mnem})"'}),
          False),
         # R0: valid-panels omits a registered tab.


### PR DESCRIPTION
Closes rf2-vuabu.

Two numeral-free stale rosters that every prior numeric census missed. Neither carries a `9` or a `nine`, so a count-word grep returned nothing and read as a check that passed — the failure mode `skills/re-frame2-xray/evals/README.md:178` already names in as many words. The reliable probe is the **roster tail**: a tab list ending `Graph` or `Frames` with no `Hicasso` after it.

Truth re-established at source at this base, not taken from the bead: `focus.cljc` `valid-panels` holds **ten** ids including `:hicasso`, and the ten `reg-l4-tab!` registrations under `tools/xray/src/day8/re_frame2_xray/panels/` give the `:order` roster **Epoch · app-db · Views · Trace · Machine · Routes · Resources · Graph · Frames · Hicasso**, mnemonics `e a v t m r s g u h` (`hicasso.cljs` `:label "Hicasso" :mnem "h" :order 10`; `module_view.cljs` `:label "Frames"`).

## What changed

**`scripts/check_skill_xray_tab_inventory_drift.py`** — the docstring of the very gate whose job is to catch this class.

| Site | Was | Now |
|---|---|---|
| Docstring roster (`:29-32`) | nine tabs ending `Frames`, mnemonics `e a v t m r s g u`, present tense | tenth row `Hicasso` added, mnemonics `e a v t m r s g u h` |
| A3 description (`:56`) — **not named by the bead** | example sequence `e a v t m r s g u` | `e a v t m r s g u h` |
| A5 description (`:62-64`) — **not named by the bead** | "the highest-`:order` tab … (today `"Frames"`)" | `"Hicasso"`, `:order 10` |
| `EVAL_NINTH_LABEL_FILE`, `ninth`, `ninth_label`, self-test case name — **not named by the bead** | `ninth`, naming the **tenth** tab | `EVAL_HIGHEST_LABEL_FILE`, `highest`, `highest_label` |

The A5 prose was not merely stale, it was **objectively false**: the check derives its subject with `max(runtime_tabs, key=order)`, which has returned `:hicasso` since rf2-hic-023. The sabotage run below prints it directly — `the highest-:order tab (:hicasso) is 'Hicasso'`. Every roster got its tenth **row** rather than a numeral swap, per the convention set on rf2-xgi62 and carried by #8428 / #8431.

**`implementation/scripts/serve-and-run-xray-feature-gate.cjs`** — smoke sizing said *"As at 2026-08-06 the split is 5 scenarios over 4 surfaces against 17 over 12 nightly."* Every number stale. Re-derived at this base by replaying **this file's own filter** (`scenario.smoke === true` plus `surfaceForScenario`) over `scenarios.cjs`: smoke is **4 scenarios over 3 staged surfaces**, nightly-full **16 over 11**. Wording carried off #8431's diff rather than invented, including its attribution of the removed fifth scenario to the rf2-0yp7w Freehand retirement (rf2-l86mm).

## Does the control avoid the case it exists to catch?

**Yes, and that is the sharpest finding here.** The gate's inputs are the Xray runtime (`PANELS_DIR`, `FOCUS_CLJC`) and the seven files in `SKILL_FILES`, all under `skills/re-frame2-xray/`. **Its own source is not among them.** It is structurally incapable of reading its own docstring, so the teaching text a reader trusts most sat at nine tabs — naming the retired ninth-tab framing — while the gate one function below printed `10 Dynamic tabs verified` on *every single run*, green throughout.

Demonstrated rather than asserted (plant 1 below): with the retired label `Modules` planted **into the gate's own docstring roster**, both `--verbose --ci` and `--self-test` returned **exit 0**. That green is not a witness failure — it *is* the result, and it is now recorded in the docstring itself so the next reader is told not to trust the roster and to re-derive it from `valid-panels`.

## Roster-tail census, and the DELTA against the bead's two sites

Census run over the whole tracked tree (`.beads/issues.jsonl` excluded — it is a whole-database export, not source). Probes: the mnemonic run without a trailing `h`; `Graph`→`Frames` with no `Hicasso`; `valid-panels`-shaped id sets without `:hicasso`; ASCII tab strips; and a numeric cross-check for contrast. Each probe was run once against something it *should* find and both results read.

**Both bead-named sites still held** at this base and are fixed here.

**Found, in my fence, not named by the bead** — the three further `check_skill_xray_tab_inventory_drift.py` sites in the table above.

**Found, OUTSIDE my fence — reported and filed, not edited:**

| Site | Defect |
|---|---|
| `tools/xray/spec/018-Event-Spine.md:19` | *"A **tab bar** of 9 surfaces (Epoch / … / Graph / Frames)"* — nine-item roster, present tense |
| `tools/xray/spec/018-Event-Spine.md:557` | §Tab strip rendering ASCII strip ends `○Frames`, no `○Hicasso` — **numeral-free**, and inconsistent with its own siblings at `:66` and `:514`, which both carry `○Hicasso` |
| `tools/xray/test/day8/re_frame2_xray/focus_cljs_test.cljs:234-238` | `doseq` over `[:resources :derivation-graph :module-view]` under a docstring naming "the L4-only Graph + Frames tabs" — `:hicasso` is L4-only too (`API.md:324`, `007-UX-IA.md:2140`), so the shipped-tab acceptance skips it |
| `skills/README.md:110-111`, `.github/workflows/test.yml:4053` | nine-roster + retired `Modules` label + stale smoke sizing — **already fixed by open PR #8431**, whose diff I read; left alone (re-confirmed still unmerged at the final base) |

Filed as **rf2-v1fg3** (`discovered-from: rf2-vuabu`) for the three `tools/xray/**` sites. Filing rather than widening is how *this* bead came to exist.

**Judged at source and REFUSED as correct** — every near-miss the probes surfaced:

- `tools/xray/spec/019-Cross-Cutting-Insight.md:8` and `:729` name the **cohesive-sub-domain** tabs (`Routing / Resources / Graph / Frames`) — an explicitly *separate axis* from the tab inventory ("a separate axis — see §0"). Four is the right count there; adding Hicasso would have been a fresh error.
- `tools/xray/spec/007-UX-IA.md:128` looked like a mnemonic run ending at `` `u` `` — it wraps to `` `h` `` on `:129`. `skills/re-frame2-xray/SKILL.md:122` and `tools/xray/spec/019:931` are likewise correct wraps/history.

## What I left standing, and why

- **`:11`** — *"the ninth Dynamic tab was renamed … from `Modules` to `Frames`"*. Past tense, accurate history, and still true: `Frames` is `:order 9`. Tense is the discriminator.
- **The whole self-test fixture block.** `rt` is a synthetic **three-tab** world (`Epoch`/`Machine`/`Frames`, `mnem = "e m u"`) — not a claim about the shipped roster — and cases `inline stale label`, `ordered stale label` and `eval highest-order label absent` plant the retired `Modules` label **on purpose**. Breaking these would be a worse defect than the one being fixed. Only the one case *label* was renamed for accuracy; no fixture data was touched.
- **`skills/re-frame2-xray/evals/**`** — nine-shaped but correct: it *pins* ten and *rejects* a nine-tab inventory.
- **`tools/xray/spec/017-Test-Coverage-Matrix.md:105`** "switch tabs via `1`–`9`" — already adjudicated on rf2-22dl8 / rf2-91dfb as correctly left alone.

## Quality gates

Which gate owns each file, established at source rather than assumed:

- **Site A** is owned by **its own two modes**, wired at `.github/workflows/test.yml:451-458` and in the spine at `scripts/test-fast-pr.sh:1210-1214`. `check_doc_slugs.py` does **not** cover it (Python, not markdown).
- **Site B** is owned by three node policy suites that read its source: `_impl-browser-runners-verdict-policy.test.cjs`, `_script-spawn-policy.test.cjs`, `_changed-surfaces.test.cjs`. They assert on **code structure only** — see the negative control below.

| Gate | Captured exit | Result |
|---|---|---|
| `check_skill_xray_tab_inventory_drift.py --self-test` | **0** | `self-test: all fixtures pass.` |
| `check_skill_xray_tab_inventory_drift.py --verbose --ci` | **0** | `No Xray tab-inventory drift (10 Dynamic tabs verified).` |
| `node --test` x 3 Site-B policy suites | **0** | 292 + 18 + 141 = **451 assertions**, 0 failures |
| `scripts/check_fast_pr_gap.py --list` | **0** | **94** required CI checks this spine does not run |
| `scripts/test-fast-pr.sh` | **1** | **RAN, in full** — 3465 lines, **one** failure, environmental (below) |

Every number above was captured with the redirect and the `echo $?` on **one command line in one shell**, and is the number quoted — never the harness's report about the same run. In both spine runs the harness reported the detaching shell's exit 0 while the captured file read **1**; the captured number governs, which is why it is the one quoted.

**The spine's single failure is the environment, not this diff.** `FAIL CLJS node integration` — `compile-node-test: could not resolve shadow-cljs: Cannot find module 'shadow-cljs/cli/runner.js'`. This is a fresh worktree with no `implementation/node_modules`; three other workers hit the identical lane today. I did **not** junction into the mayor checkout's `node_modules` to green it — this repo has two recorded incidents of that cleanup emptying the real tree. Nothing in this diff reaches that lane: it is a Python docstring, four Python identifiers and one `.cjs` comment.

**Re-run on the final base after rebasing.** The trunk moved from `98a35fece5` to `3e9330a149` mid-run (nine commits: beads checkpoints, `.claude/commands/mayor-dispatch.md`, and `docs/design/hicasso/studio/hd8-freehand-codec-donor-arm.md` — none touching my files or any census surface). Every gate above was re-run on the final base and the census re-verified there; results identical. The three-dot merge-base diff (`origin/main...HEAD`) is exactly my two files, so this push reverts nothing.

**Which tree each gate read.** The spine prints its root: `gate root: /c/Users/miket/code/re-frame2-worktrees/rostertail-vuabu`, and across all 3465 lines the only worktree path mentioned is `rostertail-vuabu` — zero sibling mentions. The two silent gates were discriminated by the planted reds below.

### Planted-fault controls

Neither gate is one I can discriminate by a printed root, so the proof is the red.

1. **Plant 1 — retired label `Modules` into the gate's own docstring roster.** Hash `dbee941f` -> `7d20aa96`, so the patch genuinely applied. Both modes came back **GREEN, exit 0**. Reported rather than retried: this is the predicted, correct result and the finding of this PR. Restored, verified `dbee941f` against the committed object by `git hash-object`, not by reading a diff.
2. **Plant 2 — a code fault in the A5 branch I was editing** (inverted `not in`, plus marker `PLANTED-FAULT-rf2-vuabu-rostertail` in the message). Hash `dbee941f` -> `c84643a7`. `--verbose --ci` **exit 1** and `--self-test` **exit 1**, both naming the marker. The marker exists only in this worktree, so both runs read this worktree. Restored, verified by content hash.
3. **Plant 3 (Site B) — a false count in the very comment I edited** (`999 scenarios over 888 staged surfaces`). Verdict-policy suite **GREEN, exit 0**. This is the honest negative result: **the comment's content has no automated coverage at all.**
4. **Plant 4 (Site B) — a code fault** (`browserState.pageErrorsPLANTEDFAULTrf2vuabu`). Suite **exit 1**, failing `xray-feature-gate: a scenario with a captured pageerror is not marked passed (rf2-mwx08)` — so the suite does read this worktree and does bite; it simply cannot see comments. Restored, hash `483731539a` reconfirmed.

No `PLANTED` marker residue remains (verified by `git grep -nF`; the surviving hits are pre-existing, unrelated tree content).

### Verified by hand, because no gate covers it

Site B's comment content. Both counts were derived by executing this file's own `surfaceForScenario` + `smoke === true` filter against `scenarios.cjs` at this base: **16 total scenarios / 11 staged surfaces; 4 smoke scenarios** (`feature matrix shell and panel handoff`, `deterministic exceptions and inline/trace surfacing`, `command palette chord ...`, `panel-gallery theme-token ...`) resolving to **3 distinct surfaces** (`counter`, `testbeds/deliberate-throw`, `testbeds/panel-gallery`), zero unmatched. These agree independently with #8431's derivation for `test.yml`.
