### PR TITLE
ci: give every workflow job a timeout-minutes cap (rf2-km7iq)

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -146,6 +146,7 @@ jobs:
   detect:
     name: Detect docs surface
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     outputs:
       docs_surface: ${{ steps.detect.outputs.docs_surface }}
     steps:
@@ -674,6 +675,7 @@ jobs:
     name: Deploy to GitHub Pages
     needs: build
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     permissions:
       pages: write
       id-token: write
@@ -708,6 +710,7 @@ jobs:
     name: Docs required
     if: ${{ always() }}
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     needs:
       - detect
       - build

--- a/.github/workflows/expensive-tests.yml
+++ b/.github/workflows/expensive-tests.yml
@@ -9,6 +9,7 @@ jobs:
   browser-bundle-and-story-gates:
     name: Browser, bundle, examples, Story/Xray gates
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     defaults:
       run:
         working-directory: implementation
@@ -274,6 +275,7 @@ jobs:
   template-emitted-app:
     name: Template emitted-app smoke
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     defaults:
       run:
         working-directory: tools/template
@@ -345,6 +347,7 @@ jobs:
   mcp-live:
     name: MCP live and client conformance
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     defaults:
       run:
         working-directory: tools/mcp-conformance
@@ -465,6 +468,7 @@ jobs:
     # `scripts/test-rigorous-local.sh`.
     name: JVM slow/stress tests (clojure -M:slow-test)
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     strategy:
       fail-fast: false
       matrix:
@@ -567,6 +571,7 @@ jobs:
       - mcp-live
       - jvm-slow-tests
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     permissions:
       issues: write     # open / edit / close the single tracking issue
       actions: read     # read this run's per-step conclusions

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -145,6 +145,7 @@ jobs:
   detect:
     name: Detect lint surface
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     outputs:
       lint_surface: ${{ steps.detect.outputs.lint_surface }}
       js_surface: ${{ steps.detect.outputs.js_surface }}
@@ -245,6 +246,7 @@ jobs:
     needs: detect
     if: needs.detect.outputs.lint_surface == 'true'
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     # The job runs with `--fail-level error` so an introduced ERROR
     # blocks the PR. Warnings stay informational and surface in the
     # job log for triage.
@@ -435,6 +437,7 @@ jobs:
     needs: detect
     if: needs.detect.outputs.lint_surface == 'true'
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     # The job runs with `--fail-on-errors` so an introduced ERROR (a
     # file Splint cannot parse) blocks the PR. Style warnings still
     # print to the log for triage but never fail the gate — the same
@@ -512,6 +515,7 @@ jobs:
     needs: detect
     if: needs.detect.outputs.js_surface == 'true'
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
@@ -559,6 +563,7 @@ jobs:
     needs: detect
     if: needs.detect.outputs.lint_surface == 'true'
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
@@ -741,6 +746,7 @@ jobs:
     name: Lint required
     if: ${{ always() }}
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     needs:
       - detect
       - clj-kondo

--- a/.github/workflows/portability.yml
+++ b/.github/workflows/portability.yml
@@ -71,6 +71,7 @@ jobs:
   no-hardcoded-paths:
     name: No hardcoded personal/home paths
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
@@ -163,6 +164,7 @@ jobs:
   ai-tracking-ratchet:
     name: No newly tracked files under ai/
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       # THE BASE IS ONE NAMED COMMIT, so the checkout fetches TWO and the step
       # below fetches THAT ONE (rf2-uol6). This job used fetch-depth: 0 and spent
@@ -292,6 +294,7 @@ jobs:
   view-lifetime-residue-ratchet:
     name: No retired view-lifetime vocabulary, repo-wide
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 

--- a/.github/workflows/post-merge-workflow-sanity.yml
+++ b/.github/workflows/post-merge-workflow-sanity.yml
@@ -77,6 +77,7 @@ jobs:
   dispatch-affected-workflows:
     name: Dispatch affected workflows
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       # DEPTH 2 HOLDS HEAD^ AND NOTHING DEEPER, which is all the FALLBACK base
       # needs (a manual dispatch, or the all-zeros first push to a fresh ref).

