### PR TITLE
ci: raise beads-pr-boundary's cap, and ratchet the cap convention (rf2-xenc6, rf2-rsn1e)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1350,7 +1350,7 @@ jobs:
   beads-pr-boundary:
     name: Beads PR boundary (no tracker database in a PR)
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -733,41 +733,20 @@ jobs:
         continue-on-error: true
         run: python scripts/check_inject_cofx_residue.py --verbose
 
-      # Workflow job-cap ratchet (rf2-rsn1e). A job with no `timeout-minutes`
-      # inherits GitHub's 360-minute default, so a wedged runner produces a
-      # check that never TERMINATES — not a red check, no check at all for six
-      # hours — and this project's merge loop has nothing to read and no remedy
-      # but a hand cancel. That is the class rf2-km7iq found the hard way: its
-      # census showed 89 of 117 jobs uncapped, so uncapped was the house
-      # MAJORITY at 76%, accreted one job at a time and noticed only because a
-      # single run hung for 49 minutes in front of somebody. Review plainly did
-      # not hold this convention, so it is held here instead, on arrival.
+      # THE WORKFLOW JOB-CAP RATCHET (rf2-rsn1e) DOES NOT LIVE HERE, AND THE
+      # REASON IS THIS JOB'S DEFINING PROPERTY. It landed beside these checkers
+      # and redded every PR: it parses the workflow documents with PyYAML —
+      # which is the whole point of it, a step-level `timeout-minutes` being
+      # indistinguishable from a job-level one to a grep — and this job installs
+      # no pip packages, so its import probe fired and it exited 3 with "NOT
+      # CHECKED ... This is NOT a pass". The checker was behaving correctly;
+      # the placement was wrong. It now runs in `verify-readme-links`, the
+      # equally unconditional job that already installs requirements.txt, for
+      # exactly the reason recorded against the doc-slug gate there.
       #
-      # IT MUST PARSE, NOT GREP, AND THAT IS THE WHOLE CHECK. A
-      # `timeout-minutes` under a STEP is not a job cap — it bounds one step and
-      # leaves the job free to hang in any other — yet the two differ only by
-      # indentation inside the same text block. This file currently carries four
-      # real step-level keys across three jobs, so the confusion is live here.
-      # The checker reads the parsed document, where a job cap is a key on the
-      # job and a step cap is a key on an element of its `steps`.
-      #
-      # Presence only: it never judges the VALUE. What a cap should BE is a
-      # per-job measurement question (rf2-xenc6 raised exactly one, on exactly
-      # that evidence); folding that in would turn a mechanical one-bit check
-      # into a heuristic that argues with its reader.
-      #
-      # Self-test first — it drives the checker RED on five shapes including a
-      # step-only cap and an uncapped job sitting second behind a capped one
-      # (the "stopped looking after the first hit" defect) — then the live sweep.
-      - name: Self-test the workflow job-cap ratchet
-        id: check_workflow_job_timeouts_selftest
-        continue-on-error: true
-        run: python scripts/check_workflow_job_timeouts.py --self-test --verbose
-
-      - name: Verify every workflow job carries a job-level timeout-minutes
-        id: check_workflow_job_timeouts
-        continue-on-error: true
-        run: python scripts/check_workflow_job_timeouts.py --verbose
+      # Keep this job dependency-free. `check_fast_pr_gap.py` is stdlib-only on
+      # purpose for the same reason, and staying free of a `pip install` step is
+      # what makes this job cost seconds rather than a minute on every PR.
 
       # The verdict. Every checker above carries `continue-on-error: true`, so
       # the job never short-circuits and its RESULT is decided only here.
@@ -1026,6 +1005,50 @@ jobs:
       # skippable. Needs bash + git + python, all already present; ~20s.
       - name: Self-test the fast-PR spine's tiering + mkdocs resolution
         run: bash scripts/_test_fixtures/test_fast_pr_docs_gate/run-self-test.sh
