### PR TITLE
docs(implementation): spec-resource has ONE consumer, not two (rf2-7b1ti)

### DIFF
--- a/implementation/README.md
+++ b/implementation/README.md
@@ -201,13 +201,13 @@ implementation/
     src/re_frame/test_quiet*       Silent-on-success reporter + runner entry points.
 
   spec-resource/             day8/re-frame2-spec-resource — the ONE build-time reader for
-                             committed `spec/` data. Macros that inline a spec-side file at
-                             macro-expansion time (the Freehand conformance fixtures, the
-                             api-manifest sidecar) read through it, so the file participates
-                             in the compiling namespace's shadow-cljs cache key instead of
-                             being frozen into it invisibly. Shared rather than copied
-                             because resolving shadow's recording reader is a cold-load
-                             race that two independent resolvers lose to each other.
+                             committed `spec/` data. The macro that inlines a spec-side file
+                             at macro-expansion time (the api-manifest sidecar) reads through
+                             it, so the file participates in the compiling namespace's
+                             shadow-cljs cache key instead of being frozen into it invisibly.
+                             Shared rather than copied because resolving shadow's recording
+                             reader is a cold-load race that two independent resolvers lose
+                             to each other.
     deps.edn                 No runtime deps, and none on shadow-cljs; build/test-time only.
     src/re_frame/build/spec_resource.clj  Recording read + walk-up fallback + the
                              require-before-resolve that makes the reader cold-load-safe.

--- a/implementation/scripts/_changed-surfaces.test.cjs
+++ b/implementation/scripts/_changed-surfaces.test.cjs
@@ -3385,8 +3385,8 @@ for (const file of TEST_QUIET_FILES) {
 }
 
 // implementation/spec-resource is the ONE build-time reader for committed
-// spec/ data: the Freehand conformance fixture loader and the api-manifest
-// CLJS probe both expand through it. Its own suite is the deterministic
+// spec/ data, and the api-manifest CLJS probe is the ONE consumer that
+// expands through it. Its own suite is the deterministic
 // control for a cold-load race that has shipped twice behind fully green
 // lanes — which is exactly why the routing has to be pinned. If the
 // classifier leaves every output false, the one job in CI that goes red
@@ -3405,12 +3405,12 @@ for (const file of [
     assert.equal(
       result.implementation_jvm,
       'true',
-      'the reader change must run its own race control (jvm-spec-resource) and the fixture loader lane (jvm-freehand)',
+      'the reader change must run its own race control (jvm-spec-resource)',
     );
     assert.equal(
       result.cljs_node_test,
       'true',
-      'the consolidated :node-test build is where both consumers macro-expand through this reader',
+      'the consolidated :node-test build is where the api-manifest probe macro-expands through this reader',
     );
   });
 }

