### PR TITLE
refactor(xray): delete the stale panel-domain->token roster; panel-accent IS the seam (rf2-9g1ea)

### DIFF
--- a/tools/xray/src/day8/re_frame2_xray/panels/routing.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/routing.cljs
@@ -88,7 +88,7 @@
 ;; ---- accent -------------------------------------------------------------
 ;;
 ;; The Routing panel's accent is the single GitHub-blue `:accent` token
-;; (per `panel-domain->token`). Both the CURRENT ROUTE id and the
+;; (per `theme.tokens/panel-accent`). Both the CURRENT ROUTE id and the
 ;; current row in the ROUTE TABLE ride this hue so the operator's eye
 ;; ties the two surfaces together (RoutesPanel `--devtools-active`).
 

--- a/tools/xray/src/day8/re_frame2_xray/theme/tokens.cljc
+++ b/tools/xray/src/day8/re_frame2_xray/theme/tokens.cljc
@@ -721,14 +721,13 @@
   [ms]
   (str "calc(" ms "ms * var(" (:scale-var-name motion) ", 1))"))
 
-;; ---- L4 panel domain colours (rf2-5kfxe.8) -----------------------------
+;; ---- L4 panel accent stripe (rf2-5kfxe.8 · rf2-ad7zx.13) ---------------
 
-(def panel-domain->token
-  "Pure semantic map from L4 tab keyword → token keyword for the
-  panel's header stripe colour.
+(defn panel-accent
+  "Resolve the L4 panel's header-stripe accent CSS-variable string.
 
-  ## Single accent (rf2-ad7zx.13 / spec/022 · spec/007 §L4 panel accent
-  stripe)
+  ## Single accent (rf2-ad7zx.13 · spec/022 · spec/021 §17.1.3 ·
+  spec/007 §L4 panel accent stripe)
 
   The prior per-panel DOMAIN-colour mapping (`:event` violet ·
   `:app-db`/`:views` cyan · `:trace` orange · `:machines` green ·
@@ -738,39 +737,39 @@
   signal, not a per-panel domain colour. Surfaces stay neutral so the
   blue accent pops.
 
-  Every tab therefore maps to the `:accent` token. Domain colour still
-  does load-bearing work where it is semantic (severity `error` red on
-  the inline Epoch exception block + the L2 event-row issue wash,
-  machine `green`, route `yellow`, the op-family bands in Trace, the
-  per-panel header icons §021 §17.1.5) — but the HEADER STRIPE is the
-  single accent.
+  Domain colour still does load-bearing work where it is semantic
+  (severity `error` red on the inline Epoch exception block + the L2
+  event-row issue wash, machine `green`, route `yellow`, the op-family
+  bands in Trace, the per-panel header icons §021 §17.1.5) — but the
+  HEADER STRIPE is the single accent.
 
-  The map is retained (rather than collapsed to a constant) so the
-  per-tab inventory stays explicit and a future per-panel signal can
-  re-diverge a single entry without restructuring call sites.
+  The tab argument is therefore accepted and IGNORED: every L4 tab id,
+  and `nil`, resolves to the one `:accent` variable, so the stripe
+  always renders.
 
-  JVM-portable pure data → keyword. Call sites do
-  `(get tokens (panel-domain->token tab))` to materialise the
-  CSS-variable string."
-  {:event           :accent
-   :app-db          :accent
-   :views           :accent
-   :trace           :accent
-   :machines        :accent
-   :routing         :accent})
+  ## This function is the re-diverge seam (rf2-9g1ea)
 
