### PR TITLE
xray: three roster/mnemonic drift repairs — 000-Vision's ten tabs, the Settings mnemonic roster, and a schema-4 warning naming a deleted namespace (rf2-yecyc, rf2-ilwcf, rf2-0ucyg)

### DIFF
--- a/tools/xray/spec/000-Vision.md
+++ b/tools/xray/spec/000-Vision.md
@@ -148,11 +148,18 @@ bar · detail panel) — see
 contract.
 
 Every open lands on the latest cascade. The Epoch panel (default tab,
-mnemonic `e`) renders the focused epoch's full computational timeline
-as a numbered vertical cascade — DISPATCH · COEFFECTS · HANDLER · FLOW ·
-FX · SUBSCRIPTIONS · VIEWS — so the canonical questions answer themselves
-on first paint; deeper investigation is one tab away (`a` App-db ·
-`v` Views · `t` Trace · `m` Machines · `r` Routing). (rf2-5gl5r retired
+label mnemonic `e`) renders the focused epoch's full computational
+timeline as a numbered vertical cascade — DISPATCH · COEFFECTS ·
+HANDLER · FLOW · FX · SUBSCRIPTIONS · VIEWS — so the canonical questions
+answer themselves on first paint; deeper investigation is one tab away,
+across the nine other shipped Dynamic tabs catalogued in
+[§The tab inventory](#the-tab-inventory) below. A tab is reached by
+clicking its L3 tab button, or by the command-palette tab-jump verb
+(`Cmd`/`Ctrl+K` → type the tab label → `Enter`): the single letters in
+that inventory are tab *label* mnemonics, rendered into each tab
+button's `title`, not keys to press — no bare-letter tab handler exists
+in `keybinding.cljs` (see [`007-UX-IA.md`](007-UX-IA.md) §Trimmed
+pending demand). (rf2-5gl5r retired
 the earlier Event/Handler tab in favour of the Epoch panel; rf2-gbz39
 removed the Issues tab per Mike's Option (c) ruling — issues surface
 inline in the Epoch panel + the L2 event-row pink-wash + the always-on

--- a/tools/xray/spec/000-Vision.md
+++ b/tools/xray/spec/000-Vision.md
@@ -159,11 +159,10 @@ clicking its L3 tab button, or by the command-palette tab-jump verb
 that inventory are tab *label* mnemonics, rendered into each tab
 button's `title`, not keys to press — no bare-letter tab handler exists
 in `keybinding.cljs` (see [`007-UX-IA.md`](007-UX-IA.md) §Trimmed
-pending demand). (rf2-5gl5r retired
-the earlier Event/Handler tab in favour of the Epoch panel; rf2-gbz39
-removed the Issues tab per Mike's Option (c) ruling — issues surface
-inline in the Epoch panel + the L2 event-row pink-wash + the always-on
-issues ribbon signal; see
+pending demand). (rf2-5gl5r retired the earlier Event/Handler tab in
+favour of the Epoch panel; rf2-gbz39 removed the Issues tab per Mike's
+Option (c) ruling — issues surface inline in the Epoch panel + the L2
+event-row pink-wash + the always-on issues ribbon signal; see
 [`021-Dynamic-Panel-Designs.md`](021-Dynamic-Panel-Designs.md) §9.1.)
 
 ## The two modes — Dynamic and Static

--- a/tools/xray/src/day8/re_frame2_xray/keybinding.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/keybinding.cljs
@@ -396,9 +396,10 @@
     ;; Space / L / j / k / G.
     ;;
     ;; rf2-ttnst — also gate on "not inside a modal". The Settings
-    ;; popup and command palette each carry bare-letter mnemonics
-    ;; (g/t/f/k/b/d, fuzzy-typing in palette, etc.) that must NOT
-    ;; also drive the spine. The modal markers are read via
+    ;; popup and command palette each carry bare letters of their own
+    ;; (the Settings inner-tab mnemonics its `tabs` vector declares,
+    ;; fuzzy-typing in the palette) that must NOT also drive the
+    ;; spine. The modal markers are read via
     ;; `target-inside-modal?` which closest-walks the event target
     ;; for `data-rf-xray-mode="settings"|"palette"`.
     :else

--- a/tools/xray/src/day8/re_frame2_xray/registry.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/registry.cljs
@@ -299,19 +299,29 @@
   registrar is current, the donor projection is not, and only a reload
   finishes the job. Loud beats silent — the alternative the audit of this
   cutover caught was stamping the process current and letting the developer
-  find out later that a second tool could not claim the slot."
+  find out later that a second tool could not claim the slot.
+
+  The message names NO view-substrate namespace, and that is deliberate
+  (rf2-0ucyg). It used to say schema 4 \"reads views through
+  re-frame.freehand.tool\", which stopped being true at schema 6 — rf2-l86mm
+  removed those three reads outright, a day before the substrate itself was
+  deleted. The load-bearing fact was never which substrate replaced the
+  donor; it is that this build has no `re-frame.ui` dependency and so cannot
+  call the donor tier's `uninstall!`. That is what it says now."
   []
   (when (exists? js/console)
     (.warn js/console
            (str "[re-frame2 Xray] Registration schema 4 needs a page reload "
                 "to finish. This process claimed the re-frame.ui ViewCell "
                 "evidence projection under schema 3 (owner "
-                ":rf.xray/viewcell-evidence). Schema 4 reads views through "
-                "re-frame.freehand.tool and has no re-frame.ui dependency, so "
-                "it cannot release that claim: the donor tier keeps Xray as "
-                "owner, keeps its sink armed, and refuses another tool the "
-                "slot until this page is RELOADED. The Xray registrations "
-                "themselves have already migrated. rf2-7gth0."))))
+                ":rf.xray/viewcell-evidence). Schema 4 moved Xray off that "
+                "donor tier, and this build carries no re-frame.ui "
+                "dependency — dropping that coordinate is the whole point of "
+                "the cutover — so it cannot call the tier's uninstall! to "
+                "release the claim: the donor tier keeps Xray as owner, keeps "
+                "its sink armed, and refuses another tool the slot until this "
+                "page is RELOADED. The Xray registrations themselves have "
+                "already migrated. rf2-7gth0."))))
 
 (defn- migrated-through-6
   "The tail clauses — schema 5's ADDITION and schema 6's REMOVAL. Both

--- a/tools/xray/src/day8/re_frame2_xray/settings/view.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/settings/view.cljs
@@ -1095,8 +1095,12 @@
   frame-aware `dispatch` (rf2-nesy9). Captures:
 
    - `Escape` → close the Settings popup (always).
-   - Bare-letter mnemonics (g/t/f/k/b/d) → switch the active inner
-     tab. Per Mike 2026-05-19 §0ter.4 the mnemonics are modal-only —
+   - Bare-letter inner-tab mnemonics → switch the active inner tab.
+     The letters are deliberately NOT enumerated here: the handler
+     below tests membership in `mnemonic->tab-id`, which is derived by
+     comprehension from the `tabs` vector, so `tabs` is the single
+     roster and this docstring cannot drift against it.
+     Per Mike 2026-05-19 §0ter.4 the mnemonics are modal-only —
      they conflict with the outer global `,` / `s` / `c` / `?` only
      in theory; the dialog stops propagation on every consumed key
      so the outer listener never sees them. Mnemonics are suppressed


### PR DESCRIPTION
Three roster-or-mnemonic drift beads in `tools/xray/`, one commit each. All three
were found by censuses that then refused to widen; each is repaired at source with
the shape a landed ruling already established, and nothing new is invented.

## rf2-yecyc — `000-Vision.md` taught a five-tab roster as keystrokes

The sentence carried **two defects pulling in opposite directions**, and fixing
only the roster would have made it worse: it would have asserted ten pressable
keys where the shipped set is zero.

Both are fixed in one edit:

- **Roster.** "one tab away (`a` App-db · `v` Views · `t` Trace · `m` Machines ·
  `r` Routing)" named five where **ten** Dynamic tabs ship. It now names the count
  and points at this file's own ten-row §The tab inventory table, rather than
  carrying a second copy of the roster that can drift against the first — which is
  the mechanism that produced the bead.
