### PR TITLE
docs(src): stop source comments teaching the removed donor substrates as live (rf2-0yp7w.9)

### DIFF
--- a/implementation/adapters/uix/src/re_frame/adapter/uix.cljs
+++ b/implementation/adapters/uix/src/re_frame/adapter/uix.cljs
@@ -2,10 +2,11 @@
   "UIx 2.x adapter for the substrate contract in Spec 006.
 
   A first-class, actively-supported adapter: UIx is a permanent sibling of
-  Freehand and the Reagent adapters, not a transition path off any of them.
+  the Reagent and reagent-slim adapters, not a transition path off any of
+  them.
 
-  The React machinery lives in `re-frame.substrate.spine`, shared with
-  Freehand's observation adapter and any future React-wrapper adapter.
+  The React machinery lives in `re-frame.substrate.spine`, shared with any
+  future React-wrapper adapter.
   This namespace supplies UIx's hooks and native `defui` `frame-provider`
   (SCOPE) + `frame-root` (ENSURE) components; keeping them native preserves
   UIx's CLJS prop and trailing-child marshalling."

--- a/implementation/hicasso/src/re_frame/hicasso/impl/slot.cljc
+++ b/implementation/hicasso/src/re_frame/hicasso/impl/slot.cljc
@@ -34,7 +34,7 @@
   rule B2) requires such a file to be selected by a CLJS lane as well as
   the JVM one. So the same corpus of authored keys, with the same
   expected slots, is asserted by `npm run test:cljs` AND by
-  `clojure -M:test` in `implementation/freehand`. One table, one
+  `clojure -M:test` in `implementation/hicasso`. One table, one
   implementation, two runtimes — and a divergence has nowhere left to
   hide, because there is no second implementation to hold a second
   answer.

--- a/implementation/hicasso/src/re_frame/hicasso/impl/slot.cljc
+++ b/implementation/hicasso/src/re_frame/hicasso/impl/slot.cljc
@@ -34,7 +34,7 @@
   rule B2) requires such a file to be selected by a CLJS lane as well as
   the JVM one. So the same corpus of authored keys, with the same
   expected slots, is asserted by `npm run test:cljs` AND by
-  `clojure -M:test` in `implementation/hicasso`. One table, one
+  `clojure -M:test` in `implementation/freehand`. One table, one
   implementation, two runtimes — and a divergence has nowhere left to
   hide, because there is no second implementation to hold a second
   answer.

--- a/tools/story/src/re_frame/story/play/presence.cljc
+++ b/tools/story/src/re_frame/story/play/presence.cljc
@@ -4,9 +4,9 @@
 
   ## Why a rung exists
 
-  A variant whose view renders a `(v/presence {:timeout-ms n} …)` boundary
-  RETAINS a removed keyed child in `:unmounting` until the `:timeout-ms`
-  safety bound fires. Playback then has a settlement problem the
+  A variant whose view renders a PRESENCE boundary (Spec 004 §Presence)
+  RETAINS a removed keyed child in `:unmounting` until the boundary's
+  `:timeout-ms` safety bound fires. Playback then has a settlement problem the
   `settled-boundary` ladder cannot solve: the retention is a CLOCK, not a
   queue. Draining the router to a fixed point (`:headless`), flushing
   reactions (`:cljs-reactive`) or awaiting a React commit (`:dom`) all leave

--- a/tools/story/src/re_frame/story/play/runner.cljc
+++ b/tools/story/src/re_frame/story/play/runner.cljc
@@ -57,7 +57,7 @@
 
   `[:flush-presence]` / `[:flush-presence ms]` advances the framework's
   PRESENCE clock (Spec 004 §Presence) so a variant whose view renders a
-  `(v/presence {:timeout-ms n} …)` boundary settles its retained
+  presence boundary with a `:timeout-ms` safety bound settles its retained
   (`:unmounting`) children DETERMINISTICALLY — the fake-clock twin of
   `[:wait ms]`, and the reason a presence-bearing variant does not need the
   determinism opt-out. It routes through

--- a/tools/xray/src/day8/re_frame2_xray/settings/effects.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/settings/effects.cljs
@@ -641,10 +641,9 @@
         ;;
         ;; `interop/activate-derived-value!` is the substrate's own "put
         ;; this derived value on your push path" op: a no-op on hosts that
