### PR TITLE
ci(test.yml): attribute the PR-smoke timing to what rf2-ano54 records (rf2-gbm4t)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4054,10 +4054,14 @@ jobs:
       #     that is 4 scenarios (ten-tab shell + panel handoff,
       #     deterministic exceptions → inline/Trace surfacing, Cmd-K
       #     palette, panel-gallery theme tokens) over 3 staged surfaces,
-      #     compiling 3 testbed bundles instead of 11 — ~80s warm as
-      #     measured at 4 bundles (rf2-ano54), so an upper bound now. The
-      #     freehand-views Views roster scenario and its staged surface
-      #     went with the rf2-0yp7w Freehand retirement (rf2-l86mm).
+      #     compiling 3 testbed bundles instead of 11. The only timing on
+      #     record is rf2-ano54's nine PR-smoke runs of 2026-08-05, taken
+      #     at FOUR bundles: 65–85s, mean 79s — the figure it rounds to
+      #     `~80s warm`. That is a prior, not a ceiling: five of those
+      #     nine ran over 80s, and the three-bundle gate has not been
+      #     remeasured. The freehand-views Views roster scenario and its
+      #     staged surface went with the rf2-0yp7w Freehand retirement
+      #     (rf2-l86mm).
       #   - Story :play-script CI-as-test gate (rf2-3qcxk): drives the
       #     live Story shell over the runner's own testbed roster and
       #     runs every variant's :play-script. This is the gate that


### PR DESCRIPTION
Closes rf2-gbm4t — the SECOND site on that bead, reopened by the merged-PR audit of #8431. The bead's first half (the ten-item Dynamic-tab roster and the retired `Modules` label in `skills/README.md`) is verified LANDED at `origin/main` and is not touched here.

The audit's finding came back **positive at source**, so this is a repair, not a refusal. One comment clause changes. No threshold, tier, gate condition, step, command or `if:` changes; the diff is a single hunk of 4 lines out / 8 in.

## The defect

`.github/workflows/test.yml:4057-4058` at `origin/main` `06deb4d867` read:

> compiling 3 testbed bundles instead of 11 — ~80s warm as measured at 4 bundles (rf2-ano54), so an upper bound now.

**rf2-ano54 records no upper bound.** Re-derived from that bead's close reason at source:

> PR smoke step, nine story-xray-browser jobs on 2026-08-05: 80/83/75/85/82/82/65/82/79s -> 65-85s, mean 79s ('~80s warm')

| | value | where from |
|---|---|---|
| runs | 9 | rf2-ano54, "nine story-xray-browser jobs on 2026-08-05" |
| statistic | **mean**, 79s (sum 713 / 9 = 79.2) | rf2-ano54 names it "mean 79s" itself |
| spread | 65–85s | rf2-ano54's own range |
| runs strictly above 80s | **5** (83, 85, 82, 82, 82) | counted from the nine recorded values |
| bundles when measured | 4 | rf2-ano54's own true-up set "testbed bundles compiled at PR time 2 -> 4" |

So `~80s` is the rounded **mean of a four-bundle sample five of whose nine runs exceeded it** — it was never a ceiling even for the configuration it was taken on. And #8431's own body says so: "`~80s warm` is left attributed to rf2-ano54 and marked an upper bound, because it was measured at 4 bundles and **was not re-measured here**." Fewer bundles may lower one component; it cannot convert an old mean into a current ceiling.

**Verdict: attribution repair, not remeasurement.** Remeasuring a justifying comment inside a workflow file to re-underwrite one clause is gold-plating under the project stance, and a clock reading taken now would be worthless anyway — five other workers are running gates on this machine. The third option (leave it standing) does not apply: the sentence at HEAD does say "so an upper bound now", so the audit read it correctly.

## The replacement

```
      #     compiling 3 testbed bundles instead of 11. The only timing on
      #     record is rf2-ano54's nine PR-smoke runs of 2026-08-05, taken
      #     at FOUR bundles: 65–85s, mean 79s — the figure it rounds to
      #     `~80s warm`. That is a prior, not a ceiling: five of those
      #     nine ran over 80s, and the three-bundle gate has not been
      #     remeasured.
```

Every figure in it is in the table above. It names the run count, the statistic, the spread and the bead, and it says the configuration in front of the reader has not been measured — which is the fact the old clause inverted.

## The surrounding clause — re-checked, and it HOLDS

The audit's earlier round claimed the roster and the 4-scenario / 3-surface vs 16 / 11 counts were correct. Treated as a claim and re-derived at this base by replaying the launcher's **own** filter (`scenario.smoke === true` plus `surfaceForScenario` from `implementation/scripts/serve-and-run-xray-feature-gate.cjs:82-105`) against `tools/xray/testbeds/feature_matrix/scenarios.cjs`:

| claim in the comment | derived | verdict |
|---|---|---|
| 4 smoke scenarios | 4 | holds |
| over 3 staged surfaces | 3 (`counter`, `testbeds/deliberate-throw`, `testbeds/panel-gallery`) | holds |
| compiling 3 testbed bundles instead of 11 | 3 of 11 — one distinct `buildId` per `STAGED_SURFACES` entry, so surfaces and bundles are 1:1 | holds |
| 16 scenarios over 11 surfaces nightly | `SCENARIOS.length` 16, `STAGED_SURFACES.length` 11 | holds |
| "ten-tab shell + panel handoff" | `PANEL_HANDOFFS.length` = 10 | holds |
| the four named scenarios | shell+panel handoff, deterministic exceptions/inline-trace, command palette, panel-gallery theme tokens | holds |

