### PR TITLE
docs(readmes): stop two READMEs teaching a deleted substrate as live (rf2-0yp7w.9)

### DIFF
--- a/implementation/adapters/reagent/README.md
+++ b/implementation/adapters/reagent/README.md
@@ -2,7 +2,7 @@
 
 Maven artefact: `day8/re-frame2-reagent`. Target: Reagent 2.x on React 19. Public ns: `re-frame.adapter.reagent`.
 
-This is the stock-Reagent adapter — a first-class, actively-supported view substrate for re-frame2, and the canonical adapter the reference test suite runs against. (`re-frame.ui` is a *new, experimental* compiled-view substrate offered alongside it, not a replacement — [EP-0030](../../../docs/EP/EP-0030-the-compiled-view-substrate-program.md) Resolved Decisions, 2026-07-17.) It implements the contract from [Spec 006 — Reactive substrate](../../../spec/006-ReactiveSubstrate.md) on top of Reagent's RAtom/Reaction graph and React commit lifecycle.
+This is the stock-Reagent adapter — a first-class, actively-supported view substrate for re-frame2, and the canonical adapter the reference test suite runs against. (Hicasso — re-frame2's own native view layer, [EP-0038](../../../docs/EP/EP-0038-the-hicasso-view-layer-programme.md) — sits alongside the adapter tier, not as a replacement for it.) It implements the contract from [Spec 006 — Reactive substrate](../../../spec/006-ReactiveSubstrate.md) on top of Reagent's RAtom/Reaction graph and React commit lifecycle.
 
 See [`../README.md`](../README.md) for the wider adapter tier and the substrate contract; [Spec 004 — Views](../../../spec/004-Views.md) for `reg-view` / `reg-view*` semantics.
 

--- a/implementation/hicasso/resources/clj-kondo.exports/day8/re-frame2-hicasso/README.md
+++ b/implementation/hicasso/resources/clj-kondo.exports/day8/re-frame2-hicasso/README.md
@@ -201,17 +201,17 @@ at all** and none of `:aria-label`, `:aria-labelledby` or `:title`. Such an
 element has no accessible name and a screen reader announces it as an
 unlabelled control.
 
-The tag set and the `href` condition are taken from this project's compiled
-substrates rather than invented here — `re-frame.ui.compiler.a11y`'s
-`:rf.ui.compile/a11y-missing-accessible-name` names a `<button>` always and an
-`<a>` only when it is a real link — so the two agree about what a nameless
+The tag set and the `href` condition were inherited from this project's retired
+compiled-view substrate rather than invented here — `re-frame.ui.compiler.a11y`'s
+`:rf.ui.compile/a11y-missing-accessible-name` named a `<button>` always and an
+`<a>` only when it was a real link — so the two agreed about what a nameless
 control is. An `<a>` without `href` is not focusable and not a link.
 
 **Refuses to know:** what any child renders. One child of any kind — even a
 symbol that turns out to be an icon with no text — makes this silent, because
 it may well render text. Dynamic props answer the same way: the name may be in
-there. `:input`, `:select` and `:textarea` are in that compiler pass's set and
-deliberately absent here: their name usually comes from a sibling
+there. `:input`, `:select` and `:textarea` were in that compiler pass's set and
+are deliberately absent here: their name usually comes from a sibling
 `<label for=…>`, which is a fact about the tree rather than about the element.
 The real accessibility pass is a separate piece of work; this is one always-
 right corner of it.


### PR DESCRIPTION
R6 prose sweep (rf2-0yp7w.9), README slice. `re-frame.ui` and `re-frame.freehand` were retired and removed by PR #8322; `git ls-files implementation/freehand/ implementation/ui/` returns 0 lines at this base.

Three files were in fence. **Two repaired, one refused in full**, plus one out-of-fence file censused and verified correct.

## What changed

### `implementation/adapters/reagent/README.md:5` — the one that mattered

The front page of a first-class, actively supported adapter told a consumer, in the present tense, that `re-frame.ui` "is a *new, experimental* compiled-view substrate offered alongside it, not a replacement". It is deleted. This line had been named by three earlier slices and repaired by none, because it sits under no `src/` and no skills tree and was correctly fenced out of each.

The sentence was quoting EP-0030's abstract almost verbatim — and EP-0030 now opens with its own banner: "**Historical record — 2026-07-30.** This programme's compiled substrate was absorbed into Freehand, and Freehand … is now **withdrawn**." So the README was citing as live a source that brackets itself as history.

The parenthetical's *question* is still live, though: a consumer wants to know whether this adapter is being superseded. So it now names the substrate that actually sits beside the adapter tier, sourced to EP-0038 (`Status: accepted`; its abstract says the programme is "not a rewrite mandate") and phrased to match `implementation/README.md`'s already-landed wording ("Reagent, reagent-slim and UIx live on as first-class, actively-supported adapters").

No donor-era normative text is re-aimed at Hicasso — rf2-0yp7w.11 rules that out, and nothing here describes Hicasso's contract or calls it "compiled-view".

### `implementation/hicasso/resources/clj-kondo.exports/…/README.md:204-213`

Credited its lint rule's tag set to "this project's compiled substrates" (present tense — the project has none; Hicasso is interpreted Hiccup per EP-0038) and cited `re-frame.ui.compiler.a11y`'s `:rf.ui.compile/a11y-missing-accessible-name` as a live sibling rule that "names" and presently "agree[s]". `:rf.ui.compile/*` is a struck-through RETIRED tombstone family in `spec/Conventions.md`.

The provenance is genuine and worth keeping, so **the donor namespace is deliberately retained**; only the tense and the liveness claim move (`were inherited` / `retired compiled-view substrate` / `named` / `agreed`). Per the epic's discrimination, historical naming of a deleted artefact stays.

## What was refused, with reasons

* **`implementation/hicasso/test/re_frame/bench/hicasso/README.md:92`** — "Hicasso had two contemporaries — `re-frame.ui` and `re-frame.freehand` — and both were retired and removed from the tree." Past-tense history under a heading literally named "Where this sits in the wider record", pointing at `docs/design/retirement/donor-surfaces.md`. Correct as it stands. **Left.**
* **`…/bench/hicasso/README.md:76`** — states that `frozen-sources.edn`'s `:forbidden-import-prefixes` bars `re-frame.bench.` and `re-frame.freehand.`. Verified against `implementation/hicasso/frozen-sources.edn:235`, which reads exactly `:forbidden-import-prefixes ["re-frame.bench." "re-frame.freehand."]`. A donor name quoted from a **live guard's declared content** is not residue. **Left.**
* **`implementation/README.md:41,162`** — outside the fence, but censused because it carries donor hits the brief did not name. Both are already past tense and correct ("were retired and removed under rf2-0yp7w"; "which rf2-0yp7w then moved out of freehand/ to test/re_frame/bench/hicasso/"). **No change needed** — reported so the next slice does not re-derive it as work.

## The freeze trap — checked before editing, not after

Neither hicasso README is pinned. `implementation/hicasso/frozen-sources.edn` carries **one** row (`front/slot.cljc` ↔ `src/re_frame/hicasso/impl/slot.cljc`) and no `.md` at all — `grep -F README` over the manifest exits 1 (the same grep finds `slot.cljc` 6 times, so the pattern is not silently failing). `check_freeze.py`'s SEALED scan walks source files' `:require` forms and its own header says "Prose may name one — a docstring citing the witness that pins a behaviour is worth keeping". So no prose edit in these files can reach the freeze gate. `frozen-sources.edn` was not touched and no row was re-pinned or retired; that decision belongs to rf2-o9yo4.

## Which gates actually cover this surface

**The brief nominated `check_doc_slugs.py`, and that gate does not read these files.** `DEFAULT_ROOTS` is `("docs", "spec", "skills", "migration")` plus `tools/*/spec`; `implementation/` is not a root. Measured rather than asserted:

* Plant A — an untracked `docs/__tmp-plant-….md` with a broken target: **exit 1**, naming that file. It existed only in this worktree, so the gate read this tree, and it bites.
* Plant B — the same class of broken target planted **in `implementation/adapters/reagent/README.md`**: **exit 0, green**. That is the measurement: the gate does not cover the path.

The gate that *does* cover it is **`scripts/check_readme_links.py --ci`**, run in `test.yml`'s `verify-readme-links` job, whose scope comment reads "every README.md outside the docs/spec/migration/skills/ surface … plus tools/*/spec/". Proven against a plant at the line this PR edits.

`mkdocs build --strict` **cannot see these files at all** — not via `exclude_docs` (which lists `tools/playground/`, `migration/from-re-frame-v1/codemod/`, `migration/reagent-to-hicasso/codemod/`, `design/freehand/`, `design/hicasso/`, `design/retirement/`, none of them these paths) but because `docs_dir: docs` and `implementation/` was never in the docs tree. `mkdocs_hooks.py:30` records it as "implementation/ (CLJS source; not docs)" and rewrites links into it to GitHub blob URLs.

No gate validates the *prose* of these three files (`check_lint_export.py` asserts the clj-kondo README merely exists). The classification was therefore done by hand and by source: every donor hit in fence was read in context, and the counts are stated above.

## Quality gates

All exit codes below were **captured** with the redirect and `echo $?` on one command line, never taken from the harness.

| Gate | When | Captured exit |
|---|---|---|
| `npm run test:hicasso-invariants` | control, before edits | **0** — `OK: 1 frozen row(s) match the bench tree` |
| `npm run test:hicasso-invariants` | after edits | **0** — same line, freeze intact |
| `python scripts/check_doc_slugs.py` | control | **0** |
| `python scripts/check_doc_slugs.py` | plant A (untracked doc, broken target) | **1** — named the planted file |
| `python scripts/check_doc_slugs.py` | plant B (broken target in reagent README) | **0** — measured non-coverage |
| `python scripts/check_doc_slugs.py` | after edits | **0** |
| `python scripts/check_readme_links.py --ci` | after edits | **0** |
| `python scripts/check_readme_links.py --ci` | planted broken link at README:5 | **1** — `BROKEN TARGET: implementation\adapters\reagent\README.md:5` |
| `python scripts/check_readme_links.py --ci` | after restore | **0** |
| `npm run test:hicasso-invariants` | **re-run on rebased base** | **0** — freeze intact |
| `python scripts/check_readme_links.py --ci` | **re-run on rebased base** | **0** |
| `python scripts/check_doc_slugs.py` | **re-run on rebased base** | **0** |
| `npm run test:cljs` | CLJS lane, direct | **0** — 11756 tests / 59627 assertions, 0 failures 0 errors |
| `scripts/test-fast-pr.sh` | **full spine, rebased base, attempt 3** | **0** — 0 FAIL lines in 4486 |

Spine attempt 3 detail, all on the rebased base: clj-kondo `errors: 0, warnings: 2110`; JVM `implementation/core` 2243 tests / 11681 assertions, 0 failures 0 errors; JVM `implementation/hicasso` 3 tests / 92 assertions, 0F 0E; CLJS node 11756 tests / 59627 assertions, 0F 0E; `mkdocs --strict` built in 16.92s; hicasso invariants, lint-export and bench-lane compile gates all green.

**Two earlier spine attempts did not produce that verdict, and both are reported rather than dropped.** Attempt 1 ran on the pre-rebase base and was killed deliberately when the trunk moved — its exit file is **ABSENT**, which is no verdict rather than a pass, and it is not quoted for anything. Attempt 2, on the rebased base, captured exit **1**: `compile-node-test: could not resolve shadow-cljs: Cannot find module 'shadow-cljs/cli/runner.js'`. That is environmental — a freshly created worktree has no `implementation/node_modules` — not a test failure, and the diff contains zero CLJS. The lane was then run directly and green (above), the environment completed, and the whole spine re-run to attempt 3's exit 0. Attempt numbers are in the artefact filenames so a killed run's orphan cannot write into a later attempt's log or exit file.

**On attempt 2 the harness reported exit 0 while the captured code was 1.** Every number in this table is the captured one, taken from the runner's own command line with the redirect and `echo $?` in a single shell.

Restores verified by content hash against the committed object, not by reading a diff: `aa048a74a7…` before/after plant B, and `0a46ae322e…` before/after the readme-links plant — equal to `git rev-parse HEAD:implementation/adapters/reagent/README.md` in both cases, with `git status --porcelain` clean.

Pattern controls for the census reproduce the values this bead's comments record: positive control `docs/design/retirement/freehand-and-ui.md` = **93**, negative control `README.md` = **0**.

**Spine.** `scripts/test-fast-pr.sh` printed `gate root: /…/re-frame2-worktrees/readmes-0yp7w9` — this worktree, which is the root-banner route for a gate too heavy to plant against. Its classifier armed the JVM and CLJS tiers because the diff's paths sit under `implementation/adapters/reagent/` and `implementation/hicasso/`, even though both changed files are markdown. `python scripts/check_fast_pr_gap.py --list` (captured exit 0) reports **96 required checks the spine does not run** — green here is not green in CI. The spine did run, in full, to exit 0.

**Rebased onto the current trunk** (`467528f1bf` → `fd490a2913`) and every gate above re-run on that final base. The trunk's only gain in the interval was a beads checkpoint, and `git diff --name-only 467528f1bf..fd490a29 -- implementation/adapters/reagent/README.md implementation/hicasso/` is empty, so no sibling touched these files.

Fence honoured: no `implementation/*/src/**`, no `frozen-sources.edn`, no `spec/**`, no `.github/**`, no `docs/**`, no `.beads/**`, and no code of any kind. The three-dot diff against the merge base is 2 files, +7/-7, reverting nothing a sibling landed.
