### PR TITLE
docs(hicasso): state the supported versions where a consumer can read them (rf2-hic-061)

### DIFF
--- a/docs/core/hicasso/00-installation.md
+++ b/docs/core/hicasso/00-installation.md
@@ -69,10 +69,10 @@ checked against. **React 18 is not supported**: nothing tests Hicasso there, and
 the Activity half of the contract has nothing to run on. A bare
 `npm install react react-dom` resolves to whatever is current that day, which is
 the other half of why the pin is written out. **And keep `shadow-cljs` in
-`devDependencies`**
-even though the JVM dependency above is what compiles: the npm package is where
-the `process` shim React's CommonJS build asks for comes from, and without it
-the build stops at `The required JS dependency "process" is not available`.
+`devDependencies`** even though the JVM dependency above is what compiles: the
+npm package is where the `process` shim React's CommonJS build asks for comes
+from, and without it the build stops at
+`The required JS dependency "process" is not available`.
 
 Hicasso interprets Hiccup at runtime, so it needs no compiler hook, macro
 allow-list, or build flag. A normal shadow-cljs browser build is enough:

--- a/docs/core/hicasso/00-installation.md
+++ b/docs/core/hicasso/00-installation.md
@@ -59,11 +59,17 @@ launcher come from npm:
 npm install
 ```
 
-Both npm lines earn their place. **Pin React**: Hicasso needs 18 or newer — it
-mounts through `createRoot`, and `:identifier-prefix` sets what `useId` answers
-— and 19.2 is what the reference implementation runs and what this chapter is
-checked against, whereas a bare `npm install react react-dom` resolves to
-whatever is current that day. **And keep `shadow-cljs` in `devDependencies`**
+Both npm lines earn their place. **Pin React, and pin it at 19.2 or newer.**
+Hicasso mounts through `createRoot` and lets `:identifier-prefix` decide what
+`useId` answers, both of which React has offered since 18 — but the lifecycle
+contract Hicasso holds itself to is written against
+[`<Activity>`](https://react.dev/reference/react/Activity), which shipped in
+19.2, and 19.2 is the pair the reference implementation runs and this chapter is
+checked against. **React 18 is not supported**: nothing tests Hicasso there, and
+the Activity half of the contract has nothing to run on. A bare
+`npm install react react-dom` resolves to whatever is current that day, which is
+the other half of why the pin is written out. **And keep `shadow-cljs` in
+`devDependencies`**
 even though the JVM dependency above is what compiles: the npm package is where
 the `process` shim React's CommonJS build asks for comes from, and without it
 the build stops at `The required JS dependency "process" is not available`.
@@ -101,6 +107,39 @@ The main namespace is `re-frame.hicasso`, conventionally required as `h`.
 Forms, overlays, motion, routing, the native tier, and the test kit use separate
 namespaces. A build that does not require an optional module does not include
 its code.
+
+## Supported versions
+
+The pins above are not arbitrary, and this table says what stands behind each of
+them. **Tested** means a gate in the re-frame2 repository runs Hicasso against
+that combination. **Expected** means the code has no version-conditional branch
+that would make it fail there, but nothing measures it — a reasonable bet rather
+than a promise. Nothing here is forbidden; the distinction is only between what
+is checked and what is not.
+
+| Combination | Tested | Expected, but unmeasured |
+| --- | --- | --- |
+| React and react-dom | 19.2.0, on every browser and Node lane Hicasso runs | Later 19.x, for the render boundary and the two-hook contract. Below 19.2 the `<Activity>` lifecycle rows have nothing to run on, and 18 and earlier is not supported at all |
+| Browser engine | Chromium, on the headless DOM lane. Firefox and WebKit, whenever a change touches the Hicasso surface | Any other engine or version — the substrate targets React's DOM contract rather than any one browser's |
+| ClojureScript and shadow-cljs | 1.12.145 and 3.4.10 | Nothing else is measured |
+| re-frame2 core and `re-frame2-ssr` | the same checkout as Hicasso, which `:local/root` is what guarantees | There is no released coordinate yet, so no released-version pair exists to be compatible with |
+
+The full matrix — every row above, plus the platform axis and the named CI job
+or explicit untested-but-expected label behind each one — is maintained in the
+repository as the Hicasso release policy, under
+`docs/design/hicasso/product/release-policy.md`. That page is a working design
+record rather than part of this site, so it is read from a checkout.
+
+**Upgrades before 1.0 may cost you a rename, and should not cost you a
+rethink.** Every published artifact ships at the same version through 1.0, and
+the project ships no back-compatibility shims: a renamed or removed door is a
+compile error at your own call site rather than a deprecation warning, so the
+compiler enumerates every site that has to move. What is genuinely promised in
+the meantime is the complaint ids — an id never changes meaning or spelling, and
+a retired one is never reused — because stored errors and monitoring rules
+outlive the code that raised them. The
+[complaint index](troubleshooting.md#the-complaint-index) is the list those
+promises are about.
 
 ## Hicasso needs a substrate adapter
 

--- a/docs/design/hicasso/product/release-policy.md
+++ b/docs/design/hicasso/product/release-policy.md
@@ -165,6 +165,16 @@ reports what it read.
 Every row carries either the CI job that backs it or an explicit **untested-but-expected** label, per
 `rf2-hic-061`'s acceptance. A row with neither would be a claim, and this page makes none.
 
+**This table has a consumer-facing abridgement, and the two must agree.** `mkdocs.yml`'s `exclude_docs`
+keeps `docs/design/hicasso/` out of the published site, so a consumer reading the guide cannot reach this
+page at all — which is how the guide came to tell readers Hicasso *"needs 18 or newer"* while this table
+said React 18 is **NOT SUPPORTED**. The abridgement now lives in
+[`docs/core/hicasso/00-installation.md` §Supported versions](../../../core/hicasso/00-installation.md#supported-versions),
+carries the React, browser-engine, ClojureScript and core-pairing rows in the same tested-versus-expected
+terms, and names this page as the full matrix without linking to it. **A change to a version row here is
+therefore a two-file change**, and nothing gates it: the site build never sees this page, and no gate
+compares the two. Whoever re-measures §3 and §4 re-reads that section in the same pass.
+
 | Combination | Pinned where | Backed by | Status |
 |---|---|---|---|
 | React 19.2.0 and react-dom 19.2.0 | `implementation/package.json` | the CLJS node lane in job `cljs`; `cljs-hicasso-controlled`; `cljs-hicasso-hmr` | **TESTED** — every Hicasso claim in this repository is a claim about this pair |


### PR DESCRIPTION
## What this is

A re-derivation of `rf2-hic-061` that found the compatibility surface stated in a
place no consumer can reach, and one reader-facing version claim that contradicted
it. Both are fixed. **No workflow file is touched** — the bead's `.github/workflows/*`
hot-zone flag is not exercised, because no release workflow was required (see below).

## The re-derivation first, because most of this bead is already landed

All three deliverables were already delivered and I verified each at source rather
than trusting the record:

1. **Versioning + release automation** — landed under `rf2-gra70`. Verified:
   `implementation/hicasso/deps.edn` carries `:clein/build` with `:lib day8/re-frame2-hicasso`,
   `:version "../../VERSION"`, `:src-dirs ["src" "resources" "test_kit/src"]`; hicasso is in
   `verify-version-lockstep.sh`'s `ARTEFACTS`/`NON_CORE` arrays; `release.yml` carries a
   `deploy-hicasso` stage. Nothing to add, so nothing was added.
2. **The compatibility matrix** — `docs/design/hicasso/product/release-policy.md` section 4,
   fourteen rows, each carrying a CI job or an explicit label. Verified row-by-row.
3. **The upgrade policy incl. complaint-id stability** — sections 5 to 5.3. Section 5.3's
   refusal to pre-write a minor/major distinction before 1.0 is correct under the pre-alpha
   no-shims stance and is left alone.

**The acceptance criterion remains unmet and is not a worker's to meet.** A tagged
release installable from the artefact is blocked by `rf2-uelji` (DEFERRED to
2026-09-16): Clojars refuses new projects in an unverified group, `day8` is not
reverse-domain and cannot be verified, and the first tag must cut on
`io.github.day8/*` after the rename campaign. Sections 1.1 and 6.1 already record this
correctly. Nothing here claims otherwise, and no release was cut or tagged.

## The defect this pass found

**The compatibility surface was stated nowhere a consumer could read it.**
`mkdocs.yml`'s `exclude_docs` block lists `design/hicasso/`, so the matrix is not part
of the published site. The one version claim the guide did make was wrong, and wrong
in the fail-open direction:

- `docs/core/hicasso/00-installation.md` told readers **"Hicasso needs 18 or newer"**.
- The matrix says **React 18 or earlier is NOT SUPPORTED**, and the lifecycle contract
  is written against `<Activity>`, which shipped in React 19.2
  (`lanes/react-compatibility-notes.md` section "Activity lifecycle witness"; nothing in
  the repo tests Hicasso on 18).

A reader following the installation chapter could pin React 18 and land outside the
supported matrix entirely, with nothing to tell them.

## The change

`docs/core/hicasso/00-installation.md`

- Corrects the React floor to **19.2 or newer**, keeping the `createRoot` / `useId`
  mechanism that explains it and adding the `<Activity>` reason the floor is 19.2 and
  not 18.
- Adds a `## Supported versions` section: a four-row table in the same
  tested-versus-expected terms as the matrix (React, browser engine, ClojureScript /
  shadow-cljs, core+ssr pairing), a statement that the full matrix lives in the
  repository at `docs/design/hicasso/product/release-policy.md`, and the upgrade cost —
  lockstep versioning through 1.0, no back-compat shims, and the complaint-id promise
  pointing at the complaint index.
- The design page is named as inline text, **not linked**: a link from the built site
  into an excluded tree publishes as a 404, which the mkdocs log demonstrates for other
  pages that do it.

`docs/design/hicasso/product/release-policy.md`

- One paragraph in section 4 recording that the matrix now has a consumer-facing
  abridgement, where it is, and that a version-row change is therefore a two-file change
  that no gate compares. That is the drift this pass found, stated where the next
  re-measurement will read it.

## What was deliberately not done

- **No release workflow was added.** `deploy-hicasso` already exists; a
  consumer-from-coordinate preflight cannot run before a coordinate exists, and
  `release.yml` already records that a consumer-compile assertion was scoped and left
  unbuilt. Writing a job that cannot run is worse than the recorded gap.
- **No release was tagged**, and the bead is not closed. Its own audit note and the
  mayor's 2026-08-18 note both say it stays open until the group/coordinate migration
  lands and a real `v*` tag publishes the family.
- **No minor/major deprecation ladder was invented.** Pre-alpha, no shims; section 5.3
  says why.

## Quality gates

The fast-PR spine did **not** run, by dispatch fence — a peer holds the machine for a
bench-class measurement, and two heavyweight runs wedge rather than fail. No
`scripts/test-fast-pr.sh`, no shadow-cljs build, no Playwright, no npm build, no JVM
gate was invoked. The gates below are the targeted ones for this surface and were each
run directly, in the foreground, redirected to a log with the runner's own exit code
echoed on the same command line. Every number quoted is the captured one.

| Gate | Captured exit | Notes |
| --- | --- | --- |
| `python scripts/check_doc_slugs.py` | **0** | Link targets + heading anchors across `docs/`, `spec/`, `skills/`, `migration/` |
| `python scripts/check_provenance_pins.py` | **0** | `121 pages inspected, 661 cited pins ... 0 findings` |
| `python -m mkdocs build --strict` | **0** | `Documentation built in 17.71 seconds`. This is the right gate here because `docs/core/hicasso/00-installation.md` **is** in the nav; built to a scratch `--site-dir` so no `site/` residue lands in the worktree |
| `python scripts/check_fast_pr_gap.py --list` | **0** | Cited per the brief: reports **96** required checks the fast spine does not run — green locally is not green in CI |

**Both plantable gates were proven to reach this worktree, not a sibling's**, since a
green exit on an empty log verifies nothing:

- Planted a broken anchor in `docs/core/hicasso/00-installation.md` (a line this PR
  edits). `check_doc_slugs.py` went **exit 1**, naming
  `BROKEN ANCHOR: docs\core\hicasso\00-installation.md:141 -> troubleshooting.md#rf2-hic-061-planted-fault-anchor`.
  Restored; `git hash-object` returned to `74c44d6f...`, byte-identical.
- Planted a second broken anchor in `docs/design/hicasso/product/release-policy.md`, to
  prove the excluded design tree is scanned by this gate at all. **Exit 1**, naming
  `release-policy.md:172 -> ../../../core/hicasso/00-installation.md#supported-versions-PLANTED-hic061`.
  Restored; hash returned to `b9c7674a...`, byte-identical.
- The fault existed only in this worktree, so a run that had wandered into a sibling's
  would have come back green. Both restores were verified by hashing against the
  committed object, not by reading a diff.

`mkdocs` was verified against its own output rather than by a plant: the built
`core/hicasso/00-installation/index.html` contains `React 18 is not supported` and
**zero** occurrences of the removed `needs 18 or newer`. That pattern is known-good —
it matched the pre-edit file.

**By-hand checks the tooling does not cover.** Nothing validates tables, rendering or
nav in `docs/design/hicasso/`, and this bead ships a matrix, so the column counts were
checked explicitly rather than assumed. Every markdown table in both changed files:

- `00-installation.md` — 2 tables: the new Supported-versions table (3 header / 3
  separator / 4 rows, all 3 cells) and the pre-existing Troubleshooting table (3/3/8).
  **0 mismatches.**
- `release-policy.md` — 3 tables: Where-each-fact-lives (2/2/8), section 3 surface table
  (4/4/6), section 4 matrix (4/4/14). **0 mismatches.**

Anchors were validated mechanically by `check_doc_slugs.py` above (proven discriminating
on both trees), which is stronger than reading them; the one new heading slug,
`#supported-versions`, is exercised by the cross-tree link added to `release-policy.md`.

Diffed against the merge base in three-dot form (`origin/main...HEAD`): exactly two
files, +57/-8, nothing reverted from a sibling's landing.
