### PR TITLE
docs(hicasso): the ladder's eleven pins are superseded, and four of them are no longer the arm (rf2-6x3by)

### DIFF
--- a/docs/design/hicasso/product/budgets.md
+++ b/docs/design/hicasso/product/budgets.md
@@ -1895,6 +1895,39 @@ nothing. The re-pin is still a run rather than an edit, and it is now a run
 whose candidate arm has to be re-registered at a path that exists before it can
 be taken at all.
 
+**[Registration half landed 2026-08-18, `rf2-6x3by`. `C1` stays `UNPINNED`, and
+no reading was taken.]** The ladder's §6 provenance now records, beside the pins
+rather than over them, that none of the eleven resolves, where the four
+surviving candidate-arm blobs live today, and why the fifth cannot be re-pinned
+at any path: `rf2-dabt3` **retired `front.sub-index`** on 2026-08-04 and the
+ladder prices that landing on its own rung, so the absence is a design change
+this corpus measured rather than collateral of the re-home. That last point
+sharpens the paragraph above, which had the fact right and the reason unstated.
+
+**One finding changes what the re-pin run has to do, and it makes the
+supersession wider rather than narrower.** The four survivors are no longer the
+candidate arm at all. The pinned `p0_hicasso.cljs` required
+`re-frame.bench.hicasso.arm1.runtime`; the blob at the tip requires
+`re-frame.hicasso`, because `rf2-fe0l` repointed the candidate seam at the
+package — the same repoint §6's *package-resident* paragraph above already
+credits with discharging the other half. So re-pinning the four at their
+re-homed path would register **the wrong files**: the frozen prototype the
+package was moved away from, whose divergence from the product §6 calls expected
+and permanent. The arm is now `re-frame.hicasso` under
+`implementation/hicasso/src/`, and the ladder records its whole-tree object so a
+run has one identity that exists to name.
+
+So the sentence above is discharged in exactly one respect — the candidate arm
+is registered at a path that exists, and a re-pin run can be attempted at all —
+and in no other. The pins are still superseded rather than repaired and still
+never can match; *"the same instrument"* still names nothing. It follows that
+the run, when it comes, sets a **new** anchor rather than restoring comparability
+with the published rows: run 3 priced the prototype and today's instrument
+prices the package, so a reading taken now differs by the arm as well as by the
+drift. `C1` remains blocked on that quiet-box run, which is not this bead's. No
+threshold was guessed, no band widened, no figure restated and no ledger count
+moved.
+
 **`C8`: the population is verifiably empty, not merely unreported.** Across the
 witness applications under
 `implementation/hicasso/test/re_frame/hicasso/examples/`, shipping view code

