### PR TITLE
docs(scripts): three gate scripts stop describing the removed donor surface as live (rf2-0yp7w.9.3)

### DIFF
--- a/scripts/check_fast_pr_gap.py
+++ b/scripts/check_fast_pr_gap.py
@@ -12,14 +12,18 @@ Neither can see the class that actually ambushed people:
 
     A REQUIRED CHECK CAN BE A **STEP INSIDE A JOB THE SPINE BELIEVES IT COVERS.**
 
-The sharpest instance is the EP-0036 donor-boundary check.  It is the last step
-of test.yml's `jvm-freehand` job, so it reports under the display name
-"JVM freehand (clojure -M:test)" -- and it is not a test at all, it is a
-`git grep` for `re-frame.ui` over `implementation/freehand`.  The spine runs that
-job's `clojure -M:test` and nothing else, so the tier is not skipped, the step is
-not a suite, and a worker reading the red goes looking for a failing test that
-does not exist.  Job-granularity comparison cannot see it.  This gate compares at
-STEP granularity, and it names the CHECK rather than the job.
+The sharpest instance was the EP-0036 donor-boundary check.  It was the last step
+of test.yml's `jvm-freehand` job, so it reported under the display name
+"JVM freehand (clojure -M:test)" -- and it was not a test at all, it was a
+`git grep` for `re-frame.ui` over `implementation/freehand`.  The spine ran that
+job's `clojure -M:test` and nothing else, so the tier was not skipped, the step
+was not a suite, and a worker reading the red went looking for a failing test
+that did not exist.  That job was deleted with the Freehand tree (rf2-0yp7w.6);
+the CLASS outlived it, and the witness this gate's self-test pins in its place is
+the `cljs` job's Hicasso `:advanced` release build, which the spine's `cljs` lane
+matches through its node-test run and never builds.  Job-granularity comparison
+cannot see either.  This gate compares at STEP granularity, and it names the
+CHECK rather than the job.
 
 HOW IT DECIDES, and why the failure direction is the safe one.
 
@@ -146,10 +150,12 @@ _SETUP_RE = tuple(re.compile(p) for p in SETUP_PATTERNS)
 # `command` matches the step's NORMALISED body (continuations joined, multiple
 # command lines joined with " ; ", whitespace collapsed).  `working_dir` may be
 # the sentinel "@impl-roster", meaning "the job's working-directory is an
-# artefact on scripts/test-jvm-implementation.sh" -- that one rule covers all
-# twenty-three per-artefact JVM jobs without naming any of them, and it is what
-# makes `jvm-freehand`'s SECOND gate step fall out of the derivation as unrun
-# rather than having to be remembered.
+# artefact on scripts/test-jvm-implementation.sh" -- that one rule covers every
+# per-artefact JVM job without naming any of them, and it is what made
+# `jvm-freehand`'s SECOND gate step fall out of the derivation as unrun rather
+# than having to be remembered.  That job went with the Freehand tree
+# (rf2-0yp7w.6) and this rule needed no edit, which is the point of it: the
+# roster is READ, never counted here.
 # ---------------------------------------------------------------------------
 class Lane:
     def __init__(self, key: str, command: str, why: str, working_dir: str | None = None):
@@ -377,9 +383,11 @@ _BLOCK_RE = re.compile(r"^[|>][-+0-9]*$")
 
 # `${{ github.workspace }}` IS the repo root, so a step declaring it needs no
 # `cd` at all -- and printing the raw expression as a local command would be
-# useless. This is the one workflow expression that reaches a required gate
-# step's location (the EP-0036 donor grep uses it); no required gate step's
-# `run:` body interpolates an expression at all.
+# useless. It is the one workflow expression ever seen to reach a required gate
+# step's location -- the EP-0036 donor grep used it, and that step went with the
+# Freehand tree (rf2-0yp7w.6), so no required gate step declares it today. The
+# handling stays because the shape is what a future one would reuse; no required
+# gate step's `run:` body interpolates an expression at all.
 _WORKSPACE_RE = re.compile(r"^\$\{\{\s*github\.workspace\s*\}\}$")
 
 
@@ -392,7 +400,9 @@ class Step:
         # job default; record that, so the job-default backfill below cannot
         # quietly put the default back after `${{ github.workspace }}` resolved
         # to "the repo root". That is exactly the shape the EP-0036 donor grep
