### PR TITLE
docs(codemod): the shared-rule guard's rationale said the twin died with Freehand; it was re-homed (rf2-0yp7w.9)

### DIFF
--- a/migration/reagent-to-hicasso/codemod/test/re_frame/migration/hicasso/shared_rule_test.clj
+++ b/migration/reagent-to-hicasso/codemod/test/re_frame/migration/hicasso/shared_rule_test.clj
@@ -67,8 +67,12 @@
             `implementation/hicasso/frozen-sources.edn` still pins that
             copy byte-for-byte — so BOTH files answer identically today
             and either would satisfy an `identical?` check taken alone.
-            Only one of them survives Freehand's retirement, and it is
-            the one a migrator's own code will meet."
+            The pin names the one a migrator's own code will meet.
+            Freehand's retirement did not settle that by deletion:
+            rf2-0yp7w P0 RE-HOMED the twin into
+            `implementation/hicasso/test/` rather than removing it, so
+            both copies still exist and the namespace guard below is
+            load-bearing rather than vestigial."
     (let [url  (io/resource "re_frame/hicasso/impl/slot.cljc")
           path (some-> url .getPath (str/replace "\\" "/"))]
       (is (some? url) "the shared slot rule is on the classpath")
@@ -78,7 +82,7 @@
       (is (not (str/includes? path "/migration/reagent-to-hicasso/"))
           "a copy of the slot rule has appeared inside the codemod's own tree")
       ;; The prototype-twin guard, spelled by NAMESPACE rather than by tree.
-      ;; rf2-r8j91 wrote it as `/implementation/freehand/`, which was where the
+      ;; rf2-r4j91 wrote it as `/implementation/freehand/`, which was where the
       ;; twin lived; rf2-0yp7w P0 re-homed the harness into
       ;; `implementation/hicasso/test/re_frame/bench/hicasso/front/` and left
       ;; that spelling matching nothing — a guard that had quietly gone slack


### PR DESCRIPTION
Slice of `rf2-0yp7w.9` (R6 prose sweep): the `skills/` + `migration/` remainder and a discrimination pass over eight root files.

## The headline: the sweep was already done, and this PR is one repair the last sweep flagged

The dispatch census (7 files, 19 hits under `freehand|re-frame\.ui\b|re_frame\.ui\b|rf\.ui\b` over `skills/` and `migration/`) reproduces **exactly** at the tip. But those 19 hits are not unswept residue — they are the **LEFT STANDING** set that closed child `rf2-0yp7w.9.1` (PR #8464) already adjudicated file-by-file, and its close reason enumerates the same 7 files and the same 19 hits. Widening the pattern (adding word-bounded `re-frame2-ui`, `implementation/(ui|freehand)/`, `rf.ui[./]`) adds **no file and no hit**; the positive control fires on `docs/design/freehand/`; the `re-frame2-uix` collision that inflated the original census by 100% is excluded and verified excluded.

So the deliverable is mostly a verified **"already fixed"**. One item was genuinely outstanding, because `rf2-0yp7w.9.1` explicitly flagged it and left it for sequencing.

## Changed — 1 file, 2 repairs, both in one `testing` docstring's neighbourhood

`migration/reagent-to-hicasso/codemod/test/re_frame/migration/hicasso/shared_rule_test.clj`

**1. A false claim that was the stated rationale for a live guard.** The docstring closed with *"Only one of them survives Freehand's retirement, and it is the one a migrator's own code will meet."* Freehand's retirement has happened (PR #8322, 2026-08-16) and **both** copies of the slot rule still exist:

- `implementation/hicasso/src/re_frame/hicasso/impl/slot.cljc` (the shipped door), and
- `implementation/hicasso/test/re_frame/bench/hicasso/front/slot.cljc` (the twin), which `rf2-0yp7w` P0 **re-homed rather than deleted**.

`implementation/hicasso/frozen-sources.edn` still pins the pair byte-for-byte (row at L242-244, `:bench "front/slot.cljc"` / `:package "src/re_frame/hicasso/impl/slot.cljc"`), so the preceding sentence — *"BOTH files answer identically today and either would satisfy an `identical?` check taken alone"* — remains **true**, and is now the entire reason the guard is needed.

This is not cosmetic staleness. The sentence is the rationale for the executable guard 18 lines below it (`(is (not (str/includes? path "re_frame/bench/")))`), and as written it argued that guard had nothing left to guard against. The comment beside that guard records it had **already gone slack once** — spelled `/implementation/freehand/`, matching nothing after the re-home. Prose inviting a second removal is the live risk. The repair keeps the historical sentence (the extraction really did land under `implementation/freehand/test/`) and corrects only the dead illustration, per the governing discrimination.

**2. A dangling bead id.** The comment beside that guard cited `rf2-r8j91`, which **does not resolve** in the tracker (`bd show` → *no issue found*). The bead is `rf2-r4j91` ("Re-aim the Reagent migration skill and codemod at hicasso"), cited correctly three other times in this artefact — this file's ns docstring L14, `deps.edn` L38, and the codemod README L298.

No behaviour change: both edits are a string literal and a comment.

## The two candidates for a LIVE BREAK — both settled as prose, one settled by execution

The dispatch flagged `deps.edn` and this test as possibly live breaks rather than documentation. **Neither is.**

- **`deps.edn` — PROSE.** All 4 hits are in comment lines (39, 46, 59, 65). The only non-`src` `:paths` entry is `../../../implementation/hicasso/src`, which exists and carries `re_frame/hicasso/impl/slot.cljc`. This is settled by **execution, not inspection**: the suite loads the shared rule across exactly that classpath entry and pins it `identical?`, and it passes. A broken coordinate would red `-M:test` and `-M:run` alike, which is what the file's own comment predicts.
- **`shared_rule_test.clj` — PROSE.** All 3 hits are docstring/comment. The executable assertions guard by **namespace segment** (`re_frame/bench/`), which matches the twin's *current* address, so the guard is live and correctly spelled.

## Left standing, each read individually (not grepped)

**`skills/` — 6 hits, 4 files, all correct.** `evals.json` L42/L87 are **negative** expectations forbidding Freehand spellings (anti-reintroduction guards — sweeping them would delete the protection); `evals.json` L5 records eval id 13's deliberate absence with a live DO-NOT-RENUMBER instruction; `authoring-prompt.md` L29 is a **Don't** list naming the retired verbs it prohibits; `design.md` L13/14/75/144/160 are dated history (L8 is explicitly marked RETIRED, L160 is a comparative — *"unlike Freehand there is no `spec/API.md` roster"* — explaining why Hicasso's lock is higher-risk); `inputs.md` L106 records the 2026-08-16 removal and is itself the anti-analogy guard.

**`migration/reagent-to-hicasso/codemod/` — README L300/L304 unchanged.** Bead-attributed historical record of why the classpath names the shipped package and deliberately not the bench tree.

**Eight root files — NEARLY NULL, as predicted, and nothing changed.** Re-censused: `README.md` **0** (control: `grep -F re-frame2-uix` = 1, confirming the `-uix` collision was the whole of its former score), `AGENTS.md` **0**, `docs/AUTHORING.md` **0**, `CLAUDE.md` 1, `CHANGELOG.md` 2, `docs/release-process.md` 2, `mkdocs.yml` 7, `TESTING.md` 44. Every survivor is historical or a live-true policy statement: `CHANGELOG.md` L71 and `docs/release-process.md` L17 record that `day8/re-frame2-ui` **never published and never will**; `CLAUDE.md` L120 is the removal status note; `mkdocs.yml`'s `exclude_docs` entry for `design/freehand/` is **load-bearing** and ruled KEEP by `rf2-0moc4` — untouched.

`TESTING.md` verified rather than assumed: L247 declares the Freehand CI section *"ALL STAGES HAVE LANDED. This section is now a RECORD, not a plan… Read the stage bodies below in the past tense"*, and the positive control holds — `grep -icE 'freehand|"test:ui' implementation/package.json` returns **0**, so no named script survives to be run.

**No donor prose was re-aimed at hicasso** (`rf2-0yp7w.11`).

## Quality gates

`mkdocs build --strict` is **NOT** the gate for this path, and I read `exclude_docs` rather than trusting prose: it excludes six trees — `tools/playground/`, `migration/from-re-frame-v1/codemod/`, **`migration/reagent-to-hicasso/codemod/`**, `design/freehand/`, `design/hicasso/`, `design/retirement/`. The edited file's tree is excluded, so the site build structurally cannot see this change. Not run.

| gate | captured exit | result |
|---|---|---|
| `cd migration/reagent-to-hicasso/codemod && clojure -M:test` (control) | **0** | 54 tests, 490 assertions, 0 failures, 0 errors |
| same, **SABOTAGE** | **1** | **1** failure, 54 tests / 490 assertions |
| same, after restore | **0** | 54 tests, 490 assertions, 0 failures |
| same, **after rebase onto `4245c2a9fc`** | **0** | 54 tests, 490 assertions, 0 failures |
| `python scripts/check_doc_slugs.py` (pre- and post-rebase) | **0**, **0** | pass |
| `python scripts/check_fast_pr_gap.py --list` | **0** | see below |

Every exit code above was captured in-shell by explicit redirect + `echo $?` on one command line, never read from a harness report. Artefacts named per worktree and per attempt.

**This is the required CI check, run verbatim.** `check_fast_pr_gap.py --list` shows the `jvm-migration-hicasso-codemod` job runs `cd migration/reagent-to-hicasso/codemod && clojure -M:test` — character-for-character the command above. Per `TESTING.md` L213 that lane arms on any change under `migration/reagent-to-hicasso/codemod/**`.

**`scripts/test-fast-pr.sh` did NOT run.** It is the ~25-minute spine against a 10-minute ceiling, and it does not cover this artefact — the codemod's own JVM lane does, and that lane ran four times. No shadow-cljs, browser, npm or Playwright gate was run.

**Tree verification — both routes, not one.** The sabotage was a single-line plant at a line I was already editing, anchor asserted unique (`grep -c -F` = 1) before writing:

1. **Planted-fault red**: exit **1**, exactly one failing assertion, the log naming the planted string `implementation/PLANTEDFAULTskillsmig/impl/slot.cljc`. Test and assertion counts identical to the control (54/490), so the plant was properly scoped and aborted no namespace.
2. **Root banner**: the failure message printed the *resolved* classpath path, which names this worktree — `…/re-frame2-worktrees/skillsmig-0yp7w9/implementation/hicasso/src/re_frame/hicasso/impl/slot.cljc`. A run that had wandered into a sibling checkout would have printed a different root **and** come back green.

**Restore verified by hashing, not by reading a diff**: `git hash-object` of the working file after restore, the committed object, and the pre-plant baseline are all `7222a3c9fa846dd59938003dac928534fc9601a1`, with zero plant residue.

Merge-base diff (`origin/main...HEAD`, three dots) read before pushing: 1 file, +7/-3, exactly the two intended repairs and nothing reverted. Main's three new commits touch neither `migration/reagent-to-hicasso/` nor `implementation/hicasso/`, so the gate's inputs were unchanged by the rebase; re-run anyway.

## Refused / not verified

- **`.github/scripts/report-changed-surfaces.sh`** still matches `jvm-freehand|ui-scaffold-smoke`. Out of fence (`.github/**`) and already owned by `rf2-0yp7w.9.5` item 2. Reported, not touched.
- **`deps.edn` L46** predicts *"They will not both EXIST for long"*. Falsified — the twin was re-homed, so both now exist permanently. Left standing: the very next paragraph (L58-66) explicitly annotates that paragraph as superseded and re-states the surviving decision correctly, so the record carries its own correction. Reported rather than edited, to keep this change minimal.
- `rf2-0yp7w.9` **not claimed and not closed**: it is already `in_progress` with sibling slices in flight, and claiming a bead another worker holds is the documented hazard. Recorded as a comment instead.