-        ;; are push-based from birth (the React-hook spine — UIx, Helix)
-        ;; and on plain-atom, and idempotent on an
-        ;; already-capturing reaction. It runs FIRST so the seed below
-        ;; reads a settled node.
+        ;; are push-based from birth (the React-hook spine — UIx, Helix) and
+        ;; on plain-atom, and idempotent on an already-capturing reaction. It
+        ;; runs FIRST so the seed below reads a settled node.
         (interop/activate-derived-value! reaction)
         ;; Seed the baseline from the reaction's CURRENT value before
         ;; `add-watch` — the reaction may hold issues that predate this

--- a/tools/xray/src/day8/re_frame2_xray/settings/effects.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/settings/effects.cljs
@@ -641,8 +641,8 @@
         ;;
         ;; `interop/activate-derived-value!` is the substrate's own "put
         ;; this derived value on your push path" op: a no-op on hosts that
-        ;; are push-based from birth (the React-hook spine — UIx, Helix,
-        ;; re-frame.ui, Freehand) and on plain-atom, and idempotent on an
+        ;; are push-based from birth (the React-hook spine — UIx, Helix)
+        ;; and on plain-atom, and idempotent on an
         ;; already-capturing reaction. It runs FIRST so the seed below
         ;; reads a settled node.
         (interop/activate-derived-value! reaction)

--- a/tools/xray/src/day8/re_frame2_xray/test_support.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/test_support.cljs
@@ -80,12 +80,12 @@
   There is NO mounted-view evidence release here, and nothing is missing where
   one used to be (rf2-7gth0). The predecessor tier had a single-owner registry
   Xray claimed at `init!`, leaving an owner, a sink, retained entries and a
-  globalThis sentinel behind for the next test to inherit.
-  `re-frame.freehand.tool` is a reader: Xray installs nothing into it and so
-  has nothing to release. A suite that MOUNTS Freehand occurrences clears the
-  substrate's own current-occurrence index in its own fixture — the door for
-  that is `re-frame.freehand.occurrences/clear!`, which belongs to Freehand and
-  not to Xray's reset tier.
+  globalThis sentinel behind for the next test to inherit. The tier that
+  replaced it, `re-frame.freehand.tool`, was a pure READER: Xray installed
+  nothing into it and so had nothing to release. Both retired with the
+  substrates they read (rf2-0yp7w), and the rule they settled still holds — a
+  substrate's own per-mount occurrence index is cleared by that substrate's
+  own fixture, never by Xray's reset tier.
 
   Call at the START of a fixture, BEFORE registering frames — clearing
   the rings wipes the per-frame recording config, so a mid-setup call


### PR DESCRIPTION
R6 slice of **rf2-0yp7w.9**: comments and docstrings under `implementation/*/src/**` and
`tools/*/src/**` that still taught the removed `re-frame.freehand` / `re-frame.ui`
substrates as live.

Behaviour is unchanged — this touches comments and docstrings only. No live code, no
keyword, no namespace alias, no var.

## The discrimination applied

Prose that TEACHES a removed surface as live comes out; HISTORICAL naming of a deleted
artefact stays. Where a sentence's key was live and only its illustration was dead, the
illustration was repaired rather than the sentence deleted. Nothing was re-aimed at
Hicasso (rf2-0yp7w.11).

Of 16 in-fence files carrying a donor hit, **5 were repaired and 11 were left with a
stated reason**. The refusals are the larger half of this change, because on this surface
most donor mentions are correct as they stand.

## Repaired (5 files, 6 sites)

| File | What it said | Why it came out |
|---|---|---|
| `implementation/adapters/uix/src/re_frame/adapter/uix.cljs` | UIx is "a permanent sibling of **Freehand** and the Reagent adapters", and the React spine is "shared with **Freehand's observation adapter**" | The front docstring of a first-class, actively-supported adapter naming a removed substrate as a live permanent sibling. Its own contract sibling, `implementation/core/src/re_frame/substrate/adapter.cljc`, already reads correctly ("THREE first-class... Reagent, reagent-slim and UIx"), so this was drift against it. |
| `tools/story/src/re_frame/story/play/presence.cljc` | "a view renders a `(v/presence {:timeout-ms n} …)` boundary" | Freehand's `v/` alias taught as the live spelling for a presence boundary — and the same docstring says 30 lines lower that "Freehand is retired (rf2-0yp7w)". Re-stated against Spec 004 §Presence, which the ns docstring already cites. |
| `tools/story/src/re_frame/story/play/runner.cljc` | the same `(v/presence …)` spelling | Same. |
| `tools/xray/src/day8/re_frame2_xray/settings/effects.cljs` | hosts push-based from birth are "UIx, Helix, **re-frame.ui, Freehand**" | A live-key / dead-illustration roster: the claim about `activate-derived-value!` is live, two of its four examples are removed substrates. |
| `tools/xray/src/day8/re_frame2_xray/test_support.cljs` | "the door for that is `re-frame.freehand.occurrences/clear!`" | A present-tense instruction to a test author naming a door no build can call. The live rule it carries — a substrate's own per-mount index is cleared by that substrate's fixture, never by Xray's reset tier — is kept; the dead instruction is gone. |

