### PR TITLE
fix(xray): the tab mnemonics stop claiming to be keys, and a fourth six-tab roster (rf2-14axc, rf2-91dfb)

### DIFF
--- a/tools/xray/spec/003-Machine-Inspector.md
+++ b/tools/xray/spec/003-Machine-Inspector.md
@@ -1262,7 +1262,7 @@ The Static-mode Machines surface is **a peer** to the post-collapse Dynamic Mach
 
 ### Tab placement
 
-The Static Machines tab is **tab 1 of 5** in the Static L3 strip (per [`007-UX-IA.md`](007-UX-IA.md) §Static mode sub-tab inventory). Mnemonic `m` (mode-scoped — see [`018-Event-Spine.md`](018-Event-Spine.md) §2.5 Mnemonic mode-scoping rule: `m` in Dynamic opens the instance inspector, `m` in Static opens the registry browse). Static Machines is the **default Static tab** because the Machines registry is the densest Static surface; opening Static on a fresh slate lands on the highest-value tab.
+The Static Machines tab is **tab 1 of 5** in the Static L3 strip (per [`007-UX-IA.md`](007-UX-IA.md) §Static mode sub-tab inventory). Label mnemonic `m` (mode-scoped — see [`018-Event-Spine.md`](018-Event-Spine.md) §2.5 Mnemonic mode-scoping rule: `m` names the instance inspector in Dynamic and the registry browse in Static; it is a `title`-attribute label, not a key). Static Machines is the **default Static tab** because the Machines registry is the densest Static surface; opening Static on a fresh slate lands on the highest-value tab.
 
 ### Master-detail layout
 
@@ -1310,7 +1310,7 @@ The 4 sub-modes (mnemonic letters `t/s/i/c` surfaced in each pill's `title`) liv
 | **Instances** (`i`) | **JUMP to Dynamic.** Clicking the pill (or the per-row `→ Dynamic` chip in the browse-list) dispatches three events against `:rf/xray`: `:rf.xray/set-mode :dynamic` · `:rf.xray/select-tab :machines` · `:rf.xray/select-machine-id <mid>`. The user lands on the Dynamic Machines tab with this machine pre-selected. Mode B/C auto-detection (Mode B for 2-8 live, Mode C for ≥8) is the Dynamic panel's responsibility — the Static-side JUMP just lands the selection. | no body — the click is the surface |
 | **Cascade** (`c`) | **Dimmed + disabled** with a tooltip: *"Cancellation cascade is a Dynamic-only surface. Switch to Dynamic mode to view."* The pill renders for muscle-memory consistency with the Dynamic sub-strip (same DOM, same letter mnemonic) but is non-interactive — `disabled` + `aria-disabled="true"` + dashed border + 0.5 opacity. The cancellation cascade composes against the trace ring buffer which is event-coupled — there is no spine in Static mode, so the surface has no source data. | no body — the pill IS the surface |
 
-The sub-strip mnemonics are mode-scoped under the same rule the L3 tabs follow (see [`018-Event-Spine.md`](018-Event-Spine.md) §2.5 Mnemonic mode-scoping rule).
+The sub-strip mnemonics (`t` · `s` · `i` · `c` above) are mode-scoped under the same rule the L3 tabs follow (see [`018-Event-Spine.md`](018-Event-Spine.md) §2.5 Mnemonic mode-scoping rule) — and, like those, they are labels rather than keys. `static/machines/helpers.cljc` `sub-mode-mnemonics` carries the letters so each pill can surface one in its `title`, and marks the keybindings that would act on them as a TODO; nothing presses them today.
 
 ### Per-row → Dynamic chip
 

--- a/tools/xray/spec/007-UX-IA.md
+++ b/tools/xray/spec/007-UX-IA.md
@@ -2029,9 +2029,12 @@ Five Static sub-tabs, mode-scoped mnemonics per the findings doc
 rf2-b2fif removed the Views + Events sub-tabs (info already in the
 source code; the tabs were not pulling their weight).
 
-Mnemonic mode-scoping: the same letter dispatches the active mode's
-tab — `m` in Dynamic opens the Machines instance-inspector, `m` in
-Static opens the Machines registry browse.
+Mnemonic mode-scoping: the same letter names the active mode's tab —
+`m` is the Machines instance-inspector in Dynamic and the Machines
+registry browse in Static. The Mnemonic column is a LABEL, surfaced in
+each tab button's `title`; the letters are not keys (§Trimmed pending
+demand), and the tab is reached by click or by the mode-aware
+command-palette tab-jump verb (§Mode-aware command surface).
 
 ### Mode-signal mechanism (4 stacked signals)
 
