### PR TITLE
docs(ci): retire the jvm-freehand comment, and dispose of check_workflow_yaml.py's CI home (rf2-0yp7w.9.5, rf2-ni5sg)

### DIFF
--- a/.github/scripts/report-changed-surfaces.sh
+++ b/.github/scripts/report-changed-surfaces.sh
@@ -1214,19 +1214,21 @@ else
         ;;
       implementation/spec-resource/*)
         # day8/re-frame2-spec-resource is the ONE build-time reader for
-        # committed spec/ data — the Freehand conformance fixture loader
-        # and the api-manifest CLJS probe both expand through it, so a
-        # change here can break either macro's compile.
+        # committed spec/ data — the api-manifest CLJS probe expands
+        # through it, so a change here can break that macro's compile.
         #
         # implementation_jvm fires this artefact's own `:test` alias, which
         # is the deterministic control for the cold-load race the reader
-        # exists to close (jvm-spec-resource), plus jvm-freehand, whose
-        # `:test` alias carries the fixture loader. cljs_node_test fires
+        # exists to close (jvm-spec-resource). cljs_node_test fires
         # the consolidated `:node-test` build, where the reader is actually
         # exercised — that is the lane whose macro expansion reaches
-        # shadow-cljs's recording read, in parallel, from both consumers at
-        # once. cljs_browser for the same reason the freehand case gives:
-        # the `-dom-cljs-test$` suites inline fixtures too.
+        # shadow-cljs's recording read. cljs_browser stays on, but its
+        # stated reason has expired: it was the Freehand fixture suites,
+        # and they left with the rf2-0yp7w retirement together with the
+        # second consumer and the `jvm-freehand` lane this comment used to
+        # name. Narrowing the arm is a routing change, not a prose one —
+        # `implementation/scripts/_changed-surfaces.test.cjs` pins this
+        # arm's outputs and would have to move in the same commit.
         #
         # No production bundle requires any of this (build-time only), so
         # cljs_prod / bundle_isolation stay off.

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1041,6 +1041,19 @@ jobs:
       # is likewise unconditional, so the ratchet gates every PR from here at
       # no extra setup cost, and the invariant job stays dependency-free.
       #
+      # ITS PARSE ARM IS LOAD-BEARING BEYOND ITS OWN CHARTER (rf2-ni5sg), so do
+      # not narrow it. The checker `yaml.safe_load`s every file under
+      # `.github/workflows/` and RETURNS 2 on a YAMLError rather than skipping,
+      # which makes these two steps also the only place in CI that asserts a
+      # workflow even PARSES. `scripts/check_workflow_yaml.py` makes that claim
+      # properly — a line number, and every broken file rather than the first —
+      # but is scheduled from `scripts/test-fast-pr.sh` only, and a second CI
+      # parse of the same files asserting a subset of the same claim would buy
+      # nothing but a second thing to keep in step. The four workflow-reading
+      # checkers in the always-on invariant job above cannot stand in: they are
+      # hand-rolled line readers and, measured with an unmatched quote planted
+      # on line 1 of this file, ALL FOUR still exit 0.
+      #
       # Self-test first — it drives the checker RED on five shapes including a
       # step-only cap and an uncapped job sitting second behind a capped one
       # (the "stopped looking after the first hit" defect) — then the live sweep.

--- a/scripts/check_workflow_yaml.py
+++ b/scripts/check_workflow_yaml.py
@@ -22,6 +22,29 @@ band and the merge criterion refuses it.  What this buys is the round trip: a
 local error naming the file and the line, instead of a push, a CI wait, and a
 confusing partial rollup.
 
+WHY IT HAS NO CI HOME, AND WHY THAT IS NOT A HOLE (rf2-ni5sg).  This script is
+scheduled only from `scripts/test-fast-pr.sh`, the local pre-checkin spine,
+which is skippable by construction — normally the "gate that runs nowhere"
+shape.  It is not one here, because the CLAIM has a scheduled home even though
+the SCRIPT does not.  `scripts/check_workflow_job_timeouts.py` walks the same
+`.github/workflows/*.{yml,yaml}` set through the same `yaml.safe_load`, and its
+parse-error arm RETURNS 2 rather than skipping — deliberately, so an unparseable
+file cannot pass vacuously there.  It runs unconditionally on every PR from
+`test.yml`'s `verify-readme-links`, which is in `all-required-passed`'s
+`needs:`.  Verified in CI rather than locally, on main run 32105342995, where
+that step reported success: PyYAML imported on the runner (or it would have
+exited 3) and every workflow file parsed.  So CI already refuses a malformed
+workflow, and a second CI parse of the same files, asserting a strict subset of
+the same claim, would buy nothing but a second thing to keep in step.  What is
+left here is the round trip above — a line number, and every broken file rather
+than the first — which is why this stays a spine lane instead of being deleted.
+
+That arm is therefore LOAD-BEARING BEYOND ITS OWN CHARTER: narrowing it to a
+skip would silently remove the only CI-side assertion that the workflows parse,
+and would reopen rf2-ni5sg without touching this file.  `test.yml`'s comment on
+those two steps says so at the wiring, which is where somebody about to narrow
+it would be reading.
+
 Usage (from anywhere — the root is derived from this file's location, or given):
     python scripts/check_workflow_yaml.py [--repo-root DIR] [--verbose]
     python scripts/check_workflow_yaml.py --self-test [--verbose]


### PR DESCRIPTION
Two beads, two commits, both prose-only. No job, step, `needs:`, condition or classifier-output change anywhere in the diff.

## rf2-0yp7w.9.5 item 2 — the stale `jvm-freehand` comment

`.github/scripts/report-changed-surfaces.sh`'s `implementation/spec-resource/*` arm justified its outputs in donor vocabulary. Verified at HEAD before editing: `git ls-files implementation/ui implementation/freehand` returns **0** (control: `implementation/adapters` returns 156), and the file has **no `implementation/freehand/*` case arm** at all. Three claims in that one comment block were therefore false:

- the `jvm-freehand` job, named as a lane `implementation_jvm` fires — the site the bead names;
- the Freehand conformance fixture loader, named as one of **two** consumers of the reader. There is one today, the api-manifest CLJS probe (`implementation/scripts/api-manifest/probe/.../cljs_publics.clj:40` is the only `:require`);
- `cljs_browser`'s justification, a cross-reference to the deleted case arm.

`cljs_browser` **stays `true`**. Narrowing it now that its stated consumer is gone is a routing change whose mirror is `implementation/scripts/_changed-surfaces.test.cjs`, outside this PR's fence — so the comment records the expired reason instead of acting on it.

**Item 1 of that bead is untouched, deliberately.** `scripts/check-ai-tracking-ratchet.sh:7-8` cites a milestone that cannot arrive and a bead id that does not resolve; the honest replacement is a statement of when the remaining tracked `ai/` trees go, which is an operator decision nobody has made. The bead does not close on this PR.

## rf2-ni5sg — a reasoned refusal, not a wiring

The bead's fact re-derived at HEAD with a fixed-string search: `scripts/check_workflow_yaml.py` appears in `scripts/test-fast-pr.sh` and in **no** workflow. Positive control — the same search for `check_workflow_job_timeouts` — finds it in `.github/workflows/test.yml` at two `run:` values. The fact holds. The conclusion does not.

**The claim already has a scheduled CI home even though the script does not.** `scripts/check_workflow_job_timeouts.py` (merged this morning, #8477) walks the same `.github/workflows/*.{yml,yaml}` set through the same `yaml.safe_load` and **returns 2** on a `YAMLError` rather than skipping — deliberately, "so an unparseable file cannot pass vacuously here". It runs unconditionally from `verify-readme-links` (no `if:` on the job), which is in `all-required-passed`'s `needs:`. So CI already refuses a malformed workflow, and a second CI parse of the same files asserting a strict subset of the same claim would buy nothing but a second thing to keep in step.

**Merging the two is refused, and not by me.** Their charters are different claims — "is the file YAML?" versus "does every job carry a job-level cap" — and `check_workflow_job_timeouts.py`'s docstring already records the reasoning for keeping them apart.

So this commit adds no checker and no CI step. It records the disposition in the two places a reader would look: a "WHY IT HAS NO CI HOME" section in `check_workflow_yaml.py` so the next audit does not refile the bead, and a note at the `test.yml` wiring marking the timeouts checker's parse arm **load-bearing beyond its own charter** — narrowing it to a skip would silently delete the only CI-side assertion that the workflows parse.

**Should `check_gate_scheduling.py` have caught this?** No, and that is itself a finding. Its roster is `implementation/package.json`'s `test:*` / `bench:*` / `build:*` npm scripts, not `scripts/check_*.py`, so a Python checker with no workflow home is outside its domain. `check_fast_pr_gap.py` covers only the other direction (required CI checks the spine does not run) — its `--list` flags `check_workflow_job_timeouts` as having "no local lane", never the reverse. Nothing holds `scripts/check_*.py` in step with a CI home.

## Quality gates

**The fast-PR spine was NOT run** — roughly 25 minutes against a 10-minute harness ceiling. The targeted gates below were run directly instead, foreground, each redirected to its own log with the runner's exit code echoed on the same command line. Every number quoted is the one captured in this checkout.

**Local verification here is a parse plus this repo's own checkers; the behaviour of a workflow change is verified by this PR's CI run.** No local proxy was invented for it.

| gate | exit |
| --- | --- |
| `bash -n .github/scripts/report-changed-surfaces.sh` | 0 |
| `node implementation/scripts/_changed-surfaces.test.cjs` | 0 (292 passed) |
| `node implementation/scripts/_lint-workflow-policy.test.cjs` | 0 (4 passed) |
| `node implementation/scripts/_docs-workflow-policy.test.cjs` | 0 (5 passed) |
| `check_workflow_yaml.py --self-test --verbose` | 0 |
| `check_workflow_yaml.py --repo-root .` | 0 (11 files) |
| `check_workflow_job_timeouts.py --self-test --verbose` | 0 |
| `check_workflow_job_timeouts.py --repo-root .` | 0 (117 jobs, 11 files) |
| `check_gate_scheduling.py --self-test` / live | 0 / 0 |
| `check_ci_reproduce_commands.py --self-test` / `--check` | 0 / 0 |
| `check_jvm_lane_rosters.py --self-test` / live | 0 / 0 |
| `check_fast_pr_gap.py --self-test` / `--check` | 0 / 0 |

Gates were re-run on the final rebased base (`origin/main` = `858452ce35`).

### Planted faults — the discrimination, not the green

A checker that passes with empty output makes exit 0 no evidence, so each claim was driven red.

1. **The classifier gate reads this tree.** `cljs_node_test=true` changed to `false` on the `implementation/spec-resource/*` arm, one line: `_changed-surfaces.test.cjs` gave **exit 1, 4 failed**. Restored and verified with `git hash-object` (`e7d920b0...`, byte-identical); re-run gave exit 0, 292 passed.
2. **The load-bearing arm, executed rather than read.** An unmatched quote planted on line 1 of an isolated `--repo-root` copy of `test.yml`: `check_workflow_yaml.py` gave **exit 1** naming file and line; `check_workflow_job_timeouts.py` gave **exit 2**, "is not well-formed YAML (ParserError). Run check_workflow_yaml.py." Control on the same unmodified copy: both exit 0. This is the proof the whole rf2-ni5sg verdict rests on.
3. **The "all four exit 0" claim, measured here rather than repeated.** The same unmatched quote planted on line 1 of this checkout's real `test.yml`: `check_gate_scheduling.py`, `check_fast_pr_gap.py --check`, `check_jvm_lane_rosters.py` and `check_ci_reproduce_commands.py --check` all exited **0** while PyYAML refused the file. Restored and verified by `git hash-object` (`a6502ec684...`, byte-identical to the committed blob); `git status` clean.

### CI-side evidence, not a local green

`verify-readme-links` on main run **32105342995** (the #8477 merge) reports step 19, "Verify every workflow job carries a job-level timeout-minutes", as **success** — so PyYAML imported on the runner (or the step would have exited 3, which is exactly how #8477's first placement failed) and every workflow file parsed there. That job installs `pip install -r requirements.txt`; PyYAML is not listed in `requirements.txt` in its own right and arrives transitively through `mkdocs==1.6.1`. No `pip install` was added to `verify-skill-mcp-drift`, whose stdlib-only property stays intact.

### Revert check

`git diff origin/main...HEAD` (three-dot) reviewed for what it would revert. The `test.yml` hunk is **purely additive** — 13 inserted comment lines, zero deletions — so it cannot undo #8469's 89 `timeout-minutes` additions or #8477's two-step relocation, both landed today. The only deletions in the whole diff are the eight comment lines in `report-changed-surfaces.sh` that this PR intentionally replaces.
