### PR TITLE
feat(hicasso-bench): a tail-quantile estimator on the lane, so U1-U4's p95/p99 has one (rf2-xa8wo)

### DIFF
--- a/docs/design/hicasso/product/budgets.md
+++ b/docs/design/hicasso/product/budgets.md
@@ -1811,6 +1811,33 @@ application's own interactions, while both drivers mount a synthetic bench page
 inside one `flushSync` window, which is a mount and not a paint. `UNPINNED`
 stands on all six rows.
 
+**[Estimator half built, 2026-08-18, `rf2-xa8wo`. `UNPINNED` still stands on
+all six rows, and no reading was taken.]** The first of the two gaps above is
+closed as a matter of source: `lane/quantile` now answers a linear-interpolated
+quantile at `h = (n-1)q` — the definition `clock_readjudicate.cjs` already
+spells out, and the one the lane's `:p50` was already computed under — and
+`lane/summarise` carries `:p95` and `:p99` beside the fields it always
+answered. The paragraph above, [§9.2](#92-what-each-not-green-row-is-waiting-on)'s
+*the instrument computes no `p95`* and
+[the tournament's §2.9.9](topology-tournament.md#299-what-was-not-concluded)
+are each a true record of the lane as it stood when they were written, and each
+is now history rather than a live constraint.
+
+**THE SECOND GAP IS UNTOUCHED, AND IT IS THE ONE THAT GOVERNS.** The
+populations still differ. `U1`–`U4` are stated over a slice application's own
+interactions — [§9.3](#93-where-this-ledger-stops-and-rf2-hic-071-begins) says
+*slice-app user-visible gates*, and §4's estimand column reads *latency to
+visible echo*, *latency to next paint*, *operation latency* and *per-frame
+latency* — while every window the lane can currently drive is a commit bracketed
+by `flushSync` on a synthetic bench page. **A `p95` over that window would be a
+`p95` of a mount, published against a line written about a paint**, which is
+worse than no `p95` at all because it is quotable. `rf2-xa8wo` therefore built
+the estimator and stopped: what it still owes, and what the gate-1 window is
+still waiting on, is a driver whose window is one discrete interaction through
+to the paint that follows it, on a witness application under
+`implementation/hicasso/test/re_frame/hicasso/examples/`. No threshold was
+guessed, no band widened, no figure restated and no ledger count moved.
+
 **What *package-resident* means here**, written down because it is mis-readable
 in a way that would silently discharge that bullet. It names what the
 instrument is **pointed at**, never where the instrument's own code ships. §6's

--- a/docs/design/hicasso/product/topology-tournament.md
+++ b/docs/design/hicasso/product/topology-tournament.md
@@ -959,6 +959,16 @@ window did not relitigate that refusal.
   [the budgets page](budgets.md#the-comparative-and-regression-rules) already
   records `C8`'s `≥ 2 ms p95` disjunct as unassessed at its witness. `S1`–`S8`
   are not this page's to move and are not moved.
+
+    **[2026-08-18, `rf2-xa8wo`.]** *Never a `p95` at all* was true of the lane
+    when this window was taken and is no longer true of the lane: `lane/quantile`
+    and `summarise`'s `:p95`/`:p99` have since landed. **Every cell above stays
+    `UNASSESSED` all the same, and nothing on this page moves**, for the reason
+    that outlived the estimator — this table's window is a commit bracketed by
+    `flushSync` on a synthetic bench page, and `U1`–`U3` are stated over a slice
+    application's interactions through to a paint. A `p95` is now computable
+    here; it would still be a `p95` of the wrong population. See
+    [budgets.md §9.4](budgets.md#94-what-rf2-hic-071-has-taken-so-far-and-what-it-still-cannot-take).
 - **`C3` and `C4` are not addressed at all**, and not merely unresolved. They
   compare Hicasso against **the best relevant adapter**; this table compares
   four read *topologies* against each other inside one runtime. The two are

--- a/implementation/adapters/reagent/test/re_frame/bench/hicasso_narrow.cljs
+++ b/implementation/adapters/reagent/test/re_frame/bench/hicasso_narrow.cljs
@@ -655,9 +655,9 @@
 ;; ---------------------------------------------------------------------------
 
 (def summarise
-  "`{:n :min :p50 :max}` over `xs`. A RANGE, always — never a mean alone.
-  Overlapping ranges mean indistinguishable, and a report that quotes a
-  central value without its range cannot say that.
+  "`{:n :min :max :p50 :p95 :p99}` over `xs`. A RANGE, always — never a
+  mean alone. Overlapping ranges mean indistinguishable, and a report that
+  quotes a central value without its range cannot say that.
 
   `lane/summarise`, not a restatement of it. This lane and the mount lane
   are two INSTRUMENTS — a mount is one timed commit, a narrow write is

--- a/implementation/hicasso/test/re_frame/bench/hicasso/lane.cljs
+++ b/implementation/hicasso/test/re_frame/bench/hicasso/lane.cljs
@@ -28,10 +28,11 @@
   was deliberate before the move and it is why `now-ms`, `summarise` and
   `quantile` are re-derived here rather than borrowed from the donor's
   `bench.measure`: a frozen donor `src/` tree is not a dependency this
-  lane should acquire. (That sentence used to count the lines — *eleven*
-  — and `rf2-xa8wo` adding `quantile` made the count wrong while leaving
-  the point untouched, so the point is what it now states.) The move did not create that independence, it
-  merely made it visible in the path.
+  lane should acquire. The move did not create that independence, it
+  merely made it visible in the path. (That sentence used to count the
+  lines — *eleven* — and `rf2-xa8wo` adding `quantile` made the count
+  wrong while leaving the point untouched, so the point is what it now
+  states.)
 
   ## What a reading is
 

--- a/implementation/hicasso/test/re_frame/bench/hicasso/lane.cljs
+++ b/implementation/hicasso/test/re_frame/bench/hicasso/lane.cljs
@@ -25,10 +25,12 @@
   nothing else is needed.
 
   Nothing here requires anything out of `implementation/freehand/`. That
-  was deliberate before the move and it is why `now-ms`/`summarise` are
-  re-derived in eleven lines rather than borrowed from the donor's
+  was deliberate before the move and it is why `now-ms`, `summarise` and
+  `quantile` are re-derived here rather than borrowed from the donor's
   `bench.measure`: a frozen donor `src/` tree is not a dependency this
-  lane should acquire. The move did not create that independence, it
+  lane should acquire. (That sentence used to count the lines — *eleven*
+  — and `rf2-xa8wo` adding `quantile` made the count wrong while leaving
+  the point untouched, so the point is what it now states.) The move did not create that independence, it
   merely made it visible in the path.
 
   ## What a reading is
@@ -91,7 +93,7 @@
             [re-frame.frame :as frame]))
 
 ;; ---------------------------------------------------------------------------
-;; Clock and summary — eleven lines, so the lane owes the donor tree nothing
+;; Clock and summary — small enough that the lane owes the donor tree nothing
 ;; ---------------------------------------------------------------------------
 
 (defn now-ms
@@ -102,8 +104,54 @@
     (js/performance.now)
     (.getTime (js/Date.))))
 
+(defn- quantile-of-sorted
+  "[[quantile]] over a vector already ascending and known non-empty."
+  [v q]
+  (let [h  (* (dec (count v)) (double q))
+        lo (int (js/Math.floor h))
+        hi (int (js/Math.ceil h))
+        a  (nth v lo)]
+    (+ a (* (- (nth v hi) a) (- h lo)))))
+
+(defn quantile
+  "The `q`-quantile of `xs`, by LINEAR INTERPOLATION between the two order
+  statistics either side of `h = (n-1)q`. That is the definition
+  `clock_readjudicate.cjs` already spells out for its effect-size
+  interval, so the lane carries one spelling of a quantile rather than a
+  second one that would have to be checked against the first.
+
+  **It is also the definition [[summarise]]'s `:p50` is already computed
+  under**, which is the reason it is the one chosen rather than
+  nearest-rank. `h` lands exactly on the middle order statistic when `n`
+  is odd and exactly midway between the two middle ones when `n` is even,
+  so `(quantile xs 0.5)` and `:p50` are one estimator and a row printing
+  a `p50` beside a `p95` is printing one method. `:p50` keeps its own
+  two-branch spelling all the same: `(a+b)/2` and `a+(b-a)/2` can differ
+  in the last representable place, and an already-published `:p50` must
+  not move because a field was added next to it. `lane_quantile_cljs_test`
+  holds the agreement — exact on odd `n`, and within a float epsilon on
+  even.
+
+  **What a short sample does to a tail quantile, stated here because a
+  bench window's `n` is small.** Interpolation cannot answer above the
+  largest reading: at `n = 20` a `p99` is `h = 18.81`, four fifths of the
+  way from the second-largest sample to the largest, and no reading in
+  the sample ever took that value. That is true of every quantile
+  estimator on a short sample rather than of this one — nearest-rank
+  answers the maximum itself and is no more truthful about the tail — and
+  the remedy is more rounds, not another formula. Every published row
+  states its `:n` beside the figure so a reader can see how much of the
+  tail was measured and how much was interpolated."
+  [xs q]
+  (let [v (vec (sort xs))]
+    (when (pos? (count v))
+      (quantile-of-sorted v q))))
+
 (defn summarise
-  "`{:n :min :max :p50}` over `xs`."
+  "`{:n :min :max :p50 :p95 :p99}` over `xs`.
+
+  The three quantiles are [[quantile]]'s definition — read it for what a
+  `p95` or a `p99` means over a sample this short."
   [xs]
   (let [v (vec (sort xs))
         c (count v)]
@@ -113,7 +161,9 @@
        :max (peek v)
        :p50 (if (odd? c)
               (nth v (quot c 2))
-              (/ (+ (nth v (dec (quot c 2))) (nth v (quot c 2))) 2.0))})))
+              (/ (+ (nth v (dec (quot c 2))) (nth v (quot c 2))) 2.0))
+       :p95 (quantile-of-sorted v 0.95)
+       :p99 (quantile-of-sorted v 0.99)})))
 
 (defn round4 [x] (/ (js/Math.round (* (double x) 10000.0)) 10000.0))
 