-        # uses to escape `jvm-freehand`'s `implementation/freehand` default.
+        # used to escape `jvm-freehand`'s `implementation/freehand` default,
+        # kept after that job's deletion because the shape, not the job, is what
+        # this handling is for.
         self.declared_wd = working_directory is not None
         if working_directory and _WORKSPACE_RE.match(working_directory.strip("'\"")):
             working_directory = None

--- a/scripts/check_gate_scheduling.py
+++ b/scripts/check_gate_scheduling.py
@@ -263,9 +263,12 @@ DISPOSITIONS: dict[str, dict] = {
     "bench:hicasso": {
         "kind": "not-a-gate",
         "why": "a benchmark runner: it produces measurement records, not a "
-               "verdict about the tree. Its sibling `bench:freehand-browser` "
-               "DOES yield a verdict, which is why that one is scheduled "
-               "(freehand-bench.yml) and pinned into the local rigorous sweep",
+               "verdict about the tree. The discrimination is real rather than "
+               "a blanket benchmark exemption: its sibling "
+               "`bench:freehand-browser` DID yield a verdict, which is why that "
+               "one was scheduled (freehand-bench.yml) and pinned into the "
+               "local rigorous sweep -- until the job, the workflow and the "
+               "benchmark all went with the Freehand tree (rf2-0yp7w.6)",
     },
     # The two `build:` aliases (rf2-rbdc, the widening above). Both are the
     # COMPILE HALF of a gate that already runs, kept as a one-word local

--- a/scripts/check_keyword_catalogue_drift.py
+++ b/scripts/check_keyword_catalogue_drift.py
@@ -97,24 +97,19 @@ its 485 active rows). The remaining 40 rows sit in 14 other `:rf.*` families
 arm that IS total over `:rf.*`: every emitted namespace must be reserved,
 whatever its family, so nothing escapes the gate entirely.
 
-OUT OF SCOPE, deliberately — `:rf.ui.compile/*`. The Freehand compiler emits
-~110 analyzer-refusal ids in that namespace (`:rf.ui.compile/bad-render-fn`,
-`…/bad-tag`, `…/unsupported-form`, …) and not one has a Spec 009 row. That is
-correct, and the reserved-namespace table already decided it: Conventions §The
-single-root reserved set says the family is the "compile-error id namespace …
-(compile-time only: thrown at macroexpansion, NEVER emitted at runtime, never
-a trace)", gives its spec home as "004 (rewrite)", and names its roster
-authority — "the id roster is pinned by the S1b analyzer reject tables". A
-never-a-trace id cannot have an error-EVENT row, so widening this scan to the
-family would not find drift; it would manufacture ~110 findings against a
-contract nobody wrote. The family's own roster gate is real and in flight
-elsewhere: `implementation/ui/test/re_frame/ui/error_roster_*`, dispositioned
-**MOVE** by the F1 absorption ledger (that archive was deleted by rf2-0yp7w.8;
-git history holds it) — it CROSSES into Freehand rather than dying with the
-donor tree, and the ids
-themselves already live on the Freehand side
-(`implementation/freehand/src/re_frame/freehand/compiler/`), so the pending
-`implementation/ui` deletion takes the donor copy only.
+OUT OF SCOPE, deliberately — `:rf.ui.compile/*`, and now doubly so. The Freehand
+compiler emitted ~110 analyzer-refusal ids in that namespace
+(`:rf.ui.compile/bad-render-fn`, `…/bad-tag`, `…/unsupported-form`, …) and not one
+had a Spec 009 row. That was correct: the family was compile-time only — thrown
+at macroexpansion, NEVER emitted at runtime, never a trace — and a never-a-trace
+id cannot have an error-EVENT row, so widening this scan to it would not have
+found drift, it would have manufactured ~110 findings against a contract nobody
+wrote. The compiler was then deleted with `implementation/ui/` on 2026-08-16
+(rf2-0yp7w): no implementation source emits the family, and its Conventions row
+is now a struck-through **RETIRED** tombstone, which `_row_is_retired` already
+keeps out of the reserved set (rf2-5kzwf). The boundary is recorded rather than
+dropped because a reader who meets the spelling in git history deserves the
+answer beside the scan.
 
 SCAN SURFACE (corpus-sweep rules — same as the sibling residue guards)
 ----------------------------------------------------------------------


### PR DESCRIPTION
R6 slice 3 of the Freehand / re-frame.ui retirement: the **gate-script** bucket.