-(defn panel-accent
-  "Resolve the L4 panel's header-stripe accent CSS-variable string —
-  the single `:accent` (GitHub blue) per spec/007 §L4 panel accent
-  stripe + spec/022. Falls back to the `:accent` variable for unknown
-  tab keywords so the stripe always renders.
+  A future per-panel signal changes THIS BODY and no call site. It
+  does not need a per-tab map reinstated. There was one here — a
+  six-key `panel-domain->token` whose every value was already
+  `:accent`, kept so \"the per-tab inventory stays explicit\" — and it
+  had drifted to naming the retired `:event` tab while omitting five
+  shipped ones (`:epoch` · `:resources` · `:derivation-graph` ·
+  `:module-view` · `:hicasso`). Nothing caught that, because this
+  function defaulted past every absent key, so the roster could not
+  drift into a wrong ANSWER, only into a wrong LIST. A hand-listed tab
+  roster with no reader is a drift attractor, not an inventory.
+
+  The live roster is `panel-registry/tab-ids-for-mode`, mirrored by
+  `focus/valid-panels` and pinned against the registry by
+  `focus-cljs-test/valid-panels-mirrors-the-live-registry`. A
+  re-diverge derives from THAT rather than restating it here.
 
   Returns a `\"var(--rf-xray-<key>)\"` string post rf2-on4cm — the
   active theme class scope on the shell root decides which palette's
   hex (`#539bf5` dark / `#0969da` light) resolves at paint time."
-  [tab]
-  (get tokens
-       (get panel-domain->token tab :accent)))
+  [_tab]
+  (:accent tokens))
 
 (defn accent-stripe-style
   "Build an inline-style map that paints the per-panel accent as a
@@ -823,8 +822,8 @@
   "Per-panel header glyph map per spec/021 §17.1.5 iconography. Each
   L4 tab carries a Unicode glyph rendered to the LEFT of the panel
   `<h1>` (or its inline-stripe header equivalent). Colour resolves
-  through `panel-domain->token` so the glyph rides the panel's domain
-  hue — a visual tie between the accent stripe and the icon.
+  through `panel-accent`, so the glyph rides the same single accent as
+  the 3px header stripe — a visual tie between the two.
 
   | Tab           | Glyph |
   |---------------|-------|

--- a/tools/xray/test/day8/re_frame2_xray/theme/tokens_cljs_test.cljc
+++ b/tools/xray/test/day8/re_frame2_xray/theme/tokens_cljs_test.cljc
@@ -190,44 +190,51 @@
       (is (re-find #"transparent\)$" out)
           "ends with the transparent partner so the result is a tint"))))
 
-;; ---- panel domain colours (rf2-5kfxe.8) --------------------------------
+;; ---- L4 panel accent stripe (rf2-5kfxe.8 · rf2-ad7zx.13) ---------------
 
