### PR TITLE
docs(hicasso): the release policy says what actually blocks the first tag, and which matrix rows are armed (rf2-hic-061)

### DIFF
--- a/docs/design/hicasso/product/release-policy.md
+++ b/docs/design/hicasso/product/release-policy.md
@@ -170,8 +170,11 @@ Every row carries either the CI job that backs it or an explicit **untested-but-
 | React 19.2.0 and react-dom 19.2.0 | `implementation/package.json` | the CLJS node lane in job `cljs`; `cljs-hicasso-controlled`; `cljs-hicasso-hmr` | **TESTED** — every Hicasso claim in this repository is a claim about this pair |
 | Any other React 19.x | — | nothing | **UNTESTED-BUT-EXPECTED** for the boundary shell and the two-hook contract, which write no version-conditional code. Not expected below 19.2 for the `Activity` lifecycle rows, whose subject shipped in 19.2 |
 | React 18 or earlier | — | nothing | **NOT SUPPORTED** |
-| Chromium 147.0.7727.15, Firefox 148.0.2 and WebKit 26.4, on Playwright 1.59.1 | `implementation/package.json`; the runner prints the triple it launched | `cljs-hicasso-controlled` — three real engines, per PR, comparing recorded rows across engines rather than running one spec three times; `cljs-hicasso-hmr` — three engines, real shadow reloads | **TESTED** |
+| Chromium 147.0.7727.15, on Playwright 1.59.1 | `implementation/package.json` | `cljs-browser`, which runs Hicasso's `*_dom_cljs_test` suites headless | **TESTED** — the broadest browser coverage Hicasso has, and it is one engine |
+| Firefox 148.0.2 and WebKit 26.4, on Playwright 1.59.1 | `implementation/package.json`; the runner prints the triple it launched | `cljs-hicasso-controlled` — three real engines, comparing recorded rows across engines rather than running one spec three times; `cljs-hicasso-hmr` — three engines, real shadow reloads | **TESTED, BUT ARMED RATHER THAN UNIVERSAL** — both jobs are conditional on the changed-surface classifier and both are declared holes in the nightly sweep. §4.2 states what that does and does not buy |
 | Any other engine or engine version | — | nothing | **UNTESTED-BUT-EXPECTED** — the substrate targets React's DOM contract, not a browser's |