--- a/.github/workflows/release-machines-viz.yml
+++ b/.github/workflows/release-machines-viz.yml
@@ -139,6 +139,7 @@ jobs:
   verify-version:
     name: Verify Machines-Viz tag matches lockstep VERSION
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     outputs:
       version: ${{ steps.version.outputs.version }}
     steps:
@@ -179,6 +180,7 @@ jobs:
     name: Machines-Viz pre-release test gate
     needs: verify-version
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
@@ -218,6 +220,7 @@ jobs:
     name: Deploy day8/re-frame2-machines-viz
     needs: [verify-version, test-machines-viz]
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:

--- a/.github/workflows/release-story.yml
+++ b/.github/workflows/release-story.yml
@@ -149,6 +149,7 @@ jobs:
   verify-version:
     name: Verify story-v tag matches lockstep VERSION
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     outputs:
       version: ${{ steps.version.outputs.version }}
     steps:
@@ -185,6 +186,7 @@ jobs:
     name: Story pre-release test gate
     needs: verify-version
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
@@ -218,6 +220,7 @@ jobs:
     name: mcp-base pre-release test gate
     needs: verify-version
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
@@ -256,6 +259,7 @@ jobs:
     name: story-mcp pre-release test gate
     needs: verify-version
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
@@ -302,6 +306,7 @@ jobs:
     name: Deploy day8/re-frame2-story
     needs: [verify-version, test-story]
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
@@ -403,6 +408,7 @@ jobs:
     name: Deploy day8/re-frame2-mcp-base
     needs: [verify-version, test-mcp-base]
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
@@ -461,6 +467,7 @@ jobs:
     name: Deploy day8/re-frame2-story-mcp
     needs: [verify-version, test-story-mcp, deploy-mcp-base, deploy-story]
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:

--- a/.github/workflows/release-xray.yml
+++ b/.github/workflows/release-xray.yml
@@ -108,6 +108,7 @@ jobs:
   verify-version:
     name: Verify Xray tag matches lockstep VERSION
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     outputs:
       version: ${{ steps.version.outputs.version }}
     steps:
@@ -147,6 +148,7 @@ jobs:
     name: Xray pre-release test gate
     needs: verify-version
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
@@ -186,6 +188,7 @@ jobs:
     name: Deploy day8/re-frame2-xray
     needs: [verify-version, test-xray]
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -176,6 +176,7 @@ jobs:
   verify-version-lockstep:
     name: Verify lockstep version contract
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
@@ -203,6 +204,7 @@ jobs:
     name: Pre-release test gate
     needs: verify-version-lockstep
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
@@ -342,6 +344,7 @@ jobs:
     name: Deploy day8/re-frame2
     needs: test
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     outputs:
       version: ${{ steps.version.outputs.version }}
     steps:
@@ -428,6 +431,7 @@ jobs:
     name: Deploy ${{ matrix.artefact }}
     needs: deploy-core
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix:
@@ -660,6 +664,7 @@ jobs:
       - deploy-core
       - deploy-leaf
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     strategy:
       matrix:
         include:
@@ -800,6 +805,7 @@ jobs:
       - deploy-core
       - deploy-leaf
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     strategy:
       matrix:
         include:
@@ -895,6 +901,7 @@ jobs:
       - deploy-ssr-ring
       - deploy-hicasso
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 

--- a/.github/workflows/template-release.yml
+++ b/.github/workflows/template-release.yml
@@ -84,6 +84,7 @@ jobs:
   verify-version:
     name: Verify template tag matches VERSION
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     outputs:
       version: ${{ steps.version.outputs.version }}
     steps:
@@ -144,6 +145,7 @@ jobs:
     name: Template pre-release test gate
     needs: verify-version
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
@@ -240,6 +242,7 @@ jobs:
     name: Cut GitHub Release for template
     needs: [verify-version, test-template]
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -67,6 +67,7 @@ jobs:
   detect_changed_surfaces:
     name: Detect changed test surfaces
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     outputs:
       implementation_jvm: ${{ steps.detect.outputs.implementation_jvm }}
       cljs_node_test: ${{ steps.detect.outputs.cljs_node_test }}
