### PR TITLE
docs(hicasso): repair slot.cljc's frozen freehand pointer; docs/api slice refused (rf2-o9yo4, rf2-0yp7w.9)

### DIFF
--- a/implementation/hicasso/src/re_frame/hicasso/impl/slot.cljc
+++ b/implementation/hicasso/src/re_frame/hicasso/impl/slot.cljc
@@ -56,6 +56,32 @@
   emission concerns and stay in the codec. This namespace holds the pure
   rule and its two vocabularies, and requires nothing but
   `clojure.string`."
+  ;; rf2-o9yo4 — THE SECTION ABOVE NAMES A DIRECTORY THAT NO LONGER EXISTS,
+  ;; and this note is the repair rather than an edit to it.
+  ;;
+  ;; `implementation/freehand` was removed by rf2-0yp7w. The JVM arm of the
+  ;; cross-host corpus now runs from `implementation/hicasso` — that
+  ;; artefact's `:test` alias, over
+  ;; `test/re_frame/bench/hicasso/front/slot_cljs_test.cljc`, gated on every
+  ;; PR as `test.yml`'s unconditional `jvm-hicasso` job. The CLJS arm is
+  ;; unchanged, and that suite's own docstring states the pair correctly.
+  ;;
+  ;; THE SENTENCE ITSELF IS NOT EDITED BECAUSE IT CANNOT BE. This file is the
+  ;; last row in `frozen-sources.edn`, and the freeze gate reconstructs it
+  ;; from the donor line by line — a docstring is a string and a string is
+  ;; code, so rewriting that line reds MOVED. None of the manifest's three
+  ;; responses is free either: the donor says `implementation/freehand` at
+  ;; the same line, so there is nothing to port; back-porting into the donor
+  ;; would falsify a MEASURED artefact; and retiring the row triggers the
+  ;; manifest's sunset clause, which takes SEALED — the package-wide bar on
+  ;; shipped source importing the bench tree — with it. rf2-o9yo4 holds that
+  ;; decision.
+  ;;
+  ;; An INSERTED COMMENT LINE is the one addition MOVED licenses, which is
+  ;; what makes this note legal where the edit is not. If you arrived here
+  ;; from a grep for `freehand`, this is the answer: read the sentence above
+  ;; as history, because the suite really did run there when the readings the
+  ;; package's budgets are set against were taken.
   (:require [clojure.string :as str]))
 
 (def ^:private dont-camel-case


### PR DESCRIPTION
Two beads. One lands a repair; one lands a **verified refusal** — the premise
does not hold, and that is the deliverable.

## rf2-o9yo4 — the frozen docstring, repaired without unfreezing the row

**Both halves of the premise verified at source.**
`implementation/hicasso/src/re_frame/hicasso/impl/slot.cljc:37` does still say
``clojure -M:test`` in ``implementation/freehand``; `git ls-files
implementation/freehand` returns 0; and the replacement the bead claims is true
of the tree now —
`implementation/hicasso/test/re_frame/bench/hicasso/front/slot_cljs_test.cljc`
exists, `implementation/hicasso/deps.edn`'s `:test` alias runs it, and
`test.yml`'s unconditional `jvm-hicasso` job gates it. **That suite's own
docstring already states the pair correctly** ("once by `npm run test:cljs` in
Node and once by `clojure -M:test` on the JVM, in `implementation/hicasso`"), so
only the frozen package copy lagged.

**The title's claim reproduced, locally, on this branch.** Editing line 37 to
say `implementation/hicasso` reds the freeze gate with the message #8485 hit in
CI, character for character — `MOVED … at package line 37, 1 donor line(s)
rewritten as 1`. That run is the negative control as well as the reproduction:
the fault existed only in this worktree, so a gate that had read a sibling
checkout would have come back green.

**Option (a)'s unverified escape is real, and better than it guessed.** The bead
wondered whether `check_freeze.py` "can tolerate an addition outside the pinned
region". There is no outside — the pinned unit is the whole file — but
`compare_moved` accepts a pure `insert` opcode whose every line matches
`^\s*;`. That is not a loophole: the gate's own module docstring states it
("the package may INSERT lines the donor lacks, and every inserted line must be
a COMMENT"), and its `--self-test` exercises both directions, asserting that an
inserted line of *code* reds and an inserted *comment* greens.

So the repair goes in as a comment block between the docstring and the
`:require` — the shape `implementation/ssr/src/re_frame/ssr/emit.cljc` already
uses, and the only such position with precedent here (0 of 322
`implementation/*/src` files open with a comment above the `ns` form). It says
where the JVM arm runs now, **and** why the line below it must not be edited, so
the next `freehand` grep stops here instead of re-reding CI.

**Nothing else moves.** `frozen-sources.edn` is untouched — no row re-pinned, no
row retired, the sunset clause not triggered, and `SEALED` keeps its
package-wide bar on shipped source importing the bench tree. The donor is
untouched, so the measured-artefact rule stands. **No manifest decision was
taken; the need for one was removed.**

Residual, stated rather than hidden: a REPL `doc` call still shows the
historical sentence, because comments are not docstrings. This is an `impl.*`
namespace and explicitly not a consumer surface, and the alternative costs
either a falsified measurement artefact or the retirement of a live gate.

## rf2-0yp7w.9, docs/api slice — REFUSED, on two counts

No file changed. The slice's instruction was "regenerate, never hand-edit".

**1. `docs/api/*.md` is NOT generated.** Nothing in the repo writes it. The
api-manifest chain's only writer is `gen.clj:430`, a `spit` whose target is
`spec/api-manifest.edn`. `doc_api_check.clj` is read-only — its `-main` takes no
arguments, so there is no `--write` or `--update` mode — and it *reconciles*
`docs/api/` against the manifest rather than emitting it. No page carries a
generated banner. These are hand-authored reference pages with a CI-enforced
completeness check over them, so "run the generator" names nothing that exists.

**2. The 12-file census is stale, and the 2 survivors are both live-true.**
Measured at this tip, case-insensitively and with `re-frame.ui` word-bounded so
the `re-frame.uix` collision cannot inflate it: **2 files, 2 hits**. The other
ten were cleaned by landings that came after the census — `ef3131f4a2`,
`c951808b47`, `0042a14fe2` and `ae322bc900` (rf2-usulq, "unpoint the API
pages"). Positive control on the same patterns over `docs/design/freehand/`: 37
and 21 files. Negative control `re-frame.uix` in `docs/api/`: 0.

Both survivors were adjudicated at source, not by eye:

- **`re-frame.core.md:845`** — `:rf.adapter/ui` and `:rf.adapter/freehand` "stay
  reserved … but the two donor view substrates were removed on 2026-08-16 and
  nothing produces either value now". Correct, and it agrees with its owning
  spec verbatim: `spec/Conventions.md:103` carries the same reservation, and
  `implementation/core/src/re_frame/substrate/adapter.cljc:27` says it in
  source. The one live use is a *defensive refusal* set
  (`tools/xray/…/mount.cljs:233`), which is a consumer of the value rather than
  a producer — so "nothing produces either value" holds as written.
- **`re-frame.ssr.md:59`** — `:rf.error/ssr-ui-tree-version-unsupported` and
  `:rf.ui/tree-version`. Both **live**:
  `implementation/ssr/src/re_frame/ssr/ui_tree.cljc` throws that id, and
  `:rf.ui/tree-version` is the wire key the SSR seam and Hicasso's test kit both
  use today. This is the `:rf.ui` trap PR #8485 warned about — a name that is
  dead in one sense and live in another.

So the donor text is not upstream of a generator; there is no residue here at
all. Left untouched, as fenced: `spec/` (hot zone, behind rf2-h89ri) and
`docs/design/freehand/` (ruled KEEP by rf2-0moc4). **rf2-0yp7w.9 stays open** —
this was one of its three remaining items.

## Quality gates

Every exit code below was **captured in the same shell as the runner**
(`cmd > log 2>&1; echo $? > exit`), never read from the harness, and never taken
through a pipe. All re-run on the **rebased** base (`10a251268b`); the
pre-rebase runs agreed.

| Gate | Captured exit | Result |
|---|---|---|
| `npm run test:hicasso-invariants` (whole chain, from `implementation/`) | **0** | `OK: 1 frozen row(s) match the bench tree, and each package file is its donor moved; no package file imports it.` 0 `FAIL` lines |
| `python hicasso/scripts/check_freeze.py --self-test` | **0** | `OK: check_freeze self-test passed` |
| **SABOTAGE** — line 37 rewritten to `implementation/hicasso` | **1** | `MOVED … at package line 37, 1 donor line(s) rewritten as 1`, naming the plant |
| restore, then `check_freeze.py` again | **0** | green |
| `clojure -M:test` in `migration/reagent-to-hicasso/codemod` | **0** | 54 tests / 490 assertions, 0 failures, 0 errors |
| `clojure -M -m re-frame.api-manifest.doc-api-check` | **0** | 307 public-var references in sync; 158 eligible vars each have a page + member entry |
| `python scripts/check_doc_slugs.py` | **0** | green |
| `clojure -M:clj-kondo --lint src` in `implementation/hicasso` | **0** | errors 0, warnings 0 |

**Restore verified by content hash, not by reading a diff.** `git hash-object`
before the plant and after the restore both give
`28b59e7d4a2a72048e3dacb62ef03d43d2ab773f`, equal to `git rev-parse` on the
committed object. Using git's own content hash rather than a plain byte digest
matters here: this checkout translates line endings (`core.autocrlf=true`) and
the file is CRLF on disk.

**Which tree the gates read is proven by the red, not by a banner.** The freeze
gate prints no root. The planted fault existed only in this worktree, the gate
reddened naming exactly that plant, and it greened again on restore.

**The `clojure -M:test` run is the reader proof.** The added lines sit *inside*
the `ns` form, so "does the file still read?" is a real question.
`shared_rule_test.clj` requires `re-frame.hicasso.impl.slot` over the codemod's
`../../../implementation/hicasso/src` classpath entry and asserts
`(identical? dest/canonical-slot slot/prop-name)` — it loaded this worktree's
edited copy on the JVM and passed.

**Not run, with reasons.** `mkdocs build --strict` — no file under `docs/` is
touched by this branch, and `mkdocs_hooks.py` records `implementation/` as "CLJS
source; not docs", so it cannot see the one file that changed. `npm run
test:cljs` — the change adds only comment lines, the reader accepted them on the
JVM above, and the CLJS reader treats `;` identically. **No anchors or table
columns were edited**, in `docs/api/` or anywhere else: this branch changes one
`.cljc` file and no markdown, so the hand-verification a `docs/api/` edit would
have required does not arise.

**Merge-base diff read before pushing** (three-dot against `origin/main`): 1
file, 26 insertions, 0 deletions. Nothing a sibling landed is reverted.