- **Keystrokes.** Tab-jump is now named as the command-palette verb, and the single
  letters as tab *label* mnemonics rendered into each tab button's `title`.

The wording follows what PR #8435 and PR #8455 landed for rf2-91dfb / rf2-14axc
(017-Test-Coverage-Matrix:105 — "switch tabs by clicking the L3 tab buttons and via
the command-palette tab-jump verb (`Cmd`/`Ctrl+K` → type the tab label → `Enter`);
there are no digit or bare-letter tab-jump keys to press"; and
`panel_registry.cljc` `:mnem` — "single-letter LABEL mnemonic … Not a key"). **No
shortcut is added and no keybinding is changed** — Mike's Option B stands.

**Roster re-derived, not taken from the bead.** From `focus.cljc` `valid-panels`
and cross-read against every `reg-l4-tab!` whose `:modes` include `:dynamic`, in
`:order`:

| order | id | label | `:mnem` |
|---|---|---|---|
| -1 | `:epoch` | Epoch | `e` |
| 1 | `:app-db` | app-db | `a` |
| 2 | `:views` | Views | `v` |
| 3 | `:trace` | Trace | `t` |
| 4 | `:machines` | Machine | `m` |
| 6 | `:routing` | Routes | `r` |
| 7 | `:resources` | Resources | `s` |
| 8 | `:derivation-graph` | Graph | `g` |
| 9 | `:module-view` | Frames | `u` |
| 10 | `:hicasso` | Hicasso | `h` |