@@ -135,6 +136,7 @@ jobs:
   verify-version-lockstep:
     name: Verify lockstep version contract (rf2-ace2)
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
@@ -184,6 +186,7 @@ jobs:
   verify-skill-mcp-drift:
     name: Repo invariant checks (skills, MCP, catalogues, namespaces)
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
@@ -815,6 +818,7 @@ jobs:
   verify-readme-links:
     name: Verify markdown link slugs — READMEs + the docs/spec/skills/migration corpus (rf2-br5u7, rf2-v7fui)
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
@@ -1417,6 +1421,7 @@ jobs:
     needs: detect_changed_surfaces
     if: needs.detect_changed_surfaces.outputs.implementation_jvm == 'true'
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     defaults:
       run:
         working-directory: implementation/core
@@ -1492,6 +1497,7 @@ jobs:
     needs: detect_changed_surfaces
     if: needs.detect_changed_surfaces.outputs.implementation_jvm == 'true'
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
@@ -1733,6 +1739,7 @@ jobs:
     needs: detect_changed_surfaces
     if: needs.detect_changed_surfaces.outputs.adapter_diagnostic == 'true'
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     defaults:
       run:
         working-directory: implementation/adapters/reagent
@@ -1778,6 +1785,7 @@ jobs:
     needs: detect_changed_surfaces
     if: needs.detect_changed_surfaces.outputs.adapter_diagnostic == 'true'
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     defaults:
       run:
         working-directory: implementation/adapters/reagent-slim
@@ -1821,6 +1829,7 @@ jobs:
     needs: detect_changed_surfaces
     if: needs.detect_changed_surfaces.outputs.adapter_diagnostic == 'true'
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     defaults:
       run:
         working-directory: implementation/adapters/uix
@@ -1866,6 +1875,7 @@ jobs:
     needs: detect_changed_surfaces
     if: needs.detect_changed_surfaces.outputs.adapter_diagnostic == 'true'
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     defaults:
       run:
         working-directory: implementation/adapters/test-react
@@ -1921,6 +1931,7 @@ jobs:
     needs: detect_changed_surfaces
     if: needs.detect_changed_surfaces.outputs.implementation_jvm == 'true'
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     defaults:
       run:
         working-directory: implementation/schemas
@@ -1964,6 +1975,7 @@ jobs:
     needs: detect_changed_surfaces
     if: needs.detect_changed_surfaces.outputs.implementation_jvm == 'true'
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     defaults:
       run:
         working-directory: implementation/machines
@@ -2009,6 +2021,7 @@ jobs:
     needs: detect_changed_surfaces
     if: needs.detect_changed_surfaces.outputs.implementation_jvm == 'true'
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     defaults:
       run:
         working-directory: implementation/routing
@@ -2082,6 +2095,7 @@ jobs:
     needs: detect_changed_surfaces
     if: needs.detect_changed_surfaces.outputs.implementation_jvm == 'true'
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
@@ -2119,6 +2133,7 @@ jobs:
     needs: detect_changed_surfaces
     if: needs.detect_changed_surfaces.outputs.implementation_jvm == 'true'
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     defaults:
       run:
         working-directory: implementation/flows
@@ -2154,6 +2169,7 @@ jobs:
     needs: detect_changed_surfaces
     if: needs.detect_changed_surfaces.outputs.implementation_jvm == 'true'
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     defaults:
       run:
         working-directory: implementation/http
@@ -2189,6 +2205,7 @@ jobs:
     needs: detect_changed_surfaces
     if: needs.detect_changed_surfaces.outputs.implementation_jvm == 'true'
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     defaults:
       run:
         working-directory: implementation/ssr
@@ -2277,6 +2294,7 @@ jobs:
     needs: detect_changed_surfaces
     if: needs.detect_changed_surfaces.outputs.implementation_jvm == 'true'
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
@@ -2314,6 +2332,7 @@ jobs:
     needs: detect_changed_surfaces
     if: needs.detect_changed_surfaces.outputs.implementation_jvm == 'true'
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     defaults:
       run:
         working-directory: implementation/security
@@ -2364,6 +2383,7 @@ jobs:
     needs: detect_changed_surfaces
     if: needs.detect_changed_surfaces.outputs.implementation_jvm == 'true'
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     defaults:
       run:
         working-directory: implementation/ssr-ring