This slice is inverted relative to its siblings. Slices 1 and 2 swept prose that *taught* a removed library; here, naming the removed surface is usually the **point** — a checker that polices retired spellings must name the retired spellings, and a disposition roster must list what was disposed of. So the default expectation was that a hit is correct, and the burden was on the sweep to show otherwise. A careless sweep here disarms gates, and a disarmed gate is worse than the residue it was policing.

**The discriminator applied was behavioural, never lexical.** A hit is CORRECT when the script names the surface in order to DETECT, FORBID, ROSTER or HISTORICALLY RECORD it. A hit is RESIDUE only when the script behaves as though the surface still exists — scanning a path that is gone, expecting a deleted file, asserting a count that included the removed artefacts, or rostering a lane that no longer runs.

## The census

Re-derived at the branch base over **tracked files only**, with a pattern widened in two directions the mayor's original could not see. Positive controls were run both ways before any count was believed: `hicasso` reaches 26 scripts, `uix` reaches 7, `re-frame.core` reaches 9, and the `:rf.ui` alternative was proved not to match `:rf.uix` — the live UIx adapter's keyword family — before it was used.

| file | hits | verdict |
|---|---|---|
| `scripts/check_adapter_disposition.py` | 20 | all CORRECT |
| `scripts/check_keyword_catalogue_drift.py` | **17** (census said 5) | 16 CORRECT, 1 block RESIDUE |
| `scripts/check_fast_pr_gap.py` | 8 | 4 CORRECT, 4 RESIDUE |
| `scripts/check_skill_implementor_partition_drift.py` | 4 | all CORRECT |
| `scripts/check_gate_scheduling.py` | 2 | 1 block RESIDUE |
| `scripts/test-epoch-prod-gate.sh` | 2 | CORRECT |
| `scripts/check-ai-tracking-ratchet.sh` | 1 | CORRECT (see refusal below) |
| `scripts/check_architecture_census.py` | 1 | CORRECT |
| `scripts/check_doc_slugs.py` | 1 | CORRECT |
| `scripts/check_jvm_lane_rosters.py` | 1 | CORRECT |
| `scripts/check_retired_spellings.py` | 1 | CORRECT |

**Delta against the bead's table: the file list is identical (11 files), the total rises 46 to 58, and the whole difference sits in one file.** `check_keyword_catalogue_drift.py` goes 5 to 17 because the census pattern could not see bare `:rf.ui/*`-family keyword spellings. The widening cost nothing — 11 of the 12 extra hits are synthetic self-test fixtures, and `:rf.ui/*` turns out **not to be a retired spelling at all**: `spec/Conventions.md` records that the structural render-tree ABI namespace *outlived* the substrate that minted it, and it is live surface consumed by `re-frame.ssr/emit-ui-tree` and the Hicasso test kit. The bead's title says "12 scripts/ files" while its own table lists 11; 11 is right.

## What changed (6 hits, 3 files)

**`check_fast_pr_gap.py`** — the module docstring taught the entire failure class ("A REQUIRED CHECK CAN BE A STEP INSIDE A JOB THE SPINE BELIEVES IT COVERS") from a worked example in the present tense: test.yml's `jvm-freehand` donor grep. That job was deleted with the Freehand tree by rf2-0yp7w.6, and the script's own self-test already records the replacement witness — the `cljs` job's Hicasso `:advanced` release build. The example now points there. Separately, the `@impl-roster` comment asserted "all twenty-three per-artefact JVM jobs"; the roster reads **21** today, and git shows the drop is exactly the donor removals (24 before R2b, 23 after the `implementation/ui` delete, 21 after R3b took `implementation/freehand` and `implementation/freehand/scaffold-smoke`). The count is **dropped rather than corrected**, because the comment's own thesis is that the rule covers them "without naming any of them" — it reads the roster, so it needed no edit when the roster shrank, and a hand-kept number in that sentence was the only thing in it that could go stale. Two `${{ github.workspace }}` comments named the donor grep as a current user of that expression; `git grep` finds **zero** uses left in any workflow, so both move to the past tense and the handling stays for the shape.

**`check_gate_scheduling.py`** — the `bench:hicasso` `not-a-gate` exemption justified itself by contrast: "Its sibling `bench:freehand-browser` DOES yield a verdict, which is why that one is scheduled (`freehand-bench.yml`)". Neither the npm script nor the workflow exists. The contrast is kept, in the past tense with its cause named, because it is what shows the classification is a real discrimination rather than a blanket benchmark exemption.

