### PR TITLE
docs(retire): adjudicate the R6 source/script/docs donor residue — 9 repairs, 6 files refused (rf2-0yp7w.9)

### DIFF
--- a/implementation/core/test/re_frame/error_catalogue_channel_conformance_test.clj
+++ b/implementation/core/test/re_frame/error_catalogue_channel_conformance_test.clj
@@ -1386,10 +1386,14 @@
 ;; `re-frame.subs/subscribe`, `re-frame.router/build-envelope`,
 ;; `re-frame.core/capture-frame`, `rf.ssr/hydrate!`, `rf.http/managed`,
 ;; `rf.machine/spawn`, `rf.route/navigate-handler`, … across core, http,
-;; machines, routing, flows, resources, ssr, freehand and ui — as does the
-;; `where` argument threaded through `require-frame-provider-target!` and
-;; `re-frame.ui.frames/resolve-frame`. There is no keyword producer in src or
-;; in test. Spec 009's row and the schema's own comment both already said
+;; machines, routing, flows, resources and ssr — as does the `where` argument
+;; threaded through `require-frame-provider-target!`. (The census that read
+;; this also covered the two view substrates, whose own producers included
+;; `re-frame.ui.frames/resolve-frame`; both were removed on 2026-08-16 by
+;; rf2-0yp7w and neither the artefacts nor that emitter survive.) There is no
+;; keyword producer in src or in test. The reading is unchanged by the
+;; removal: every surviving producer still emits a quoted symbol.
+;; Spec 009's row and the schema's own comment both already said
 ;; "a SYMBOL … not a keyword"; only the slot disagreed.
 
 (def ^:private no-frame-context-where-mutants
@@ -1470,21 +1474,26 @@
 ;;   FrameDestroyedTags — ONE producer. Only
 ;;     `substrate/observation/throw-frame-destroyed!` stamps `:where`; its three
 ;;     call sites pass `'re-frame.substrate.observation/acquire!` (twice) and
-;;     `'re-frame.substrate.observation/probe`. The other three emitters of this
-;;     category (router, subs, ui/frames) never stamp the slot at all.
+;;     `'re-frame.substrate.observation/probe`. The other emitters of this
+;;     category (router, subs) never stamp the slot at all — there was a third,
+;;     the removed `re-frame.ui`'s `ui/frames`, and it did not stamp it either.
 ;;
 ;;   BadFrameProviderArgTags — the SHARP one, and why the bead was filed rather
 ;;     than left. `frame/require-frame-provider-target!` threads ONE `where`
 ;;     argument into BOTH payloads: the nil branch builds `no-frame-context`
 ;;     (typed `:symbol` by rf2-j4bg3) and the else branch builds this one. Until
 ;;     this change a single argument from a single call site carried two
-;;     different declared types. Nine src call sites, all quoted fn symbols
-;;     (`'re-frame.views.provider/frame-provider`,
+;;     different declared types. THREE src call sites today, all quoted fn
+;;     symbols (`'re-frame.views.provider/frame-provider`,
 ;;     `'re-frame.adapter.uix/frame-provider`,
-;;     `'re-frame.substrate.spine/build-frame-provider-element`,
-;;     `'re-frame.freehand.substrate/frame-provider`, `'v/->react`,
-;;     `'re-frame.ui/frame-provider`, `'re-frame.ui/frame`,
-;;     `'re-frame.ui/->react`), plus `'test/where` / `'test` in test.
+;;     `'re-frame.substrate.spine/build-frame-provider-element`), plus
+;;     `'test/where` in test. It was NINE when rf2-am6qs typed the slot; the
+;;     other six were the two view substrates' providers
+;;     (`re-frame.freehand.substrate/frame-provider`, `v/->react`,
+;;     `re-frame.ui/frame-provider` twice — once via `require-scope-frame!` —
+;;     `re-frame.ui/frame`, `re-frame.ui/->react`) and went with them on
+;;     2026-08-16 (rf2-0yp7w). Every survivor is still a quoted symbol, so the
+;;     reading that chose `:symbol` is narrowed, not overturned.
 ;;
 ;;   ResourceSsrBlockingTimeoutTags — ONE producer, one emit:
 ;;     `re-frame.resources.ssr/settle-blocking-timeout` stamps its own quoted

--- a/implementation/hicasso/test/re_frame/hicasso/consumer_app.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/consumer_app.cljs
@@ -40,7 +40,8 @@
 
   ## Why it lives under `test/`
 
-  For the reason the sibling `re-frame.freehand.release-app` does:
+  For the reason the removed `re-frame.freehand.release-app` did (rf2-0yp7w
+  deleted it with its tree; the reason is the package layout, not the donor):
   `hicasso/deps.edn` publishes `src` and `resources` alone, so a fixture
   that exists to be compiled stays out of the artefact a consumer
   resolves, while shadow-cljs — which carries `hicasso/test` on

--- a/implementation/hicasso/test_kit/src/re_frame/hicasso/test.cljs
+++ b/implementation/hicasso/test_kit/src/re_frame/hicasso/test.cljs
@@ -71,10 +71,12 @@
   [`spec/004B-UI-Tree-and-Conversion.md`](../../../../../../spec/004B-UI-Tree-and-Conversion.md)
   §The node schema already pins — the same closed node set, the same
   discrimination order, the same `:rf.ui/tree-version` root gate, the
-  same `{:rf.ui/opaque :fn}` sentinel — so a tree from a Hicasso body and
-  a tree from a Freehand declaration are the same VALUE KIND and read
-  with the same vocabulary. rf2-hic-020 audited that schema before
-  writing anything and reuses it whole; the projections below carry
+  same `{:rf.ui/opaque :fn}` sentinel — so the tree a Hicasso body answers
+  is 004B's own VALUE KIND, read with 004B's vocabulary rather than one
+  invented here. That was a CROSS-SUBSTRATE claim when it was written: a
+  tree from a Freehand declaration was the same kind, until rf2-0yp7w
+  removed that substrate on 2026-08-16. rf2-hic-020 audited that schema
+  before writing anything and reuses it whole; the projections below carry
   `re-frame.freehand.test`'s semantics for the same reason.
 
   Two things the audit found are stated rather than left to be

--- a/implementation/routing/test/re_frame/routing_path_census_test.clj
+++ b/implementation/routing/test/re_frame/routing_path_census_test.clj
@@ -61,9 +61,11 @@
   scanned from 101 to 231 and the claims found from 39 to 39.
 
   So the reader is now `clojure.tools.reader` at `:features #{:cljs}` over the
-  whole file — the same instrument `re-frame.freehand.compiler.harvest` reads
-  ClojureScript source with, and on the classpath for the same reason (it
-  ships with `org.clojure/clojurescript`, a hard dep of core). Reading forms
+  whole file — on the classpath because it ships with
+  `org.clojure/clojurescript`, a hard dep of core, so reading CLJS source
+  structurally costs no new dependency. (`re-frame.freehand.compiler.harvest`
+  read source with the same instrument for the same reason; it was removed
+  with its tree on 2026-08-16, rf2-0yp7w.) Reading forms
   rather than lines answers the load-time question STRUCTURALLY:
 
     - The walk descends the whole file but never into a function body — `fn`,
@@ -243,8 +245,8 @@
   namespace-load time.
 
   Framework and tool testbeds are deliberately outside this list: they compile
-  into their own bundles (`:node-test-freehand`, the per-tool testbed builds),
-  so a path they share with an example is not a collision."
+  into their own bundles (`:node-test-testbed-support`, the per-tool testbed
+  builds), so a path they share with an example is not a collision."
   ["examples"
    "testbeds"
    "implementation/hicasso/test"])