@@ -2417,6 +2437,7 @@ jobs:
     needs: detect_changed_surfaces
     if: needs.detect_changed_surfaces.outputs.implementation_jvm == 'true'
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     defaults:
       run:
         working-directory: implementation/epoch
@@ -2506,6 +2527,7 @@ jobs:
     needs: detect_changed_surfaces
     if: needs.detect_changed_surfaces.outputs.implementation_jvm == 'true'
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
@@ -2554,6 +2576,7 @@ jobs:
     needs: detect_changed_surfaces
     if: needs.detect_changed_surfaces.outputs.implementation_jvm == 'true'
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     defaults:
       run:
         working-directory: implementation/resources
@@ -2606,6 +2629,7 @@ jobs:
     needs: detect_changed_surfaces
     if: needs.detect_changed_surfaces.outputs.implementation_jvm == 'true'
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     defaults:
       run:
         working-directory: implementation/spec-resource
@@ -2648,6 +2672,7 @@ jobs:
     needs: detect_changed_surfaces
     if: needs.detect_changed_surfaces.outputs.implementation_jvm == 'true'
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     defaults:
       run:
         working-directory: implementation/reply-conformance
@@ -2690,6 +2715,7 @@ jobs:
     needs: detect_changed_surfaces
     if: needs.detect_changed_surfaces.outputs.implementation_jvm == 'true'
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     defaults:
       run:
         working-directory: implementation/derivation-conformance
@@ -2733,6 +2759,7 @@ jobs:
     needs: detect_changed_surfaces
     if: needs.detect_changed_surfaces.outputs.implementation_jvm == 'true'
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     defaults:
       run:
         working-directory: implementation/event-conformance
@@ -3277,6 +3304,7 @@ jobs:
   js-harness-self-tests:
     name: JS harness self-tests (quiet reporters + path policy)
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     defaults:
       run:
         working-directory: implementation
@@ -3595,6 +3623,7 @@ jobs:
     needs: detect_changed_surfaces
     if: needs.detect_changed_surfaces.outputs.cljs_prod == 'true'
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     defaults:
       run:
         working-directory: implementation
@@ -3827,6 +3856,7 @@ jobs:
     needs: detect_changed_surfaces
     if: needs.detect_changed_surfaces.outputs.bundle_isolation == 'true'
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     defaults:
       run:
         working-directory: implementation
@@ -3886,6 +3916,7 @@ jobs:
     needs: detect_changed_surfaces
     if: needs.detect_changed_surfaces.outputs.adapter_testbed_smokes == 'true'
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     defaults:
       run:
         working-directory: implementation
@@ -4470,6 +4501,7 @@ jobs:
     needs: detect_changed_surfaces
     if: needs.detect_changed_surfaces.outputs.tools_jvm == 'true'
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     defaults:
       run:
         working-directory: tools/xray
@@ -4512,6 +4544,7 @@ jobs:
     needs: detect_changed_surfaces
     if: needs.detect_changed_surfaces.outputs.tools_jvm == 'true'
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     defaults:
       run:
         working-directory: tools/story
@@ -4555,6 +4588,7 @@ jobs:
     needs: detect_changed_surfaces
     if: needs.detect_changed_surfaces.outputs.tools_jvm == 'true'
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     defaults:
       run:
         working-directory: tools/story-mcp
@@ -4606,6 +4640,7 @@ jobs:
     needs: detect_changed_surfaces
     if: needs.detect_changed_surfaces.outputs.tools_jvm == 'true'
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     defaults:
       run:
         working-directory: tools/mcp-base
@@ -4683,6 +4718,7 @@ jobs:
     needs: detect_changed_surfaces
     if: needs.detect_changed_surfaces.outputs.tools_jvm_machines_viz == 'true'
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     defaults:
       run:
         working-directory: tools/machines-viz
@@ -4884,6 +4920,7 @@ jobs:
     needs: detect_changed_surfaces
     if: needs.detect_changed_surfaces.outputs.tools_jvm_testbed_support == 'true'
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     defaults:
       run:
         working-directory: tools/testbed-support
