### PR TITLE
docs(method): widen the guard-root rule past committed files, and reap poll loops (rf2-tlnmc)

### DIFF
--- a/docs/the-mayor-method/dispatch-prompt-template.md
+++ b/docs/the-mayor-method/dispatch-prompt-template.md
@@ -485,9 +485,9 @@ Use ABSOLUTE paths under <ASSIGNED_WORKTREE> for every edit and write. A
 start-of-session guard is NOT sufficient — verify per edit.
 
 Report that root to the mayor in your completion message, and never write it, or
-any absolute home path, into a committed file — if your deliverable is itself a
-written record, what makes the guard evidence is that it RAN and exited 0, not
-the machine-specific path it printed.
+any absolute home path, into any committed file, PR body or tracker text — if
+your deliverable is itself a written record, what makes the guard evidence is
+that it RAN and exited 0, not the machine-specific path it printed.
 
 After your first edit, and after writing any NEW file, confirm it landed in your
 worktree and NOT the mayor checkout. Check BOTH trees: a new ignored file leaking
@@ -523,6 +523,8 @@ actually caught both observed collisions.
 
 If you create a link into shared dependencies, remove the LINK (never its target)
 before you report done: later cleanup follows it and deletes what it points at.
+And kill any poll loops you armed before you report done — each survivor fires
+its own completion notification after the work has landed, costing a turn apiece.
 ```
 
 A project may add a **mayor-side commit guard** — a pre-commit hook in the mayor checkout that refuses


### PR DESCRIPTION
Two rules the mayor enforces in every dispatch brief were missing from the pasted worker block in `docs/the-mayor-method/dispatch-prompt-template.md`. Both were re-verified absent at source with a positive control before editing.

**Defect 1 — the guard-root rule stopped at "committed file".** A change body and a tracker close reason are both durable and public, and neither is a committed file; the hardcoded-home-path CI gate sees neither. Widened in place to "any committed file, PR body or tracker text". The paragraph's positive form — what makes the guard evidence is that it RAN and exited 0 — is unchanged.

**Defect 2 — nothing said to reap the poll loops a worker arms.** The block sanctions detaching a long gate and polling its log and exit file in a bounded loop, but never said to kill those loops. Added as a clause on the existing cleanup sentence (remove the link, never its target), which carries the same class of obligation: a worker cleans up what it created.

Diff is +5/-3, one file. No restructuring, no restated rules, no added justification paragraphs.

## Quality gates

`scripts/test-fast-pr.sh` — RAN, in the foreground, to completion. Classifier line and captured exit code quoted in the worker's completion report.

`scripts/check_fast_pr_gap.py --list` cited as the one path deriving which required CI checks the spine does not run.

**Planted-fault control.** A broken `.md` link target (not a directory link) was planted at a line already being edited in this file; `scripts/check_doc_slugs.py` went RED naming exactly the planted target, then GREEN on restore. The restore was verified with version control's own content hash against the committed object, not a byte digest — this checkout translates line endings.

**Coverage established at source.** `DEFAULT_ROOTS` in `scripts/check_doc_slugs.py` includes `docs`, so this file is covered. `exclude_docs` in `mkdocs.yml` lists six trees and `the-mayor-method/` is not among them, so `mkdocs build --strict` covers this file too.

**Merge-base diff** read in the three-dot form for reverts before pushing: the only hunks are this change's own, reverting nothing.

Closes rf2-tlnmc.