### PR TITLE
docs(hicasso): repair the api-reference roster, point the recert parent at its third run, decline the ps7ia relocation (rf2-75q3l, rf2-ps7ia, rf2-hic-090)

### DIFF
--- a/docs/core/hicasso/api-reference.md
+++ b/docs/core/hicasso/api-reference.md
@@ -31,15 +31,17 @@ name the ids a door raises; [Errors](17-errors.md) explains the shape and
 
 ## What this page does not enumerate
 
-Three rosters exist elsewhere and are authoritative there. Copying one here
-would produce a second answer that goes stale the day the first one moves, so
-this page points at each instead.
+Four questions are answered authoritatively elsewhere. Copying an answer here
+would produce a second one that goes stale the day the first moves, so this page
+points at each instead. Every target below is a page of this guide except the
+naming ledger, which is a working design record in the repository and does not
+publish — a reader who cannot reach that one is missing history, not behaviour.
 
 | Question | Where it is answered |
 | --- | --- |
-| What each surface does on the server, and under hydration | `docs/design/hicasso/product/dispositions.md` §2.1 and §2.2 |
-| Which spellings changed, when, and under whose ruling | `docs/design/hicasso/product/naming-ledger.md` |
-| Every refusal id, its reason and its recovery | `docs/design/hicasso/product/complaints.md`, and [Errors](17-errors.md) |
+| What each surface does on the server, and under hydration | [SSR and hydration](18-ssr-and-hydration.md#server-policy-by-surface) |
+| Which spellings changed, when, and under whose ruling | the naming ledger, `docs/design/hicasso/product/naming-ledger.md`, in the repository |
+| Every refusal id, its reason and its recovery | [Troubleshooting](troubleshooting.md#the-complaint-index), with [Errors](17-errors.md) for the shape each one carries |
 | Which doors this guide teaches under a spelling the code does not yet carry | the Status block on [the guide index](index.md) |
 
 ## `re-frame.hicasso` — the door

--- a/docs/design/hicasso/product/post-rename-recertification.md
+++ b/docs/design/hicasso/product/post-rename-recertification.md
@@ -273,3 +273,8 @@ The certification stays **partial**, and one thing about the partiality has chan
 - **Family 5 still does not exist**, and §4's correction is unchanged rather than merely un-rechecked:
   `budgets.md`'s ledger row `C1` reads `UNPINNED` with instrument `— (none)`, repointed to `rf2-85og2`,
   which is open and sitting in the measurement lane. There is no pinned regression gate to re-run.
+
+## 7. The re-run, 2026-08-18 — recorded on its own page
+
+A third re-run followed the donor retire, and it is written up separately rather than as a section
+here: [`post-rename-recertification-2026-08-18.md`](post-rename-recertification-2026-08-18.md).


### PR DESCRIPTION
Three beads about where Hicasso's authoritative documentation lives. Two produced an edit; one produced a reasoned refusal and no edit. **No bead is closed by this PR.**

## rf2-75q3l — partial repair, and the bead's sharpest claim does not hold

The bead says `api-reference.md`'s "What each surface does on the server, and under hydration" is "answered nowhere reachable". **It is reachable.** `docs/core/hicasso/18-ssr-and-hydration.md` carries a `### Server policy by surface` section with a ten-row per-surface server-policy table, and that page is in the nav (29 tracked pages under `docs/core/hicasso/`, 29 unique nav rows, zero orphans in either direction). Likewise "Every refusal id, its reason and its recovery": `troubleshooting.md`'s `## The complaint index` carries a section per id grouped by surface.

So two of the three rows needed no relocation ruling at all, and they are re-pointed at those published pages. **Both new targets are pages of this guide rather than the design tree, so neither is invalidated whichever way `rf2-ps7ia`'s split ruling lands** — which is why this did not have to wait on it.

**What was NOT repaired, and why.** The naming-ledger row keeps its repository path because no published page carries naming history; the row and the paragraph above it now say plainly that it does not publish. `escape-ladder.md:107,109` and `troubleshooting.md:80` were left alone: both cite the design tree as *provenance*, under a "Where those numbers come from" admonition and as "the register of record" respectively, and both answer the reader on the page itself. A provenance citation to a repository path is honest; a column headed "Where it is answered" that points off-site is not. The bead stays open on that residue.

**Scope note.** Every one of these six references is an inline code span, not a markdown link. That is why they never appeared in the bead's own 13-link mkdocs census from PR #8399 — that census is a disjoint measurement (11 of its 13 are `spec/004-Views.md` into `design/freehand/decisions/`). The 2026-08-16 comment reading rf2-75q3l as "the 11 links themselves" conflates the two.

## rf2-ps7ia — declined, no edit, left open

**The trigger HAS fired**, contrary to what a hold might assume: commit `c0a7223804651eacbc26e7f2c3ac1dacbdbbcdc1` (2026-08-14, "docs: ship the Hicasso guide, retire the Freehand guide") landed the main-guide section, with the nav verification above.

But the bead's own text reserves the destination: "do not invent the destination ... surface this bead to Mike for the split ruling FIRST; only then dispatch the move itself." **No split ruling exists** — of 47 open beads only `rf2-75q3l` and `rf2-ps7ia` mention `ps7ia` at all, and the tracker carries no ruling comment. The dependency `rf2-0yp7w` is also still open. The relocation is therefore not due, and nothing was moved.

## rf2-hic-090 — the one-line pointer its own worker asked for

The 2026-08-18 record links back to its parent; the parent had no forward link, so a reader arriving there could not learn a third run existed. Added as section 7, matching the page's own per-run section convention. **Nothing else on the page is touched and no verdict is changed**, and the bead is left open: its fifth evidence family has no gate and `rf2-t32wg` is unruled.

## A finding filed rather than actioned

`rf2-ps7ia`'s 2026-08-16 comment asks that `tool-consumer-census.md` row X1 be corrected from STILL-LIVE "in passing". Verified — and the defect is **six rows, not one**. On this base X1's coordinate is gone (`tools/xray/deps.edn` carries only a comment recording its removal, and `git ls-files implementation/freehand` returns 0 against a control of 464 for `implementation/hicasso`), and X2, X4, X6 and X7 name files that no longer exist, while X8's scenario string is absent from a file that does still exist. X3 and X13 remain accurate (2 hits each). Correcting one row while five siblings still claim STILL-LIVE would make the page *more* self-contradictory, and the roll-up counts in four other places depend on all of them. Filed as its own bead instead. `tools/xray/**` is also fenced off this worker.

## Quality gates

Every exit code below was captured by an explicit echo of the runner's status on the same command line as the redirect, never read from the harness. Artefacts are named for this worktree and attempt.

| Gate | Captured exit | Covers |
| --- | --- | --- |
| `scripts/test-fast-pr.sh` (attempt 2, on the final rebased base) | `0` — `PASS fast PR spine` | both changed files; includes `check_doc_slugs`, `check_provenance_pins` and `mkdocs --strict build` |
| `python scripts/check_doc_slugs.py` (direct) | `0` | link targets and heading anchors across `docs/`, including the design tree |
| `python scripts/check_provenance_pins.py --changed-since origin/main` | `0` — **1 page inspected**, 21 cited pins, 21 landed, 0 findings | the changed design-tree page (a real verdict, not the 0-page non-verdict) |
| `sh scripts/check-no-hardcoded-paths.sh` | `0` | tracked files |

**Classifier line**: `=== fast PR spine: docs=true jvm=false node=false (classified) ===`. **Root banner**: the spine printed a gate root naming this worker's own worktree, so it read this tree and not a sibling. `python scripts/check_fast_pr_gap.py --list` derives the **94** required CI checks the spine does not run.

`mkdocs build --strict` DOES cover `api-reference.md` and it ran green inside the spine. It does **not** cover the recertification page: `mkdocs.yml`'s `exclude_docs` block holds six trees — `tools/playground/`, `migration/from-re-frame-v1/codemod/`, `migration/reagent-to-hicasso/codemod/`, `design/freehand/`, `design/hicasso/`, `design/retirement/` — read at source rather than from prose.

**Planted-fault controls, one per changed file, because a link validator passes silently.**

1. `api-reference.md`, anchor half — `#server-policy-by-surface` retargeted to `#server-policy-by-surface-PLANTED`. Gate **exit 1**, reporting `BROKEN ANCHOR` at `api-reference.md:42` and naming the planted anchor. Baseline blob `c6a56b3abe1a2ff26d40f8e1ec56bc0c68bea1c2`, planted `ef8e56e81d9d1b085e286a4c8ccdd22e45c2b9ea` (so the patch applied and was not a silent no-op), restored `c6a56b3abe1a2ff26d40f8e1ec56bc0c68bea1c2` — verified by git content hash against the committed object, not by reading a diff, because this checkout translates line endings.
2. `post-rename-recertification.md`, target half — the new `.md` link retargeted to a non-existent file. Gate **exit 1**, reporting `BROKEN TARGET` at `post-rename-recertification.md:280`. Baseline `34e8c0798da2f57130eaaa1ccbde4787fdc4e6f0`, planted `0d6d317bca27958ada8faba6b8c06c83cea88a9f`, restored `34e8c0798da2f57130eaaa1ccbde4787fdc4e6f0`.

Both faults existed only in this worktree, so a run that had wandered into a sibling checkout would have come back green. That red — not the artefact naming — is the tree-verification evidence for the silent gate; the spine additionally prints its own root, and it names this worktree.

**Hand-verified, because nothing validates a design page's tables, rendering or nav.** The `api-reference.md` roster table is 2 columns: header, separator and all four body rows carry exactly 3 pipes, counted at the file. No cell contains a literal pipe. Both new anchor targets were confirmed to exist as headings — `### Server policy by surface` at `18-ssr-and-hydration.md:331` and `## The complaint index` at `troubleshooting.md:75`. The recertification edit adds no table.

**Merge-base diff read for reverts**: `git diff origin/main...HEAD` (three dots) shows 2 files, 13 insertions / 6 deletions, both files in this worker's own surface. Every deletion is a line this PR deliberately rewrites; nothing a sibling landed is undone. The trunk moved 5 commits under this branch while it worked, all of them `.beads/issues.jsonl` checkpoints touching no gated surface — the spine was nonetheless re-run on the final rebased base rather than the pre-rebase one, and the table above quotes that second run.

**Line numbers re-derived rather than trusted.** The bead's `api-reference.md:38-43` is now the table at 40-45, with the three design-tree rows having sat at 40-42 before this change; `troubleshooting.md:79-80` is one line, 80; `escape-ladder.md` carries two references the bead did not number, at 107 and 109. The census row the ps7ia comment placed at `tools/xray/deps.edn` L53/L57 is at L58.