@@ -5058,6 +5095,7 @@ jobs:
     needs: detect_changed_surfaces
     if: needs.detect_changed_surfaces.outputs.migration_hicasso_codemod == 'true'
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     defaults:
       run:
         working-directory: migration/reagent-to-hicasso/codemod
@@ -5109,6 +5147,7 @@ jobs:
     needs: detect_changed_surfaces
     if: needs.detect_changed_surfaces.outputs.migration_v1_codemod == 'true'
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     defaults:
       run:
         working-directory: migration/from-re-frame-v1/codemod
@@ -5161,6 +5200,7 @@ jobs:
     needs: detect_changed_surfaces
     if: needs.detect_changed_surfaces.outputs.ssr_node == 'true'
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     defaults:
       run:
         working-directory: implementation
@@ -5201,6 +5241,7 @@ jobs:
     needs: detect_changed_surfaces
     if: needs.detect_changed_surfaces.outputs.mcp_conformance == 'true'
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     defaults:
       run:
         working-directory: tools/re-frame2-pair-mcp
@@ -5281,6 +5322,7 @@ jobs:
     needs: detect_changed_surfaces
     if: needs.detect_changed_surfaces.outputs.mcp_conformance == 'true'
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     defaults:
       run:
         working-directory: tools/story-mcp
@@ -5543,6 +5585,7 @@ jobs:
     needs: detect_changed_surfaces
     if: needs.detect_changed_surfaces.outputs.mcp_conformance == 'true'
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     defaults:
       run:
         working-directory: tools/mcp-conformance
@@ -5639,6 +5682,7 @@ jobs:
     needs: detect_changed_surfaces
     if: needs.detect_changed_surfaces.outputs.mcp_conformance == 'true'
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     defaults:
       run:
         working-directory: tools/mcp-conformance/wire-vocab
@@ -5684,6 +5728,7 @@ jobs:
     needs: detect_changed_surfaces
     if: needs.detect_changed_surfaces.outputs.skills_structural == 'true'
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
@@ -5816,6 +5861,7 @@ jobs:
     needs: detect_changed_surfaces
     if: needs.detect_changed_surfaces.outputs.skills_structural == 'true'
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     defaults:
       run:
         working-directory: skills/re-frame2-pair/tests/fixture
@@ -5891,6 +5937,7 @@ jobs:
     needs: detect_changed_surfaces
     if: needs.detect_changed_surfaces.outputs.playground == 'true'
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     defaults:
       run:
         working-directory: docs/tools/playground
@@ -6068,6 +6115,7 @@ jobs:
     name: All required checks passed
     if: ${{ always() }}
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     needs:
       - detect_changed_surfaces
       - verify-version-lockstep


### PR DESCRIPTION
Closes rf2-km7iq.

A GitHub Actions job with no `timeout-minutes` inherits the platform's
360-minute default. When a runner wedges, such a job produces a check that
**never terminates** — a merge loop has nothing to read and no remedy but a
hand cancel. A cap does not prevent the wedge; it converts the wedge into a
fast, legible failure.

## The bead's numbers reproduced — all of them

The bead was filed off run `32094188039`. That run was cancelled by hand and
re-run, so `gh run view` now serves **attempt 2** and shows both jobs healthy.
Attempt 1 is the evidence, via
`gh api .../actions/runs/32094188039/attempts/1/jobs`:

| job | attempt-1 window | elapsed | conclusion |
|---|---|---|---|
| `JVM tools/template (clojure -M:test)` | 03:09:37Z → 03:44:51Z | 35.2 min | `cancelled` — hit its `timeout-minutes: 35` |
| `docs/cljs playground` | 03:09:36Z → 03:58:47Z | 49.2 min | `cancelled` — by hand, no cap to stop it |

Both match the bead. The capped sibling died at its cap and said so; the
uncapped one ran until a human intervened. That asymmetry is the whole defect.

## The census overturns the bead's central premise

The bead records `tools-playground` as "an outlier, not the house style", while
correctly flagging that it was found by reading one run rather than by a sweep
and asking for the claim to be re-derived. It does not hold.

Parsing the YAML structurally — not grepping, so a `timeout-minutes` under a
*step* is never miscounted as a *job* cap:

```
TOTALS: capped=28  uncapped=89  reusable=0
```

**89 of 117 jobs carried no cap.** Uncapped was the house *majority* (76%), not
the exception. `tools-playground` was ordinary, not anomalous. All 89 are capped
here — one hot-zone toucher, one PR.

### Census controls

A search returning zero is not a check that passed, so the method was run
against known-good and known-bad inputs:

- **Positive control** — jobs that do carry a cap are classified as capped:
  28 found pre-change, including `jvm-tools-template` at
  `timeout-minutes: 35`, the exact value the bead cites at `test.yml:4924`.
- **Negative control** — `tools-playground` pre-change was reported
  `UNCAPPED`, naming the job the bead names.
- **Sabotage** — against a scratch copy of the *post-change* tree (0 uncapped),
  two defects were planted: `tools-playground`'s new cap stripped, and a
  fixture job whose only `timeout-minutes` sits under a **step**. The census
  went **red**, reporting exactly 2 uncapped and counting the step-level key
  separately. It did not run green, so the clean zero on the real tree is a
  real zero and the step-vs-job distinction demonstrably works.
- A structural before/after assertion on the parsed YAML confirms the two trees
  are identical **apart from 89 added job-level `timeout-minutes` keys** — no
  job added, none removed, no other key touched. The text diff agrees:
  **89 insertions, 0 deletions**, and every changed line matches
  `^\+    timeout-minutes: [0-9]+$`.

## How each cap was sized

A cap here is a **circuit breaker, not a performance budget**. Too tight turns
an ordinary slow day into a red PR, which is worse than the defect, so every
figure is deliberately generous: rounded up onto the house ladder (multiples of
5) well above the job's measured worst case.

Durations were measured per job from recent successful runs of each workflow —
934 job records across 25 runs of `test.yml`, `docs.yml`, `lint.yml`,
`portability.yml` and 15 each of `expensive-tests.yml` and
`post-merge-workflow-sanity.yml`.

**`tools-playground` gets `timeout-minutes: 15`** — 8.1x its measured worst
case. Eleven real executions were sampled (the job is surface-gated and skipped
in the other sampled runs): runs `32082472715`, `32080996828`, `32075666654`,
`32034770938`, `32034703923`, `32029213690`, `32026686600`, `31950191962`,
`31944202439`, `31937686450`, `31937406717`. Spread **1.35 – 1.85 min**, median
1.55. The bead's "1.4–1.7 min" from three runs reproduces; the wider sample
extends the top of the band slightly, to 1.85. The 35 from `tools/template` was
deliberately **not** copied.

Headroom is sized against cold-cache risk, not just the warm band: this job
restores a Maven cache, runs `npm ci`, installs Chromium and does a
shadow-cljs `:advanced` build, all of which are far slower on a cache miss than
the sampled runs suggest.

Resulting distribution of the 89 added caps:

| cap | jobs | basis |
|---|---|---|
| 5 min | 3 | pure aggregator gates (`all-required-passed`, `docs-required`, `lint-required`) — no checkout, measured max 0.08 min |
| 10 min | 38 | measured max under ~1 min |
| 15 min | 22 | measured max 1–3 min |
| 20 min | 7 | measured max 3–6 min |
| 30 min | 17 | measured max 6–13 min, plus release/deploy jobs with no recent runs to measure |
| 60 min | 2 | `expensive-tests` browser sweep (measured max 39.05 min) and `release.yml`'s pre-release gate (14 `clojure -M:test` invocations plus 4 CLJS suites) |

The floor is 10 rather than 5 for anything that checks out the repo: the
`detect`-style jobs measure up to **4.6 min** on this repo despite doing almost
no work, so checkout and toolchain provisioning alone consume several minutes.

Release and deploy jobs had **no successful runs in the sampled window**, so
their caps are judgement, not measurement, and are set generously (30) —
publishing to Clojars is network-bound and irreversible, and a red release is
expensive.

Per file:

