### PR TITLE
ci(classifier): the spec-resource arm no longer schedules a browser lane, and the mirror test now pins that (rf2-7b1ti)

### DIFF
--- a/.github/scripts/report-changed-surfaces.sh
+++ b/.github/scripts/report-changed-surfaces.sh
@@ -1222,19 +1222,36 @@ else
         # exists to close (jvm-spec-resource). cljs_node_test fires
         # the consolidated `:node-test` build, where the reader is actually
         # exercised — that is the lane whose macro expansion reaches
-        # shadow-cljs's recording read. cljs_browser stays on, but its
-        # stated reason has expired: it was the Freehand fixture suites,
-        # and they left with the rf2-0yp7w retirement together with the
-        # second consumer and the `jvm-freehand` lane this comment used to
-        # name. Narrowing the arm is a routing change, not a prose one —
-        # `implementation/scripts/_changed-surfaces.test.cjs` pins this
-        # arm's outputs and would have to move in the same commit.
+        # shadow-cljs's recording read.
+        #
+        # cljs_browser is deliberately OFF (rf2-7b1ti). It was on for the
+        # Freehand `-dom-cljs-test` fixture suites, which left with the
+        # rf2-0yp7w retirement along with the second consumer and the
+        # `jvm-freehand` lane this comment used to name — and no browser
+        # namespace replaced them. `re-frame.build.spec-resource` is
+        # macro-side `.clj`, so a CLJS build can reach it only through a
+        # macro require, and the single such path is
+        # `re-frame.api-manifest.cljs-publics`. That namespace has exactly
+        # two consumers — `re-frame.api-manifest.cljs-manifest-probe-cljs-test`
+        # and `day8.re-frame2-xray.panel-enum-guard-cljs-test` — both
+        # plain `-cljs-test`, and nothing requires either of them. The
+        # cljs_browser job compiles only the `:browser-test` build, whose
+        # `:ns-regexp` is `.*-dom-cljs-test$`, so it selected no namespace
+        # that expands through this reader: the lane cost a Chromium
+        # install, compile and run on every spec-resource diff and could
+        # not have gone red for one.
+        #
+        # The spec-resource block in
+        # `implementation/scripts/_changed-surfaces.test.cjs` now asserts
+        # all three outputs, cljs_browser included, so re-adding it here
+        # reds that suite. Until rf2-7b1ti it asserted only the other two,
+        # which is how the expired reason survived unnoticed — a change to
+        # this arm's browser output moved nothing.
         #
         # No production bundle requires any of this (build-time only), so
         # cljs_prod / bundle_isolation stay off.
         implementation_jvm=true
         cljs_node_test=true
