### PR TITLE
fix(xray): finish the stranded roster sweep — ten-tab rosters, and the tab letters stop claiming to be keys (rf2-v1fg3, rf2-gui26, rf2-91dfb)

### DIFF
--- a/tools/xray/spec/003-Machine-Inspector.md
+++ b/tools/xray/spec/003-Machine-Inspector.md
@@ -1262,7 +1262,7 @@ The Static-mode Machines surface is **a peer** to the post-collapse Dynamic Mach
 
 ### Tab placement
 
-The Static Machines tab is **tab 1 of 5** in the Static L3 strip (per [`007-UX-IA.md`](007-UX-IA.md) §Static mode sub-tab inventory). Mnemonic `m` (mode-scoped — see [`018-Event-Spine.md`](018-Event-Spine.md) §2.5 Mnemonic mode-scoping rule: `m` in Dynamic opens the instance inspector, `m` in Static opens the registry browse). Static Machines is the **default Static tab** because the Machines registry is the densest Static surface; opening Static on a fresh slate lands on the highest-value tab.
+The Static Machines tab is **tab 1 of 5** in the Static L3 strip (per [`007-UX-IA.md`](007-UX-IA.md) §Static mode sub-tab inventory). Label mnemonic `m` (mode-scoped — see [`018-Event-Spine.md`](018-Event-Spine.md) §2.5 Mnemonic mode-scoping rule: `m` names the instance inspector in Dynamic and the registry browse in Static; it is a `title`-attribute label, not a key). Static Machines is the **default Static tab** because the Machines registry is the densest Static surface; opening Static on a fresh slate lands on the highest-value tab.
 
 ### Master-detail layout
 
@@ -1310,7 +1310,7 @@ The 4 sub-modes (mnemonic letters `t/s/i/c` surfaced in each pill's `title`) liv
 | **Instances** (`i`) | **JUMP to Dynamic.** Clicking the pill (or the per-row `→ Dynamic` chip in the browse-list) dispatches three events against `:rf/xray`: `:rf.xray/set-mode :dynamic` · `:rf.xray/select-tab :machines` · `:rf.xray/select-machine-id <mid>`. The user lands on the Dynamic Machines tab with this machine pre-selected. Mode B/C auto-detection (Mode B for 2-8 live, Mode C for ≥8) is the Dynamic panel's responsibility — the Static-side JUMP just lands the selection. | no body — the click is the surface |
 | **Cascade** (`c`) | **Dimmed + disabled** with a tooltip: *"Cancellation cascade is a Dynamic-only surface. Switch to Dynamic mode to view."* The pill renders for muscle-memory consistency with the Dynamic sub-strip (same DOM, same letter mnemonic) but is non-interactive — `disabled` + `aria-disabled="true"` + dashed border + 0.5 opacity. The cancellation cascade composes against the trace ring buffer which is event-coupled — there is no spine in Static mode, so the surface has no source data. | no body — the pill IS the surface |
 
-The sub-strip mnemonics are mode-scoped under the same rule the L3 tabs follow (see [`018-Event-Spine.md`](018-Event-Spine.md) §2.5 Mnemonic mode-scoping rule).
+The sub-strip mnemonics (`t` · `s` · `i` · `c` above) are mode-scoped under the same rule the L3 tabs follow (see [`018-Event-Spine.md`](018-Event-Spine.md) §2.5 Mnemonic mode-scoping rule) — and, like those, they are labels rather than keys. `static/machines/helpers.cljc` `sub-mode-mnemonics` carries the letters so each pill can surface one in its `title`, and marks the keybindings that would act on them as a TODO; nothing presses them today.
 
 ### Per-row → Dynamic chip
 

--- a/tools/xray/spec/007-UX-IA.md
+++ b/tools/xray/spec/007-UX-IA.md
@@ -1562,8 +1562,9 @@ on `Esc`, click-outside, or invocation of any item.
 - Registered handlers (id + `:doc`)
 - Frames
 - Machines with current state
-- L4 tab jumps — Dynamic: Epoch / App DB / Views / Trace / Machines
-  / Routes; Static: Machines / Routes /
+- L4 tab jumps — Dynamic: every registered `:dynamic` tab (today
+  Epoch / app-db / Views / Trace / Machine / Routes / Resources /
+  Graph / Frames / Hicasso); Static: Machines / Routes /
   Schemas / Flows / Interceptors (see §Mode-aware command surface below)
 - Command verbs (recents-boosted; see §Command verbs below)
 - Settings entries

--- a/tools/xray/spec/007-UX-IA.md
+++ b/tools/xray/spec/007-UX-IA.md
@@ -2029,9 +2029,12 @@ Five Static sub-tabs, mode-scoped mnemonics per the findings doc
 rf2-b2fif removed the Views + Events sub-tabs (info already in the
 source code; the tabs were not pulling their weight).
 
-Mnemonic mode-scoping: the same letter dispatches the active mode's
-tab — `m` in Dynamic opens the Machines instance-inspector, `m` in
-Static opens the Machines registry browse.
+Mnemonic mode-scoping: the same letter names the active mode's tab —
+`m` is the Machines instance-inspector in Dynamic and the Machines
+registry browse in Static. The Mnemonic column is a LABEL, surfaced in
+each tab button's `title`; the letters are not keys (§Trimmed pending
+demand), and the tab is reached by click or by the mode-aware
+command-palette tab-jump verb.
 
 ### Mode-signal mechanism (4 stacked signals)
 
@@ -2144,9 +2147,10 @@ Routes / Schemas / Flows / Interceptors — see §Sub-tab inventory
 above). New tabs MUST declare which mode(s) they belong to; tab-id
 keyword collisions across modes (`:machines`) are deliberate and
 resolved by the active-mode dispatch, not by renaming. Mnemonic
