### PR TITLE
docs(hicasso): three published pages answer the questions they routed into the excluded design tree (rf2-75q3l)

### DIFF
--- a/docs/core/hicasso/api-reference.md
+++ b/docs/core/hicasso/api-reference.md
@@ -31,18 +31,21 @@ name the ids a door raises; [Errors](17-errors.md) explains the shape and
 
 ## What this page does not enumerate
 
-Four questions are answered authoritatively elsewhere. Copying an answer here
-would produce a second one that goes stale the day the first moves, so this page
-points at each instead. Every target below is a page of this guide except the
-naming ledger, which is a working design record in the repository and does not
-publish — a reader who cannot reach that one is missing history, not behaviour.
+Three questions are answered authoritatively on another page of this guide.
+Copying an answer here would produce a second one that goes stale the day the
+first moves, so this page points at each instead.
 
 | Question | Where it is answered |
 | --- | --- |
 | What each surface does on the server, and under hydration | [SSR and hydration](18-ssr-and-hydration.md#server-policy-by-surface) |
-| Which spellings changed, when, and under whose ruling | the naming ledger, `docs/design/hicasso/product/naming-ledger.md`, in the repository |
 | Every refusal id, its reason and its recovery | [Troubleshooting](troubleshooting.md#the-complaint-index), with [Errors](17-errors.md) for the shape each one carries |
 | Which doors this guide teaches under a spelling the code does not yet carry | the Status block on [the guide index](index.md) |
+
+A fourth — *which spellings changed, when, and under whose ruling* — has no
+other page to be answered on, and a lookup page is where a reader meets it: you
+type a name you remember, the compiler says it does not exist, and you want to
+know what it became. So it is answered here, at [Names that
+changed](#names-that-changed).
 
 ## `re-frame.hicasso` — the door
 
@@ -628,6 +631,48 @@ hm/this-frame
 Green from `hm/shadow!` means the two implementations were indistinguishable
 **for the flows in the script**, and proves nothing about a path the script did
 not walk.
+
+## Names that changed
+
+Hicasso is pre-alpha and some of its doors have been renamed since they were
+first written down. There is no alias and no deprecation path for any of them:
+an old spelling is gone rather than deprecated, so what you get is a compile
+error rather than a warning. This is what to type instead.
+
+| What you may have written | What it is today | When, and on whose authority |
+| --- | --- | --- |
+| `hfn`, taught as `h/fn` | `h/event` | Ruled by the project operator on 2026-08-11 and swept through code and guide alike on 2026-08-15. `event` is the word this project already reserves for *turn the invoker's arguments into one event vector, or `nil`*, while `handler` names imperative work whose return is ignored — so `handler` would have been a false friend to anyone arriving from another adapter |
+| `h/root!`, taking the frame keyword positionally | `h/mount!`, over a config map — `(node config view)` | Named by the same 2026-08-11 ruling, but it could not be carried out as a rename: the config map this guide teaches carries `:initial-events`, and the door underneath implemented no such option. It landed on 2026-08-15 as the contract rather than the spelling, which is why it arrived after the sweep that renamed the callback form |
+| `h/hydrate-root!` | `h/hydrate!` | The same ruling. This half was a true rename and landed first, which is why the two doors changed on different days |
+| `hm/render!`, on the mounted test kit | `hm/rerender!` | Ruled 2026-08-11, swept 2026-08-15. `render!` would have collided with the product facade's own `h/render!`, and a test that reads `render!` should not have to know which of the two it is looking at |
+| `ht/render`, with a `{:reads …}` fixture | `ht/tree`, with a `{:subs …}` fixture | Applied on 2026-08-11. L2 answers a data tree and never DOM — the kit's own docstring says it is not a renderer — so `render` both misdescribed the door and collided with two others |
+| `:ssr`, on a `defhost` or `n/defcomponent` declaration | `:server` | Applied without waiting on the naming sitting, because by then the two spellings had diverged code-against-code inside one shipped artefact, which is a defect rather than an open question of taste. `:ssr` names the technique where `:server` names the side that renders, which is what the two values distinguish. A declaration still carrying `:ssr` now raises `:rf.error/hicasso-host-unknown-option` |
+| `server/fresh-frame-id`, `server/setup-events` | Neither is public. The server module's whole public surface is `server/render`, `server/payload-script`, `server/document` and `server/render-twice` | Operator override of 2026-08-15, argued name by name against what an external host can actually do with each. Nothing an application writes calls either of the two: `server/render` mints its own frame id and refuses to have it overridden, and the event setup is a short fold over options `server/render` already accepts directly |
+
+Two rules explain most of what looks inconsistent above.
+
+**A refusal id is not a spelling, and never follows one.** An id is frozen for
+the life of the refusal and is never reused after retirement, because a
+consumer's stored errors and an error monitor's grouping rule both outlive the
+code. So `:rf.error/hicasso-test-bad-reads` still carries the retired word
+`reads` and always will — it names the refusal, not the option the refusal was
+about. Its `:recovery` keyword did move, from `:add-the-query-to-reads` to
+`:add-the-query-to-subs`, because a recovery is concrete advice about a live API
+and is rewritten whenever that API is renamed.
+
+**One taught spelling still differs from the code, and it is not waiting for a
+sweep.** This guide writes `h/frame`; the door exports `h/hframe`. The
+recommendation on record is to retire the verb rather than respell it — a bare
+`frame` shadows on a `:refer`, and `rf/current-frame-id` and `rf/capture-frame`
+are already the frame doors — but retiring it needs the ambient-read seam to
+admit those two core doors inside a Hicasso body, which is a behaviour change
+rather than a rename. The Status block on [the guide index](index.md) is the
+live record of that one divergence.
+
+Naming questions are consolidated and settled by the project operator in a
+working design record that is not published, so the table above is the published
+account of what has been decided: a row appears here when the change has landed
+in the shipped package, not when it is proposed.
 
 ## How this page is kept honest
 

--- a/docs/core/hicasso/api-reference.md
+++ b/docs/core/hicasso/api-reference.md
@@ -656,9 +656,11 @@ the life of the refusal and is never reused after retirement, because a
 consumer's stored errors and an error monitor's grouping rule both outlive the
 code. So `:rf.error/hicasso-test-bad-reads` still carries the retired word
 `reads` and always will — it names the refusal, not the option the refusal was
-about. Its `:recovery` keyword did move, from `:add-the-query-to-reads` to
-`:add-the-query-to-subs`, because a recovery is concrete advice about a live API
-and is rewritten whenever that API is renamed.
+about. What did move is the advice beside it: the `:recovery` keywords that
+named the retired option were rewritten with it, so the test kit's
+missing-fixture refusal now recovers with `:add-the-query-to-subs` rather than
+`:add-the-query-to-reads`. A `:recovery` is concrete advice about a live API and
+is not frozen the way an id is.
 
 **One taught spelling still differs from the code, and it is not waiting for a
 sweep.** This guide writes `h/frame`; the door exports `h/hframe`. The

--- a/docs/core/hicasso/escape-ladder.md
+++ b/docs/core/hicasso/escape-ladder.md
@@ -103,13 +103,36 @@ because the rung you justified against last quarter's topology is not
 automatically justified against this one.
 
 !!! note "Where those numbers come from"
-    The three thresholds are the performance contract's, in §6 of the Hicasso
-    specification (`docs/design/hicasso/product/specification.md`), and are
-    registered for reconciliation as rule C8 of the budget record
-    (`docs/design/hicasso/product/budgets.md` §4). They are thresholds on a
-    *ratio*, so they do not go stale the way a measured constant does — but the
-    measurement you compare against them does, which is why the rule says re-run
-    rather than remember.
+    They are not this page's invention. Hicasso's performance contract states
+    the escape-benefit rule in exactly the three disjuncts above, and pairs it
+    with the sentence that supplies their teeth: an island missing its
+    threshold is simplified or removed, and thresholds do not widen to keep it.
+    The contract registers the rule for reconciliation against measured
+    evidence, so it is adjudicated rather than merely asserted.
+
+    Three properties of it are worth carrying into a review.
+
+    - **It is adjudicated per landed escape, not corpus-wide.** Every escape
+      that ships carries its own measured benefit and is judged on that. A
+      figure published for a mechanism in general is a reference price your own
+      adjudication may cite; it is never a pass, and never a veto, for your
+      site. The project's own reading for direct return sits close enough to
+      the 20% line that its range straddles it, which is exactly why the
+      mechanism cannot stand in for the site.
+    - **An interoperability escape is outside the population**, by the rule's
+      own wording rather than as an exception granted to it. That is the next
+      section, and it is the reason the rule is written over escapes *taken
+      for a benefit*.
+    - **The thresholds are on a *ratio*,** so they do not go stale the way a
+      measured constant does. The measurement you compare against them does,
+      which is why the rule says re-run rather than remember.
+
+    The contract that states the rule and the budget record that tracks it
+    are working design records rather than published pages, so this note is
+    the whole of the rule as it bears on a decision about one escape. What
+    they hold beyond it is the project's own reconciliation bookkeeping — which
+    rows are green, which are still waiting on evidence — and nothing there
+    moves the three numbers above.
 
 ## The rule an interoperability escape is not judged by
 

--- a/docs/core/hicasso/troubleshooting.md
+++ b/docs/core/hicasso/troubleshooting.md
@@ -888,7 +888,7 @@ the same change. So a reservation is promoted, never drifted into.
 
 | Reserved | What it will refuse |
 | --- | --- |
-| `:rf.error/hicasso-view-called-directly` | a `defview` invoked as a function instead of mounted as a hiccup head. The static case is already an error — the clj-kondo config Hicasso ships raises `:re-frame.hicasso/direct-view-call` — and this is the runtime half |
+| `:rf.error/hicasso-view-called-directly` | a `defview` invoked as a function instead of mounted as a hiccup head. The static case is caught already — the clj-kondo export Hicasso ships reports it as `:re-frame.hicasso/direct-view-call`, at error level — and this is the runtime half |
 | `:rf.error/hicasso-test-hook-is-opaque` | a React hook reached from a body run at L2, where no React is running |
 | `:rf.error/hicasso-test-native-is-opaque` | a native-tier element reaching the L2 semantic tree, as host and raw-React elements already do |
 | `:rf.error/hicasso-contenteditable-not-controllable` | a controlled `:value` binding on a contenteditable region |

--- a/docs/core/hicasso/troubleshooting.md
+++ b/docs/core/hicasso/troubleshooting.md
@@ -75,15 +75,15 @@ a live API, so it is rewritten when that API is renamed.
 ## The complaint index
 
 Every complaint the shipped package raises today, grouped by the surface that
-raises it. The register of record — which ids exist, which spellings are
-reserved for surfaces not built yet, and which are dead forever — is
-`docs/design/hicasso/product/complaints.md`, and the normative meaning and
-payload of each id is `spec/009-Instrumentation.md`. This page is the reader's
-route into both.
+raises it. The normative meaning and payload of each id is
+`spec/009-Instrumentation.md`, and this page is the reader's route into it.
 
 An id you cannot find here is either not Hicasso's or not from this version.
 Check the namespace first — core, routing and the resources model raise their
-own — and then check that your application and test-kit versions match.
+own — and then check that your application and test-kit versions match. A few
+further spellings are claimed without being raised — reserved for surfaces not
+built yet, or dead forever — and they are listed under [Ids that are claimed but
+not raised](#ids-that-are-claimed-but-not-raised) at the foot of this page.
 
 ### Hiccup, heads and children
 
@@ -853,3 +853,68 @@ useful report is the complaint it was trying to raise.
 You minted a refusal missing one of the four required slots.
 
 Recovery: `:give-the-refusal-every-required-field`.
+
+## Ids that are claimed but not raised
+
+The index above is what the shipped package raises. A few further spellings are
+claimed without being raised, and knowing which is which saves a fruitless
+search: none of them can appear in an error you caught, and none of them is a
+spelling to mint for yourself.
+
+Three rules govern the whole set, and they are the reason an id is worth
+asserting on in the first place.
+
+1. **An id never changes meaning.** If the refusal it names becomes a different
+   refusal, that is a new id and the old one retires.
+2. **An id never changes spelling.** A rename is a retirement plus a mint, and
+   both are recorded.
+3. **A retired id is tombstoned and never reused.** A consumer's stored errors,
+   an error monitor's grouping rule and a page of prose all outlive the code, so
+   a reused spelling makes every one of them silently wrong about which failure
+   it saw.
+
+### Reserved
+
+Each of these names a refusal this guide already teaches by mechanism, on a
+surface that is not built yet. The reservation is not bookkeeping: a refusal
+with no id is invisible to a round trip — nothing raises it and no index carries
+it, so the raise-set and the index agree while the coverage is entirely missing.
+Claiming the spelling makes that gap countable, stops two builders minting two
+names for one refusal, and lets a chapter cite an id today.
+
+A reserved id carries no payload and no `:recovery` yet; those are settled by
+the work that writes the emitter, which moves the row up into the index above in
+the same change. So a reservation is promoted, never drifted into.
+
+| Reserved | What it will refuse |
+| --- | --- |
+| `:rf.error/hicasso-view-called-directly` | a `defview` invoked as a function instead of mounted as a hiccup head. The static case is already an error — the clj-kondo config Hicasso ships raises `:re-frame.hicasso/direct-view-call` — and this is the runtime half |
+| `:rf.error/hicasso-test-hook-is-opaque` | a React hook reached from a body run at L2, where no React is running |
+| `:rf.error/hicasso-test-native-is-opaque` | a native-tier element reaching the L2 semantic tree, as host and raw-React elements already do |
+| `:rf.error/hicasso-contenteditable-not-controllable` | a controlled `:value` binding on a contenteditable region |
+| `:rf.error/hicasso-route-link-bad-prefetch` | a route link's `:prefetch` carrying a value the link does not accept |
+
+### Retiring later
+
+[`:rf.error/hicasso-route-link-prefetch-declined`](#hicasso-route-link-prefetch-declined)
+is live today and already decided against. It retires when route links accept
+`:prefetch` rather than declining the key outright, and its successor is the
+reserved `:rf.error/hicasso-route-link-bad-prefetch` above.
+
+The declined spelling is never reused for the successor, and the reason is worth
+seeing: the two say different things — *this key does nothing here* against
+*this value is not one of the ones it takes* — so an error monitor grouping by
+id would silently merge a v0 report with a later one about a typo.
+
+### Dead
+
+`:rf.error/hicasso-test-residue-after-quiescence` is tombstoned. It was reserved
+for a raising clean-state assertion on the mounted test kit, and the kit landed
+choosing to report instead: `hm/assert-clean!` files residue through the test
+runner rather than throwing, because residue is a test failure and not a refusal
+of the instrument. A throw would make the tool that detects a leak
+indistinguishable from the tool breaking, and would abort at the first finding
+instead of reporting all of them. So the reservation named a refusal its own
+surface decided not to have. It was never minted and never raised, so no stored
+error and no monitor rule anywhere carries it — and by rule 3 above it stays
+dead rather than being recycled for the next refusal on that surface.


### PR DESCRIPTION
Closes rf2-75q3l.

Three published Hicasso pages asked a reader to go to `docs/design/hicasso/product/`. `mkdocs.yml`'s `exclude_docs` block carries `design/hicasso/`, so on the published site each of those was a dead end: the file exists in a checkout and does not exist on the site.

Under the mayor's ruling of 2026-08-18 22:58 AUSEST, this does **not** repoint them. Where the Hicasso normative set finally lives is rf2-ps7ia's and is reserved for Mike, so each page now **answers its own question instead**. Nothing moves out of `docs/design/`, no destination is created, and no new link into the excluded tree is added. Every answer below was written from the design records at source, read in this checkout.

## What each page now says

**`docs/core/hicasso/api-reference.md`** — the "What this page does not enumerate" table listed four questions and routed one of them, *which spellings changed, when, and under whose ruling*, at `docs/design/hicasso/product/naming-ledger.md`. The table is now three questions, each genuinely owned by another published page, and the fourth is answered on this page under a new **Names that changed** section: the six renames that have landed in the shipped package plus the two names that left its public surface, what to type instead, and the ruling behind each. Two rules follow it, because they explain what otherwise looks like inconsistency — a refusal id is not a spelling and never follows one (so `:rf.error/hicasso-test-bad-reads` keeps the retired word `reads` forever while its sibling's `:recovery` moved), and one taught spelling still differs from the code (`h/frame` against the exported `h/hframe`), which is a behaviour change rather than a rename and so is not waiting for a sweep.

Only landed changes are tabulated. The ledger also records dispositions that have **not** been carried out — `h/reg-state` "remove from core", for one — and `h/reg-state` is still on the door and still taught on this very page, so it is deliberately absent from the table. Each row was verified against the shipped source or against this page's own roster before it was written; `server/fresh-frame-id` and `server/setup-events` were confirmed `defn-` in `implementation/hicasso/src/re_frame/hicasso/server.cljs`, leaving exactly the four public names the row states.

Note the bead's sharpest claim — that api-reference's *"What each surface does on the server, and under hydration"* is answered nowhere reachable — **no longer holds at HEAD**: PR #8451 repaired that row and the SSR row, and both already point at published pages. Re-derived and left alone.

**`docs/core/hicasso/escape-ladder.md`** — the "Where those numbers come from" admonition cited `specification.md` §6 and `budgets.md` §4 for the three escape-benefit thresholds. It now states the rule's own substance: that the thresholds are the performance contract's and are paired with *thresholds do not widen to keep an island that misses them*; that the rule is **adjudicated per landed escape rather than corpus-wide**, so a figure published for a mechanism in general is a reference price a site adjudication may cite and never a pass or a veto; that an interoperability escape sits outside the population by the rule's own wording, which is what the next section is about; and that the thresholds are on a *ratio*, so the measurement rather than the number is what goes stale. It closes by saying plainly that the contract and the budget record are working design records rather than published pages, and that what they hold beyond the rule is reconciliation bookkeeping that does not move the three numbers.

**`docs/core/hicasso/troubleshooting.md`** — the complaint index routed *"which ids exist, which spellings are reserved for surfaces not built yet, and which are dead forever"* at `docs/design/hicasso/product/complaints.md`. That question is now answered on the page, in a new **Ids that are claimed but not raised** section at its foot: the three stability rules, the five reserved spellings with what each will refuse, the one id retiring later with why its successor may never reuse its spelling, and the one tombstone with the reasoning that killed it. The index intro now points there instead of off-site.

Those counts are not asserted from prose. `check_complaint_catalogue.py` prints them independently and agrees exactly: **77 live, 5 reserved, 1 pending retirement, 1 retired**.

## The by-hand route check

**No gate covers this defect class**, so the check is recorded here rather than delegated. `mkdocs build --strict` cannot see it, for two independent reasons — MkDocs caps *"contains a link to X which is excluded from the built site"* at INFO in code, so `--strict` never aborts on it; and all six of these references were inline **code spans** rather than markdown links, so MkDocs never saw them at all. The base commit is exit 0 with every one of them present.

| Page | Routes it carried before | What it says now |
| --- | --- | --- |
| `api-reference.md` | `:43` → `docs/design/hicasso/product/naming-ledger.md` (one row of the four-question table; the other two design-tree rows were repaired earlier by PR #8451) | The row now links to `#names-that-changed` on the same page, and that section answers the question in full |
| `escape-ladder.md` | `:107` → `docs/design/hicasso/product/specification.md`; `:109` → `docs/design/hicasso/product/budgets.md` §4 | The admonition states the rule, its adjudication unit, its population and its ratio property inline, and says the two records are unpublished working records |
| `troubleshooting.md` | `:80` → `docs/design/hicasso/product/complaints.md` | The index intro points at a new on-page section carrying the reserved, retiring and dead sets in full |

**Positive control for the search.** The sweep is `git grep -nF 'design/hicasso/'` — a fixed-string match, so no shell-stripped metacharacter can make it silently miss. Run over the three files it returns nothing. Run with the *same pattern and the same command* over all of `docs/core/`, it returns `docs/core/hicasso/00-installation.md:130` — so a surviving route in my three files would have been found. That survivor is **out of this bead's fence and is not a defect**: it names the release policy as a working design record, states plainly that the record is read from a checkout rather than the site, and carries the compatibility matrix itself on the page — which is the very shape this ruling asks for.

**Anchors and table column counts verified by hand.** Three anchors are load-bearing: `#names-that-changed` and `#ids-that-are-claimed-but-not-raised` are new same-page targets, and `#hicasso-route-link-prefetch-declined` is an existing explicit anchor now linked from the new section. All three resolve — `check_doc_slugs.py` validates exactly this, and the planted-fault run below proves it reached these files. Column counts were audited across all three changed files by comparing every table row's delimiter count against its own header: zero mismatches, including the new seven-row and five-row tables.

## Quality gates

Every exit code below is the one **captured by the runner itself** (`cmd > log; echo $? > exit`, redirect and echo on one command line, never piped through a filter), not one reported about the run. Artefacts are named for this worktree and for the attempt.

Re-run on the **final rebased base** (`origin/main` = `4852631958`), because main moved under this branch mid-flight — it deleted `spec/004-Views.md` and the S3/S4/S5 conformance profiles under rf2-h89ri.

| Gate | Captured exit | Notes |
| --- | --- | --- |
| `python scripts/check_doc_slugs.py` | **0** | The nominated gate. Covers `docs/`, validates link targets and heading anchors |
| `python -m mkdocs build --strict` | **0** | With `spec/` and `migration/` staged into `docs/` as `docs.yml` does. Ran from this worktree — its banner names this worktree's `site/`. Staged copies and `site/` removed afterwards; tree clean |
| `python implementation/hicasso/scripts/check_complaint_catalogue.py` | **0** | R1–R10. Confirms the numbers written onto troubleshooting.md |
| `python implementation/hicasso/scripts/check_guide_samples.py` | **0** | 223 fenced blocks pinned across 29 pages, 104 verb use-sites resolved. This edit adds **no fenced block** — R1 reds on one added, edited or removed |
| `sh scripts/check-no-hardcoded-paths.sh` | **0** | Portability gate |

**Planted-fault control, proving the gate read *this* tree.** `check_doc_slugs.py` prints no root, so the discrimination is the red. `#ids-that-are-claimed-but-not-raised` in `troubleshooting.md` was changed to `#ids-that-are-claimed-but-not-raised-PLANTEDFAULT` — a fault that exists in no other checkout. The gate came back **exit 1**, naming `docs/core/hicasso/troubleshooting.md:86 -> #ids-that-are-claimed-but-not-raised-PLANTEDFAULT`. A run that had wandered into a sibling worktree would have come back green. The plant was anchored on a single line and asserted to match exactly once, so it could not silently no-op.

**Restore verified by content hash, not by reading a diff.** `git hash-object` on the file before the plant, `6cbd16abfaacec5be7b24469644f0cc7875999a6`; after restore, `6cbd16abfaacec5be7b24469644f0cc7875999a6`; and `git rev-parse HEAD:docs/core/hicasso/troubleshooting.md` agrees. The gate then re-ran clean at **exit 0**.

**What did NOT run, and the gap.** The fast-PR spine **did not run** — `worker/workcount-n1b9h` is holding a shadow-cljs release build for a bench-class measurement, and two heavyweight runs wedge rather than fail. No shadow-cljs, no browser, no Playwright, no npm build, no JVM gate. The gates above were invoked directly. `python scripts/check_fast_pr_gap.py --list` (exit 0) enumerates **96 required checks the spine does not run** — green there would not be green in CI either, and most are surface-gated and skip on a diff that does not reach them. This diff is three markdown files under `docs/core/hicasso/`, so the surfaces those 96 gate are not reached. Two were checked specifically because they *do* read `docs/core/`: the `api-manifest` job's `doc-guide-check`, which extracts call-position `(rf/<var>` references only and so is untouched by inline code spans naming `h/…`, `hm/…` and `server/…`; and `check_guide_samples.py`, run directly above.

**Revert audit.** `git diff origin/main...HEAD` (three-dot, against the merge base) is 154 insertions / 19 deletions across the three files. Every one of the 19 deleted lines is prose this change itself replaced — listed and read individually. Nothing a sibling landed is undone. Re-derived at start-up and again before the first edit: no open PR touches `docs/core/hicasso/`.