--- a/docs/design/hicasso/studio/reads-per-boundary-heap-ladder.md
+++ b/docs/design/hicasso/studio/reads-per-boundary-heap-ladder.md
@@ -1050,6 +1050,81 @@ two-macro file — did not. Runs 1 and 2 were taken against
 pre-rebase readings in [the three runs](#the-three-runs-and-the-arm-the-last-one-was-taken-against)
 remain checkable rather than merely asserted.
 
+**Not one of these eleven pins resolves at the 2026-08-18 tree, and they are
+superseded rather than repairable (`rf2-6x3by`).** The tables above stay exactly
+as written, because they are what run 3 was taken on and editing them would
+falsify the run rather than repair it. What follows is where each pin has gone,
+hashed with `git hash-object` at `7902167197` rather than assumed, so that a
+reader who tries to resolve one is told why it will not resolve instead of being
+left to find out. **No row above moves, and nothing here restates a figure.**
+
+The six instrument blobs have all moved *in place* — the paths are still the
+paths, so this half is ordinary drift:
+
+| file | pinned blob | at 2026-08-18 |
+|---|---|---|
+| `p0_run.cjs` | `4718aaea…` | `9c993e96…` |
+| `p0_heap.cljs` | `34c9210d…` | `2d922d31…` |
+| `p0_hicasso.cljs` | `f2440e30…` | `7a91564f…` |
+| `p0_reagent.cljs` | `b1f5ec92…` | `419e166a…` |
+| `p0_uix.cljs` | `deec8976…` | `f1aaf9cb…` |
+| `p0_fixture.cljc` | `867ad583…` | `de27135c…` |
+
+The candidate arm's five are not drift, and the pinned path no longer exists.
+The benchmark harness was re-homed into `implementation/hicasso/` on 2026-08-14
+by `e61e175341`; `implementation/freehand` was then deleted whole on 2026-08-15
+by `c951808b47` (`rf2-0yp7w.6`). **The re-home is what moved these files — the
+deletion only removed what was left behind**, which is worth stating because the
+two are easy to conflate and only the first bears on the pins. Four of the five
+are therefore findable, under
+`implementation/hicasso/test/re_frame/bench/hicasso/`, and every one of them
+differs from its pin there:
+
+| candidate-arm file | pinned blob | at the re-homed path, 2026-08-18 |
+|---|---|---|
+| `arm1/runtime.cljs` | `69bfc6fc…` | `202f7612…` |
+| `arm1/mount.cljs` | `4653e168…` | `780b2962…` |
+| `arm1/lang.clj` | `0151ddaf…` | `95f057e8…` |
+| `front/codec.cljs` | `5eb17dbd…` | `ea859037…` |
+| `front/sub_index.cljs` | `394927d6…` | **retired; no such file** |
+
+`front/sub_index.cljs` is the one that cannot be re-pinned at any path, and this
+page already prices the reason. `rf2-dabt3` **retired `front.sub-index`** on
+2026-08-04, moving the reverse edge onto each key cell's own reader list, and
+[the fusion section below](#the-sub-index-fusion-priced-on-the-ladder-rf2-zei9w)
+is that landing measured on this very ladder. The file was deleted by
+`383ba2d645`, eleven days before the re-home — so its absence is a design change
+this corpus measured and published, not collateral of either tree move.
+
+`arm1/lang.clj` earns a line for the opposite reason. The paragraph above
+records it as the one file that did **not** move across runs 1–3, which is what
+made it the stable member of the set; it has moved since, so that no longer
+holds either.
+
+**The deeper supersession is that these five are no longer the candidate arm at
+all**, and this is why the re-pin is a re-registration rather than a re-hash.
+The pinned `p0_hicasso.cljs` (`f2440e30`) required
+`re-frame.bench.hicasso.arm1.runtime` and `…arm1.lang`; the blob at the tip
+(`7a91564f`) requires `re-frame.hicasso` — the shipped package — because
+`rf2-fe0l` repointed the candidate seam there, and that file's own docstring now
+records the arm as *"the shipped package, not a model of it"*. So re-pinning the
+four survivors at their re-homed path would register **the wrong files**: a
+frozen prototype the package was deliberately moved away from, whose divergence
+from the product that same docstring calls expected and permanent. The candidate
+arm as it stands is `re-frame.hicasso` under `implementation/hicasso/src/`, 27
+files, whose whole-tree object at `7902167197` is
+`d8700409dee4ecaa1f207f11839327bb3a001d65` — one identity for the arm, recorded
+here so the re-pin run has something that exists to name.
+
+**What this does not do.** It does not restore comparability with the rows
+above, and no edit can: run 3 priced the prototype, today's instrument prices
+the package, and a reading taken now would differ by the arm as well as by the
+drift. A re-pin run therefore establishes a **new** anchor rather than repairing
+this one, which is what *superseded rather than repaired* has meant on this page
+throughout. That run is a quiet-box window and is deliberately not taken here,
+so `C1`'s 5% same-instrument regression gate stays `UNPINNED` in
+[`budgets.md`](../product/budgets.md) until it is.
+
 Reproduce:
 
 ```


### PR DESCRIPTION
Closes rf2-6x3by. Documentation only: two files, **108 insertions and 0 deletions**.

## What the tree said, against what the brief claimed

The dispatch brief said the five candidate-arm blobs were UNREACHABLE because their tree
"was removed whole on 2026-08-16 (rf2-0yp7w, PR #8322)". **That premise does not hold**, and
the bead already knew: a self-audit comment on rf2-6x3by (2026-08-18 05:23Z) corrects it, and
the bead's *description* was never amended to match — its text is byte-identical across all 36
history commits, so the brief was carrying the superseded half. Verified independently here
rather than taken from either:

* The harness was **re-homed** into `implementation/hicasso/` on 2026-08-14 by `e61e175341`
  (the last commit to touch the pinned path), and `implementation/freehand` was deleted on
  2026-08-15 by `c951808b47`. The re-home moved the files; the deletion removed what was left.
  PR #8322 is not the commit that moved them.
* **Four of the five survive** at `implementation/hicasso/test/re_frame/bench/hicasso/`, each
  with different content. Only `front/sub_index.cljs` is gone — deleted 2026-08-03 by
  `383ba2d645`, because `rf2-dabt3` retired `front.sub-index`, a landing **this same page
  prices on its own rung**. So the absence is a measured design change, not collateral.
* All eleven pins were hashed at the tip with `git rev-parse HEAD:<path>` and `git hash-object`
  (they agree, so no CRLF divergence). Eleven of eleven fail to resolve.

## The finding that governs

The bead asked whether the live arm is already correct and only the *registration* is stale.
It is — and more strongly than filed. The pinned `p0_hicasso.cljs` (`f2440e30`) required
`re-frame.bench.hicasso.arm1.runtime` and `…arm1.lang`; the tip blob (`7a91564f`) requires
`re-frame.hicasso`, because `rf2-fe0l` repointed the candidate seam at the shipped package.
**The four survivors are therefore no longer the candidate arm at all**, and re-pinning them at
their re-homed path would register the wrong files — the frozen prototype the package was moved
away from. The arm is recorded at the path and whole-tree object that exist today.

## What was refused

`C1` stays `UNPINNED`. No measurement window was taken, no benchmark run, no figure restated,
no threshold guessed and no band widened. Run 3's provenance tables are left **byte-for-byte
intact** — they identify the tree that run was taken on, and editing them would falsify the run
rather than repair it; the supersession is recorded *beside* them, which is this corpus's own
beside-amendment convention. budgets.md §9.4's original C1 bullet is likewise left standing as
a dated record and amended beside, for the same reason.

Most of budgets.md §9.4 was **already repaired** by rf2-85og2's merged self-audit; this PR adds
only what that pass could not know — the seam repoint, and `sub_index.cljs`'s actual fate.

## Quality gates

Exit codes below are the ones **I captured** (`echo $?` redirected on the same command line),
never a harness-reported number.

| gate | result | captured exit |
|---|---|---|
| `python scripts/check_provenance_pins.py --changed-since origin/main` | 2 pages inspected, 81 cited pins, **0 findings** | **0** |
| `python scripts/check_doc_slugs.py` | pass, silent | **0** |
| `python scripts/check_fast_pr_gap.py --list` | cited: 96 required checks the spine does not decide | 0 |

**Both gates were proven to read this worktree by planted faults**, since neither prints a root:

* Broken anchor planted at a line I added → `check_doc_slugs.py` **red, exit 1**, naming
  `…-rf2-NOSUCHANCHOR` at line 1094.
* Lone stranded commit pin planted in my own added block → `check_provenance_pins.py` **red,
  exit 1**, naming it at line 1119 and reporting `commit word 'commit' nearest on the left`.

Both faults existed only in this worktree, so a run that had wandered elsewhere would have come
back green. Both restores were **verified by hashing against the committed object**
(`29fc4afb…` before plant and after restore, matching `git rev-parse HEAD:<path>`), not by
reading a diff. One multi-line plant anchor matched 0 occurrences and was caught by its
assertion with the hash unchanged — re-done as a single-line anchor.

`scripts/test-fast-pr.sh` **was not run**: this diff is prose-only under `docs/design/hicasso/`,
and the two gates that decide it were run directly and in the foreground.

**`mkdocs build --strict` does not cover this diff.** I read `exclude_docs` in `mkdocs.yml`
myself; it excludes six trees, `design/hicasso/` among them.

**Table column counts verified by hand.** Nothing validates them, so every one of the 15 table
lines I added (2 headers, 2 separators, 11 rows) was counted: **all exactly 3 columns**,
matching the tables they sit beside.

Diffed against the **merge base** (`origin/main...HEAD`, three dots) before pushing: 108
insertions, **0 deletions**, so nothing a sibling landed can be reverted by this change.
