### PR TITLE
fix(bench): the alloc row states WHICH of its three gates screened it (rf2-fir5n)

### DIFF
--- a/implementation/core/test/re_frame/bench/p0_ladder_structural.test.cjs
+++ b/implementation/core/test/re_frame/bench/p0_ladder_structural.test.cjs
@@ -66,6 +66,8 @@ const {
   allocSiteReport,
   allocIntraLegRefusals,
   allocWindowVerdict,
+  allocInstrumentNote,
+  ALLOC_BY_SITE,
   ALLOC_SITES,
   ALLOC_SITE_NAMES,
 } = require('./p0_run.cjs');
@@ -1305,6 +1307,49 @@ test('INERT AT THE SHIPPED STRIDE — every published row is untouched', () => {
   assert.deepStrictEqual(allocIntraLegRefusals([], 1), []);
   assert.deepStrictEqual(allocIntraLegRefusals([{ dispatch: -9, drain: 1, leg: -8 }], 1), [],
     'a single leg is the prime, and the prime is in no figure and no certificate');
+});
+
+test('AND THE ROW SAYS SO — a stride-2 record does not claim three gates screened it', () => {
+  // rf2-fir5n. The inertness above is CORRECT and nothing here arms anything;
+  // what was wrong was the record. `instrument` closed with "All three refuse"
+  // on every row, including the stride-2 rows that are the only ones ever
+  // published, where the third gate returned `[]` by construction. Driven
+  // through the real function at both strides rather than matched in the source,
+  // because the claim is about what the string SAYS and a source match can only
+  // restate it.
+  const off = allocInstrumentNote(false);
+  const on = allocInstrumentNote(true);
+
+  // The stride-3 text is unchanged to the byte: this bead moves no by-site row.
+  assert.ok(on.endsWith('other two can see. All three refuse'), on.slice(-80));
+
+  // And the stride-2 text does not, which is the whole repair.
+  assert.doesNotMatch(off, /All three refuse/, 'two of the three ran on a published row');
+  assert.match(off, /TWO OF THE THREE RAN ON THIS ROW \(rf2-fir5n\)/);
+  assert.match(off, /returned an empty list BY CONSTRUCTION rather than by a switch/);
+  assert.match(off, /certified by the falling-step gate and by the leg tolerance and NO MORE/);
+  // It states the CONSTRAINT, not a TODO: the two strides are not comparable, so
+  // this is not a switch a reader should go looking for.
+  assert.match(off, /not comparable byte for byte/);
+  assert.match(off, /can never be screened by all three/);
+
+  // Both branches still describe the same instrument — the shared half is shared
+  // rather than forked, so a future edit to the sampling description cannot
+  // reach one stride and miss the other.
+  const shared = 'in-page performance.memory.usedJSHeapSize sampled at every leg boundary';
+  assert.ok(on.startsWith(shared) && off.startsWith(shared), 'one instrument, two verdicts');
+
+  // THE DEFAULT IS THE RESOLVED CONSTANT, so the row the driver writes gets the
+  // branch its own stride earned. The mode is off in this process, exactly as it
+  // is on every published run.
+  assert.strictEqual(ALLOC_BY_SITE, false, 'the by-site mode is opt-in and off by default');
+  assert.strictEqual(allocInstrumentNote(), off);
+  // And the driver passes it rather than letting the default drift out of step
+  // with the `bySite` field printed beside it.
+  has(
+    /instrument: allocInstrumentNote\(ALLOC_BY_SITE\),/,
+    'the record states the stride it was actually taken at'
+  );
 });
 
 test('THE FENCE HOLDS — `allocSteps` is untouched and no published quantity moves', () => {

--- a/implementation/core/test/re_frame/bench/p0_run.cjs
+++ b/implementation/core/test/re_frame/bench/p0_run.cjs
@@ -1807,10 +1807,12 @@ function allocSiteWitness(siteLegs, prime = ALLOC_PRIME_WRITES) {
 // stride 2, where this gate adjudicates nothing: the class of comparison that
 // most wants a third gate is precisely the class that cannot use one. The
 // record says so per row — see `allocInstrumentNote` — rather than leaving a
-// reader to derive it, and rf2-fir5n carries the two ways out (price the extra
-// read off the idle control and correct stride-3 bytes back, which wants a
-// hermetic build and a ruling; or state the limitation on every page that takes
-// such a comparison) with neither taken here.
+// reader to derive it. The only other way out is rf2-e3p0r, HELD FOR A RULING:
+// price the extra read off the idle control (rf2-ojehu read it at 16 B per leg
+// and its stride pair met its own falsifiable claim) and correct stride-3 bytes
+// back to stride-2 ones, which would make a byte-for-byte witness screenable by
+// all three. That is an instrument change wanting a hermetic build, and it may
+// equally be judged not worth building; it is not taken here.
 //
 // WHAT IT DOES NOT CLOSE, stated because a gate that oversells itself is worse
 // than none. A reclamation bracketed inside ONE SITE — collected and
@@ -1992,7 +1994,7 @@ function allocWindowVerdict(steps, siteLegs = [], prime = ALLOC_PRIME_WRITES) {
 // can never be screened by all three. Saying so on the row is the honest half of
 // that; correcting stride-3 bytes back to stride-2 ones off the idle control's
 // per-leg price is the other half, and it is an instrument change wanting a
-// hermetic build and a ruling, not a quiet box.
+// hermetic build and a ruling, not a quiet box (rf2-e3p0r).
 //
 // THE BY-SITE BRANCH IS UNCHANGED TO THE BYTE, on `summariseAllocFits`'s rule:
 // the stride-3 text is the string this file has always emitted, lifted out whole

--- a/implementation/core/test/re_frame/bench/p0_run.cjs
+++ b/implementation/core/test/re_frame/bench/p0_run.cjs
@@ -1794,6 +1794,24 @@ function allocSiteWitness(siteLegs, prime = ALLOC_PRIME_WRITES) {
 // step to be negative and this returns `[]`. Every row ever published was taken
 // at stride 2, so no published figure and no published verdict moves.
 //
+// AND THE CONVERSE, WHICH IS THE HALF A READER NEEDS AND THE PARAGRAPH ABOVE
+// DOES NOT STATE (rf2-fir5n). "No published verdict moves" is the reassurance;
+// the cost is that `certified` on a stride-2 window means certified by the falls
+// gate and the leg tolerance and NO MORE. That is not a defect in this gate and
+// widening it would be the wrong repair — there is no site step at stride 2 to
+// widen a test on, only a reading that was never taken — but it does close a
+// class of question off. The note at `ALLOC_BY_SITE` records that a stride-3 leg
+// magnitude is not comparable byte for byte with a stride-2 one, because each
+// leg there carries one extra sampler read. So a witness whose criterion IS a
+// byte-for-byte comparison against a figure published at stride 2 must run at
+// stride 2, where this gate adjudicates nothing: the class of comparison that
+// most wants a third gate is precisely the class that cannot use one. The
+// record says so per row — see `allocInstrumentNote` — rather than leaving a
+// reader to derive it, and rf2-fir5n carries the two ways out (price the extra
+// read off the idle control and correct stride-3 bytes back, which wants a
+// hermetic build and a ruling; or state the limitation on every page that takes
+// such a comparison) with neither taken here.
+//
 // WHAT IT DOES NOT CLOSE, stated because a gate that oversells itself is worse
 // than none. A reclamation bracketed inside ONE SITE — collected and
 // re-allocated between the same two readings — is invisible here for the reason
@@ -1946,6 +1964,58 @@ function allocWindowVerdict(steps, siteLegs = [], prime = ALLOC_PRIME_WRITES) {
     refusals: [...steps.refusals, ...intraLegRefusals],
     certified: steps.certified && intraLegRefusals.length === 0,
   };
+}
+
+// WHICH GATES ACTUALLY SCREENED THIS ROW (rf2-fir5n) — the record's `instrument`
+// string, as a pure function of the stride so a pin can DRIVE it rather than
+// read the source and hope.
+//
+// THE DEFECT IT REPAIRS. The string was one constant, emitted on every row, and
+// it closed with "All three refuse". On a stride-2 row that is at best ambiguous
+// between a claim about the INSTRUMENT's design — all three gates refuse, none
+// widens — and a claim about THIS ROW, and on a field whose whole stated purpose
+// is criterion 6's "a reader of any row can tell FROM THE ROW how it was taken"
+// the row reading is the one that governs. Two gates screened every published
+// row. rf2-4ctls already made the COUNT honest by omission — off the mode the
+// summary prints no intra-leg line and the record gains no
+// `intraLegRefusalReasons` field, because a 0 would claim the instrument looked
+// when it could not — and this closes the same hole in the prose beside it.
+//
+// AND IT IS NOT A SWITCH THAT COULD BE FLIPPED HERE, which is why the stride-2
+// branch states a constraint rather than a TODO. `allocSiteSplit` yields no site
+// legs at a stride of 2 because there is no interior reading per leg to
+// subtract, so there is no site step whose sign could be read; arming the gate
+// needs the stride-3 reading, and a stride-3 leg magnitude is not comparable
+// byte for byte with a stride-2 one. A witness whose criterion IS a byte-for-
+// byte comparison against a figure published at stride 2 must therefore run at
+// stride 2, where this gate adjudicates nothing — so that class of comparison
+// can never be screened by all three. Saying so on the row is the honest half of
+// that; correcting stride-3 bytes back to stride-2 ones off the idle control's
+// per-leg price is the other half, and it is an instrument change wanting a
+// hermetic build and a ruling, not a quiet box.
+//
+// THE BY-SITE BRANCH IS UNCHANGED TO THE BYTE, on `summariseAllocFits`'s rule:
+// the stride-3 text is the string this file has always emitted, lifted out whole
+// rather than guarded in place.
+function allocInstrumentNote(bySite = ALLOC_BY_SITE) {
+  const shared =
+    'in-page performance.memory.usedJSHeapSize sampled at every leg boundary, ' +
+    'rising steps accumulated separately from falling ones; --enable-precise-memory-info. ' +
+    'A falling step is a collection this counter SAW; a leg that deviates from its cohort ' +
+    'median by more than the leg tolerance is a work unit that is not one; and under the ' +
+    'by-site stride a NEGATIVE SITE STEP is a collection inside one leg that neither of the ' +
+    'other two can see. ';
+  if (bySite) return shared + 'All three refuse';
+  return (
+    shared +
+    'TWO OF THE THREE RAN ON THIS ROW (rf2-fir5n): it was taken at a stride of 2, where a leg ' +
+    'has no interior reading and so no site step to be negative, and the intra-leg gate ' +
+    'returned an empty list BY CONSTRUCTION rather than by a switch. `certified` here means ' +
+    'certified by the falling-step gate and by the leg tolerance and NO MORE. Arming the third ' +
+    'needs the stride-3 reading, whose leg magnitudes are not comparable byte for byte with ' +
+    'these (see `bySite`), so a witness comparing byte for byte against a figure published at ' +
+    'stride 2 can never be screened by all three'
+  );
 }
 
 // The witness over a whole collected row, as a PURE FUNCTION of it — the
@@ -2400,13 +2470,12 @@ async function allocRow(chromium) {
     writeSelector: ALLOC_WRITE,
     write: `${ALLOC_WRITE_SPEC.event} — ${ALLOC_WRITE_SPEC.note}`,
     plan: { name: ALLOC_PLAN, ...ALLOC_PLAN_SHAPE },
-    instrument:
-      'in-page performance.memory.usedJSHeapSize sampled at every leg boundary, ' +
-      'rising steps accumulated separately from falling ones; --enable-precise-memory-info. ' +
-      'A falling step is a collection this counter SAW; a leg that deviates from its cohort ' +
-      'median by more than the leg tolerance is a work unit that is not one; and under the ' +
-      'by-site stride a NEGATIVE SITE STEP is a collection inside one leg that neither of the ' +
-      'other two can see. All three refuse',
+    // WHICH OF THE THREE GATES SCREENED THIS ROW (rf2-fir5n), and not merely
+    // which three exist. It reads `ALLOC_BY_SITE` for the same reason `bySite`
+    // above does: at a stride of 2 the intra-leg gate returns `[]` by
+    // construction, so a row that closed with "All three refuse" named a gate
+    // that adjudicated nothing on it. See `allocInstrumentNote`.
+    instrument: allocInstrumentNote(ALLOC_BY_SITE),
     fallThresholdB: ALLOC_FALL_THRESHOLD_B,
     legTolerance: ALLOC_LEG_TOLERANCE,
     verification: { unverified, detail: unverifiedDetail },
@@ -3495,6 +3564,12 @@ module.exports = {
   // by running both functions over one window and comparing.
   allocIntraLegRefusals,
   allocWindowVerdict,
+  // And the row's own statement of WHICH of the three screened it (rf2-fir5n),
+  // exported on the same rule again: it is a pure function of the stride, so the
+  // pin drives both branches instead of matching the source for a phrase. The
+  // property that matters is a claim about what the string says at stride 2,
+  // which a source match cannot make without restating the string.
+  allocInstrumentNote,
   // The measurement surface (rf2-gxrr), exported so the structural pin can
   // DRIVE it rather than read its source: the tables as values, the plan
   // filter as a pure function, and the two resolved selections so the env


### PR DESCRIPTION
Closes rf2-fir5n. Files rf2-e3p0r for the half deliberately not built.

## The verdict: the gate's inertness is CORRECT, and what was wrong was the record

The bead's finding re-derives at `origin/main` in full, and every clause holds. The remedy it
points at does not follow from it, and the reason is worth stating before the change:

* `allocSiteSplit(samples, 2)` returns `siteLegs: []` (`p0_run.cjs:1610`) because at a stride
  of 2 a leg has **no interior reading** — only `pre` and `post`. There is no site step whose
  sign could be read.
* So `allocIntraLegRefusals` returns `[]` and `allocWindowVerdict` is the identity on `steps`.
  Not a switch — a shape.
* Arming it therefore cannot mean widening a test: **there is no reading to widen a test on.**
  It would mean taking a different measurement (`P0_ALLOC_BY_SITE=1`, stride 3).
* And a stride-3 leg magnitude "is not comparable byte for byte" with a stride-2 one, because
  each leg there carries one extra sampler read (`:1363`).

So the bead's structural claim is exactly right and irreducible: a witness whose criterion IS a
byte-for-byte comparison against a stride-2 figure **must** run at stride 2, where the third
gate adjudicates nothing. **No arming behaviour changes in this PR. No reading changes verdict.
τ is untouched. `allocSteps` is untouched.** The list of readings whose verdict changes is empty,
by construction rather than by inspection: nothing on the adjudicating path was edited.

What was wrong was the row's own provenance. `instrument` was **one constant emitted on every
row**, closing with the words `All three refuse`. Every row ever published is a stride-2 row. On
a field whose stated purpose is the sibling comment's criterion 6 — "a reader of any row can
tell FROM THE ROW how it was taken" (`:2377-2380`) — that names a gate which adjudicated nothing
on it. The string is at best ambiguous between a claim about the *instrument's design* (all
three gates refuse; none widens) and a claim about *this row*; on a provenance record the row
reading governs, and ambiguity in the direction of over-claiming is the defect.

**rf2-4ctls had already made the COUNT honest by omission** and left the prose beside it
over-claiming. Off the mode the summary prints no intra-leg line and the record gains no
`intraLegRefusalReasons` field, "because a 0 would claim the instrument looked when it could
not" — pinned at `p0_ladder_structural.test.cjs:1399-1409`. This closes the same hole in the one
place on the row that still spoke.

## The change

`allocInstrumentNote(bySite)` — pure and exported, so the pin **drives both branches** rather
than matching the source for a phrase, on the rule this file already states about
`allocSiteSplit` and `allocSiteReport`.

* **The stride-3 branch is unchanged TO THE BYTE**, lifted out whole rather than guarded in
  place, on `summariseAllocFits`'s rule. No by-site row moves.
* The stride-2 branch states the **constraint, not a TODO**: two of the three ran, `certified`
  here means the falls gate and the leg tolerance and NO MORE, the third returned an empty list
  **by construction rather than by a switch**, and arming it needs a stride whose magnitudes are
  not comparable byte for byte with these — so this class of comparison can never be screened by
  all three.
* The shared half is **shared rather than forked**, so a future edit to the sampling description
  cannot reach one stride and miss the other. Pinned.
* `INERT AT THE SHIPPED STRIDE` (`:1792`) gains the converse it did not state. It said only the
  reassuring half — "no published figure and no published verdict moves". The cost is that
  `certified` on a stride-2 window means certified by two gates. Both comments now point at
  **rf2-e3p0r**, the correction route, held for a ruling.

## Line numbers: re-derived, DELTA = 0

The bead cites `p0_run.cjs:1792-1795` and a stride note "around `:1360`". The brief expected both
to be stale after PRs #8425 and #8437. **They are not.** Both merges added lines strictly *below*
the anchors, so neither moved:

| commit | `INERT AT THE SHIPPED STRIDE` | `not comparable byte for byte` | file lines |
| --- | --- | --- | --- |
| `3592c20482` (rf2-4ctls; the bead was filed against this) | 1792 | 1363 | 3663 |
| `1eb77f126a` (#8425, rf2-stals) | 1792 | 1363 | 3672 |
| `cd8d00c511` (#8437, rf2-gxrr) | 1792 | 1363 | 3754 |
| `f12535331a` (#8437) | 1792 | 1363 | 3754 |
| base of this branch | 1792 | 1363 | 3754 |

`:1360` lands inside the same `WHAT IT COSTS, STATED` paragraph (`:1358-1366`) whose sentence at
`:1363` is the one the bead quotes. **Both citations were exact; the DELTA is 0.**

## Quality gates

Every exit code below is the one the **running shell** captured with `echo "EXIT=$?"` into a
`.exit` file, on the same command line as the redirect — never one the harness reported about the
same run.

| gate | attempt | captured exit | result |
| --- | --- | --- | --- |
| `node core/test/re_frame/bench/p0_ladder_structural.test.cjs` — BASELINE, pre-edit | -1 | **0** | `83 passed` |
| same, post-edit | -2 | **0** | `84 passed` |
| same, post-restore after three plants | -3 | **0** | `84 passed` |
| same, after the rf2-e3p0r cross-reference commit | -4 | **0** | `84 passed` |
| `python scripts/check_allocation_non_claim.py` | -1 | **0** | `OK`; 230 publication files scanned, positive control fired in 7 design files |
| `python scripts/check_allocation_non_claim.py --self-test` | -1 | **0** | `self-test OK (9 fixtures)` |
| `scripts/test-fast-pr.sh` | -1 | **NO VERDICT** | killed mid-run at 44 log lines; **no `.exit` file was ever written**, so it did not run. Re-run, not quoted. |
| `scripts/test-fast-pr.sh` (post-rebase base) | -2 | **0** | `PASS fast PR spine` |
| `scripts/test-fast-pr.sh` (final HEAD) | -3 | **0** | `PASS fast PR spine` |

83 → 84 is my one added test; nothing dropped. (The runner prints a **test** count, not an
assertion count — `tests.length`, at the foot of the file. The brief's "82/83 assertions" is that
number.)

**The classifier line, printed by the spine itself:**

```
gate root: /c/Users/miket/code/re-frame2-worktrees/intraleg-fir5n
=== fast PR spine: docs=false jvm=true node=true (classified) ===
```

Both JVM and node lanes armed, and `implementation/node_modules` was needed. Doc gates skipped by
the spine's own reason: `--- documentation surface unchanged → skipping doc gates ---`. Inside the
spine:

* JVM `implementation/core` — `Ran 2243 tests containing 11681 assertions. 0 failures, 0 errors.`
* CLJS node integration — `Ran 11771 tests containing 59589 assertions. 0 failures, 0 errors.`
* `p0_ladder_structural.test.cjs: 84 passed`, run by the spine from this worktree.

**The spine prints its root**, and both runs named this worktree on line 1 of their logs —
`gate root: /c/Users/miket/code/re-frame2-worktrees/intraleg-fir5n` — so neither read a sibling
checkout. Run -3 was taken on **final HEAD** (`ab89ae5088`), not on the tree run -2 saw, and its
JVM and node totals are identical to run -2's. `PASS fast PR spine` appears exactly once in each
log, so neither artefact was spliced by an orphan.

**`implementation/node_modules` was junctioned into this worktree and the LINK removed** (never a
recursive delete). Mayor tree counted with the same command either side; **equality is the test**,
and the two tools disagree on the constant, which is why:

| tool | before | after |
| --- | --- | --- |
| `ls -1 …/node_modules \| wc -l` | 101 | **101** |
| `Get-ChildItem -Force …\node_modules` | 103 | **103** |

**`check_allocation_non_claim` does NOT cover this change and is NOT armed on it — verified at
source rather than taken from #8437.** `docs.yml:198`'s `detect` case list is
`docs/*|spec/*|migration/*|mkdocs.yml|…|scripts/check_allocation_non_claim.py|tools/*/spec/*|.github/workflows/docs.yml`;
`implementation/core/test/**` matches none of it. And the gate's own surface is `README.md`,
`CHANGELOG.md` and tracked `docs/**/*.md` **outside** `docs/design/` (its docstring, `:55-61`), so
it would be inert on this diff even if armed. Run anyway, green, both arms.

**`scripts/check_fast_pr_gap.py --list`** is the one path deriving what the spine leaves to CI:
**94 required checks it does not run**, and it names `check_allocation_non_claim` and
`check_allocation_non_claim --self-test` explicitly as "2 `python scripts/check_*.py`
invocation(s) with no local lane". Green here is not green in CI.

### The planted-fault control

Three single-token plants, each run to a captured exit code, each restored and the restore
verified with **git's own content hash against the committed blob** — this checkout is
`core.autocrlf=true` with CRLF working files and LF blobs, so a plain byte digest would report a
correct restore as failed.

| # | plant | captured exit | what the red named | rest of suite |
| --- | --- | --- | --- | --- |
| 1 | `if (bySite)` → `if (true)` | **1** | `two of the three ran on a published row` — my stride-2 assertion | `1/84 failed`; **the stride-3 byte-identity pin still passed** |
| 2 | `'All three refuse'` → `'All three refuses'` | **1** | quoted the planted token back: `… All three refuses` | `1/84 failed`; **every stride-2 pin still passed** |
| 3 | `allocInstrumentNote(ALLOC_BY_SITE)` → `allocInstrumentNote(false)` in the record | **1** | `expected /instrument: allocInstrumentNote\(ALLOC_BY_SITE\),/ — the record states the stride it was actually taken at` | `1/84 failed` |

Plants 1 and 2 red in **opposite directions on the same function**, each leaving the other
branch's pin green — so the pins discriminate rather than blanket-suppress. Plant 3 proves the
wiring pin is not a no-op. Every run failed **exactly one** test of 84: the runner wraps each test
in its own `try`/`catch`, so nothing aborted and the counts are directly comparable to the clean
run's 84.

Restore verification, `git hash-object` vs `git rev-parse HEAD:<path>`:

```
base / restored : cc7ca8d86b79da40980556ed755ad5a8fe4636ca   (== committed blob; git diff --quiet exit 0)
plant 1         : d2e019b06bbcbcfc6a761c3b184384f0965de978
plant 2         : fded0736e553c4a746e0d9e1bf0b493918491388
plant 3         : cf45f34bc77e609c13b4b59eec5f3c5f55615bda
```

All four differ, so every plant genuinely applied — no silently no-op patch behind a green.

### Merge-base diff, read for reverts

`git diff origin/main...HEAD` — three-dot, against the merge base, not the tip. `p0_run.cjs` took
two merges in the hour before this branch, so this was live. The diff carries **exactly one
deletion**: the seven-line `instrument:` string literal this PR replaces with a call. No other
line is removed; nothing #8425 or #8437 landed is touched. Rebased onto `e4a6f482c9` when the
trunk moved (three `.beads` checkpoints, zero bench files) and the spine re-run on that base and
again on final HEAD.

**The trunk moved once more after that** (`e4a6f482c9..cc33d7e485`, twelve commits) and I did
**not** rebase again, deliberately: those commits touch `.beads/issues.jsonl`,
`docs/design/hicasso/studio/**` and `spec/009-Instrumentation.md` — **five files, zero under
`implementation/**`, zero under `bench/`**. They cannot conflict with this branch, cannot change
its classification, and cannot move a lane the spine ran. Re-running twenty minutes of JVM and
node suites to re-confirm a green against a disjoint base is the gold-plating this project rejects.
One thing that move *did* invalidate was a **line number I quote**, so it is corrected below.

### Not run, and why

* `mkdocs build --strict` — no file under `docs/`, `spec/` or `migration/` changed; the diff is
  entirely under `implementation/`. The spine skipped the doc gates for the same reason and said
  so.
* No measurement window, no browser run, no `--only alloc`. Settling this needed no figure, and
  producing one would be a separate window under its own rules.

## What I left standing, deliberately

* **The summary's silence at stride 2.** rf2-4ctls ruled on that surface and its pin is explicit
  (`p0_ladder_structural.test.cjs:1399-1409`): off the mode the intra-leg line is absent and the
  record gains no count field, so the published summary is unchanged to the byte. Adding a printed
  line would re-open a settled ruling and move output this row pins byte-for-byte. The record is
  the right place for a per-row statement; the summary is not.
* **`allocSteps`, τ, `rise`, `falls`, `maxStep`, `legs`, `legMedian`, `legWorstDeviation`.**
  rf2-rs8q6's fence is load-bearing and this bead does not reach it.
* **The correction remedy — now rf2-e3p0r, HELD FOR A RULING.** Price the extra per-leg sampler
  read off the idle control and correct stride-3 bytes back to stride-2 ones. It is **bounded**,
  in the shape the rf2-rs8q6 fence note calls route (b), because the constant is already measured:
  rf2-ojehu read **16 B per leg per site in all 36 idle windows**, and its stride pair met its own
  falsifiable claim (idle Δ +16 B predicted, arm Δ median +16 B observed). So it is a build, not a
  search. Whether to build it is a ruling — closing rf2-e3p0r on the record with this PR standing
  as the whole remedy is a live option under the stance.
* **`docs/design/hicasso/**`** — outside the fence; `worker/allocaudit-3` (PR #8442) holds it, and
  that branch touches one studio page and no bench file. Nothing here requires a record change:
  `the-floor-certifies-and-the-control-does-not.md` already says "**The intra-leg gate screened
  nothing here**, so no window on this page is certified against a collection bracketed inside a
  single leg" — at `:275` when this branch was cut and at `:296` on `cc33d7e485` after rf2-nkeba's
  edit landed above it. This PR makes the *instrument* say it on every row rather than relying on a
  page author to remember.
