### PR TITLE
docs(retire): the tools/ prose subset stops promising two removed substrates (rf2-0yp7w.9.4)

### DIFF
--- a/tools/story/spec/API.md
+++ b/tools/story/spec/API.md
@@ -227,7 +227,7 @@ transitional dual-acceptance. See [`001-Authoring.md`](001-Authoring.md)
 | `[:dispatch event-vec]`              | `rf/dispatch` (async) into the variant's frame             |
 | `[:dispatch-sync event-vec]`         | `rf/dispatch-sync` (synchronous) into the variant's frame  |
 | `[:wait ms]`                         | Sleep N ms                                                 |
-| `[:flush-presence]`                  | Advance the compiled-view presence clock to quiescence — every retained (`:unmounting`) child reaches its terminal removal (spec/017 §Presence-bearing variants) |
+| `[:flush-presence]`                  | Advance the presence clock to quiescence — every retained (`:unmounting`) child reaches its terminal removal (spec/017 §Presence-bearing variants) |
 | `[:flush-presence ms]`               | Advance the presence clock by N ms — only the exits that come due fire, so a script can observe a child still retained |
 | `[:assert assertion-atom]`           | Evaluate a canonical `[:rf.assert/…]` atom at this point — the primary assertion form (see [Canonical assertion events](#canonical-assertion-events--the-one-assertion-vocabulary)) |
 | `[:assert-db path value]`            | **Sugar** → folds to `[:assert [:rf.assert/path-equals path value]]` |

--- a/tools/template/spec/001-Substrate-Variants.md
+++ b/tools/template/spec/001-Substrate-Variants.md
@@ -168,9 +168,7 @@ Reserved space — not implemented:
   `release.yml` deploys **thirteen** coordinates — `day8/re-frame2`
   core, eleven `deploy-leaf` matrix values, and `ssr-ring` in its own
   ordered job — plus `hicasso` in the stage above. The twelve
-  `artefact:` rows are the non-core leaves, not the workflow's total.
-  `re-frame.ui` is explicitly **not** published, and must not be added
-  to the roster.)
+  `artefact:` rows are the non-core leaves, not the workflow's total.)
 
   **Hicasso is also not a substrate peer of `:reagent` and `:uix`, and
   that ordering matters.** It mints no adapter — there is no

--- a/tools/template/spec/DESIGN-RATIONALE.md
+++ b/tools/template/spec/DESIGN-RATIONALE.md
@@ -139,8 +139,7 @@ afterthought.
 > dependency. The in-repo gates were green only because they rewrote
 > that coordinate to `:local/root`, an affordance no consumer has. A
 > scaffold for a substrate that will not exist is not worth
-> maintaining, and Freehand gets its own variant when its publication
-> gate lands.
+> maintaining.
 >
 > The menu is now `:reagent` (default) and `:uix`; the decision record
 > above is kept as history.


### PR DESCRIPTION
R6 slice 4 of `rf2-0yp7w.9` — the `tools/` PROSE subset outside `tools/xray`.
`implementation/ui/` and `implementation/freehand/` are retired and removed
(`git ls-files` returns **0** under both, verified at this branch's base), so
the question on each hit is whether the page still speaks of them in the
present tense.

**Changed: 3 lines. Left standing: 4 hits in the fence, plus everything the
wider sweep turned up.** The left-standing list is the larger half and is
below.

## Census, re-derived — and one control figure corrected

Pattern (the six-spelling form recorded on `rf2-0yp7w.9`):

```
git grep -ciIP 'freehand|re-frame\.ui(?!x)|re-frame2-ui(?!x)|implementation/(ui|freehand)/|004D'
```

| control | expected | measured |
|---|---|---|
| negative — `README.md` | 0 | **0** — passes |
| negative — `grep -c -F re-frame2-uix README.md` accounts for its former score | 1 | **1** — passes |
| positive — `docs/design/retirement/freehand-and-ui.md` | 64 | **93** — delta |

**The positive control's briefed figure of 64 is wrong, and it is worth
recording why rather than just noting the delta.** The control file is
byte-identical to what was measured: `git rev-parse` on the blob at both the
census commit and this branch's base returns the same oid, and the file's last
touch predates both. 64 is the score of `git grep -ciIF freehand` — the
one-spelling fixed string — not of the six-spelling pattern, which scores 93 on
the same bytes. So the control *passes* in substance (the pattern reaches the
tree and finds far more than the narrow spelling could), but the number was
carried over from an older, narrower measurement. **A later slice should assert
93, not 64.**

Slice membership: the delta against the briefed table is **zero**, on
membership and on magnitude. All five files, all five counts, exact. The nine
deliberately-excluded source and build-config files also match their briefed
counts exactly and are **untouched** — `git diff --name-only
origin/main...HEAD` over `tools/story/{src,test}`, `tools/story/deps.edn`,
`tools/re-frame2-pair-mcp/{src,test}`, `tools/template/test` and `tools/xray`
is empty.

## Changed — 3 hits

**`tools/template/spec/DESIGN-RATIONALE.md`** (2 hits → 1)

The `rf2-qmvep` amendment closed with *"…and Freehand gets its own variant when
its publication gate lands."* A live forward promise for a substrate that no
longer exists. The clause it hangs off — *a scaffold for a substrate that will
not exist is not worth maintaining* — is the reasoning, and it stands; the
promise is removed. The block's other hit (`day8/re-frame2-ui`, recording what
the retired `:ui` variant emitted) is **kept**: it is exactly the legitimate
historical hit a rationale is entitled to.

**`tools/template/spec/001-Substrate-Variants.md`** (1 hit → 0)

*"`re-frame.ui` is explicitly **not** published, and must not be added to the
roster."* A live instruction guarding a release roster against an artefact that
no longer exists in the tree. Nothing can be added; the sentence's only effect
now is to imply the surface still exists. Deleted. The parenthetical's actual
subject — the corrected deploy-coordinate count — is untouched, and **verified
at source**: `release.yml` carries 13 `artefact:` rows (11 in `deploy-leaf`,
plus `ssr-ring` and `hicasso` in their own jobs), so "thirteen coordinates"
(core + 11 leaves + ssr-ring) and "the twelve `artefact:` rows are the non-core
leaves" both still hold.

**`tools/story/spec/API.md`** (0 hits under the pattern — found by paraphrase)

The `[:flush-presence]` row described *"the **compiled-view** presence clock"*.
`compiled-view` **is** `re-frame.ui`: EP-0030 is titled *The Compiled-View
Substrate Program (re-frame.ui)*, `CHANGELOG.md:71` says *"No compiled-view
substrate, under any coordinate… `re-frame.ui` is retired and has been removed
from the tree"*, and `docs/design/retirement/donor-surfaces.md:21` names
`implementation/ui/` as *"the compiled-view substrate"*. This was the **only**
site in the repo carrying that qualifier: its own sibling row
(`[:flush-presence ms]`), `017-Testing-Story.md`'s step table, and every Story
source docstring all say plainly *"the presence clock"*. A stale donor
qualifier on a **live** API row, so the qualifier goes and the row now agrees
with its own normative source.

This file is not one of the five, and it scores **0** under the six-spelling
pattern. It is in the fence under *"any further `tools/*/spec` markdown your
re-derivation proves carries the same residue"*, and it is the sixth spelling's
class one level on: a donor **paraphrase** rather than a donor name.

## Left standing — 4 hits in the fence, each with its reason

| site | why it stays |
|---|---|
| `tools/re-frame2-pair-mcp/spec/003-Tool-Catalogue.md:2573-2574` (2 hits) | *"This family **replaced** five tools aimed at `re-frame.freehand.tool`… Freehand **published** a view registry and a compiler manifest, so it **could** answer…"* — uniformly past tense, and it is the whole reason the Hicasso evidence door ships three tools rather than five. Sweeping it would delete the rationale and leave the "Three, because" heading unexplained. |
| `tools/story/spec/015-Test-Coverage.md:335` | *"arm 1 of the **retired** re-frame.ui consumer test"* — a historical annotation naming where the surviving arm came from, on a row whose test home is Story's own live suite. |
| `tools/story/spec/017-Testing-Story.md:1190` | *"**Story ships no bridge for any substrate.** It **once shipped** an optional one for Freehand; that substrate **is retired**…"* — records the removal, and is load-bearing: it is why `install-presence-flush!` is the whole contract. |
| `tools/template/spec/DESIGN-RATIONALE.md:135` | `day8/re-frame2-ui` inside a dated `rf2-qmvep` amendment describing what the removed `:ui` variant emitted. The kept half of that block. |

**Also checked and deliberately left:**
`tools/template/spec/005-Repo-Split.md:14` — *"that variant **was retired**
(rf2-qmvep) rather than adopted, so nothing gates this split on it"*, past
tense, and it is the sentence that voids a prerequisite; the nine
`re-frame.story.ui.test-mode.*` hits on `ui.test` across `tools/story/spec/`,
which are Story's **own** namespace and not `re-frame.ui.test`; and
`compiled-view-args-schema` in three Story spec pages, which is Story's own
compiled Malli schema and unrelated to the substrate.

An alias sweep over the whole fence (`tools/story/spec`,
`tools/template/spec`, `tools/re-frame2-pair-mcp/spec`) for the spellings the
pattern cannot see — bare `ui/<member>`, `v/<member>`, `:rf.adapter/ui`,
`:rf.ui*`, `re-frame2-freehand`, `004D` — returned **zero**. A `hicasso`
positive control over the same paths matched 3 files, so those zeros are real
rather than a broken pattern.

## The substrate angle — checked at source, not assumed

The brief's premise was that a stale variant row here would be a
consumer-facing lie about what the template can emit. **It does not hold — no
row was stale.** `tools/template/src/day8/re_frame2_template/hooks.clj`'s
`substrate-registry` declares exactly two substrates, `:reagent` and `:uix`,
and the emitted resource trees are exactly `_reagent/` and `_uix/`. There is no
`_ui` and no `_freehand`. `001-Substrate-Variants.md`'s variants table (2 rows,
`:reagent` / `:uix`) and DESIGN-RATIONALE's *"The menu is now `:reagent`
(default) and `:uix`"* both match source. The Future-variants list reserves UIx
SSR, reagent-slim and Hicasso — no donor substrate. The residue on this surface
was a **roster guard** and a **forward promise**, not a variant row.