-        cljs_browser=true
         ;;
       implementation/test-quiet/src/*|implementation/test-quiet/test/*|implementation/test-quiet/deps.edn)
         # rf2-am7grp — implementation/test-quiet is the test-runtime

--- a/implementation/scripts/_changed-surfaces.test.cjs
+++ b/implementation/scripts/_changed-surfaces.test.cjs
@@ -3391,6 +3391,19 @@ for (const file of TEST_QUIET_FILES) {
 // is exactly why the routing has to be pinned. If the classifier leaves
 // every output false, the one job in CI that goes red when the racy shape
 // returns simply SKIPS, and the aggregator passes.
+//
+// The cljs_browser assertion pins the arm in the OTHER direction, and it
+// is here because its absence is what let a stale lane survive (rf2-7b1ti).
+// The arm carried cljs_browser=true for the Freehand -dom-cljs-test
+// fixture suites; those retired with rf2-0yp7w and nothing browser-side
+// replaced them, but because this block asserted only the two outputs
+// above, the dead lane was invisible to the suite that supposedly pinned
+// the arm. re-frame.build.spec-resource is macro-side .clj, so a CLJS
+// build reaches it only via a macro require, and the one such path is
+// re-frame.api-manifest.cljs-publics — whose only two consumers are plain
+// -cljs-test namespaces that nothing else requires, while :browser-test
+// selects .*-dom-cljs-test$. Asserting 'false' costs nothing today and
+// means a future re-add has to argue for itself here first.
 
 for (const file of [
   'implementation/spec-resource/src/re_frame/build/spec_resource.clj',
@@ -3400,7 +3413,7 @@ for (const file of [
   // must route too, and the rot would otherwise be silent.
   'implementation/spec-resource/src/re_frame/build/deeply/nested.clj',
 ]) {
-  test(`${file} arms implementation_jvm + cljs_node_test (shared spec/ reader)`, () => {
+  test(`${file} arms implementation_jvm + cljs_node_test, and NOT cljs_browser (shared spec/ reader)`, () => {
     const result = classify(file);
     assert.equal(
       result.implementation_jvm,
@@ -3411,6 +3424,11 @@ for (const file of [
       result.cljs_node_test,
       'true',
       'the consolidated :node-test build is where the api-manifest probe macro-expands through this reader',
+    );
+    assert.equal(
+      result.cljs_browser,
+      'false',
+      'no browser namespace reaches this reader: :browser-test selects .*-dom-cljs-test$, and the one macro path in (re-frame.api-manifest.cljs-publics) has only plain -cljs-test consumers — re-add cljs_browser here only with a namespace that shows otherwise',
     );
   });
 }


### PR DESCRIPTION
Closes the ROUTING half of rf2-7b1ti. The prose half landed as #8487.

## The finding

The `implementation/spec-resource/*` arm set `cljs_browser=true` for the Freehand
`-dom-cljs-test` fixture suites. Those retired with rf2-0yp7w and nothing browser-side
replaced them, so the arm booked a Chromium install, compile and run on every
spec-resource diff — a lane that could not have gone red for one.

**The verdict is that the arm does not earn it**, established at source rather than from
the expired comment:

* `re-frame.build.spec-resource` is macro-side `.clj`, so a CLJS build reaches it only
  through a macro require.
* The single such path is `re-frame.api-manifest.cljs-publics`
  (`implementation/scripts/api-manifest/probe/src/re_frame/api_manifest/cljs_publics.clj:40`
  is the only `:require` of the reader outside the artefact and its own suite).
* That namespace has exactly two consumers —
  `re-frame.api-manifest.cljs-manifest-probe-cljs-test` and
  `day8.re-frame2-xray.panel-enum-guard-cljs-test` — both plain `-cljs-test`, and nothing
  requires either of them, so there is no transitive path in either.
* `cljs_browser` gates exactly one job (`cljs-browser`, `.github/workflows/test.yml:3418`),
  which runs only `npm run test:browser` → the `:browser-test` build, whose `:ns-regexp`
  is `.*-dom-cljs-test$` (`implementation/shadow-cljs.edn:976`).

So the lane selected no namespace that expands through the reader. Over-scheduling fails
safe, so this was cost rather than correctness.

Note the browser lane itself is alive and large — 139 real `-dom-cljs-test` namespaces
across the adapters, core and hicasso. The claim is only that none of them reaches this
reader.

## Why both files move together

The mirror test's spec-resource block asserted `implementation_jvm` and `cljs_node_test`
and **nothing else** — there was no `cljs_browser` assertion, despite the landed comment
saying the two files "pin each other". Demonstrated rather than assumed: with the arm
narrowed and no assertion added, the suite passed at **an unchanged 292**, exit 0. The
block now asserts `cljs_browser` too, so a re-add reds the suite instead of passing
unnoticed.

## Quality gates

All exit codes below were captured by the running shell (`echo "$?"` on the same command
line as the redirect), never read from a harness report.

| Gate | Result | Captured exit |
|---|---|---|
| `node scripts/_changed-surfaces.test.cjs` — control, pre-change | 292 passed | **0** |
| Planted fault A: `implementation_jvm=PLANTEDFAULT` in the arm | **4 failed**, naming `PLANTEDFAULT` and "the reader change must run its own race control (jvm-spec-resource)" | **1** |
| Narrowed arm, assertion NOT yet added (the hole) | 292 passed — routing change invisible | **0** |
| `node scripts/_changed-surfaces.test.cjs` — final, both files | 292 passed | **0** |
| Planted fault B: `cljs_browser=true` re-added to the arm | **4 failed**, naming the new assertion "no browser namespace reaches this reader…" | **1** |
| `npm run test:script-policy` (full chain, 30+ policy tests) | all passed | **0** |
| `bash -n .github/scripts/report-changed-surfaces.sh` | parse OK | **0** |
| `python scripts/check_workflow_yaml.py` | PASS, 11 files | **0** |
| `python scripts/check_fast_pr_gap.py --list` | 96 required checks the spine does not run | **0** |
| `scripts/test-fast-pr.sh` — attempt 1 | 41 passed, **1 FAIL**: `Cannot find module 'shadow-cljs/cli/runner.js'` — worktree had no `node_modules`, environmental | **1** |
| `scripts/test-fast-pr.sh` — attempt 2, on the final rebased base | **0 FAIL lines.** JVM `implementation/core` 2243 tests / 11681 assertions, CLJS node 11756 tests / 59627 assertions, 0 failures 0 errors each | **0** |

**The spine ran, in full.** It does not split — its tiers are selected by the classifier
itself, with no per-tier CLI flag or env override — so it was detached and polled in a
bounded loop within the same turn. Plan for this diff: docs skipped, JVM tier
`implementation/core`, node/CLJS suite, clj-kondo. Attempt 1 failed only for a missing
`implementation/node_modules` in a fresh worktree; a junction to the primary checkout's
real one was created for attempt 2, then removed with `cmd /c rmdir` (the link, never the
target) and the primary's `node_modules` re-verified intact afterwards.

**Targeted gates run directly**, beyond the spine: the mirror test itself (the surface's
own gate), the full `test:script-policy` chain that contains it, `bash -n`, and
`check_workflow_yaml.py`.

**Tree verification, both routes.** Plant A reds naming a fault that existed only in this
worktree, so the run cannot have wandered into a sibling checkout. The spine independently
prints `gate root:` naming this worktree. Restores after both plants were verified by
`git hash-object` against the committed object, not by reading a diff — plant A restored
to `e7d920b0`, plant B to `327785bc`, both byte-exact.

**Rebase.** Rebased onto `fd490a29` and the gates re-run there. The two commits main
gained touch only `.beads/issues.jsonl`; the merge-base diff was read for reverts and
contains nothing but the two files below.

## Refused / out of fence

* `.github/workflows/**` untouched — this changes what the classifier emits, not the jobs
  that consume it. No job needed to change: `cljs-browser` is already `if:`-gated on the
  output, so it simply stops firing for this surface.
* `implementation/spec-resource/deps.edn:10` and `spec_resource_test.clj:31-33` left alone
  — they say "two consumers" about resolver race semantics, not live consumer count, and
  are correct as written.
* Item 1 of the bead's remainder (`implementation/spec-resource/deps.edn:4-6`, the fifth
  prose instance) is outside this fence and remains open on rf2-7b1ti.

## One thing noticed, deliberately not fixed here

`implementation/scripts/_browser-dom-lane-partition.test.cjs:6-14` (wired into
`test:script-policy`) describes `:browser-test` as partitioned against a
`browser-test-freehand-bench` build id with a negative lookahead excluding
`re-frame.freehand.bench.*`. Neither that build id nor any lookahead exists in the live
`shadow-cljs.edn`, whose regexp is a plain `.*-dom-cljs-test$` — the same class of
retirement residue as this bead, in a neighbouring file. The suite is green, so this is
stale prose rather than a broken gate. Out of fence; worth its own bead.