Independent cross-check: `scripts/check_skill_xray_tab_inventory_drift.py
--verbose` reads the runtime registry itself and prints
`No Xray tab-inventory drift (10 Dynamic tabs verified).`, captured exit **0**.

## rf2-ilwcf — the Settings inner-tab mnemonic roster was six letters where four are derived

`handle-keydown`'s docstring named `g/t/f/k/b/d`. The `tabs` vector declares
general / keybindings / buffer / diff with `g/k/b/d`; `mnemonic->tab-id` builds the
lookup from that same vector by comprehension; the handler tests membership in that
map. So `t` and `f` were two keys the modal cannot fire — they are the mnemonics of
the **Telemetry** tab (removed per rf2-jh9ws) and the **Filters** tab (removed per
rf2-wknb3), left behind when the tabs went.

Rather than re-list four letters that can go stale the same way, the docstring now
points at `tabs` / `mnemonic->tab-id` as the single roster.
`spec/007-UX-IA.md` §Settings already carries the correct four-row table and the
"(g / k / b / d)" sentence — **verified at source**, so no spec change is needed.

**A second site, found by re-derivation and not named in the bead**, carrying the
identical false roster: `keybinding.cljs`' modal-gate comment said the Settings
popup and palette carry "(g/t/f/k/b/d, fuzzy-typing in palette, etc.)". It now
names the source instead of enumerating. `git grep -nF "g/t/f/k/b/d"` over
`tools/xray` found exactly these two sites before the change and finds **none**
after.

**Not touched, deliberately:** `theme/tokens.cljc`'s `panel-domain->token` map and
the set literal it derives from. Those belong to **rf2-9g1ea**, an open ruling
awaiting the operator, and nothing here required them. The file does not appear in
this diff.

## rf2-0ucyg — the schema-4 reload warning named a namespace this build has not read since rf2-l86mm

The only real bug of the three, and the only one that is **output rather than
prose**: `warn-donor-ownership-resident!` is a live `console.warn` on the
schema-migration path, reached when a process that booted schema-3 code hot-reloads
forward. It said *"Schema 4 reads views through `re-frame.freehand.tool`"*.

That stopped being true at schema 6 — **rf2-l86mm removed those three tool-door
reads outright, a day before `implementation/freehand` was deleted** — and the same
file already says so twenty lines away in its schema-6 clause. So the sentence was
false before the retirement, and today it names a namespace that ships nowhere.

**Reworded, not deleted.** The load-bearing fact was never which substrate replaced
the donor: it is that this build carries no `re-frame.ui` dependency and therefore
cannot call the donor tier's `uninstall!` to release the claim. The message now
says that, and the docstring records why it names no view substrate at all.

The warn/predicate pair is **kept**. Dropping it was the bead's other option, but
that changes `migrate-schema!`'s refusal semantics — a donor-resident process would
be stamped current — which is exactly the outcome the rf2-7gth0 audit rejected.
"Loud beats silent" stands, and that is a design call for the operator, not a
side-effect of a string fix.

`registry_cljs_test.cljs`
(`schema-4-refuses-to-stamp-a-donor-resident-process-rf2-7gth0`) asserts three
`re-find`s over this message — `reload`, `re-frame.ui`, `:rf.xray/viewcell-evidence`
— and all three tokens survive the reword. The wording is **not** pinned in
`tools/xray/spec/**`: `git grep -nF "needs a page reload"` and `git grep -nF
"cannot release that claim"` each return the source line and nothing else, and
`014-Registry-Catalogue.md` §"Schema 4 is reload-required" describes the warning
by role ("one `console.warn` names the owner id still holding the donor slot")
rather than quoting it.

