### PR TITLE
fix(bench): the alloc report states the shape it actually measured (rf2-gxrr)

### DIFF
--- a/implementation/core/test/re_frame/bench/p0_ladder_structural.test.cjs
+++ b/implementation/core/test/re_frame/bench/p0_ladder_structural.test.cjs
@@ -2150,6 +2150,86 @@ const FLOOR_ARMS = () =>
     ])
   );
 
+// EVERY ARM THE FULL PLAN MOUNTS, keyed exactly as the driver keys them and
+// built FROM `ladderPlan` rather than spelled out — so a rung added to the
+// ladder arrives here too, and the full-plan control below cannot quietly go
+// stale while still passing.
+const FULL_ARMS = () =>
+  Object.fromEntries(
+    ladderPlan({ list: 300, grid: 6 }, 4).flatMap(({ segment, arms }) =>
+      arms.map((a) => [
+        a.key,
+        {
+          segment,
+          arm: a.arm,
+          rung: a.rung,
+          reads: a.reads || 0,
+          boundaries: 24,
+          ...allocSteps(stream([5000, 5000, 5000, 5000])),
+          primeLegs: [11788],
+          primeExcess: 6788,
+          perWrite: 5000,
+          perBoundaryPerWrite: 208,
+        },
+      ])
+    )
+  );
+
+// The fits a full run carries, one per (segment, substrate), derived from the
+// same plan for the same reason. Only the full plan reaches
+// `summariseAllocFits`; the narrow ones print the NO FITTED LINE block.
+const FULL_FITS = () => {
+  const mean = {};
+  const perRound = {};
+  for (const { segment, arms } of ladderPlan({ list: 300, grid: 6 }, 4)) {
+    for (const sub of [...new Set(arms.map((a) => a.substrate).filter(Boolean))]) {
+      mean[`${segment}|${sub}`] = {
+        slope: 12,
+        intercept: 100,
+        shell: 90,
+        firstRead: 110,
+        r2: 0.999,
+        linear: true,
+        why: 'a synthetic fit, measured against nothing',
+      };
+      perRound[`${segment}|${sub}`] = [1, 2].map(() => ({
+        slope: 12,
+        intercept: 100,
+        shell: 90,
+        firstRead: 110,
+        linear: true,
+      }));
+    }
+  }
+  return { perRound, mean };
+};
+
+// THE FULL PLAN IS THE CONTROL FOR THE TWO PINS BELOW (rf2-gxrr), and it is
+// not decoration. Each narrowed pin asserts that a run does NOT say something,
+// and a `doesNotMatch` passes just as quietly when the summary says it under
+// NO plan at all — a later edit that deleted "Q = E on every rung" outright
+// would leave both narrowed pins green while silently retiring the claim from
+// the published row. So every string they forbid is asserted PRESENT here, on
+// the plan this bead left unchanged to the byte.
+test('the FULL plan still makes every claim the narrowed plans may not', () => {
+  const { row, out } = allocSummaryFor('full', FULL_ARMS(), { allocFits: FULL_FITS() });
+  assert.match(out, /WARM 1\/3\/7\/20 READS \(rf2-2rtt6\.76\)/, 'the published banner');
+  assert.match(out, /held FIXED across every rung/);
+  assert.match(out, /Q = E on every rung\./);
+  assert.match(out, /The arm stays MOUNTED across the window/);
+  assert.match(out, /THE WRITE IS `/, 'and the write is named as DRIVEN');
+  assert.match(out, /THE PLAN IS `full` — controls, floor and every rung, fitted\./);
+  assert.match(out, /THE FITTED LINES/);
+  assert.match(out, /---- reagent-subs ----/);
+  assert.match(out, /^;; hicasso {8}20 /m, 'the R=20 rung is in the arm table');
+  // And it says none of the narrowed plans' absence lines.
+  assert.doesNotMatch(out, /NO ARM WAS MOUNTED/);
+  assert.doesNotMatch(out, /NO WRITE EVENT WAS DRIVEN/);
+  assert.doesNotMatch(out, /NO RUNG WAS MOUNTED/);
+  assert.doesNotMatch(out, /NO FITTED LINE/);
+  assert.strictEqual(row.writeDriven, true, 'the arm loop ran, so the selected write fired');
+});
+
 test("V3's CONTROLS-ONLY summary RUNS, and states absence rather than zero", () => {
   const { row, out } = allocSummaryFor('controls');
   assert.match(out, /NO ARM WAS MOUNTED/, 'absence is stated, not left to be read as zero');
@@ -2168,10 +2248,37 @@ test("V3's CONTROLS-ONLY summary RUNS, and states absence rather than zero", () 
   // a run that printed no prime line at all would be hiding the one term this
   // instrument now has a name for.
   assert.match(out, /prime excess over the measured cohort median: 0 B mean/);
+
+  // AND IT CLAIMS NOTHING THE FULL PLAN CLAIMS (rf2-gxrr). Every line below
+  // printed unconditionally when the modes first landed, so this artefact
+  // stated that rungs were held at Q = E, that an arm stayed mounted, and
+  // that a write fired — over a run that mounted nothing and drove nothing —
+  // and then admitted "no arm mounted" twenty lines further down. V3's
+  // controls artefact is provenance for a validity witness, and a record that
+  // misstates its own measurement shape cannot be that.
+  assert.match(out, /CONTROLS ONLY, NO ARM/, 'the banner names the shape');
+  assert.doesNotMatch(out, /WARM 1\/3\/7\/20 READS/, 'no rung was read');
+  assert.doesNotMatch(out, /held FIXED across every rung/, 'there is no rung to hold B across');
+  assert.doesNotMatch(out, /Q = E on every rung/, 'and none to hold Q = E on');
+  assert.doesNotMatch(out, /The arm stays MOUNTED/, 'no arm was mounted to stay');
+  assert.doesNotMatch(out, /NO RUNG WAS MOUNTED/, "that is the FLOOR plan's line, not this one");
+
+  // THE WRITE, WHICH IS THE FALSE ATTRIBUTION THIS PIN EXISTS FOR. The
+  // selected write is driven only inside the arm loop, so a plan with no arms
+  // resolves the switch and fires nothing. Naming it is the one failure a
+  // provenance line may not have.
+  assert.doesNotMatch(out, /THE WRITE IS `/, 'no write event is NAMED as driven');
+  assert.match(out, /NO WRITE EVENT WAS DRIVEN, and no figure below is a reading of one/);
+  assert.match(out, /P0_ALLOC_WRITE resolved to `page`/, 'the SELECTION is still on the record');
+  // And the raw record says it too, so a reader of the JSON is not left to
+  // infer it from the plan name. Measured off `perRound`, not read off
+  // `plan.arms`: a flag derived from the configuration would be the
+  // instrument checking itself against itself and agreeing.
+  assert.strictEqual(row.writeDriven, false, 'the record itself denies the event');
 });
 
 test("V1's FLOOR-ONLY summary RUNS, prints the floor, and prints no rung", () => {
-  const { out } = allocSummaryFor('floor', FLOOR_ARMS());
+  const { row, out } = allocSummaryFor('floor', FLOOR_ARMS());
   // NOT VACUOUS: this plan DOES mount an arm, so the two modes are told apart
   // by the summary and not merely by the shape table.
   assert.doesNotMatch(out, /NO ARM WAS MOUNTED/);
@@ -2196,6 +2303,24 @@ test("V1's FLOOR-ONLY summary RUNS, prints the floor, and prints no rung", () =>
     new RegExp(`The window drives ${ALLOC_WINDOW_WRITES} — the first ${ALLOC_PRIME_WRITES} is a PRIME`),
     'and the header says how many work units ran against how many are published'
   );
+
+  // AND IT CLAIMS NO RUNG, NO FIT AND NO Q = E (rf2-gxrr). V1's floor arm
+  // holds no subscription, so there is no read count for Q = E to be about
+  // and no 1/3/7/20 ladder to hold B fixed across — three sentences the
+  // header printed unconditionally when this mode first landed.
+  assert.match(out, /FLOOR ARM ONLY, NO RUNG/, 'the banner names the shape');
+  assert.doesNotMatch(out, /WARM 1\/3\/7\/20 READS/);
+  assert.doesNotMatch(out, /held FIXED across every rung/);
+  assert.doesNotMatch(out, /Q = E on every rung/);
+
+  // THE OTHER HALF, AND IT IS WHAT SEPARATES THIS MODE FROM V3's. A floor arm
+  // IS mounted and it DOES drive the selected write, so both claims stand
+  // here — the narrowing is about rungs, and a pin that suppressed these too
+  // would be reporting V3's shape under V1's name.
+  assert.match(out, /The arm stays MOUNTED across the window/);
+  assert.match(out, /THE WRITE IS `/);
+  assert.doesNotMatch(out, /NO WRITE EVENT WAS DRIVEN/);
+  assert.strictEqual(row.writeDriven, true, 'the floor arm loop ran, so the write fired');
 });
 
 test('the DRIVER honours both switches — the write, the plan, and the record', () => {

--- a/implementation/core/test/re_frame/bench/p0_run.cjs
+++ b/implementation/core/test/re_frame/bench/p0_run.cjs
@@ -2390,6 +2390,13 @@ async function allocRow(chromium) {
     // Criterion 6's separation is that a reader of any row can tell FROM THE
     // ROW which write produced it; a hard-coded string could only ever have
     // named one, and would have gone on naming it after the selector landed.
+    //
+    // BOTH ARE THE SELECTION, NOT THE EVENT. The selected write is driven only
+    // inside the arm loop, so a plan that mounts no arm resolves these two and
+    // fires nothing. `writeDriven` is the record's answer to "did it fire?",
+    // and `summariseAlloc` derives it off `perRound` — measured, not
+    // configured — beside `controlVerdict` and the other verdicts this row
+    // learns about itself only once its rounds are in.
     writeSelector: ALLOC_WRITE,
     write: `${ALLOC_WRITE_SPEC.event} — ${ALLOC_WRITE_SPEC.note}`,
     plan: { name: ALLOC_PLAN, ...ALLOC_PLAN_SHAPE },
@@ -2549,21 +2556,77 @@ function allocSiteReport(row) {
 
 function summariseAlloc(row, refused) {
   const B = row.boundaries;
-  console.log('\n;; ==== P0 STEADY-STATE ALLOCATION — WARM 1/3/7/20 READS (rf2-2rtt6.76) ====');
-  console.log(
-    `;; ${row.roots} root(s) held per arm, ${row.perRoot.grid} cells each — B = ${B} boundaries, ` +
-      'held FIXED across every rung'
-  );
-  console.log(
-    `;; ${row.rounds} rounds x ${row.writes} warm bulk writes, after ${row.warmups} full-size ` +
-      'warm-up windows. Q = E on every rung.'
-  );
+  // WHAT THIS RUN ACTUALLY MOUNTED, AND WHAT IT ACTUALLY DROVE (rf2-gxrr).
+  //
+  // The header states the SHAPE of the measurement, and under a narrowed plan
+  // the full plan's sentences are not merely uninteresting — they are FALSE of
+  // the run. "held FIXED across every rung" and "Q = E on every rung" describe
+  // rungs a floor-only run never mounts; "the arm stays MOUNTED" describes an
+  // arm a controls-only run never mounts; and "THE WRITE IS ..." names an
+  // event a controls-only run never drives, because the selected write reaches
+  // the page only inside the arm loop. These modes exist to be the PROVENANCE
+  // of a validity witness, and a record that misstates its own measurement
+  // shape cannot be that — a reader of V3's controls artefact would take a
+  // named write for an executed one.
+  //
+  // MEASURED OFF THE ROUNDS, NOT READ OFF THE SWITCH. `writeDriven` asks the
+  // record whether any arm window ran, which is the only thing that can drive
+  // the write. Deriving it from `plan.arms` would be the instrument checking
+  // its own configuration against itself and agreeing.
+  //
+  // The `full` branches are lifted out WHOLE rather than guarded in place, on
+  // `summariseAllocFits`'s rule: today's published run is unchanged to the
+  // byte, and the narrow plans simply do not reach those lines.
+  const armed = row.plan.arms;
+  const runged = row.plan.rungs;
+  const writeDriven = row.perRound.some((r) => Object.keys(r.arms || {}).length > 0);
+  row.writeDriven = writeDriven;
+  if (runged) {
+    console.log('\n;; ==== P0 STEADY-STATE ALLOCATION — WARM 1/3/7/20 READS (rf2-2rtt6.76) ====');
+    console.log(
+      `;; ${row.roots} root(s) held per arm, ${row.perRoot.grid} cells each — B = ${B} boundaries, ` +
+        'held FIXED across every rung'
+    );
+    console.log(
+      `;; ${row.rounds} rounds x ${row.writes} warm bulk writes, after ${row.warmups} full-size ` +
+        'warm-up windows. Q = E on every rung.'
+    );
+  } else if (armed) {
+    console.log('\n;; ==== P0 STEADY-STATE ALLOCATION — FLOOR ARM ONLY, NO RUNG (rf2-gxrr) ====');
+    console.log(
+      `;; ${row.roots} root(s) held per arm, ${row.perRoot.grid} cells each — B = ${B} boundaries. ` +
+        'NO RUNG WAS MOUNTED:'
+    );
+    console.log(
+      ';; this run makes no statement about 1/3/7/20 reads, fits nothing, and reports no Q = E —'
+    );
+    console.log(
+      ';; the floor arm holds no subscription, so there is no read count for Q = E to be about.'
+    );
+    console.log(
+      `;; ${row.rounds} rounds x ${row.writes} warm bulk writes, after ${row.warmups} full-size ` +
+        'warm-up windows.'
+    );
+  } else {
+    console.log('\n;; ==== P0 STEADY-STATE ALLOCATION — CONTROLS ONLY, NO ARM (rf2-gxrr) ====');
+    console.log(';; NO ARM WAS MOUNTED AND NO WRITE EVENT WAS DRIVEN. The three control windows');
+    console.log(';; below are the whole measurement: no rung, no fit, no Q = E, and no statement');
+    console.log(
+      `;; about any substrate. The page this run was CONFIGURED for and never mounted is B = ${B}.`
+    );
+    console.log(
+      `;; ${row.rounds} rounds x ${row.writes} warm bulk writes, after ${row.warmups} full-size ` +
+        'warm-up windows.'
+    );
+  }
   console.log(
     `;; The window drives ${row.windowWrites} — the first ${row.primeWrites} is a PRIME and is in ` +
       'no figure below (rf2-oiy1).'
   );
-  console.log(';; The arm stays MOUNTED across the window: this is what a standing page');
-  console.log(';; allocates when it is written to, not what a mount costs.');
+  if (armed) {
+    console.log(';; The arm stays MOUNTED across the window: this is what a standing page');
+    console.log(';; allocates when it is written to, not what a mount costs.');
+  }
 
   // THE ARM'S SIZE, AND WHERE IT CAME FROM (rf2-2rtt6.140). Printed beside the
   // figures rather than left in a source comment, because the one question a
@@ -2589,23 +2652,42 @@ function summariseAlloc(row, refused) {
   // from the record rather than asserted from a literal. `page` and `full`
   // are the defaults every published row is taken under; anything else is a
   // validity witness saying so on its own face.
-  console.log(`;;   THE WRITE IS \`${row.write}\`.`);
-  if (row.writeSelector === 'page') {
-    console.log(
-      `;;   It rebuilds the grid at ${B} cells — one per mounted boundary. \`:p0/write-all\``
-    );
-    console.log(
-      ';;   rebuilt 300 whatever was mounted, and that fixed cost was 57% of the retired budget'
-    );
-    console.log(';;   before a single boundary had been measured.');
+  //
+  // AND A SELECTED WRITE IS NOT A DRIVEN ONE. `P0_ALLOC_WRITE` names the event
+  // the ARM LOOP will drive, and a controls-only plan has no arm loop — so the
+  // switch resolves, the record carries it, and nothing fires. Saying "THE
+  // WRITE IS `:p0/write-page`" over that run would attribute an event that did
+  // not execute, which is the one failure a provenance line may not have.
+  if (writeDriven) {
+    console.log(`;;   THE WRITE IS \`${row.write}\`.`);
+    if (row.writeSelector === 'page') {
+      console.log(
+        `;;   It rebuilds the grid at ${B} cells — one per mounted boundary. \`:p0/write-all\``
+      );
+      console.log(
+        ';;   rebuilt 300 whatever was mounted, and that fixed cost was 57% of the retired budget'
+      );
+      console.log(';;   before a single boundary had been measured.');
+    } else {
+      console.log(
+        ';;   THIS IS V1\'s F_old CONTROL, NOT A PUBLISHED ROW — the fixed 300-cell rebuild, which'
+      );
+      console.log(
+        `;;   is flat in B by construction and is the only way the two writes can be compared like`
+      );
+      console.log(';;   for like. Selected by P0_ALLOC_WRITE=all; the default is `page`.');
+    }
   } else {
+    console.log(';;   NO WRITE EVENT WAS DRIVEN, and no figure below is a reading of one. The');
     console.log(
-      ';;   THIS IS V1\'s F_old CONTROL, NOT A PUBLISHED ROW — the fixed 300-cell rebuild, which'
+      ';;   selected write reaches the page only inside the arm loop, and this plan mounted no'
     );
     console.log(
-      `;;   is flat in B by construction and is the only way the two writes can be compared like`
+      `;;   arm — so P0_ALLOC_WRITE resolved to \`${row.writeSelector}\`, the record carries it,`
     );
-    console.log(';;   for like. Selected by P0_ALLOC_WRITE=all; the default is `page`.');
+    console.log(
+      ';;   and nothing fired. The control windows below allocate doubles and nothing else.'
+    );
   }
   console.log(';;   The clock, bulk, fan-out and retention rows drive `:p0/write-all` unchanged,');
   console.log(';;   at the published width, whatever this switch says.');


### PR DESCRIPTION
Closes **rf2-gxrr** — the REOPENED half.

## What the bead actually asked for

The brief for this dispatch assumed nothing had been built. **The bead disagrees, and
the bead governs.** rf2-gxrr's three enumerated parts — the write selector, the
controls-only mode and the floor-only mode — all landed on 2026-08-14 in
`e9674879ba` / `cd1cba7b6a` / `fcd414d0d5`, and are on `origin/main` today. The bead was
closed at 00:10, audited, and **reopened at 01:15** with a new acceptance clause in its
NOTES that no commit has ever discharged (the last rf2-gxrr commit is 00:14, five
minutes before that clause was written). It was reopened a second time on 2026-08-17 at
20:34 by a status-only mutation.

That clause, verbatim:

> Acceptance: make the report header and write provenance plan-aware. Controls-only must
> explicitly say no arm and no write event was driven; floor-only must not claim rungs,
> fits, or Q = E. Keep the full plan's claims intact. Extend the structural pins to reject
> these stale full-plan claims in both narrowed outputs and to prove controls-only does not
> claim an executed write.

**This PR is that clause and only that clause.** No gate is widened, no band moved, no
threshold touched. `ALLOC_MIN_WRITES` stays 6, `ALLOC_FALL_THRESHOLD_B` stays 600,000,
τ stays the uncalibrated placeholder. No measurement window was run.

## The defect, reproduced before it was fixed

`summariseAlloc` printed the **full plan's header every time**. Driven over a synthetic
controls-only row it emitted, in this order:

```
;; ==== P0 STEADY-STATE ALLOCATION — WARM 1/3/7/20 READS (rf2-2rtt6.76) ====
;; 4 root(s) held per arm, 6 cells each — B = 24 boundaries, held FIXED across every rung
;; 2 rounds x 6 warm bulk writes, after 3 full-size warm-up windows. Q = E on every rung.
;; The arm stays MOUNTED across the window: this is what a standing page
;;   THE WRITE IS `:p0/write-page — ...`.
```

…and then, twenty lines later, `THE PLAN IS `controls` — the controls only, no arm mounted`.

`allocPlanArms` returns `[]` for the controls shape, and the selected write is passed to
`window.P0H.allocWindow` **only inside the arm loop** (`p0_run.cjs` :2253, :2260) — the
control windows drive `kind` `idle`/`control`, which take the `ctl?` branch in
`p0_heap.cljs` and never reach `write-page!`/`write-all!`. So V3's controls artefact
attributed an event that never executed. That defeats the entire purpose of these modes,
which is to be the **provenance** of a validity witness.

## What changed

**`p0_run.cjs` — the header and the write provenance are plan-aware.** The `full`
branches are lifted out *whole* rather than guarded in place, on `summariseAllocFits`'s
existing rule, so today's published run is unchanged to the byte.

**`writeDriven` joins the raw record** beside `writeSelector` and `write`, so a reader of
the JSON can tell a **selected** write from a **driven** one. It is derived off
`perRound` — measured — rather than off `plan.arms`; deriving it from the configuration
would be the instrument checking itself against itself and agreeing. `summariseAlloc`
assigns it, beside `controlVerdict` / `fallsInMeasuredWindows` / `refusedWindows`, which
is this function's existing house pattern, and the record is serialised afterwards
(:3716 > :3563).

## The control: enumerated selection, knob on and knob off

`summariseAlloc` driven over a synthetic row at each plan shape, before and after.
**The `full` plan's output is byte-identical** — its only line in the diff is the
harness's own record marker, reporting the new field.

| plan | banner | rung claims | `The arm stays MOUNTED` | write provenance | `row.writeDriven` |
|---|---|---|---|---|---|
| `full` | `WARM 1/3/7/20 READS` *(unchanged)* | present *(unchanged)* | present *(unchanged)* | `THE WRITE IS \`…\`` *(unchanged)* | `true` |
| `floor` | → `FLOOR ARM ONLY, NO RUNG` | **removed** | present (a floor arm *is* mounted) | `THE WRITE IS \`…\`` (a floor arm *does* drive it) | `true` |
| `controls` | → `CONTROLS ONLY, NO ARM` | **removed** | **removed** | → `NO WRITE EVENT WAS DRIVEN` | `false` |

Full diff of the two narrowed plans:

```diff
 ########## PLAN=floor ##########
-;; ==== P0 STEADY-STATE ALLOCATION — WARM 1/3/7/20 READS (rf2-2rtt6.76) ====
-;; 4 root(s) held per arm, 6 cells each — B = 24 boundaries, held FIXED across every rung
-;; 2 rounds x 6 warm bulk writes, after 3 full-size warm-up windows. Q = E on every rung.
+;; ==== P0 STEADY-STATE ALLOCATION — FLOOR ARM ONLY, NO RUNG (rf2-gxrr) ====
+;; 4 root(s) held per arm, 6 cells each — B = 24 boundaries. NO RUNG WAS MOUNTED:
+;; this run makes no statement about 1/3/7/20 reads, fits nothing, and reports no Q = E —
+;; the floor arm holds no subscription, so there is no read count for Q = E to be about.
+;; 2 rounds x 6 warm bulk writes, after 3 full-size warm-up windows.

 ########## PLAN=controls ##########
-;; ==== P0 STEADY-STATE ALLOCATION — WARM 1/3/7/20 READS (rf2-2rtt6.76) ====
-;; 4 root(s) held per arm, 6 cells each — B = 24 boundaries, held FIXED across every rung
-;; 2 rounds x 6 warm bulk writes, after 3 full-size warm-up windows. Q = E on every rung.
+;; ==== P0 STEADY-STATE ALLOCATION — CONTROLS ONLY, NO ARM (rf2-gxrr) ====
+;; NO ARM WAS MOUNTED AND NO WRITE EVENT WAS DRIVEN. The three control windows
+;; below are the whole measurement: no rung, no fit, no Q = E, and no statement
+;; about any substrate. The page this run was CONFIGURED for and never mounted is B = 24.
+;; 2 rounds x 6 warm bulk writes, after 3 full-size warm-up windows.
 ;; The window drives 7 — the first 1 is a PRIME and is in no figure below (rf2-oiy1).
-;; The arm stays MOUNTED across the window: this is what a standing page
-;; allocates when it is written to, not what a mount costs.
...
-;;   THE WRITE IS `:p0/write-page — ...`.
-;;   It rebuilds the grid at 24 cells — one per mounted boundary. `:p0/write-all`
-;;   rebuilt 300 whatever was mounted, and that fixed cost was 57% of the retired budget
-;;   before a single boundary had been measured.
+;;   NO WRITE EVENT WAS DRIVEN, and no figure below is a reading of one. The
+;;   selected write reaches the page only inside the arm loop, and this plan mounted no
+;;   arm — so P0_ALLOC_WRITE resolved to `page`, the record carries it,
+;;   and nothing fired. The control windows below allocate doubles and nothing else.
```

## The pins, and the third one that makes the other two mean anything

Three tests in `p0_ladder_structural.test.cjs` (82 → 83), all hermetic — no browser, no
build, driven through the shipped `summariseAlloc`.

The two narrowed pins assert a run does **not** say `held FIXED across every rung`,
`Q = E on every rung`, `The arm stays MOUNTED` or `THE WRITE IS `. A `doesNotMatch`
passes just as quietly when the summary says those under **no plan at all** — a later
edit retiring one outright would leave both green while silently changing the published
row. So the new **`the FULL plan still makes every claim the narrowed plans may not`**
asserts every one of those strings *present*, on the plan this PR left byte-identical.
Its arms and fits are built **from `ladderPlan`**, not spelled out, so a rung added to
the ladder arrives in the control too.

The floor pin holds the two narrowings apart from the other side: a floor arm **is**
mounted and **does** drive the selected write, so those two claims stand under `floor`
and are refused only under `controls`. A pin that suppressed both would be reporting V3's
shape under V1's name.

## Quality gates

Every number below is the exit code **captured by the same shell that ran the gate**
(`cmd > log 2>&1; echo "EXIT=$?"`), never one reported about the run.

| gate | command | exit |
|---|---|---|
| structural pins — baseline, before any edit | `node core/test/re_frame/bench/p0_ladder_structural.test.cjs` | **0** — 82 passed |
| structural pins — final, on the rebased base | same | **0** — 83 passed |
| **fast-PR spine** — first run | `sh scripts/test-fast-pr.sh` | **0** |
| **fast-PR spine** — re-run on the FINAL rebased base | same | **0** |

**The spine RAN, and it ran against this worktree.** Its own banner:

```
gate root: /c/Users/miket/code/re-frame2-worktrees/allocinstr-gxrr
=== fast PR spine: docs=false jvm=true node=true (classified) ===
```

That is the classifier line: a diff under `implementation/` armed both the JVM and node
lanes, as expected, and the docs lane correctly stayed off.

`python scripts/check_fast_pr_gap.py --list` — **94** required checks the spine does not
decide. Cited as the one path that derives them; not enumerated by hand here.

**Skipped, with reasons:**

- `scripts/check_allocation_non_claim.py` — **not armed by this diff.** `docs.yml`'s
  `docs_surface` classifier (:198) lists `docs/*`, `spec/*`, the gate's own source and a
  fixed set of scripts; `implementation/core/test/**` is in none of them. Named in the
  dispatch brief, verified out of scope rather than assumed.
- The bench's own run (`--only alloc`) — **that is the instrument, not a gate.** This
  dispatch is instrument work; running a window on a rig changed minutes earlier is
  exactly what criterion 5 exists to prevent.

### The planted-fault control

Two plants, each anchored to a **single line** I was already editing, each run to red,
each restored and the restore verified by **content hash against the committed object**
(`git hash-object` vs `git rev-parse HEAD:<path>`) rather than by reading a diff.

**Plant A — `if (runged)` → `if (runged || true)`**, i.e. the header reverted to
unconditional.

```
pre-plant / HEAD blob : 5558987b9e3112dddef964434b7826c84c5efa65
planted               : 42feb26701b92574bc1ceb77325a8459ac64b115   ← the patch DID apply
EXIT=1    2/83 failed
  FAIL  V3's CONTROLS-ONLY summary RUNS, and states absence rather than zero
        the banner names the shape
  FAIL  V1's FLOOR-ONLY summary RUNS, prints the floor, and prints no rung
        the banner names the shape
restored              : 5558987b9e3112dddef964434b7826c84c5efa65   ← byte-identical
```

**Plant B — `if (writeDriven)` → `if (writeDriven || true)`**, i.e. the write named as
driven regardless.

```
planted               : caf7dd8c256c497e4c68626a6e48c33044772085   ← the patch DID apply
EXIT=1    1/83 failed
  FAIL  V3's CONTROLS-ONLY summary RUNS, and states absence rather than zero
        no write event is NAMED as driven
restored              : 5558987b9e3112dddef964434b7826c84c5efa65   ← byte-identical
post-restore re-run   : EXIT=0, 83 passed
```

Both failures name **exactly what was planted**, and the discrimination is the red
itself: the fault existed only in this worktree, so a run that had wandered into a
sibling's would have come back green. Note plant B reds **one** test and not three —
`floor` and `full` both drive the write, so only `controls` may refuse it. That
asymmetry is the pins doing the right thing rather than a blanket suppression.

### Merge-base diff, read for reverts

`git diff origin/main...HEAD` (three-dot, against the merge base — not the tip):
**2 files, +230 / −23.** Every one of the 23 deleted lines is my own re-indentation or
re-guarding of text this PR re-emits. **Nothing a sibling landed is reverted.**

The trunk moved under this branch mid-flight (five commits: the rf2-nkeba studio pages,
rf2-gbm4t, rf2-vuabu, beads checkpoints). None touched the bench tree —
`p0_run.cjs` hashes to `c57c824a6f` at both the old and the new base — so the before/after
enumeration above holds on the final base. Rebased and the gates re-run on it regardless.

## The mean-vs-median finding, checked and declined

The dispatch brief flagged `worker/allocctrl-nkeba`'s live finding: the published
2026-08-08 targets are the round **median** of `rise/W` while the runner printed the
**mean**. **It holds**, and PR #8434 merged it as `4c8fd96953` while this branch was in
flight. The brief's paraphrase — "the runner had no `median` function at all" — drops the
revision scope and is false of today's tree: `median` exists in `p0_run.cjs` (landed with
rf2-2rtt6.140) and is used for `legMedian`. The merged page is careful and correct: it
scopes the claim to `p0_run.cjs@4a1537cb71`, the runner *of the day*. Today `rise/W` is
still published as `stat().mean`.

**Nothing done here.** Changing the published statistic is moving the rig, it is
explicitly outside what this bead asks for ("no gate is widened, no band moved"), and the
merged page states it is filed as its own bead against a rig that must not move
mid-window. Recorded so it is not rediscovered.

## What this unblocks

`rf2-gxrr` blocks **rf2-2rtt6.140** (P1) and **rf2-0gjqi** (P2) directly, and
rf2-2rtt6.140 in turn blocks **rf2-2rtt6.139** (P1). With the reopened clause discharged,
the measurement surface is both *runnable* and *honest about what it ran* — which is what
a validity witness needs from its provenance.
