### PR TITLE
bench(p0): the allocation record retains each window's raw sample stream, and a window commits its dataset (rf2-erre5)

### DIFF
--- a/implementation/core/test/re_frame/bench/p0_ladder_structural.test.cjs
+++ b/implementation/core/test/re_frame/bench/p0_ladder_structural.test.cjs
@@ -1383,6 +1383,106 @@ test('THE FENCE HOLDS — `allocSteps` is untouched and no published quantity mo
   );
 });
 
+// --- the record's RAW STREAM (rf2-erre5) ------------------------------------
+//
+// A window with a collection in the PRIME's GAP — the one step no recorded
+// scalar walks. `allocPrimeSplit` drops the leading `2·prime` samples, so
+// `pre0 − s0` is in neither `measured` nor `primeLegs`, and every gate, figure
+// and array the record carries is computed downstream of that drop.
+//
+// Otherwise it is the shape rf2-e9wr measured — a 26,044 B prime over six alike
+// 19,256 B legs — so the cohort is a real one rather than a contrived one.
+const PRIME_GAP_WINDOW = (() => {
+  const s0 = 10000000;
+  const gaps = [-50000, 128, 96, 160, 96, 128, 96];
+  const legs = [26044, 19256, 19256, 19256, 19256, 19256, 19256];
+  let h = s0;
+  const raw = [h];
+  for (let k = 0; k < legs.length; k++) {
+    h += gaps[k];
+    raw.push(h); // pre_k
+    h += legs[k];
+    raw.push(h); // post_k
+  }
+  return { raw, gaps, legs, s0 };
+})();
+
+test('THE RECORD RETAINS EACH WINDOW’S RAW STREAM, so a later estimator can be driven over a past run', () => {
+  // BOTH WINDOW SITES, and the PAGE's stream rather than any collapse of it —
+  // a record of the collapsed stream would drop a stride-3 run's mid samples,
+  // which is the half `siteLegs` exists to keep.
+  assert.strictEqual(
+    (SRC.match(/samples: win\.samples,/g) || []).length,
+    1,
+    'the arm window records the raw stream the page filled'
+  );
+  assert.strictEqual(
+    (SRC.match(/samples: w\.samples,/g) || []).length,
+    1,
+    'and so does the control window — one window shape, not two'
+  );
+
+  const { raw, legs, gaps } = PRIME_GAP_WINDOW;
+
+  // HALF ONE — THE SHAPE CLAIM. `samples` is what the driver's own three calls
+  // are handed, and `sites` beside it is the stride they decode against, so
+  // every array the record carries re-derives from the pair exactly.
+  const site = allocSiteSplit(raw, 2);
+  assert.deepStrictEqual(site.collapsed, raw, 'at the shipped stride the split is the identity');
+  const { primeLegs, measured } = allocPrimeSplit(site.collapsed);
+  const steps = allocSteps(measured);
+  assert.deepStrictEqual(primeLegs, legs.slice(0, ALLOC_PRIME_WRITES), 'the prime legs');
+  assert.deepStrictEqual(steps.legs, legs.slice(ALLOC_PRIME_WRITES), 'the measured legs');
+  assert.deepStrictEqual(steps.gaps, gaps.slice(ALLOC_PRIME_WRITES), 'the measured gaps');
+
+  // HALF TWO — WHAT IT ADDS OVER THE ARRAYS ALREADY RECORDED, which is the
+  // whole reason the field earns its bytes. A 50 KB collection ran inside this
+  // window and every recorded quantity reports a window that never fell...
+  assert.strictEqual(steps.falls, 0, 'the falls gate never walks the prime gap');
+  assert.strictEqual(steps.fall, 0, 'and nothing is netted there either');
+  assert.ok(!steps.gaps.includes(gaps[0]), 'nor is it among the measured gaps');
+  assert.ok(!primeLegs.includes(gaps[0]), 'nor among the prime legs, which are legs');
+  // ...and off `samples` it is one subtraction.
+  assert.strictEqual(raw[1] - raw[0], -50000, 'the prime gap, recoverable only from the stream');
+
+  // AND THE ABSOLUTE LEVEL. Every recorded quantity is a DIFFERENCE, so
+  // translating the whole stream moves not one of them — which is exactly why
+  // a record of them alone fixes the stream only up to that translation, and
+  // why a question about the level itself is not askable of such a record.
+  const shifted = raw.map((x) => x + 7654321);
+  const shiftedSteps = allocSteps(allocPrimeSplit(allocSiteSplit(shifted, 2).collapsed).measured);
+  for (const f of ['rise', 'fall', 'falls', 'maxStep', 'endpoints', 'legMedian']) {
+    assert.strictEqual(shiftedSteps[f], steps[f], `${f} cannot see the level`);
+  }
+  assert.deepStrictEqual(shiftedSteps.legs, steps.legs, 'nor can the legs');
+  assert.deepStrictEqual(shiftedSteps.gaps, steps.gaps, 'nor the gaps');
+  assert.notStrictEqual(shifted[0], raw[0], 'yet the two streams are different readings');
+
+  // AND THE FENCE. This is retention: no gate reads the field, and nothing
+  // hands it to `allocSteps` in place of the measured collapsed region.
+  lacks(/allocSteps\(win\.samples\)|allocSteps\(w\.samples\)/, 'the certificate is unmoved');
+});
+
+test('AN ALLOCATION WINDOW COMMITS ITS RAW RECORD — stated where the file is written', () => {
+  // rf2-erre5 part (1) is a CONVENTION, deliberately not a mechanism: nothing
+  // in this driver can tell whether an operator committed a file, and a gate
+  // that guessed would refuse every run that was not a published window. What
+  // it gets instead is a line the operator actually sees, at the moment the
+  // artefact exists, plus the reason beside the code that writes it.
+  has(
+    /an allocation window COMMITS this file beside its studio page/,
+    'the operator is told, on the run that produced the artefact'
+  );
+  has(
+    /data\/alloc-<bead>\//,
+    'and where it goes — the path rf2-2rtt6.138 used, which is the only one that exists'
+  );
+  // The env var that produces it is named in the usage banner. It was reachable
+  // only by reading the last twenty lines of a 3,800-line driver, which is a
+  // fair part of why three windows in a row published no dataset.
+  has(/P0_RAW_OUT=.*node \.\.\.\/p0_run\.cjs/, 'the banner names the switch');
+});
+
 test('THE GATE HAS NO DIAL, AND τ IS NOT IT', () => {
   // Every gate on this rig exists because something once passed that should
   // not have, so widening one to admit today's run retro-admits that failure.

--- a/implementation/core/test/re_frame/bench/p0_run.cjs
+++ b/implementation/core/test/re_frame/bench/p0_run.cjs
@@ -8,6 +8,12 @@
 //   node implementation/core/test/re_frame/bench/p0_run.cjs --only fanout
 //   node implementation/core/test/re_frame/bench/p0_run.cjs --only ladder
 //   P0_ROUNDS=6 P0_SAMPLES=12 node .../p0_run.cjs
+//   P0_RAW_OUT=.../data/alloc-<bead>/run1.json node .../p0_run.cjs
+//
+// `P0_RAW_OUT` writes the whole collected record as JSON, and an allocation
+// window COMMITS that file beside its studio page. See the write site at the
+// foot of this file for why, and `samples` on each window for what the record
+// now retains so a later estimator can be driven over it.
 //
 // `--only ladder` is the PER-READ row (rf2-2rtt6.34): B and the witness
 // held fixed while READS walk HD-002's 1/3/7/20 at Q = E, on three
@@ -2249,6 +2255,10 @@ async function allocRow(chromium) {
         sites: site.sites,
         siteLegs: site.siteLegs,
         siteWitness: site.siteLegs.length ? allocSiteWitness(site.siteLegs) : null,
+        // THE RAW STREAM THIS WINDOW WAS READ OFF (rf2-erre5). See the arm
+        // window below for why; the controls carry it for the same reason
+        // they carry the prime — one window shape, not two.
+        samples: w.samples,
       };
     };
     const idle = await controlOf('idle', 0);
@@ -2383,6 +2393,39 @@ async function allocRow(chromium) {
           sites: site.sites,
           siteLegs: site.siteLegs,
           siteWitness: site.siteLegs.length ? allocSiteWitness(site.siteLegs) : null,
+          // THE RAW STREAM, SO A FUTURE ESTIMATOR CAN BE APPLIED TO A PAST RUN
+          // (rf2-erre5). Everything else in this object is DERIVED — `collapsed`
+          // from `allocSiteSplit(samples, sites)`, `measured` and `primeLegs`
+          // from `allocPrimeSplit` on that, and `rise`, `fall`, `falls`,
+          // `maxStep`, `endpoints`, `legs`, `gaps` and the certificate from
+          // `allocSteps` on that again. Recording the stream the three of them
+          // are handed makes the record CLOSED under re-analysis: an estimator
+          // written after the run can be driven over it and get the number this
+          // run would have published, instead of over a reconstruction.
+          //
+          // WHAT IT ADDS OVER `legs` AND `gaps`, which have been recorded since
+          // rf2-2rtt6.140 and already re-derive every published figure exactly.
+          // Two things, and they are the two a scalar record cannot hold:
+          //
+          //   - THE PRIME REGION'S GAPS. `primeLegs` keeps the prime's LEGS and
+          //     nothing keeps the steps between them, so "did a collection land
+          //     in the prime?" is not askable of a record. The prime is exactly
+          //     the term rf2-oiy1 took out of every published quantity, which
+          //     makes it the term a later bead is most likely to come back to.
+          //   - THE ABSOLUTE HEAP LEVEL. Every recorded quantity is a
+          //     difference, so a record of them fixes the stream only up to a
+          //     translation. Drift across a page's rounds is a question about
+          //     the level itself and no arithmetic on the deltas reaches it.
+          //
+          // WHY THIS AND NOT THE COLLAPSED STREAM. `sites` is recorded beside
+          // it, and `allocSiteSplit` is a pure function of the two, so the raw
+          // stream determines the collapsed one and a stride-3 run keeps its
+          // mid samples as well. The collapsed stream determines neither.
+          //
+          // IT MOVES NOTHING. No gate reads this field, no figure is computed
+          // from it, and `allocSteps` is handed exactly what it was handed
+          // before — rf2-rs8q6's fence stands untouched. This is retention.
+          samples: win.samples,
           // WHERE THIS WINDOW SITS IN THE PAGE'S OWN WORK-UNIT SEQUENCE.
           // `alloc-tick` is monotone for the life of the page — the warm-ups
           // advance it too — so this pair is what a round index actually IS,
@@ -3795,11 +3838,29 @@ if (require.main === module) (async () => {
   } finally {
     server.close();
   }
+  // THE RAW RECORD, AND WHAT AN ALLOCATION WINDOW IS EXPECTED TO DO WITH IT
+  // (rf2-erre5). **An allocation window commits this file beside its studio
+  // page**, under
+  // `implementation/hicasso/test/re_frame/bench/hicasso/data/alloc-<bead>/`,
+  // exactly as rf2-2rtt6.138 did — and that is a CONVENTION rather than a
+  // mechanism, because nothing here can tell whether an operator committed a
+  // file, and a gate that guessed would go red on every run that was not a
+  // published window.
+  //
+  // WHY IT IS WORTH THE HABIT. The 2026-08-08 window is the only allocation
+  // window that ever did it, and it is the only one that has since been
+  // re-analysed: rf2-nkeba re-derived its figures under an estimator that did
+  // not exist when it was taken, and settled that the published values were the
+  // MEDIAN of rise/W rather than the mean the summary printed. The 2026-08-13,
+  // 2026-08-16 and 2026-08-17 windows published records and no dataset, so the
+  // same question is not askable of them at all. The convention has paid for
+  // itself once; the three windows that skipped it cannot be made to pay later.
   const raw = process.env.P0_RAW_OUT;
   if (raw) {
     fs.mkdirSync(path.dirname(raw), { recursive: true });
     fs.writeFileSync(raw, JSON.stringify(out, null, 2));
     console.error(`[p0] raw data -> ${raw}`);
+    console.error('[p0] an allocation window COMMITS this file beside its studio page');
   }
   // THE PAGES' OWN FAILURES, JOINING THE LIST THE EXIT ALREADY READS
   // (rf2-sib23). It joins `failures` rather than taking a code of its own


### PR DESCRIPTION
Closes rf2-erre5 part (2), and lands part (1) as the convention it is.

This is a **rig** change. No measurement was taken, no figure is published here, and no
past record is retro-fitted.

## What the bead asked, and what was already true

rf2-erre5 has two parts. Both premises were re-derived at source rather than taken from
the bead, and one of them has moved since it was filed.

**Part (1) — an allocation window commits its raw per-window record beside its studio
page.** HOLDS. Exactly one allocation dataset is tracked:

```
$ git ls-files | grep -F 'data/alloc'
implementation/hicasso/test/re_frame/bench/hicasso/data/alloc-2rtt6-138/run1.json
```

Positive control, same machinery one character shorter (`data/allo`): the same single
path. Widening to `/data/` returns **50 tracked files across 16 dataset locations**
(`clock-*`, `censusclock-*`, `hd8clock-*`, `inpage-ladder-*`, `jsfb-*`, `ladder-*`,
`readprofile-*`) — so the convention is broadly practised in this tree for other window
types, and the allocation row is the one that has done it once. No `.json` is tracked
anywhere under `docs/design/hicasso/`.

**Part (2) — the record retains the raw samples array per window.** HOLDS as stated, but
its motivating gap is **substantially narrower than the bead's filing**, and this is the
correction worth reading before the diff:

- The committed 2026-08-08 artefact does store scalars and no samples:
  `grep -c -F '"samples"' run1.json` → **0** (exit 1), against a positive control of
  `"maxStep"` → **150**. An arm window in that file carries exactly
  `arm, boundaries, cdpBracket, endpoints, fall, falls, headroom, maskable, maxStep,
  perBoundaryPerWrite, perWrite, reads, rise, rung, segment, text` — no `legs`, no
  `gaps`, no `primeLegs`.
- **But `allocSteps` has returned `legs` and `gaps` since `eb17886c5b`
  (rf2-2rtt6.140, 2026-08-08 17:13), and both window sites already spread its result
  into the record at that commit** (`git show eb17886c5b:…/p0_run.cjs` shows `...s,` at
  the control and arm sites). `run1.json` landed at `4a1537cb71`, 2026-08-08 **10:14** —
  seven hours earlier. That is why it lacks them, and it means a record taken by today's
  runner already re-derives `rise`, `fall`, `falls`, `maxStep`, `endpoints` and the whole
  leg cohort exactly. **rf2-nkeba's "could not recover the actual legs" is a fact about
  the 2026-08-08 artefact, not about the rig as it stands.**
- The runner had **no** `samples` retention path: `grep -nF 'samples:' p0_run.cjs` → no
  match (exit 1), against a positive control of `siteLegs:` → 3 matches.

## So why land part (2) at all

Because two things are still unrecoverable from `legs`/`gaps`/`primeLegs`, and they are
the two a scalar record structurally cannot hold:

1. **The prime region's gap steps.** `allocPrimeSplit` drops the leading `2·prime`
   samples, so `pre0 − s0` is in neither `measured` nor `primeLegs`. A collection there
   is in **no recorded quantity at all** — `falls` reads 0 and every array is silent.
   The prime is exactly the term rf2-oiy1 took out of every published figure, which
   makes it the term a later bead is most likely to come back to.
2. **The absolute heap level.** Every recorded quantity is a difference, so the record
   fixes the stream only up to a translation. Drift across a page's rounds is a question
   about the level itself, and no arithmetic on the deltas reaches it.

`samples` + the already-recorded `sites` is the pair `allocSiteSplit` → `allocPrimeSplit`
→ `allocSteps` is driven from, so recording it makes the record **closed under
re-analysis**: an estimator written after a run is driven over the run, not over a
reconstruction. Recording the *collapsed* stream instead would have been cheaper by two
samples and would have dropped a stride-3 run's mid samples; the raw stream determines
the collapsed one and not conversely.

**Nothing moves.** No gate reads the field, no figure is computed from it, and
`allocSteps` is handed exactly what it was handed before — rf2-rs8q6's fence stands
unedited. This is retention.

## Part (1): a convention, deliberately not a mechanism

Nothing in the driver can tell whether an operator committed a file, and a gate that
guessed would refuse every run that was not a published window. Under the project stance
that is over-engineering, so part (1) lands as three cheap things instead, all inside the
rig's own fence:

- the reason, in prose beside the `P0_RAW_OUT` write site that produces the artefact;
- a line the operator actually sees on the run that produced it —
  `[p0] an allocation window COMMITS this file beside its studio page`;
- `P0_RAW_OUT` named in the driver's usage banner with the target path shape. Before this
  change it appeared **exactly once in the whole tree** — `git grep P0_RAW_OUT fa64f4dce4`
  returns the single `process.env` read at `p0_run.cjs:3798`, against a positive control
  of `P0_ROUNDS` at the same ref returning two files — so it was reachable only by reading
  the last twenty lines of a 3,800-line driver. That is a fair part of why three windows
  in a row published no dataset.

The studio pages are owned by their own beads and fenced out of this branch; no published
record is touched.

## The measured cost

Measured, not estimated, and with the same serialiser the driver uses
(`JSON.stringify(out, null, 2)`): the 2026-08-08 record's own 150-window census, given a
15-element `samples` array per window (stride 2, `ALLOC_WINDOW_WRITES` = 7, so
`1 + 2·7`), at realistic 8-digit `usedJSHeapSize` magnitudes.

| | bytes | lines |
|---|---|---|
| baseline (re-serialised) | 102,896 | 3,140 |
| with `samples` | 162,746 | 5,690 |
| **delta** | **+59,850** | **+2,550** |
| **per window** | **+399** | **+17** |

Against the bead's "a few thousand lines of JSON per window": read as a whole measurement
row, the bead's estimate is **right** — the record is 3,140 lines today and ~5,700 after
this change, still a few thousand. This change roughly doubles a dataset, from ~103 KB to
~160 KB. It is not an unbounded artefact: the array length is fixed by
`ALLOC_WINDOW_WRITES` and the window count by `ALLOC_ROUNDS` × arms, both configured
before the run.

(Aside worth recording: the committed file measures 106,035 bytes on disk against 102,896
re-serialised. The difference is exactly 3,139 — one byte per CRLF line ending on this
`core.autocrlf=true` checkout — which confirms the re-serialisation is otherwise
byte-identical to the committed artefact.)

## Quality gates

**Which gates cover this, and how that was established.** Derived from
`.github/scripts/report-changed-surfaces.sh`, run over the two changed paths explicitly.
**A first invocation passing `origin/main` returned all-false — that was a false read**:
the script takes explicit *paths*, not a base ref, so it had classified a path literally
named `origin/main`. Corrected, the two changed paths arm 14 surfaces, identical to the
set a `implementation/core/src/**` path arms (positive control): `implementation_jvm`,
`cljs_node_test`, `adapter_diagnostic`, `cljs_browser`, `cljs_prod`, `bundle_isolation`,
`tools_jvm`, `tools_jvm_machines_viz`, `tools_jvm_testbed_support`,
`tools_cljs_machines_viz`, `template_expensive`, `mcp_conformance`, `mcp_live`,
`playground`. The no-argument form (deriving from `HEAD^`, i.e. this commit) agrees.

The closest witness is `implementation/core/test/re_frame/bench/p0_ladder_structural.test.cjs`,
which CI runs inside `npm run test:script-helpers` (`test.yml:3292`).

Every number below is the one **this worker's own shell captured** on the same command
line as the redirect (`ec=$?; echo "$ec" > ….exit`), never one the harness reported about
the same run.

| gate | base | captured exit |
|---|---|---|
| bench structural witness | pre-rebase | **0** — 86 passed |
| bench structural, SABOTAGED | pre-rebase | **1** — 1/86 failed |
| bench structural, after restore | pre-rebase | **0** — 86 passed |
| fast-PR spine | pre-rebase | **0** — `PASS fast PR spine` |
| bench structural witness | **final base** | **0** — 86 passed |
| bench structural, SABOTAGED | **final base** | **1** — 1/86 failed |
| bench structural, after restore | **final base** | **0** — 86 passed |
| fast-PR spine | **final base** | **0** — `PASS fast PR spine` |

`node core/test/re_frame/bench/p0_ladder_structural.test.cjs` and
`sh <abs>/scripts/test-fast-pr.sh`, the latter invoked by absolute path.

**Everything was re-run on the final base.** The trunk moved nine commits under this
branch while it was in flight (#8440's 18 files under `tools/xray/**` among them); the
branch was rebased onto `d3c3a2d60d` and every gate re-run there, because a pre-rebase
green is evidence about a tree that no longer exists. None of those nine commits touches
either changed file (`git diff --name-only <base>..origin/main | grep -F 'bench/p0_'` →
no match, against a positive control of `tools/xray/` → 18).

Spine classifier line, read from its own output:

```
=== fast PR spine: docs=false jvm=true node=true (classified) ===
```

**Which tree the spine read** — it prints its root, so that is the route used here rather
than a planted fault: its log names
`…\re-frame2-worktrees\dataset-erre5\implementation\shadow-cljs.edn`, this worktree and
not a sibling.

`python scripts/check_fast_pr_gap.py --list` is the one path deriving which required CI
checks the spine does not run: it reports **94** required checks not decided locally, so
a green spine is not a green CI. The spine's own PASS line additionally names three
families it did not run: the documentation gates (surface unchanged), the JVM artefact
suites the diff did not touch, and the browser / prod-elision / bundle-isolation / perf /
adapter / Xray / mcp-conformance / tool-JVM lanes (CI only).

**The planted-fault control, run twice — once on each base.** `samples: win.samples,` — a
line this PR adds — was renamed to `rawSamples: win.samples,` in the worktree only. Both
times the gate went **red, exit 1**, naming exactly what was planted:

```
FAIL  THE RECORD RETAINS EACH WINDOW’S RAW STREAM, so a later estimator can be driven over a past run
      the arm window records the raw stream the page filled
0 !== 1
```

Total test count was 86 in all three runs, so the plant refused one assertion rather than
aborting the lane. The fault existed only in this worktree, so a run that had wandered
into a sibling checkout would have come back green — that red is the discrimination.
Restored with `git checkout --`, and verified by git's own content hash rather than a byte
digest (this checkout is `core.autocrlf=true`): working file
`e88d2be45efd59d023a9d23da9e4ff1f9800b5c0` == committed blob
`e88d2be45efd59d023a9d23da9e4ff1f9800b5c0`, and `git diff --quiet` clean.

**The new field's test is part of the deliverable**, not a source pin alone. It drives the
driver's own three calls over a fixture window carrying a 50 KB collection in the prime's
gap, and adjudicates two real claims: that every recorded array re-derives from
`samples` + `sites` exactly, and that the prime gap and the absolute level are in none of
the recorded quantities and one subtraction away from `samples`.

**Merge-base diff read for reverts** (`git diff --numstat origin/main...HEAD`, three-dot,
on the final base): 2 files, **161 insertions and 0 deletions** — `100 0` and `61 0`.
A pure addition reverts nothing, and both files are inside this dispatch's fence.
