### PR TITLE
docs(ci,spec-006): the job-cap ratchet's host job, and spec/006's removed test flush (rf2-yclap, rf2-p7p4f)

### DIFF
--- a/scripts/check_workflow_job_timeouts.py
+++ b/scripts/check_workflow_job_timeouts.py
@@ -45,8 +45,13 @@ validating the Actions grammar.  (2) It is wired only into
 job at all.  A ratchet living there would not run in CI, which is the one place
 it has to run to ratchet anything — the "gate that runs nowhere" shape that
 this repo's own `check_gate_scheduling.py` exists to catch.  So this is a
-sibling of that script, wired into test.yml's `Repo invariant checks` job
-alongside the rest of the family.
+sibling of that script, wired into test.yml's `verify-readme-links` job, which
+installs `requirements.txt` and therefore has PyYAML.  It is NOT in the
+always-on `Repo invariant checks` job (`verify-skill-mcp-drift`) alongside the
+rest of the family: that job installs no pip packages, and both of this
+checker's steps exited 3 there on their first run — the exit-3 contract below
+turning a misplacement into one visible failure rather than a silent green.
+test.yml's own comment on the two steps records the move at length.
 
 EXEMPTION: REUSABLE-WORKFLOW CALLS.  A job whose body is a job-level `uses:`
 calls a reusable workflow, and GitHub REJECTS `timeout-minutes` on it outright

