### PR TITLE
fix(bench): exit via process.exitCode so piped output drains before exit

### DIFF
--- a/implementation/hicasso/test/re_frame/bench/hicasso/clock_readjudicate.cjs
+++ b/implementation/hicasso/test/re_frame/bench/hicasso/clock_readjudicate.cjs
@@ -1769,7 +1769,18 @@ module.exports = {
 // Requiring this file must not run it: `clock_exit_path.test.cjs` drives the
 // two predicates above directly, which it cannot do if the module body reads
 // argv and exits.
+//
+// `process.exitCode`, never `process.exit()`. When stdout is a pipe — which is
+// what `spawnSync` hands this program — console.log is asynchronous, and
+// `process.exit()` tears the process down without draining what is still
+// queued. The tail of the report is exactly where the `;; EXIT 4` roster
+// prints, so under load the exit CODE survived while the roster it announces
+// vanished: the mutation witness in `clock_exit_path.test.cjs` failed that way
+// on CI on 2026-08-16 (PR #8375, which widened the diagnostics) and again on
+// 2026-08-18 (main run 32086796745, where the widened message proved the
+// truncation). `main` is synchronous and holds no handles, so assigning
+// exitCode lets the process exit on its own once the pipe drains — same code,
+// whole report.
 if (require.main === module) {
-  const code = main(process.argv.slice(2));
-  if (code !== 0) process.exit(code);
+  process.exitCode = main(process.argv.slice(2));
 }

--- a/implementation/hicasso/test/re_frame/bench/hicasso/jsfb_compare.cjs
+++ b/implementation/hicasso/test/re_frame/bench/hicasso/jsfb_compare.cjs
@@ -409,7 +409,11 @@ function main() {
 
 module.exports = { verdict, buildRows, readTheirs, readOurs, EXPECTED_CELLS, PAIRS, OTHERS, BASE, AGREEMENT_BAND };
 
+// `process.exitCode`, never `process.exit()` — the same lost-tail race the
+// clock readjudicator hit on CI (2026-08-16, 2026-08-18): piped stdio is
+// asynchronous and `process.exit()` drops what has not drained, so the verdict
+// lines this program exists to print can vanish while the code survives.
+// `main` is synchronous and holds no handles; natural exit keeps both.
 if (require.main === module) {
-  const code = main();
-  if (code !== 0) process.exit(code);
+  process.exitCode = main();
 }


### PR DESCRIPTION
Fixes the recurring CI flake in the rf2-8a746 mutation witness (clock_exit_path.test.cjs, 1/375), which failed on main run 32086796745 today and on PR #8375's CI on 16 August 2026.

## The failure

The witness spawns clock_readjudicate.cjs and asserts 2 things: the process exits 4, and the output carries the ';; EXIT 4' roster naming each lost run and pair. Today's failure shows exit 4 arriving while the roster is absent and the captured output stops mid-report — the diagnostics PR #8375's follow-up (rf2-vam35) added print exactly this.

## The cause

The program prints its whole report with console.log, then calls process.exit(code). Under spawnSync, stdout is a pipe, piped writes are asynchronous in Node, and process.exit() tears the process down without draining what is still queued. The report tail — where the roster prints — is what gets dropped, and only under load, which is why the failure is intermittent and CI-only. The 16 August response widened the assertion messages but left this cause in place.

## The fix

Assign process.exitCode and let the process exit naturally once the pipe drains: same exit code, whole report. main() is synchronous and holds no handles in both changed programs, so nothing else keeps them alive.

- clock_readjudicate.cjs — the program the failing witness spawns
- jsfb_compare.cjs — the identical print-then-exit tail with the same spawn-and-assert test shape, fixed before it flakes the same way
- jsfb_ours_run.cjs — deliberately untouched: its exits sit mid-flow in a driver that can hold live handles, where process.exit is load-bearing

## Verification (local, foreground)

- node clock_exit_path.test.cjs → 375 passed (includes the witness, which spawns the fixed program and still observes exit 4 plus the full roster)
- node jsfb_compare_exit_path.test.cjs → 46 passed
- both test files' source-pin assertions (require.main guard, main(process.argv.slice(2)) call shape) still match the edited tails