### PR TITLE
docs: the topo clock driver's arm-specific floor, and §4's Ribbon table (rf2-yorfi, rf2-rpivn)

### DIFF
--- a/implementation/hicasso/test/re_frame/bench/hicasso/topo/clock_app.cljs
+++ b/implementation/hicasso/test/re_frame/bench/hicasso/topo/clock_app.cljs
@@ -78,10 +78,30 @@
 
   The same ruling is the reason every row count also carries a `:noop`
   row. `[:topo/noop-write]` moves a key no arm reads, so its window holds
-  exactly the cost that does **not** move with the arm — dispatch, the
+  the per-commit cost of a commit that builds no markup — dispatch, the
   `flushSync` boundary, the commit React schedules regardless. That is the
   quantity that killed the windowed arm, and a reader handed an
   arm-to-arm ratio without it cannot tell a topology result from a floor.
+
+  **That cost is ARM-SPECIFIC, and the premise this file used to state —
+  that the row holds *\"exactly the cost that does not move with the
+  arm\"* — is FALSIFIED.** The window `rf2-w01c` took on this driver
+  reads, at `B = 1000`, **31.75 / 31.60 / 31.85 ms on `fine`** against
+  **8.00 / 8.20 / 8.40 on `coarse`** and **9.40 / 9.40 / 9.55 on
+  `chunked`** — `fine`'s floor is 3.97, 3.85 and 3.79 times `coarse`'s
+  across the three runs. The floor MOVES with the arm, by about 4x.
+  **What it varies with is not settled**, and this file fits no cost for
+  it: the arms differ in boundary count, in subscription count and in
+  nothing else the window separates, so the statement the measurement
+  supports is *the floor is larger on the arm with more boundaries and
+  reads* and nothing sharper. See
+  [§2.9.7](../../../../../../../docs/design/hicasso/product/topology-tournament.md#297-the-floor-row-and-the-thing-it-turned-out-not-to-be).
+
+  The sentence above — that a reader handed an arm-to-arm ratio without
+  the floor cannot tell a topology result from a floor — is
+  **STRENGTHENED** by that and not weakened: a floor that is itself
+  arm-specific is one a reader cannot even bound by taking the smallest
+  arm's.
 
   **It is published beside every cell and it adjudicates nothing.** The
   same ruling rejected subtracting a separately-measured floor on three
@@ -168,8 +188,11 @@
   "The fifth row, and the only one that is not a tournament operation.
 
   `[:topo/noop-write]` moves a key no arm reads, so its window holds the
-  per-commit cost that does not move with the arm. REPORTED beside the
-  cells; it corrects nothing. See the namespace docstring."
+  per-commit cost of a commit that builds no markup. That cost is
+  ARM-SPECIFIC — about 4x larger on `fine` than on `coarse` at
+  `B = 1000` — rather than the shared constant this row was named for.
+  REPORTED beside the cells; it corrects nothing. See the namespace
+  docstring."
   :noop)
 
 (def rows
@@ -488,20 +511,27 @@
 ;; ---------------------------------------------------------------------------
 
 (defn floor-shares
-  "How much of each cell's window is the per-commit cost that does NOT
-  move with the arm, as `{[arm op b] share}`.
+  "How much of each cell's window is that cell's OWN ARM's floor, as
+  `{[arm op b] share}`.
 
   `share` is the floor row's centre over the operation row's centre on
   the SAME arm at the SAME row count — a ratio of two measurements, never
   a correction applied to either. `rf2-4t36` rejected subtracting a
   floor and the sharpest of its three reasons is that there is nothing
   stable to subtract: the identical fit returns +47% on one arm and
-  negative constants on three.
+  negative constants on three. The window STRENGTHENED that reason, by
+  measuring a floor that is arm-specific — see the namespace docstring.
 
-  A reader uses this exactly as that ruling used it — a cell whose window
-  is mostly floor is a cell whose arm-to-arm ratio is compressed toward
-  1, and the compression is arithmetic rather than a defect. Nothing here
-  adjudicates on it."
+  **The received rule for reading a mostly-floor cell does not apply to
+  this table, and the reason is that same falsification.** *\"A cell
+  whose window is mostly floor has its arm-to-arm ratio compressed
+  toward 1\"* is true when both arms carry the SAME floor. These do not,
+  so the limit here is a different number: were an operation to add
+  nothing at all to either arm, the ratio would read this table's own
+  floor ratio — `coarse`/`fine` of 0.254-0.268 at `B = 1000` — and not
+  1.00. **No corrected ratio is computed here**, because computing one
+  needs the additive cost model `rf2-4t36` refused. Nothing here
+  adjudicates on any of it."
   [table]
   (into {}
         (for [b   row-counts

--- a/tools/xray/spec/019-Cross-Cutting-Insight.md
+++ b/tools/xray/spec/019-Cross-Cutting-Insight.md
@@ -744,9 +744,9 @@ separate axis — see §0). The placement is uniform across areas:
 
 | Ribbon (L1) | Cross-cutting growth |
 |---|---|
-| Active-managed-effects chip (`⧖ 3 HTTP · 1 WS · 2 actors`) — F-C4 entry. |
-| SSR indicator chip (`📄 SSR @ <hash>`) — S-C1 entry. |
-| Expanded event-list badge taxonomy on L2 rows: `🌐 🔌 📄 🌊 🤖 🧭` (F-C1, R-C1, S-C1). |
+| **Active-managed-effects chip** | `⧖ 3 HTTP · 1 WS · 2 actors` — F-C4 entry. |
+| **SSR indicator chip** | `📄 SSR @ <hash>` — S-C1 entry. |
+| **Expanded event-list badge taxonomy** | On L2 rows: `🌐 🔌 📄 🌊 🤖 🧭` (F-C1, R-C1, S-C1). |
 
 ---
 


### PR DESCRIPTION
Two prose beads, two commits, in the order dispatched.

## `rf2-yorfi` — the topo clock driver's `:noop` docstring

`rf2-w01c`'s clock window falsified a premise the driver asserted about its own
floor row: that `[:topo/noop-write]`'s window holds *"exactly the cost that does
not move with the arm"*. Verified against the published record, now on `main` as
[§2.9.5](docs/design/hicasso/product/topology-tournament.md) and §2.9.7 — at
`B = 1000` the floor row reads **31.75 / 31.60 / 31.85 ms** on `fine` against
**8.00 / 8.20 / 8.40** on `coarse` and **9.40 / 9.40 / 9.55** on `chunked`, so
`fine`'s floor is 3.97, 3.85 and 3.79 times `coarse`'s across the three runs.
The floor is arm-specific.

**Three docstrings in the file carried the premise, not one.** The bead names
two of them and the search found the third; all three now state what was
measured:

- the **namespace docstring**'s floor-row section, which asserted it directly.
  It now records the falsification with the figures, links §2.9.7, and says
  that what the floor varies with is **not settled** — the arms differ in
  boundary count and in subscription count and this window separates neither,
  so the statement the measurement supports is *"larger on the arm with more
  boundaries and reads"* and nothing sharper. Its later sentence — that a
  reader handed an arm-to-arm ratio without the floor cannot tell a topology
  result from a floor — is **strengthened** rather than weakened, and now says
  so;
- **`floor-op`**, which restated the premise in one line;
- **`floor-shares`**, which additionally repeated the received rule that a
  mostly-floor cell has its ratio *"compressed toward 1"*. That rule assumes a
  **shared** floor. The limit here is the table's own floor ratio —
  `coarse`/`fine` of 0.254–0.268 at `B = 1000` — not 1.00. **No corrected ratio
  is published**, because computing one needs the additive cost model
  `rf2-4t36` refused, which this change does not relitigate.

**Prose only, and deliberately so.** The sampling, `batch-k`, the band, the
arms and the probe pairs are untouched, so the published table remains a table
taken on this instrument. The window is not re-run — `rf2-w01c` pre-registered
three runs and three ran.

**Sites searched and deliberately left alone**, so the next reader does not
re-open them:

- `topo/clock_witness_dom_cljs_test.cljs:129` says the floor window *"holds the
  per-commit cost and no row of markup"*. That is a claim about markup, not
  about arm-invariance, and it is accurate. Untouched.
- `implementation/hicasso/test/re_frame/bench/hicasso/clock_app.cljs:710`
  ("every ratio was compressed toward 1.0 by it") is the **walk-vs-Reagent**
  lane, where the ~1.2 ms contamination genuinely is shared across the
  segment's arms. Different instrument, sound claim, and outside this bead's
  fence.
- `topology-tournament.md:394` ("a large constant term is shared between the
  arms") is about the **within-arm doubling control**, where the constant is
  shared by construction. Sound in context.
- `topology-tournament.md:872` and `:912` quote the falsified premise **in
  order to falsify it**. Correct as written; the record is read, not edited.

## `rf2-rpivn` — the malformed `Ribbon (L1)` table

Re-derived at the current tip: **`tools/xray/spec/019-Cross-Cutting-Insight.md`
lines 745–749**, unchanged in membership since the bead was filed. The table is
headed over two columns and its three data rows each carried **one** cell, so
every row rendered with an empty right-hand column.

The editorial judgement the bead asked for is **settled by §4's own
convention** rather than invented. Its two sibling tables — `Tab` at :732 and
`Popover` at :740 — put the surface on the left and what that surface grows on
the right, and the Ribbon table's header says exactly the same thing. So its
left column wants the ribbon element and its right column wants the growth.

**The split adds no content.** Each row already carried the element's name, its
rendering and its cross-cutting tags inside the single cell; the repair only
moves the boundary between them. The one added token in the whole change is a
capital `O` on "On L2 rows", where that clause became the start of its own cell.
Nothing was invented to fill a cell.

This is a `tools/xray/spec/` change, so the project's *"a dispatch touching
`tools/xray/` updates `tools/xray/spec/*` in the same PR"* obligation is met by
construction — the spec **is** the change.

## Quality gates

**The fast-PR spine was NOT run, and that is deliberate.** A heavyweight bench
run holds this box; a gate large enough that two cannot coexist wedges rather
than fails, so no shadow-cljs build, browser, Playwright, npm build or JVM suite
was started. **CI is the verification for everything below that line**, and
`python scripts/check_fast_pr_gap.py --list` (exit **0**) is the citation for
the size of that gap: **94 required checks the spine does not run**, including
`test.yml`'s `CLJS (shadow-cljs :node-test)` lane.

`rf2-yorfi` edits a `.cljs` file, so the covering gate is normally a CLJS
compile. **That compile was not run here; CI's CLJS lane is the verification.**
What was done instead, because a docstring edit must stay a docstring edit:

| gate | what it covers | exit code captured |
|---|---|---|
| Clojure delimiter/string balance over the edited `clock_app.cljs` (string-, comment- and char-literal-aware) | the edit did not unbalance a form or leave a string open | **0** — `BALANCED ok; closed string literals = 67` |
| markdown column-count sweep over `019-Cross-Cutting-Insight.md` | table shape, which no repo gate validates | **0** — `tables scanned: 4, tables with a mismatched row: 0` |
| `python scripts/check_doc_slugs.py` | markdown link targets + heading anchors; its roster is `DEFAULT_ROOTS` (`docs`, `spec`, `skills`, `migration`) plus `tools/*/spec`, read from `_iter_markdown`, so it **does** reach `tools/xray/spec/` | **0** (silent on success) |

Every number above is the one captured by the run itself (`echo "EXIT=$?"` on
the same command line as the redirect), not one reported about the run.

**Both gates were sabotage-verified in this tree, and both restores verified by
hashing the bytes** rather than by reading a diff:

- an unescaped `"` planted on a single edited line of `clock_app.cljs` took the
  balance check to exit **1**, naming `UNBALANCED close ) line 394`; restored
  file re-hashed to `95200ae8…`, matching the pre-plant hash exactly.
- a `[…](#planted-anchor-that-does-not-exist)` planted on a single edited row of
  the Ribbon table took `check_doc_slugs.py` to exit **1**, naming
  `tools\xray\spec\019-Cross-Cutting-Insight.md:748` — so the validator was
  reading this branch's tree and not a sibling's; restored file re-hashed to
  `116bab08…`, matching the pre-plant hash exactly.

**Not applicable, checked rather than assumed:**

- `mkdocs build --strict` — `mkdocs.yml`'s `exclude_docs` governs what the build
  can see, and neither `tools/xray/spec/` (not under `docs/` at all) nor
  `implementation/**` is in the site. Nominating it here would be a green run
  over an excluded path.
- `scripts/check_provenance_pins.py` — roots at `docs/design/hicasso`
  (`DEFAULT_ROOT`), and this PR changes no page under it. The `clock_app.cljs`
  docstring's new §2.9.7 link points **into** that tree; the target heading was
  verified present verbatim and the anchor slug derived with the checker's own
  `SLUGIFY`, since nothing validates links out of `.cljs`.
- no test in `topo/` pins the docstring text (searched), so this is not a
  two-file change of the guide-code-block class.

**Column counts, hand-verified over all four tables in the file** (the
finding's own method, since nothing in the repo validates table shape). The 23
pipe-leading lines in the file account for exactly these four tables and
nothing else:

| table | header | separator | data rows |
|---|---|---|---|
| §3 matrix, :711 | 5 | 5 | 5 rows × 5 |
| `Tab`, :732 | 2 | 2 | 5 rows × 2 |
| `Popover`, :740 | 2 | 2 | 2 rows × 2 |
| `Ribbon (L1)`, :745 | 2 | 2 | **was 3 rows × 1**, now 3 rows × 2 |

**Revert check.** `git diff --name-status origin/main...HEAD` (three-dot) is
exactly the two files this PR intends. Rebased onto `origin/main` after
`rf2-krdb7` landed, and **all three gates were re-run on the final base** — the
exit codes quoted above are the post-rebase runs.
