### PR TITLE
docs(dev-testbed): make the port-band mirror claim non-exhaustive (rf2-puwyb)

### DIFF
--- a/implementation/scripts/dev-testbed.cjs
+++ b/implementation/scripts/dev-testbed.cjs
@@ -134,11 +134,15 @@ const { REPO_ROOT, IMPL_ROOT } = require('./_path-policy.cjs');
 //                                         must share an origin.
 //   8765        Xray panel-gallery        :dev-http (shadow-cljs.edn).
 //
-// The :dev-http bands (8030-8035 / 8040-8045 / 8765) are mirrored in the
-// DEV_HTTP map below (READ-only — shadow-cljs.edn is hot-zone). The 805x
-// examples band is NOT a :dev-http port — it is the test-orchestrator's
-// http-server default, resolved at runtime — so it lives only here + in
-// examples-port.cjs, not in DEV_HTTP.
+// Every band whose Notes above read `:dev-http (shadow-cljs.edn)` is
+// mirrored entry-for-entry in the DEV_HTTP map below (READ-only —
+// shadow-cljs.edn is hot-zone). DEV_HTTP is the roster, and is deliberately
+// NOT re-listed here: a transcribed band list goes stale in silence, which
+// this sentence proved by naming 8030-8035 / 8040-8045 / 8765 while the live
+// 806x band sat in the table right above it (rf2-puwyb). A band whose Notes
+// read otherwise is not in DEV_HTTP — the 805x examples band is the test-
+// orchestrator's http-server default, resolved at runtime, so it lives only
+// here + in examples-port.cjs.
 // ===========================================================================
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Answers the MERGED-PR AUDIT comment on **rf2-puwyb** (2026-08-17T12:06:46Z, on PR #8430 at `98a35fece5`). Comment-only; no runtime and no guard change, exactly as the audit directed. The functional cleanup and the inverse orphan guard from #8430 stand untouched.

## The defect

`implementation/scripts/dev-testbed.cjs` said:

> The :dev-http bands (8030-8035 / 8040-8045 / 8765) are mirrored in the DEV_HTTP map below

That wording is exhaustive and the transcription was stale. The live 806x band sits in the same table right above the sentence and is mirrored right below it.

## Re-derived DEV_HTTP census (not taken from the audit)

`DEV_HTTP` is exported, so it was enumerated by requiring the module rather than read by eye:

| band | count | entries |
|---|---|---|
| 8030-8035 | 6 | two-frame-isolation, standard-epochs, routes-epochs, machine-epochs, edn-inspector, managed-http |
| 8040-8045 | 6 | nine-states-with-stories, login-with-stories, counter-with-stories, login-form, linearlite, hicasso-counter |
| 8060-8061 | 2 | `:testbeds/tenant-switcher` 8060, `:hicasso/hmr-testbed` 8061 |
| 8765 | 1 | `:testbeds/panel-gallery` |
| **total** | **15** | |

**Delta against the audit's figures: zero.** 15 total, 6/6/2/1 — identical. Re-derived at the base, and again on the final rebased base.

## Repair shape, and why this one will not re-drift

Two shapes were on offer: extend the parenthetical to `8030-8035 / 8040-8045 / 8060-8061 / 8765`, or make the sentence non-exhaustive. **Chose non-exhaustive**, quantified over the table's own `:dev-http (shadow-cljs.edn)` annotation, with `DEV_HTTP` named as the roster.

The parenthetical is a census of a live map, held in a comment. Extending it fixes today's count and leaves the mechanism intact: the next band added re-drifts it, which is exactly how it broke — 8060/8061 landed, the map and the table and the README were all updated, and only the transcribed list was missed. A sentence that points at the map cannot go stale; a sentence that transcribes it stays true only by luck.

The decisive evidence is in-tree. `implementation/README.md:418` carries the **same mirror** in the authority-naming shape — "The build→port table mirrors the `:dev-http` map in `shadow-cljs.edn`" — and it did **not** drift when 8060/8061 landed, while the transcribing sentence one file over did. Same event, two shapes, one survivor.

The new wording also self-covers: a future band is added to the table carrying the same `:dev-http (shadow-cljs.edn)` annotation its siblings already carry, so the quantifier picks it up with no edit. Line numbers and offsets were kept out of the replacement text for the same reason — a first draft said "two lines above" and was corrected, since that is the same drift class.

## Quantifier verified by parse, not by eye

The claim "every band annotated `:dev-http (shadow-cljs.edn)` is mirrored entry-for-entry in DEV_HTTP" was checked by parsing the table's sub-list column (column 45 exactly; 43 is prose) and diffing against the exported map:

```
claimed by comment: 15  8030..8035, 8040..8045, 8060, 8061, 8765
live in DEV_HTTP  : 15  8030..8035, 8040..8045, 8060, 8061, 8765
comment-only: []   DEV_HTTP-only: []   QUANTIFIER_HOLDS= true
```

The two non-annotated bands (8037 xray-feature-gate, 805x examples orchestrator) claim no DEV_HTTP entries, as the sentence's second half says.

A first pass at that parser reported two mismatches (8036, 8040); both were parser artefacts — 8036 scraped from the "8036 is FREE again" prose at column 43, 8040 missed because it sits on the band row's second line. Reported because a scrape that disagrees with the map is a claim like any other, and it was checked before being believed rather than after.

## The other two surfaces carrying these entries

- **`implementation/README.md` — no defect, not touched.** Its table carries all 15 rows and its sentence names the map as authority rather than transcribing bands. Verified by parse against `DEV_HTTP`: 15 rows, zero missing, zero orphan, zero port mismatch.
- **`implementation/shadow-cljs.edn` (HOT ZONE) — no defect, not touched, nothing to escalate.** Its band comments at `:576` and `:622` are written from each band's own perspective, and the 806x one enumerates the roster correctly ("Xray testbeds own 803x + 8765, Story 804x, the examples orchestrator 805x"). `git grep -nF 'bands'` over it returns nothing; positive control: the same search finds the line in `dev-testbed.cjs`. No hot-zone change is needed.

## Quality gates

**The repaired comment has NO automated coverage anywhere in the repo, and that is a finding rather than an aside.** `dev-testbed.test.cjs` parses `shadow-cljs.edn` and the exported `DEV_HTTP` map; its own `stripEdnComments` helper explicitly discards comment text before parsing. Nothing asserts anything about this prose. That is why the residue survived both a merge and an audit, and it is why the control below is shaped as two plants rather than one.

**Control A — the gate is BLIND to this class. Planted fault came back GREEN, reported as the finding it is.** Before the repair, the sentence was rewritten to claim bands `8090-8099 / 8111-8112 / 9999`, none of which exist anywhere in the repo.

```
node implementation/scripts/dev-testbed.test.cjs
CAPTURED_EXIT=0     PASS=13  FAIL=0     "All dev-testbed tests passed."
```

A green sabotage run is normally a reason to stop. Here it *is* the deliverable: direct proof that no gate can see this sentence, which is the completeness residue's whole explanation. Restored; `git hash-object` = `8d8168311ccb4ec175e7a1033b17a449babc8444` = the committed object.

**Control B — the gate does bite this file, and it read THIS worktree. Planted fault went RED.** Because Control A cannot discriminate worktrees, a second plant went into the map immediately below the edited comment: `:testbeds/tenant-switcher` 8060 to 8062.

```
node implementation/scripts/dev-testbed.test.cjs
CAPTURED_EXIT=1     PASS=12  FAIL=1
  FAIL  DEV_HTTP covers every :dev-http-served build in shadow-cljs.edn (drift guard)
        DEV_HTTP port(s) disagree with shadow-cljs.edn :dev-http:
        :testbeds/tenant-switcher: DEV_HTTP=8062 but :dev-http=8060.
```

The failure names exactly what was planted, and that fault existed only in `re-frame2-worktrees/portband-puwyb` — a run that had wandered into a sibling checkout would have come back green. Restored; hash re-verified identical to the committed object.

**Owning gate, before and after.** `node implementation/scripts/dev-testbed.test.cjs` — baseline `CAPTURED_EXIT=0`, 13 PASS / 0 FAIL; after the repair `CAPTURED_EXIT=0`, 13 PASS / 0 FAIL; on the final rebased base `CAPTURED_EXIT=0`, 13 PASS / 0 FAIL. Unchanged either side, and unchanged from the 13 that PR #8430 measured. **No test change was needed** — the repair is comment-only and changes nothing the suite should assert.

**Spine — `sh scripts/test-fast-pr.sh`, RAN IN FULL, twice.** Detached (it needs roughly 15 minutes, past the foreground ceiling) and polled to completion within the turn both times, never left to a notification.

- base `b5ed97aac2`: `CAPTURED_EXIT=0`
- final rebased base `7bb26864e4`: `CAPTURED_EXIT=0`

Classifier line, identical on both runs: `=== fast PR spine: docs=false jvm=false node=true (classified) ===` — node tier only, which is right for a lone `.cjs` under `implementation/scripts/`. `PASS fast PR spine` on both; zero lines matching `^(FAIL|ERROR)`. Each number quoted is the runner's own exit code, echoed in the same shell as the redirect.

The spine's log names this worktree 13 times, including `shadow-cljs - config: ...re-frame2-worktrees/portband-puwyb/implementation/shadow-cljs.edn` — the printed-root route to proving which tree it read. Both logs checked for splicing: 0 NUL bytes, exactly one classifier line and one PASS summary each.

**Gap citation.** `python scripts/check_fast_pr_gap.py --list` (exit 0) is the one path deriving what the spine leaves to CI: **94 required checks it does not run**, across `test.yml`, `lint.yml` and `docs.yml`. Green here is not green in CI.

**Rebased once, onto `7bb26864e4`.** The trunk moved 7 commits during the first spine and moved again mid-rebase, since `origin/*` refs are repo-global and a peer's fetch moves them under you. Both gates were re-run on the final base rather than carried over. None of the intervening landings touched `dev-testbed.cjs`, `shadow-cljs.edn` or `implementation/README.md`, and the census re-derived on the final base is still 15 / 6-6-2-1.

**Merge-base diff read for reverts.** `git diff origin/main...HEAD` is one file, +9/-5, entirely inside the comment block. Nothing a sibling landed is undone.

**node_modules junction.** Created and removed twice, `cmd /c rmdir` on the link only. Mayor checkout measured with the same commands both times: 101 immediate entries / 2933 recursive files before, and 101 / 2933 after each removal.

**Not run, with reasons.** `mkdocs build --strict` and `scripts/check_doc_slugs.py` — neither covers `.cjs`, and no markdown changed. No browser or CLJS suite beyond what the spine's node tier already ran — nothing compiled changed; the only edit is a JS line comment.