## Quality gates

**Classifier line, read from the spine's own output:**
`=== fast PR spine: docs=true jvm=false node=true (classified) ===`

| Gate | Covers | Captured exit |
|---|---|---|
| `python scripts/check_doc_slugs.py` | `tools/*/spec` via `TOOLS_ROOT` in `_iter_markdown` — read at source, confirming it reaches `000-Vision.md` | **0** |
| `python scripts/check_skill_xray_tab_inventory_drift.py --verbose` | the ten-tab roster, read independently from the `reg-l4-tab!` runtime and cross-checked against `valid-panels` (check R0) | **0** |
| `cd tools/xray && clojure -M:test` (JVM, `re-frame.test-quiet.runner`) | `tools/xray/test/**` JVM artefacts — 1320 tests / 6246 assertions, 0 failures | **0** |
| `node scripts/compile-node-test.cjs node-test out/node-test.js` | compiles `tools/xray/src` + `tools/xray/test` (both are `:node-test` source paths in `implementation/shadow-cljs.edn`) | **0** |
| `node out/node-test.js` | the CLJS lane covering `registry_cljs_test.cljs` — 11760 tests / 59621 assertions, 0 failures | **0** |
| `bash scripts/test-fast-pr.sh` | **IT RAN, to completion** — `PASS fast PR spine`, zero `FAIL in` / `ERROR in` lines, node tier 11760 / 59621 | **0** |

**The spine's first attempt produced NO VERDICT and is not quoted.** It was killed
at the runtime ceiling with 432 KB of log and **no exit-code file**, which is no
verdict rather than a pass. It was re-run whole — not one step — detached with its
own attempt-numbered log and exit file, and polled to completion in the same turn.
That first, killed attempt had shown three failures, all in
`re_frame/test_quiet_shadow_node_cljs_test.cljs` — a child-process spawn returning
Windows status `3221225794` (`STATUS_DLL_INIT_FAILED`), i.e. spawn pressure under a
saturated machine, in tests that spawn subprocesses and touch nothing in
`tools/xray`. They did **not** recur on the completed run, and two direct runs of
the same CLJS build were green either side of them.

`scripts/check_fast_pr_gap.py --list` is the one path deriving what the spine does
not decide: **94 required checks**, none of them decided locally. The spine's own
PASS line names two families it did not run — all JVM artefact suites
(`implementation_jvm` surface unchanged, correct: this diff touches only `tools/`),
and the browser lanes / prod-elision / bundle-isolation / perf gates / adapter
probes and smokes / Xray feature matrix / mcp-conformance / **tool JVM suites**.
That last is why the xray JVM suite was run directly above rather than relied on
through the spine.

The CLJS lane was split into its two phases and each run in the foreground, rather
than detached as one compound command; both halves finished well inside the
runtime ceiling.

**One ordering note, stated rather than glossed.** The final commit is a
whitespace-only reflow of one paragraph, made about a minute after the spine's docs
tier had run. The spine's code tiers (clj-kondo over `tools/xray`, errors 0; the
node tier) both ran *after* it. For the docs side: `mkdocs.yml` stages `spec/` and
`migration/` into `docs/` and **never `tools/`**, so the MkDocs build cannot see
`tools/xray/spec/000-Vision.md` at all — `check_doc_slugs.py` is the gate that
covers it, and it was re-run directly on the final tree at captured exit **0**.

### Planted-fault controls

**Doc gate — both arms, planted at lines this PR edits.** A broken same-file anchor
(`#the-tab-inventory-PLANTEDFAULT`) and a broken target
(`007-UX-IA-PLANTEDFAULT.md`). `check_doc_slugs.py` went **RED, captured exit 1**,
naming both:

```
BROKEN TARGET: tools\xray\spec\000-Vision.md:161 -> 007-UX-IA-PLANTEDFAULT.md
BROKEN ANCHOR: tools\xray\spec\000-Vision.md:156 -> #the-tab-inventory-PLANTEDFAULT
```

