### PR TITLE
docs(method): rename template placeholder to WORKTREE_PARENT, and say where the guard root goes (rf2-f5cma)

### DIFF
--- a/docs/the-mayor-method/dispatch-prompt-template.md
+++ b/docs/the-mayor-method/dispatch-prompt-template.md
@@ -4,9 +4,9 @@ Copy-adaptable shapes for delegating bounded work to a background worker. Assume
 a capable agent. Placeholders:
 
 - `<MAYOR_CHECKOUT>` — the mayor's primary checkout (absolute path)
-- `<WORKTREE_ROOT>` — the directory holding worker worktrees (derive it from your
+- `<WORKTREE_PARENT>` — the directory holding worker worktrees (derive it from your
   version-control tool at dispatch time; never hardcode a path)
-- `<ASSIGNED_WORKTREE>` — this worker's worktree, a subdirectory of `<WORKTREE_ROOT>`
+- `<ASSIGNED_WORKTREE>` — this worker's worktree, a subdirectory of `<WORKTREE_PARENT>`
 - `<ITEM_ID>` — the tracker id
 
 > **Project-specifics live with the project, not here.** Your hot-zone file list,
@@ -483,6 +483,11 @@ Before EVERY edit, confirm you are in your worktree: ask version control for the
 top level of <ASSIGNED_WORKTREE> and check it prints <ASSIGNED_WORKTREE>.
 Use ABSOLUTE paths under <ASSIGNED_WORKTREE> for every edit and write. A
 start-of-session guard is NOT sufficient — verify per edit.
+
+Report that root to the mayor in your completion message, and never write it, or
+any absolute home path, into a committed file — if your deliverable is itself a
+written record, what makes the guard evidence is that it RAN and exited 0, not
+the machine-specific path it printed.
 
 After your first edit, and after writing any NEW file, confirm it landed in your
 worktree and NOT the mayor checkout. Check BOTH trees: a new ignored file leaking


### PR DESCRIPTION
Closes rf2-f5cma. Two defects in `docs/the-mayor-method/dispatch-prompt-template.md`, both verified at source before editing. A rename plus one sentence: +7/-2 in one file.

## Defect 1 — `WORKTREE_ROOT` named two different directories

The template's glossary defined `<WORKTREE_ROOT>` as *the directory holding worker worktrees*, with `<ASSIGNED_WORKTREE>` a subdirectory of it. `scripts/assert-worker-worktree.sh:166` prints `WORKTREE_ROOT=` **the worker's own worktree** (`printf 'WORKTREE_ROOT=%s\n' "$GIT_ROOT"`), and its header at `:9` documents that as `<absolute git toplevel>`. Same token, two referents, one the parent of the other.

Renamed the **template placeholder only**, to `<WORKTREE_PARENT>`. The script is untouched: its name matches what it prints, and every dispatch in flight says "report the printed `WORKTREE_ROOT`".

**The rename adopts vocabulary the script already uses.** `scripts/assert-worker-worktree.sh` calls this concept `WORKTREE_PARENT` internally (`:45`, `:129-150`), overridable via `RF2_WORKTREE_PARENT`, and `CLAUDE.md:89` says "the worktree parent as its `re-frame2-worktrees` sibling". So this is not a new coinage — it aligns the template with the two files that already name the thing.

**Blast radius, re-derived.** The placeholder occupied exactly **two** lines in the template, 7 and 9 — both changed. The bead proposed updating "the three lines that use it"; there were two. Line numbers otherwise match the bead's `:7-9`.

**One occurrence outside the fence, reported not edited.** `AGENTS.md:104` uses the bracketed `<WORKTREE_ROOT>` in a gate-invocation example — `sh <WORKTREE_ROOT>/scripts/test-fast-pr.sh` — where it means *the worker's own worktree*, i.e. the script's sense, not the template's. That is a fenced file for this bead, so it is left alone. It is also now consistent: after this rename `<WORKTREE_ROOT>` means the worker's own tree everywhere it appears (script, `AGENTS.md`, `CLAUDE.md:89`, `scripts/git-hooks/README.md:432`), and `<WORKTREE_PARENT>` means the parent.

Not touched, noted: template line 13 says "your worktree root" in running prose, meaning the parent. Renaming prose is beyond a placeholder rename and would grow the diff.

## Defect 2 — the report-it-to-the-mayor rule existed only in briefs

Every dispatch carries a rule that the guard's printed root goes to the mayor in the completion message and never into a committed file. It exists because a worker whose deliverable *was* a written record read "REPORT the printed `WORKTREE_ROOT`" as "record it", and committed a table row containing an absolute worktree path — reddening the CI gate "No hardcoded personal/home paths".

Added **one sentence** inside the pasted boundary block, beside the per-edit verification instruction, saying where the value goes rather than only that it goes. It carries the bead's positive form as a trailing clause rather than a second sentence, because that half is what makes the rule usable for exactly the worker who tripped it — a record-writing worker told only "never write it" still has evidence to produce, and is told what the evidence actually is.

## Searches, with positive controls

Both forms searched, since a pattern ignoring the brackets conflates the two things this bead is about. `git grep -nF` throughout (plain `grep` has produced a false empty on this corpus).

| Search | Scope | Result |
|---|---|---|
| `<WORKTREE_ROOT>` (bracketed) | whole repo | 3 lines / 2 files — template `:7`, `:9`; `AGENTS.md:104` |
| `WORKTREE_ROOT` (bare) | whole repo, excl. `.beads` | 11 lines / 6 files |
| `completion message` | `docs/the-mayor-method`, `.claude/commands` | **0** |
| `hardcoded` / `home path` / `personal` | same | **0** each |

The four zeros are the defect-2 premise, so each was run against a **positive control of the same command shape over the same two paths**: `worktree` returns 9 files (73 lines), and `WORKTREE BOUNDARY` returns 2 lines. The paths resolve and the searches work; the absences are real.

**What these patterns could not have matched.** A fixed-string search cannot match the rule stated in different words — "in your final handoff" (`AGENTS.md:24`) expresses a neighbouring idea and none of the four patterns reach it. `-F` is literal, so no case, spacing or hyphenation variant is covered beyond the `-i` runs. And the bracketed pattern cannot see a placeholder written without backticks or with different delimiters. The bare-form search is the superset that bounds this: 11 lines total repo-wide, all enumerated and all inspected by hand, so nothing bearing the token escaped review.

## Quality gates

`scripts/test-fast-pr.sh` **ran, in full, in the foreground**, invoked by absolute path, on the final base (`origin/main` did not move during this work — merge-base equals `origin/main`, so no rebase and no stale-green risk).

- **Captured exit code: `0`** — captured with the redirect and `echo $?` on one command line, in one shell, never piped. Quoted from my own capture, not from any harness report.
- **Classifier line: `=== fast PR spine: docs=true jvm=false node=false (classified) ===`** — as expected for a docs-only diff.
- **Tree verification, both routes available and both used.** The spine prints its root, and it named this worktree (`gate root: .../re-frame2-worktrees/naming-f5cma`). Independently, the planted fault below reds only in this tree.
- Docs tier ran the two gates that cover this file: `docs corpus anchor validator` (`scripts/check_doc_slugs.py`) and `mkdocs --strict build`.
- No gate skipped.

**Gate coverage established at source, not assumed.**

- `scripts/check_doc_slugs.py` — `DEFAULT_ROOTS = ("docs", "spec", "skills", "migration")`, and `EXCLUDE_DIR_NAMES` (`findings`, `node_modules`, `site`, `.git`, `.beads`, `ai`, `__pycache__`) does not contain `the-mayor-method`. **Covers this file.**
- `mkdocs build --strict` — `exclude_docs` in `mkdocs.yml` lists exactly six trees: `tools/playground/`, `migration/from-re-frame-v1/codemod/`, `migration/reagent-to-hicasso/codemod/`, `design/freehand/`, `design/hicasso/`, `design/retirement/`. `the-mayor-method/` is **not** among them, and `docs_dir: docs`. **Covers this file** — confirming the enumeration a peer reported, checked here independently.
- `python scripts/check_fast_pr_gap.py --list` is the one path deriving which required CI checks the spine does not run; the spine printed that map at the end of its own run.

### The planted-fault control

Planted at **line 7 — a line this change already edits** — as a broken `.md` **target** (not a directory link, which has falsely come back green for a peer):

```
- `<WORKTREE_PARENT>` — the [directory](./no-such-file-f5cma.md) holding worker worktrees ...
```

- **RED, captured exit `1`**, and the failure names exactly what was planted:
  `BROKEN TARGET: docs\the-mayor-method\dispatch-prompt-template.md:7 -> ./no-such-file-f5cma.md`
- The plant genuinely applied: content hash moved `107079ccdb…` → `6c73ea93e0…`, so this is not a silent no-op reading as a false green.
- **Discrimination:** the fault existed only in this worktree, so a run that had wandered into a sibling checkout would have returned green. The red is the proof of which tree was read.
- **Restore verified by version control's own content hash against the committed object**, not a byte digest — this checkout is `core.autocrlf=true` with CRLF working files and LF blobs, where a plain digest reports a correct restore as failed. `git hash-object` on the working file returns `107079ccdb0f728c6b5bc1d29ed79a89a8630890`, identical to `git rev-parse HEAD:docs/the-mayor-method/dispatch-prompt-template.md`; `git diff --quiet` exits 0.

### Merge-base diff, read for reverts

`git diff --stat origin/main...HEAD` (three-dot) — one file, `+7/-2`. The commit-side check agrees: `git log origin/main..HEAD` is one commit whose touched-path union is that same single file. This branch reverts nothing. The only other open PR (#8454) touches `docs/design/hicasso/product/tool-consumer-census.md` — no overlap.

By hand, since no gate validates the file's semantics: the two renamed lines are the only uses of the placeholder in the template, and the added sentence sits inside the `text` fence that is pasted verbatim into editing dispatches, so it reaches workers rather than only readers of the method.