--- a/implementation/scripts/_rigorous-local-inventory.test.cjs
+++ b/implementation/scripts/_rigorous-local-inventory.test.cjs
@@ -51,19 +51,25 @@
  * window today are correctly outside the script too. The `test.yml`-only ones
  * fail (b): that workflow is surface-classified, so the change that would break
  * such a gate is the change that queues it, and a PR cannot land past it in
- * silence. `build:freehand-matched` fails (a) — it is the matched-pair build
- * step feeding `freehand-bench.yml`, not a gate. `test:freehand` fails (b) for a
- * subtler reason worth knowing: `freehand-bench.yml` runs it to CAPTURE the B5
- * records, but its assertions already gate every PR through the `:node-test`
- * build, which `test:cljs` runs — test.yml calls it "the cheap NAMED surface for
- * local + worker iteration, not a second gate". (`test:cljs` and
- * `test:script-helpers` reach here transitively anyway, via `test-fast-pr.sh`,
- * which the rigorous script runs first.)
+ * silence. The sharpest worked examples of (a) and (b) were the Freehand ones,
+ * and they are kept because what they teach is the DERIVATION rather than the
+ * commands: `build:freehand-matched` failed (a) — it was the matched-pair
+ * build step feeding `freehand-bench.yml`, not a gate. `test:freehand` failed
+ * (b) for a subtler reason worth knowing: `freehand-bench.yml` ran it to
+ * CAPTURE the B5 records, but its assertions already gated every PR through
+ * the `:node-test` build, which `test:cljs` runs — test.yml calls that "the
+ * cheap NAMED surface for local + worker iteration, not a second gate".
+ * (`test:cljs` and `test:script-helpers` reach here transitively anyway, via
+ * `test-fast-pr.sh`, which the rigorous script runs first.)
  *