## The one repair that was made and then REVERTED

`implementation/hicasso/src/re_frame/hicasso/impl/slot.cljc:37` says the cross-host
corpus is asserted by `clojure -M:test` in **`implementation/freehand`** — a directory
PR #8322 deleted. I repaired it to `implementation/hicasso` (which is factually right:
the suite is `.../bench/hicasso/front/slot_cljs_test.cljc` and hicasso's `:test` alias
runs it), **CI went red on the hicasso freeze gate, and I reverted it.**

`front/slot.cljc` is the **last remaining row** in
`implementation/hicasso/frozen-sources.edn` after three recorded retirements. Each of the
manifest's three documented responses was tested against the evidence rather than picked:

1. **Port from the bench tree and re-pin.** Does not apply — I read the donor, and
   `implementation/hicasso/test/re_frame/bench/hicasso/front/slot.cljc` says
   `implementation/freehand` at the same line. Package and donor agreed until my edit.
2. **Back-port into the donor.** Refused by the tree's own rules, in two places: the
   bench tree is a *measured* artefact, and "editing a donor to carry a facility invented
   afterwards would invalidate the readings the package's own budgets are set against, to
   buy a digest."
3. **Retire the row.** This is the manifest's response for a package-side fix and it
   would work — but the sunset clause reads *"when `front/slot.cljc` diverges for its own
   reasons, the manifest and the gate go together."* Retiring it also drops **SEALED**,
   the package-wide scan barring any file under `implementation/hicasso/` from importing
   the bench tree, which the manifest itself calls the one of its three checks "that was
   always package-wide".

Fixing one stale directory name in an internal docstring therefore costs either a
falsified measurement artefact or the retirement of a gate that still guards shipped-
package independence. That is not a comment sweep's decision to take, so the line stays
as **historical naming** — this slice's own rule, and true on its own terms: the suite
really did run there when the readings were taken. Restore verified by content hash
against the committed object, not by reading a diff.

Filed as **rf2-o9yo4 (P3)** with the full option set, so the manifest decision gets an
owner instead of riding in on a prose sweep.

## Left standing, with reasons (the other refusals)

* **`tools/xray/src/day8/re_frame2_xray/mount.cljs` — untouched entirely, 8 hits.** The
  bead's explicit carve-out (and rf2-wtznc) keeps the `react-element-render-kinds` set on
  a deliberate defensive footing. Every Freehand mention in that file *is* the
  justification for the `:rf.adapter/freehand` member, and the set's own docstring
  already states the retirement. Editing the surrounding prose while the member stays
  would orphan its rationale — strictly worse than leaving it.
