### PR TITLE
fix(hicasso): ship the test kit in the jar — test_kit/src joins :clein/build's :src-dirs

### DIFF
--- a/docs/core/hicasso/15-testing.md
+++ b/docs/core/hicasso/15-testing.md
@@ -16,16 +16,22 @@ The test kit is split across two namespaces:
 
 ## Put the test kit on the classpath
 
-Neither namespace arrives with the artifact. The kit has its own source root,
-`test_kit/src`, deliberately outside the Hicasso artifact's `:paths` — so an
-application that writes no test carries none of it, and bundle isolation holds by
-construction rather than by convention. The cost of that is one line you have to
-add yourself, and until you add it every `ht` and `hm` require on this page fails
-to resolve.
+Where the kit comes from depends on how you resolve Hicasso, and the two routes
+differ.
 
-Following the [`:local/root` setup](00-installation.md#add-the-dependencies) — the
-only shape available while nothing is published — put the kit's root on a test
-alias in `deps.edn`:
+**From a published coordinate**, both namespaces arrive in the jar and there is
+nothing to add. The kit's source root is on the artifact's `:src-dirs`, which is
+what decides jar content, so it is packaged alongside `re-frame.hicasso` itself.
+What keeps it out of your production bundle is not packaging but reachability: no
+shipping namespace requires the kit, so a build that never requires `ht` or `hm`
+compiles none of it — the same property the diagnostic and SSR modules have.
+
+**From a `:local/root` checkout** — the only shape available while nothing is
+published — the kit is one line you add yourself. It has its own source root,
+`test_kit/src`, deliberately outside the Hicasso artifact's `:paths`, so an
+application that writes no test carries none of it; and until you put that root on
+a test alias every `ht` and `hm` require on this page fails to resolve. Following
+the [`:local/root` setup](00-installation.md#add-the-dependencies):
 
 ```clojure
 ;; deps.edn

--- a/docs/core/hicasso/api-reference.md
+++ b/docs/core/hicasso/api-reference.md
@@ -513,9 +513,10 @@ evidence/projection-fields evidence/projection-invariants evidence/envelope-fiel
 
 ## `re-frame.hicasso.test` — the L0/L1 test kit
 
-Ships from `test_kit/src`, off `:paths`, so an application that writes no test
-carries none of it. Twenty-three names, and none of them mounts anything: this
-tier reads values and runs bodies.
+Ships from `test_kit/src` — in the jar, but off the artifact's `:paths`, so a
+`:local/root` consumer names that root explicitly and no shipping namespace ever
+requires it. Twenty-three names, and none of them mounts anything: this tier reads
+values and runs bodies.
 
 ```clojure
 (ns my.app-test

--- a/docs/design/hicasso/product/release-policy.md
+++ b/docs/design/hicasso/product/release-policy.md
@@ -39,8 +39,9 @@ rather than pending"* until that bead landed, and each of the three measurements
 by the same change:
 
 1. `implementation/hicasso/deps.edn` carries a **`:clein/build` alias** naming `day8/re-frame2-hicasso`,
-   with `:version "../../VERSION"` and `:src-dirs ["src" "resources"]` — the second entry because the
-   clj-kondo export reaches a consumer over the classpath.
+   with `:version "../../VERSION"` and `:src-dirs ["src" "resources" "test_kit/src"]` — the second entry
+   because the clj-kondo export reaches a consumer over the classpath, the third because `:src-dirs` is the
+   only key that decides jar content and the testing kit would otherwise ship in no jar at all (rf2-rxf49).
 2. It is **in the lockstep inventory**. `verify-version-lockstep.sh`'s `ARTEFACTS` array now names fourteen
    artefacts and Hicasso is one of them. The array is not decorative: the same script fails the build when a
    directory declares a `:clein/build` without a matching inventory entry, so the presence is enforced in
@@ -109,7 +110,7 @@ renamed without something going red.
 | The native tier, `re-frame.hicasso.native` | the `native.cljc` namespace docstring, rowed in [`naming-ledger.md`](naming-ledger.md) | `native_surface_cljs_test.cljs` on the CLJS lane | **10 SURFACE + 4 INTERNAL** public vars |
 | Refusal ids | [`complaints.md`](complaints.md#the-stability-rule) | `implementation/hicasso/scripts/check_complaint_catalogue.py`, CI job `hicasso-complaint-catalogue` | **76 live, 6 reserved, 1 pending retirement, 1 retired** |
 | Optional modules — forms, motion, overlay, server | the `MODULES` roster in the script beside it | `implementation/hicasso/scripts/check_optional_module_reachability.py` | four modules, each proving zero reachable production code when absent |
-| The testing kit, `re-frame.hicasso.test` | `implementation/hicasso/test_kit/src`, deliberately outside the artefact's `:paths` | the kit's own witnesses on the CLJS lane | reachable only from a test, by packaging rather than convention |
+| The testing kit, `re-frame.hicasso.test` | `implementation/hicasso/test_kit/src`, on `:src-dirs` so the jar carries it, deliberately outside the artefact's `:paths` | the kit's own witnesses on the CLJS lane, plus the `rf.error/hicasso-test-` sentinel in `check_production_erasure.cjs` | reachable only from a test, by reachability — no shipping namespace requires it (rf2-rxf49) |
 | Server/hydration policy, per surface | [`lanes/react-compatibility-notes.md`](lanes/react-compatibility-notes.md#public-surface-ssrhydration-matrix) | each `dispositions.md` inventory id points at its policy row | see §4 — the Phase 4 exit this rests on is **NOT MET** |
 
 Reproduce the first and third rows with:

--- a/implementation/hicasso/deps.edn
+++ b/implementation/hicasso/deps.edn
@@ -79,6 +79,7 @@
 ;; `src/` namespace may require the kit. A classpath entry costs no bundle bytes;
 ;; a `:require` does. Off `:paths` it stays, so the in-repo lane and the
 ;; `:local/root` route keep asking for the kit explicitly.
+;;
 ;; `resources` is on :paths for ONE reason: the clj-kondo export
 ;; (rf2-hic-022) reaches a consumer over the CLASSPATH. `clj-kondo --lint
 ;; "$(clojure -Spath)" --dependencies --copy-configs` scans the classpath for

--- a/implementation/hicasso/deps.edn
+++ b/implementation/hicasso/deps.edn
@@ -56,6 +56,29 @@
 ;; does: the clj-kondo export reaches a consumer over the CLASSPATH, so a jar
 ;; without it silently ships no lint layer at all.
 ;;
+;; IT ALSO CARRIES `test_kit/src`, WHICH `:paths` DOES NOT (rf2-rxf49). The two
+;; keys are not the same lever and this artefact is the one place they diverge:
+;; `:paths` is the classpath a `:local/root` consumer inherits, while `:src-dirs`
+;; is the ONLY thing that decides jar content — clein's `create-jar` is
+;; `copy-src` then `b/jar`, and `copy-src` is `b/copy-dir` over
+;; `(concat :src-dirs :resource-dirs)` into `:class-dir`, so a root that is off
+;; `:src-dirs` is off the jar and nothing else puts it back. Left as it was, the
+;; first `v*` tag would publish a `day8/re-frame2-hicasso` containing no
+;; `re-frame.hicasso.test` and no `re-frame.hicasso.test.mounted` — the supported
+;; testing surface, absent from the artefact that documents it, with no second
+;; coordinate to get it from.
+;;
+;; This does NOT weaken the kit's dev-only property, because that property was
+;; never the separate root's to give. `re-frame.hicasso.evidence` and
+;; `re-frame.hicasso.tool` ship from `src/` and are dev-only by REACHABILITY —
+;; no `src/` namespace requires them, so a consumer who never asks for the
+;; projection never bundles a byte of it — and `scripts/check_production_erasure.cjs`
+;; is what checks that, by scanning the release bundle for each surface's
+;; sentinel. The kit is on that same roster, under the sentinel
+;; `rf.error/hicasso-test-`, and its entry already states the real rule: no
+;; `src/` namespace may require the kit. A classpath entry costs no bundle bytes;
+;; a `:require` does. Off `:paths` it stays, so the in-repo lane and the
+;; `:local/root` route keep asking for the kit explicitly.
 ;; `resources` is on :paths for ONE reason: the clj-kondo export
 ;; (rf2-hic-022) reaches a consumer over the CLASSPATH. `clj-kondo --lint
 ;; "$(clojure -Spath)" --dependencies --copy-configs` scans the classpath for
@@ -103,13 +126,15 @@
  {:test {:extra-paths ["test"
                        ;; rf2-hic-020 — `re-frame.hicasso.test`, the supported
                        ;; L0–L2 testing surface. Its own root, and NOT in
-                       ;; `:paths` above: a consumer that never writes a test
-                       ;; never carries it, so the kit's zero production
-                       ;; reachability is a packaging fact rather than a
-                       ;; convention. Listed here so the classpath probe sees
-                       ;; it; the CLJS lane reaches it through the
-                       ;; `hicasso/test_kit/src` :source-paths entry in
-                       ;; implementation/shadow-cljs.edn.
+                       ;; `:paths` above, so the in-repo lane and any
+                       ;; `:local/root` consumer ask for it by name. It IS on
+                       ;; `:clein/build`'s `:src-dirs`, so the published jar
+                       ;; carries it (rf2-rxf49) — see the `:src-dirs` paragraph
+                       ;; in the header for why those are different levers and
+                       ;; why a classpath entry is not a bundle byte. Listed
+                       ;; here so the classpath probe sees it; the CLJS lane
+                       ;; reaches it through the `hicasso/test_kit/src`
+                       ;; :source-paths entry in implementation/shadow-cljs.edn.
                        "test_kit/src"]
          :extra-deps  {day8/re-frame2-test-quiet {:local/root "../test-quiet"}
                        ;; The Node lane's substrate. The prototype's own
@@ -147,4 +172,4 @@
    :version  "../../VERSION"
    :license  {:name "MIT"
               :url  "https://opensource.org/licenses/MIT"}
-   :src-dirs ["src" "resources"]}}}
+   :src-dirs ["src" "resources" "test_kit/src"]}}}


### PR DESCRIPTION
Closes rf2-rxf49.

## The defect, reproduced

Every clause of the bead held at source. `test_kit/src` — the root carrying
`re-frame.hicasso.test` (`ht`) and `re-frame.hicasso.test.mounted` (`hm`) — was on
the in-repo `:test` alias's `:extra-paths` and on `implementation/shadow-cljs.edn`'s
`:source-paths`, and on neither `:paths` nor `:clein/build`'s `:src-dirs`.

`:src-dirs` really is the jar-content key, and that is read out of the build tool
rather than inferred from the name. clein's `create-jar` is `clean` → `copy-src` →
`b/jar`, and `copy-src` is `b/copy-dir` over `(concat :src-dirs :resource-dirs)`
into `:class-dir`, which is what `b/jar` zips (`noahtheduke/clein.cljc` lines
115-132 at the pinned sha `2b83503246`). `deploy` and `install` take the same
`copy-src`. A root off `:src-dirs` is off the jar, and nothing puts it back.

Built both ways to prove it rather than assert it, with `clojure -M:clein jar` —
the same build-only invocation `release.yml` uses as its deploy dry-run:

| `:src-dirs` | jar entries | test-kit entries |
|---|---|---|
| `["src" "resources"]` (before) | 39 | **none — the kit shipped in no jar** |
| `["src" "resources" "test_kit/src"]` (after) | 42 | `re_frame/hicasso/test.cljs`, `re_frame/hicasso/test/mounted.cljs` |

So the first `v*` tag would have published a `day8/re-frame2-hicasso` with no
testing surface in it, silently expiring the route `docs/core/hicasso/15-testing.md`
teaches, with no second coordinate to get the kit from.

## Why this option

An existing pattern in the repo answered it, so no new one was invented.

Four publishable artefacts already ship a consumer-facing testing surface **inside
the main jar, from `src/`** — `re-frame.test-support` and `re-frame.test-helpers`
(core), `re-frame.http.test-support`, `re-frame.resources.test-support`,
`re-frame.routing.test-support`. Across all fourteen publishable artefacts there is
**no separate test-kit coordinate**, and `:paths` equals `:src-dirs` everywhere but
here. The project's answer to "how does a test kit reach a consumer?" is already
"in the artefact's own jar".

A **second coordinate** was weighed and rejected: it is real machinery — a
`verify-version-lockstep.sh` ARTEFACTS entry, a `release.yml` deploy-DAG stage, a
release-notes row — for a surface of two files, against a repo with zero precedent
for it. It also lands squarely in the hot zone this PR is fenced out of.

`:paths` is deliberately **not** touched, so the in-repo lane and the `:local/root`
route keep naming the kit explicitly.

The kit's dev-only property is unaffected, because it was never the separate root's
to give. `re-frame.hicasso.evidence` and `re-frame.hicasso.tool` ship from `src/`
and are dev-only by REACHABILITY — no shipping namespace requires them — and
`check_production_erasure.cjs` is what checks it. The kit is already on that same
roster under the `rf.error/hicasso-test-` sentinel, whose entry states the real
rule in its own words: *"The kit is a separate source root that no `src/` namespace
may require."* A classpath entry costs no bundle bytes; a `:require` does.

## Coordinates and the held rename

This adds **no new coordinate**, so `.github/scripts/verify-version-lockstep.sh`
needs no inventory edit and `release.yml` no new stage — the gate passes unchanged
(quoted below). Nothing here pre-empts **rf2-fo4ng**'s held `day8/*` →
`io.github.day8/*` campaign: no coordinate is spelled that the campaign does not
already sweep.

## Docs

`15-testing.md` said *"Neither namespace arrives with the artifact"* and taught one
route. That is right for a `:local/root` checkout and wrong for a published one, so
both are now spelled. `api-reference.md` and the `release-policy.md` design record
carried the same two literals and are corrected, including the `:src-dirs` vector
the record quotes. **All doc edits are prose-only** — every fenced block in
`docs/core/hicasso/**` is digest-pinned by `check_guide_samples.py`, and no fence
was touched, added, or reordered. Table column counts in `release-policy.md` were
verified by hand (4 columns, unchanged across all rows).

## Quality gates

**The fast-PR spine was NOT run.** A Shape 6 measurement window is running on this
box under an authorised fleet drain, and the spine's browser and shadow-cljs work
would have invalidated it. No browser, Playwright, full shadow-cljs build, or
release preflight was run. The gates below were run directly instead; each exit
code is the one captured in the running shell via `> log 2>&1; echo $?`, on the
final rebased base, never read back from the harness.

| Gate | Captured exit |
|---|---|
| `clojure -M:clein jar` (hicasso — the real jar-content gate) | **0** |
| `.github/scripts/verify-version-lockstep.sh` | **0** |
| `implementation/hicasso/scripts/check_guide_samples.py` | **0** |
| `scripts/check_doc_slugs.py` | **0** |
| `scripts/check_provenance_pins.py` | **0** |
| `implementation/hicasso/scripts/check_lint_export.py` | **0** |
| `implementation/hicasso/scripts/check_freeze.py` | **0** |
| `implementation/scripts/_release-dag-policy.test.cjs` | **0** (13 passed) |
| `implementation/scripts/_changed-surfaces.test.cjs` | **0** (292 passed) |

Separately from what was run, `scripts/check_fast_pr_gap.py --list` derives **94
required checks the spine does not run** — a fact about the spine, which here did
not run at all.

`check_doc_slugs.py` prints nothing on success, so its green was discriminated
rather than trusted: a single-line broken-anchor plant in `15-testing.md` turned it
**red (exit 1)** naming that file and line, and the restore was verified by
`git hash-object` against the committed blob rather than by reading a diff. The
before/after jar table above is the same discrimination for the packaging change.

**No verification is outstanding.** The heavy gates the machine reservation
excluded — browser, shadow-cljs, release preflight — do not cover jar content;
`clein jar` does, and it ran.

One incidental observation, not a defect and not actioned: a developer machine that
has run clj-kondo locally leaves a `resources/clj-kondo.exports/**/.cache/`
directory which `:src-dirs` then packages (9 extra entries). It is gitignored and
absent from CI's fresh checkout, so no released jar is affected; the 42-entry
figure above is from a clean-room rebuild with that cache removed.