## Stopped on — outside this fence, not fixed here

- **`implementation/adapters/reagent/README.md:5`** carries live present-tense
  donor prose on a first-class adapter's front page: *"(`re-frame.ui` is a
  **new, experimental** compiled-view substrate offered alongside it, not a
  replacement…)"*. Not `tools/`; belongs to the `implementation/` slice.
- **`spec/004-Views.md` §Presence** (from ~L1334) is written in Freehand's `v/`
  alias (`(v/presence …)`) and in *"interpreted mode / compiled mode"*
  vocabulary, and `tools/story/spec/017` cites it as the presence contract. HOT
  ZONE `spec/`, and held on `rf2-h89ri` — flagged, not touched.
- **`tools/xray/`** (18 files) untouched — PR #8467 and `worker/topodoc-yorfi`
  hold it.

## Quality gates

**The fast-PR spine was NOT run, deliberately.** A heavyweight allocation
window holds this machine, and two workers running the same heavyweight suite
concurrently here **wedged** rather than failed. Per the dispatch, no
shadow-cljs, browser, Playwright, npm or JVM gate was run. This is a 3-line
markdown change; the heavy lanes are CI's.

**Covering gate, derived rather than taken from the brief.**
`scripts/check_doc_slugs.py`'s `_iter_markdown` walks `DEFAULT_ROOTS` (`docs`,
`spec`, `skills`, `migration`) **plus `tools/<tool>/spec`** — read at source and
confirmed. All four touched and inspected files live under `tools/*/spec/`, and
none is under an excluded `findings/` directory. Its own docstring records that
repo-root markdown is not its (that is `check_readme_links.py`); not relevant
here, since this PR touches no repo-root file.