* **`implementation/core/src/re_frame/substrate/adapter.cljc`** — the retired
  `:rf.adapter/*` members are a Conventions **tombstone** row ("stay reserved and are
  never recycled... nothing here can produce one"). Correct as it stands.
* **`implementation/ssr/src/re_frame/ssr/ui_tree.cljc`** — **already fixed** before this
  slice: "were once a deliberate verbatim COPY... **That substrate has been retired
  (rf2-0yp7w), so these tables are now the ORIGINALS and the pin is gone.**"
* **`implementation/hicasso/src/re_frame/hicasso/forms.cljs`** — cites
  `docs/design/freehand/decisions/D016-…md` as the buffered/revision LAW. That tree is
  **KEPT** (rf2-0moc4), and I confirmed the target file exists, so the citation resolves.
* **`tools/xray/.../registry.cljs` (22 hits), `preload.cljs`,
  `tools/re-frame2-pair-mcp/.../hicasso_tool.cljs`, `tools/story/.../late_bind.cljc`** —
  all historical: a registration-schema changelog, a "both are gone with the substrates
  they read" note, and two records explaining *why* a surface is absent.
* **`implementation/hicasso/src/.../impl/route_link.cljs` and `impl/intent.cljs`** — a
  structured design-provenance ledger ("What is taken from whom, and what is declined")
  attributing rows to routing, Freehand and Replicant. Deleting the Freehand rows would
  destroy the rationale for live design decisions — the same class as
  `docs/design/hicasso/` citing Freehand as the substrate it replaced, which the bead
  rules LEAVE.
* **`implementation/hicasso/test_kit/src/re_frame/hicasso/test.cljs`** — an attributed
  audit record (rf2-hic-020) explaining why the namespace reuses 004B v1 rather than
  minting a schema, with the donor named as the comparand the audit used.
* **The `compiled-view` paraphrase class in `implementation/core/src` (7 sites),
  `adapters/reagent-slim/src/reagent2/ratom.cljs`, `ssr/src/install.cljc`** — checked
  against the spec rather than assumed. **Spec 006 §The internal observation port is live
  and normative**, and `spec/Conventions.md:1730` (§internal seam) names the port's
  consumer as the `day8/re-frame2-hicasso` view runtime. So "a compiled-view substrate
  uses this port" names a live architectural category with a live named member, not a
  donor-only one, and `views.cljs:591` is a past-tense bead record. Sweeping the phrase
  would have rewritten working prose — and re-spelling it onto Hicasso is what
  rf2-0yp7w.11 forbids.

## Census method

Re-derived at this branch's merge base, not carried from the bead. The six-spelling
pattern recorded on rf2-0yp7w.9:

```
git grep -ciIP 'freehand|re-frame\.ui(?!x)|re-frame2-ui(?!x)|implementation/(ui|freehand)/|004D'
```

* negative control `README.md` = **0** (and `grep -c -F re-frame2-uix README.md` = 1,
  accounting for its entire former score under the unanchored pattern)
* positive control `docs/design/retirement/freehand-and-ui.md` = **93** — the corrected
  value asserted on the bead, reproduced exactly.

Two method notes worth carrying forward:

1. **`-i` is load-bearing, not optional.** Dropping it silently hid the two
   `adapters/uix` hits, `intent.cljs`, all four `route_link.cljs` hits and every bare
   `Freehand` in prose — the pattern returned a plausible, wrong, smaller list.
2. **A directory pathspec of the form `tools/*/src` returns ZERO** on this setup while
   `tools/*/src/*` returns the real hits. That zero is a false empty, not a clean tree.
   Caught by running the positive control on the same pathspec.

Per the bead's slice-4 finding, the paraphrase class was swept **by reading**, not only
by grep: `compiled-view`, `compiled mode` / `interpreted mode`, and the bare `v/` alias.
That is what found the two Story `(v/presence …)` sites, which score **zero** under all
six spellings.

**Re-run on the final tree**, so the change set is verified rather than asserted:
`adapter/uix.cljs` drops off the list entirely, `test_support.cljs` goes 3 → 1 and
`settings/effects.cljs` 1 → 0; every file left deliberately holds its previous count
exactly, and the positive control still reads **93**.

## Stopped on — outside this fence, not missed

* **`implementation/adapters/reagent/README.md:5`** still says in the present tense that
  `re-frame.ui` "is a *new, experimental* compiled-view substrate offered alongside it".
  The highest-visibility donor residue left in the tree — the front page of a first-class
  supported adapter — handed on from slice 4. Not under any `src/`, so outside this
  slice's write surface. **Needs an owner.**
* `implementation/scripts/api-manifest/src/.../doc_api_check.clj` (2 hits) and
  `.../probe/src/.../cljs_probe.cljc` (1) — under `implementation/scripts/**`, which this
  fence excludes and a peer holds.
* `implementation/hicasso/deps.edn:12` names
  `implementation/freehand/test/re_frame/bench/hicasso/{front,arm1}/` — build config, not
  `src/`.
* `tools/xray/.../registry.cljs:315-318` carries the donor name inside a **live
  diagnostic string**, not a comment. Correct as written and out of scope for a comment
  sweep either way.
* **Adjacent, not donor:** `:rf.adapter/helix` survives in the `effects.cljs` roster this
  PR edited. Helix was removed at S7/W13 (rf2-d6epb) — a different retirement — so it was
  deliberately left rather than swept in under this bead's fence.
* **A spec/code drift found while checking a "leave".** `spec/Conventions.md:1730` states
  the one "internal seam" is `re-frame.substrate.observation`, whose "named consumer is
  the `day8/re-frame2-hicasso` view runtime (`.../impl/collector.cljs`)", consumed **"by
  direct `:require`"**. That file carries no such require — its ns form requires
  `re-frame.subs` and `re-frame.interop`, and every `substrate.observation` mention in it
  is prose. Tree-wide, the port's only real requirers are **test** namespaces (positive
  control: `[re-frame.substrate.spine` finds the three adapter requires, so the grep
  discriminates). Live code plus hot-zone spec, not donor prose — **filed as rf2-63t1i
  (P2), and already fixed on main** by `1911198a42` ("the observation port's named
  consumer does not require it, so stop asserting a live edge") while this PR was in
  flight.

## Base

Gates were run on `a601953e52`. `origin/main` has since moved two commits ahead
(`467528f1bf`) — a beads checkpoint and the rf2-63t1i spec fix above. **Neither touches
any file in this diff**, and this branch's base is an ancestor of current main, so the
merge is a clean fast-forward and the green above still describes the merge result. I did
not re-rebase-and-re-gate for two commits that cannot interact with these five files.

## Quality gates

**Every number below is the exit code I captured from the redirect, on the same command
line as the runner** — not one the harness reported. On the first spine run those two
disagreed: the harness reported the background job as "exit code 0" while the number I
captured was **1**. The captured number was right.

| Gate | Captured exit | Result |
|---|---|---|
| `scripts/test-fast-pr.sh --plan` | **0** | tiers: JVM + node/CLJS + kondo; docs skipped |
| `scripts/test-fast-pr.sh` (attempt 1) | **1** | RED — `CLJS node integration`, `Cannot find module 'shadow-cljs/cli/runner.js'`. Environmental: the worktree had no `implementation/node_modules`. Everything else green. |
| `npm run test:cljs` (attempt 2, after junctioning `node_modules`) | **0** | **11756 tests / 59627 assertions, 0 failures, 0 errors** |
| `npm run test:hicasso-invariants` (the actual failing CI step) | **0** | `OK: 1 frozen row(s) match the bench tree, and each package file is its donor moved; no package file imports it` |
| **`scripts/test-fast-pr.sh` (attempt 4, final base, after revert + rebase)** | **0** | **FULLY GREEN — 0 `FAIL` lines in 4034 log lines** |
| `python scripts/check_fast_pr_gap.py --list` | **0** | 96 required checks the spine does not decide |

**Attempt 4 is the one that counts** — it ran on the final rebased base, and with
`node_modules` present it exercised the CLJS lane attempt 1 could not reach:

* clj-kondo (pinned, CI's own command) — **errors: 0**
* JVM `implementation/core` — **2243 tests / 11681 assertions, 0 failures, 0 errors**
* JVM `implementation/adapters/uix` — 0 tests (no JVM suite), 0 failures
* CLJS node integration — **11756 tests / 59627 assertions, 0 failures, 0 errors**
* per-ns test isolation, **hicasso invariants gate**, hicasso lint-export gate, hicasso
  bench-lane compile, JS harness helpers, bundle-isolation — all ran, none failed

`implementation/hicasso` no longer appears in the JVM tier for attempt 4, correctly: the
revert removed it from the diff, and the spine selects artefact suites by changed surface.
The hicasso invariants gate — the step CI went red on — still ran, inside the node tier,
and passed.

**Tree verification** used the root-banner route, which this gate affords and prints on
its own first line: `gate root: …/donorsrc-0yp7w9` — this worktree, not a sibling and not
the primary checkout. Each run's log was checked for exactly one `gate root:` line and
for NUL bytes (`tr -d '\0' | cmp`), to rule out an orphan from a killed attempt splicing
into the artefacts; every log was clean. Artefacts are named per worktree **and per
attempt**.

**Gate coverage of the `tools/` half, stated honestly.** The spine's own plan says *"No
browser, bundle, adapter, Xray, MCP or tool-JVM gate is in any tier"*, so the three
`tools/` files here get no JVM/node suite locally — CI's tool-JVM and Xray jobs own them.
They are not unchecked, though: the spine's pinned clj-kondo pass lints `tools/xray`,
`tools/story` and `tools/re-frame2-pair-mcp` explicitly and reported `errors: 0`, which is
the check that would catch the realistic failure mode for a docstring edit — an
unbalanced delimiter. I did not measure the warning count against `origin/main`, so I make
no claim about it.

`scripts/check_retired_spellings.py` runs in the spine and passes, but it is **not**
evidence about this change: it scopes to four specific retired shapes (the `:frame`
coeffect read, SSR redirect `:url`/`:to`, route `:query-retain`, and hicasso
`front.*`/`arm1.*` bench coordinates). No donor-substrate spelling is among them.