--- a/implementation/scripts/_changed-surfaces.test.cjs
+++ b/implementation/scripts/_changed-surfaces.test.cjs
@@ -3386,11 +3386,11 @@ for (const file of TEST_QUIET_FILES) {
 
 // implementation/spec-resource is the ONE build-time reader for committed
 // spec/ data, and the api-manifest CLJS probe is the ONE consumer that
-// expands through it. Its own suite is the deterministic
-// control for a cold-load race that has shipped twice behind fully green
-// lanes — which is exactly why the routing has to be pinned. If the
-// classifier leaves every output false, the one job in CI that goes red
-// when the racy shape returns simply SKIPS, and the aggregator passes.
+// expands through it. Its own suite is the deterministic control for a
+// cold-load race that has shipped twice behind fully green lanes — which
+// is exactly why the routing has to be pinned. If the classifier leaves
+// every output false, the one job in CI that goes red when the racy shape
+// returns simply SKIPS, and the aggregator passes.
 
 for (const file of [
   'implementation/spec-resource/src/re_frame/build/spec_resource.clj',

--- a/implementation/shadow-cljs.edn
+++ b/implementation/shadow-cljs.edn
@@ -180,7 +180,7 @@
                 ;; resolvable. Data only: no sources, nothing compilable,
                 ;; and no production build requires any of it.
                 ;;
-                ;; Two consumers today, both macros that inline a
+                ;; One consumer today, a macro that inlines a
                 ;; committed file at macro-expansion time — which by
                 ;; itself hides that file from the build, because a
                 ;; ClojureScript compile that caches the namespace has no
@@ -190,8 +190,8 @@
                 ;; checking. Reading through `shadow.resource/slurp-resource`
                 ;; instead records the file's classpath path and
                 ;; last-modified against the compiling namespace, so the
-                ;; data participates in that namespace's cache key. Both
-                ;; consumers reach that reader through the one namespace
+                ;; data participates in that namespace's cache key. That
+                ;; consumer reaches that reader through the one namespace
                 ;; above, never directly.
                 ;;
                 ;;   api-manifest-metadata.edn — inlined by


### PR DESCRIPTION
`implementation/spec-resource` is the one build-time reader for committed `spec/` data, and
since the Freehand substrate was removed (rf2-0yp7w, PR #8322) it has **one** consumer, not two.
Four places under `implementation/` still described two, and two of them were assertion messages
that would print `jvm-freehand` — a CI job deleted in August.

Closes the prose half of rf2-7b1ti. **The bead stays open for the routing half** — see below.

## What changed

Comment and message text only. No assertion subject changed, no classifier touched, no behaviour.

| File | Was | Now |
| --- | --- | --- |
| `implementation/shadow-cljs.edn` | "Two consumers today, both macros that inline a committed file…" then enumerates **one**; later "**Both** consumers reach that reader…" | "One consumer today, a macro that inlines a committed file…"; "**That** consumer reaches that reader…" |
| `implementation/README.md` | "(the Freehand conformance fixtures, the api-manifest sidecar)" | "(the api-manifest sidecar)", paragraph reflowed |
| `_changed-surfaces.test.cjs` block comment | "the Freehand conformance fixture loader and the api-manifest CLJS probe both expand through it" | "the api-manifest CLJS probe is the ONE consumer that expands through it" |
| `_changed-surfaces.test.cjs` assertion msg | "…race control (jvm-spec-resource) **and the fixture loader lane (jvm-freehand)**" | "…race control (jvm-spec-resource)" |
| `_changed-surfaces.test.cjs` assertion msg | "where **both consumers** macro-expand through this reader" | "where **the api-manifest probe** macro-expands through this reader" |

### Evidence for "one consumer"

* `implementation/scripts/api-manifest/probe/src/re_frame/api_manifest/cljs_publics.clj:40` carries
  the only `:require` of `re-frame.build.spec-resource` outside the artefact and its own suite.
* Within that namespace the sidecar is read by `emit-cljs-only-rows` and `emit-classification-rows`
  (both via `read-sidecar`). `emit-ns-publics` — the macro Xray's `panel_enum_guard_cljs_test.cljs`
  refers — does **not** read the sidecar, so it is not a second consumer of the `../spec` root.
* The surviving consumer's witness ns is `re-frame.api-manifest.cljs-manifest-probe-cljs-test`,
  which matches the `:node-test` build's `:ns-regexp "cljs-test$"`, and the probe's `src`/`test`
  are on the top-level `:source-paths`. So the retained `cljs_node_test` assertion message is
  true as rewritten.
* `jvm-freehand` no longer exists as a job in `.github/workflows/test.yml`; at this base its only
  surviving mention repo-wide is a comment in `.github/scripts/report-changed-surfaces.sh`, which
  is out of this PR's fence (PR #8482 holds that file).

## The routing half — deliberately NOT done here, and one premise corrected

`.github/scripts/report-changed-surfaces.sh`'s `implementation/spec-resource/*` arm sets
`cljs_browser=true`, and its only stated reason is "the `-dom-cljs-test$` suites inline fixtures
too". On the evidence above that reason has **expired**: no `-dom-cljs-test$` namespace reaches the
reader, directly or through the probe. Both live consumers of the probe macro-namespace end in
`cljs-test`, not `-dom-cljs-test`, so they ride the node lane. The arm over-schedules a Playwright
lane on every spec-resource diff. Over-scheduling fails safe, so this is cost, not correctness.

**PR #8482 merged while this was in flight**, so the classifier's *comment* is already correct on
main (`c9a944e646`): it now reads "the api-manifest CLJS probe expands through it", no longer names
`jvm-freehand`, and records that `cljs_browser`'s reason has expired. This PR was rebased onto that
tip and its gates re-run there. What is left of the routing half is the routing change alone — and
it is now **unblocked**, since #8482 has released the file.

**One claim in that newly-landed comment is wrong, and the follow-up will be misled by it.** It says
(`report-changed-surfaces.sh:1229-1231`) that `_changed-surfaces.test.cjs` "pins this arm's outputs
and would have to move in the same commit". True of two of the three outputs; **false of
`cljs_browser`**. The spec-resource block asserts `implementation_jvm` and `cljs_node_test` and
nothing else — there is no `cljs_browser` assertion for any `spec-resource` path. Re-verified on the
rebased tree with a positive control (`cljs_browser` occurs 85 times elsewhere in that file, so the
absence is real rather than a bad pattern).

So dropping `cljs_browser=true` will **not** red this suite, and a green run must not be read as
confirmation the narrowing was seen. The same-commit rule is still right, but because the follow-up
must **add** the missing assertion — not because an existing one would catch it.

**The routing half is therefore dispatchable now, as its own bead.** Nothing holds
`.github/scripts/report-changed-surfaces.sh` any more. What it must do, in ONE commit: drop
`cljs_browser=true` from the `implementation/spec-resource/*` arm, and **add** an assertion to the
spec-resource block in `_changed-surfaces.test.cjs` pinning `cljs_browser` false, so the arm cannot
silently regrow. Sequence against rf2-fo4ng, which will rewrite coordinates across that tree when
released. rf2-7b1ti stays OPEN carrying this plus the fifth file below.

## A FIFTH file has the same defect, and it is outside this PR's fence

The bead enumerates four files. A repo-wide sweep (`git grep -F "both consumers" / "two consumers"`
over tracked files) found a fifth:

```
implementation/spec-resource/deps.edn:4-6
  "Several macros inline a committed file from `spec/` at macro-expansion time
   (the Freehand conformance fixtures; the api-manifest sidecar)."
```

Identical error to the README's. It was **not** edited here — this PR's fence is the three files it
was dispatched with, and quietly widening it is how a fence stops meaning anything. It is recorded
on rf2-7b1ti as part of the remainder.

Two nearby lines look like the same defect and are **not** — leave them alone. `deps.edn:10` ("so
two consumers cannot solve it two ways and race each other") and
`spec_resource_test.clj:31-33` ("leaves two consumers free to race each other") are both statements
about why the resolver is *shared* — two independent resolvers would race — not claims about how
many consumers exist today. Both are correct as written.

## Quality gates

Every exit code below was captured in the same shell as the runner (`cmd > log 2>&1; echo $? > exit`),
never read from a harness report, and no gate was piped through a filter.

| Gate | Invocation | Captured exit | Result |
| --- | --- | --- | --- |
| changed-surfaces mirror test (control) | `node implementation/scripts/_changed-surfaces.test.cjs` | **0** | 292 passed |
| changed-surfaces mirror test (**sabotage**) | same, with `implementation_jvm` expectation flipped to `'false'` | **1** | 4 failed |
| changed-surfaces mirror test (final content) | same as control | **0** | 292 passed |
| `shadow-cljs.edn` EDN validity | `clojure -M -e "(clojure.edn/read-string …)"` | **0** | parses; 78 builds, keys `(:builds :dependencies :dev-http :source-paths)` |
| README link/anchor gate (control) | `python scripts/check_readme_links.py` | **0** | clean |
| README link/anchor gate (**sabotage**) | same, broken link planted in prose | **1** | `BROKEN TARGET: implementation\README.md:13 -> ./definitely-missing-file-xyz9.md` |
| README link/anchor gate (final) | same as control | **0** | clean |
| consolidated node script-policy lane (pre-rebase) | `npm run test:script-policy` (from `implementation/`) | **0** | 0 failures |
| consolidated node script-policy lane (**on the final rebased base**) | same | **0** | 25 reported summaries, 655 assertions, **0 failures**; `changed-surfaces tests: 292 passed` |
| `python scripts/check_doc_slugs.py` | as listed | **0** | clean |
| `python scripts/check_fast_pr_gap.py --list` | as listed | **0** | 96 required checks this spine does not decide |

**Tree verification — both edited surfaces proven, by planted fault.** Neither gate prints a root
banner, so the discrimination is the red itself: the fault existed only in this worktree, so a run
that had wandered into a sibling checkout would have come back green.

* The mirror-test sabotage printed the **new** message text (`race control (jvm-spec-resource)`,
  4 occurrences) — a string that exists nowhere on `origin/main`. That proves both which tree was
  read and that a failing assertion now prints the corrected text, which is the bead's subject.
* Pass counts were compared against the control to confirm the plant was scoped: 292 before,
  292 after restore, so nothing was suppressed by an aborted namespace.

**A first README plant was discarded rather than believed.** It was placed inside the fenced layout
block, where the link gate correctly ignores it, and came back green. A green sabotage run is a
reason to stop, not to proceed — it was re-planted in real prose, where it red as shown above.
Note the consequence: this PR's README edit is itself inside that fence, so the link gate does not
validate it. It contains no links, and the surrounding table/column alignment was checked by hand.

**Rebased onto `4245c2a9fc` mid-flight and the gates re-run there.** The trunk moved by 9 commits
while this was in progress, including `c9a944e646` (PR #8482) which touches the very classifier this
suite spawns — so the pre-rebase green was evidence about a tree that no longer existed. The
merge-base diff (`origin/main...HEAD`, three dots) was re-read after the rebase: it contains only
this PR's own hunks, and the mirror test's base blob is unchanged (`13e3bc818d`), so nothing that
landed on main was reverted.

**eslint was not run locally** — this worktree has no `node_modules` and the job installs from the
root lockfile. It cannot bite this diff regardless: `eslint.config.mjs` covers `**/*.cjs` but
declares no `max-len`, `printWidth`, or quote rule, and the file already carries a 1403-character
line. CI's `Lint required` decides it.

**Restores were verified by hashing, not by reading a diff.** `git hash-object` before each plant
and after each restore: mirror test `01f95f405c…` → `01f95f405c…`; README `ddef53743e…` →
`ddef53743e…` (matching its committed blob). `git status` is clean.

**The script-policy lane was run whole, not just the one suite.** The edited file is one of 38
`.test.cjs` policy suites that lint each other, so running only its own suite would have missed a
sibling policy asserting something about these files' text. `npm run test:script-policy` exceeds the
foreground ceiling, so it was detached and its log **and** exit-code file polled to completion in a
bounded loop. The quoted 0 is the runner's own shell's, captured on the same command line
(`… > log 2>&1; echo $? > exit`); the harness's report of the same run is a different measurement
and is not what is quoted here.

Log integrity was checked rather than assumed: 30732 bytes / 413 lines, **0 NUL bytes**, exactly one
npm lifecycle banner — so no orphan from an earlier attempt spliced into these artefacts.

**Two counting errors were caught and corrected rather than published.** `grep -c $'\0'` in bash
searches for the EMPTY string, so it "found" 413 NUL bytes — the line count — in exactly the voice a
real answer would use; it was redone in Python against the raw bytes, which reports 0. And a loose
`grep -c 'tests: .* passed'` gave 31 suites / 664 assertions against a precise
`tests: (\d+) passed` regex's 25 / 655. The precise figures are the ones in the table.

**The fast-PR spine itself was NOT run**, and that is a deliberate call rather than an omission.
The diff is comment and message text plus one reflowed README paragraph, with no behavioural
surface; the gates that actually decide it were run directly, three were proven discriminating
above, and the spine's node lane for this surface *is* the script-policy suite that ran green. The
full spine is ~25 min and multi-GB against a live wave of concurrent worker worktrees — the
machine-contention wedge, for no added signal on a diff of this shape. `check_fast_pr_gap.py --list`
is cited above for what green here does not settle; CI's required matrix decides the rest.