--- a/implementation/hicasso/test/re_frame/bench/hicasso/lane_control_strict_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/bench/hicasso/lane_control_strict_cljs_test.cljs
@@ -140,8 +140,16 @@
       (is (= 4.5 predicted)
           "the across-round median judged leg is 2.25 ms, so the band is
            [3.375 – 5.625] in milliseconds")
-      (is (= {:n 5 :min 4.4 :max 4.6 :p50 4.5} s-ctl)
-          "and the control's whole measured range is 4.40 – 4.60 ms")
+      (is (= {:n 5 :min 4.4 :max 4.6 :p50 4.5}
+             (select-keys s-ctl [:n :min :max :p50]))
+          "and the control's whole measured range is 4.40 – 4.60 ms. Named
+           fields rather than whole-map equality: this row is about the
+           RANGE, and spelling it as `=` on the whole summary also froze
+           `lane/summarise`'s key set here, a long way from the function
+           and from any reader who would think to look. `rf2-xa8wo` adding
+           `:p95`/`:p99` reddened it for a reason this row has no opinion
+           about. The key set is frozen in `lane_quantile_cljs_test`, where
+           it belongs")
       (is (true? (:ok? aggregate))
           "the aggregate rule PASSES — not by overlap but by containment,
            which is the stronger of the two readings it could have taken")

--- a/implementation/hicasso/test/re_frame/bench/hicasso/lane_quantile_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/bench/hicasso/lane_quantile_cljs_test.cljs
@@ -180,6 +180,15 @@
       (is (= (lane/quantile xs 0.95) (:p95 s)))
       (is (= (lane/quantile xs 0.99) (:p99 s)))))
 
+  (testing "and the summary carries EXACTLY these six keys"
+    ;; Frozen here, next to the function, because it used to be frozen by
+    ;; accident: `lane_control_strict_cljs_test`'s aggregate row compared a
+    ;; whole summary map with `=` while meaning only to state a range, so
+    ;; adding a field reddened a test with no opinion about fields. A shape
+    ;; worth holding is worth holding where a reader would look for it.
+    (is (= #{:n :min :max :p50 :p95 :p99}
+           (set (keys (lane/summarise [1.0 2.0 3.0]))))))
+
   (testing "an empty sample is still `nil` rather than a map of nothings"
     (is (nil? (lane/summarise [])))
     (is (nil? (lane/summarise nil))))

--- a/implementation/hicasso/test/re_frame/bench/hicasso/lane_quantile_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/bench/hicasso/lane_quantile_cljs_test.cljs
@@ -1,0 +1,190 @@
+(ns re-frame.bench.hicasso.lane-quantile-cljs-test
+  "THE LANE'S QUANTILE ESTIMATOR, WITNESSED (rf2-xa8wo).
+
+  `budgets.md` registers `U1`–`U4` at `p95` or `p99` and `C8`'s benefit
+  disjunct at `≥ 2 ms p95`, and until this bead the lane answered
+  `{:n :min :max :p50}` and computed no tail quantile anywhere. So the
+  block on those rows was a line of source rather than a missing box, and
+  [[re-frame.bench.hicasso.lane/quantile]] is that line. This file is what
+  keeps it honest.
+
+  ## Why a DEFINITION needs a witness at all
+
+  Because a percentile is not one thing. Nearest-rank, linear
+  interpolation, and the exclusive and inclusive rank conventions all
+  answer differently, and they differ MOST at exactly the sample sizes a
+  bench window has: at `n = 20` the two spellings of `p95` here are `19`
+  and `19.05`. A row that quoted one under the other's name would be
+  wrong by less than a rounding error and unfalsifiable by inspection.
+
+  Every case below therefore follows `lane_bytes_cljs_test`'s discipline
+  — **assert the fixture DISCRIMINATES before asserting it is correct**.
+  A fixture on which the two conventions agree tests the arithmetic and
+  says nothing about the definition, and a fixture that quietly stopped
+  discriminating would fail here rather than go on passing.
+
+  ## The one consistency that matters more than the choice
+
+  `:p50` and `:p95` are printed side by side in a single row, so they had
+  better be one estimator. The lane's `:p50` was already a
+  linear-interpolated median — a single order statistic at odd `n`, the
+  mean of the two middle ones at even — which is `h = (n-1)q` at
+  `q = 0.5`, and that is why that convention was taken rather than
+  nearest-rank. The agreement is asserted below rather than asserted in a
+  docstring: exactly at odd `n`, and within a float epsilon at even,
+  where `(a+b)/2` and `a+(b-a)/2` may part company in the last place.
+
+  ## NO READING IS TAKEN HERE, and none may be
+
+  This is a test over known inputs. It runs on a loaded box, touches no
+  clock, mounts nothing, and pins no figure any budget row reads. The
+  window that will point the estimator at an application is a separate
+  quiet-box run and is not this bead's — see `budgets.md` §9.4."
+  (:require [cljs.test :refer-macros [deftest is testing]]
+            [re-frame.bench.hicasso.lane :as lane]))
+
+;; ---------------------------------------------------------------------------
+;; Helpers
+;; ---------------------------------------------------------------------------
+
+(def ^:private eps
+  "A float epsilon. Two spellings of one arithmetic may part company in
+  the last representable place and nowhere else; anything wider than this
+  is a different definition, not a rounding."
+  1e-9)
+
+(defn- close?
+  [a b]
+  (< (js/Math.abs (- (double a) (double b))) eps))
+
+(defn- nearest-rank
+  "The OTHER convention, present only so the fixtures can be shown to
+  discriminate between it and the lane's. Never called by the lane."
+  [xs q]
+  (let [v (vec (sort xs))
+        r (js/Math.ceil (* (double q) (count v)))]
+    (nth v (max 0 (min (dec (count v)) (dec (int r)))))))
+
+;; ---------------------------------------------------------------------------
+;; The definition
+;; ---------------------------------------------------------------------------
+
+(deftest quantile-is-linear-interpolation-at-h-of-n-minus-one-q
+  (testing "the fixture DISCRIMINATES — the two conventions disagree on it"
+    (let [xs (vec (range 1 21))]                            ; 1..20, n = 20
+      (is (= 20 (count xs)))
+      (is (not (close? (lane/quantile xs 0.95) (nearest-rank xs 0.95)))
+          "if these agree the case below has stopped testing the definition")))
+
+  (testing "and the answer is the interpolated one, not the nearest rank"
+    (let [xs (vec (range 1 21))]
+      ;; h = (20-1)*0.95 = 18.05 -> v[18] + (v[19] - v[18]) * 0.05
+      ;;                          = 19   + 1 * 0.05 = 19.05
+      (is (close? 19.05 (lane/quantile xs 0.95)))
+      (is (= 19 (nearest-rank xs 0.95))
+          "the convention NOT taken, stated so the difference is on the page")))
+
+  (testing "q = 0 is the minimum and q = 1 is the maximum, exactly"
+    (let [xs [7.5 2.25 9.0 4.0]]
+      (is (= 2.25 (lane/quantile xs 0)))
+      (is (= 9.0 (lane/quantile xs 1)))))
+
+  (testing "the sample need not arrive sorted"
+    (let [asc  (vec (range 1 21))
+          desc (vec (reverse asc))
+          shuf [13 2 20 7 1 19 4 11 16 6 3 18 9 14 5 12 17 8 15 10]]
+      (is (= (set asc) (set shuf)) "the shuffled fixture is the same sample")
+      (is (close? (lane/quantile asc 0.95) (lane/quantile desc 0.95)))
+      (is (close? (lane/quantile asc 0.95) (lane/quantile shuf 0.95)))))
+
+  (testing "a one-sample and an empty sample"
+    (is (= 4.0 (lane/quantile [4.0] 0.99)))
+    (is (nil? (lane/quantile [] 0.95)))
+    (is (nil? (lane/quantile nil 0.95)))))
+
+;; ---------------------------------------------------------------------------
+;; The consistency with `:p50`, which is why this convention and not another
+;; ---------------------------------------------------------------------------
+
+(deftest quantile-at-one-half-is-summarise-s-p50
+  (testing "EXACTLY, on an odd count — both are one member of the sample"
+    (doseq [xs [[3.0 1.0 2.0]
+                [5.0 1.0 4.0 2.0 3.0]
+                (vec (range 1 22))]]
+      (let [p50 (:p50 (lane/summarise xs))]
+        (is (= p50 (lane/quantile xs 0.5))
+            (str "p50 and quantile 0.5 must be one estimator on " (count xs) " samples"))
+        (is (some #(= % p50) xs)
+            "an odd count answers a member of its own sample"))))
+
+  (testing "and within a float epsilon on an even count, where the two
+            spellings of the midpoint may differ in the last place"
+    (doseq [xs [[1.0 2.0 3.0 4.0]
+                [0.1 0.3]
+                [2.4 2.5 2.6 2.7 2.8 2.9]
+                (vec (range 1 21))]]
+      (is (close? (:p50 (lane/summarise xs)) (lane/quantile xs 0.5))
+          (str "p50 and quantile 0.5 must agree on " (count xs) " samples"))))
+
+  (testing "`:p50`'s own spelling is UNCHANGED by this bead — the two-branch
+            median still answers what it always did"
+    ;; The values below are the pre-`rf2-xa8wo` behaviour, transcribed. A
+    ;; refactor that routed `:p50` through `quantile` would move a published
+    ;; figure by up to one ulp, and this is the assertion that would catch it.
+    (is (= 2.0 (:p50 (lane/summarise [1.0 2.0 3.0]))))
+    (is (= 2.5 (:p50 (lane/summarise [1.0 2.0 3.0 4.0]))))
+    (is (= (/ (+ 0.1 0.3) 2.0) (:p50 (lane/summarise [0.1 0.3]))))))
+
+;; ---------------------------------------------------------------------------
+;; What a SHORT sample does to a tail quantile — the docstring's own caveat,
+;; pinned, because it is the property a reader of a published row needs
+;; ---------------------------------------------------------------------------
+
+(deftest a-tail-quantile-on-a-short-sample-is-mostly-interpolation
+  (testing "at n = 20 a p99 sits between the top two readings and is no
+            reading the sample ever took"
+    (let [xs  (vec (range 1 21))
+          p99 (lane/quantile xs 0.99)]
+      ;; h = 19*0.99 = 18.81 -> 19 + (20-19)*0.81 = 19.81
+      (is (close? 19.81 p99))
+      (is (< 19 p99 20) "strictly between the second-largest and the largest")
+      (is (not (some #(close? % p99) xs))
+          "no member of the sample took this value — this is the caveat")))
+
+  (testing "a quantile never exceeds the maximum, however short the sample"
+    (doseq [n [1 2 3 5 20 101]]
+      (let [xs (vec (range 1 (inc n)))
+            s  (lane/summarise xs)]
+        (is (<= (:p50 s) (:p95 s) (:p99 s) (:max s))
+            (str "quantiles must be monotone and bounded by :max at n = " n))
+        (is (>= (:p95 s) (:min s)))))))
+
+;; ---------------------------------------------------------------------------
+;; `summarise`'s contract — the shape existing callers destructure, plus the
+;; two fields this bead adds
+;; ---------------------------------------------------------------------------
+
+(deftest summarise-carries-the-tail-quantiles-and-keeps-everything-else
+  (testing "the four fields every existing caller destructures are unmoved"
+    (let [xs (vec (range 1 21))
+          s  (lane/summarise xs)]
+      (is (= 20 (:n s)))
+      (is (= 1 (:min s)))
+      (is (= 20 (:max s)))
+      (is (= 10.5 (:p50 s)))))
+
+  (testing "and `:p95` / `:p99` are [[lane/quantile]] and not a second spelling"
+    (let [xs [4.2 1.9 3.3 8.8 2.7 5.1 6.4 7.0 9.6 0.5
+              3.9 2.1 6.9 5.5 1.2 8.1 4.7 7.7 0.9 9.1]
+          s  (lane/summarise xs)]
+      (is (= (lane/quantile xs 0.95) (:p95 s)))
+      (is (= (lane/quantile xs 0.99) (:p99 s)))))
+
+  (testing "an empty sample is still `nil` rather than a map of nothings"
+    (is (nil? (lane/summarise [])))
+    (is (nil? (lane/summarise nil))))
+
+  (testing "a one-sample answers that sample at every quantile"
+    (let [s (lane/summarise [3.75])]
+      (is (= 1 (:n s)))
+      (is (= 3.75 (:min s) (:max s) (:p50 s) (:p95 s) (:p99 s))))))


### PR DESCRIPTION
Closes part of `rf2-xa8wo`. **The bead stays open** — see *What this does not do*.

`budgets.md` registers every one of `U1`–`U4` at `p95` or `p99` (`U2` is *50 ms p95 / 100 ms p99*) and `C8`'s benefit disjunct at `≥ 2 ms p95`, while `lane/summarise` answered `{:n :min :max :p50}` and no `p95` or `p99` was computed anywhere on the lane. The block on those rows was therefore a **line of source**, not a missing box. This adds the line.

**No reading is taken here.** No benchmark was run, no browser launched, no figure published, no `budgets.md` row, cell or ledger count moved. `check_budget_ledger.py` still reads **49 rows: 31 MET, 5 BREACH, 3 UNRESOLVED, 10 UNPINNED**, and `U1`–`U4` stay `UNPINNED`.

## The estimator, and why this definition

`lane/quantile` is linear interpolation between the order statistics either side of `h = (n-1)q`.

Two reasons, and the second outranks the first:

1. `clock_readjudicate.cjs` already spells that definition out for its effect-size interval, so the lane now carries **one** spelling of a quantile rather than a second that would have to be checked against the first.
2. **It is the definition `summarise`'s `:p50` was already computed under.** `h` lands exactly on the middle order statistic at odd `n` and exactly midway between the two middle ones at even `n` — which is what the existing two-branch median does. `:p50` and `:p95` are printed side by side in one row, so consistency with the sibling statistic mattered more than which convention is theoretically nicer. Nearest-rank would have made the two halves of a row disagree about method; at `n = 20` the two spellings of `p95` here are `19` and `19.05`.

`:p50` **keeps its own two-branch spelling.** Routing it through `quantile` would be tidier and is wrong: `(a+b)/2` and `a+(b-a)/2` can differ in the last representable place, and an already-published `:p50` must not move because a field was added beside it. The agreement between the two is asserted rather than claimed — exact at odd `n`, within `1e-9` at even.

The docstring states the small-`n` caveat, because a bench window's `n` is small: at `n = 20` a `p99` is `h = 18.81`, four fifths of the way from the second-largest reading to the largest, a value no sample ever took. That is true of every quantile estimator on a short sample rather than of this one, and the remedy is rounds, not another formula.

## What this does NOT do — the population, which is the half that governs

**`U1`–`U4` are stated over a slice application's own interactions.** Read at source, not inferred from the row titles: §4's estimand column gives *latency to visible echo*, *latency to next paint*, *operation latency* and *per-frame latency*; §9.3 names them *Slice-app user-visible gates at 50 ms p95 / 100 ms p99 and one-frame keystroke echo*.

**The statistic added here is over a different population.** Every window the lane can currently drive is a commit bracketed by `react-dom/flushSync` on a synthetic bench page — the lane's own *What a reading is* says so. That is a **mount, not a paint**. So:

> **This PR does not unblock `rf2-85og2`'s gate 1.** A `p95` computed over the lane's present windows would be a `p95` of a mount published against a line written about a paint, which is worse than no `p95` at all because it is quotable.

**What still remains**, and it is the bead's own deliverable 2, left undone deliberately rather than overlooked: *a driver whose window is one discrete interaction through to the paint that follows it, on a witness application under `implementation/hicasso/test/re_frame/hicasso/examples/`* — the slice app is the one `U1`–`U4` are stated over. Two things established for whoever takes it: such a driver **needs no hot-zone edit** (`run.cjs` takes `HICASSO_INIT_FN` and rides the existing `:hicasso-bench` build id, which is `rf2-fe0l`'s precedent), and the real risk in it is that the slice app has never been compiled under `:advanced` — `:hicasso-release` uses `consumer-app` rather than an examples tree for exactly that reason.

## Scope

Additive. `summarise` gains `:p95` and `:p99`; the four fields it always answered are unchanged in name and in value. **There are 36 pre-existing `lane/summarise` call sites across 18 files**, plus 2 uses inside `lane.cljs` itself and one aliasing `def` in the Reagent adapter's narrow lane (used once there). Every one either destructures named fields or reads `:p50`, and all still work — the whole `:node-test` suite is green.

One of them turned out to compare the whole summary map with `=`: `lane_control_strict_cljs_test`'s aggregate row, which meant only to state *the control's whole measured range is 4.40 – 4.60 ms* and incidentally froze `summarise`'s key set a long way from the function. It now names its four fields, and the key set is frozen in `lane_quantile_cljs_test` next to what it describes. **This gate caught that; a grep did not.**

## Prose kept true

Three sites asserted the lane computes no tail quantile and would otherwise now be false:

- **`budgets.md` §9.4** — a dated bracketed note, permitted by the fence as *recording that the instrument exists*. It moves no row, cell, ledger count or verdict, and it states plainly that the population gap is untouched and gate 1 stays blocked.
- **`topology-tournament.md` §2.9.9** — *never a `p95` at all*. **Outside the fence I was given, and flagged as such**: it is a present-tense claim about the file this PR changes, and leaving it would have been drift I created. One added bracketed sentence; every cell stays `UNASSESSED`, nothing on the page moves.
- **`hicasso_narrow.cljs`** — an alias docstring restating the shape of the function it aliases.

The lane's ns docstring said `now-ms`/`summarise` were re-derived *in eleven lines*; adding `quantile` made the count wrong, so the sentence now states the point instead of counting.

## Quality gates

Every number below is the exit code **this branch captured itself** (`ec=$?` written to its own `.exit` file, one shell, no pipeline), not one reported about the run.

| gate | command | captured exit |
|---|---|---|
| `:node-test` compile | `node scripts/compile-node-test.cjs node-test out/node-test.js` | **0** |
| `:node-test` run | `node out/node-test.js` | **0** — `Ran 11763 tests containing 59699 assertions. 0 failures, 0 errors.` |
| hicasso bench `:advanced` compile | `node …/compile_gate.cjs` | **0** — 150 namespaces, zero warnings |
| hicasso invariants (incl. `check_budget_ledger.py`) | `npm run test:hicasso-invariants` | **0** — `49 ledger rows -- 31 MET, 5 BREACH, 3 UNRESOLVED, 10 UNPINNED` |
| doc slugs / anchors | `python scripts/check_doc_slugs.py` | **0** |
| provenance pins | `python scripts/check_provenance_pins.py` (+ `--self-test`) | **0 / 0** — 120 pages, 645 pins, 0 findings |

All re-run **after** the rebase onto `origin/main`; each shadow-cljs run printed `config: …\p95lane-xa8wo\implementation\shadow-cljs.edn`, i.e. this branch's tree.

**Discrimination — the suite was proved able to fail.** `lane_quantile_cljs_test`'s `p95` expectation was changed on one line from the interpolated `19.05` to the nearest-rank `19.0`, recompiled and re-run: **captured exit 1**, `FAIL in (quantile-is-linear-interpolation-at-h-of-n-minus-one-q) (…/lane_quantile_cljs_test.cljs:83:11)`. Test and assertion counts were **identical to the control run** — 11763 / 59699, exactly one failure — so the plant stopped no namespace. The plant was restored and the restore verified by `git hash-object` against the pre-plant blob, not by reading a diff.

The same was done for the docs gate: a deliberately broken anchor made `check_doc_slugs.py` exit **1** naming the file and line; restored and hash-verified; clean re-run exit **0**. Both checkers were therefore shown to see these files rather than skip them.

**Fast-PR spine: not run** (`scripts/test-fast-pr.sh` measures past this harness's ceiling). The gates above were run directly instead. `python scripts/check_fast_pr_gap.py --list` derives the 96 required CI checks the spine does not decide; the surface-relevant one it names for this diff is `test.yml`'s *Hicasso release build (`:advanced`, `goog.DEBUG` false)* step, which CI runs.

**Manual verification of the docs edits**, since nothing validates `docs/design/**` tables or rendering (`mkdocs.yml`'s `exclude_docs` keeps the design trees out of the site): no table was added or edited on either page, so no column count changed; the three anchors cited (`#93-…`, `#94-…`, `topology-tournament.md#299-…`) are validated by `check_doc_slugs.py` above, and two of the three were already in use elsewhere in the corpus.