-collisions across modes (`m` · `r`) are likewise resolved by the
-mode-scoped resolver (Cmd-Shift-M flips the active mode; the letter
-then dispatches the active mode's tab — see §Keyboard).
+collisions across modes (`m` · `r`) need no resolver at all: the
+letters are tab LABELS rather than keys (§Trimmed pending demand), so
+the only thing a collision costs is that the reader must know which
+mode is active — which the 4 stacked mode signals already tell them.
 
 **Shared-token rule.** Design tokens — colours, spacing, typography,
 motion — live ONCE in the HCM token registry (`theme/tokens.cljc`,

--- a/tools/xray/spec/018-Event-Spine.md
+++ b/tools/xray/spec/018-Event-Spine.md
@@ -141,9 +141,11 @@ Static mode is unconditionally available. The mode dropdown mounts at chrome-rib
 
 ### Mnemonic mode-scoping rule
 
-The 5-letter Static sub-tab mnemonics (`m` Machines · `r` Routes · `c` Schemas · `f` Flows · `i` Interceptors per [`007-UX-IA.md`](007-UX-IA.md) §Static mode) are **mode-scoped**: the same letter dispatches the active mode's tab, not a globally-fixed target. `m` in Dynamic opens the Machines instance-inspector (per §5); `m` in Static opens the Machines registry browse (per [`003-Machine-Inspector.md`](003-Machine-Inspector.md) §Static Machines surface). The keybinding wiring rides the same chord-detection ns (`keybinding.cljs`) but routes through a mode-aware dispatcher.
+The 5-letter Static sub-tab mnemonics (`m` Machines · `r` Routes · `c` Schemas · `f` Flows · `i` Interceptors per [`007-UX-IA.md`](007-UX-IA.md) §Static mode) are **mode-scoped**: each letter names the active mode's tab, not a globally-fixed target. `m` in Dynamic names the Machines instance-inspector (per §5); `m` in Static names the Machines registry browse (per [`003-Machine-Inspector.md`](003-Machine-Inspector.md) §Static Machines surface).
 
-The mode-scoping rule is what lets the mnemonic vocabulary stay small (single letters) without colliding across modes — switching modes flips both the chrome AND the meaning of the letter keys, and the user reads which is active from the 4 stacked mode signals above.
+**These are LABELS, not keys.** No bare-letter tab handler exists in `keybinding.cljs` — the shipped bare keys are exactly those in §11's complete map, and the tab mnemonics sit in [`007-UX-IA.md` §Trimmed pending demand](./007-UX-IA.md#trimmed-pending-demand-rf2-f7748x--the-post-freeze-upgrade-path) as never-implemented. Each letter is surfaced in its tab button's `title` attribute and nowhere else; the tab is reached by click or by the command palette's tab-jump verb, which is itself mode-aware (per [`007-UX-IA.md`](007-UX-IA.md) §Mode-aware command surface).
+
+The rule is stated here because it governs the vocabulary: single letters stay small and collision-free across modes, so the letter a user reads on a Static tab is the same one they read on its Dynamic peer. Were the keys ever wired — a new feature, not a documented-existing one — this is the semantics they would take.
 
 ### Frame isolation
 

--- a/tools/xray/spec/018-Event-Spine.md
+++ b/tools/xray/spec/018-Event-Spine.md
@@ -16,7 +16,7 @@ Make the five canonical questions ([`000-Vision.md`](000-Vision.md) §Why it exi
 
 1. A **two-ribbon chrome** (rf2-4vp5j) — a chrome ribbon (`Event History` label + nav cluster + `+ filter` + frame view-scope + Dynamic/Static mode dropdown + settings/close) above an events ribbon (filter pills + hidden-by-filters count). The events ribbon is hidden by default and animates open only once the first filter exists (rf2-pjjwh). The focus-dimension feature (focus button / focus-chip / per-row focus gutter / out-of-focus dimming) and the `Clear Filters` button were RETIRED per rf2-pjjwh — they were not in the Figma surface; row click still SELECTS the cascade and drives every panel.
 2. An **event list** that is the orienting timeline + canonical scrubber.
-3. A **tab bar** of 9 surfaces (Epoch / App-db / Views / Trace / Machines / Routing / Resources / Graph / Frames — the Issues tab was removed per rf2-gbz39 Option (c); the Resources / Graph / Frames tabs are the cohesive-sub-domain L4 lenses added per EP-0016 / EP-0014 / EP-0013).
+3. A **tab bar** of 10 surfaces (Epoch / App-db / Views / Trace / Machines / Routing / Resources / Graph / Frames / Hicasso — the Issues tab was removed per rf2-gbz39 Option (c); the Resources / Graph / Frames tabs are the cohesive-sub-domain L4 lenses added per EP-0016 / EP-0014 / EP-0013, and Hicasso is the evidence lens added per rf2-hic-023).
 4. A **detail panel** whose content is always the current tab's projection of the focused event.
 
 Every selection event passes through a single spine sub — `:rf.xray/focus` — so every panel reading the spine rebinds atomically. No panel reads `(peek history)`; no panel carries its own `:selected-*-id` slot.
@@ -553,9 +553,9 @@ noise that flagged the Xray events-list as a problem.)
 ### Tab strip rendering
 
 ```
-┌──────────────────────────────────────────────────────────────────────────────────────────┐
-│ ◉Epoch ○App-db ○Views 8 ○Trace 47 ○Machines 1 ○Routing ○Resources ○Graph ○Frames         │
-└──────────────────────────────────────────────────────────────────────────────────────────┘
+┌───────────────────────────────────────────────────────────────────────────────────────────┐
+│ ◉Epoch ○App-db ○Views 8 ○Trace 47 ○Machines 1 ○Routing ○Resources ○Graph ○Frames ○Hicasso │
+└───────────────────────────────────────────────────────────────────────────────────────────┘
 ```
 
 - **Active:** `◉` gutter + 2px violet underline + `text-primary`.
@@ -1437,7 +1437,7 @@ Every consumer (event list, scrubber, issues ribbon signal, palette verbs) reads
 | # | Invariant | Enforcement |
 |---|---|---|
 | **I1** | **Frame picker excludes `:rf/xray`** from the inspectable-frame list by default. Internal frames (`:rf/xray`, future `:rf/re-frame2-pair`) are filtered out at the available-frames consumer in `frame_switcher.cljs` (the chrome-ribbon frame dropdown). | Settings popup (§9) carries a power-user toggle **"Show tool frames in picker"** under View → Power user (off by default; off in fresh installs; on only when a framework dev is debugging Xray itself). |
-| **I2** | **No Xray UI view reads from `:rf/xray` for data purposes.** Subscribes inside a Xray view that need host-app data MUST target the selected frame (`(rf/sub :the-sub :frame (sub :rf.xray/focus.frame))` form). Subscribes targeting Xray's own state (selection, mode, filters, settings) are fine but never appear in the inspected-data panels (Event/App-db/Views/Trace/Machines/Routing). | Code review + dev-time lint: a predicate added to `tools/xray/src/.../shell.cljs` mount path walks the registered sub graph and asserts no Xray-namespaced sub feeds an Event/App-db/Views/Trace/Machines/Routing render path. Throws useful error during dev mount; no-op in production. |
+| **I2** | **No Xray UI view reads from `:rf/xray` for data purposes.** Subscribes inside a Xray view that need host-app data MUST target the selected frame (`(rf/sub :the-sub :frame (sub :rf.xray/focus.frame))` form). Subscribes targeting Xray's own state (selection, mode, filters, settings) are fine but never appear in any inspected-data panel. | Code review + dev-time lint: a predicate added to `tools/xray/src/.../shell.cljs` mount path walks the registered sub graph and asserts no Xray-namespaced sub feeds an inspected-data panel's render path. Throws useful error during dev mount; no-op in production. |
 | **I3** | **Views panel render-attribution is scoped to the selected frame ONLY.** The frame's per-cascade render projection must filter component-render entries to those whose owning frame matches `:rf.xray/focus.frame`. Xray's own React subtrees must not bleed in even when both frames mount under the same `react-dom` root. | Implementation: render tracker tags each component-render with `:owning-frame` at capture time; Views panel reads `(filter #(= (:owning-frame %) frame) renders)`. |
 | **I4** | **Test gate — Xray-self-observation is disallowed by CI.** Feature test: drive a host app + Xray, trigger Xray-internal renders, assert the inspected frame's surfaces do NOT include any Xray-namespaced component. | Lives in `tools/xray/test/day8/re_frame2_xray/panels_e2e/multi_frame_isolation_e2e_cljs_test.cljs` (the focused-frame / cross-frame isolation gate) + `self_noise_cljs_test.cljc` (the `xray-internal-event?` / `collect-trace` drop logic that keeps Xray's own sub-reads + view-renders out of the inspected stream). Runs under `npm run test:cljs`. **Failure blocks merge.** |
 

--- a/tools/xray/spec/021-Dynamic-Panel-Designs.md
+++ b/tools/xray/spec/021-Dynamic-Panel-Designs.md
@@ -5190,7 +5190,7 @@ What the panel design needs from the substrate (per §1.4 captured-not-replayed)
 | Sub-decision | Pick | Notes |
 |---|---|---|
 | Unchanged subs in cascade | **Dim, collapsed by default with "Show N unchanged"** | §3.4. Toggle in Settings → View. |
-| Meta-epoch section ordering | **Fixed order: the L3 tab `:order` — Epoch > app-db > Views > Trace > Machine > Routes > Resources > Graph > Frames > Hicasso** | Matches the L3 tab order. Predictable beats dynamic. (rf2-4v67l — Chrome A11y removed in favour of Story's shipped panel.) |
+| Meta-epoch section ordering | **Fixed order: ascending L4 tab `:order`** (`panel-registry/tabs-for-mode :dynamic`) | Matches the L3 tab order, and follows it automatically — an enumeration here would be a second inventory to keep in step. Predictable beats dynamic. (rf2-4v67l — Chrome A11y removed in favour of Story's shipped panel.) |
 | Epoch panel section default-expansion | **All cascade steps expanded by default; collapsible per-step via header click; collapse-all keyboard `[`** | The Epoch panel IS the handling-pipeline view — collapsing by default would hide the punch. |
 | Dispatch-origin display on L2 rows | **Short text label prefix** (`user · :checkout/submit`) | No icon-only or coloured chip — keeps L2 row scannable. Matches the existing L1 ribbon density. |
 | Pattern view (4th lens) | **Post-v1, untracked note** (see trigger below) | The 3-lens model (handling / reactive / state) is sufficient for MVP. |

--- a/tools/xray/spec/021-Dynamic-Panel-Designs.md
+++ b/tools/xray/spec/021-Dynamic-Panel-Designs.md
@@ -5190,7 +5190,7 @@ What the panel design needs from the substrate (per §1.4 captured-not-replayed)
 | Sub-decision | Pick | Notes |
 |---|---|---|
 | Unchanged subs in cascade | **Dim, collapsed by default with "Show N unchanged"** | §3.4. Toggle in Settings → View. |
-| Meta-epoch section ordering | **Fixed order: Event > App-db > Reactive > Trace > Machines > Routing > Issues** | Matches the L3 tab order. Predictable beats dynamic. (rf2-4v67l — Chrome A11y removed in favour of Story's shipped panel.) |
+| Meta-epoch section ordering | **Fixed order: the L3 tab `:order` — Epoch > app-db > Views > Trace > Machine > Routes > Resources > Graph > Frames > Hicasso** | Matches the L3 tab order. Predictable beats dynamic. (rf2-4v67l — Chrome A11y removed in favour of Story's shipped panel.) |
 | Epoch panel section default-expansion | **All cascade steps expanded by default; collapsible per-step via header click; collapse-all keyboard `[`** | The Epoch panel IS the handling-pipeline view — collapsing by default would hide the punch. |
 | Dispatch-origin display on L2 rows | **Short text label prefix** (`user · :checkout/submit`) | No icon-only or coloured chip — keeps L2 row scannable. Matches the existing L1 ribbon density. |
 | Pattern view (4th lens) | **Post-v1, untracked note** (see trigger below) | The 3-lens model (handling / reactive / state) is sufficient for MVP. |

--- a/tools/xray/spec/Conventions.md
+++ b/tools/xray/spec/Conventions.md
@@ -215,10 +215,12 @@ locks the bare-`Panel` convention.
 **Why bare `Panel` wins.**
 
 1. **Panels are addressed by tab-key, not class name.** The 4-layer
-   shell switches over the 6 L3 tab ids enumerated in
-   [`018-Event-Spine.md`](./018-Event-Spine.md) §5
+   shell mounts by L3 tab id, and the inventory is the registry's
+   (`panel-registry/tabs-for-mode :dynamic`) rather than a literal
+   switch — see [`018-Event-Spine.md`](./018-Event-Spine.md) §5
    (`:epoch` · `:app-db` · `:views` · `:trace` · `:machines` ·
-   `:routing` — post rf2-5gl5r after the Event/Handler tab
+   `:routing` · `:resources` · `:derivation-graph` · `:module-view` ·
+   `:hicasso` — post rf2-5gl5r after the Event/Handler tab
    retirement, post rf2-gbz39 after the Issues tab removal) per
    [`021-Dynamic-Panel-Designs.md`](./021-Dynamic-Panel-Designs.md).
    The reg-view symbol name is internal plumbing; the tab-key is the

--- a/tools/xray/src/day8/re_frame2_xray/palette/events.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/palette/events.cljs
@@ -344,9 +344,12 @@
                                       (get db-with-recent :palette-recents)]))]
         (case verb
           :palette/select-panel
-          ;; Panel ids in `palette-panels` are the 6 L3 tab ids per
-          ;; spec/018 §5. Dispatch into `:rf.xray/select-tab` so the
-          ;; visible tab flips — the slot the 4-layer shell reads.
+          ;; Panel ids in `palette-panels` are not a frozen list at all:
+          ;; that fn maps `panel-registry/tabs-for-mode :dynamic` at
+          ;; sub-recompute time, so the ids are exactly whatever the L4
+          ;; tab registry currently holds for `:dynamic` (spec/018 §5).
+          ;; Dispatch into `:rf.xray/select-tab` so the visible tab
+          ;; flips — the slot the 4-layer shell reads.
           {:db close-db
            :fx (conj base-fx [:dispatch [:rf.xray/select-tab (first args)]])}
 

--- a/tools/xray/src/day8/re_frame2_xray/panel_registry.cljc
+++ b/tools/xray/src/day8/re_frame2_xray/panel_registry.cljc
@@ -41,7 +41,13 @@
             (Dynamic) or `:rf.xray.static/selected-tab` (Static)
             when the tab is selected.
     :label  string — visible tab label.
-    :mnem   string — single-letter keyboard mnemonic.
+    :mnem   string — single-letter LABEL mnemonic, rendered into the
+                     tab button's `title` (`\"Trace (t)\"`) by both
+                     shells and read by nothing else. Not a key: no
+                     bare-letter tab handler exists in
+                     `keybinding.cljs`, and tab-jump is a
+                     command-palette verb (spec/007 §Trimmed pending
+                     demand).
     :modes  set    — subset of #{:dynamic :static}. Tabs registered
                      against multiple modes appear in every matching
                      tab bar.

--- a/tools/xray/src/day8/re_frame2_xray/panels/epoch_panel.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/epoch_panel.cljs
@@ -291,9 +291,9 @@
   ;; ---- L4 tab registration ----------------------------------------------
   ;;
   ;; The Epoch tab is the master inverse of the other Dynamic tabs:
-  ;; the six tabs (Epoch · App-db · Views · Trace · Machines ·
-  ;; Routing) read in event-bundle order, and Epoch renders every step
-  ;; the other tabs detail as one timeline. (History: Epoch was
+  ;; each of the registered Dynamic lenses reads one slice in
+  ;; event-bundle order, and Epoch renders every step they detail as
+  ;; one timeline. (History: Epoch was
   ;; added alongside the then-existing tabs; rf2-5gl5r since retired
   ;; the Handler tab and rf2-gbz39 removed the Issues tab — issues
   ;; surface inline in the Epoch panel + the L2 event-row pink-wash

--- a/tools/xray/src/day8/re_frame2_xray/shell.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/shell.cljs
@@ -13,7 +13,7 @@
       ├───────────────────────────────────────────────────────┤
       │ L2  Event list (8 rows default; resizable; min 2)     │  the spine / timeline
       ├───────────────────────────────────────────────────────┤
-      │ L3  Tab bar (40px) — 6 tabs                           │  projection selector
+      │ L3  Tab bar (40px) — one tab per registered lens      │  projection selector
       ├───────────────────────────────────────────────────────┤
       │ L4  Detail panel (fills remaining canvas)             │  per-tab content
       └───────────────────────────────────────────────────────┘
@@ -58,12 +58,16 @@
 
   ## Tab bar (L3)
 
-  Six tabs, mnemonic letters per spec/018 §11:
+  The strip is whatever `panel-registry/tabs-for-mode :dynamic` has
+  registered, ordered by `:order` — it is not a literal in this ns, so
+  adding a tab is one `reg-l4-tab!` call and nothing here changes. As
+  registered today, with mnemonic letters per spec/018 §11:
 
-      Event (e) · App-db (a) · Views (v) · Trace (t) · Machines (m) · Routing (r)
+      Epoch (e) · app-db (a) · Views (v) · Trace (t) · Machine (m) ·
+      Routes (r) · Resources (s) · Graph (g) · Frames (u) · Hicasso (h)
 
   Selection lives on `:rf.xray/selected-tab` and drives the L4
-  detail panel's case switch. Routing was promoted to its own tab
+  detail panel's registry lookup. Routing was promoted to its own tab
   per rf2-nrbs9 (Mike's design call, 2026-05-18) — it follows the
   cohesive-sub-domain rule (sub-domains earn their own lens tab
   rather than overloading the parent tab).
@@ -85,12 +89,14 @@
   panel is registry-driven (rf2-2moh1): each tab registers its
   `:panel` via `panel-registry/reg-l4-tab!` and the shell mounts the
   active tab through `panel-registry/tab-by-id`. Post rf2-5gl5r +
-  rf2-gbz39 the six Dynamic tabs all mount real panels — Epoch →
+  rf2-gbz39 every registered Dynamic tab mounts a real panel — Epoch →
   `epoch-panel/Panel` (the canonical numbered event-bundle per 021 §9.1;
-  supersedes the retired Event/Handler panel), App-db →
+  supersedes the retired Event/Handler panel), app-db →
   `app-db-diff/Panel`, Views → `reactive-panel/Panel` (the 021 §3
   three-stacked-tables design, rf2-8ve8z), Trace → `trace/Panel`,
-  Machines → `machine-inspector/Panel`, Routing → `routing/Panel`.
+  Machine → `machine-inspector/Panel`, Routes → `routing/Panel`,
+  Resources → `resources/Panel`, Graph → `derivation-graph/Panel`,
+  Frames → `module-view/Panel`, Hicasso → `hicasso/Panel`.
 
   ## Frame isolation (rf2-tijr Option C + rf2-in6l2)
 
@@ -188,10 +194,12 @@
 ;; L4 detail-panel read the registry via `tabs-for-mode :dynamic`
 ;; (driven by the `:modes` set on each entry).
 ;;
-;; The seven Dynamic tabs registered against `#{:dynamic}` retain the
-;; canonical left-to-right order via `:order` (0..6) — spec/018 §5
-;; ordering is preserved as registration metadata rather than a literal
-;; vector in this ns.
+;; The Dynamic tabs registered against `#{:dynamic}` retain the
+;; canonical left-to-right order via `:order` — spec/018 §5 ordering is
+;; preserved as registration metadata rather than a literal vector in
+;; this ns, so the inventory and its span are whatever the registry
+;; holds (Epoch sits leftmost at `:order -1`; the values are sparse and
+;; deliberately leave gaps for retired tabs).
 ;;
 ;; Most labels use spaces so the rendered text carries no `-` glyphs.
 ;; The app-db tab's label is the lowercase library term `app-db`
@@ -2241,10 +2249,11 @@
      label]))
 
 (rf/reg-view tab-bar
-  "L3 tab bar — six tabs per spec/018 §5 The 6 tabs (Routing
-  promoted per rf2-nrbs9 — follows the cohesive-sub-domain rule;
-  the Issues tab was removed per rf2-gbz39 — issues surface inline
-  in the Epoch panel + the L2 event-row pink-wash + the ribbon).
+  "L3 tab bar — renders `panel-registry/tabs-for-mode :dynamic` in
+  `:order`, per spec/018 §5 (Routing promoted per rf2-nrbs9 — follows
+  the cohesive-sub-domain rule; the Issues tab was removed per
+  rf2-gbz39 — issues surface inline in the Epoch panel + the L2
+  event-row pink-wash + the ribbon).
 
   Per rf2-in6l2 `reg-view`-registered so subscribes resolve to
   `:rf/xray`.
@@ -2388,10 +2397,10 @@
 (rf/reg-view detail-panel
   "L4 detail panel — mounts the active `:rf.xray/selected-tab`'s panel
   via the registry-driven `panel-registry/tab-by-id :dynamic` lookup
-  (rf2-2moh1). All six Dynamic tabs mount real panels (Event /
-  App-db / Views / Trace / Machines / Routing); the former
-  literal case-switch is gone, and the Issues tab was removed per
-  rf2-gbz39 (Option (c) — issues surface inline + event-row + ribbon).
+  (rf2-2moh1). Every registered Dynamic tab mounts a real panel — the
+  inventory is the registry's, not a list here; the former literal
+  case-switch is gone, and the Issues tab was removed per rf2-gbz39
+  (Option (c) — issues surface inline + event-row + ribbon).
   An unrecognised tab falls back to `unknown-tab-stub`.
 
   Per rf2-in6l2 `reg-view`-registered so subscribes resolve to

--- a/tools/xray/src/day8/re_frame2_xray/shell.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/shell.cljs
@@ -61,10 +61,15 @@
   The strip is whatever `panel-registry/tabs-for-mode :dynamic` has
   registered, ordered by `:order` — it is not a literal in this ns, so
   adding a tab is one `reg-l4-tab!` call and nothing here changes. As
-  registered today, with mnemonic letters per spec/018 §11:
+  registered today, with each entry's `:mnem` in brackets:
 
       Epoch (e) · app-db (a) · Views (v) · Trace (t) · Machine (m) ·
       Routes (r) · Resources (s) · Graph (g) · Frames (u) · Hicasso (h)
+
+  Those letters are LABEL mnemonics, surfaced in each tab button's
+  `title` (see `tab-button` below) — they are not keys. No bare-letter
+  tab handler exists in `keybinding.cljs`; tab-jump is a command-palette
+  verb, per spec/007 §Trimmed pending demand.
 
   Selection lives on `:rf.xray/selected-tab` and drives the L4
   detail panel's registry lookup. Routing was promoted to its own tab

--- a/tools/xray/src/day8/re_frame2_xray/static/shell.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/static/shell.cljs
@@ -62,14 +62,19 @@
       Interceptors (i)
 
   Tab order + mnemonics per the findings doc §5.2 (mode-scoped: same
-  letter, different target per mode — `m` in Dynamic opens the
-  Machines instance inspector, `m` in Static opens the Machines
-  registry browse).
+  letter, different target per mode — `m` names the Machines instance
+  inspector in Dynamic and the Machines registry browse in Static).
+
+  Those letters are LABELS, not keys. They ride the registry entry's
+  `:mnem` into each tab button's `title` and are read by nothing else;
+  there is no `static/keybinding.cljs`, and the global
+  `keybinding.cljs` binds no bare letter to a tab. A tab is reached by
+  click or by the command palette's `select-static-tab` verb. See
+  spec/018 §2.5 Mnemonic mode-scoping rule + spec/007 §Trimmed pending
+  demand.
 
   Static has no standalone Views or Events sub-tabs — the information
   those would surface already lives in the source code.
-
-  Tab-mnemonic mode-scoping lives in `static/keybinding.cljs`.
 
   ## Frame isolation
 

--- a/tools/xray/test/day8/re_frame2_xray/focus_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/focus_cljs_test.cljs
@@ -232,15 +232,54 @@
 
 (deftest focus-shipped-l4-tabs-select-real-panels
   (testing "rf2-1sddi6 / rf2-7ed9ms acceptance — every shipped Dynamic
-            tab id (incl. the L4-only Graph + Frames tabs) is focusable
-            and resolves to an installed panel, never the unknown-tab stub"
+            tab id (including the L4-only Graph, Frames and Hicasso
+            tabs) is focusable and resolves to an installed panel,
+            never the unknown-tab stub.
+
+            rf2-v1fg3 — this used to walk a HAND-LISTED
+            `[:resources :derivation-graph :module-view]` while
+            claiming to cover 'every shipped Dynamic tab id'. When
+            rf2-hic-023 shipped `:hicasso` as a fourth L4-only registry
+            tab on exactly the same footing, the list was not extended
+            and the newest shipped tab went unasserted — the docstring
+            said 'every' and the loop meant 'three'. It now walks
+            `focus/valid-panels`, so the claim is true by construction
+            and a tab cannot be skipped by omission again."
     (setup-xray-frame!)
-    (doseq [panel [:resources :derivation-graph :module-view]]
+    (doseq [panel focus/valid-panels]
       (let [result (focus/focus! {:frame :checkout :panel panel :sync? true})]
         (is (:ok? result) (str panel " is a focusable shipped tab"))
         (is (= panel (selected-tab)) (str panel " tab is selected"))
         (is (some? (panel-registry/tab-by-id :dynamic (selected-tab)))
             (str panel " resolves to an installed tab — no unknown-tab stub"))))))
+
+(deftest focus-acceptance-inventory-cannot-silently-shrink
+  (testing "rf2-v1fg3 ADVERSARIAL — the negative half of the acceptance
+            above. Walking `focus/valid-panels` only proves 'every
+            shipped tab' if `valid-panels` is itself the shipped set; a
+            tab registered at runtime but missing from the mirror would
+            be skipped by BOTH, silently, which is the exact shape of
+            the defect this bead fixes. Assert the mirror against the
+            LIVE registry, and assert a retired id is still rejected so
+            the mirror cannot be widened into a rubber stamp."
+    (setup-xray-frame!)
+    (is (= (set (panel-registry/tab-ids-for-mode :dynamic))
+           (set focus/valid-panels))
+        (str "focus/valid-panels mirrors the live Dynamic registry — "
+             "registered but unmirrored: "
+             (pr-str (sort (remove (set focus/valid-panels)
+                                   (panel-registry/tab-ids-for-mode :dynamic))))
+             ", mirrored but unregistered: "
+             (pr-str (sort (remove (set (panel-registry/tab-ids-for-mode :dynamic))
+                                   focus/valid-panels)))))
+    ;; A RETIRED tab id is not a typo — it is the regression that would
+    ;; follow from widening the mirror carelessly. `:issues` was removed
+    ;; per rf2-gbz39 and must stay rejected.
+    (let [result (focus/focus! {:frame :checkout :panel :issues :sync? true})]
+      (is (false? (:ok? result))
+          ":issues was retired per rf2-gbz39 and is still rejected")
+      (is (not= :issues (selected-tab))
+          "a retired tab id never becomes the selected tab"))))
 
 (deftest command-is-host-agnostic
   (testing "the SAME command shape drives Xray regardless of who built

--- a/tools/xray/test/day8/re_frame2_xray/focus_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/focus_cljs_test.cljs
@@ -236,15 +236,15 @@
             tabs) is focusable and resolves to an installed panel,
             never the unknown-tab stub.
 
-            rf2-v1fg3 — this used to walk a HAND-LISTED
-            `[:resources :derivation-graph :module-view]` while
-            claiming to cover 'every shipped Dynamic tab id'. When
-            rf2-hic-023 shipped `:hicasso` as a fourth L4-only registry
-            tab on exactly the same footing, the list was not extended
-            and the newest shipped tab went unasserted — the docstring
-            said 'every' and the loop meant 'three'. It now walks
-            `focus/valid-panels`, so the claim is true by construction
-            and a tab cannot be skipped by omission again."
+            rf2-v1fg3 — this walked a HAND-LISTED
+            `[:resources :derivation-graph :module-view]` while claiming
+            'every shipped Dynamic tab id'. `:hicasso` then shipped as a
+            fourth L4-only registry tab and nobody extended the list, so
+            the docstring said 'every' and the loop meant 'three'.
+            Walking `focus/valid-panels` makes the claim true by
+            construction — and it is `valid-panels-mirrors-the-live-registry`
+            above that makes `valid-panels` the SHIPPED set rather than a
+            second hand-list."
     (setup-xray-frame!)
     (doseq [panel focus/valid-panels]
       (let [result (focus/focus! {:frame :checkout :panel panel :sync? true})]
@@ -252,34 +252,6 @@
         (is (= panel (selected-tab)) (str panel " tab is selected"))
         (is (some? (panel-registry/tab-by-id :dynamic (selected-tab)))
             (str panel " resolves to an installed tab — no unknown-tab stub"))))))
-
-(deftest focus-acceptance-inventory-cannot-silently-shrink
-  (testing "rf2-v1fg3 ADVERSARIAL — the negative half of the acceptance
-            above. Walking `focus/valid-panels` only proves 'every
-            shipped tab' if `valid-panels` is itself the shipped set; a
-            tab registered at runtime but missing from the mirror would
-            be skipped by BOTH, silently, which is the exact shape of
-            the defect this bead fixes. Assert the mirror against the
-            LIVE registry, and assert a retired id is still rejected so
-            the mirror cannot be widened into a rubber stamp."
-    (setup-xray-frame!)
-    (is (= (set (panel-registry/tab-ids-for-mode :dynamic))
-           (set focus/valid-panels))
-        (str "focus/valid-panels mirrors the live Dynamic registry — "
-             "registered but unmirrored: "
-             (pr-str (sort (remove (set focus/valid-panels)
-                                   (panel-registry/tab-ids-for-mode :dynamic))))
-             ", mirrored but unregistered: "
-             (pr-str (sort (remove (set (panel-registry/tab-ids-for-mode :dynamic))
-                                   focus/valid-panels)))))
-    ;; A RETIRED tab id is not a typo — it is the regression that would
-    ;; follow from widening the mirror carelessly. `:issues` was removed
-    ;; per rf2-gbz39 and must stay rejected.
-    (let [result (focus/focus! {:frame :checkout :panel :issues :sync? true})]
-      (is (false? (:ok? result))
-          ":issues was retired per rf2-gbz39 and is still rejected")
-      (is (not= :issues (selected-tab))
-          "a retired tab id never becomes the selected tab"))))
 
 (deftest command-is-host-agnostic
   (testing "the SAME command shape drives Xray regardless of who built

--- a/tools/xray/test/day8/re_frame2_xray/palette/sources_cljs_test.cljc
+++ b/tools/xray/test/day8/re_frame2_xray/palette/sources_cljs_test.cljc
@@ -15,8 +15,10 @@
 ;; ---- fixture inputs -----------------------------------------------------
 
 (def sample-panels
-  ;; rf2-qy0nu / rf2-nrbs9 / rf2-gbz39 — palette-panels mirrors the 6 L3 tab ids
-  ;; (Issues tab removed per Mike's Option (c) ruling). We use
+  ;; rf2-qy0nu / rf2-nrbs9 / rf2-gbz39 — in production `palette-panels`
+  ;; maps whatever the L4 tab registry holds for `:dynamic`, so it has no
+  ;; fixed size; these three rows are a DELIBERATE minimal fixture for the
+  ;; shape tests below, not a mirror of the shipped inventory. We use
   ;; `:event` first (so the panel-items-shape test pins the first row's
   ;; action) and include `:trace` for the cross-source collision tests.
   ;; A third entry rounds out the panel-items-shape `(count items) = 3`

--- a/tools/xray/test/day8/re_frame2_xray/shell_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/shell_cljs_test.cljs
@@ -20,8 +20,9 @@
        dropped the explicit `● LIVE` / `◐ RETRO` mode pill — the
        state is derivable, and Space / L / G preserve toggles.)
 
-    3. The L3 tab bar renders six tabs (Event / App-db / Views /
-       Trace / Machines / Issues) and clicking a tab updates
+    3. The L3 tab bar renders one button per registered Dynamic tab
+       (Epoch / app-db / Views / Trace / Machine / Routes / Resources /
+       Graph / Frames / Hicasso) and clicking a tab updates
        `:rf.xray/selected-tab` so the L4 detail panel rebinds.
 
     4. The L2 event list reads `:rf.xray/event-bundles` and clicking a
@@ -42,6 +43,7 @@
   Same approach as the original shell test — we walk the view's
   hiccup tree by `data-testid` rather than mounting to a DOM."
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [clojure.string :as str]
             [re-frame.core :as rf]
             [re-frame.frame :as frame]
             [re-frame.test-helpers :as th]
@@ -647,12 +649,21 @@
           ":rf.xray/follow-head dispatched on ⏭ click"))))
 
 ;; -------------------------------------------------------------------------