**`check_keyword_catalogue_drift.py`** — its OUT-OF-SCOPE paragraph for `:rf.ui.compile/*` quotes two cells of the very `spec/Conventions.md` table this gate parses: a spec home of "004 (rewrite)" and an S1b roster authority. That row is now a struck-through **RETIRED (rf2-0yp7w)** tombstone whose spec-home cell reads an em dash, and `_row_is_retired` already excludes it from the reserved set (rf2-5kzwf). The paragraph also called a roster gate "real and in flight" (its archive was deleted by rf2-0yp7w.8) and the `implementation/ui` deletion "pending" (it landed 2026-08-16). The scan boundary is kept — it is still correct, and now doubly so — with its reasoning restated as history. **A gate docstring that misquotes its own input file is the defect being fixed.**

## What was deliberately left standing

- **`check_adapter_disposition.py` (20)** — every hit is a FORBID pattern's explanation string (`only-taught layer`, `replaces the adapter trio`, `defaults to re-frame.ui`, `collapse to one re-frame.ui scaffold`), a self-test fixture proving those patterns fire, the module docstring transcribing the ruling it guards, or the `ACTIVE_AUTHORITIES` comment recording 004D's removal from the roster. The gate's live function — stopping "frozen Reagent/UIx" and "reagent-slim deleted" prose from returning to active authorities — is untouched by the retirement, and stripping the strings would delete FORBID patterns. The roster's `spec/004-Views.md` entry is **correct today**; 004's fate is held for the operator on **rf2-h89ri**, and repairing it now would pre-empt a reserved ruling. It will need the same repair the 004D comment records if 004 is later deleted.
- **`check_skill_implementor_partition_drift.py` (4)** — the retirement record for the two L5 arms that read `implementation/ui/`'s own source. `LIFECYCLE_ARM_SOURCES` holds no L5 entry: nothing is scanned, and the comment explains why those contracts were *dissolved* rather than re-pointed. Deleting it would leave the next reader unable to tell a dissolved contract from an unguarded one.
- **`check_architecture_census.py` (1)** — `re-frame\.ui\.` and `re-frame\.freehand\.` are alternatives inside the `FOREIGN_EMITTER` **refusal** regex. Narrowing a forbid list is a disarm; if either namespace ever returned to the Hicasso runtime's requires, this must still fire.
- **`check_doc_slugs.py` (1)** — `docs/design/freehand/` is **ruled KEPT** (rf2-0moc4). Verified still present: 37 tracked files. The reference is a deliberately-not-taken scope extension and is correct.
- **`check_jvm_lane_rosters.py` (1)** — inside an intentionally **empty** `BASELINE`, recording that both entries the gate shipped with were resolved. Historical; no path is scanned, and `scripts/test-jvm-implementation.sh` itself carries no donor entry (0 hits).
- **`check_retired_spellings.py` (1)** — records that the hicasso bench harness was re-homed *out of* `implementation/freehand/test/`. `COORD_EXCLUDE_PATHS` names the current home only.
- **`test-epoch-prod-gate.sh` (2)** — one past-tense statement of the gap that motivated the lane, and one inside a block explicitly dated "Measured 2026-08-15", which is a dated historical snapshot. Its gate is also a JVM lane that was **not run** under the measurement-window reservation, so under the "a gate whose behaviour you cannot demonstrate is unchanged must be left alone" rule it could not have been edited even had it been residue.
- **`check-ai-tracking-ratchet.sh` (1)** — see the refusal below.

## Source-located refusals

1. **`check-ai-tracking-ratchet.sh:7-8`** says "Files stay tracked as long as they are needed; **rf2-vxgfnd.99.1 removes the remaining trees at re-frame.ui S7**." That milestone can never arrive, and the bead id **does not resolve in the tracker**. The honest replacement is a statement of when the tracked `ai/` trees now go, which is an operator decision nobody has made; inventing one would be worse than the staleness. The gate itself is a git-derived set difference that names no tree, so nothing is behaviourally wrong. **Left for a ruling.**
2. **`.github/scripts/report-changed-surfaces.sh:1223`** still names `jvm-freehand` in a comment. `.github/**` is hot zone and fenced out of this slice, and `worker/citimeout-km7iq` holds the workflows. **Reported, not touched.**

## Quality gates