--- a/spec/006-ReactiveSubstrate.md
+++ b/spec/006-ReactiveSubstrate.md
@@ -1879,18 +1879,27 @@ mark of the window, cannot run until the synchronous stack unwinds, so it fires 
 before a torn frame can show (rf2-vxgfnd.40). That microtask is the window's **guaranteed**
 closer, and outside a synchronous host flush it is still the only one that ever runs;
 [§The second closer](#the-second-closer--a-synchronous-host-commit-must-be-able-to-close-the-window)
-below covers the one that runs inside one. The headless (JVM/SSR) host has no async
-render loop and drains through the explicit test flush. On CLJS, the substrate's
-test flush returns a Promise; its optional thunk runs inside direct React 19
-`act`, then framework drains and React commits alternate until both are quiescent. On
-the JVM the zero-arity flush is synchronous and returns nil. It is the sole public test
-flush, and the substrate publishes no production twin of it. A call while an event drain is still open
-throws `:rf.error/flush-in-open-epoch` synchronously before Promise construction,
-notifications, or host work, carrying the active `:frame` and `:frame-epoch` (per
-[009 §Error event catalogue](009-Instrumentation.md#error-event-catalogue)). That guard
-rejects a misuse of the **explicit** flush; it is not the automatic scheduling boundary,
-which consults no drain state at all. The
-adapter's distinct production/tooling `flush-render!` contract is unchanged.
+below covers the one that runs inside one. The third closer in the enumeration above — the
+explicit headless/test flush — is a caller's door, and the doors that exist are narrow
+ones. The headless (plain-atom / SSR) adapters have no live host commit and so ship no
+flush at all: `render-to-string` is their only render path
+([§`flush-render!`](#flush-render-f--nil)). The three React adapters ship `flush-views!`,
+a dev/test-scoped boundary around direct React 19 `act` that returns nil, and whose
+production counterpart is `flush-render!`.
+
+A substrate that publishes a synchronous **registry-flush** — one that drains its OWN cell
+registry, and can therefore publish a render phase — MUST reject the call while a frame's
+run-to-completion event drain is still open, by calling the shared
+`re-frame.frame/guard-open-drain!` in core. It throws `:rf.error/flush-in-open-epoch`
+synchronously, before the caller touches its registry, carrying the active `:frame` and
+`:frame-epoch`. The requirement is a **standing** one: no in-repo substrate publishes such
+a flush today — its callers went with the donor view substrates removed by rf2-0yp7w — and
+the law stayed in core because it is core's rather than theirs. It rejects a misuse of an
+**explicit** flush; it is not the automatic scheduling boundary, which consults no drain
+state at all, and the adapter's distinct production/tooling `flush-render!` contract is
+unchanged (RULED, rf2-cydkp).
+[009 §Error event catalogue](009-Instrumentation.md#error-event-catalogue) carries the
+category and the reasoning.
 
 #### The second closer — a synchronous host commit must be able to close the window
 


### PR DESCRIPTION
Two beads, disjoint surfaces, one PR. Both prose-only; no behaviour change and no code change.

Fixes **rf2-yclap**, fixes **rf2-p7p4f**.

## rf2-yclap — the job-cap ratchet's docstring named the wrong host job

`scripts/check_workflow_job_timeouts.py` closed its "WHY IT IS NOT FOLDED INTO `check_workflow_yaml.py`" section by saying the ratchet is *"wired into test.yml's `Repo invariant checks` job alongside the rest of the family"*. It is not.

`Repo invariant checks (skills, MCP, catalogues, namespaces)` is the display **name** of the `verify-skill-mcp-drift` job (`.github/workflows/test.yml:186-187`), which installs no pip packages. The ratchet's two steps live in `verify-readme-links` (`test.yml:833`, steps at `:1060-1064` on this base), which installs `requirements.txt` and therefore has PyYAML. test.yml's own comment on those steps records the move and its cause: both steps exited 3 — "NOT CHECKED ... This is NOT a pass" — on the first run from the dependency-free job.

Corroborated by two further independent sources. `scripts/check_fast_pr_gap.py --list` files both `check_workflow_job_timeouts` invocations under the job "Verify markdown link slugs — READMEs + the docs/spec/skills/migration corpus", and records that neither has a local lane in the fast-PR spine. And `a99923d165` (#8482, merged onto this base while this branch was open) states it directly in its own commit body: the timeouts checker "runs unconditionally from `verify-readme-links`". The same commit re-confirms the sentence immediately preceding the fixed one — `check_workflow_yaml.py` is still scheduled from `scripts/test-fast-pr.sh` alone and still has no CI home — so this edit and that one agree rather than overlap.

Only the docstring still pointed at the job the gate was moved out of, and it misdirects exactly the reader most likely to be reading it: somebody deciding where a new PyYAML-dependent checker belongs.

## rf2-p7p4f — spec/006's "explicit test flush" was `re-frame.ui.test/flush!`, removed

The bead asked whether to keep or delete `re-frame.frame/guard-open-drain!`, which has zero call sites. The answer is **keep**, and that was already ruled and already written down; what was actually broken is a paragraph in spec/006 describing a function that no longer exists.

### What the "sole public test flush" is

`spec/006-ReactiveSubstrate.md` §Render-batch finalization described the third window closer in the present tense: *"the substrate's test flush returns a Promise; its optional thunk runs inside direct React 19 `act`, then framework drains and React commits alternate until both are quiescent. On the JVM the zero-arity flush is synchronous and returns nil. It is the sole public test flush, and the substrate publishes no production twin of it."*

Nothing in this tree is that. Every living flush door was enumerated and read:

| surface | shape | is it the described flush? |
|---|---|---|
| `re-frame.adapter.{reagent,reagent-slim,uix}/flush-views!` (the contract's test door, via the spine resolver) | CLJS-only `act()` wrapper, returns **nil**, no Promise, no convergence loop, no JVM arm | no |
| `re-frame.substrate.spine/flush-render!` / `substrate.adapter/flush-render!` | production render-commit via `flushSync` | no — and expressly outside the guard's law (rf2-cydkp) |
| `reagent2.dom.client/flush-views!` (reagent-slim's internal, one layer below its contract slot) | `goog.DEBUG`-gated, **Promise**-returning, `act`-composing 3-phase drain | closest living relative — see the open question below |
| `re-frame.hicasso.test.mounted/settle!` (and `settle-until!`, `dispatch-and-settle!`) | `re-frame.hicasso.impl.mount/settle!` = `(react-dom/flushSync (fn [] nil))`, synchronous, returns the handle | no |
| headless plain-atom / SSR adapters | ship no flush at all; `render-to-string` is the only render path | no |

The described surface is `re-frame.ui.test/flush!`, removed with the donor view substrates by rf2-0yp7w / PR #8322. The removed source settles it: at `ef3131f4a2^`, `implementation/ui/src/re_frame/ui/test.cljc:545-604` defined a private wrapper delegating `(frame/guard-open-drain! 'rf.ui.test/flush!)` and called it from all four `flush!` / `flush-presence!` arities; the fn's own docstring opens *"The sole public compiled-view test flush"* and its body is guard → `act!` → `reactive/flush-pending!`, looping on `reactive/pending-cell-count` until zero — a **registry** flush. `docs/EP/EP-0032:163-166` and `docs/EP/EP-0034:187-193` both name `ui.test/flush!` in the same words spec/006 uses.

### Why it survived the donor sweep, and why the file contradicts itself

R6a swept spec/006 for donor references, but this paragraph names no donor symbol — it says only "the substrate's test flush" — so a grep for `re-frame.ui` or `ui.test/*` could not see it. Left standing, it contradicts §`flush-render!` in the same file (`:274-285`), which records that the three React adapters ship `flush-views!` as their dev/test-scoped `act()` boundary, that `flush-render!` is exactly the production twin the stale paragraph says does not exist, and that the headless adapters ship no flush at all.

### The remedy, and what it deliberately does not touch

The description goes; the **law** stays, restated as the standing requirement spec/009's `:rf.error/flush-in-open-epoch` row already rules (rf2-cydkp, PR #8475): a substrate publishing a synchronous *registry-flush* must call `re-frame.frame/guard-open-drain!`. The guard is retained normative surface rather than residue, and the reasons are already written into both the fn's docstring and the 009 catalogue row — **neither is touched here**, so the 009 table and its column count are untouched, and `implementation/` carries no change at all.

### One question this deliberately does not answer

`reagent2.dom.client/flush-views!` — reagent-slim's internal, Promise-returning, `act`-composing test drain, sitting one layer below the adapter's own `flush-views!` slot — is the closest living relative of the removed `ui.test/flush!`, and it drains `reagent2.impl.batching/flush!` (rea-queue + dirty set) inside `act`. **Whether that counts as the "registry-flush" the guard's law names is not settled.** rf2-cydkp ruled on the `flush-render!` slot and did not reach `flush-views!`.

The reading this PR's wording is consistent with — and does not assert — is that it does not: the discriminator cydkp set is whether the flush drains *the substrate's own* cell registry, and Reagent's component render queue is the host's, not the substrate's. Wiring a throw into three shipped adapters' test doors would also be a behaviour change on shipping surface, not a prose repair.

So the paragraph as rewritten states the law positively and says nothing about `flush-views!`'s membership in it. If that membership should be ruled, it is a separate bead and the operator's call.

## Quality gates

Targeted gates only, run directly and to completion in the foreground; `scripts/test-fast-pr.sh` was **not** run (it exceeds the time ceiling, and a bench-class worker held the box). Exit codes below are the ones captured by the runner itself, not reported by the harness.

| gate | covers | captured exit |
|---|---|---|
| `python scripts/check_workflow_job_timeouts.py --self-test --verbose` | rf2-yclap's file; 4 accept + 5 reject cases | **0** |
| `python scripts/check_workflow_job_timeouts.py --verbose` | live sweep, 117 jobs across 11 workflow files | **0** |
| `python scripts/check_doc_slugs.py --self-test` | the spec-corpus link/anchor gate's own fixtures | **0** |
| `python scripts/check_doc_slugs.py` | `spec/` link targets + heading anchors (rf2-p7p4f's file and its new intra-file anchor) | **0** (re-run after the final wording: **0**) |
| `python scripts/check_doc_slugs.py` — **sabotage control** | one-line planted broken anchor in the edited paragraph | **1**, naming `spec/006-ReactiveSubstrate.md:1886` |
| `python scripts/check_doc_slugs.py` — after restore | re-run on restored bytes | **0** |
| `python scripts/check_skill_re_frame2_drift.py` | its anchored block in spec/006 (untouched by this diff) | **0** |

**Rebased onto `3785d3ac63` after #8482 merged, and every gate above re-run on that final base** — `check_workflow_job_timeouts --self-test` **0**, live sweep **0** (117 jobs, 11 files), `check_doc_slugs.py` **0**. That rebase matters for this PR specifically: #8482 changed `.github/workflows/test.yml`, which is the very file the job-cap sweep reads.

The sabotage run is the discrimination that the doc-slug gate reads *this* checkout and *this* hunk: it went red at exit 1 naming the exact edited line. The restore was verified by hashing the bytes — `git hash-object` on the restored file matched the pre-sabotage copy exactly — rather than by reading a diff.

No local run is evidence about the CI runner's environment. Both PyYAML-dependent steps run in `verify-readme-links`, which installs `requirements.txt`, so the exit-3 "NOT CHECKED" arm that redded #8477 does not apply here; `verify-readme-links` also runs `check_doc_slugs.py` unconditionally on every PR (rf2-v7fui).

`mkdocs build --strict` is not nominated: it sees `spec/` only after docs.yml's copy step stages it into `docs/spec/`, and `check_doc_slugs.py` is the gate that owns `spec/` link and anchor validation on every PR.