-(deftest panel-domain-map-keys-are-pinned
-  (testing "rf2-5kfxe.8 — `panel-domain->token` is NOT the L4 tab
-            inventory and does not track it: rf2-ad7zx.13 superseded
-            the per-panel domain colours with a single `:accent`,
-            leaving this map a six-key vestige. Five of the ten live
-            Dynamic tabs (`focus/valid-panels`) are absent from it —
-            `:epoch`, which superseded the retired `:event` id the map
-            still names (rf2-5gl5r), plus the four L4 lenses registered
-            since (`:resources` · `:derivation-graph` · `:module-view`
-            · `:hicasso`). `panel-accent` falls back to `:accent` for
-            any key absent here, so every shipped tab renders correctly
-            regardless. This pins the keys so the vestige cannot grow
-            back into a second inventory. (rf2-gui26 — this docstring
-            read 'the 6 L4 tabs', a word-numeral roster claiming to be
-            the tab count. The map itself is rf2-9g1ea's subject: a
-            design call, not doc drift.)"
-    (let [tabs #{:event :app-db :views :trace :machines
-                 :routing}]
-      (is (= tabs (set (keys t/panel-domain->token)))))))
+(deftest panel-accent-is-tab-independent
+  (testing "rf2-9g1ea — `panel-accent` is TOTAL and tab-independent:
+            spec/022 + spec/021 §17.1.3 rule the L4 header stripe to a
+            SINGLE accent, so every tab id, every keyword that is not a
+            tab id, and `nil` all resolve to the one `:accent`
+            variable. The stripe always renders.
 
-(deftest panel-accent-resolves-through-tokens
-  (testing "`panel-accent` is a thin wrapper:
-            (get tokens (panel-domain->token tab))."
-    (doseq [[tab token-kw] t/panel-domain->token]
-      (is (= (get t/tokens token-kw)
-             (t/panel-accent tab))
-          (str "tab " tab " resolves via token " token-kw)))))
+            ASSERTED UNIVERSALLY, NOT AGAINST A ROSTER, ON PURPOSE.
+            A hand-listed roster here WAS the rf2-9g1ea defect: the
+            deleted `panel-domain->token` map named six tabs — one of
+            them the retired `:event` (rf2-5gl5r) — while five shipped
+            ones (`:epoch` · `:resources` · `:derivation-graph` ·
+            `:module-view` · `:hicasso`) were absent, and the pinning
+            test could not fail on that because it compared the map
+            with a copy of itself. A universal assertion covers every
+            shipped tab without introducing a second inventory to
+            drift. The shipped roster has exactly ONE control and it
+            is registry-derived, not hand-listed:
+            `focus-cljs-test/valid-panels-mirrors-the-live-registry`
+            asserts `focus/valid-panels` equals
+            `panel-registry/tab-ids-for-mode :dynamic`.
 
-(deftest panel-accent-falls-back-for-unknown-tab
-  (testing "unknown tab → :accent (the mode-accent fallback per
-            rf2-ad7zx / spec/022). The stripe always renders rather
-            than disappearing."
-    (is (= (:accent t/tokens)
-           (t/panel-accent :unknown-tab-kw)))
-    (is (= (:accent t/tokens)
-           (t/panel-accent nil)))))
+            The vector below is a SAMPLE, not an inventory — one
+            shipped tab, one of the newest, one retired id, one that
+            was never registered, and `nil`. Nothing here needs
+            maintaining when a tab ships or retires; the property is
+            universal over the argument."
+    (let [accent (:accent t/tokens)]
+      (is (string? accent) "the single accent resolves (sanity guard)")
+      (doseq [tab [:machines :hicasso :event :never-a-tab nil]]
+        (is (= accent (t/panel-accent tab))
+            (str "panel-accent " (pr-str tab) " is the single accent"))))))
+
+(deftest panel-accent-resolves-through-the-var-map
+  (testing "rf2-on4cm — `panel-accent` materialises its answer through
+            `tokens`, the CSS-variable map, rather than a palette hex.
+            The active theme class on the shell root decides which
+            palette paints."
+    (let [v (t/panel-accent :machines)]
+      (is (re-find #"^var\(--rf-xray-accent\)$" v)
+          "resolves to the accent CSS variable")
+      (is (not (re-find #"#[0-9A-Fa-f]" v))
+          "no hex literal — the theme class scope owns the paint"))))
 
 (deftest accent-stripe-style-emits-3px-left-border
   (testing "`accent-stripe-style` returns a merge-able style map
@@ -560,10 +567,25 @@
 
 ;; ---- rf2-ezx8w — per-panel header icons (spec/021 §17.1.5) -------------
 
-(deftest panel-icon-map-covers-every-l4-tab
-  (testing "rf2-ezx8w — every L4 tab has a header-icon glyph per
-            spec/021 §17.1.5. Mirrors `panel-domain->token` so the
-            icon and the accent stripe address the same tab keys.
+(deftest panel-icon-map-keys-are-pinned
+  (testing "rf2-ezx8w — the glyph table of spec/021 §17.1.5.
+
+            THE NAME NO LONGER CLAIMS COMPLETENESS, because it never
+            held (rf2-9g1ea). This map is seven keys against ten live
+            Dynamic tabs (`focus/valid-panels`): it names TWO retired
+            ids (`:event`, superseded by `:epoch` per rf2-5gl5r, and
+            `:reactive`) and omits FIVE shipped ones (`:epoch` ·
+            `:resources` · `:derivation-graph` · `:module-view` ·
+            `:hicasso`). The old name — `…-covers-every-l4-tab` — read
+            as a completeness control while asserting set equality
+            against a copy of the map, so it could not fail on the very
+            drift it appeared to guard.
+
+            Nothing in `src` reads `panel-icon`: spec/021 §14.1
+            (rf2-6xezz) deleted the panel `<h1>` elements the glyphs
+            lived in. The map's disposition is a separate design call;
+            this pins its keys so it cannot quietly grow into a second
+            tab inventory in the meantime.
             (rf2-gbz39 — the Issues tab + its ⚠ glyph were removed per
             Mike's Option (c) ruling. rf2-4v67l — Chrome A11y removed
             in favour of Story's already-shipped chrome-a11y dogfood
@@ -592,8 +614,8 @@
 
 (deftest panel-icon-style-rides-panel-accent
   (testing "rf2-ezx8w — `panel-icon-style` resolves the glyph colour
-            through `panel-accent` so the icon hue tracks the same
-            domain token as the 3px stripe."
+            through `panel-accent` so the icon hue tracks the 3px
+            stripe: post rf2-ad7zx.13 that is the single accent."
     (doseq [tab (keys t/panel-icon)]
       (let [s (t/panel-icon-style tab)]
         (is (= (t/panel-accent tab) (:color s))
@@ -601,10 +623,11 @@
         (is (string? (:font-size s)))
         (is (= 600 (:font-weight s)))))))
 
-(deftest panel-icon-style-falls-back-for-unknown
-  (testing "unknown tab → :accent (same mode-accent fallback as panel-
-            accent, rf2-ad7zx). The icon always paints rather than
-            dropping to a colourless stroke."
+(deftest panel-icon-style-is-tab-independent-too
+  (testing "an unregistered tab id still paints the single accent —
+            `panel-icon-style` reads `panel-accent`, which is total
+            (rf2-ad7zx.13 / rf2-9g1ea). The icon always paints rather
+            than dropping to a colourless stroke."
     (is (= (:accent t/tokens)
            (:color (t/panel-icon-style :unknown-tab-kw))))))
 

--- a/tools/xray/test/day8/re_frame2_xray/theme/var_resolution_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/theme/var_resolution_cljs_test.cljs
@@ -49,6 +49,7 @@
             [day8.re-frame2-xray.panels.event.event-status-colour :as event-status]
             [day8.re-frame2-xray.panels.issues-ribbon-helpers :as issues-h]
             [day8.re-frame2-xray.panels.trace-helpers :as trace-h]
+            [day8.re-frame2-xray.focus :as focus]
             [day8.re-frame2-xray.views.edn-inspector :as ei]
             [day8.re-frame2-xray.theme.perf-tier :as perf-tier]
             [day8.re-frame2-xray.theme.tokens :as tokens]))
@@ -94,10 +95,18 @@
            (tokens/css-var :accent)))))
 
 (deftest panel-accent-returns-css-variable-string
-  (testing "rf2-on4cm — `panel-accent` materialises the panel-domain
-            accent through the var-map. Used by the 3px left-border
-            on every L4 panel <h1>."
-    (doseq [tab (keys tokens/panel-domain->token)]
+  (testing "rf2-on4cm — `panel-accent` materialises the panel accent
+            through the var-map. Used by the 3px left-border on every
+            L4 panel container.
+
+            The roster is `focus/valid-panels`, which mirrors the LIVE
+            registry (`panel-registry/tab-ids-for-mode :dynamic`) and
+            is pinned against it by `focus-cljs-test`. rf2-9g1ea —
+            this walk used to read the keys of a hand-listed
+            `tokens/panel-domain->token` map, which had drifted to six
+            stale ids, so 'every L4 panel' excluded four of the shipped
+            ten and included a retired one."
+    (doseq [tab focus/valid-panels]
       (let [v (tokens/panel-accent tab)]
         (is (string? v))
         (is (re-find #"^var\(--rf-xray-" v)
@@ -106,8 +115,8 @@
 (deftest accent-stripe-style-border-references-css-variable
   (testing "rf2-on4cm — the canonical 3px-left-border builder produces
             a border-left value that references a CSS variable, not
-            a hardcoded hex."
-    (doseq [tab (keys tokens/panel-domain->token)]
+            a hardcoded hex. Walks the live tab roster (rf2-9g1ea)."
+    (doseq [tab focus/valid-panels]
       (let [border (:border-left (tokens/accent-stripe-style tab))]
         (is (string? border))
         (is (re-find #"3px solid var\(--rf-xray-" border)
@@ -309,9 +318,10 @@
                    "(should be a var(--rf-xray-…) reference)")))))))
 
 (deftest accent-stripe-style-output-has-no-palette-hex-literal
-  (testing "rf2-on4cm — every panel's accent-stripe style map (the
-            3px left border on L4 panel <h1>) is hex-free."
-    (doseq [tab (keys tokens/panel-domain->token)]
+  (testing "rf2-on4cm — every shipped panel's accent-stripe style map
+            (the 3px left border on the L4 panel container) is
+            hex-free. Roster is `focus/valid-panels` (rf2-9g1ea)."
+    (doseq [tab focus/valid-panels]
       (let [s (tokens/accent-stripe-style tab)]
         (doseq [[k v] s]
           (when (string? v)


### PR DESCRIPTION
Closes rf2-9g1ea.

## What the bead claimed, and what is actually at `origin/main`

Re-derived at `26e8069092` before any edit. The bead is **partly stale** — one of its two headline claims was fixed by PR #8455 (rf2-14axc) after it was filed.

| Bead claim | At HEAD | Verdict |
|---|---|---|
| `tokens.cljc:726` `panel-domain->token` is 6 entries, all `:accent` | line 726, 6 entries, all `:accent` | **holds** |
| carries the retired `:event`, omits `:epoch` and the 4 newest Dynamic tabs | exactly so | **holds** |
| shipped inventory is 10 per `focus/valid-panels` | `#{:epoch :app-db :views :trace :machines :routing :resources :derivation-graph :module-view :hicasso}` | **holds** |
| `panel-accent` falls back to `:accent`, so nothing behaves differently | `(get tokens (get panel-domain->token tab :accent))` — the fn was already a constant function for every input including `nil` | **holds** |
| docstring wording "retained (rather than collapsed to a constant) so the per-tab inventory stays explicit…" | verbatim at 748–750 | **holds** |
| pinned by a test **named** `panel-domain-map-covers-every-l4-tab` whose docstring opens "the 6 L4 tabs each get a domain colour" | **NO.** PR #8455 renamed it `panel-domain-map-keys-are-pinned` and rewrote the docstring to say the map is *not* the tab inventory | **STALE** |

So the bead's title — "pinned by a test whose name claims completeness" — no longer described this test. The mislabelling was already repaired; the design call the bead exists for was not.

## The design call

The bead offered (a) complete to ten / (b) collapse. The mayor's comment recommended collapse and named the deciding evidence: *"if any consumer branches on the KEY rather than the value, then (a) is right."* That census is the whole decision, so it was run at source.

**Nothing branches on the key. Nothing reads the map except one function.**

- `panel-domain->token` — **1** production reader: `panel-accent`.
- `panel-accent` — **2** readers, both in the same file: `accent-stripe-style`, `panel-icon-style`.
- `accent-stripe-style` — **1** production call site in the whole repo: `static/machines/definition_detail.cljs:75`, passing a **literal** `:machines`.
- `panel-icon-style` — **0** production call sites.
- Zero spec documents name `panel-domain->token`. Zero markdown of any kind does. (Both zero-results run with a positive control: the identical `grep -rnF` pattern against `--include=*.cljc` returns 9 hits.)

So the "future re-diverge without restructuring call sites" the docstring bought had **one call site** to protect, and it passes a constant. The map was not an inventory — it was a lookup nothing could observe, whose only measurable effect on the project was to cost a census on rf2-gui26, a docstring repair on rf2-14axc, and this bead.

**Chosen: collapse.** The map is deleted.

The seam the docstring wanted is kept, and moved somewhere it cannot go stale: **`panel-accent` itself is the seam.** It keeps its tab argument, so a future per-panel signal changes one function body and no call site — which is strictly the property the map was justified by — and a re-diverge would derive its roster from `panel-registry/tab-ids-for-mode`, not restate one in the theme layer. Deriving the map from `valid-panels` was considered and rejected as machinery: an override map for a signal nobody has asked for, wrapping a value that is currently constant.

## The pinning test: hollow, and the evidence

The project's defect class is *a control constructed so that it avoids the case it exists to catch.* Applied here:

`panel-domain-map-keys-are-pinned` asserted `(= #{:event :app-db :views :trace :machines :routing} (set (keys panel-domain->token)))` — a set literal against a copy of itself. It reads `valid-panels` nowhere, so **it cannot fail when the map and the shipped roster disagree.**

The delete-the-signal-keep-the-fault demonstration needed no experiment, because **the fault is already live in the tree**: the map disagrees with the shipped roster today, by five absent ids and one retired one — and the control run of the covering gate at unmodified `origin/main` was **green, exit 0, 1320 tests / 6246 assertions**. Fault present, control green. That is the result.

Post-#8455 the test's *name and docstring* had stopped claiming otherwise, so it was honest-but-narrow rather than actively misleading. It is still **replaced, not patched.**

**What the control becomes.** There is no inventory left to drift, so the fault class is *eliminated* rather than guarded — strictly better than a control, which can only detect. `panel-accent-is-tab-independent` asserts the property **universally**: every tab id, every keyword that was never a tab, and `nil` resolve to the one accent. Universal quantification covers every shipped tab without a second roster, so a new tab is covered the day it ships with nothing to maintain. Its sample vector is documented as a sample, not an inventory.

**The next tab addition is not left unguarded.** It never depended on the theme layer. The shipped roster has exactly one control and it is registry-derived: `focus-cljs-test/valid-panels-mirrors-the-live-registry` asserts `focus/valid-panels` equals `panel-registry/tab-ids-for-mode :dynamic`. That is the control that can fail, and it already exists.

## Second finding: three more walks were reading the stale map as the tab roster

`var_resolution_cljs_test.cljs` walked `(keys tokens/panel-domain->token)` in three tests whose prose said *"every L4 panel"* / *"every panel's accent-stripe style map"*. They covered six ids, one of them retired, and none of the four newest tabs. Deleting the map forced these; they now walk `focus/valid-panels`, which mirrors the live registry — repointing a stale roster at the live one, which makes the prose true and extends real coverage from 6 ids to the shipped 10.

## Also in this PR, and deliberately bounded

`panel-icon-map-covers-every-l4-tab`'s docstring cross-referenced the deleted map (*"Mirrors `panel-domain->token`"*), so it had to be edited. Its **name** is the identical falsehood one screen down: it claims completeness over a **7**-key map that names **two** retired ids (`:event`, `:reactive`) against ten shipped tabs. Renamed `panel-icon-map-keys-are-pinned` and the docstring corrected. **Name and prose only — the map and its glyph assertions are untouched**, because `panel-icon`'s disposition is a separate design call: nothing in `src` reads it at all — nor does anything read `panel-icon-style` — and spec/021 §14.1 (rf2-6xezz) records that the glyphs were removed along with the panel `<h1>` elements they lived in. Filed as **rf2-qm2rt** (discovered-from rf2-9g1ea, sequence after this PR merges) rather than widened into this PR.

## Spec

**`tools/xray/spec/*` unchanged, because no spec document describes this surface.** No spec file names `panel-domain->token` (zero-result grep, positive control passing). What the specs *do* say is already what this PR makes the code say: spec/021 §17.1.3 rules the L4 panel header stripe to "the **mode `accent`** … the per-panel domain-colour stripe … is superseded by the single mode-accent identity", and spec/007 §L4 panel accent stripe says the same. The code was carrying a vestige of the design those sections superseded; deleting it moves the code toward the spec, not away. spec/007's only reference to this area is to `accent-stripe-style`, whose name, signature and output are unchanged.

None of the three contested files (`000-Vision.md`, `007-UX-IA.md`, `019-Cross-Cutting-Insight.md`, held by PR #8462) is touched — nor is `018-Event-Spine.md`, which that branch also holds and the dispatch brief did not list.

## Quality gates

**The fast-PR spine did NOT run.** A Shape 6 measurement window is running on this host under an authorised fleet drain, and `scripts/test-fast-pr.sh` and every browser / full-shadow-cljs lane were withheld so the window stays valid. Only targeted, low-load gates were run. The gap the spine leaves *when it does run* is derived at step granularity by `scripts/check_fast_pr_gap.py --list` (94 required checks); that is a fact about the spine and is cited rather than enumerated — but it is **not** a census of what ran here, which is the list below.

Every exit code below was captured by the invoking shell on the same command line as the redirect, and is quoted from the file that shell wrote.

| Gate | Command | Exit (captured) | Result |
|---|---|---|---|
| Control, unmodified `origin/main` | `cd tools/xray && clojure -M:test` | **0** | 1320 tests / 6246 assertions, 0 failures |
| Planted fault (sabotage witness) | same | **1** | 7 failures |
| Final, restored + changed | same | **0** | 1319 tests / 6245 assertions, 0 failures |
| clj-kondo, the `tools/xray` arm of the required `lint.yml` job | `clj-kondo --parallel --fail-level error --lint tools/xray` | **0** | errors: 0, warnings: 168 (baseline) |

**Why this is the covering gate.** `tools/xray`'s per-artefact JVM lane is `clojure -M:test` from the artefact directory (`jvm-tools-xray`, per `TESTING.md`), and it loads `tokens_cljs_test.cljc` — established independently by rf2-14axc's plant, and re-established by the plant below. clj-kondo's `tools/xray` arm is lifted verbatim from `.github/workflows/lint.yml`.

**Sabotage witness.** `panel-accent`'s body was changed on a single line from `(:accent tokens)` to `(:error tokens)` — a value change, so it crashes no namespace and cannot abort the lane (namespace/assertion counts confirm: 1319 tests / 6245 assertions in the planted run, identical to the clean run). The lane went **red, exit 1**, and the failures name the planted value and the new deftests, both of which exist only on this branch:

```
FAIL in (panel-accent-resolves-through-the-var-map) (tokens_cljs_test.cljc:234)
  actual: (not (re-find #"^var\(--rf-xray-accent\)$" "var(--rf-xray-error)"))
FAIL in (panel-accent-is-tab-independent) (tokens_cljs_test.cljc:225)
FAIL in (panel-icon-style-is-tab-independent-too) (tokens_cljs_test.cljc:631)
```

A run that had wandered into another checkout would have come back green. Restore verified by `git hash-object` against the committed object (`autocrlf=true` makes a plain byte digest unreliable here): pre-plant `652438ee…`, planted `f61dbd1a…` — differing, so the plant genuinely applied rather than silently no-opping — restored `652438ee…`, byte-identical.

**Not run, and stated rather than implied.** `var_resolution_cljs_test.cljs` is `.cljs`; its only lane is `cljs_node_test`, a full shadow-cljs compile, which the reservation forbids. It is left to CI. The static risk in that file is one added `:require` and three symbol substitutions, and clj-kondo — a required CI job, and a linter rather than a compile — resolved `focus/valid-panels` in it with zero errors. Four sibling `.cljs` tests in the same build already require `day8.re-frame2-xray.focus`, so no new module-graph edge is introduced. Both `clojure.string` warnings clj-kondo reports on the changed test files are pre-existing (identical `string/` usage counts at `HEAD` and in the working tree).

**Base.** `git diff --name-status origin/main...HEAD` (three-dot) is the four files above and nothing else — no revert of a sibling's landed work. `origin/main` advanced from `26e8069092` to `1f004b15ff` during this work; those ten commits touch **no** file under `tools/xray/src` or `tools/xray/test` (the rf2-9foby commits are spec markdown), so the gate result stands on the surface as merged and no rebase-and-re-gate was owed.