-;; (3) L3 tab bar — six tabs, mnemonics, selection
+;; (3) L3 tab bar — every registered Dynamic tab, mnemonics, selection
 ;; -------------------------------------------------------------------------
 
 (def ^:private expected-tab-ids
-  "Authoritative tab inventory per spec/018 §5 The 6 tabs (Routing
-  promoted to its own L3 tab per rf2-nrbs9). rf2-5gl5r retired the
+  "Authoritative tab inventory per spec/018 §5 — every id registered
+  against `#{:dynamic}`, in `:order`. This vector is a DELIBERATE
+  hand-maintained mirror of the registry, not a read of it: the point
+  of the assertions below is to fail when a tab is added or removed
+  without the shell test noticing, which a live read could not do.
+  It drifted to a stale seven exactly that way (rf2-gui26) — the
+  three newest tabs shipped while this whitelist silently filtered
+  them out of its own count. Re-derive from `focus.cljc`
+  `valid-panels` when you touch it.
+
+  (Routing promoted to its own L3 tab per rf2-nrbs9). rf2-5gl5r retired the
   Event/Handler tab in favour of the Epoch panel — `:epoch` now
   occupies the leftmost position (the same default-landing slot the
   prior `:event` tab held). rf2-gbz39 removed the Issues tab (Mike
@@ -665,31 +676,60 @@
   removed; its spine-INDEPENDENT browse-all canvas relocated to the
   Static Machines sub-tab. Resources — Spec 016 §Xray and AI tooling —
   earns its own L3 tab after Routing per Mike's cohesive-sub-domain
-  ruling.)"
-  [:epoch :app-db :views :trace :machines :routing :resources])
+  ruling. rf2-9ett2d added Graph per EP-0014; rf2-wtg9z4 added Frames
+  per EP-0013; rf2-hic-023 added Hicasso.)"
+  [:epoch :app-db :views :trace :machines :routing :resources
+   :derivation-graph :module-view :hicasso])
 
