### PR TITLE
bench: the allocation window can drive BOTH writes in one process — a PAIRED mode (rf2-irxrw)

### DIFF
--- a/implementation/core/test/re_frame/bench/p0_ladder_structural.test.cjs
+++ b/implementation/core/test/re_frame/bench/p0_ladder_structural.test.cjs
@@ -58,6 +58,11 @@ const {
   ALLOC_PRIME_WRITES,
   ALLOC_WINDOW_WRITES,
   ALLOC_WRITE_SPECS,
+  // The paired selection (rf2-irxrw) — the table, the key and the provenance
+  // adjudicator, so the pins DRIVE the shipped code rather than restate it.
+  ALLOC_WRITE_SELECTIONS,
+  allocWindowKey,
+  allocWriteProvenance,
   ALLOC_PLAN_SHAPES,
   allocPlanArms,
   summariseAlloc,
@@ -840,7 +845,12 @@ test('the prime is CONFIGURED IN ONE PLACE and the divisor is not it', () => {
     assert.match(p, /ALLOC_WINDOW_WRITES/, `sized for the window it drives: ${p}`);
     assert.match(p, /ALLOC_SITES/, `and the stride is stated at the same call: ${p}`);
   }
-  has(/\[ALLOC_WINDOW_WRITES, drain, ALLOC_WRITE_SPEC\.kind\]/, 'the window drives the full count');
+  // `leg.spec.kind` since rf2-irxrw, where the run's write became a LIST and
+  // the arm pass runs once per member. This pin is about the COUNT — the
+  // window drives `ALLOC_WINDOW_WRITES`, the measured writes plus the prime —
+  // and the paired switch does not touch that half; what moved is only where
+  // the kind beside it is read from.
+  has(/\[ALLOC_WINDOW_WRITES, drain, leg\.spec\.kind\]/, 'the window drives the full count');
   // NO DIAL. The prime decides what a window MEANS, so it is a constant for
   // `ALLOC_LEG_TOLERANCE`'s reason: a knob on it is a knob on the certificate.
   lacks(/P0_ALLOC_PRIME|P0_ALLOC_WINDOW_WRITES/, 'the prime has no env dial on it');
@@ -2143,6 +2153,82 @@ test('THE WRITE SELECTOR — `page` is the DEFAULT and `all` is a NAMED switch',
   has(/unknown P0_ALLOC_WRITE/, 'and the preflight refuses it BY NAME, before a browser');
 });
 
+test('THE PAIRED SELECTION — `paired` names BOTH writes and is not a third one', () => {
+  // The two writes are still two (the pin above holds `ALLOC_WRITE_SPECS` at
+  // exactly `page` and `all`). What `paired` adds is a SELECTION over them,
+  // which is why it lives in its own table: a third entry in the spec table
+  // would be a third write, and there is no third event.
+  assert.deepStrictEqual(
+    Object.keys(ALLOC_WRITE_SELECTIONS),
+    ['page', 'all', 'paired'],
+    'three selections over two writes'
+  );
+  assert.deepStrictEqual(ALLOC_WRITE_SELECTIONS.page, ['page'], 'the default names one');
+  assert.deepStrictEqual(ALLOC_WRITE_SELECTIONS.all, ['all'], "and V1's control names one");
+  assert.deepStrictEqual(
+    ALLOC_WRITE_SELECTIONS.paired,
+    ['page', 'all'],
+    'and `paired` names both, in the order a round drives them on even parity'
+  );
+  for (const keys of Object.values(ALLOC_WRITE_SELECTIONS)) {
+    for (const k of keys) {
+      assert.ok(ALLOC_WRITE_SPECS[k], `every selected key is one of the two writes: ${k}`);
+    }
+  }
+
+  // THE ENV ROUTE, in a fresh process, exactly as `all` is pinned above.
+  assert.deepStrictEqual(
+    constUnderEnv('ALLOC_WRITE_LEGS', { P0_ALLOC_WRITE: '' }),
+    [{ selector: 'page', spec: ALLOC_WRITE_SPECS.page }],
+    'an unset switch drives ONE leg, and it is the page write'
+  );
+  assert.strictEqual(constUnderEnv('ALLOC_WRITE_PAIRED', { P0_ALLOC_WRITE: '' }), false);
+  assert.deepStrictEqual(
+    constUnderEnv('ALLOC_WRITE_LEGS', { P0_ALLOC_WRITE: 'all' }),
+    [{ selector: 'all', spec: ALLOC_WRITE_SPECS.all }],
+    'and so does `all` — one process, one write, which is what rf2-irxrw is about'
+  );
+  assert.strictEqual(constUnderEnv('ALLOC_WRITE_PAIRED', { P0_ALLOC_WRITE: 'all' }), false);
+  assert.deepStrictEqual(
+    constUnderEnv('ALLOC_WRITE_LEGS', { P0_ALLOC_WRITE: 'paired' }),
+    [
+      { selector: 'page', spec: ALLOC_WRITE_SPECS.page },
+      { selector: 'all', spec: ALLOC_WRITE_SPECS.all },
+    ],
+    'and `paired` resolves BOTH in one process — the thing the instrument could not do'
+  );
+  assert.strictEqual(constUnderEnv('ALLOC_WRITE_PAIRED', { P0_ALLOC_WRITE: 'paired' }), true);
+
+  // THERE IS NO ONE SPEC UNDER `paired`, and the record does not pretend
+  // there is. `ALLOC_WRITE_SPEC` answers "this run drives exactly one write,
+  // and it is this one", which has no answer here — so it is `undefined`, and
+  // the legs are what tell a valid selection from a mistyped one.
+  assert.strictEqual(constUnderEnv('ALLOC_WRITE_SPEC', { P0_ALLOC_WRITE: 'paired' }), null);
+  assert.strictEqual(constUnderEnv('ALLOC_WRITE_LEGS', { P0_ALLOC_WRITE: 'pged' }), null);
+  assert.strictEqual(constUnderEnv('ALLOC_WRITE_PAIRED', { P0_ALLOC_WRITE: 'pged' }), false);
+  has(
+    /if \(ALLOC_WRITE_LEGS === undefined\) \{/,
+    'the preflight refuses on the LEGS, so `paired` is not mistaken for a typo'
+  );
+  has(
+    /one of \$\{Object\.keys\(ALLOC_WRITE_SELECTIONS\)\.join\(' \| '\)\}/,
+    'and the refusal names every selection an operator may ask for'
+  );
+
+  // THE KEY. Off `paired` it is the identity, so a published run's record is
+  // keyed exactly as it always was; on it, each leg is its own window.
+  assert.strictEqual(allocWindowKey('reagent-subs|grid/floor', 'page', false), 'reagent-subs|grid/floor');
+  assert.strictEqual(allocWindowKey('reagent-subs|grid/floor', 'all', false), 'reagent-subs|grid/floor');
+  assert.strictEqual(
+    allocWindowKey('reagent-subs|lad/hicasso#R3', 'page', true),
+    'reagent-subs|lad/hicasso#R3@page'
+  );
+  assert.strictEqual(
+    allocWindowKey('reagent-subs|lad/hicasso#R3', 'all', true),
+    'reagent-subs|lad/hicasso#R3@all'
+  );
+});
+
 test('THE PLAN SELECTOR — `full` is the DEFAULT; the others SUBTRACT arms', () => {
   assert.deepStrictEqual(Object.keys(ALLOC_PLAN_SHAPES), ['full', 'floor', 'controls']);
   assert.deepStrictEqual(ALLOC_PLAN_SHAPES.full, { arms: true, rungs: true, fits: true });
@@ -2245,6 +2331,12 @@ function allocSummaryFor(planName, arms = {}, extra = {}) {
     warmups: 3,
     rounds: 2,
     writeSelector: 'page',
+    // THE LEGS AS THE DRIVER RECORDS THEM (rf2-irxrw). One member off
+    // `paired`, and `extra` is how a paired fixture states two — the same
+    // overlay the by-site mode is driven through, for the same reason: the
+    // parameter is what the PLAN decides, and this is what a SELECTION does.
+    writeLegs: ['page'],
+    writePaired: false,
     write: ':p0/write-page — a synthetic row, measured against nothing',
     plan: { name: planName, ...ALLOC_PLAN_SHAPES[planName] },
     controlDoubles: { d1: 1000, d2: 400 },
@@ -2275,75 +2367,113 @@ function allocSummaryFor(planName, arms = {}, extra = {}) {
   return { row, out: lines.join('\n') };
 }
 
-const FLOOR_ARMS = () =>
+// WHAT EVERY RECORDED WINDOW CARRIES ABOUT ITS OWN WRITE (rf2-irxrw), stated
+// once so the fixtures below cannot drift apart from one another. `pairKey` is
+// the arm key the legs of a pair share; off `paired` it is the key the window
+// is stored at, which is the same statement with one leg.
+const winWrite = (pairKey, selector) => ({
+  writeSelector: selector,
+  write: `${ALLOC_WRITE_SPECS[selector].event} — a synthetic window, measured against nothing`,
+  pairKey,
+});
+
+// `selectors` DEFAULTS TO THE PUBLISHED ONE, so every existing call site is
+// the record it always built plus the provenance the driver now records.
+const FLOOR_ARMS = (selectors = ['page'], paired = selectors.length > 1) =>
   Object.fromEntries(
-    ['reagent-subs', 'uix-subs'].map((seg) => [
-      `${seg}|grid/floor`,
-      {
-        segment: seg,
-        arm: 'grid/floor',
-        rung: 'floor',
-        reads: 0,
-        boundaries: 24,
-        ...allocSteps(stream([5000, 5000, 5000, 5000])),
-        // The bead's own excess, 6,788 B, riding on a synthetic floor window.
-        primeLegs: [11788],
-        primeExcess: 6788,
-        perWrite: 5000,
-        perBoundaryPerWrite: 208,
-      },
-    ])
+    ['reagent-subs', 'uix-subs'].flatMap((seg) =>
+      selectors.map((sel) => {
+        const pairKey = `${seg}|grid/floor`;
+        return [
+          allocWindowKey(pairKey, sel, paired),
+          {
+            segment: seg,
+            arm: 'grid/floor',
+            rung: 'floor',
+            reads: 0,
+            boundaries: 24,
+            ...winWrite(pairKey, sel),
+            ...allocSteps(stream([5000, 5000, 5000, 5000])),
+            // The bead's own excess, 6,788 B, riding on a synthetic floor window.
+            primeLegs: [11788],
+            primeExcess: 6788,
+            perWrite: 5000,
+            perBoundaryPerWrite: 208,
+          },
+        ];
+      })
+    )
   );
 
 // EVERY ARM THE FULL PLAN MOUNTS, keyed exactly as the driver keys them and
 // built FROM `ladderPlan` rather than spelled out — so a rung added to the
 // ladder arrives here too, and the full-plan control below cannot quietly go
 // stale while still passing.
-const FULL_ARMS = () =>
+const FULL_ARMS = (selectors = ['page'], paired = selectors.length > 1) =>
   Object.fromEntries(
     ladderPlan({ list: 300, grid: 6 }, 4).flatMap(({ segment, arms }) =>
-      arms.map((a) => [
-        a.key,
-        {
-          segment,
-          arm: a.arm,
-          rung: a.rung,
-          reads: a.reads || 0,
-          boundaries: 24,
-          ...allocSteps(stream([5000, 5000, 5000, 5000])),
-          primeLegs: [11788],
-          primeExcess: 6788,
-          perWrite: 5000,
-          perBoundaryPerWrite: 208,
-        },
-      ])
+      arms.flatMap((a) =>
+        selectors.map((sel) => [
+          allocWindowKey(a.key, sel, paired),
+          {
+            segment,
+            arm: a.arm,
+            rung: a.rung,
+            reads: a.reads || 0,
+            boundaries: 24,
+            ...winWrite(a.key, sel),
+            ...allocSteps(stream([5000, 5000, 5000, 5000])),
+            primeLegs: [11788],
+            primeExcess: 6788,
+            perWrite: 5000,
+            perBoundaryPerWrite: 208,
+          },
+        ])
+      )
     )
   );
+
+// AND THE OVERLAY THAT MAKES A ROW A PAIRED ONE (rf2-irxrw), so a paired
+// fixture states its selection in one place rather than three.
+const PAIRED_ROW = {
+  writeSelector: 'paired',
+  writeLegs: ['page', 'all'],
+  writePaired: true,
+  write:
+    ':p0/write-page — a synthetic row, measured against nothing  AND  ' +
+    ':p0/write-all — a synthetic row, measured against nothing',
+};
 
 // The fits a full run carries, one per (segment, substrate), derived from the
 // same plan for the same reason. Only the full plan reaches
 // `summariseAllocFits`; the narrow ones print the NO FITTED LINE block.
-const FULL_FITS = () => {
+const FULL_FITS = (selectors = ['page'], paired = selectors.length > 1) => {
   const mean = {};
   const perRound = {};
   for (const { segment, arms } of ladderPlan({ list: 300, grid: 6 }, 4)) {
     for (const sub of [...new Set(arms.map((a) => a.substrate).filter(Boolean))]) {
-      mean[`${segment}|${sub}`] = {
-        slope: 12,
-        intercept: 100,
-        shell: 90,
-        firstRead: 110,
-        r2: 0.999,
-        linear: true,
-        why: 'a synthetic fit, measured against nothing',
-      };
-      perRound[`${segment}|${sub}`] = [1, 2].map(() => ({
-        slope: 12,
-        intercept: 100,
-        shell: 90,
-        firstRead: 110,
-        linear: true,
-      }));
+      // ONE FIT PER WRITE UNDER `paired` (rf2-irxrw), keyed by the same
+      // function the windows are — a line through both writes would be a
+      // slope over a mixture.
+      for (const sel of selectors) {
+        const id = allocWindowKey(`${segment}|${sub}`, sel, paired);
+        mean[id] = {
+          slope: 12,
+          intercept: 100,
+          shell: 90,
+          firstRead: 110,
+          r2: 0.999,
+          linear: true,
+          why: 'a synthetic fit, measured against nothing',
+        };
+        perRound[id] = [1, 2].map(() => ({
+          slope: 12,
+          intercept: 100,
+          shell: 90,
+          firstRead: 110,
+          linear: true,
+        }));
+      }
     }
   }
   return { perRound, mean };
@@ -2479,14 +2609,46 @@ test('the DRIVER honours both switches — the write, the plan, and the record',
   // `ALLOC_WINDOW_WRITES` at both, since rf2-oiy1: the window drives the
   // measured writes PLUS the prime, and a warm-up shorter than the window is
   // the very defect the warm-up pass exists to avoid.
+  //
+  // `leg.spec.kind` SINCE rf2-irxrw, and the count is why it still bites. The
+  // run's write is a LIST now and the arm pass runs once per member, so both
+  // call sites have to take THIS PASS's leg — a warm-up left on the run's
+  // first leg while the window took the pass's would warm the page under one
+  // write and measure it under the other, which is the same defect the pin
+  // was written for with the two writes one pass apart instead of one process
+  // apart.
   assert.strictEqual(
     (SRC.match(
-      /window\.P0H\.allocWindow\(n, k, d\),\s*\[ALLOC_WINDOW_WRITES, drain, ALLOC_WRITE_SPEC\.kind\]/g
+      /window\.P0H\.allocWindow\(n, k, d\),\s*\[ALLOC_WINDOW_WRITES, drain, leg\.spec\.kind\]/g
     ) || []).length,
     2,
     'the warm-up AND the measured window both drive the SELECTED write'
   );
   lacks(/window\.P0H\.allocWindow\(n, 'write', d\)/, 'and neither is pinned to a literal kind');
+  lacks(
+    /\[ALLOC_WINDOW_WRITES, drain, ALLOC_WRITE_SPEC\.kind\]/,
+    'and neither is pinned to the RUN\'s write, which under `paired` is not a single one'
+  );
+  // THE PASS ITSELF (rf2-irxrw), so the pins over the record cannot drift off
+  // the loop that fills it. One pass per (segment, leg); the leg order flips
+  // on the same parity the segment order does, or the write would be
+  // confounded with within-round position — which is the defect this switch
+  // exists to remove; and the pass re-seeds, because `:p0/write-all` leaves
+  // `:cells` at `cells-n` and a page leg following it on an unseeded frame
+  // would rebuild 300 cells and BE the bulk write, reading back correctly and
+  // saying nothing.
+  has(
+    /const legs = round % 2 === 0 \? ALLOC_WRITE_LEGS : \[\.\.\.ALLOC_WRITE_LEGS\]\.reverse\(\);/,
+    'the leg order alternates on round parity'
+  );
+  has(
+    /const passes = segs\.flatMap\(\(\{ segment, arms \}\) =>\s*legs\.map\(\(leg\) => \(\{ segment, arms, leg \}\)\)\s*\);/,
+    'and every segment is passed once per leg'
+  );
+  has(
+    /for \(const \{ segment, arms, leg \} of passes\) \{[\s\S]{0,2000}?window\.P0H\.prepare\(s, gw\), \[segment, B\]\);/,
+    're-seeding the grid at B as the first thing every pass does'
+  );
   has(
     /const plan = allocPlanArms\(ladderPlan\(perRoot, ROOTS\), ALLOC_PLAN_SHAPE\);/,
     'and the plan is the shipped ladder plan narrowed by the shape'
@@ -2499,15 +2661,193 @@ test('the DRIVER honours both switches — the write, the plan, and the record',
   // hard-coded string satisfied only because there was one write to name and
   // would have gone on naming it after the selector landed.
   has(/writeSelector: ALLOC_WRITE,/, 'the record carries the switch');
+  // AMENDED, NOT DELETED (rf2-irxrw), and this is the second time this pin has
+  // moved rather than gone — rf2-gxrr moved its sibling in `p0_heap.cljs` from
+  // ABSENCE to REACHABILITY for the same reason, and called that the delicate
+  // half of the work. Its CONTENT is criterion 6's separation: "a reader of
+  // any row can tell FROM THE ROW which write produced it". Its SHAPE was a
+  // single interpolated spec, and that shape was only ever adequate because a
+  // process drove one write — the row's one answer was every window's answer.
+  // Under `paired` a row carries both, so the row-level string is a list and
+  // the claim moves to WINDOW granularity, where the pin below adjudicates it
+  // against a record rather than against this source. Both stay: the row still
+  // names what it drove, and now every window does too, which is strictly more
+  // than absence-of-a-literal could ask.
   has(
-    /write: `\$\{ALLOC_WRITE_SPEC\.event\} — \$\{ALLOC_WRITE_SPEC\.note\}`,/,
-    'and the write it actually drove'
+    /write: ALLOC_WRITE_LEGS\.map\(\(l\) => `\$\{l\.spec\.event\} — \$\{l\.spec\.note\}`\)\.join\('  AND  '\),/,
+    'and the write — or writes — it actually drove'
+  );
+  has(/writeLegs: ALLOC_WRITE_LEGS\.map\(\(l\) => l\.selector\),/, 'as a list, in the driven order');
+  has(/writePaired: ALLOC_WRITE_PAIRED,/, 'and the row says whether it is a pair');
+  // AND EVERY WINDOW NAMES ITS OWN, which is where criterion 6 now lives.
+  has(/writeSelector: leg\.selector,/, 'the window carries the write it drove');
+  has(
+    /write: `\$\{leg\.spec\.event\} — \$\{leg\.spec\.note\}`,/,
+    'and names the event, not merely the switch'
+  );
+  has(/pairKey: entry\.key,/, 'and the arm key its legs share, so a pair is a field not a parse');
+  has(
+    /armsOut\[allocWindowKey\(entry\.key, leg\.selector\)\] = \{/,
+    'and it is keyed by the write it drove — the identity off `paired`'
   );
   has(/plan: \{ name: ALLOC_PLAN, \.\.\.ALLOC_PLAN_SHAPE \},/, 'and the plan it ran');
   lacks(
     /write: ':p0\/write-page — the grid is rebuilt at the width the mounted page reads',/,
     'the record may no longer hard-code one write for every run'
   );
+});
+
+// --- THE AMENDED PIN, DRIVEN OVER RECORDS (rf2-irxrw) ----------------------
+//
+// The pins above read the driver's source; this one reads what the driver
+// PRODUCES, because "each recorded window names its own kind" is a property of
+// a record and a source match cannot make it without restating the assignment.
+// `allocWriteProvenance` is the shipped adjudicator and is pure, so both the
+// paired shape and the shape that preceded it are driven through it here.
+
+test('a PAIRED record names every window\'s write and every pair is WHOLE', () => {
+  const arms = FULL_ARMS(['page', 'all']);
+  const { row } = allocSummaryFor('full', arms, {
+    ...PAIRED_ROW,
+    allocFits: FULL_FITS(['page', 'all']),
+  });
+  // NOT VACUOUS: a paired full plan records TWICE the windows a single-write
+  // one does, and both legs of every arm are present under their own key.
+  assert.strictEqual(Object.keys(arms).length, 44, '22 arms x 2 writes');
+  assert.ok(arms['reagent-subs|grid/floor@page'], 'the FLOOR is paired too — that is the point');
+  assert.ok(arms['reagent-subs|grid/floor@all'], 'under both writes, in the same round');
+  assert.ok(arms['uix-subs|lad/hicasso#R20@page'] && arms['uix-subs|lad/hicasso#R20@all']);
+
+  const prov = allocWriteProvenance(row);
+  assert.deepStrictEqual(prov.unnamed, [], 'every window names its own write');
+  assert.deepStrictEqual(prov.incomplete, [], 'and every pair carries both legs');
+  assert.strictEqual(prov.ok, true);
+  assert.strictEqual(prov.windows, 88, '44 windows x 2 rounds');
+  assert.strictEqual(prov.pairs, 44, '22 pairs x 2 rounds');
+  // The record's own copy, so a reader of the JSON is not left to recompute it.
+  assert.strictEqual(row.writeProvenance.ok, true);
+});
+
+test('THE SAME PIN REFUSES an UNPAIRED-SHAPED record — the windows name nothing', () => {
+  // The shape every allocation record had before this bead: the row named the
+  // write and the windows did not, which was adequate while a process drove
+  // one write and is exactly what a paired record may not be.
+  const arms = Object.fromEntries(
+    Object.entries(FULL_ARMS(['page', 'all'])).map(([k, a]) => {
+      const { writeSelector, write, pairKey, ...rest } = a;
+      return [k, rest];
+    })
+  );
+  const { row, out } = allocSummaryFor('full', arms, {
+    ...PAIRED_ROW,
+    allocFits: FULL_FITS(['page', 'all']),
+  });
+  const prov = allocWriteProvenance(row);
+  assert.strictEqual(prov.ok, false, 'the pin must REFUSE the shape it was amended away from');
+  assert.strictEqual(prov.unnamed.length, 88, 'every window, on every round');
+  assert.match(prov.unnamed[0], /names no write$/, 'and the reason NAMES the defect');
+  assert.match(prov.unnamed[0], /^round 1 /, 'per round and per key, not one undifferentiated count');
+  // And the summary says so where an operator would see it.
+  assert.match(out, /WRITE UNNAMED round 1 /);
+  assert.match(out, /PROVENANCE: 88 recorded windows across 0 pairs — 88 unnamed/);
+});
+
+test('and it refuses a HALF PAIR, which is well-formed window by window', () => {
+  // The failure the first half cannot see: every window names its write, and
+  // one leg of a pair is simply missing. An estimator differencing this would
+  // be back to comparing unmatched populations without anything saying so.
+  const arms = FULL_ARMS(['page', 'all']);
+  delete arms['reagent-subs|lad/hicasso#R7@all'];
+  const row = {
+    ...PAIRED_ROW,
+    perRound: [1, 2].map((round) => ({ round, arms })),
+  };
+  const prov = allocWriteProvenance(row);
+  assert.deepStrictEqual(prov.unnamed, [], 'nothing is unnamed — that is what makes it dangerous');
+  assert.strictEqual(prov.incomplete.length, 2, 'one incomplete pair, on each of two rounds');
+  assert.match(prov.incomplete[0], /reagent-subs\|lad\/hicasso#R7: page — this run drives page \+ all/);
+  assert.strictEqual(prov.ok, false);
+});
+
+test('and a window naming a write this run did NOT drive is refused too', () => {
+  // A record whose windows name a write the row never selected is not a
+  // provenance record; it is two runs' windows in one file, which is the
+  // reconstruction rf2-irxrw exists to make unnecessary.
+  const arms = FULL_ARMS(['page']);
+  arms['reagent-subs|grid/floor'] = {
+    ...arms['reagent-subs|grid/floor'],
+    writeSelector: 'all',
+    write: ':p0/write-all — from some other run',
+  };
+  const prov = allocWriteProvenance({
+    writeSelector: 'page',
+    writeLegs: ['page'],
+    writePaired: false,
+    perRound: [{ round: 1, arms }],
+  });
+  assert.strictEqual(prov.ok, false);
+  assert.strictEqual(prov.unnamed.length, 1);
+  assert.match(prov.unnamed[0], /names `all`, which is not a write this run drove/);
+  // And a window whose named kind and recorded EVENT disagree, which a
+  // selector-only check would admit.
+  const crossed = FULL_ARMS(['page']);
+  crossed['uix-subs|grid/floor'] = {
+    ...crossed['uix-subs|grid/floor'],
+    write: ':p0/write-all — but the selector says page',
+  };
+  const p2 = allocWriteProvenance({
+    writeSelector: 'page',
+    writeLegs: ['page'],
+    writePaired: false,
+    perRound: [{ round: 1, arms: crossed }],
+  });
+  assert.strictEqual(p2.ok, false);
+  assert.match(p2.unnamed[0], /names `page` but records `:p0\/write-all/);
+});
+
+test('THE PAIRED SUMMARY runs, prints a table per write, and claims no single one', () => {
+  const { out } = allocSummaryFor('full', FULL_ARMS(['page', 'all']), {
+    ...PAIRED_ROW,
+    allocFits: FULL_FITS(['page', 'all']),
+  });
+  assert.match(out, /THE TWO WRITES ARE DRIVEN AS A MATCHED PAIR \(rf2-irxrw\)/);
+  assert.match(out, /EVERY ARM IS MEASURED UNDER BOTH — the FLOOR included/);
+  assert.match(out, /the leg ORDER alternates on round parity/);
+  assert.match(out, /under `:p0\/write-page` \(P0_ALLOC_WRITE=paired\)/, 'a table per write');
+  assert.match(out, /under `:p0\/write-all` \(P0_ALLOC_WRITE=paired\)/);
+  assert.match(out, /PROVENANCE: 88 recorded windows across 44 pairs — every window names its own/);
+  // AND IT MAKES NEITHER SINGLE-WRITE CLAIM. Both are FALSE of a paired run:
+  // the first says the grid was rebuilt at B, the second calls the row V1's
+  // F_old control and names the switch that selected it.
+  assert.doesNotMatch(out, /THE WRITE IS `/, 'there is no ONE write to name');
+  assert.doesNotMatch(out, /Selected by P0_ALLOC_WRITE=all/);
+  assert.doesNotMatch(out, /It rebuilds the grid at 24 cells/);
+  assert.doesNotMatch(out, /NO WRITE EVENT WAS DRIVEN/, 'both writes fired');
+  // The fits are per write as well, so no slope is a line over a mixture.
+  assert.match(out, /reagent-subs\|hicasso@page /);
+  assert.match(out, /reagent-subs\|hicasso@all /);
+  assert.match(out, /\(under `:p0\/write-page`\)/, "and HD-002's difference is stated per write");
+});
+
+test('an UNPAIRED summary says NONE of it — the third option is not a redefinition', () => {
+  for (const [name, arms, extra] of [
+    ['full', FULL_ARMS(), { allocFits: FULL_FITS() }],
+    ['floor', FLOOR_ARMS(), {}],
+    ['controls', {}, {}],
+  ]) {
+    const { row, out } = allocSummaryFor(name, arms, extra);
+    assert.doesNotMatch(out, /MATCHED PAIR/, `${name}: no pairing is claimed`);
+    assert.doesNotMatch(out, /P0_ALLOC_WRITE=paired/, `${name}: no paired sub-header`);
+    assert.doesNotMatch(out, /PROVENANCE: /, `${name}: a healthy unpaired run prints no line of it`);
+    assert.doesNotMatch(out, /WRITE UNNAMED/, `${name}`);
+    assert.doesNotMatch(out, /PAIR INCOMPLETE/, `${name}`);
+    assert.doesNotMatch(out, /@page|@all/, `${name}: nothing is keyed by a write`);
+    // It is still ADJUDICATED, and recorded — the claim is one claim, and only
+    // the printing is mode-dependent.
+    assert.strictEqual(row.writeProvenance.ok, true, `${name}: and it holds`);
+    assert.deepStrictEqual(row.writeLegs, ['page'], `${name}: one leg`);
+    assert.strictEqual(row.writePaired, false, `${name}`);
+  }
 });
 
 // ===========================================================================

--- a/implementation/core/test/re_frame/bench/p0_ladder_structural.test.cjs
+++ b/implementation/core/test/re_frame/bench/p0_ladder_structural.test.cjs
@@ -2649,6 +2649,33 @@ test('the DRIVER honours both switches — the write, the plan, and the record',
     /for \(const \{ segment, arms, leg \} of passes\) \{[\s\S]{0,2000}?window\.P0H\.prepare\(s, gw\), \[segment, B\]\);/,
     're-seeding the grid at B as the first thing every pass does'
   );
+  // AND THE RE-SEED IS UNCONDITIONAL, read off the page's own sources. This is
+  // the property the leg pass rests on, and it is the one failure here that
+  // would be SILENT: `:p0/write-all` rebuilds `:cells` at `cells-n` whatever
+  // is mounted, `:p0/write-page` rebuilds at `(count (:cells db))`, and the
+  // mounted boundaries read cells 0..(B/roots − 1) either way — so a page leg
+  // that inherited an all leg's grid would read back correctly while
+  // measuring the bulk write. `enter-segment!` destroys the frame and
+  // re-creates it with `[[:p0/seed grid-width]]` on EVERY call, so no pass can
+  // inherit a width; a branch that skipped the re-seed for an already
+  // installed segment would reintroduce exactly that.
+  const ARMS_SRC = fs.readFileSync(path.join(__dirname, 'p0_arms.cljs'), 'utf8');
+  const FIXTURE_SRC = fs.readFileSync(path.join(__dirname, 'p0_fixture.cljc'), 'utf8');
+  assert.match(
+    ARMS_SRC,
+    /\(rf\/make-frame \{:id frame-id :initial-events \[\[:p0\/seed \(long grid-width\)\]\]\}\)/,
+    'every segment entry re-seeds the grid at the width it was given'
+  );
+  assert.match(
+    ARMS_SRC,
+    /\(teardown! "destroy-frame!" #\(rf\/destroy-frame! frame-id\)\)/,
+    'and it destroys the frame first, so no previous write survives into a pass'
+  );
+  assert.match(
+    FIXTURE_SRC,
+    /\(rf\/reg-event :p0\/seed \(fn \[_ \[_ grid-width\]\] \{:db \(seed-db \(or grid-width cells-n\)\)\}\)\)/,
+    'and `:p0/seed` is what sets the width, from the argument it was handed'
+  );
   has(
     /const plan = allocPlanArms\(ladderPlan\(perRoot, ROOTS\), ALLOC_PLAN_SHAPE\);/,
     'and the plan is the shipped ladder plan narrowed by the shape'

--- a/implementation/core/test/re_frame/bench/p0_ladder_structural.test.cjs
+++ b/implementation/core/test/re_frame/bench/p0_ladder_structural.test.cjs
@@ -2444,6 +2444,29 @@ const PAIRED_ROW = {
     ':p0/write-all — a synthetic row, measured against nothing',
 };
 
+// A RECORD WITH NAMED FIELDS TAKEN OUT OF EVERY WINDOW — the negative
+// fixtures the provenance pin is driven against, built by SUBTRACTION from
+// the healthy one so a field added to `winWrite` cannot leave them stale.
+//
+// The fields are a PARAMETER rather than a fixed set, because the shapes this
+// pin has to refuse are not one shape. Removing all three gives the record
+// every allocation run had before rf2-irxrw; removing `pairKey` alone gives
+// the far more dangerous one, where every window names its write correctly
+// and none of them belongs to a pair.
+//
+// Written as an explicit key filter and not as `const { a, b, ...rest } = x`.
+// That idiom needs the omitted keys BOUND to omit them, this repo's ESLint
+// config deliberately does not set `ignoreRestSiblings` — "unused *variables*
+// stay on: that is the arm that catches a dead `require`" — and a disable
+// comment would be more machinery than the subtraction is worth.
+const without = (arms, fields) =>
+  Object.fromEntries(
+    Object.entries(arms).map(([key, a]) => [
+      key,
+      Object.fromEntries(Object.entries(a).filter(([f]) => !fields.includes(f))),
+    ])
+  );
+
 // The fits a full run carries, one per (segment, substrate), derived from the
 // same plan for the same reason. Only the full plan reaches
 // `summariseAllocFits`; the narrow ones print the NO FITTED LINE block.
@@ -2759,12 +2782,7 @@ test('THE SAME PIN REFUSES an UNPAIRED-SHAPED record — the windows name nothin
   // The shape every allocation record had before this bead: the row named the
   // write and the windows did not, which was adequate while a process drove
   // one write and is exactly what a paired record may not be.
-  const arms = Object.fromEntries(
-    Object.entries(FULL_ARMS(['page', 'all'])).map(([k, a]) => {
-      const { writeSelector, write, pairKey, ...rest } = a;
-      return [k, rest];
-    })
-  );
+  const arms = without(FULL_ARMS(['page', 'all']), ['writeSelector', 'write', 'pairKey']);
   const { row, out } = allocSummaryFor('full', arms, {
     ...PAIRED_ROW,
     allocFits: FULL_FITS(['page', 'all']),
@@ -2776,6 +2794,45 @@ test('THE SAME PIN REFUSES an UNPAIRED-SHAPED record — the windows name nothin
   assert.match(prov.unnamed[0], /^round 1 /, 'per round and per key, not one undifferentiated count');
   // And the summary says so where an operator would see it.
   assert.match(out, /WRITE UNNAMED round 1 /);
+  assert.match(out, /PROVENANCE: 88 recorded windows across 0 pairs — 88 unnamed/);
+});
+
+test('and it refuses a record whose windows name their write but carry NO pairKey', () => {
+  // THE SHAPE THAT WOULD SURVIVE THE TEST ABOVE. Every window names its own
+  // write, correctly, and the record satisfies criterion 6's separation to the
+  // letter — so a reader checking only "can I tell which write produced this
+  // row?" passes it. What it does not carry is the thing that makes the pair a
+  // PAIR: the arm key its two legs share. An estimator handed this can see two
+  // populations and cannot match them, which is precisely the reconstruction
+  // rf2-irxrw exists to make unnecessary, and it would be back to differencing
+  // unmatched medians with nothing on the record to say so.
+  //
+  // This is the branch the pin's other cases cannot reach. Strip all three
+  // fields and the "names no write" branch fires first, so the pairKey arm is
+  // never exercised; strip `pairKey` alone and it is the only one that can.
+  const arms = without(FULL_ARMS(['page', 'all']), ['pairKey']);
+  const { row, out } = allocSummaryFor('full', arms, {
+    ...PAIRED_ROW,
+    allocFits: FULL_FITS(['page', 'all']),
+  });
+  const prov = allocWriteProvenance(row);
+  assert.strictEqual(prov.ok, false, 'a record whose pairs cannot be formed is not a paired record');
+  assert.strictEqual(prov.unnamed.length, 88, 'every window, on every round');
+  assert.match(
+    prov.unnamed[0],
+    /carries no pairKey, so it belongs to no pair$/,
+    'and the reason names THIS defect, not the one above'
+  );
+  // NOT VACUOUS, and this is what separates it from the test above: the write
+  // half is intact on every window, so the failure is the pairing alone.
+  assert.doesNotMatch(prov.unnamed[0], /names no write/);
+  for (const a of Object.values(arms)) {
+    assert.ok(a.writeSelector && a.write, 'the windows DO name their write');
+  }
+  // No pair could be formed, so there is nothing to be incomplete — the census
+  // reads zero rather than reporting 44 half-pairs, which is the honest count.
+  assert.strictEqual(prov.pairs, 0, 'no window joined a pair');
+  assert.deepStrictEqual(prov.incomplete, [], 'and none is reported as a HALF pair, which it is not');
   assert.match(out, /PROVENANCE: 88 recorded windows across 0 pairs — 88 unnamed/);
 });
 

--- a/implementation/core/test/re_frame/bench/p0_run.cjs
+++ b/implementation/core/test/re_frame/bench/p0_run.cjs
@@ -1501,12 +1501,60 @@ const ALLOC_WRITE_SPECS = {
       'control, flat in B by construction',
   },
 };
+// --- AND `paired`, WHICH DRIVES BOTH IN ONE PROCESS (rf2-irxrw) ------------
+//
+// V1/V2 require the two writes to be compared as a SAME-PAGE, SAME-RUN pair
+// (allocation-instrument-rework.md:231-232), and until this switch the
+// instrument could not do it: the resolved kind was ONE spec, passed into
+// every arm window of the run, so a `write-all` versus `write-page`
+// comparison was necessarily a difference of two sequential PROCESS runs in
+// a fixed order. rf2-0gjqi's re-analysis is what that cost — eight mid-rung
+// sign comparisons that share one run order, one floor per segment per
+// write, and a page-global floor level (rf2-77gz8) that moves both segments
+// by the same amount, so eight cells are one draw rather than eight.
+//
+// THE SELECTION IS THEREFORE A LIST, NOT A SPEC. There are still exactly TWO
+// writes — `ALLOC_WRITE_SPECS` above is unchanged and `paired` is not a third
+// one — and what `P0_ALLOC_WRITE` names is which of them this run drives, in
+// what order. `page` and `all` name one each and behave exactly as they did;
+// `paired` names both, and the arm pass below runs once per leg inside every
+// round, on the same page, in the same process.
+const ALLOC_WRITE_SELECTIONS = {
+  page: ['page'],
+  all: ['all'],
+  paired: ['page', 'all'],
+};
 const ALLOC_WRITE = process.env.P0_ALLOC_WRITE || 'page';
 // `undefined` for an unknown switch, and the preflight refuses on it BY NAME
 // rather than this line throwing: requiring this module must never drive it
 // (`p0_ladder_structural.test.cjs` requires it on every PR), so the refusal
 // belongs where every other one already is — before a browser is launched.
-const ALLOC_WRITE_SPEC = ALLOC_WRITE_SPECS[ALLOC_WRITE];
+const ALLOC_WRITE_KEYS = ALLOC_WRITE_SELECTIONS[ALLOC_WRITE];
+const ALLOC_WRITE_LEGS =
+  ALLOC_WRITE_KEYS &&
+  ALLOC_WRITE_KEYS.map((selector) => ({ selector, spec: ALLOC_WRITE_SPECS[selector] }));
+const ALLOC_WRITE_PAIRED = ALLOC_WRITE_LEGS !== undefined && ALLOC_WRITE_LEGS.length > 1;
+// THE SINGLE SPEC, WHERE THERE IS ONE. `page` and `all` resolve to the same
+// object they always did — every consumer below reads the LEGS, and this is
+// kept because the surface's own pins read it, and because "this run drives
+// exactly one write, and it is this one" is a real question with a real
+// answer under two of the three selections. It is `undefined` under `paired`
+// for the same reason it is `undefined` under a typo: there is no ONE write.
+// The two are told apart by `ALLOC_WRITE_LEGS`, and the preflight refuses on
+// that rather than on this.
+const ALLOC_WRITE_SPEC =
+  ALLOC_WRITE_LEGS && ALLOC_WRITE_LEGS.length === 1 ? ALLOC_WRITE_LEGS[0].spec : undefined;
+
+// WHERE A WINDOW IS RECORDED (rf2-irxrw). Off `paired` this is the identity,
+// so a published run's record is keyed exactly as it always was; on it, the
+// two legs of a pair are two windows and each is keyed by the write it drove.
+// The pair itself is not left to be reconstructed from the string: every
+// recorded window carries `pairKey` — the arm key its legs share — beside the
+// write it names, so a later estimator groups on a field rather than parsing
+// one.
+function allocWindowKey(armKey, selector, paired = ALLOC_WRITE_PAIRED) {
+  return paired ? `${armKey}@${selector}` : armKey;
+}
 
 // --- THE PLAN (V3's controls-only, and V1's floor-only) --------------------
 //
@@ -2083,6 +2131,82 @@ function allocRefusedWindowCount(row) {
   return n;
 }
 
+// EVERY RECORDED WINDOW NAMES ITS OWN WRITE, AND EVERY PAIR IS WHOLE
+// (rf2-irxrw). This is criterion 6's separation read at WINDOW granularity.
+//
+// WHY IT MOVED THERE. While one process drove one write, "a reader of any row
+// can tell FROM THE ROW which write produced it" was satisfied by the row's
+// own `writeSelector`: every window under that row had the same answer. A
+// `paired` row has both, so a row-level field answers nothing about a given
+// window and the claim has to be carried by the window. The pin over this
+// asserts exactly that, which is strictly more than the row-level one asked
+// and is why the row-level fields stay rather than being replaced.
+//
+// AND THE SECOND HALF IS WHAT MAKES THE PAIR USABLE. A record in which one
+// leg of a pair refused to record, or recorded under the wrong key, still
+// looks well-formed window by window — and an estimator differencing it would
+// silently be back to comparing unmatched populations, which is the whole
+// defect this switch exists to remove. So the pairs are counted: within each
+// round, the windows sharing a `pairKey` must name EVERY leg the run drove.
+// Off `paired` that is the identity — one leg, one window per key — and the
+// check is the same code saying so.
+//
+// IT IS A RECORDED FACT AND GATES NOTHING. No figure is computed from it and
+// no run exits on it; the pins are what adjudicate it, on every PR.
+function allocWriteProvenance(row) {
+  const legs = row.writeLegs || [];
+  const known = new Set(legs);
+  const unnamed = [];
+  const incomplete = [];
+  let windows = 0;
+  let pairCount = 0;
+  for (const r of row.perRound || []) {
+    const pairs = new Map();
+    for (const [key, a] of Object.entries(r.arms || {})) {
+      windows++;
+      const spec = ALLOC_WRITE_SPECS[a.writeSelector];
+      if (typeof a.writeSelector !== 'string' || !known.has(a.writeSelector) || !spec) {
+        unnamed.push(
+          `round ${r.round} ${key}: ` +
+            (typeof a.writeSelector === 'string'
+              ? `names \`${a.writeSelector}\`, which is not a write this run drove`
+              : 'names no write')
+        );
+        continue;
+      }
+      if (typeof a.write !== 'string' || !a.write.startsWith(spec.event)) {
+        unnamed.push(
+          `round ${r.round} ${key}: names \`${a.writeSelector}\` but records ` +
+            `${typeof a.write === 'string' ? `\`${a.write}\`` : 'no event'}, not \`${spec.event}\``
+        );
+        continue;
+      }
+      if (typeof a.pairKey !== 'string') {
+        unnamed.push(`round ${r.round} ${key}: carries no pairKey, so it belongs to no pair`);
+        continue;
+      }
+      if (!pairs.has(a.pairKey)) pairs.set(a.pairKey, new Set());
+      pairs.get(a.pairKey).add(a.writeSelector);
+    }
+    for (const [pairKey, got] of pairs) {
+      pairCount++;
+      if (got.size !== legs.length) {
+        incomplete.push(
+          `round ${r.round} ${pairKey}: ${[...got].sort().join(' + ') || 'nothing'} — ` +
+            `this run drives ${legs.join(' + ')}`
+        );
+      }
+    }
+  }
+  return {
+    windows,
+    pairs: pairCount,
+    unnamed,
+    incomplete,
+    ok: unnamed.length === 0 && incomplete.length === 0,
+  };
+}
+
 async function allocRow(chromium) {
   // THE PREFLIGHT REFUSAL, before a browser is launched and a byte is
   // measured. It refuses only on grounds it can defend WITHOUT a sizing model
@@ -2113,10 +2237,14 @@ async function allocRow(chromium) {
   // that is deliberate: the no-arms route out of a refused page is a mode
   // with a name on it, not a page of zero boundaries. V3 states its page like
   // any other run, and the averaging floor still holds its six writes.
-  if (ALLOC_WRITE_SPEC === undefined) {
+  // REFUSED ON THE LEGS, NOT ON THE SPEC (rf2-irxrw). `ALLOC_WRITE_SPEC` is
+  // `undefined` under `paired` as well as under a typo — there is no ONE
+  // write in either case — so the test that separates a valid selection from
+  // a mistyped one is whether the SELECTION resolved, and that is the legs.
+  if (ALLOC_WRITE_LEGS === undefined) {
     throw new Error(
       `unknown P0_ALLOC_WRITE ${JSON.stringify(ALLOC_WRITE)} — the allocation window drives ` +
-        `one of ${Object.keys(ALLOC_WRITE_SPECS).join(' | ')}, and \`page\` is the default ` +
+        `one of ${Object.keys(ALLOC_WRITE_SELECTIONS).join(' | ')}, and \`page\` is the default ` +
         'every published row is taken under'
     );
   }
@@ -2267,7 +2395,31 @@ async function allocRow(chromium) {
 
     // --- the arms, in the order this round's parity dictates ------------
     const segs = round % 2 === 0 ? plan : [...plan].slice().reverse();
-    for (const { segment, arms } of segs) {
+    // AND THE WRITE LEGS, ON THE SAME PARITY (rf2-irxrw). One pass over the
+    // segment's arms per write this run drives, so a `paired` round measures
+    // EVERY arm — the floor included, and the floor is the dominant shared
+    // term — under both writes on the same page in the same process. Off
+    // `paired` there is one leg, `passes` is `segs` with it attached, and the
+    // body below runs exactly the calls it ran before, in the same order.
+    //
+    // THE PASS RE-SEEDS, AND IT HAS TO. `:p0/write-all` replaces `:cells`
+    // with a `cells-n`-wide vector whatever is mounted, and `:p0/write-page`
+    // rebuilds at `(count (:cells db))` — so a page leg that followed an all
+    // leg on an unseeded frame would rebuild 300 cells and BE the bulk write,
+    // reading back correctly and saying nothing. `prepare(segment, B)` is
+    // already the first statement of every pass and already re-seeds; running
+    // one pass per leg is what keeps that true rather than a new mechanism.
+    //
+    // THE ORDER ALTERNATES for the reason the segment order does: a fixed one
+    // confounds the write with within-round position, which is exactly the
+    // defect this switch exists to remove, and a drift within a run would be
+    // read as a difference between the writes. Over the six default rounds
+    // each leg leads three times.
+    const legs = round % 2 === 0 ? ALLOC_WRITE_LEGS : [...ALLOC_WRITE_LEGS].reverse();
+    const passes = segs.flatMap(({ segment, arms }) =>
+      legs.map((leg) => ({ segment, arms, leg }))
+    );
+    for (const { segment, arms, leg } of passes) {
       // THE GRID WIDTH IS B, AND IT IS SEEDED WITH THE FRAME (rf2-2rtt6.140).
       // `:p0/write-page` rebuilds `:cells` at the width the mounted page
       // actually reads — one cell per boundary — so the write's own machinery
@@ -2307,7 +2459,8 @@ async function allocRow(chromium) {
         if (!v.ok) {
           unverified++;
           unverifiedDetail.push(
-            `${entry.key}: elements ${v.elements}/${v.expected}, keys ${v.keys}/${v.keysExpected}`
+            `${allocWindowKey(entry.key, leg.selector)}: elements ${v.elements}/${v.expected}, ` +
+              `keys ${v.keys}/${v.keysExpected}`
           );
         }
         // A WARM-UP PASS at the REAL window size, and not a token one. A
@@ -2329,17 +2482,24 @@ async function allocRow(chromium) {
           ([dd, n, s]) => window.P0H.allocPrepare(dd, n, s),
           [0, ALLOC_WINDOW_WRITES, ALLOC_SITES]
         );
+        //
+        // AND THEY WARM THIS PASS'S OWN WRITE (rf2-irxrw). A site warmed
+        // under one write and measured under the other reads its settled
+        // value for neither, and under `paired` the other write is one pass
+        // away rather than one process away — so `leg` is what both the
+        // warm-ups and the measured window below take, and the pin counts
+        // both call sites rather than matching one.
         for (let w = 0; w < ALLOC_WARMUPS; w++) {
           await page.evaluate(
             ([n, d, k]) => window.P0H.allocWindow(n, k, d),
-            [ALLOC_WINDOW_WRITES, drain, ALLOC_WRITE_SPEC.kind]
+            [ALLOC_WINDOW_WRITES, drain, leg.spec.kind]
           );
         }
         await gc();
         const pre = await read();
         const win = await page.evaluate(
           ([n, d, k]) => window.P0H.allocWindow(n, k, d),
-          [ALLOC_WINDOW_WRITES, drain, ALLOC_WRITE_SPEC.kind]
+          [ALLOC_WINDOW_WRITES, drain, leg.spec.kind]
         );
         const post = await read();
         await page.evaluate(() => window.P0H.release());
@@ -2366,16 +2526,33 @@ async function allocRow(chromium) {
         if (win.text !== want) {
           unverified++;
           unverifiedDetail.push(
-            `${entry.key}: warm write read-back "${win.text}", expected "${want}"`
+            `${allocWindowKey(entry.key, leg.selector)}: warm write read-back "${win.text}", ` +
+              `expected "${want}"`
           );
         }
-        armsOut[entry.key] = {
+        armsOut[allocWindowKey(entry.key, leg.selector)] = {
           segment,
           arm: entry.arm,
           rung: entry.rung,
           reads: R,
           boundaries: B,
           text: win.text,
+          // WHICH WRITE THIS WINDOW DROVE, AND WHICH PAIR IT BELONGS TO
+          // (rf2-irxrw). Criterion 6's separation — "a reader of any row can
+          // tell FROM THE ROW which write produced it" — held at ROW
+          // granularity while a process drove one write; under `paired` a row
+          // carries both, so it has to hold at WINDOW granularity instead.
+          // Every window names its own kind under every selection, so the
+          // property is one claim rather than a mode-dependent one.
+          //
+          // `pairKey` IS THE ARM KEY THE LEGS SHARE, and it is what makes the
+          // pairing a field rather than a parse. An estimator wanting matched
+          // within-round differences groups a round's windows by it and reads
+          // `writeSelector` off each leg; off `paired` it equals the key the
+          // window is stored at, which is the same statement with one leg.
+          writeSelector: leg.selector,
+          write: `${leg.spec.event} — ${leg.spec.note}`,
+          pairKey: entry.key,
           ...verdict,
           // THE PRIME LEG, RECORDED RATHER THAN DISCARDED (rf2-oiy1). It is
           // in no published quantity and in no certificate, and it is the
@@ -2437,7 +2614,17 @@ async function allocRow(chromium) {
         };
       }
     }
-    rounds.push({ round, controls: { idle, ctl1, ctl2 }, arms: armsOut });
+    // `writeLegs` IS THE ORDER THIS ROUND ACTUALLY DROVE THEM IN (rf2-irxrw),
+    // not the configured order. The parity flip above is the whole reason the
+    // pair is not order-confounded, and an estimator that wants to know which
+    // leg led in a given round has to be able to read it off the round rather
+    // than recompute the parity rule.
+    rounds.push({
+      round,
+      controls: { idle, ctl1, ctl2 },
+      arms: armsOut,
+      writeLegs: legs.map((l) => l.selector),
+    });
   }
 
   // --- the fits, through the LADDER's rule, with the page still open ----
@@ -2448,27 +2635,35 @@ async function allocRow(chromium) {
   // line — V1 and V3 both state "no fits" in their configurations, and a
   // line fitted through one point would be the instrument answering a
   // question it was not asked.
+  //
+  // AND ONE FIT PER WRITE (rf2-irxrw). A `paired` run has two rungs at every
+  // R, taken under two different writes, and a single line through both would
+  // be a slope over a mixture. So the fit id carries the write exactly as the
+  // window key does — `allocWindowKey`, on the same identity off `paired`, so
+  // every published run's `allocFits` is keyed as it always was.
   const fits = { perRound: {}, mean: {} };
   for (const { segment } of ALLOC_PLAN_SHAPE.fits ? plan : []) {
     for (const sub of LADDER_SUBSTRATES[segment]) {
-      const id = `${segment}|${sub}`;
-      const rungsOf = (r) =>
-        LADDER_RUNGS.map((R) => ({
-          rung: `R${R}`,
-          reads: R,
-          y: r.arms[`${segment}|lad/${sub}#R${R}`].perBoundaryPerWrite,
+      for (const { selector } of ALLOC_WRITE_LEGS) {
+        const id = allocWindowKey(`${segment}|${sub}`, selector);
+        const rungsOf = (r) =>
+          LADDER_RUNGS.map((R) => ({
+            rung: `R${R}`,
+            reads: R,
+            y: r.arms[allocWindowKey(`${segment}|lad/${sub}#R${R}`, selector)].perBoundaryPerWrite,
+          }));
+        fits.perRound[id] = [];
+        for (const r of rounds) {
+          fits.perRound[id].push(await page.evaluate((rs) => window.P0H.ladderFit(rs), rungsOf(r)));
+        }
+        const all = rounds.map(rungsOf);
+        const meanRungs = all[0].map((g, i) => ({
+          ...g,
+          y: all.reduce((acc, rr) => acc + rr[i].y, 0) / all.length,
         }));
-      fits.perRound[id] = [];
-      for (const r of rounds) {
-        fits.perRound[id].push(await page.evaluate((rs) => window.P0H.ladderFit(rs), rungsOf(r)));
+        fits.mean[id] = await page.evaluate((rs) => window.P0H.ladderFit(rs), meanRungs);
+        fits.mean[id].rungs = meanRungs;
       }
-      const all = rounds.map(rungsOf);
-      const meanRungs = all[0].map((g, i) => ({
-        ...g,
-        y: all.reduce((acc, rr) => acc + rr[i].y, 0) / all.length,
-      }));
-      fits.mean[id] = await page.evaluate((rs) => window.P0H.ladderFit(rs), meanRungs);
-      fits.mean[id].rungs = meanRungs;
     }
   }
 
@@ -2512,8 +2707,14 @@ async function allocRow(chromium) {
     // and `summariseAlloc` derives it off `perRound` — measured, not
     // configured — beside `controlVerdict` and the other verdicts this row
     // learns about itself only once its rounds are in.
+    //
+    // AND UNDER `paired` IT IS BOTH (rf2-irxrw), so the row states the legs
+    // it drove as a list rather than a scalar. Off `paired` the list has one
+    // member and `write` is the same string it always was, to the byte.
     writeSelector: ALLOC_WRITE,
-    write: `${ALLOC_WRITE_SPEC.event} — ${ALLOC_WRITE_SPEC.note}`,
+    writeLegs: ALLOC_WRITE_LEGS.map((l) => l.selector),
+    writePaired: ALLOC_WRITE_PAIRED,
+    write: ALLOC_WRITE_LEGS.map((l) => `${l.spec.event} — ${l.spec.note}`).join('  AND  '),
     plan: { name: ALLOC_PLAN, ...ALLOC_PLAN_SHAPE },
     // WHICH OF THE THREE GATES SCREENED THIS ROW (rf2-fir5n), and not merely
     // which three exist. It reads `ALLOC_BY_SITE` for the same reason `bySite`
@@ -2772,7 +2973,43 @@ function summariseAlloc(row, refused) {
   // switch resolves, the record carries it, and nothing fires. Saying "THE
   // WRITE IS `:p0/write-page`" over that run would attribute an event that did
   // not execute, which is the one failure a provenance line may not have.
-  if (writeDriven) {
+  //
+  // AND UNDER `paired` THE SENTENCE IS A DIFFERENT ONE (rf2-irxrw). Neither
+  // branch below is true of a run that drove both writes: the first says the
+  // grid was rebuilt at B, the second calls the row V1's F_old control and
+  // names the switch that selected it. So the paired shape is lifted out
+  // WHOLE on `summariseAllocFits`'s rule — an unpaired run does not reach a
+  // line of it and its output is unchanged to the byte.
+  if (writeDriven && row.writePaired) {
+    console.log(';;   THE TWO WRITES ARE DRIVEN AS A MATCHED PAIR (rf2-irxrw):');
+    for (const leg of row.writeLegs) {
+      const spec = ALLOC_WRITE_SPECS[leg];
+      console.log(`;;     \`${spec.event}\` — ${spec.note}`);
+    }
+    console.log(
+      ';;   EVERY ARM IS MEASURED UNDER BOTH — the FLOOR included, which is the point: the floor'
+    );
+    console.log(
+      ';;   is the dominant shared term in (arm − floor), so a pairing that left it under one'
+    );
+    console.log(';;   write would buy nothing. Both legs run inside the SAME round, on the same');
+    console.log(';;   page, in the same process, and the leg ORDER alternates on round parity so');
+    console.log(';;   that neither write leads every round.');
+    console.log(
+      ';;   WHAT THAT REPLACES: until this switch one process drove one write, so every write-all'
+    );
+    console.log(
+      ';;   versus write-page comparison differenced two sequential PROCESS runs in a fixed order'
+    );
+    console.log(
+      ';;   and its two arms shared run order, session and floor. A residual read off such a'
+    );
+    console.log(';;   difference could not be separated from those terms (rf2-0gjqi).');
+    console.log(
+      ';;   THIS IS A VALIDITY-WITNESS CONFIGURATION, NOT A PUBLISHED ROW. `page` is the default,'
+    );
+    console.log(';;   and every published figure is taken under it alone.');
+  } else if (writeDriven) {
     console.log(`;;   THE WRITE IS \`${row.write}\`.`);
     if (row.writeSelector === 'page') {
       console.log(
@@ -2803,6 +3040,26 @@ function summariseAlloc(row, refused) {
       ';;   and nothing fired. The control windows below allocate doubles and nothing else.'
     );
   }
+  // THE PROVENANCE OF EVERY WINDOW, ADJUDICATED AND RECORDED (rf2-irxrw). It
+  // is on the row under every selection, because it is one claim rather than
+  // a mode-dependent one; it is PRINTED under `paired`, where a reader has to
+  // be able to see that the pairs are whole before differencing them, and
+  // under any selection where it FAILED. A healthy unpaired run therefore
+  // prints not one line of this and its summary is unchanged to the byte.
+  const provenance = allocWriteProvenance(row);
+  row.writeProvenance = provenance;
+  if (row.writePaired) {
+    console.log(
+      `;;   PROVENANCE: ${provenance.windows} recorded window` +
+        `${provenance.windows === 1 ? '' : 's'} across ${provenance.pairs} pair` +
+        `${provenance.pairs === 1 ? '' : 's'} — ` +
+        (provenance.ok
+          ? 'every window names its own write and every pair is whole.'
+          : `${provenance.unnamed.length} unnamed, ${provenance.incomplete.length} incomplete.`)
+    );
+  }
+  for (const m of provenance.unnamed) console.log(`;;   WRITE UNNAMED ${m}`);
+  for (const m of provenance.incomplete) console.log(`;;   PAIR INCOMPLETE ${m}`);
   console.log(';;   The clock, bulk, fan-out and retention rows drive `:p0/write-all` unchanged,');
   console.log(';;   at the published width, whatever this switch says.');
   console.log(
@@ -3014,31 +3271,44 @@ function summariseAlloc(row, refused) {
     console.log(';;   The three controls above are the whole measurement. Nothing below this');
     console.log(';;   line is a statement about any substrate.');
   }
+  //
+  // ONE TABLE PER WRITE (rf2-irxrw). A `paired` run measured every arm twice
+  // and a single table would have to pick one or average them; both would be
+  // a table that cannot be read back to a window. `allocWindowKey` is the
+  // identity off `paired` and the sub-header is printed only on it, so an
+  // unpaired run's table is the table it always was, to the byte.
+  const paired = Boolean(row.writePaired);
+  const tableLegs = row.writeLegs || [row.writeSelector];
   for (const segment of row.plan.arms ? Object.keys(LADDER_SUBSTRATES) : []) {
     console.log(';;');
     console.log(`;; ---- ${segment} ----`);
-    console.log(
-      ';; arm            reads        B/boundary/write [min–max]        B/write        falls'
-    );
-    const floorKey = `${segment}|grid/floor`;
-    const fl = stat(row.perRound.map((r) => r.arms[floorKey].perBoundaryPerWrite));
-    const flw = stat(row.perRound.map((r) => r.arms[floorKey].perWrite));
-    console.log(
-      `;; floor              — ${(n0(fl.mean) + ' [' + n0(fl.min) + '–' + n0(fl.max) + ']').padStart(30)}` +
-        `${n0(flw.mean).padStart(15)}   (no subscription: the WRITE's own cost)`
-    );
-    for (const sub of row.plan.rungs ? LADDER_SUBSTRATES[segment] : []) {
-      for (const R of LADDER_RUNGS) {
-        const key = `${segment}|lad/${sub}#R${R}`;
-        const s = stat(row.perRound.map((r) => r.arms[key].perBoundaryPerWrite));
-        const w = stat(row.perRound.map((r) => r.arms[key].perWrite));
-        const f = row.perRound.reduce((a, r) => a + r.arms[key].falls, 0);
-        console.log(
-          `;; ${sub.padEnd(11)}${String(R).padStart(6)} ` +
-            `${(n0(s.mean) + ' [' + n0(s.min) + '–' + n0(s.max) + ']').padStart(30)}` +
-            `${n0(w.mean).padStart(15)}${String(f).padStart(9)}` +
-            (R === 0 ? '   (anchor — regressed nowhere; cannot re-render)' : '')
-        );
+    for (const selector of tableLegs) {
+      if (paired) {
+        console.log(`;;   under \`${ALLOC_WRITE_SPECS[selector].event}\` (P0_ALLOC_WRITE=paired)`);
+      }
+      console.log(
+        ';; arm            reads        B/boundary/write [min–max]        B/write        falls'
+      );
+      const floorKey = allocWindowKey(`${segment}|grid/floor`, selector, paired);
+      const fl = stat(row.perRound.map((r) => r.arms[floorKey].perBoundaryPerWrite));
+      const flw = stat(row.perRound.map((r) => r.arms[floorKey].perWrite));
+      console.log(
+        `;; floor              — ${(n0(fl.mean) + ' [' + n0(fl.min) + '–' + n0(fl.max) + ']').padStart(30)}` +
+          `${n0(flw.mean).padStart(15)}   (no subscription: the WRITE's own cost)`
+      );
+      for (const sub of row.plan.rungs ? LADDER_SUBSTRATES[segment] : []) {
+        for (const R of LADDER_RUNGS) {
+          const key = allocWindowKey(`${segment}|lad/${sub}#R${R}`, selector, paired);
+          const s = stat(row.perRound.map((r) => r.arms[key].perBoundaryPerWrite));
+          const w = stat(row.perRound.map((r) => r.arms[key].perWrite));
+          const f = row.perRound.reduce((a, r) => a + r.arms[key].falls, 0);
+          console.log(
+            `;; ${sub.padEnd(11)}${String(R).padStart(6)} ` +
+              `${(n0(s.mean) + ' [' + n0(s.min) + '–' + n0(s.max) + ']').padStart(30)}` +
+              `${n0(w.mean).padStart(15)}${String(f).padStart(9)}` +
+              (R === 0 ? '   (anchor — regressed nowhere; cannot re-render)' : '')
+          );
+        }
       }
     }
   }
@@ -3114,15 +3384,24 @@ function summariseAllocFits(row) {
   console.log(';;   recomputations and a React element tree. So the quantity that answers it is');
   console.log(';;   the candidate slope LESS the same-run donor slope, in the SAME segment.');
   const slopeOf = (id) => fits.mean[id] && fits.mean[id].slope;
+  // AND ONCE PER WRITE UNDER `paired` (rf2-irxrw). The difference is stated
+  // "in the SAME segment" because a cross-segment one would compare two
+  // pages; a cross-WRITE one would compare two writes, which is the same
+  // error one axis over. `allocWindowKey` is the identity off `paired`, so
+  // the published run prints the two lines it always did.
+  const paired = Boolean(row.writePaired);
   for (const seg of Object.keys(LADDER_SUBSTRATES)) {
-    const donor = LADDER_SUBSTRATES[seg][0];
-    const hc = slopeOf(`${seg}|hicasso`);
-    const dn = slopeOf(`${seg}|${donor}`);
-    if (typeof hc !== 'number' || typeof dn !== 'number') continue;
-    console.log(
-      `;;   ${seg.padEnd(13)} candidate ${n0(hc)} − ${donor} ${n0(dn)} = ` +
-        `${n0(hc - dn)} B/read of EXCESS steady-state allocation`
-    );
+    for (const selector of row.writeLegs || [row.writeSelector]) {
+      const donor = LADDER_SUBSTRATES[seg][0];
+      const hc = slopeOf(allocWindowKey(`${seg}|hicasso`, selector, paired));
+      const dn = slopeOf(allocWindowKey(`${seg}|${donor}`, selector, paired));
+      if (typeof hc !== 'number' || typeof dn !== 'number') continue;
+      console.log(
+        `;;   ${seg.padEnd(13)} candidate ${n0(hc)} − ${donor} ${n0(dn)} = ` +
+          `${n0(hc - dn)} B/read of EXCESS steady-state allocation` +
+          (paired ? `   (under \`${ALLOC_WRITE_SPECS[selector].event}\`)` : '')
+      );
+    }
   }
 }
 
@@ -3622,6 +3901,19 @@ module.exports = {
   ALLOC_WRITE_SPECS,
   ALLOC_WRITE,
   ALLOC_WRITE_SPEC,
+  // The paired selection (rf2-irxrw), exported on exactly the rule above: the
+  // selection table as a value and the RESOLVED legs, so the env route to
+  // `paired` is pinned from outside the process the way `all` already is —
+  // configuration is read once, at require, and no in-process assignment can
+  // reach it. `allocWindowKey` and `allocWriteProvenance` come too because
+  // they are pure: the pin can DRIVE a paired-shaped record and an
+  // unpaired-shaped one through the shipped adjudicator rather than restate
+  // what it would say.
+  ALLOC_WRITE_SELECTIONS,
+  ALLOC_WRITE_LEGS,
+  ALLOC_WRITE_PAIRED,
+  allocWindowKey,
+  allocWriteProvenance,
   ALLOC_PLAN_SHAPES,
   ALLOC_PLAN,
   ALLOC_PLAN_SHAPE,


### PR DESCRIPTION
Closes rf2-irxrw. Blocks-side of rf2-0gjqi (left OPEN — its audit obligation is unmet until matched certified pairs are compared).

**NO MEASUREMENT IS TAKEN OR PUBLISHED HERE.** This changes the instrument so a later window can ask a question it currently cannot. The rig was run only to prove the change behaves as claimed.

## The problem, re-derived at source

Every source fact the bead cites was re-checked on this branch's base rather than taken from the bead, and every line number still resolves:

| bead's citation | verified |
|---|---|
| `p0_run.cjs:1504` — `ALLOC_WRITE` read once from `process.env` at module scope | yes, `const ALLOC_WRITE = process.env.P0_ALLOC_WRITE \|\| 'page';` at 1504 |
| `p0_run.cjs:1490` — `ALLOC_WRITE_SPECS` has two members, no paired option | yes, `page` and `all`, at 1490 |
| `p0_run.cjs:2335, 2342` — the resolved kind passed into every arm window | yes, `[ALLOC_WINDOW_WRITES, drain, ALLOC_WRITE_SPEC.kind]` at both, the warm-up and the measured window |
| `p0_heap.cljs:1182-1188` — `alloc-window!` takes the write as a per-window kind argument | yes: `[n kind drain]` at 1182, `all? (= kind "write-all")` at 1187, `write? (or (= kind "write") all?)` at 1188 |
| `allocation-instrument-rework.md:231-232` — V2 requires both writes on the same page in the same run | yes, verbatim: "**V2 measures both writes on the same page in the same run and requires that it does not.**" |

So requirement 1's premise holds: the page already affords per-window kinds and **`p0_heap.cljs` needs no change at all**. Only the driver's process-global pin prevented pairing.

**One source fact the bead does not state, and it decides the design.** `:p0/write-all` is `(assoc db :cells (vec (repeat cells-n v)))` and `:p0/write-page` is `(vec (repeat (count (:cells db)) v))` (`p0_fixture.cljc`). A write-all therefore leaves the db's grid at `cells-n` whatever is mounted, and a page write that followed it on an unseeded frame would rebuild 300 cells and **be** the bulk write — reading back correctly (the mounted boundaries read cells `0..(B/roots − 1)` either way) and saying nothing. Any pairing that interleaves the two writes without re-seeding measures the same write twice under two names. That is why the pairing is a **pass** and not a per-window interleave.

## What was built

### (1) A paired mode that drives both kinds at each arm inside one round

`P0_ALLOC_WRITE` gains a third value, `paired`. The selection became a **list** rather than a spec: `ALLOC_WRITE_SPECS` is untouched and still holds exactly two writes (the "two writes, no more" pin is unmoved), and a new `ALLOC_WRITE_SELECTIONS` says which of them a run drives and in what order — `page: ['page']`, `all: ['all']`, `paired: ['page','all']`.

The arm loop runs **one pass per (segment, leg)**. Off `paired` there is one leg, `passes` is `segs` with it attached, and the body issues exactly the calls it issued before in the same order. On `paired` every arm — **the floor included** — is measured under both writes inside the same round, on the same page, in the same process.

- **The pass re-seeds.** `prepare(segment, B)` was already the first statement of every segment pass and already re-seeds the grid at B; running one pass per leg is what keeps that true, rather than a new page-side door. This is the answer to the fixture hazard above.
- **The leg order alternates on round parity**, exactly as the segment order does (`round % 2`). A fixed order would confound the write with within-round position — which is the defect this switch exists to remove — and a drift within a run would read as a difference between the writes. Over the six default rounds each leg leads three times.
- The preflight now refuses on `ALLOC_WRITE_LEGS === undefined` rather than on `ALLOC_WRITE_SPEC === undefined`, because `ALLOC_WRITE_SPEC` is `undefined` under `paired` as well as under a typo — there is no *one* write in either case. Both are pinned.

### (2) The floor is paired too

The floor is an arm of the plan (`grid/floor`, rung `floor`), so the leg pass takes it under both writes like every other arm. It is the dominant shared term in `(arm − floor)` and a pairing that left it under one write would buy nothing. Pinned explicitly rather than left to follow from the loop: the paired-record test asserts `reagent-subs|grid/floor@page` **and** `reagent-subs|grid/floor@all` are both present.

### (3) The record carries the pairing

- Every recorded window carries `writeSelector` (`page`/`all`), `write` (the event and its note) and **`pairKey`** — the arm key its legs share. An estimator wanting matched within-round differences groups a round's windows by `pairKey` and reads `writeSelector` off each leg. It parses no key and reconciles no second file.
- The window **key** is `allocWindowKey(armKey, selector, paired)` — the identity off `paired`, `armKey@selector` on it. Off `paired` the record is keyed exactly as it always was.
- Each **round** records `writeLegs` — the order it *actually* drove them in, after the parity flip, not the configured order.
- The **row** records `writeLegs` and `writePaired` beside the existing `writeSelector`/`write`.
- **Fits are per write** (`segment|substrate@selector` under `paired`), so no slope is a line through a mixture of two writes.

### (4) The structural pin, AMENDED not deleted

This is the second time this family of pins has moved rather than gone; rf2-gxrr moved its sibling in `p0_heap.cljs` from ABSENCE to REACHABILITY and called that the delicate half of the work. The same reasoning applies here and is written into the file.

The pin's **content** is criterion 6's separation — *a reader of any row can tell FROM THE ROW which write produced it*. Its **shape** was `write: ${ALLOC_WRITE_SPEC.event} — ${ALLOC_WRITE_SPEC.note}` matched in the driver's source, and that shape was adequate only because a process drove one write: the row's one answer was every window's answer. Under `paired` a row carries both, so the claim moves to **window granularity**.

The amended pin therefore asserts that **each recorded window names its own kind**, and it adjudicates a *record* through the shipped, exported `allocWriteProvenance` rather than matching source. It refuses:

- an **unpaired-shaped record** (windows carrying no write) — 88 of 88 windows named;
- a **half pair** — well-formed window by window, which is what makes it dangerous, and what an estimator would silently difference as unmatched populations;
- a window naming a write **the run did not drive**;
- a window whose **selector and recorded event disagree** (which a selector-only check would admit).

Nothing was deleted. The row-level `writeSelector` pin stays; the `write:` pin was rewritten to the list form and the `lacks` that forbids a hard-coded single write stays; a new `lacks` forbids either `allocWindow` call site being pinned back to the **run's** write. Both `allocWindow` call sites are still **counted** at 2, on `leg.spec.kind`, for the original reason: a site warmed under one write and measured under the other reads its settled value for neither — and under `paired` the other write is one pass away rather than one process away, so the pin matters more, not less.

## Additivity — how it was established

`page` and `all` behave exactly as before: one leg, the same calls in the same order, the same record keys, the same figures.

**Measured, not asserted.** The same synthetic row was driven through `origin/main`'s `summariseAlloc` and through the amended one, on all three plans, and the printed summaries are byte-identical:

```
full      old 8103 chars / 112 lines   new 8103 chars / 112 lines   IDENTICAL
floor     old 4749 chars / 69 lines    new 4749 chars / 69 lines    IDENTICAL
controls  old 4299 chars / 62 lines    new 4299 chars / 62 lines    IDENTICAL
```

**Not vacuous**: one character was changed in a summary literal the new driver prints (`row is NOT.` → `row is NOT!`) and the same probe reported `DIFFERS` on all three plans, naming the line; the character was restored and the comparison returned to IDENTICAL, with the file's `git hash-object` back at its pre-plant value.

Every new **printed** line sits inside a paired branch or a failure branch, which is what makes that identity hold. A permanent pin asserts it from the other side: `an UNPAIRED summary says NONE of it` drives `full`, `floor` and `controls` and forbids `MATCHED PAIR`, `P0_ALLOC_WRITE=paired`, `PROVENANCE:`, `WRITE UNNAMED`, `PAIR INCOMPLETE` and any `@page`/`@all` key, while asserting the provenance is still adjudicated and still holds.

**What DID change on an unpaired run**, stated plainly: the JSON record gains two row fields (`writeLegs`, `writePaired`), one round field (`writeLegs`), and three per-window provenance fields (`writeSelector`, `write`, `pairKey`). No figure, no gate, no certificate and no printed line reads them except the amended pin. Making them unconditional is deliberate — a provenance claim that held only under one mode would be a weaker pin than the one it replaces.

**What is NOT asked for and was not done**: no gate widened, no band moved, no threshold touched. `ALLOC_MIN_WRITES` stays 6, `ALLOC_FALL_THRESHOLD_B` stays 600,000, τ stays where it is. `p0_heap.cljs`, `p0_arms.cljs` and `p0_fixture.cljc` are untouched. rf2-77gz8 is open and was not chased; what this removes for it is the cross-process confound, not the mode.

## Quality gates

**`implementation/core/test/re_frame/bench/p0_ladder_structural.test.cjs` is the primary witness.** Runner derived at source: `implementation/package.json`'s `test:script-helpers` runs `node core/test/re_frame/bench/p0_ladder_structural.test.cjs` from `implementation/`.

| run | captured exit | result |
|---|---|---|
| baseline, before any edit | `0` | `86 passed` |
| after the change | `0` | `93 passed` (7 new tests) |
| **planted fault** | `1` | `2/93 failed` |
| after restore | `0` | `93 passed` |
| after the re-seed pin was added | `0` | `93 passed` |
| **ESLint plant** (the pairKey branch) | `1` | `1/94 failed` |
| after restore | `0` | `94 passed` |
| post-rebase, final base | `0` | `94 passed` |

**The planted-fault control, and it targets the amendment itself.** `allocWriteProvenance`'s returned `unnamed` list was replaced with `[]` — a single line, in code this PR adds, that makes the adjudicator under-report exactly the failure requirement 4 guards against. The red was:

```
FAIL  THE SAME PIN REFUSES an UNPAIRED-SHAPED record — the windows name nothing
      every window, on every round
      0 !== 88
FAIL  and a window naming a write this run did NOT drive is refused too
      0 !== 1
```

That is the rule intended: both reds are the amended pin's own assertions about windows that do not name their write, and no bystander test moved (93 tests before, 93 after — the plant did not abort a namespace). A **first, cruder plant** (inverting the guard condition) was rejected rather than reported: it came back red for the wrong reason — a `TypeError` reading `.event` of `undefined`, plus one unrelated test — so it was restored and re-planted to exercise the intended rule.

The restore was verified with version control's own content hash against the working file (`core.autocrlf=true`, so a plain byte digest would misreport): `git hash-object` read `9c993e96b36f4878d03912743154e938ffff896e` before the plant, `d861efc2075f97fb436be7cb8be8ceade7292680` with it, and `9c993e96b36f4878d03912743154e938ffff896e` after.

**A second commit pins the re-seed the leg pass rests on.** `enter-segment!` destroys the frame and re-creates it with `[[:p0/seed grid-width]]` on every call, so a pass cannot inherit the previous leg's grid width; three positive `assert.match`es over `p0_arms.cljs` and `p0_fixture.cljc` now hold that. Positive assertions cannot pass vacuously, so no plant was needed to show they bite — a wrong pattern fails rather than passing quietly.


### ESLint, and the case it found

`npm run lint:js` (CI's own command: `eslint .` from the repo root, ESLint pinned at 10.8.0 in the root lockfile) failed on this branch with **captured exit 1**, three `no-unused-vars` errors at one line — a `const { writeSelector, write, pairKey, ...rest } = a` used to omit the three provenance fields from a negative fixture.

**It was the second reading: an assertion was missing, and deleting the bindings would have removed the evidence rather than the error.**

The bindings are not vestigial — in that idiom the omitted keys must be *bound* to be omitted — and this repo's config deliberately does not set `ignoreRestSiblings`, saying so in its own comment ("Unused *variables* stay on: that is the arm that catches a dead `require`"). So a disable comment was not the answer either. But stripping all three fields at once meant only the **first** branch of `allocWriteProvenance` could ever fire, and its `pairKey` arm was **dead in the suite**: `git grep -nF "carries no pairKey"` returned the driver and no test, against a positive control on the sibling string `names no write`, which did appear in the test file.

The fix is therefore both halves:

1. the omission became a named `without(arms, fields)` key filter — no unused bindings, no suppression, and the removed fields are a **parameter**, which is what makes the second case expressible at all;
2. the missing assertion was written: **a record whose every window names its own write correctly — satisfying criterion 6's separation to the letter — and none of which carries the `pairKey` its legs share.** That shape passes the test above it, and it is the more dangerous of the two: an estimator handed it sees two populations and cannot match them, which is exactly the reconstruction this bead exists to make unnecessary. The census reads **0 pairs and 88 unnamed** rather than 44 half-pairs, which is the honest count — no pair could be formed, so none is incomplete.

**Shown biting.** Admitting an `undefined` `pairKey` in the driver (one line, in code this PR adds) took the suite to `1/94 failed`, captured exit 1, red on this assertion alone:

```
FAIL  and it refuses a record whose windows name their write but carry NO pairKey
      a record whose pairs cannot be formed is not a paired record
      true !== false
```

No bystander test moved (94 tests both runs), and the red is the rule intended: the other three provenance cases keep their `pairKey`, so only the new one can reach that branch. Restored and verified by `git hash-object` back at `9c993e96b36f4878d03912743154e938ffff896e`. `npm run lint:js` then read **captured exit 0**, and again **exit 0** on the final base.

**Which tree the gate read.** `scripts/test-fast-pr.sh` prints its root and named this worktree; ESLint printed the absolute path of the offending file, also in this worktree. The structural test prints none, so the discrimination there is the red itself: the planted fault existed only in this tree.

**Surface classification**, derived by running `.github/scripts/report-changed-surfaces.sh` with the two changed paths as explicit arguments (it takes paths, not a base ref):

```
implementation_jvm=true  cljs_node_test=true  adapter_diagnostic=true  cljs_browser=true
cljs_prod=true  bundle_isolation=true  tools_jvm=true  tools_jvm_machines_viz=true
tools_jvm_testbed_support=true  tools_cljs_machines_viz=true  template_expensive=true
mcp_conformance=true  mcp_live=true  playground=true
examples_compile=false  reagent_slim_bundle=false  adapter_testbed_smokes=false
machines_viz_viewer_page=false  story_*=false  tenant_switcher_smoke=false
skills_structural=false  migration_*=false  hicasso_controlled=false  hicasso_hmr=false
ssr_node=false
```

Positive control on that classifier: the same script over `some/nonsense/path.txt` returns every key `false`, so the `true`s above are a real classification and not a catch-all.

**`scripts/test-fast-pr.sh` RAN, to completion, twice** — once before the rebase and once on the final base — invoked by absolute path, detached, with the log and the exit code written on one command line and polled in a bounded loop. Both captured `EXIT=0`, both ended `PASS fast PR spine`.

- Classifier line, both runs: `=== fast PR spine: docs=false jvm=true node=true (classified) ===`
- Root banner, both runs: `gate root: /c/Users/miket/code/re-frame2-worktrees/paired-irxrw` — this worktree, not a sibling.
- The spine's `implementation JS harness helpers` step runs `npm run test:script-helpers`, which runs the structural test; both spine logs carry `p0_ladder_structural.test.cjs: 93 passed`.
- Skipped by the spine, with reasons it printed itself: the documentation gates (documentation surface unchanged), its own tiering self-test (the spine is not in the diff), the JVM artefact suites the diff did not touch, and the browser / prod-elision / bundle-isolation / perf / adapter-probe / adapter-smoke / Xray-matrix / mcp-conformance / tool-JVM lanes, which are CI-only.

**A `node_modules` junction was created into the mayor checkout's real one for the node tier and removed with `cmd /c rmdir` (the link, never its target) before reporting. The **root** `node_modules` was junctioned the same way for ESLint and removed the same way. Counted with the same command each time: `implementation/node_modules` **101 before, 101 after**; root `node_modules` **59 before, 59 after**.**

**Re-run after every rebase — three spine runs in all, all `EXIT=0`, all `PASS fast PR spine`.** The last is on the current base, which gained #8460 (4 files under `tools/xray/`) and #8458 (2 files under `docs/design/hicasso/studio/`, the analysis that produced this bead) plus beads checkpoints. Checked rather than assumed: `git diff --name-only` over that range names only those six files and `.beads/issues.jsonl`, none of them on this PR's surface. The final spine log carries `p0_ladder_structural.test.cjs: 94 passed`, and `npm run lint:js` was re-run on that base at exit 0.

`python scripts/check_fast_pr_gap.py --list` is the one path deriving which required CI checks the spine does not run; it reports **94** such checks, including steps inside jobs the spine does run. Green here is not green in CI.

**Searches, and what they could NOT have matched.** `git grep -nF` over all tracked files found no consumer of `writeSelector`, `allocFits` or `perBoundaryPerWrite` outside the driver, its structural test, and the committed alloc datasets (which are unpaired records and keep their shape). Positive control in the same sweep: `git grep -lF P0_ALLOC_WRITE` returned 11 files, so the tool was matching. Those patterns could **not** have seen: a destructured consumer (`const { writeSelector } = row`), a computed-key access (`row[field]`), a consumer that reconstructs the key by concatenation rather than naming it, or any reader living outside the repository.

**Merge-base diff, read for reverts.** `git diff origin/main...HEAD` (three-dot) is 2 files, +744/−112, both in the fenced surface. Every deleted line was read: they are the two amended pins and the re-parameterised fixtures, all replaced in the same hunks. Nothing a sibling landed is undone. The trunk moved during the work (`1e5eb2d79b` → `76b3e2b3a5`); the delta is two `chore(beads): checkpoint` commits touching `.beads/issues.jsonl` only, so no code moved under this branch.