+
+      # Workflow job-cap ratchet (rf2-rsn1e). A job with no `timeout-minutes`
+      # inherits GitHub's 360-minute default, so a wedged runner produces a
+      # check that never TERMINATES — not a red check, no check at all for six
+      # hours — and this project's merge loop has nothing to read and no remedy
+      # but a hand cancel. That is the class rf2-km7iq found the hard way: its
+      # census showed 89 of 117 jobs uncapped, so uncapped was the house
+      # MAJORITY at 76%, accreted one job at a time and noticed only because a
+      # single run hung for 49 minutes in front of somebody. Review plainly did
+      # not hold this convention, so it is held here instead, on arrival.
+      #
+      # IT MUST PARSE, NOT GREP, AND THAT IS THE WHOLE CHECK. A
+      # `timeout-minutes` under a STEP is not a job cap — it bounds one step and
+      # leaves the job free to hang in any other — yet the two differ only by
+      # indentation inside the same text block. This file currently carries four
+      # real step-level keys across three jobs, so the confusion is live here.
+      # The checker reads the parsed document, where a job cap is a key on the
+      # job and a step cap is a key on an element of its `steps`.
+      #
+      # Presence only: it never judges the VALUE. What a cap should BE is a
+      # per-job measurement question (rf2-xenc6 raised exactly one, on exactly
+      # that evidence); folding that in would turn a mechanical one-bit check
+      # into a heuristic that argues with its reader.
+      #
+      # WHY THIS JOB AND NOT THE ALWAYS-ON INVARIANT JOB — the same reason the
+      # doc-slug gate above gives, and this gate learnt it the expensive way.
+      # Parsing the document means PyYAML, and PyYAML is not stdlib. It landed
+      # in `verify-skill-mcp-drift`, which installs no pip packages, and both
+      # its steps exited 3 on the very first run: "NOT CHECKED ... This is NOT
+      # a pass" — the checker refusing to report a green it had not earned,
+      # which is the behaviour that made the misplacement visible in one run
+      # instead of silently vouching for 117 jobs it never opened. This job
+      # already installs requirements.txt (PyYAML arrives through mkdocs) and
+      # is likewise unconditional, so the ratchet gates every PR from here at
+      # no extra setup cost, and the invariant job stays dependency-free.
+      #
+      # Self-test first — it drives the checker RED on five shapes including a
+      # step-only cap and an uncapped job sitting second behind a capped one
+      # (the "stopped looking after the first hit" defect) — then the live sweep.
+      - name: Self-test the workflow job-cap ratchet
+        run: python scripts/check_workflow_job_timeouts.py --self-test --verbose
+
+      - name: Verify every workflow job carries a job-level timeout-minutes
+        run: python scripts/check_workflow_job_timeouts.py --verbose
 
   # THE HICASSO COMPLAINT-CATALOGUE CONTRACT (rf2-hic-021; this routing is the
   # #7808 merged-PR audit's reverse-edge repair, landed under rf2-ibje because

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -733,6 +733,42 @@ jobs:
         continue-on-error: true
         run: python scripts/check_inject_cofx_residue.py --verbose
 
+      # Workflow job-cap ratchet (rf2-rsn1e). A job with no `timeout-minutes`
+      # inherits GitHub's 360-minute default, so a wedged runner produces a
+      # check that never TERMINATES — not a red check, no check at all for six
+      # hours — and this project's merge loop has nothing to read and no remedy
+      # but a hand cancel. That is the class rf2-km7iq found the hard way: its
+      # census showed 89 of 117 jobs uncapped, so uncapped was the house
+      # MAJORITY at 76%, accreted one job at a time and noticed only because a
+      # single run hung for 49 minutes in front of somebody. Review plainly did
+      # not hold this convention, so it is held here instead, on arrival.
+      #
+      # IT MUST PARSE, NOT GREP, AND THAT IS THE WHOLE CHECK. A
+      # `timeout-minutes` under a STEP is not a job cap — it bounds one step and
+      # leaves the job free to hang in any other — yet the two differ only by
+      # indentation inside the same text block. This file currently carries four
+      # real step-level keys across three jobs, so the confusion is live here.
+      # The checker reads the parsed document, where a job cap is a key on the
+      # job and a step cap is a key on an element of its `steps`.
+      #
+      # Presence only: it never judges the VALUE. What a cap should BE is a
+      # per-job measurement question (rf2-xenc6 raised exactly one, on exactly
+      # that evidence); folding that in would turn a mechanical one-bit check
+      # into a heuristic that argues with its reader.
+      #
+      # Self-test first — it drives the checker RED on five shapes including a
+      # step-only cap and an uncapped job sitting second behind a capped one
+      # (the "stopped looking after the first hit" defect) — then the live sweep.
+      - name: Self-test the workflow job-cap ratchet
+        id: check_workflow_job_timeouts_selftest
+        continue-on-error: true
+        run: python scripts/check_workflow_job_timeouts.py --self-test --verbose
+
+      - name: Verify every workflow job carries a job-level timeout-minutes
+        id: check_workflow_job_timeouts
+        continue-on-error: true
+        run: python scripts/check_workflow_job_timeouts.py --verbose
+
       # The verdict. Every checker above carries `continue-on-error: true`, so
       # the job never short-circuits and its RESULT is decided only here.
       # `toJSON(steps)` is the map of every step that declared an `id`. Each