- * `bench:freehand-browser` is the one command that satisfies both, which is
- * exactly why it is pinned and the others are not. The full census sits on
- * rf2-0l1nv rather than here, because a list of command names in this file would
- * be a second authority with nothing holding it in step with the workflows.
+ * `bench:freehand-browser` was the one command that satisfied both, which is
+ * why it was pinned and the others were not. All three retired with the
+ * Freehand tree on 2026-08-16 (rf2-0yp7w) — no `freehand` script survives in
+ * `package.json` and `freehand-bench.yml` is gone — so none of them is pinned
+ * today, and the `DIRECT_PINS` map below is the authority on what is. The full
+ * census sits on rf2-0l1nv rather than here, because a list of command names in
+ * this file would be a second authority with nothing holding it in step with
+ * the workflows.
  *
  * A package.json census would ALSO not have caught the failure that raised the
  * question. rf2-mf4uy (PR #7193) moved the seven `re-frame.freehand.bench.*` DOM
@@ -74,9 +80,11 @@
  * census would not have moved and would have stayed green while the local
  * sweep's coverage narrowed. That failure was a migration of test CONTENT, and
  * the gate that sees that class is `_browser-dom-lane-partition.test.cjs`, which
- * derives both lanes' `:ns-regexp` from `shadow-cljs.edn` and proves they
- * partition the repo's `*_dom_cljs_test` namespaces. Content-level derivation is
- * the answer to content-level drift; a name-level census is not.
+ * derives the DOM lane's `:ns-regexp` from `shadow-cljs.edn` and proves it
+ * selects every `*_dom_cljs_test` namespace in the repo. (It proved a PARTITION
+ * of two lanes until the bench lane retired with the Freehand corpus; see that
+ * file's header.) Content-level derivation is the answer to content-level
+ * drift; a name-level census is not.
  *
  * A command earns a `DIRECT_PINS` entry on top of that when it must also declare
  * a `kind` — and that declaration is CHECKED against the workflow rather than


### PR DESCRIPTION
One slice of rf2-0yp7w.9 (R6, the prose sweep). **Does not close the bead** — other slices remain.

**9 sites repaired across 5 files; 6 of the 11 enumerated files refused outright, with source-located reasons.** That ratio is the expected one: the mayor's 2026-08-18 20:00 note records 8 repaired / 14 refused across the three slices that ran before this, and the two most recent sibling slices both ended in refusals that were the correct deliverable.

## The census, re-derived

Dispatch derived its list at `10a251268b` with `git grep -lF "re-frame.freehand"`. Re-run at this branch's merge base:

* whole tree: **78 files** carry `re-frame.freehand`.
* Positive control: `docs/design/freehand/` returns 19 of 37 tracked files — a pattern that finds nothing there is broken.
* Negative control: `re-frame.zzzznotreal` returns 0.
* Removal control: `git ls-files implementation/ui implementation/freehand` returns **0**; `implementation/adapters` returns 156.

**One correction to the dispatch list.** `docs/EP/EP-template.md` carries **no** `re-frame.freehand` hit — `git grep -cF` over it is empty. Its donor hit is `re-frame.ui` (L62), so the stated derivation could not have returned that file. It is adjudicated below anyway, since the file does carry a donor reference.

The other ten reproduce exactly. A broader pattern over the eleven (`freehand|re-frame.ui(not uix)|re_frame/ui|re-frame2-ui|implementation/ui`) surfaced no additional in-fence hit.

## Per-file verdicts

| File | Hits | Verdict | Reason |
|---|---|---|---|
| `docs/EP/EP-template.md` | 1 | **REFUSE** | Live-true exemplar. "the six re-frame.ui EPs carry both" — EP-0030…0035 all exist and each carries both `Created:` and `Resolution:`, verified at source. The claim is checkable today and the files it points at are deliberately kept. |
| `docs/EP/README.md` | 8 index rows | **REFUSE** | Archival index over kept historical records. The 2026-08-15 ruling on the parent names `docs/EP/*` as archival prose that REMAINS. Each EP file opens with its own dated "Historical record" banner (0034/0035/0036 carry the 2026-08-16 removal), so the record a reader lands on is self-dating and correct. The Status column is machine-synced against each EP's own `Status:` line by `scripts/check_ep_status_sync.py`, which reads only columns 1 and 3 — the summary column is not tool-consumed, and the status column is in sync. |
| `docs/release-process.md` | 2 | **REFUSE** | L17 is live-true and already carries the removal ("retired and removed from the tree (rf2-0yp7w)"). L162 sits inside a `> **Closed — …**` block and is past tense throughout. Named by the 2026-08-15 comment as "historical record", verified rather than taken on trust. |
| `implementation/core/test/re_frame/error_catalogue_channel_conformance_test.clj` | 3 | **1 refuse / 2 repair** | L1221 ("Lowered 94 → 93 by rf2-0yp7w.4") is correct history explaining why a pinned integer moved — kept. The two producer ROSTERS were falsified: see below. |
| `implementation/hicasso/scripts/check_budget_ledger.py` | 3 | **REFUSE** | All three are already past-tense retirement notes explaining why a control changed shape ("THERE USED TO BE TWO", "retired with the Freehand tree"), and one names the synthetic replacement it now uses (`:browser-test-neighbour`). Nothing present-tense survives. |
| `implementation/hicasso/test/re_frame/hicasso/consumer_app.cljs` | 1 | **REPAIR** | "the **sibling** `re-frame.freehand.release-app` **does**" — present tense about a namespace `git ls-files` no longer returns. |
| `implementation/hicasso/test_kit/src/re_frame/hicasso/test.cljs` | 3 | **1 repair / 2 refuse** | The 004B same-VALUE-KIND sentence was a CROSS-substrate claim and now has one substrate — re-tensed. The two provenance mentions of `re-frame.freehand.test` are KEPT: `implementation/hicasso/frozen-sources.edn` states in-tree that "Prose may name them — a docstring citing the witness that pins a behaviour is worth more than a clean grep", and adopted semantics stay true after the donor goes. |
| `implementation/routing/test/re_frame/routing_path_census_test.clj` | 2 | **REPAIR ×2** | The `clojure.tools.reader` justification led with a dead namespace as its precedent; the live half (it ships with ClojureScript, a hard dep of core) now leads. `:node-test-freehand` was the only example given for "framework testbeds compile into their own bundles" and that build id no longer exists — replaced with `:node-test-testbed-support`, verified present in `implementation/shadow-cljs.edn`. |
| `implementation/scripts/_browser-dom-lane-partition.test.cjs` | 6 | **REFUSE** | Already adjudicated. `aed83a7950` (rf2-3g2p8, 2026-08-18) re-tensed this file's header, executors preamble and prefix-trap note. Every survivor is correct past tense explaining why the two-lane partition retired. |
| `implementation/scripts/_rigorous-local-inventory.test.cjs` | 5 | **3 repair / 2 refuse** | The rf2-rmtj0 and rf2-mf4uy history is correct past tense — kept. Three present-tense claims were false: see below. |
| `implementation/scripts/api-manifest/test/re_frame/api_manifest/api_md_check_test.clj` | ~50 | **REFUSE** | Parser FIXTURE DATA — the census/partition class. `root-manifest-rows` and the `freehand-*-lines` vectors are hand-built markdown lines fed to `parse-var-rows` to prove namespace inheritance under nested headings; they are tied to the recorded rf2-etj5i (3 reopens) and rf2-asxo3 reproductions. The parser is namespace-agnostic, so renaming the fixtures would be pure churn and would break the tie to the bugs they reproduce. Nothing here reads the real `docs/api/` or `spec/API.md` with these strings. |

## What the two repaired rosters actually said

**`error_catalogue_channel_conformance_test.clj`.** Two measured claims, both falsified by the removal, both re-measured rather than guessed:

* the `no-frame-context` `:where` census read "across core, http, machines, routing, flows, resources, ssr, **freehand and ui**" and named `re-frame.ui.frames/resolve-frame` as a second threading site. Neither artefact exists.
* `BadFrameProviderArgTags` claimed "**Nine** src call sites" and listed eight spellings, five of them dead. Re-measured at this base: `require-frame-provider-target!` has **three** src call sites (`views/provider.cljs:159`, `substrate/spine.cljs:1701`, `adapters/uix/…/uix.cljs:102`) plus four in `frame_lifecycle_test.clj`. The six that went were the two substrates' providers.
* "The other **three** emitters of this category (router, subs, ui/frames)" → two.

In each case the *reading* that chose `:symbol` is narrowed, not overturned — every survivor is still a quoted symbol — and the comment now says so. The historical measurement is preserved beside the current one rather than erased.

**`_rigorous-local-inventory.test.cjs`.** The header's worked examples of its own (a)/(b) derivation named three package.json scripts and a workflow that no longer exist (`grep freehand implementation/package.json` → nothing; `freehand-bench.yml` → gone). The sharpest one was load-bearing and wrong: "`bench:freehand-browser` **is** the one command that satisfies both, which is exactly why **it is pinned**" — `DIRECT_PINS` holds `test:examples-compile` and `test:story-play-scripts`. The prose now points at the map rather than restating it, which is the posture the same file argues for two paragraphs down. Its cross-reference also claimed the sibling gate "derives **both lanes'** `:ns-regexp` … and proves they **partition**" — `aed83a7950` retired exactly that claim one file over the same day.

## Quality gates

**The fast-PR spine was NOT run**, per the dispatch fence (a shadow-cljs release build for a bench-class measurement was live on this machine). No `scripts/test-fast-pr.sh`, no shadow-cljs build, no Playwright, no npm build. Targeted gates only, each foreground, each with its own captured exit code (never a harness-reported one, never through a pipe).

All re-run on the FINAL base after rebasing onto `6120eff90f`:

| Gate | Exit | Result |
|---|---|---|
| `clojure -M:test` from `implementation/core` | **0** | 2243 tests, 11681 assertions, 0 failures |
| `clojure -M:test` from `implementation/routing` | **0** | 527 tests, 3127 assertions, 0 failures |
| `node implementation/scripts/_rigorous-local-inventory.test.cjs` | **0** | 6 passed |
| `node implementation/scripts/_browser-dom-lane-partition.test.cjs` | **0** | 2 passed |
| `python implementation/hicasso/scripts/check_freeze.py` | **0** | 1 frozen row matches; no package file imports the bench tree |
| `python scripts/check_doc_slugs.py` | **0** | clean |

**Each gate over an edited surface was sabotage-proved, and each restore was verified by hashing against the committed object (`git hash-object`), never by reading a diff.** Two plants silently no-opped first — a multi-line anchor against a CRLF working tree matched nothing, the gate came back green, and only the hash caught it. Both were re-anchored on a single newline-free line:

* core: pinned integer `93` → `9377`. Exit **1**, 2 failures reading `(not (>= 93 9377))`. Namespace and assertion totals identical to the control run (2243 / 11681), so the plant was scoped and aborted nothing downstream. Restore byte-identical (`17d2791e18…`).
* routing: planted `"rf2-planted-missing-root"` into `app-roots`. Exit **1**, failure names the planted token. Restore byte-identical (`36428b9c93…`).
* rigorous-local-inventory: `PIN_KINDS` narrowed. Exit **1**, "unknown kind \`belt-and-braces\`" ×2. Restore byte-identical (`6cde3cda7d…`).

The fault exists only in this worktree, so a run that had wandered into a sibling checkout would have come back green — that red is the discrimination, since a repo-relative path cannot tell two checkouts apart.

**`mkdocs build --strict` was NOT run and is not owed: no file under `docs/` changed** (all three docs files were refused). Read against `mkdocs.yml`'s `exclude_docs` block rather than a prose list, that block excludes six trees — `tools/playground/`, `migration/from-re-frame-v1/codemod/`, `migration/reagent-to-hicasso/codemod/`, `design/freehand/`, `design/hicasso/`, `design/retirement/`. So `docs/release-process.md`, `docs/EP/EP-template.md` and `docs/EP/README.md` **would** have been visible to it had they changed; none of this branch's five files is.

**`python scripts/check_fast_pr_gap.py --list`** — exit **0**, reporting 96 required checks the fast spine does not run. Relevant to this branch: the CLJS `:node-test` shadow-cljs lane (which compiles the two edited `.cljs` docstrings) and the Hicasso release build sit inside that gap and are decided in CI, not here. Both edits are comment/docstring-only and introduce **zero** `"` or `\` characters (`git diff | grep -cE '["\\]'` over added lines → 0), and `consumer_app.cljs` is read-parsed by the routing census through `clojure.tools.reader` at `:features #{:cljs}`, which is green.

## Out of fence — named, not touched

* `implementation/shadow-cljs.edn:827,839` — two comments still say ":node-test-freehand **above**" and "Riding `:node-test-freehand` would compile the package under the FREEHAND artefact's regexp". No such build exists. HOT ZONE, and adjacent to rf2-7b1ti's existing charge over the same file.
* `examples/real-apps/realworld_http/article_editor.cljs:75` and `examples/real-apps/realworld_resources/article_editor.cljs:103` — both carry a `re-frame.freehand` docstring reference. Outside the eleven enumerated files and outside every peer fence derived at start-up.
* `docs/EP/EP-0030…0033`'s own banners are dated 2026-07-30 and record only the WITHDRAWAL, while EP-0034/0035/0036's are dated 2026-08-16 and record the REMOVAL as well. Those files are carved out of this slice as kept historical records; the asymmetry is recorded here for whoever rules on it.

Fence respected: `spec/**` untouched, `implementation/*/bench/**` untouched, `implementation/hicasso/frozen-sources.edn` untouched, `docs/EP/EP-00{30..36,38}` untouched, `docs/design/**` untouched. No `.beads` path is in the diff.
