### PR TITLE
docs(EP): EP-0036 records the 2026-08-16 donor removal (rf2-0unal)

### DIFF
--- a/docs/EP/EP-0036-the-freehand-view-substrate-programme.md
+++ b/docs/EP/EP-0036-the-freehand-view-substrate-programme.md
@@ -5,6 +5,21 @@ Type: standards-track
 Created: 2026-07-22
 Resolution: accepted 2026-07-22 (D001–D021 ratified and folded); withdrawn 2026-07-30
 
+> **Historical record — 2026-08-16.** This programme was **withdrawn** on
+> 2026-07-30 (banner below), and both it and the donor it absorbed
+> ([EP-0030](EP-0030-the-compiled-view-substrate-program.md)) were then
+> **removed from the tree** on 2026-08-16 under the operator ruling recorded as
+> `rf2-0yp7w` — `implementation/freehand/` and `implementation/ui/` return
+> nothing from `git ls-files`, and `spec/004D-Freehand-Compiled-Grammar.md`,
+> which the slice table below plans for, went with them. The EP is kept as the
+> record of the programme and no work is in flight under it: the withdrawal
+> banner's "**The code is not removed**" paragraph states the disposition as it
+> stood on 2026-07-30, and `rf2-0yp7w` is the separate, later decision it
+> anticipated. The design record is not affected — `docs/design/freehand/`
+> remains a durable frozen record per
+> [§Design-record posture](#design-record-posture) below, re-affirmed by the
+> `rf2-0moc4` ruling of 2026-08-18.
+
 > **Withdrawn — 2026-07-30 (operator ruling, Mike).** The Freehand
 > view-substrate programme is closed as a failed experiment. No further work is
 > authorised under this EP. The document is kept, as EP-0009 requires of every


### PR DESCRIPTION
EP-0034 and EP-0035 each open with a dated `Historical record — 2026-08-16` banner recording that `implementation/ui/` and `implementation/freehand/` were removed from the tree under the operator ruling `rf2-0yp7w`. EP-0036 — the Freehand programme EP itself — carried no such marker.

That matters beyond tidiness here: EP-0036's 2026-07-30 withdrawal banner contains a paragraph headed **"The code is not removed."**, which was true when written and stopped being true on 2026-08-16. A reader arriving at EP-0036 directly, rather than through the index, met a programme document that positively asserted the opposite of the tree's state.

## What changed

One banner, inserted above the withdrawal banner — the same stacking EP-0034 uses for its own 2026-08-16 banner over an older 2026-07-21 addendum, newest first. It follows the siblings' form (opening `> **Historical record — 2026-08-16.**`, the removal fact with the `rf2-0yp7w` citation and the `git ls-files` evidence, then a per-EP tail), adapted because EP-0036 is the withdrawn programme itself rather than one of its donors. The tail does three things: names the stale "The code is not removed" paragraph as superseded, records that `rf2-0yp7w` is the "separate, later decision" that paragraph anticipated, and states that the design record is *not* affected.

**Deliberately unchanged**, since EP-0030–EP-0036 are ruled kept and EP-0036 is load-bearing for the `rf2-0moc4` ruling that keeps `docs/design/freehand/`:

- the `Status:` / `Type:` / `Resolution:` front matter;
- the 2026-07-30 withdrawal banner, byte-for-byte;
- **§Design-record posture**, byte-for-byte — verified by hashing the section's bytes before and after (`git hash-object` on the extracted section: `8958c5f334926cfcc2a67535b8d6f72583e0f65b` both sides), not by reading a diff.

The diff is `+15 / -0` in one file, so nothing anywhere in the document was rewritten. No table was touched, so no column counts changed.

## Verified at source

- `git ls-files implementation/ui` → 0, `git ls-files implementation/freehand` → 0 (control: `git ls-files implementation/adapters` → 156, so the zero is a real absence, not a broken invocation).
- `spec/004D-Freehand-Compiled-Grammar.md` is gone (`spec/004-Views.md`, `004B`, `004C`, `006`, `008` remain), which is why the banner names it — EP-0036's slice table plans for that file in four places.
- `docs/design/freehand/` → 37 tracked files, alive, matching the `rf2-0moc4` ruling.

## Reported, not swept

**EP-0030, EP-0031, EP-0032 and EP-0033 also lack the 2026-08-16 removal marker.** Each carries an older `Historical record — 2026-07-30` banner recording only Freehand's withdrawal; none mentions that the substrates were removed from the tree. That is the same gap this PR closes for EP-0036, in four more files. It is left alone here on purpose: EP-0030…EP-0036 each carry their own disposition, and this bead's fence is EP-0036.

## Quality gates

The spine did **not** run. `scripts/test-fast-pr.sh` and every shadow-cljs / browser / Playwright / npm / JVM lane were withheld deliberately: a heavyweight bench run (`worker/pairedwin-0gjqi`) holds this machine, and a gate heavy enough that two cannot coexist wedges rather than fails. The change is one markdown banner, so the targeted doc gates below are the ones that cover it; CI owns the rest.

Every exit code below was captured by the runner itself (redirect + `echo $?` on one command line), never read back from a harness summary.

| Gate | Exit | Notes |
|---|---|---|
| `scripts/check_ep_status_sync.py` | **0** | Owns the EP index and the `Status:`/`Type:` grammar. Re-run on the post-rebase base: **0**. |
| `scripts/check_doc_slugs.py` | **0** | `DEFAULT_ROOTS` includes `docs`, and `docs/EP` is not in `EXCLUDE_DIR_NAMES`, so `_iter_markdown` reaches this file. Re-run on the post-rebase base: **0**. |
| `scripts/check_fast_pr_gap.py --list` | 0 | Cited for the spine-vs-required-CI gap: 94 required checks the spine does not run. |

Both gates print **nothing** on a clean run, so exit 0 on its own asserts nothing. Each was therefore discriminated with a planted fault on a single line:

- **`check_doc_slugs.py`** — the new banner's anchor link was broken to `#design-record-posture-PLANTED-FAULT`. Gate went **red, exit 1**, naming `docs/EP/EP-0036-…:20 -> #design-record-posture-PLANTED-FAULT` — my line, in my tree.
- **`check_ep_status_sync.py`** — `Status: withdrawn` → `Status: plantedfault`. Gate went **red, exit 1**, with both `STATUS MISMATCH` against `docs/EP/README.md:50` and `INVALID STATUS`.

Both restores were verified by hashing the file, not by reading a diff: `git hash-object` returned `4f5dcfa8b21f9b683bba68abcec5779a9ae34787` before each plant and again after each restore.

`mkdocs build --strict` is not nominated: it was not run (heavyweight lane), and `mkdocs.yml`'s `exclude_docs` is the authority on what it can see.

## Not touched

`docs/EP/README.md` is held by PR #8470 and is not in this diff. `git diff origin/main...HEAD` (three-dot, post-rebase) is `+15 / -0` in the one EP file, so this push reverts nothing a sibling landed.