The gate prints no root banner (its green output is zero bytes), so the red **is**
the tree-verification: the fault existed only in this branch's checkout, and a run
that had wandered into a sibling would have come back green. Restore verified with
version control's own content hash against the committed object — this checkout is
`core.autocrlf=true`, so a plain byte digest would misreport — `98e2225…` before
the plant and `98e2225…` after, `git diff --quiet` clean, gate green again at
captured exit 0.

**CLJS suite — a load-bearing plant.** The owner id inside the warning string was
changed to `:rf.xray/PLANTED-FAULT`. The recompile reported **218 files compiled**,
which is the positive evidence that the runtime observed the plant rather than
serving a stale compile. The suite went **RED, captured exit 1**, with exactly one
failure, at the assertion that reads the runtime message:

```
FAIL in (schema-4-refuses-to-stamp-a-donor-resident-process-rf2-7gth0)
      (day8/re_frame2_xray/registry_cljs_test.cljs:1360:17)
expected: (re-find #":rf\.xray\/viewcell-evidence" msg)
```

Test and assertion **totals were identical to the control run** (11760 / 59621), so
the plant was scoped and aborted no namespace. Restored, re-hashed to the pre-plant
blob, recompiled and re-run: 0 failures, captured exit 0.

Every exit code quoted here was captured by the gate's own shell on the same command
line as the redirect, never read back from a harness report.

### Merge-base diff, read for reverts

`git diff --name-status origin/main...HEAD` (three-dot) shows **four files, all in
this branch's own surface**, and `git log origin/main..HEAD` plus the union of paths
those four commits touch agrees exactly. **Nothing from PR #8440 or PR #8455 is
undone**: `5f9fee9451` (#8455, "003's Static Machines mnemonics are labels, not
keys") is this branch's *base*, so its content is inherited rather than rewritten,
and this PR follows its wording rather than competing with it. Rebased once onto a
trunk that had moved by ten commits; `git log <base>..origin/main -- <the four
files>` returns **empty**, so none of them touched this surface, and the gates above
were re-run on the final base.

### Verified by hand, and what the searches could not have matched

`tools/xray/spec/**` has no gate over table rendering or column counts, so the
000-Vision edit was read by hand: the sentence sits in running prose, adds no table
row, and the ten-row §The tab inventory table it now points at is unchanged at 6
columns × 10 rows plus its header.

Fixed-string searches were used throughout (`git grep -nF`), each run once against
something it should find. What they could **not** have matched, stated rather than
implied:

- Case. `freehand` and `Freehand` were searched separately; the capitalised form has
  many legitimate historical hits this PR deliberately leaves alone.
- Different spellings of the six-letter roster. `-F "g/t/f/k/b/d"` cannot see
  `g, t, f, k, b, d` or `g t f k b d`; a regex sweep for those separator variants
  over `tools/xray` returned nothing, against a positive control confirming the
  tree is searchable.
- `git ls-files` and `git grep` see **tracked files only** — untracked or ignored
  copies are invisible to every count here.

### Left standing on purpose, and why

- **`registry.cljs`'s schema-4 version-history entry** still names
  `re-frame.freehand.tool`. That is deliberate and the file says so: "Its entry
  stays as a record of what schema 4 WAS; a version history that rewrote itself when
  a later version undid it would stop being a history."
- **`preload.cljs`** names the same namespace in the past tense, describing two
  predecessors that are gone. Correct as written.
- **`test_support.cljs`** carries a present-tense docstring claim about
  `re-frame.freehand.tool` and `re-frame.freehand.occurrences/clear!`. It is a
  docstring, squarely inside **rf2-0yp7w.9**'s open prose sweep — which is the
  distinction rf2-0ucyg was filed to make, its own site being a runtime string that
  no such sweep would reach. Reported, not widened into.
- **`theme/tokens.cljc`** — rf2-9g1ea, open operator ruling. Untouched, and absent
  from this diff.
- **Two further stale rosters in `000-Vision.md` itself**, both outside rf2-yecyc's
  site and both a third shape no census here was looking for: a six-row tab table at
  §One event at a time whose first row is the **retired** Event tab under the `e`
  mnemonic that now belongs to Epoch, and a Popovers table with a **Key** column
  (`r`, `f`) for keys `spine-key-id` does not bind, cross-referencing
  `018-Event-Spine.md` §10, which is titled "Reserved". Filed as **rf2-9foby** rather
  than swept in: the popover half spans four files and needs the same adjudication
  rf2-91dfb gave the tab mnemonics, and the table half is a design call about whether
  an illustrative table should carry a roster at all.