No smoke scenario's URL fails to resolve to a staged surface, so the surface count is not silently under-derived. Nothing under `tools/xray/` is touched (fenced) and nothing needed to be.

## Quality gates

Every exit code below was **captured in the same shell as the run** (`cmd > log 2>&1; echo $? > exit`) and quoted from that file — never a number reported about the run.

- **`scripts/test-fast-pr.sh` — RAN, twice, and both runs captured exit 1.** Its first line printed `gate root: /c/Users/miket/code/re-frame2-worktrees/smokebound-gbm4t` on both, so it read this worktree and not a sibling's. Classifier line, identical on both: `=== fast PR spine: docs=false jvm=true node=true (classified) ===` — a `.github/workflows/**` change arms **every** surface in `report-changed-surfaces.sh` (28 outputs, all `true`), which is why the whole spine ran for a comment edit.

  **The single failure in each run is `FAIL CLJS node integration`, and it is environmental, not this change**: `compile-node-test: could not resolve shadow-cljs: Cannot find module 'shadow-cljs/cli/runner.js'` — a fresh worktree with no `implementation/node_modules`. `repro: cd implementation && npm run test:cljs`. It is the same lane and the same cause #8431's worker reported on this file an hour ago. Every one of the other **58** lanes passed, including all four that actually parse this file: `workflow YAML well-formed (11 files)`, the `gate-scheduling audit` (`35 gate commands, 30 scheduled, 5 declared`, whose self-test row `a npm run in a COMMENT does not schedule a gate` is precisely about the text I edited), `CI reproduce-commands`, and the JS harness lane carrying `changed-surfaces tests: 292 passed.`

  **Second run was on the FINAL base after rebase** (`8cbd9ccace`, which picked up #8442) — same classifier line, same one failure, `changed-surfaces tests: 292 passed`, `workflow YAML well-formed` PASS. So the green half is evidence about the tree being merged, not a pre-rebase one.
- **`python scripts/check_workflow_yaml.py --repo-root <this worktree>` — captured exit 0**, `PASS workflow YAML well-formed (11 files under .github/workflows)`. This is the gate that answers "did the edit disturb the YAML"; it parses the file, and a comment cannot break it in the ordinary case, but an edit that mangled indentation or a block scalar would.
- **`node implementation/scripts/_changed-surfaces.test.cjs` — captured exit 0, 292 tests passed.** This is the gate that can actually *see* a comment in this job: `storyXrayJobBlock()` slices the raw `story-xray-browser` job text, prose included, and asserts over it.
- `python scripts/check_fast_pr_gap.py --list` — the one path deriving what the spine does not decide: **94 required checks**, headed "Green here is not green in CI."
- **NOT nominated, and why:** `python scripts/check_doc_slugs.py` does not cover this path. `DEFAULT_ROOTS` at `scripts/check_doc_slugs.py:93-98` is `("docs", "spec", "skills", "migration")` plus `tools/*/spec`; `.github/workflows/**` is in neither. Its own docstring warns that briefs have nominated it for out-of-roots edits and got "a green exit code that verified nothing".

### Planted-fault control — the deliverable

A comment in this file is not ungated, and this proves it rather than asserting it.

1. Baseline: `node implementation/scripts/_changed-surfaces.test.cjs` → **captured exit 0**, `changed-surfaces tests: 292 passed.`
2. Plant, on a line this PR already edits (single-line anchor), swapping `the three-bundle gate has` for a bare `npm run test:xray-feature-gate` — the one string the block's `assert.doesNotMatch(/npm run test:xray-feature-gate(?!:smoke)/)` at `_changed-surfaces.test.cjs:2636` forbids. Blob hash moved `857a14cc06…` → `ff00237c4f…`, so the patch genuinely applied.
3. Sabotage run: **captured exit 1**, `FAIL PR story-xray-browser job still keeps the rest of the sweep nightly (rf2-wa3oo)`, `1 failed` of 292 — the plant was scoped, nothing else regressed.
4. **The red names what was planted, and discriminates the worktree**: the assertion dump echoes the job block verbatim, including this PR's *new* lines (`record is rf2-ano54's nine PR-smoke runs of 2026-08-05…`) and the planted line. That text exists only in this worktree, so a run that had wandered into a sibling checkout would have come back green.
5. Restore, verified by version control's own content hash rather than a byte digest (this checkout is `core.autocrlf=true`, CRLF working file / LF blob): `git hash-object` = `857a14cc06dc07fc6faf8dbdb8b2f63819f2d710` = `git rev-parse HEAD:.github/workflows/test.yml`, and `git diff --quiet` exit 0.
6. Re-run after restore: **captured exit 0, 292 passed.**

### Merge-base diff, read for reverts

`git diff origin/main...HEAD` (three-dot, against the merge base — not the two-dot tip form), re-read after the rebase onto `8cbd9ccace`: one file, one hunk, `-4 / +8`, entirely inside the PR-smoke comment. `.github/workflows/test.yml` took PR #8431 within the hour, and nothing here reverts any part of it — the 4/3-vs-16/11 counts and the `As at 2026-08-17` idiom that PR introduced are kept verbatim; only its `so an upper bound now` clause is replaced. `.github/workflows/**` is hot zone: derived at start-up and again before the edit, no other open PR (#8440, #8442, #8443) touches any workflow file.
