### PR TITLE
docs(hicasso): re-verify all three budget-gate refusals at the tip (rf2-85og2)

### DIFF
--- a/docs/design/hicasso/product/budgets.md
+++ b/docs/design/hicasso/product/budgets.md
@@ -1843,15 +1843,30 @@ at this branch's base with `git hash-object`:
 | `p0_uix.cljs` | `deec8976…` | `f1aaf9cb…` |
 | `p0_fixture.cljc` | `867ad583…` | `de27135c…` |
 
-The other five are the candidate arm's, and §6 records one of them —
-`front/sub_index.cljs` — as absent. **All five are now unreachable rather than
-one**: the table pins them under
-`implementation/freehand/test/re_frame/bench/hicasso/`, and that tree was
-removed whole on 2026-08-16 (`rf2-0yp7w`, PR #8322), so `git ls-files` returns
-nothing under it. Eleven of eleven, then — six changed and five at a deleted
-path. *"The same instrument"* still names nothing, and the re-pin is still a run
-rather than an edit; now a run whose candidate arm has to be re-sited before it
-can be taken at all.
+The other five are the candidate arm's, and **the pinned path itself is gone**:
+they are pinned under `implementation/freehand/test/re_frame/bench/hicasso/`,
+the benchmark harness was re-homed into `implementation/hicasso/` on 2026-08-14
+by `e61e175341`, and `implementation/freehand` was deleted whole on 2026-08-15
+by `c951808b47` (`rf2-0yp7w.6`). Four of the five survive the move under
+`implementation/hicasso/test/re_frame/bench/hicasso/`, and **all four have
+different content there**; the fifth is gone from the repository altogether,
+which is the absence §6 already records:
+
+| candidate-arm file | pinned blob | at its re-homed path, 2026-08-18 |
+|---|---|---|
+| `arm1/runtime.cljs` | `69bfc6fc…` | `202f7612…` |
+| `arm1/mount.cljs` | `4653e168…` | `780b2962…` |
+| `arm1/lang.clj` | `0151ddaf…` | `95f057e8…` |
+| `front/codec.cljs` | `5eb17dbd…` | `ea859037…` |
+| `front/sub_index.cljs` | `394927d6…` | **absent from the tree** |
+
+`arm1/lang.clj` is worth one line of its own: the ladder's provenance says it
+was the one file that did **not** move across that page's own three runs. It has
+moved since. So the count is eleven of eleven — six changed in place, four
+changed and re-homed, one gone — and *"the same instrument"* still names
+nothing. The re-pin is still a run rather than an edit, and it is now a run
+whose candidate arm has to be re-registered at a path that exists before it can
+be taken at all.
 
 **`C8`: the population is verifiably empty, not merely unreported.** Across the
 witness applications under

--- a/docs/design/hicasso/product/budgets.md
+++ b/docs/design/hicasso/product/budgets.md
@@ -1782,3 +1782,93 @@ this section's heading:
 now a ledger row with a witness a pull request runs, and every remaining gate
 is blocked on an instrument rather than on an edit. That is the honest boundary
 today, and moving it needs a quiet box rather than another pass over this page.
+
+**[Re-verified 2026-08-18, `rf2-85og2`, on a drained fleet.] All three are
+still refused, and the drain is what establishes it.** The measurement lane was
+cleared to zero for this bead's window and the window took **no reading** —
+because a precondition re-tested at the tip is what a window is for when the
+question is whether a trustworthy number can be taken at all. Each of the three
+above was re-tested at source rather than carried; two came back *stronger*
+than they were written, and the first came back the same but for a sharper
+reason. No threshold was guessed, no band widened and no figure restated.
+`U1`–`U4`, `C1`, `C3`, `C4` and `C8` all keep the status they had.
+
+**`U1`–`U4` and `C3`/`C4`: the reason has moved from *absence* to *estimator*.**
+Two clock drivers have landed since the bullet above was written, and one of
+them **is** pointed at the package: §4's `S8` clocks mount time through
+`re-frame.bench.hicasso.direct-return-clock-app`, which requires
+`re-frame.hicasso` itself and whose row this page already calls a **package
+figure**. The other, `re-frame.bench.hicasso.topo.clock-app` (`rf2-w01c`,
+window taken 2026-08-18), requires `re-frame.bench.hicasso.arm1.runtime` and is
+a bench-tree instrument. **Neither can pin `U1`–`U4`, and the block is now a
+line of source rather than a gap**: `lane/summarise` answers
+`{:n :min :max :p50}`, and no `p95` and no `p99` is computed anywhere on this
+lane, while every one of `U1`–`U4` is stated at `p95` or `p99`.
+[§9.2](#92-what-each-not-green-row-is-waiting-on) already records exactly that
+about `C8`'s `≥ 2 ms p95` disjunct — *the instrument computes no `p95`* — and
+it is the same lane. The populations differ as well: `U1`–`U4` are the slice
+application's own interactions, while both drivers mount a synthetic bench page
+inside one `flushSync` window, which is a mount and not a paint. `UNPINNED`
+stands on all six rows.
+
+**What *package-resident* means here**, written down because it is mis-readable
+in a way that would silently discharge that bullet. It names what the
+instrument is **pointed at**, never where the instrument's own code ships. §6's
+heading is *the instrument does not measure the package*, its diagnosis is *no
+heap instrument pointed at the package at all*, and `rf2-fe0l` discharged that
+half by **repointing** the P0 ladder's candidate seams at `re-frame.hicasso`
+rather than by repackaging anything; §4's *package figure* / *bench-tree
+figure* column sorts readings on the same axis. So `rf2-rxf49` putting
+`test_kit/src` on `:clein/build`'s `:src-dirs` — which does ship
+`re-frame.hicasso.test` and `re-frame.hicasso.test.mounted` in the jar, while
+`:paths` still does not carry it — moves nothing here, and the
+jar-versus-classpath distinction it creates is not the axis this gate turns on.
+The kit carries no clock estimand in any case: `mounted.cljs` installs a **fake**
+clock that replaces `Date.now` so that timers become deterministic, and its
+docstring records that it deliberately leaves `performance.now` alone. That is
+the opposite of an instrument, and `js/performance` appears nowhere in
+`test_kit/`.
+
+**`C1`: the supersession has widened rather than closed.** The ladder's
+provenance table pins eleven blobs. Six are the P0 driver's, under
+`implementation/core/test/re_frame/bench/`, and **all six have moved** — hashed
+at this branch's base with `git hash-object`:
+
+| file | pinned blob | at 2026-08-18 |
+|---|---|---|
+| `p0_run.cjs` | `4718aaea…` | `9c993e96…` |
+| `p0_heap.cljs` | `34c9210d…` | `2d922d31…` |
+| `p0_hicasso.cljs` | `f2440e30…` | `7a91564f…` |
+| `p0_reagent.cljs` | `b1f5ec92…` | `419e166a…` |
+| `p0_uix.cljs` | `deec8976…` | `f1aaf9cb…` |
+| `p0_fixture.cljc` | `867ad583…` | `de27135c…` |
+
+The other five are the candidate arm's, and §6 records one of them —
+`front/sub_index.cljs` — as absent. **All five are now unreachable rather than
+one**: the table pins them under
+`implementation/freehand/test/re_frame/bench/hicasso/`, and that tree was
+removed whole on 2026-08-16 (`rf2-0yp7w`, PR #8322), so `git ls-files` returns
+nothing under it. Eleven of eleven, then — six changed and five at a deleted
+path. *"The same instrument"* still names nothing, and the re-pin is still a run
+rather than an edit; now a run whose candidate arm has to be re-sited before it
+can be taken at all.
+
+**`C8`: the population is verifiably empty, not merely unreported.** Across the
+witness applications under
+`implementation/hicasso/test/re_frame/hicasso/examples/`, shipping view code
+carries exactly one `h/as-element` call — `ledger/views.cljs`'s `:render-row`,
+handing a boundary to the vendor virtualizer, which is the interoperability
+site the bullet above already names — and **no `re-frame.hicasso.native` island
+at all**. Nothing under `examples/` mounts Hicasso either. So there is still
+nothing for *"simplify or remove"* to name, and `S8` remains this mechanism's
+published reference price rather than a verdict about a site.
+
+**And one correction to *What this leaves*, above.** That paragraph says every
+remaining gate is blocked on an instrument rather than on an edit, and needs a
+quiet box rather than another pass. For `C8` that holds — its blocker is a
+landed site, which no amount of machine time supplies. For the other two it
+does not: `U1`–`U4` are blocked on an **estimator this lane does not compute**,
+and `C1` on a candidate arm that has to be re-sited, and **both of those are
+edit-shaped work that builds fine on a loud box.** Only the runs that follow
+them need the drain. Recording that distinction is what this window bought with
+a quiet fleet; it is a scheduling fact and it moves no row.


### PR DESCRIPTION
`rf2-85og2` owes three budget gates, each of which a previous worker **refused at source** rather than guessing a threshold. The measurement lane was drained to zero for this window. **The window took no reading**, and that is the result rather than a failure to get one: every one of the three preconditions was re-tested at the current tip and all three still hold.

Two of the three refusals came back **stronger** than they were written; the first came back the same, but for a sharper and more actionable reason. No threshold was guessed, no band widened, no published figure restated, and no row's status moved.

## What was re-verified, and on what evidence

**Gate 1 — `U1`–`U4`, `C3`/`C4`.** The refusal read *no package-resident clock instrument exists*. That sentence is now imprecise: two clock drivers have landed since, and one of them **is** pointed at the package — §4's `S8` clocks mount time through `re-frame.bench.hicasso.direct-return-clock-app`, which requires `re-frame.hicasso` itself, and the page already calls that row a *package figure*. The gate is still refused, for a better-located reason: `lane/summarise` answers `{:n :min :max :p50}` and computes **no `p95` and no `p99` anywhere**, while every one of `U1`–`U4` is stated at `p95` or `p99`. §9.2 already records exactly that fact about `C8`'s `≥ 2 ms p95` disjunct, and it is the same lane. The populations differ too: `U1`–`U4` are the slice application's own interactions, and both drivers mount a synthetic bench page inside one `flushSync` window — a mount, not a paint.

*What `package-resident` means is written down*, because it is mis-readable in a way that would silently discharge this gate. In this corpus it names what the instrument is **pointed at**, never where the instrument's own code ships — §6's heading is *the instrument does not measure the package*, and `rf2-fe0l` discharged its heap half by **repointing** seams at `re-frame.hicasso`. So `rf2-rxf49` putting `test_kit/src` on `:clein/build`'s `:src-dirs` moves nothing here, and the kit's clock is the *opposite* of an instrument: `mounted.cljs` installs a **fake** clock replacing `Date.now` so timers become deterministic, and its docstring records that it deliberately leaves `performance.now` alone. `js/performance` appears nowhere in `test_kit/`.

**Gate 2 — `C1`.** Still refused, and the supersession has **widened**. Eleven of eleven pinned blobs fail to resolve, all hashed here with `git hash-object` (two tables on the page). Six are the P0 driver's and **all six have changed in place**. The other five are pinned under `implementation/freehand/test/re_frame/bench/hicasso/`, a path that no longer exists — the harness was re-homed into `implementation/hicasso/` on 2026-08-14 by `e61e175341` and `implementation/freehand` was deleted on 2026-08-15 by `c951808b47`. **Four of those five survive the move and all four differ from their pins there**; only `front/sub_index.cljs` is gone from the tree, which is the absence §6 already records. `arm1/lang.clj` gets a line of its own: the ladder's provenance says it was the one file that did *not* move across that page's three runs, and it has moved since.

*(The second commit on this branch is a self-audit that corrected this paragraph. The first commit attributed the removal to PR #8322 on 2026-08-16 and called all five "unreachable"; git says otherwise on both counts, and the corrected reading is the stronger one.)*

**Gate 3 — `C8`.** Still refused, population verifiably empty. Shipping view code across the witness applications carries exactly one `h/as-element` call — the ledger's `:render-row` interoperability site the page already names — and **no `re-frame.hicasso.native` island at all**. Nothing under `examples/` mounts Hicasso.

**One correction to the section's closing paragraph.** It says every remaining gate is blocked on an instrument rather than an edit and needs a quiet box. That holds for `C8` only. `U1`–`U4` are blocked on an estimator this lane does not compute, and `C1` on a candidate arm that has to be re-sited — both **edit-shaped, buildable on a loud box**. Only the runs that follow them need the drain.

## Scope

One file: `docs/design/hicasso/product/budgets.md` §9.4, appended. `git diff origin/main...HEAD --stat` is **1 file changed, 90 insertions(+), 0 deletions(-)** — a pure addition, reverting nothing. The page annotates and never erases: the three original bullets are untouched.

## Quality gates

All exit codes below were captured in this worktree with `; echo $?` after a redirect to a log — never read from a pipeline and never taken from a harness report. All five were run three times: on the original commit, again **after** the rebase onto `1caf2829d9` (the base this branch now sits on), and again **after** the self-audit correction in the second commit. The exit codes above are the third run's — the tree as it stands.

| gate | command | exit |
|---|---|---|
| budget-ledger self-test | `python implementation/hicasso/scripts/check_budget_ledger.py --self-test` | **0** |
| budget-ledger | `python implementation/hicasso/scripts/check_budget_ledger.py` | **0** |
| doc slugs / anchors | `python scripts/check_doc_slugs.py` | **0** |
| provenance pins | `python scripts/check_provenance_pins.py` | **0** |
| allocation non-claim | `python scripts/check_allocation_non_claim.py` | **0** |

`check_budget_ledger.py` reports *49 ledger rows — 31 MET, 5 BREACH, 3 UNRESOLVED, 10 UNPINNED*, unchanged by this PR: no row's status moved. `check_provenance_pins.py` reports *119 pages inspected, 642 cited pins, 0 findings*.

**`check_doc_slugs.py` prints nothing on success, so it was proved by a planted fault.** A single line of this PR's own text had its `#92-…` anchor replaced with `#92-this-anchor-does-not-exist-rf2-85og2-plant`; the gate went **red, exit 1**, naming `budgets.md:1807 -> #92-this-anchor-does-not-exist-rf2-85og2-plant`. The plant was then reverted and the revert verified **by hash** — `git hash-object` returned `4a0ee13b…` both before the plant and after the restore, and equal to `git rev-parse HEAD:docs/design/hicasso/product/budgets.md`. (A `git status` ` M` persisted from a line-ending rewrite while the content hash was identical, which is precisely why a diff is not the check here.)

**Hand checks this tree has no gate for.** `mkdocs.yml`'s `exclude_docs` keeps `design/hicasso/` out of the site, so `mkdocs build --strict` does not see this page and was not nominated. Anchors and table shape were therefore checked by hand as well: the one table added is **8 rows — header, separator and 6 data rows — every one exactly 3 cells**; the only link added is `[§9.2](#92-what-each-not-green-row-is-waiting-on)`, an anchor already in use elsewhere on the page; and **no new heading was added**, so no anchor anywhere else can have moved.

**The fast-PR spine was NOT run, deliberately.** `scripts/check_fast_pr_gap.py --list` (exit **0**) derives 94 required checks the spine does not run, so a green spine would not have been a green CI in any case. This diff is one markdown file in an mkdocs-excluded tree, and `scripts/lint_kondo.py`'s own self-test asserts that a change to `docs/design/hicasso/product/budgets.md` **does not arm the lint lane**, naming this exact path. The five gates above are the ones that actually read the file; CI decides the rest.