--- a/scripts/check_workflow_job_timeouts.py
+++ b/scripts/check_workflow_job_timeouts.py
@@ -1,0 +1,435 @@
+#!/usr/bin/env python3
+"""Assert that every job in `.github/workflows/` carries a job-level `timeout-minutes`.
+
+WHY THIS EXISTS (rf2-rsn1e).  A job with no `timeout-minutes` inherits GitHub
+Actions' 360-minute default.  A wedged runner then produces a check that never
+TERMINATES — not a red check, no check at all for six hours.  That is a
+different and worse thing than a failure: this project's merge loop reads CI
+verdicts to decide what to merge, and a verdict that never arrives gives it
+nothing to read and no remedy but a hand cancel.  The cap is a circuit breaker,
+not a performance budget; it converts a hang into a legible failure.
+
+WHY A RATCHET RATHER THAN REVIEW.  Because review demonstrably did not hold it.
+rf2-km7iq's structural census found 89 of 117 jobs uncapped — uncapped was the
+house MAJORITY at 76%, accreted one job at a time over a long period, and it
+was noticed only because a single run wedged for 49 minutes and somebody
+happened to be watching.  A convention three quarters of whose instances
+violate it is not a convention; the next detection would have been the next
+49-minute hang.  This closes it at the cheapest possible point: on arrival.
+
+WHY IT PARSES RATHER THAN GREPS — THE WHOLE POINT OF THE FILE.  A
+`timeout-minutes` under a STEP is not a job cap.  It bounds one step and leaves
+the job free to hang in any other, so a job carrying only a step-level key is
+exactly as unprotected as one carrying none.  The two are indistinguishable to
+a line-oriented search: both produce a `timeout-minutes:` hit inside the job's
+text block, differing only in indentation, which is not a fact a grep can
+reason about.  This tree currently holds four real step-level keys across three
+jobs (Playwright installs and one MCP conformance run), so the confusion is
+live here and not hypothetical.  Reading the parsed document makes the
+distinction structural: a job cap is a key on the job mapping, a step cap is a
+key on an element of its `steps` sequence, and nothing has to infer one from
+the other.
+
+WHAT IT DOES NOT DO.  It does not judge the VALUE.  Any cap is accepted, and no
+opinion is offered about whether a number is too generous or too tight — that
+is a per-job measurement question (see rf2-xenc6, which raised exactly one cap
+on exactly that evidence) and folding it in here would turn a mechanical
+one-bit check into a heuristic that argues with its reader.  Presence only:
+one bit per job, exactly one correct answer, nothing to tune.
+
+WHY IT IS NOT FOLDED INTO check_workflow_yaml.py.  Two reasons, and the second
+is decisive.  (1) That script declares a deliberately single-question charter
+in its own docstring — "is the file YAML?" — and explicitly disclaims
+validating the Actions grammar.  (2) It is wired only into
+`scripts/test-fast-pr.sh`, the LOCAL pre-checkin spine, and into no workflow
+job at all.  A ratchet living there would not run in CI, which is the one place
+it has to run to ratchet anything — the "gate that runs nowhere" shape that
+this repo's own `check_gate_scheduling.py` exists to catch.  So this is a
+sibling of that script, wired into test.yml's `Repo invariant checks` job
+alongside the rest of the family.
+
+EXEMPTION: REUSABLE-WORKFLOW CALLS.  A job whose body is a job-level `uses:`
+calls a reusable workflow, and GitHub REJECTS `timeout-minutes` on it outright
+— the cap belongs to the called workflow's own jobs.  Requiring the key there
+would demand invalid YAML.  There are none in this tree today, so that arm is
+covered by the self-test rather than by the live sweep; it is here so the first
+one to land is not greeted with an impossible instruction.
+
+Usage (from anywhere — the root is derived from this file's location, or given):
+    python scripts/check_workflow_job_timeouts.py [--repo-root DIR] [--verbose]
+    python scripts/check_workflow_job_timeouts.py --self-test [--verbose]
+
+Exit codes:
+    0  every job carries a job-level timeout-minutes (or is an exempt `uses:` job)
+    1  at least one job has no job-level cap
+    2  usage error, or the workflow directory holds no jobs to check
+       (a sweep that examined nothing is not a pass)
+    3  PyYAML is not importable — NOT CHECKED, and the caller must say so
+"""
+from __future__ import annotations
+
+import argparse
+import pathlib
+import sys
+
+WORKFLOW_DIR = pathlib.Path(".github") / "workflows"
+SUFFIXES = (".yml", ".yaml")
+KEY = "timeout-minutes"
+
+
+def audit_document(doc) -> tuple[list[tuple[str, str]], int]:
+    """Return ([(job_id, why)], jobs_examined) for one parsed workflow document.
+
+    `why` names the shape rather than restating the rule, because the two
+    failing shapes want different fixes and a reader who is told which one they
+    have does not need to go and look.  A step-level cap in particular reads, at
+    a glance in the file, like the job is covered.
+    """
+    if not isinstance(doc, dict):
+        return [], 0
+
+    jobs = doc.get("jobs")
+    if not isinstance(jobs, dict):
+        return [], 0
+
+    offenders = []
+    for job_id, job in jobs.items():
+        if not isinstance(job, dict):
+            # Not a shape GitHub accepts; check_workflow_yaml.py owns
+            # well-formedness, so this file declines to have an opinion.
+            continue
+
+        # A reusable-workflow call cannot carry the key at all.
+        if "uses" in job:
+            continue
+
+        cap = job.get(KEY, None)
+        if KEY in job and cap is not None:
+            continue
+
+        # Distinguish the two failing shapes.  `steps` may be absent entirely.
+        steps = job.get("steps")
+        step_capped = isinstance(steps, list) and any(
+            isinstance(step, dict) and step.get(KEY) is not None for step in steps
+        )
+
+        if KEY in job:
+            why = f"`{KEY}:` is present but empty, which caps nothing"
+        elif step_capped:
+            why = (
+                f"only a STEP carries `{KEY}`; the JOB is uncapped and can still "
+                "hang in any other step"
+            )
+        else:
+            why = f"no job-level `{KEY}`"
+
+        offenders.append((str(job_id), why))
+
+    return offenders, len(jobs)
+
+
+# ---------------------------------------------------------------------------
+# Self-test.  A live sweep over a tree that is currently clean cannot tell the
+# difference between "every job is capped" and "the checker has stopped
+# looking" — and this repo has a named defect class for exactly that: a control
+# built so it cannot meet the case it exists to catch.  A scanner here once
+# missed every forbidden import after the first, because its permanent test
+# planted the forbidden import as the first and only entry.
+#
+# So the negative controls below include the two shapes that specifically defeat
+# a naive implementation: a step-level cap masquerading as a job cap (which a
+# grep cannot tell apart), and an uncapped job sitting SECOND behind a capped
+# one (which a checker that stops at the first job, or inspects only jobs[0],
+# would sail past).
+# ---------------------------------------------------------------------------
+_ACCEPT = (
+    (
+        "plain capped job",
+        """\
+name: t
+on:
+  pull_request:
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - run: echo hi
+""",
+    ),
+    (
+        "job cap AND a step cap — the common real shape",
+        """\
+name: t
+on:
+  pull_request:
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: slow install
+        timeout-minutes: 8
+        run: echo hi
+""",
+    ),
+    (
+        "reusable-workflow call is exempt (GitHub rejects the key there)",
+        """\
+name: t
+on:
+  pull_request:
+jobs:
+  call:
+    uses: ./.github/workflows/other.yml
+""",
+    ),
+    (
+        "every job capped, several files' worth of jobs",
+        """\
+name: t
+on:
+  pull_request:
+jobs:
+  a:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - run: echo a
+  b:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - run: echo b
+""",
+    ),
+)
+
+_REJECT = (
+    (
+        "no cap anywhere",
+        """\
+name: t
+on:
+  pull_request:
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo hi
+""",
+        ["build"],
+    ),
+    (
+        "STEP-level cap only — the shape a grep cannot tell from a job cap",
+        """\
+name: t
+on:
+  pull_request:
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: slow install
+        timeout-minutes: 8
+        run: echo hi
+""",
+        ["build"],
+    ),
+    (
+        "uncapped job SECOND, behind a capped one",
+        """\
+name: t
+on:
+  pull_request:
+jobs:
+  capped:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - run: echo a
+  uncapped:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo b
+""",
+        ["uncapped"],
+    ),
+    (
+        "two uncapped jobs — both must be named, not just the first",
+        """\
+name: t
+on:
+  pull_request:
+jobs:
+  one:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo a
+  two:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo b
+""",
+        ["one", "two"],
+    ),
+    (
+        "key present but empty, which caps nothing",
+        """\
+name: t
+on:
+  pull_request:
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    timeout-minutes:
+    steps:
+      - run: echo hi
+""",
+        ["build"],
+    ),
+)
+
+
+def run_self_test(verbose: bool) -> int:
+    import yaml
+
+    failures = []
+
+    for label, text in _ACCEPT:
+        offenders, examined = audit_document(yaml.safe_load(text))
+        if offenders:
+            failures.append(
+                f"ACCEPT case rejected — {label}: flagged {[o[0] for o in offenders]}"
+            )
+        elif examined == 0:
+            failures.append(f"ACCEPT case examined NO jobs — {label}")
+        elif verbose:
+            print(f"  ok  accepted: {label} ({examined} job(s))")
+
+    for label, text, expected in _REJECT:
+        offenders, _ = audit_document(yaml.safe_load(text))
+        got = sorted(o[0] for o in offenders)
+        if got != sorted(expected):
+            failures.append(
+                f"REJECT case wrong — {label}: expected {sorted(expected)}, got {got}"
+            )
+        elif verbose:
+            reasons = "; ".join(f"{j}: {w}" for j, w in offenders)
+            print(f"  ok  rejected: {label} -> {reasons}")
+
+    if failures:
+        print("FAIL check_workflow_job_timeouts self-test:", file=sys.stderr)
+        for problem in failures:
+            print(f"  - {problem}", file=sys.stderr)
+        return 1
+
+    print(
+        "PASS check_workflow_job_timeouts self-test "
+        f"({len(_ACCEPT)} accept + {len(_REJECT)} reject cases)"
+    )
+    return 0
+
+
+def run_check(root: pathlib.Path, verbose: bool) -> int:
+    import yaml
+
+    directory = root / WORKFLOW_DIR
+    if not directory.is_dir():
+        print(
+            f"ERROR: no workflow directory at {directory}. Wrong --repo-root?",
+            file=sys.stderr,
+        )
+        return 2
+
+    files = sorted(p for p in directory.iterdir() if p.suffix in SUFFIXES and p.is_file())
+    if not files:
+        print(f"ERROR: no {'/'.join(SUFFIXES)} files under {directory}.", file=sys.stderr)
+        return 2
+
+    total_jobs = 0
+    offenders = []
+    for path in files:
+        try:
+            doc = yaml.safe_load(path.read_text(encoding="utf-8"))
+        except yaml.YAMLError as exc:
+            # check_workflow_yaml.py is the gate that reports this properly; fail
+            # rather than skip, so an unparseable file cannot pass vacuously here.
+            print(
+                f"ERROR: {path.relative_to(root).as_posix()} is not well-formed YAML "
+                f"({exc.__class__.__name__}). Run check_workflow_yaml.py.",
+                file=sys.stderr,
+            )
+            return 2
+
+        found, examined = audit_document(doc)
+        total_jobs += examined
+        rel = path.relative_to(root).as_posix()
+        for job_id, why in found:
+            offenders.append((rel, job_id, why))
+        if verbose and examined:
+            print(f"  ok  {rel}: {examined - len(found)}/{examined} job(s) capped")
+
+    if total_jobs == 0:
+        # A sweep that examined nothing is not a sweep that passed.
+        print(f"ERROR: no jobs found under {directory}.", file=sys.stderr)
+        return 2
+
+    if offenders:
+        print(f"FAIL {len(offenders)} workflow job(s) have no job-level {KEY}:", file=sys.stderr)
+        for rel, job_id, why in offenders:
+            print(f"  {rel}: {job_id} — {why}", file=sys.stderr)
+        print(
+            f"\nAn uncapped job inherits GitHub's 360-minute default, so a wedged\n"
+            f"runner yields a check that never terminates — nothing for the merge\n"
+            f"loop to read. Add `{KEY}:` to the JOB (a step-level key does not\n"
+            "count), sized generously above the job's measured worst case.",
+            file=sys.stderr,
+        )
+        return 1
+
+    print(
+        f"PASS every workflow job carries a job-level {KEY} "
+        f"({total_jobs} jobs across {len(files)} files under {WORKFLOW_DIR.as_posix()})"
+    )
+    return 0
+
+
+def main(argv=None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("--self-test", action="store_true", help="run the checker's own cases")
+    parser.add_argument("--verbose", action="store_true", help="name every file checked")
+    parser.add_argument(
+        "--repo-root",
+        default=None,
+        help="repository root (default: this script's parent directory's parent)",
+    )
+    args = parser.parse_args(argv)
+
+    # ONE probe, at the top, so both arms below can assume the import.  PyYAML is
+    # not in requirements.txt in its own right; it arrives through mkdocs.
+    try:
+        import yaml  # noqa: F401
+    except ImportError:
+        print(
+            "NOT CHECKED: workflow job timeouts. PyYAML is not importable on this\n"
+            "  interpreter, so nothing here examined .github/workflows/.  This is\n"
+            "  NOT a pass.  Install it (pip install -r requirements.txt, which\n"
+            "  pulls PyYAML in through mkdocs) and re-run.",
+            file=sys.stderr,
+        )
+        return 3
+
+    if args.self_test:
+        return run_self_test(args.verbose)
+
+    root = (
+        pathlib.Path(args.repo_root).resolve()
+        if args.repo_root
+        else pathlib.Path(__file__).resolve().parent.parent
+    )
+    return run_check(root, args.verbose)
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Two beads on one surface, smallest first. `.github/workflows/` takes one toucher at a time, which is why they ride one PR.

## rf2-xenc6 — `beads-pr-boundary` was capped 1.06x above its own worst run

The bead's figures were a claim, so they were re-measured rather than copied. Twenty successful `test.yml` runs sampled after #8469 landed:

| | minutes |
|---|---|
| max | **4.72** (run `32098265972`) |
| median | 4.09 |
| mean | 3.92 |
| min | 2.15 |

The bead reported max 4.67 / median 4.10. **Reproduced** — the median is unmoved (4.09), which is what a cap-only change should do to runtime, and the independent sample found a run slightly *worse* than the bead's max. The worst observed run finished 17 seconds under its own 5-minute cap.

The headroom is not the interesting part; where the time goes is. A step breakdown of that slowest run:

| step | minutes |
|---|---|
| `actions/checkout` (`fetch-depth: 0`) | **4.55** |
| hook self-test | 0.12 |
| boundary enforcement | 0.00 |

So the cap sits above a **full-history clone of this repository**, not above the job's work. This job pins `fetch-depth: 0` deliberately — the guard diffs from the branch point (rf2-5z20y) and a shallow clone frequently lacks the fork commit. That cost grows monotonically as history does, so a cap that is tight today gets tighter on its own without anyone touching it.

Crossing it does not even read as a failure: GitHub reports a job killed at its cap as `cancelled`, not `failure`, so a merge loop sees "not passed" with no explanation.

**10 is derived from this job's own numbers**, not copied from a sibling: 2.1x the observed max, 2.4x the median. Enough to absorb a slow runner and the clone's continued growth, still short enough to convert a wedge into a legible failure in minutes rather than six hours.

**The five other pre-existing 5-caps in this file are deliberately untouched**, and that was checked rather than assumed. Measured in the same run: `hicasso-complaint-catalogue` 0.23, `-budget-ledger` 0.18, `-facade-inventory` 0.17, `-guide-samples` 0.18, `-naming-census` 0.20, `all-required-passed` 0.07. They take the default shallow checkout, so they sit at roughly 22x headroom. `beads-pr-boundary` was the only pre-existing 5-cap in the file with `fetch-depth: 0`, which is exactly what made it the outlier.

Diff: one line.

## rf2-rsn1e — the ratchet, built

The bead argues both sides and asks for a judgement. This builds it, for two reasons.

**The empirical base rate refutes the reject-if clause.** The bead says to close it "if the convention will hold by review alone". The census that prompted the bead is the evidence against: 89 of 117 jobs uncapped, so the convention held for 24% of instances, accreted one job at a time over a long period, and surfaced only because a single run hung for 49 minutes in front of somebody. A convention three quarters of whose instances violate it is not being enforced by review.

**The failure mode is a liveness defect, not a style complaint.** An uncapped job inherits GitHub's 360-minute default, so a wedged runner produces a check that never *terminates* — not a red check, no check at all for six hours. This project merges by reading CI verdicts; a verdict that never arrives leaves nothing to read and no remedy but a hand cancel. That is not the nag-diagnostic class the project stance rejects.

The cost is proportionate: one script joining 38 siblings under `scripts/`, two steps in an existing job, **no new gate and no new job**, milliseconds of runtime. And it is presence-only — one bit per job, exactly one correct answer, nothing to tune and nothing to argue with.

### Divergence from the bead: where it lives

The bead proposed folding the assertion into `scripts/check_workflow_yaml.py`. This does not, for two reasons, and the second is decisive.

1. That script declares a deliberately single-question charter in its own docstring — "is the file YAML?" — and explicitly disclaims validating the Actions grammar.
2. **The bead states it is "already wired into CI". It is not.** `check_workflow_yaml.py` appears only in `scripts/test-fast-pr.sh`, the local pre-checkin spine, and in no workflow job at all. A ratchet folded in there would never run in CI — precisely the "gate that runs nowhere" shape that this repo's own `check_gate_scheduling.py` exists to catch.

So it is a sibling script, `scripts/check_workflow_job_timeouts.py`, wired into `test.yml`'s `Repo invariant checks` job alongside the rest of the family — which still gives the bead what it wanted (no new gate, no new job).

### The job-versus-step distinction

This is the whole reason the check parses instead of grepping. A `timeout-minutes` under a **step** is not a job cap: it bounds one step and leaves the job free to hang in any other, so a job carrying only a step-level key is exactly as unprotected as one carrying none. The two differ only by indentation inside the same text block, which no line-oriented search can reason about.

That confusion is **live in this tree, not hypothetical** — a structural census finds four real step-level keys across three jobs (two Playwright installs, two in `mcp-conformance-re-frame2-pair`). Reading the parsed document makes the distinction structural: a job cap is a key on the job mapping, a step cap is a key on an element of its `steps` sequence.

Also exempted: jobs whose body is a job-level `uses:` (a reusable-workflow call), where GitHub rejects the key outright. There are none in this tree today, so that arm is honestly covered by the self-test rather than by the live sweep.

Scope held to presence: no cap-value policy, no "is this cap reasonable" heuristic, no report of generous caps.

### Controls — the check can fail

A live sweep over a tree that is currently clean cannot distinguish "every job is capped" from "the checker stopped looking", so the negative controls target the two shapes that defeat a naive implementation.

**Self-test, 4 accept + 5 reject, exit 0:**

- accepts: a plain capped job; a job with **both** a job cap and a step cap (the common real shape); a reusable-workflow call; a two-job file where both are capped
- rejects: no cap anywhere; **a step-only cap** (the grep-confusion shape); **an uncapped job sitting second behind a capped one** (the "stopped after the first hit" defect); two uncapped jobs where *both* must be named; a present-but-empty key

**Sabotage against real content, exit 1.** Fixtures can be tuned to pass. So the job-level cap was stripped from the real `cljs-reagent-slim-bundle-isolation` job — which keeps a step-level cap — in an isolated `--repo-root` copy. The checker exits 1 naming that job and that reason:

```
FAIL 1 workflow job(s) have no job-level timeout-minutes:
  .github/workflows/test.yml: cljs-reagent-slim-bundle-isolation — only a STEP carries
  `timeout-minutes`; the JOB is uncapped and can still hang in any other step
```

A grep would have passed that file. The plant was anchored to a single line behind an assertion that the anchor matched, so it could not silently no-op, and it went into a copy — the working tree's `test.yml` was verified byte-identical to its committed blob by `git hash-object` afterwards.

## Quality gates

**The spine did not run, deliberately.** A clock measurement window was running on the same machine under an authorised fleet drain, and a clock measurement is only valid on a quiet box. No shadow-cljs, browser, Playwright, npm or JVM lane was started. Both beads' deliverables are YAML and Python, so the covering gates are the cheap Python checkers, run directly and each with its own captured exit code.

**Local verification here is a YAML parse plus this repo's own workflow checkers. The behaviour of a workflow change is verified by CI running it — this PR's own run is that verification**, and no local proxy was invented to stand in for it.

Gates re-run after the wiring commit, on the final base (`origin/main` unmoved at `1caf2829d9` throughout):

| gate | exit |
|---|---|
| `python scripts/check_workflow_yaml.py` | **0** — 11 files well-formed |
| `python scripts/check_ci_reproduce_commands.py` | **0** — 45 checker steps in sync (43 before; picked up both new steps) |
| `python scripts/check_gate_scheduling.py` | **0** — 35 gate commands, 30 scheduled, 5 declared |
| `python scripts/check_jvm_lane_rosters.py` | **0** — 31 rostered artefacts, bijection holds |
| `python scripts/check_workflow_job_timeouts.py --self-test` | **0** — 4 accept + 5 reject |
| `python scripts/check_workflow_job_timeouts.py` | **0** — 117 jobs across 11 files, all capped |
| `python scripts/check_workflow_job_timeouts.py --repo-root <sabotaged copy>` | **1** — the negative control, red as designed |
| `python scripts/check_fast_pr_gap.py --list` | **0** |

`check_ci_reproduce_commands.py --emit` resolves both new step ids to their exact commands, so a failure on either names a runnable reproduce line rather than a reconstruction.

**Spine gap, cited from the tool rather than enumerated by hand:** `check_fast_pr_gap.py --list` reports `check_workflow_job_timeouts, check_workflow_job_timeouts --self-test` among the required checks `scripts/test-fast-pr.sh` does not run. That is expected for a CI-side ratchet and is a map, not a failure — the tool exits 0. The checker was not added to the spine, to keep the diff minimal.

### Follow-up fix: the ratchet was wired into a job that cannot run it

The run above went red on **`Repo invariant checks (skills, MCP, catalogues, namespaces)`**, and the fix is a re-homing of the two new steps.

Both of them exited **3**, with the checker's own refusal:

```
NOT CHECKED: workflow job timeouts. PyYAML is not importable on this
  interpreter, so nothing here examined .github/workflows/.  This is
  NOT a pass.  Install it (pip install -r requirements.txt, which
  pulls PyYAML in through mkdocs) and re-run.
```

**The checker was right; the placement was wrong.** Parsing the document is the entire point of this ratchet — a step-level `timeout-minutes` is indistinguishable from a job-level one to a grep — and parsing means PyYAML, which is not stdlib. `verify-skill-mcp-drift` installs no pip packages, deliberately, and that property is recorded three separate times in this repo: in the job's own comment ("Fast — pure Python stdlib, no setup beyond `actions/setup-python`"), in the `verify-readme-links` disposition for the doc-slug gate ("dropping it beside the stdlib checkers — which have no `pip install` step — would have redded every PR"), and in `check_fast_pr_gap.py`'s module docstring, which stayed stdlib-only naming *PyYAML specifically* for exactly this reason.

Every local gate in the table above passed because this developer machine has PyYAML on its interpreter. The CI job does not, and nothing local distinguished the two.

**The remedy is the one already written down.** The two steps move to `verify-readme-links` — equally unconditional, already running `pip install -r requirements.txt` for the slugifier, and already the home of four other non-link gates (README inventories, test-lane bijection, JVM roster bijection, adapter disposition). They shed `continue-on-error`/`id`, matching that job, where a gate reds directly instead of reporting through the invariant job's aggregator.

Both jobs are in `all-required-passed`'s `needs:`, so **the required set is unchanged** — the ratchet still gates every PR. No gate was loosened, no cap relaxed, and rf2-rsn1e's ratchet is intact rather than reverted. `verify-skill-mcp-drift` keeps its dependency-free, seconds-not-minutes property, and a comment in its place records why the ratchet is not there.

Gates re-run **after the rebase**, on the final base (branch 0 behind `origin/main`), each exit code captured directly:

| gate | exit |
|---|---|
| `python scripts/check_workflow_job_timeouts.py --verbose` | **0** — 117 jobs across 11 files, all capped |
| `python scripts/check_workflow_job_timeouts.py --self-test --verbose` | **0** — 4 accept + 5 reject |
| `python scripts/check_workflow_yaml.py` | **0** — 11 files well-formed |
| `python scripts/check_ci_reproduce_commands.py --verbose` | **0** |
| `python scripts/check_ci_reproduce_commands.py --self-test` | **0** |
| `python scripts/check_fast_pr_gap.py` | **0** |
| `python scripts/check_fast_pr_gap.py --self-test` | **0** |
| `python scripts/check_gate_scheduling.py` | **0** |
| `python scripts/check_jvm_lane_rosters.py --verbose` | **0** |
| `python scripts/check_test_lane_bijection.py --verbose` | **0** |
| `python scripts/check_workflow_job_timeouts.py --repo-root <sabotaged copy>` | **1** — negative control |

The negative control was re-run against the moved gate: an isolated copy of `.github/workflows/` with the **single** `timeout-minutes` line deleted from `verify-readme-links` itself, which the checker rejected by name — proving the run read the tree under test and not a sibling. The copy was discarded and the working tree confirmed carrying only the intended edit.

**Structural placement verified by parsing rather than by grep**, the same discipline the ratchet enforces: `verify-skill-mcp-drift` now holds 46 steps and zero `check_workflow_job_timeouts` steps; `verify-readme-links` holds 18 steps and both of them.

**No revert of concurrent work.** `git diff origin/main...HEAD` (three-dot) touches two files and contains exactly one removed `timeout-minutes` line — the deliberate `beads-pr-boundary` 5 → 10 raise of rf2-xenc6, paired with its addition. Job-level cap count in `test.yml` is 73 on `origin/main` and 73 on this branch, so the 89 caps added across 11 files by #8469 are intact.

## Sequencing

`rf2-fo4ng` is held pending an operator act and will later rewrite Maven coordinates across the release workflows. It is not running, so this is not a race; the diff here is one changed line in `test.yml` plus an appended block in one job, so its rebase stays trivial.