+| Linux (`ubuntu-latest`), JDK 21 (temurin), Node 24 | the `runs-on` and `setup-java`/`setup-node` pins on every Hicasso job | all of them; there is no matrix on any of these three axes | **TESTED, and singly** |
+| Windows or macOS, any other JDK or Node | — | nothing | **UNTESTED-BUT-EXPECTED.** No Hicasso job runs off `ubuntu-latest`, and `portability.yml` names Hicasso nowhere. The substrate is browser and JVM code with no platform-conditional branch, but nothing measures that |
 | `day8/re-frame2` and `day8/re-frame2-ssr` **at the same commit** | `implementation/hicasso/deps.edn`, both at `:local/root` | `jvm-hicasso`; the CLJS node lane in `cljs` | **TESTED**, and the only supported combination there is — see the row below |
 | Hicasso against any *released* core version | — | nothing yet | **NOT APPLICABLE, PENDING A FIRST RELEASE** — `rf2-gra70` landed the wiring, so both sides of the pair are publishable coordinates on one lockstep train (§1). What is missing is not only a version to name but the ability to create the coordinates at all: see [§1.1](#11-three-ruled-prerequisites-stand-in-front-of-the-first-tag). The row goes green on the first `v*` tag and its install witness, not on the wiring |
 | ClojureScript 1.12.145 and shadow-cljs 3.4.10 | `implementation/core/deps.edn`; `implementation/package.json` | every CLJS job | **TESTED** |
@@ -190,6 +193,27 @@ witness, and the three-engine controlled gate. A React bump that does not re-run
 §4 asserted about a version nobody tested — and because the pin is one line and the gates are green either
 way, nothing would announce it. That is the whole reason this obligation is written down rather than
 assumed.
+
+### 4.2 What "backed by a CI job" means when the job is armed rather than universal
+
+**A row backed by a conditional job is backed more weakly than a row backed by an unconditional one, and
+this section exists so the table does not have to pretend otherwise.** The two three-engine gates are the
+only place Firefox and WebKit run at all, and each carries an `if:` on the changed-surface classifier
+arming its surface. On a change the classifier does not arm for Hicasso, they do not run — and
+[`expensive-tests.yml`](../../../../.github/workflows/expensive-tests.yml) names both as **DECLARED HOLES**
+in the nightly sweep in its own words, because it installs neither Firefox nor WebKit. So there is no second
+schedule that catches what an unarmed PR missed.
+
+**This is a real property of the coverage rather than a criticism of it**: the reason is stated where the
+holes are declared, and a named hole is the honest form. What follows for a reader of §4 is narrow and
+worth stating exactly. The Firefox and WebKit rows mean *these engines have been exercised on this
+substrate, and are re-exercised whenever the classifier sees Hicasso move*. They do not mean *every change
+that reaches this substrate was proven on three engines*. Chromium is the engine with unconditional-in-kind
+coverage, through `cljs-browser`.
+
+**The recheck obligation in §4.1 therefore has a second trigger.** A React bump arms it, and so does a
+change to the classifier's own Hicasso arming rules: narrowing what arms `hicasso_controlled` silently
+narrows two rows of this matrix, and no gate here would go red.
 
 ## 5. The upgrade policy — no shims, and what that buys
 
@@ -282,3 +306,24 @@ Three consequences, and this page states them rather than working around them:
 The other open item is not this bead's to close either: §4's last row rests on a Phase 4 exit that
 [`checkpoint-4-coverage.md`](checkpoint-4-coverage.md) returned **NOT MET**. A compatibility matrix cannot
 promise a green its own evidence page declines to give, so it does not.
+
+### 6.1 The consumer app exists, and it does not yet consume an artefact
+
+**There is a tiny consumer app, and it is exercised on every armed PR — from source, never from a jar.**
+`implementation/hicasso/test/re_frame/hicasso/consumer_app.cljs` is the `:init-fn` of the `hicasso-release`
+build, and job `cljs` compiles it under `:advanced` and then runs the production-erasure and
+bundle-isolation checks over the resulting bundle. That is real coverage of the *build*, and §4 rows it as
+such.
+
+**What it is not is the acceptance criterion.** That criterion turns on *from the artefact (not the repo)*,
+and the compile resolves Hicasso from `:source-paths` in `implementation/shadow-cljs.edn` — no
+`:mvn/version` coordinate is involved anywhere. Nor does the deploy stage close the gap from the other
+side: `deploy-hicasso` runs checkout, JDK, Clojure CLI, cache, install core, install ssr, rewrite
+`:local/root` to `:mvn/version`, deploy. There is no preflight step between the rewrite and the publish.
+The one published-package preflight in the release workflow is `reagent-slim`'s, guarded to that leaf.
+
+**So the honest statement is that the automation is ready and only a real release would prove it.** Writing
+the artefact-consuming witness before a coordinate exists would mean writing a job that cannot run, and the
+resolution to build one is not this page's to take. The shape it would have is already on record next door
+— `release.yml` says a consumer-compile assertion was scoped and left unbuilt because the temp-project npm
+and shadow wiring is awkward on the runner — so this is a known cost rather than an unexamined one.

--- a/docs/design/hicasso/product/release-policy.md
+++ b/docs/design/hicasso/product/release-policy.md
@@ -7,11 +7,18 @@ compatibility/release policy*: what the artefact is, which combinations it is co
 upgrade costs the consumer who takes one. Where a claim here and its owning document disagree, the owner
 governs and this page is the defect.
 
-**Everything below is measured, and the measurement is dated.** The counts in §3 and §4 were taken on
-2026-08-15 against `origin/main`, each with the command beside it, because a compatibility statement that
+**Everything below is measured, and the measurement is dated.** The counts in §3 and §4 were re-taken on
+2026-08-18 against `origin/main`, each with the command beside it, because a compatibility statement that
 cannot be re-derived is a compatibility statement nobody can check. The two things this page deliberately
 does **not** do are assert a version number and list the public door by name: neither is stable, and §1 and
 §3 say why.
+
+**Two §3 figures moved between the 2026-08-15 reading and this one, which is the case for dating them.**
+The refusal catalogue went from 76 live / 6 reserved to **77 live / 5 reserved** — a reservation acquired an
+emitter, which is the one direction the catalogue's own rules permit — and the optional-module roster went
+from four modules to **five**, the native tier having joined it. Neither figure was wrong when it was
+written and neither announced itself when it changed, which is exactly why §3 records the command rather
+than only the number.
 
 ## Where each fact lives
 
@@ -49,11 +56,38 @@ by the same change:
 3. It is **in the release workflow**, in a stage of its own — `deploy-hicasso`, gated on `deploy-core` and
    the whole `deploy-leaf` matrix, for the reason §2 gives.
 
-So Hicasso is consumable from a released coordinate, and `:local/root` from this repository is now the
-in-tree development path rather than the only one. The knock-on for Xray went with it: Hicasso was **the one
-coordinate `release-xray.yml` deliberately left at `:local/root`** while rewriting the other nine, and
-`preflight-xray-package.sh` refused an `xray-v*` deploy over it. All ten are rewritten now, and what remains
-is tag ORDER — `v*` before `xray-v*`, at the same VERSION.
+So Hicasso is **wired to publish**. It is not yet *consumable* from a released coordinate, and §1.1 is the
+difference: `:local/root` from this repository remains the only path a consumer has, and the spelling above
+is not the spelling the first release will carry. The knock-on for Xray went with the wiring: Hicasso was
+**the one coordinate `release-xray.yml` deliberately left at `:local/root`** while rewriting the other nine,
+and `preflight-xray-package.sh` refused an `xray-v*` deploy over it. All ten are rewritten now, and what
+remains is tag ORDER — `v*` before `xray-v*`, at the same VERSION.
+
+### 1.1 Three ruled prerequisites stand in front of the first tag
+
+**An earlier reading of this section said only a tag was missing. That was wrong in the direction that costs
+a reader most**, because it invites them to write `day8/re-frame2-hicasso` into a `deps.edn` and wait for it
+to resolve. Three things stand in front of the first tag, none of them wiring and none of them a worker's:
+
+1. **The group is not verified, so the coordinate cannot be created.** Clojars requires a NEW project to
+   live in a *verified* group, and verification requires a reverse-domain group name, which `day8` is not.
+   This is measured rather than feared: a tag-triggered publish under that group drew a 403 reading *"Group
+   'day8' isn't verified, so can't contain new projects"*. The block is release-wide — it reaches every
+   `day8/re-frame2-*` coordinate that has never published, which is all of them — and
+   [`docs/release-process.md` §How `story-mcp` and `mcp-base` got their publish path](../../../release-process.md#how-story-mcp-and-mcp-base-got-their-publish-path)
+   owns the statement. Clearing it is an operator act against Clojars, not a change to this repository.
+2. **The coordinate is scheduled to be renamed, so today's spelling is not the one that ships.** A held
+   campaign renames all nineteen `day8/*` Maven coordinates to `io.github.day8/*` — the reverse-domain group
+   verification (1) needs — and it is deliberately held until the verification lands. **The first tag
+   therefore cuts on `io.github.day8/re-frame2-hicasso`, not on the `day8/re-frame2-hicasso` committed
+   today**, and a tag pushed before that campaign merges would 403 on every coordinate rather than on one.
+3. **The deploy token is scoped to the new group and is minted only when a tag is imminent.**
+
+**What this page will not do is pre-write the new spelling into §1's opening line.** The committed tree says
+`day8/re-frame2-hicasso` in both places §1 names, and a page disagreeing with the tree it documents is a
+second defect rather than a fix. The spelling changes here when it changes in `deps.edn`, under the campaign
+that owns it — which is also why the naming record still carries the two group ids as an open question
+rather than a settled one.
 
 **No version has been cut, of anything.** The repo-root `VERSION` file reads `0.0.1.alpha`, and
 `git ls-remote --tags origin` returns nothing at all — this repository has never carried a release tag. That
@@ -61,9 +95,11 @@ is why §2 describes a scheme and names no current version: a number written on 
 stale before the page was read.
 
 **The consequence for `rf2-hic-061`'s own acceptance criterion, stated plainly.** That criterion reads *"a
-tagged release installable by the tiny consumer app from the artefact (not the repo)"*. It is **executable
-now and still unexecuted**: `rf2-gra70` built the automation the criterion needs, but cutting a tag is the
-operator's act, not a worker's, and this repository has still never carried one. §6 records what is left.
+tagged release installable by the tiny consumer app from the artefact (not the repo)"*. The automation it
+needs exists — `rf2-gra70` built it — but the criterion is **not executable today**, and the distinction
+matters because "executable and unexecuted" reads as *someone need only push a tag*, which is how this
+obligation fell out of the open ledger once already. It is **blocked, on §1.1's first two prerequisites**,
+and it becomes executable when they clear. §6 records what is left.
 
 ## 2. The versioning scheme
 
@@ -104,12 +140,12 @@ not its contents.
 Every row below points at a record that is machine-checked, so the surface cannot grow, shrink or be
 renamed without something going red.
 
-| Surface | Where it is enumerated | The gate that keeps it honest | Measured 2026-08-15 |
+| Surface | Where it is enumerated | The gate that keeps it honest | Measured 2026-08-18 |
 |---|---|---|---|
 | The ordinary authoring door, `re-frame.hicasso` | [`dispositions.md` §2.1](dispositions.md#21-surface-inventory-and-dispositions) and [§2.2](dispositions.md#22-public-surfaces-with-no-server-render-behavior) | `implementation/hicasso/scripts/check_facade_inventory.py`, CI job `hicasso-facade-inventory` | **16 names on the door, 43 inventory rows** — 13 attributed by name, 3 by declaration |
 | The native tier, `re-frame.hicasso.native` | the `native.cljc` namespace docstring, rowed in [`naming-ledger.md`](naming-ledger.md) | `native_surface_cljs_test.cljs` on the CLJS lane | **10 SURFACE + 4 INTERNAL** public vars |
-| Refusal ids | [`complaints.md`](complaints.md#the-stability-rule) | `implementation/hicasso/scripts/check_complaint_catalogue.py`, CI job `hicasso-complaint-catalogue` | **76 live, 6 reserved, 1 pending retirement, 1 retired** |
-| Optional modules — forms, motion, overlay, server | the `MODULES` roster in the script beside it | `implementation/hicasso/scripts/check_optional_module_reachability.py` | four modules, each proving zero reachable production code when absent |
+| Refusal ids | [`complaints.md`](complaints.md#the-stability-rule) | `implementation/hicasso/scripts/check_complaint_catalogue.py`, CI job `hicasso-complaint-catalogue` | **77 live, 5 reserved, 1 pending retirement, 1 retired** |
+| Optional modules — forms, motion, native, overlay, server | the `MODULES` roster in the script beside it | `implementation/hicasso/scripts/check_optional_module_reachability.py` | five modules, each proving zero reachable production code when absent |
 | The testing kit, `re-frame.hicasso.test` | `implementation/hicasso/test_kit/src`, on `:src-dirs` so the jar carries it, deliberately outside the artefact's `:paths` | the kit's own witnesses on the CLJS lane, plus the `rf.error/hicasso-test-` sentinel in `check_production_erasure.cjs` | reachable only from a test, by reachability — no shipping namespace requires it (rf2-rxf49) |
 | Server/hydration policy, per surface | [`lanes/react-compatibility-notes.md`](lanes/react-compatibility-notes.md#public-surface-ssrhydration-matrix) | each `dispositions.md` inventory id points at its policy row | see §4 — the Phase 4 exit this rests on is **NOT MET** |
 
@@ -137,7 +173,7 @@ Every row carries either the CI job that backs it or an explicit **untested-but-
 | Chromium 147.0.7727.15, Firefox 148.0.2 and WebKit 26.4, on Playwright 1.59.1 | `implementation/package.json`; the runner prints the triple it launched | `cljs-hicasso-controlled` — three real engines, per PR, comparing recorded rows across engines rather than running one spec three times; `cljs-hicasso-hmr` — three engines, real shadow reloads | **TESTED** |
 | Any other engine or engine version | — | nothing | **UNTESTED-BUT-EXPECTED** — the substrate targets React's DOM contract, not a browser's |
 | `day8/re-frame2` and `day8/re-frame2-ssr` **at the same commit** | `implementation/hicasso/deps.edn`, both at `:local/root` | `jvm-hicasso`; the CLJS node lane in `cljs` | **TESTED**, and the only supported combination there is — see the row below |
-| Hicasso against any *released* core version | — | nothing yet | **NOT APPLICABLE, PENDING A TAG** — `rf2-gra70` landed the wiring, so both sides of the pair are now publishable coordinates on one lockstep train (§1). What is still missing is a released version to name: this repository has never carried a release tag. The row goes green on the first `v*` tag and its install witness, not on the wiring |
+| Hicasso against any *released* core version | — | nothing yet | **NOT APPLICABLE, PENDING A FIRST RELEASE** — `rf2-gra70` landed the wiring, so both sides of the pair are publishable coordinates on one lockstep train (§1). What is missing is not only a version to name but the ability to create the coordinates at all: see [§1.1](#11-three-ruled-prerequisites-stand-in-front-of-the-first-tag). The row goes green on the first `v*` tag and its install witness, not on the wiring |
 | ClojureScript 1.12.145 and shadow-cljs 3.4.10 | `implementation/core/deps.edn`; `implementation/package.json` | every CLJS job | **TESTED** |
 | Production build, `:advanced` with `goog.DEBUG` false | the `hicasso-release` build id in `implementation/shadow-cljs.edn` | the `build:hicasso-release` step in job `cljs`, which chains production-erasure and bundle-isolation checks | **TESTED** |
 | The optional Node service, `re-frame.hicasso.server` | `implementation/hicasso/deps.edn`'s one `day8/re-frame2-ssr` entry | `server_render_ssr_dom_cljs_test.cljs` on the CLJS lane | **TESTED as a render witness.** The per-surface SSR/hydration policy it serves is the next row |
@@ -233,9 +269,10 @@ it ships from a post-matrix stage of its own beside `ssr-ring`.
 
 Three consequences, and this page states them rather than working around them:
 
-- `rf2-hic-061`'s acceptance criterion — a tagged release installable from the artefact — is now
-  **executable and unexecuted**. Cutting a `v*` tag is the operator's act; no worker does it, and nothing on
-  this page should be read as a claim that a release has happened.
+- `rf2-hic-061`'s acceptance criterion — a tagged release installable from the artefact — is **blocked, not
+  merely unexecuted**, on the group verification and the coordinate rename [§1.1](#11-three-ruled-prerequisites-stand-in-front-of-the-first-tag)
+  enumerates. Both are the operator's acts; no worker does either, and nothing on this page should be read
+  as a claim that a release has happened.
 - §4's *any released core version* row stays **NOT APPLICABLE** until that tag exists, for want of a version
   rather than for want of wiring.
 - Xray's publishability is no longer blocked. Hicasso was the one coordinate `release-xray.yml` left at


### PR DESCRIPTION
Re-derives `rf2-hic-061` against the tip before writing anything. The bead's description was written 2026-08-09 and most of its deliverables have since landed; the half that remained was not the writing but the fact that the page had drifted false in two directions. One file changed.

## What the bead asked for, and where each part actually stands

| Deliverable | State at the tip | Evidence |
|---|---|---|
| Versioning + release automation for the package | **ALREADY DONE**, under `rf2-gra70` | `implementation/hicasso/deps.edn` carries `:clein/build` with `:version "../../VERSION"`; `verify-version-lockstep.sh` names `hicasso` in `ARTEFACT_PATHS`, `ARTEFACTS` and `NON_CORE`; `release.yml` carries a `deploy-hicasso` stage gated on `deploy-core` + the whole `deploy-leaf` matrix |
| The compatibility matrix | **ALREADY WRITTEN**, and it was wrong in two rows | `release-policy.md` §4 existed with backed-by/untested labels; this PR corrects the browser row and adds the platform axis |
| The upgrade / deprecation policy | **ALREADY DONE**, and correctly declines to invent one | §5–§5.3; complaint-id stability per `rf2-hic-021` is §5.1 |
| Complaint-id stability | **ALREADY DONE** | `complaints.md` §The stability rule, mechanised in `check_complaint_catalogue.py` |
| Acceptance: a tagged release installed by the consumer app from the artefact | **BLOCKED — operator's, and not merely unexecuted** | see below |
| The artefact inventory question that held this bead | **UNBLOCKED** — `rf2-rxf49` closed today via PR #8468, test kit joins `:src-dirs` | the page already reflected it; verified against `deps.edn` |

## What this PR actually changes, and why each is a defect rather than a polish

**1. §1 told a reader Hicasso is consumable from a released coordinate. It is not, and the coordinate it names is not the one that will ship.** A reader following §1 would write `day8/re-frame2-hicasso` into a `deps.edn` and wait for a resolve that cannot happen. Three ruled prerequisites stand in front of the first tag, none of them wiring and none of them a worker's: the `day8` group is unverified and Clojars refuses new projects in it (a real 403, not a fear); a held campaign renames all nineteen coordinates to `io.github.day8/*` before the first tag, so the first tag cuts on a spelling the tree does not yet carry; and the deploy token is scoped to that new group. New §1.1 states all three and links `docs/release-process.md`, which already owns the statement release-wide. The page deliberately does **not** pre-write the new spelling into §1's opening line — the committed tree says `day8/…` in both places §1 cites, and a page disagreeing with the tree it documents is a second defect.

**2. "Executable and unexecuted" is the wording that bounced this obligation out of the open ledger once already.** It reads as *someone need only push a tag*. Corrected to blocked-on-§1.1, in §1 and again in §6.

**3. The browser row claimed the three-engine gate runs "per PR". It does not.** `cljs-hicasso-controlled` and `cljs-hicasso-hmr` each carry `if: needs.detect_changed_surfaces.outputs.hicasso_{controlled,hmr} == 'true'`, and `expensive-tests.yml` names both **DECLARED HOLES** in the nightly sweep in its own words, because it installs neither Firefox nor WebKit. So a row a reader takes as universal is classifier-armed with no second schedule behind it — the fail-open shape this repo hunts. Split into a Chromium row (`cljs-browser`, the broadest coverage Hicasso has, one engine) and a Firefox/WebKit row labelled **TESTED, BUT ARMED RATHER THAN UNIVERSAL**, with new §4.2 stating exactly what that buys and what it does not. §4.2 also notes a second trigger for §4.1's recheck obligation: narrowing the classifier's Hicasso arming rules silently narrows two matrix rows and no gate goes red.

**4. Two §3 counts had drifted, and the page's own rule is that the script wins.** Re-ran both reproduction commands: refusal catalogue is **77 live / 5 reserved** (page said 76/6 — a reservation acquired an emitter, the one direction the catalogue's rules permit); the optional-module roster is **five** modules, the native tier having joined (page said four). Facade inventory (16 names / 43 rows) and the native roster (10 SURFACE + 4 INTERNAL) re-measured **unchanged**. Measurement date moved to 2026-08-18 and the two moves are called out in the header, since a figure that changes without announcing itself is the case for dating them.

**5. Added the platform axis, which was absent entirely.** Every Hicasso job is `ubuntu-latest`, JDK 21 temurin, Node 24, with no matrix on any of the three; `portability.yml` names Hicasso nowhere. Rowed as TESTED-and-singly plus an honest untested-but-expected row for Windows/macOS.

**6. New §6.1 answers the acceptance test's third premise.** A tiny consumer app exists and is exercised — `consumer_app.cljs` is the `:init-fn` of the `hicasso-release` build, compiled `:advanced` in job `cljs` with production-erasure and bundle-isolation checks over the bundle — but it resolves Hicasso from `:source-paths`, never from a coordinate. `deploy-hicasso` has no preflight step at all (checkout → JDK → CLI → cache → install core → install ssr → rewrite → deploy); the only published-package preflight in the workflow is `reagent-slim`'s, guarded to that leaf. So the honest statement is that the automation is ready and only a real release would prove it.

## What I refused

**No release was cut, tagged or published**, and no version bumped — that is outward-facing and the operator's.

**No policy was invented.** Where a genuine choice exists it is named as the operator's rather than silently settled: the group-verification act, the coordinate rename, and the token are recorded as ruled-and-held, not decided here. Where the project's stance already answers the question I say so and move on — §5.3's refusal to pre-write a minor/major distinction before 1.0 is correct under pre-alpha/no-back-compat-shims and was left exactly as it stood.

**`.github/workflows/release.yml` was NOT edited.** It is hot zone; I re-derived holders at start-up (`gh pr list --state open --json number,headRefName,files` plus `git worktree list`) and nobody held it, so I could have. I did not, because the gap I demonstrated is documentary rather than mechanical: the missing artefact-consuming witness cannot be written before a coordinate exists, and building a job that cannot run is worse than recording the gap. §6.1 records it instead.

## Operator decision this surfaces

`rf2-hic-061` is blocked by `rf2-uelji`, which is **deferred to 2026-09-16**, and `rf2-v04s` (pilot prep) is blocked by `rf2-hic-061`. So the pilot chain is currently gated on a Clojars act a month out, not on any diff. If the pilot chain should move before then, the choice is to split this bead — close the documentary half and carry the tagged-release acceptance as its own owner behind `rf2-uelji`. That is the mayor's call, not mine; nothing here presumes it.

## Quality gates

Doc-surface edit, confined to `docs/design/hicasso/product/`.

- `python scripts/check_doc_slugs.py` — **captured exit 0**, silent on success. Because it prints nothing, its tree was proven by a planted fault rather than a banner: I broke one anchor target on a line I was already editing, and the gate went **red, captured exit 1**, naming `release-policy.md:273 -> #11-PLANTED-FAULT-NO-SUCH-ANCHOR`. The fault existed only in this worktree, so a run that had wandered into a sibling's would have come back green. Restored and verified **by hashing the bytes**, not by reading a diff: `git hash-object` returned `ea617d7f1e1629462d6d8fb2d3c1f019f6546a4d` both before the plant and after the restore. Re-run green afterwards, captured exit 0.
- `python scripts/check_provenance_pins.py --changed-since origin/main` — **captured exit 0**: *"1 page inspected, 0 cited pins — 0 landed, 0 stranded, 0 unresolvable, 0 foreign; 0 accompanied in scope; 0 findings."* It names the page count, which is this gate's own route to proving it read this tree; the baseline run before any edit said *"0 pages inspected … NOTHING was checked"*, so the 1 is discriminating. No commit SHA is cited anywhere in the new prose, deliberately.
- `python implementation/hicasso/scripts/check_facade_inventory.py` — **captured exit 0**, printed *"16 names on `re-frame.hicasso`, 43 inventory rows read"*, matching the page unchanged.
- `python implementation/hicasso/scripts/check_complaint_catalogue.py` — **captured exit 0**, printed *"77 live, 5 reserved, 1 pending retirement, 1 retired"* — the drift this PR corrects.
- `python implementation/hicasso/scripts/check_optional_module_reachability.py` — **captured exit 0**, printed all five modules *(motion, overlay, native, forms, server)* — the second drift.

Every exit code above is the one captured in the same shell as the run, via a redirect to a log plus an explicit echo on one command line; none is a harness-reported number, and no gate was piped through a filter.

**`mkdocs build --strict` is NOT the gate for this path and was not run.** I read `mkdocs.yml`'s `exclude_docs` block rather than trusting prose. It lists six trees, and `design/hicasso/` is one of them by name (alongside `tools/playground/`, two codemod trees, `design/freehand/` and `design/retirement/`), so the page this PR edits is not in the site at all and the build cannot see it either way.

**Nothing validates table rendering or column counts, so I verified every table row's column count by hand** — enumerating all 34 table lines in the file with their column counts and reading them row by row. The fact-owner table is 2 columns across all 10 rows; §3 is 4 columns across all 8; §4 is 4 columns across all 16, including the four rows added. No row deviates from its header. Heading anchors were verified by the slug gate above, including the two new links to §1.1.

`scripts/test-fast-pr.sh` was **not** run: it is the code spine and this change compiles nothing. `python scripts/check_fast_pr_gap.py --list` — **captured exit 0** — reports **96 required checks the spine does not run**, under the three required contexts `All required checks passed` (test.yml), `Lint required` (lint.yml) and `Docs required` (docs.yml), and states in its own header that most are surface-gated and skip on a diff that does not reach them. So the spine would have decided nothing about this path. The targeted gates listed above are the ones that do cover it: `check_doc_slugs.py` runs unconditionally in `test.yml`'s markdown-link-slug job on every PR, and `check_provenance_pins.py` is its own `docs.yml` job for changed pages under `docs/design/hicasso/`.

Merge-base diff (`origin/main...HEAD`, three dots) read before pushing: 100 insertions / 18 deletions in one file, and every removed line is one this PR deliberately replaces. Nothing a sibling landed is reverted.

**Rebased once, and the gates were re-run on the final base rather than trusted from before it.** Four commits landed on the trunk while this was being written, one of them another `docs/design/hicasso/` change. After rebasing onto `1f634be044`: `check_doc_slugs.py` **captured exit 0**, `check_provenance_pins.py --changed-since origin/main` **captured exit 0** (*"1 page inspected … 0 findings"*), and both count gates whose numbers this diff asserts were re-measured on that base — `check_complaint_catalogue.py` **captured exit 0** still printing *"77 live, 5 reserved"*, and `check_optional_module_reachability.py` **captured exit 0** still naming all five modules. The figures written into §3 are therefore true of the trunk this merges into, not merely of the tree they were taken on.