The fast-PR spine was **NOT run**, and neither was any shadow-cljs, browser, Playwright, npm-build or JVM gate: a heavyweight allocation window (`worker/pairedwin-0gjqi`) held this machine for the bench ladder, and two such gates run concurrently here **wedge** rather than fail. The covering gate for this diff is the checkers themselves — `test.yml`'s "Repo invariant checks (skills, MCP, catalogues, namespaces)" job runs all three edited scripts in exactly the forms reproduced below, derived via `scripts/check_fast_pr_gap.py --list`.

Every number below was captured by the runner itself (`cmd > log 2>&1; echo $?` on one command line, in one shell), never taken from a harness report and never read through a pipe.

**Before / after — the three edited scripts, both CI forms:**

| gate | before | after |
|---|---|---|
| `python scripts/check_fast_pr_gap.py` | **0** | **0** |
| `python scripts/check_fast_pr_gap.py --self-test --verbose` | **0** | **0** |
| `python scripts/check_gate_scheduling.py --verbose` | **0** | **0** |
| `python scripts/check_gate_scheduling.py --self-test --verbose` | **0** | **0** |
| `python scripts/check_keyword_catalogue_drift.py --verbose` | **0** | **0** |
| `python scripts/check_keyword_catalogue_drift.py --self-test --verbose` | **0** | **0** |

All six **reports are byte-identical** before and after the change (`diff -q` over the captured logs), so the derivations are provably unchanged.

**Every control was then sabotaged and confirmed to still bite.** A green sabotage run would have been a reason to stop; none was green.

- `check_fast_pr_gap.py` — a **single-line** fault planted in `scripts/test-jvm-implementation.sh`, breaking the `artefacts=(` array-open the roster parser anchors on. Gate exit **1**, self-test exit **1**, and it named the right thing: *"spine lane `jvm-artefact-suite` matches no required gate step any more."* Restored by `git checkout` and verified by **hashing the bytes** — `git hash-object` returns `3a5ab08aa0c998c2b3753a79919a87c381400af7`, identical to the committed object; gate back to **0**.
- `check_gate_scheduling.py` — an orphan gate script planted into an isolated copy of the tree passed via `--repo-root`. Control run on the unmodified copy: **0**. Sabotaged: **1**, *"defined in implementation/package.json, invoked by no workflow, and carrying no DISPOSITIONS entry."* Nothing in the repository was touched.
- `check_keyword_catalogue_drift.py` — a **new** probe file emitting an unreserved `:rf.zzznewplanted/*`, added under `implementation/core/src/`. Gate exit **1**, CHECK B naming both the planted namespace and the planting file. Removed afterwards; `git status` shows only the three edited scripts. The fault existed only in this worktree, which is what makes the red evidence about *this* tree.

That gate's own teeth are visible in its verbose log: `A: uncatalogued id FIRES`, `B: unreserved namespace FIRES`, `B: deleting the :rf.ui.tool/* row makes it FIRE`, `B: emitting retired-row vocabulary FIRES` — 42 cases passing.

**The eight untouched cheap checkers were run as well, to show the sweep broke nothing adjacent** — `check_adapter_disposition`, `check_skill_implementor_partition_drift`, `check_architecture_census`, `check_jvm_lane_rosters`, `check_retired_spellings`, `check_doc_slugs` (all `python`, all exit **0**) and `sh scripts/check-ai-tracking-ratchet.sh` (exit **0**).

**Did auditing `check_fast_pr_gap.py` change confidence in it as the gap authority? Yes, upward.** Its required set is derived from the three aggregators' `needs:` lists and its JVM coverage from the roster file, never from a hand-kept list — which is exactly why the deletion of two artefacts and of a whole required job needed **no code change**, only a narrative correction. The one hand-kept number in the file lived in a comment, and it was the one thing that had drifted. Its self-test carries a real-repo arm (`real.problems == []`) plus a **named** item-3 witness rather than a non-empty count, and the planted fault reddened both the gate and that self-test.

## Fence

Owned and edited: `scripts/**` only. Nothing under `.github/**`, `spec/**`, `implementation/**`, `tools/**`, `examples/**`, `docs/**`, `TESTING.md`, `CHANGELOG.md`, `CLAUDE.md` or `mkdocs.yml` is modified — `git diff origin/main...HEAD` is three files. Re-derived at start-up: no live worker or open PR holds top-level `scripts/**`. `worker/orphans-k9rzr` holds `scripts/check_skill_xray_tab_inventory_drift.py`, which is not in this census and is not touched.