@@ -2144,9 +2147,10 @@ Routes / Schemas / Flows / Interceptors — see §Sub-tab inventory
 above). New tabs MUST declare which mode(s) they belong to; tab-id
 keyword collisions across modes (`:machines`) are deliberate and
 resolved by the active-mode dispatch, not by renaming. Mnemonic
-collisions across modes (`m` · `r`) are likewise resolved by the
-mode-scoped resolver (Cmd-Shift-M flips the active mode; the letter
-then dispatches the active mode's tab — see §Keyboard).
+collisions across modes (`m` · `r`) need no resolver at all: the
+letters are tab LABELS rather than keys (§Trimmed pending demand), so
+the only thing a collision costs is that the reader must know which
+mode is active — which the 4 stacked mode signals already tell them.
 
 **Shared-token rule.** Design tokens — colours, spacing, typography,
 motion — live ONCE in the HCM token registry (`theme/tokens.cljc`,

--- a/tools/xray/spec/018-Event-Spine.md
+++ b/tools/xray/spec/018-Event-Spine.md
@@ -141,9 +141,11 @@ Static mode is unconditionally available. The mode dropdown mounts at chrome-rib
 
 ### Mnemonic mode-scoping rule
 
-The 5-letter Static sub-tab mnemonics (`m` Machines · `r` Routes · `c` Schemas · `f` Flows · `i` Interceptors per [`007-UX-IA.md`](007-UX-IA.md) §Static mode) are **mode-scoped**: the same letter dispatches the active mode's tab, not a globally-fixed target. `m` in Dynamic opens the Machines instance-inspector (per §5); `m` in Static opens the Machines registry browse (per [`003-Machine-Inspector.md`](003-Machine-Inspector.md) §Static Machines surface). The keybinding wiring rides the same chord-detection ns (`keybinding.cljs`) but routes through a mode-aware dispatcher.
+The 5-letter Static sub-tab mnemonics (`m` Machines · `r` Routes · `c` Schemas · `f` Flows · `i` Interceptors per [`007-UX-IA.md`](007-UX-IA.md) §Static mode) are **mode-scoped**: each letter names the active mode's tab, not a globally-fixed target. `m` in Dynamic names the Machines instance-inspector (per §5); `m` in Static names the Machines registry browse (per [`003-Machine-Inspector.md`](003-Machine-Inspector.md) §Static Machines surface).
 
-The mode-scoping rule is what lets the mnemonic vocabulary stay small (single letters) without colliding across modes — switching modes flips both the chrome AND the meaning of the letter keys, and the user reads which is active from the 4 stacked mode signals above.
+**These are LABELS, not keys.** No bare-letter tab handler exists in `keybinding.cljs` — the shipped bare keys are exactly those in §11's complete map (Space · `l` · Shift+`G` · `j` · `k` · `,` · `s`), and the tab mnemonics sit in [`007-UX-IA.md` §Trimmed pending demand](./007-UX-IA.md#trimmed-pending-demand-rf2-f7748x--the-post-freeze-upgrade-path) as never-implemented. Each letter is surfaced in its tab button's `title` attribute and nowhere else; the tab is reached by click or by the command palette's tab-jump verb, which is itself mode-aware (per [`007-UX-IA.md`](007-UX-IA.md) §Mode-aware command surface).
+
+The rule is stated here because it governs the vocabulary: single letters stay small and collision-free across modes, so the letter a reader sees on a Static tab is the same one they see on its Dynamic peer. Were the keys ever wired — a new feature, not a documented-existing one — this is the semantics they would take.
 
 ### Frame isolation
 

--- a/tools/xray/src/day8/re_frame2_xray/panel_registry.cljc
+++ b/tools/xray/src/day8/re_frame2_xray/panel_registry.cljc
@@ -41,7 +41,13 @@
             (Dynamic) or `:rf.xray.static/selected-tab` (Static)
             when the tab is selected.
     :label  string — visible tab label.
-    :mnem   string — single-letter keyboard mnemonic.
+    :mnem   string — single-letter LABEL mnemonic, rendered into the
+                     tab button's `title` (`\"Trace (t)\"`) by both
+                     shells and read by nothing else. Not a key: no
+                     bare-letter tab handler exists in
+                     `keybinding.cljs`, and tab-jump is a
+                     command-palette verb (spec/007 §Trimmed pending
+                     demand).
     :modes  set    — subset of #{:dynamic :static}. Tabs registered
                      against multiple modes appear in every matching
                      tab bar.

--- a/tools/xray/src/day8/re_frame2_xray/static/shell.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/static/shell.cljs
@@ -62,14 +62,19 @@
       Interceptors (i)
 
   Tab order + mnemonics per the findings doc §5.2 (mode-scoped: same
-  letter, different target per mode — `m` in Dynamic opens the
-  Machines instance inspector, `m` in Static opens the Machines
-  registry browse).
+  letter, different target per mode — `m` names the Machines instance
+  inspector in Dynamic and the Machines registry browse in Static).
+
+  Those letters are LABELS, not keys. They ride the registry entry's
+  `:mnem` into each tab button's `title` and are read by nothing else;
+  there is no `static/keybinding.cljs`, and the global
+  `keybinding.cljs` binds no bare letter to a tab. A tab is reached by
+  click or by the command palette's `select-static-tab` verb. See
+  spec/018 §2.5 Mnemonic mode-scoping rule + spec/007 §Trimmed pending
+  demand.
 
   Static has no standalone Views or Events sub-tabs — the information
   those would surface already lives in the source code.
-
-  Tab-mnemonic mode-scoping lives in `static/keybinding.cljs`.
 
   ## Frame isolation
 

--- a/tools/xray/test/day8/re_frame2_xray/theme/tokens_cljs_test.cljc
+++ b/tools/xray/test/day8/re_frame2_xray/theme/tokens_cljs_test.cljc
@@ -192,16 +192,22 @@
 
 ;; ---- panel domain colours (rf2-5kfxe.8) --------------------------------
 
-(deftest panel-domain-map-covers-every-l4-tab
-  (testing "rf2-5kfxe.8 — the 6 L4 tabs each get a domain colour, so
-            panels are distinguishable at a glance via the 3px left
-            border on their header. (rf2-gbz39 — the Issues tab was
-            removed per Mike's Option (c) ruling; issues surface inline
-            + event-row pink-wash + the always-on issues ribbon signal.
-            rf2-4v67l — Chrome A11y was removed in favour of Story's
-            already-shipped chrome-a11y dogfood per rf2-18t6p. rf2-ga16q
-            — Machines Canvas removed; its browse-all canvas relocated
-            to the Static Machines sub-tab.)"
+(deftest panel-domain-map-keys-are-pinned
+  (testing "rf2-5kfxe.8 — `panel-domain->token` is NOT the L4 tab
+            inventory and does not track it: rf2-ad7zx.13 superseded
+            the per-panel domain colours with a single `:accent`,
+            leaving this map a six-key vestige. Five of the ten live
+            Dynamic tabs (`focus/valid-panels`) are absent from it —
+            `:epoch`, which superseded the retired `:event` id the map
+            still names (rf2-5gl5r), plus the four L4 lenses registered
+            since (`:resources` · `:derivation-graph` · `:module-view`
+            · `:hicasso`). `panel-accent` falls back to `:accent` for
+            any key absent here, so every shipped tab renders correctly
+            regardless. This pins the keys so the vestige cannot grow
+            back into a second inventory. (rf2-gui26 — this docstring
+            read 'the 6 L4 tabs', a word-numeral roster claiming to be
+            the tab count. The map itself is rf2-9g1ea's subject: a
+            design call, not doc drift.)"
     (let [tabs #{:event :app-db :views :trace :machines
                  :routing}]
       (is (= tabs (set (keys t/panel-domain->token)))))))


### PR DESCRIPTION
Carries across the work PR #8450 had and merged PR #8440 does not, per **rf2-14axc**. #8450 is closed; this re-derives its unique repairs at current trunk rather than replaying its branch.

Every site was re-derived at `origin/main` `436d3aa084` with `git grep -nF`. All eight still held verbatim, at the line numbers rf2-14axc names, because #8440 touched none of them.

## Part A — rf2-91dfb's live finding: five sites teaching that bare letters dispatch tabs

rf2-91dfb's ORIGINAL headline (017:105 digit tab-jump keys, :127 bare-`r`) was fixed by PR #8435 and is **verified fixed at trunk** — 017:105 now reads "there are no digit or bare-letter tab-jump keys to press" and :127 calls `r` a tab label. **This PR does not touch 017 at all.** What is live is rf2-91dfb's NEWEST text: the 2026-08-17 audit of #8435, which reopened it because that PR claimed an exhaustive mnemonic sweep while these sites still taught the opposite. Mike's Option B governs — reconcile the docs to the shipped set, add no shortcuts.

| Site | Was | Now |
|---|---|---|
| `007-UX-IA.md:2032` | "the same letter **dispatches** the active mode's tab" | the letter **names** it; the Mnemonic column is a `title` LABEL, not a key |
| `007-UX-IA.md:2148` | collisions "resolved by the **mode-scoped resolver**" | labels need no resolver; says what a collision actually costs |
| `018-Event-Spine.md:144` | "routes through a **mode-aware dispatcher**" | dispatcher removed; new **LABELS, not keys** paragraph naming the shipped bare-key set |
| `static/shell.cljs:72` | "mode-scoping lives in `static/keybinding.cljs`" — **that file does not exist** | names the `title` attribute and the palette's `select-static-tab` verb |
| `panel_registry.cljc:44` | ":mnem string — single-letter **keyboard** mnemonic" | LABEL mnemonic, rendered into the tab button's `title`, read by nothing else |

The fifth was **not named by the audit** — #8450's worker found it by re-derivation, and it is the worst of the five because the registry seam's own definition teaches the false claim to every future tab author.

The 018 rule itself **stands** as the vocabulary rule it is, with the semantics it would take were the keys ever wired. Nothing is deleted that was true.

### Evidence re-derived at source before writing

- `keybinding.cljs`'s bare-key dispatcher `spine-key-id` binds Space, `l`, Shift+`G`, `j`, `k`, `,` and `s`, and nothing else (keybinding.cljs:280-310). Its `m` and `c` occurrences are inside Ctrl/Cmd+Shift chords — `mode-toggle-key?` (:154) and `xray-toggle-key?` (:126).
- `:mnem` has exactly **one** consumer in each shell: `shell.cljs:2211`/`:2223` and `static/shell.cljs:294`/`:314` both destructure it and render `(str label " (" mnem ")")` into the tab button's `:title`.
- `static/keybinding.cljs` **does not exist**: `git ls-files` returns 0 rows for it. Positive control — the sibling `static/shell.cljs` returns its path. The only `keybinding*` files under `tools/xray` are `src/day8/re_frame2_xray/keybinding.cljs` and its test.
- Every link/symbol target the new prose names resolves: 007 §Trimmed pending demand (007:1251), 007 §Mode-aware command surface (007:1576), 018 §11 Keyboard map (018:1731), `:palette/select-static-tab` (palette/events.cljs:356).

### Left standing, deliberately

`static/machines/helpers.cljc:65` says "keyboard mnemonic letter" but marks the keybindings a TODO three lines down, so it claims no shipped key. `spec/DESIGN-RATIONALE.md:298` records a past design pick and 018 §11 already logs `c` as unbound. The Settings modal's inner-tab mnemonics (007:776) **are genuinely wired keys** — `settings/view.cljs:1124` dispatches on `mnemonic->tab-id` in the dialog keydown handler — so that passage is correct as written. `000-Vision.md:154` teaches the roster via those letters and is **rf2-yecyc's** subject, filed and out of this fence.

## Part B — a FOURTH six-tab roster, in `theme/tokens_cljs_test.cljc`

Of rf2-gui26's class, and missed by **both** censuses: the count is a word-numeral inside a `testing` docstring, invisible to a `9`/`nine` grep and to a roster-tail grep alike.

`tokens_cljs_test.cljc:196` opened *"the 6 L4 tabs each get a domain colour"*. Re-derived at trunk: `panel-domain->token` is **not** the tab inventory and does not track it. rf2-ad7zx.13 superseded the per-panel domain colours with a single `:accent` (tokens.cljc:730-746), leaving a six-key vestige. **Five** of the ten live Dynamic tabs in `focus/valid-panels` are absent from it — `:epoch`, which superseded the `:event` id the map still names (rf2-5gl5r), plus the four L4 lenses registered since: `:resources` · `:derivation-graph` · `:module-view` · `:hicasso`. `panel-accent` falls back to `:accent` for any absent key (tokens.cljc:772-773), so every shipped tab renders correctly regardless — which is why nothing caught the drift.

**The count differs from the branch this is carried from.** worker/xrayfinish-v1fg3 wrote "the four tabs registered since"; re-deriving at trunk makes it FIVE absent live ids, because `:epoch` is absent too and is a distinct registered tab rather than a rename of `:event`. Confirmed independently: `scripts/check_skill_xray_tab_inventory_drift.py --verbose` prints "No Xray tab-inventory drift (10 Dynamic tabs verified)" from the runtime registry.

The deftest's NAME made the same claim its docstring did — `panel-domain-map-covers-every-l4-tab` covers six of ten — so it is renamed to **`panel-domain-map-keys-are-pinned`**, which is what the assertion actually does. `git grep -nF` finds no other reference to the old name in tracked source.

**`panel-domain->token`'s map is deliberately UNTOUCHED,** as is the `tabs` set literal the assertion pins. Completing it to ten or collapsing it post-single-accent is **rf2-9g1ea's** subject and a design call; rf2-gui26 refused it for exactly that reason and this PR honours the refusal.

## Part C — `003-Machine-Inspector.md` at :1265 and :1313

Both live at trunk at the bead's line numbers. `:1265` "Mnemonic `m` … `m` in Dynamic **opens** the instance inspector" becomes "**Label** mnemonic `m` … `m` **names** …; it is a `title`-attribute label, not a key". `:1313` now names the four letters it is about and cites its evidence: `static/machines/helpers.cljc` `sub-mode-mnemonics` (helpers.cljc:65-72) carries `t`/`s`/`i`/`c` so each pill can surface one in its `title`, and marks the keybindings that would act on them as a TODO — the same TODO is recorded at `static/machines/definition_detail.cljs:20-22`. The file's other mnemonic lines (:1247, :1304, :1311) are accurate registration metadata or accurate DOM-consistency prose and are left standing.

## Not taken, deliberately

The three shared-file differences where #8450 and #8440 both had defensible versions — `focus_cljs_test.cljs`, `021:5193`, `shell.cljs:64` — are **not** relitigated. #8440's decomposition is merged and stands; #8450's own worker recommended dropping its versions, and that recommendation is honoured.

## Census: what the search patterns could NOT have matched

The reliable census for this class is the **claim verb**, not the letter. Stated so the next sweep knows the shape of the hole:

- `git grep -nF "the same letter dispatches the active mode"` cannot match a re-wording (`"routes"`, `"selects"`, `"opens"`, `"jumps to"`), a line-wrapped variant that splits the phrase across a newline, or a passive construction. It was run alongside `-nF "mode-scoped resolver"` and `-nF "mode-aware dispatcher"` for that reason, and backstopped by a full `-icF "mnemonic"` census (80 lines across 30 files) read and classified by hand.
- `git grep -nF ":mnem"` matches `:mnemonic` as a substring, and did — the Settings-modal hits in `settings/view.cljs` are that, not the registry key. Conversely it CANNOT see a destructured `{:keys [... mnem ...]}` consumer, which is exactly how both shells read it; `-nF "mnem"` (no colon) was run to find those.
- `git grep -nF "single-letter keyboard mnemonic"` would miss any other spelling of the same definition (`"keyboard shortcut"`, `"hotkey"`, `"accelerator"`). The `-icF "mnemonic"` census is what covers that gap; a `hotkey`/`accelerator` sweep is not part of it.
- The word-numeral roster in Part B is invisible to a `9`, `nine`, `10` or `ten` search **and** to a roster-tail search, because it carries no roster and no numeral — only the digit `6` inside prose. It was found from the bead, not from a pattern.
- **None of these searches returned zero.** Each returned the site it was run for. The one search that legitimately returned zero — `git ls-files` for `static/keybinding.cljs` — was paired with the sibling positive control that returns a path.

## Quality gates

| Gate | Covers | Captured exit | Result |
|---|---|---|---|
| `python scripts/check_doc_slugs.py` | 003, 007, 018 (via `tools/*/spec`) | **0** | green (silent) |
| `python scripts/check_doc_slugs.py` **(sabotage)** | " | **1** | **RED, as designed** |
| `python scripts/check_skill_xray_tab_inventory_drift.py --verbose` | tab roster / registry | **0** | "No Xray tab-inventory drift (10 Dynamic tabs verified)" |
| `python scripts/check_skill_xray_tab_inventory_drift.py --self-test` | the gate itself | **0** | all fixtures pass |
| xray JVM: `clojure -M:test` in `tools/xray` | `tools/xray/test/**` incl. the `.cljc` | **0** | 1320 tests / 6246 assertions, 0 failures |
| xray JVM **(sabotage)** | " | **1** | **RED**, 1 failure, same 1320/6246 |
| CLJS `node-test` compile (`compile-node-test.cjs node-test`) | `../tools/xray/test` is on `:source-paths` | **0** | 1985 files, 0 warnings |
| CLJS `node-test` run (`node out/node-test.js`) | `:ns-regexp "cljs-test$"` | **0** | 11760 tests / 59621 assertions, 0 failures |
| CLJS `node-test` **(sabotage, ns-filtered)** | `day8.re-frame2-xray.theme.tokens-cljs-test` | **1** | **RED**, names the planted key |
| `scripts/test-fast-pr.sh` | the spine | see below | see below |

Every number above is the exit code **this branch's own shell captured** with `echo $? > <file>` on the same command line as the redirect — not one the harness reported. Each log and exit file is named for this worktree and for the attempt.

### Which gate covers which file, and how that was established

- **`003` / `007` / `018`** — `scripts/check_doc_slugs.py`. Established at source: `DEFAULT_ROOTS` is `("docs", "spec", "skills", "migration")`, and `_iter_markdown` additionally walks `tools/<tool>/spec` for every tool (script lines 93-99, 716-724). `tools/xray/spec` is therefore in scope. **The gate is link/anchor-only** — it cannot see a false procedural claim, so the substance of Parts A and C is a read-and-judge fix, verified by hand against the sources cited above.
- **`panel_registry.cljc` / `static/shell.cljs`** — docstring-only changes; no gate reads a docstring's prose. Both files compile in the CLJS `node-test` build (1985 files, 0 warnings) and in the xray JVM suite, which is what covers them for well-formedness. The `panel_registry.cljc` edit sits inside the ns docstring and uses the file's existing `\"…\"` escaping convention.
- **`tokens_cljs_test.cljc`** — **both** the xray JVM suite and the CLJS `node-test` lane, established by planting a fault and watching each go red (below). `implementation/shadow-cljs.edn` puts `../tools/xray/test` on the `:node-test` `:source-paths`, and `:ns-regexp "cljs-test$"` matches `…theme.tokens-cljs-test`. **rf2-14axc records that #8450's CLJS half had no green run behind it; this side was gated from scratch here, not inherited.**

### Planted-fault controls — both sides

Neither the doc gate nor the CLJS runner prints a worktree root, so the planted red is the discrimination: the fault exists only in this worktree, so a run that had wandered into a sibling's would have come back green.

**Prose side.** A broken **anchor** (not a directory link — a directory link has come back falsely green here) planted at the 018 line this PR edits:

```
1 broken anchor link(s) found:
  BROKEN ANCHOR: tools\xray\spec\018-Event-Spine.md:146 -> ./007-UX-IA.md#rf2-14axc-planted-anchor-that-does-not-exist
```

Captured exit **1**; the failure names the planted anchor, at the edited line. Restored, then re-run green (captured exit 0).

**CLJS side.** A load-bearing fault — one key swapped in the `tabs` set the assertion pins, chosen because the set-equality assertion reads it:

```
FAIL in (panel-domain-map-keys-are-pinned) (day8/re_frame2_xray/theme/tokens_cljs_test.cljc:213:11)
  actual: (not (= #{:trace :rf2-14axc-planted-key :machines :event :app-db :views}
                  #{:event :app-db :views :trace :machines :routing}))
Ran 47 tests containing 686 assertions.  1 failures, 0 errors.
```

Captured exit **1**. Three things this establishes beyond "the gate is red": the failure names the value planted; it names the **renamed** deftest, so the run read this branch's file and not trunk's; and the recompile reported "2 compiled", positive evidence the runtime observed the plant rather than serving a stale build. The namespace's counts are unchanged at 47/686 against its green control, so the plant was scoped and crashed nothing. The same plant reddened the **xray JVM** suite too (captured exit 1, 1 failure, same 1320/6246 totals), which is how that lane's coverage of the `.cljc` was established.

**Restores verified by version control's own content hash**, not a byte digest — this checkout is `core.autocrlf=true` with CRLF working files and LF blobs, where a plain digest reports a correct restore as failed.

| File | pre-plant | planted | restored | `HEAD` blob |
|---|---|---|---|---|
| `018-Event-Spine.md` | `4e99117c10` | `2b0a7e2b80` | `4e99117c10` | `4e99117c10` |
| `tokens_cljs_test.cljc` | `ba3b7cf545` | `0f9543f240` | `ba3b7cf545` | `ba3b7cf545` |

Each planted hash **differs** from its pre-plant hash, which is what rules out a patch that silently never applied; each restored hash equals both the pre-plant hash and the committed object, and `git diff --quiet HEAD -- <file>` is clean for both.

### `scripts/test-fast-pr.sh` — DID IT RUN

**Yes.** Classifier line, verbatim from the spine's own output:

```
=== fast PR spine: docs=true jvm=false node=true (classified) ===
```

The spine printed its `gate root:` as this worktree — the root-banner route, independently of the planted faults above.

**Captured exit 0**, and the spine's own last line is `PASS fast PR spine`. Its CLJS node integration tier ran 11760 tests / 59621 assertions, 0 failures — matching the standalone `node-test` run above.

Two operational notes, because both bear on how much this verdict is worth:

- **The first attempt produced NO VERDICT and is not quoted anywhere.** A runtime cap killed the shell mid-run; the log stopped at 387KB with no `.exit` file written. An absent exit code is not a pass, so the whole spine was re-run detached under a fresh attempt number and polled to completion in-turn. The verdict above is attempt 2's. Attempt 2's log carries exactly one `gate root:` line and no NUL bytes, so it is not spliced by an orphan of attempt 1.
- **The `CLJS node integration` tier did NOT fail environmentally here**, which a fresh worktree would normally produce: `implementation/node_modules` was junctioned to the primary checkout's for the duration, so the tier really ran. The junction was removed afterwards — the link, never its target — and the primary checkout's `node_modules` was re-counted afterwards and is unchanged.

### Targeted gates the spine does NOT run

`python scripts/check_fast_pr_gap.py --list` (captured exit 0) is the one path deriving which required CI checks the spine does not run. It reports **94** such checks and its own closing summary names `jvm-tools-xray` among the **40** required `test.yml` jobs with no lane in the spine at all:

```
  (B) REQUIRED JOBS WITH NO LANE IN THIS SPINE AT ALL.
      test.yml -- required context `All required checks passed` (40 jobs)
        - jvm-tools-xray: "JVM tools/xray (clojure -M:test)"
            step "Run JVM tests (tools/xray artefact)"
              $ cd tools/xray && clojure -M:test
```

and the spine itself closes with:

```
NOT RUN by this spine (2):
  - all JVM artefact suites (implementation_jvm surface unchanged; --all forces)
  - browser lanes, prod-elision/bundle-isolation/perf gates, adapter probes + smokes,
    Xray feature matrix, mcp-conformance, tool JVM suites (CI only; see TESTING.md)
```

**That is precisely the lane this PR's `.cljc` test change lives in, so it was run directly** — `cd tools/xray && clojure -M:test`, the identical command CI uses, captured exit 0, 1320/6246. Green here is not green in CI; the claim is only that this lane is not left undecided locally.

### Re-run on the final base after rebase

The branch was rebased from `436d3aa084` onto `e24b0e8946`. The trunk gained nine commits in the interval — eight beads checkpoints plus one bench change touching `implementation/core/test/re_frame/bench/{p0_run.cjs,p0_ladder_structural.test.cjs}` — none of it under `tools/xray/`. **Gates were re-run on the final base**, not carried forward:

| Gate | Captured exit | Result on final base |
|---|---|---|
| `check_doc_slugs.py` | **0** | green |
| `check_skill_xray_tab_inventory_drift.py --verbose` | **0** | 10 Dynamic tabs verified |
| xray JVM `clojure -M:test` | **0** | 1320 / 6246, 0 failures — **unchanged** |
| CLJS `node-test` compile | **0** | 1985 files, 0 warnings |
| CLJS `node-test` run | **0** | 11760 / 59621, 0 failures — **unchanged** |

Both totals are identical to the pre-rebase run, which is the expected result given what the trunk actually gained; had either moved, the move would have been the trunk's rather than this change's, and worth saying so.

### Merge-base diff, read for reverts

Read in the **three-dot** form, `git diff origin/main...HEAD`, against the merge base — `436d3aa084` before the rebase, `e24b0e8946` after it, re-read at both — not the two-dot form, which buries the branch's own hunks under everything the trunk gained.

Six files, all inside this dispatch's fence, and the commit-side check agrees exactly: the union of paths touched by `git log origin/main..HEAD` is the same six.

**Explicit attention to PR #8440.** #8440 changed 18 files under `tools/xray/`; this branch overlaps it on exactly **two** — `007-UX-IA.md` and `018-Event-Spine.md`. Nothing of #8440's is undone. This branch was **not** cherry-picked from worker/xrayfinish-v1fg3, which predates #8440 and would have reverted it; every hunk here was re-applied at trunk. Verified positively: every line #8440's `135496b6be` added to those two files was searched for at this branch's `HEAD` and **all are present** — the ten-tab bar sentence, the ten-surface tab-bar diagram, the L4-tab-jump palette list, and the I2 invariant row. The two hunks this PR contributes to those files are confined to the mnemonic paragraphs and touch no line #8440 wrote.

No other in-flight branch touches `tools/xray/` (checked by three-dot diff across every worker branch with commits ahead of `origin/main`), so this branch is the sole toucher, as rf2-14axc's sequencing requires.

### Manual verification, since no gate covers the substance

`check_doc_slugs.py` validates anchors and link targets, not claims. The prose corrections were verified by hand against the sources cited in Part A, and:

- **Markdown table column counts are unchanged** — this PR edits no table row in any of the three markdown files. The only structural change is one added paragraph in 018 §2.5; heading levels, list nesting and code fences are untouched.
- The one anchored link this PR introduces (`007-UX-IA.md#trimmed-pending-demand-rf2-f7748x--the-post-freeze-upgrade-path`) is the same anchor already used at 018:1754, and `check_doc_slugs.py` resolves it — proven by the sabotage run, which reddened on that exact anchor when it was corrupted and went green again on restore.

## Observed but NOT actioned — for triage, not for this PR

`settings/view.cljs:1098` documents the Settings modal's inner-tab mnemonics as **"(g/t/f/k/b/d)"** — six letters. `tabs` (:224-227) defines exactly four, `g` `k` `b` `d`, and `mnemonic->tab-id` (:233) derives the handler's map from it. So the docstring names two keys (`t`, `f`) the handler cannot fire. It is rf2-gui26's word-roster class in a code comment, prose-only with correct code beneath, and it is **not** among the sites rf2-14axc enumerates — reported here rather than widened into this PR. `spec/007-UX-IA.md:776` has it right at four.

Beads: **rf2-14axc** (this PR's owner), **rf2-91dfb** (Part A discharges its live finding), rf2-gui26 (Part B's class, closed), rf2-9g1ea (owns the map Part B deliberately leaves alone), rf2-yecyc (owns `000-Vision.md`, left alone).