| file | caps added |
|---|---|
| `.github/workflows/test.yml` | 48 |
| `.github/workflows/release.yml` | 7 |
| `.github/workflows/release-story.yml` | 7 |
| `.github/workflows/lint.yml` | 6 |
| `.github/workflows/expensive-tests.yml` | 5 |
| `.github/workflows/docs.yml` | 3 |
| `.github/workflows/portability.yml` | 3 |
| `.github/workflows/release-machines-viz.yml` | 3 |
| `.github/workflows/release-xray.yml` | 3 |
| `.github/workflows/template-release.yml` | 3 |
| `.github/workflows/post-merge-workflow-sanity.yml` | 1 |

## Scope

Caps only. No job restructured, no step touched, no reusable workflow, no
workflow-level default, and **no linter to enforce caps in future** — that last
one is deliberately left unbuilt and filed as **rf2-rsn1e**, with the argument
for and against it recorded there, rather than smuggled in here.

One observation surfaced by the census and deliberately **not** actioned,
because this change's fence is cap *additions* only: `beads-pr-boundary`
carries a pre-existing `timeout-minutes: 5` against a measured max of
**4.67 min** — 1.07x headroom, a latent flake by the standard applied above.
Filed as **rf2-xenc6**; not changed here.

## Relationship to rf2-krdb7

`rf2-krdb7` owns the mayor-side rule for what to do when a check never
terminates, and is in flight separately against
`.claude/commands/mayor-merge.md` — untouched by this PR. The two are
**complementary, not duplicates**: this one adds the cap so the hang becomes a
legible failure; that one tells the mayor what to do when a check hangs anyway
(a cap cannot help a check that is queued, or one whose runner dies without
reporting). Neither should be closed as a duplicate of the other.

`rf2-fo4ng` is held and will later rewrite Maven coordinates across the release
workflows. This diff is one added line per job and rebases trivially under it.

## Quality gates

**The fast-PR spine was NOT run.** A Shape 6 measurement window was running on
the machine under an authorised fleet drain, and a clock measurement is only
valid on a quiet box, so no shadow-cljs, browser, npm-build or JVM gate was
started. Only cheap, non-loading checkers were run. Every exit code below was
captured with the redirect and the `echo $?` on one command line in one shell,
and is quoted as the number captured locally.

There is a genuine irony worth stating plainly: **the surface being edited is
verified by CI itself**, and the only complete verification of a workflow change
is CI running it. The local evidence is a YAML parse plus the census; the
workflow's own behaviour is verified by this PR's own CI run. No local proxy was
invented that would "pass" without exercising the change.

All gates below were re-run on the **post-rebase** base (`origin/main` moved
during the work; no `.github/` change landed in it, and the rebase was clean).

| check | captured exit |
|---|---|
| `scripts/check_workflow_yaml.py` — PASS, well-formed, 11 files | `0` |
| structural before/after assertion vs `origin/main` — 89 added, nothing else | `0` |
| census of `.github/workflows/*.yml` — `capped=117 uncapped=0` | `0` |
| census **sabotage** (2 planted defects) — correctly **red** | `1` (expected) |
| `scripts/check_gate_scheduling.py` | `0` |
| `scripts/check_ci_reproduce_commands.py` | `0` |
| `scripts/check_jvm_lane_rosters.py` | `0` |
| `scripts/check_fast_pr_gap.py --list` | `0` |
| `node scripts/_lint-workflow-policy.test.cjs` | `0` |
| `node scripts/_docs-workflow-policy.test.cjs` | `0` |
| `node scripts/_release-dag-policy.test.cjs` | `0` |
| `node scripts/_post-merge-sanity-base.test.cjs` | `0` |
| `node scripts/_changed-surfaces.test.cjs` — 292 passed | `0` |

The sabotage run is listed with its red exit deliberately: a green sabotage
would have been a reason to stop rather than to proceed.

For the spine-versus-required-CI gap, `scripts/check_fast_pr_gap.py --list`
derives it at step granularity and reports **94 required checks the spine does
not run**. Since the spine was not run at all here, that gap is total: none of
the three required contexts (`All required checks passed`, `Lint required`,
`Docs required`) is decided locally. They are decided by this PR's CI run.

`git diff origin/main...HEAD` (three-dot) was read for reverts before pushing:
**11 files, 89 insertions, 0 deletions.** Nothing on the trunk is reapplied
stale or silently dropped.