`mkdocs build --strict` is **not** nominated and would have been a false green:
`mkdocs.yml` sets `docs_dir: docs`, so `tools/*/spec/` is not in the site at
all. It is not an `exclude_docs` entry — the tree is simply outside the build.

| gate | how run | exit code (captured by this worker) |
|---|---|---|
| `scripts/check_doc_slugs.py` — baseline | foreground; redirect and exit-echo on one command line | **0** |
| `scripts/check_doc_slugs.py` — **planted fault** | same | **1** (red, as required) |
| `scripts/check_doc_slugs.py` — after restore | same | **0** |
| `scripts/check_doc_slugs.py` — **re-run on the final rebased base** | same | **0** |
| `scripts/check_fast_pr_gap.py --list` | foreground; redirected | **0** — reports **94** required checks the spine does not run |

**The planted fault, because this gate prints nothing on success — exit 0 alone
proves nothing.** A single-line plant on `tools/story/spec/API.md:230`, the
exact line this PR edits, turning it into a link to a non-existent
`999-Nonexistent.md`, produced:

```
1 broken target file(s) found:
  BROKEN TARGET: tools\story\spec\API.md:230 -> 999-Nonexistent.md
```

— naming this branch's file at the edited line, so the gate demonstrably read
**this** tree and demonstrably covers `tools/*/spec`. The restore was verified
by **hashing the bytes** (`git hash-object` against the committed blob:
identical oid, and `git status` clean), not by reading a diff.

**Table shape, verified by hand — nothing validates it.** The one table touched
is `tools/story/spec/API.md` §Script steps, lines 225–239: 15 table lines,
**every one exactly 2 columns**, including the edited row 230. The edit changed
only the second cell's prose and added or removed no pipe.

**Relied on CI, declared.** `implementation/scripts/api-manifest`'s
`story_spec_check` (lint.yml, `api-manifest` job) is the only counterpart
reader of `tools/story/spec/API.md`; `.github/scripts/report-changed-surfaces.sh:1886`
says so explicitly and arms it on any `tools/*` change. It is a JVM lane and
was not run here. **The edit is provably inert to it**: the check reads
`table-var-rows`, the back-ticked identifier in each row's **first** cell, and
resolves it against the manifest. The first cell (`` `[:flush-presence]` ``) is
unchanged, so the row set, the row count and the non-vacuity floor of 20 are
all identical. `tools/template/spec/*.md` falls to the default branch of the
same classifier and arms `tools_jvm` plus `mcp_conformance` in CI.

**Rebase.** Rebased onto `origin/main` twice as the trunk moved, past 5
commits in total (4 hicasso/beads, then PR #8467's `tools/xray/src` merge), none
of them touching these files, and the covering gate re-run on the final base — the exit **0** in the
table above is the post-rebase run. `git diff origin/main...HEAD` (three-dot)
reverts nothing: 3 files, 3 insertions, 6 deletions, all mine.

Closes `rf2-0yp7w.9.4`.