-(deftest tab-bar-renders-six-tabs
-  (testing "spec/018 §5 — Epoch / App-db / Views / Trace / Machines /
-            Routing / Resources (Epoch supersedes the retired
-            Event/Handler tab per rf2-5gl5r; rf2-gbz39 removed the
-            Issues tab per Option (c)). rf2-4v67l removed the
-            Chrome A11y dogfood in favour of Story's shipped panel;
-            rf2-ga16q removed the Machines Canvas tab (relocated to
-            Static); Resources added per Spec 016."
+(deftest tab-bar-renders-every-registered-dynamic-tab
+  (testing "spec/018 §5 — Epoch / app-db / Views / Trace / Machine /
+            Routes / Resources / Graph / Frames / Hicasso (Epoch
+            supersedes the retired Event/Handler tab per rf2-5gl5r;
+            rf2-gbz39 removed the Issues tab per Option (c)). rf2-4v67l
+            removed the Chrome A11y dogfood in favour of Story's
+            shipped panel; rf2-ga16q removed the Machines Canvas tab
+            (relocated to Static); Resources added per Spec 016; Graph
+            / Frames / Hicasso per EP-0014 / EP-0013 / rf2-hic-023."
     (xray-setup!)
     (rf/with-frame :rf/xray
-      (let [tree (shell/shell-view)
-            tabs (find-all-by-testid-prefix tree "rf-xray-tab-")]
-        ;; Need to filter out the L4 detail panel and tab-bar root.
-        (is (= 7 (count (filter (fn [n]
-                                  (let [t (:data-testid (second n))]
-                                    (some #(= t (str "rf-xray-tab-" (name %)))
-                                          expected-tab-ids)))
-                                tabs)))
-            "7 tab buttons render")
+      (let [tree     (shell/shell-view)
+            tabs     (find-all-by-testid-prefix tree "rf-xray-tab-")
+            ;; Every `rf-xray-tab-*` testid actually in the tree, as the
+            ;; ids they encode. Derived from the RENDER, never from
+            ;; `expected-tab-ids` — see the adversarial assertion below.
+            ;;
+            ;; The `rf-xray-tab-bar` PREFIX is dropped, not just the
+            ;; exact root: the tab-bar's own chrome children
+            ;; (`-bar-context-label`, `-bar-reset`, `-bar-spacer`) share
+            ;; the `rf-xray-tab-` prefix without being tab buttons, so an
+            ;; exact-match exclusion lets three non-tabs into the set.
+            ;; No tab id begins with `bar`, so the prefix is unambiguous.
+            rendered (->> tabs
+                          (keep #(:data-testid (second %)))
+                          (remove #(str/starts-with? % "rf-xray-tab-bar"))
+                          (map #(keyword (subs % (count "rf-xray-tab-"))))
+                          set)]
+        (is (= (count expected-tab-ids) (count rendered))
+            (str (count expected-tab-ids) " tab buttons render"))
         (doseq [tab-id expected-tab-ids]
           (is (some? (find-by-testid tree (str "rf-xray-tab-" (name tab-id))))
-              (str "tab button for " tab-id)))))))
+              (str "tab button for " tab-id)))
+        ;; ADVERSARIAL — the negative half, and the one that was missing.
+        ;; The prior assertion counted only buttons already named in
+        ;; `expected-tab-ids`, so the count was computed from the
+        ;; whitelist and could never disagree with it: a tab REGISTERED
+        ;; but not whitelisted was filtered out before it was counted.
+        ;; Three shipped that way (Graph / Frames / Hicasso) and this
+        ;; deftest stayed green throughout (rf2-gui26). Comparing the
+        ;; rendered set against the expected set fails in BOTH
+        ;; directions — a tab dropped from the bar, and a tab added to
+        ;; the registry that nobody taught this suite about.
+        (is (= (set expected-tab-ids) rendered)
+            (str "the rendered L3 tab set is exactly the expected "
+                 "inventory — unexpected: "
+                 (pr-str (sort (remove (set expected-tab-ids) rendered)))
+                 ", missing: "
+                 (pr-str (sort (remove rendered (set expected-tab-ids))))))))))
 
 (deftest tab-bar-uses-tablist-aria-pattern
   (testing "rf2-lvf8t (rf2-q7who Thread B) — the L3 tab strip uses the

--- a/tools/xray/test/day8/re_frame2_xray/theme/tokens_cljs_test.cljc
+++ b/tools/xray/test/day8/re_frame2_xray/theme/tokens_cljs_test.cljc
@@ -192,16 +192,18 @@
 
 ;; ---- panel domain colours (rf2-5kfxe.8) --------------------------------
 
-(deftest panel-domain-map-covers-every-l4-tab
-  (testing "rf2-5kfxe.8 — the 6 L4 tabs each get a domain colour, so
-            panels are distinguishable at a glance via the 3px left
-            border on their header. (rf2-gbz39 — the Issues tab was
-            removed per Mike's Option (c) ruling; issues surface inline
-            + event-row pink-wash + the always-on issues ribbon signal.
-            rf2-4v67l — Chrome A11y was removed in favour of Story's
-            already-shipped chrome-a11y dogfood per rf2-18t6p. rf2-ga16q
-            — Machines Canvas removed; its browse-all canvas relocated
-            to the Static Machines sub-tab.)"
+(deftest panel-domain-map-keys-are-pinned
+  (testing "rf2-5kfxe.8 — `panel-domain->token` is NOT the tab
+            inventory and does not track it: rf2-ad7zx.13 superseded the
+            per-panel domain colours with a single `:accent`, leaving
+            this map a six-key vestige that still names the retired
+            `:event` id and knows nothing of the four tabs registered
+            since. `panel-accent` falls back to `:accent` for any key
+            absent here, so every shipped tab renders correctly
+            regardless. This pins the keys so the vestige cannot grow
+            back into a second inventory. (rf2-gui26 — the docstring
+            here read 'the 6 L4 tabs', a word-numeral roster claiming to
+            be the tab count.)"
     (let [tabs #{:event :app-db :views :trace :machines
                  :routing}]
       (is (= tabs (set (keys t/panel-domain->token)))))))

--- a/tools/xray/testbeds/feature_matrix/README.md
+++ b/tools/xray/testbeds/feature_matrix/README.md
@@ -34,8 +34,9 @@ state, the last trace rows, load stats when applicable, and a screenshot path.
 ## Current slice
 
 After the 4-layer chrome refactor (`rf2-xy4yb`) the live L3/L4 tabs are
-Epoch / App-DB / Views / Trace / Machines / Routing / Resources /
-Derivation-Graph / Module-View. The dedicated Event-Detail, Time-Travel,
+whatever `panel-registry/tabs-for-mode :dynamic` holds — today, in
+`:order`: Epoch / app-db / Views / Trace / Machine / Routes / Resources /
+Graph / Frames / Hicasso. The dedicated Event-Detail, Time-Travel,
 Schema, Flows, and Performance panels were retired, so this gate exercises
 only the surviving tabs (chiefly Epoch / Trace / Routing / Machines) plus
 the 20-event/load re-check:

--- a/tools/xray/testbeds/panel_gallery/core.cljs
+++ b/tools/xray/testbeds/panel_gallery/core.cljs
@@ -167,10 +167,12 @@
 (defn- landing-view []
   [:div {:class "gallery-landing"}
    [:h1 "Xray panel gallery"]
-   [:p "A visual gallery of the 6-tab Xray chrome (per "
+   [:p "A visual gallery of the 4-layer Xray chrome (per "
     [:code "tools/xray/spec/018-Event-Spine.md"]
-    ") and each of the six L4 tab panels — Epoch · App-db · Reactive ·
-    Trace · Machines · Routing. Issues is not a tab; it surfaces inline
+    ") and of six of its L4 tab panels — Epoch · App-db · Reactive ·
+    Trace · Machines · Routing. Resources · Graph · Frames · Hicasso
+    ship in the chrome but sit deliberately outside this gallery.
+    Issues is not a tab; it surfaces inline
     in the Epoch panel + the L2 event-row pink-wash + the ribbon signal
     (rf2-gbz39)."]
    [:p "The centrepiece is the "

--- a/tools/xray/testbeds/panel_gallery/gallery_app_db.cljs
+++ b/tools/xray/testbeds/panel_gallery/gallery_app_db.cljs
@@ -1,5 +1,5 @@
 (ns panel-gallery.gallery-app-db
-  "Story coverage for the **App-db tab** of the new 6-tab Xray chrome
+  "Story coverage for the **app-db tab** of the Xray 4-layer chrome
   (rf2-sszlr — gallery rebuild for spec/018-Event-Spine).
 
   The App-db tab body is the `app-db-diff/Panel` view: the changed-

--- a/tools/xray/testbeds/panel_gallery/gallery_machines.cljs
+++ b/tools/xray/testbeds/panel_gallery/gallery_machines.cljs
@@ -1,5 +1,5 @@
 (ns panel-gallery.gallery-machines
-  "Story coverage for the **Machines tab** of the new 6-tab Xray chrome
+  "Story coverage for the **Machine tab** of the Xray 4-layer chrome
   (rf2-sszlr — gallery rebuild for spec/018-Event-Spine).
 
   The Machines tab body is the `machine-inspector/Panel` view

--- a/tools/xray/testbeds/panel_gallery/gallery_routing.cljs
+++ b/tools/xray/testbeds/panel_gallery/gallery_routing.cljs
@@ -1,5 +1,5 @@
 (ns panel-gallery.gallery-routing
-  "Story coverage for the **Routes tab** of the 6-tab Xray chrome
+  "Story coverage for the **Routes tab** of the Xray 4-layer chrome
   (rf2-nrbs9, reshaped per rf2-lq0ef).
 
   The Routes tab body is the `routing/Panel` view. The panel reads:

--- a/tools/xray/testbeds/panel_gallery/gallery_trace.cljs
+++ b/tools/xray/testbeds/panel_gallery/gallery_trace.cljs
@@ -1,5 +1,5 @@
 (ns panel-gallery.gallery-trace
-  "Story coverage for the **Trace tab** of the 6-tab Xray chrome
+  "Story coverage for the **Trace tab** of the Xray 4-layer chrome
   (rf2-sszlr — gallery rebuild for spec/018-Event-Spine; epoch-scoped
   rewire rf2-ofoqu; FLAT-list refresh rf2-aqusw).
 

--- a/tools/xray/testbeds/panel_gallery/panel_views.cljs
+++ b/tools/xray/testbeds/panel_gallery/panel_views.cljs
@@ -19,8 +19,10 @@
 
   ## The L4 tabs
 
-  Per spec/018-Event-Spine.md §5 the chrome surfaces six tabs whose
-  bodies are existing per-panel Panel views:
+  Per spec/018-Event-Spine.md §5 the chrome surfaces one tab per
+  registered Dynamic lens. This gallery wraps six of them, whose bodies
+  are existing per-panel Panel views (Resources · Graph · Frames ·
+  Hicasso ship but are deliberately not galleried here):
 
     - **Epoch**           → `epoch-panel/Panel` (rf2-sc3r1; supersedes
                             the retired Event/Handler panel — rf2-5gl5r)


### PR DESCRIPTION
DRAFT — work in progress. Finishing the stranded `worker/xrayroster-2` work
(PR #8440, salvaged to `origin/salvage/xrayroster-2` at `66bacb2f6a`) on a
current base, plus rf2-91dfb.

## Quality gates

Not yet run — this body is rewritten before the PR is marked ready.
