### PR TITLE
chore(retire): clear three donor-prose pockets — shadow-cljs comments, two example docstrings, EP-0030..0033 banners (rf2-0yp7w.9)

### DIFF
--- a/docs/EP/EP-0030-the-compiled-view-substrate-program.md
+++ b/docs/EP/EP-0030-the-compiled-view-substrate-program.md
@@ -5,10 +5,13 @@ Type: standards-track
 Created: 2026-07-16
 Resolution: accepted 2026-07-11 (program ratification); adapter disposition reframed 2026-07-17
 
-> **Historical record — 2026-07-30.** This programme's compiled substrate was
+> **Historical record — 2026-08-16.** This programme's compiled substrate was
 > absorbed into Freehand, and Freehand
-> ([EP-0036](EP-0036-the-freehand-view-substrate-programme.md)) is now
-> **withdrawn**. Nothing is in flight under this EP or its siblings
+> ([EP-0036](EP-0036-the-freehand-view-substrate-programme.md)) was
+> **withdrawn** on 2026-07-30. Both donor substrates were then **removed from
+> the tree** on 2026-08-16 under the operator ruling recorded as `rf2-0yp7w` —
+> `implementation/ui/` and `implementation/freehand/` return nothing from
+> `git ls-files`. Nothing is in flight under this EP or its siblings
 > EP-0031–EP-0035; they are kept as the record of the donor programme.
 
 ## Abstract

--- a/docs/EP/EP-0031-re-frame-ui-programming-model.md
+++ b/docs/EP/EP-0031-re-frame-ui-programming-model.md
@@ -5,11 +5,14 @@ Type: standards-track
 Created: 2026-07-16
 Resolution: final 2026-07-19
 
-> **Historical record — 2026-07-30.** This EP's programme
+> **Historical record — 2026-08-16.** This EP's programme
 > ([EP-0030](EP-0030-the-compiled-view-substrate-program.md)) was absorbed into
 > Freehand, and Freehand
-> ([EP-0036](EP-0036-the-freehand-view-substrate-programme.md)) is now
-> **withdrawn**; the EP is kept as the record of the donor programme and no work
+> ([EP-0036](EP-0036-the-freehand-view-substrate-programme.md)) was **withdrawn**
+> on 2026-07-30. Both donor substrates were then **removed from the tree** on
+> 2026-08-16 under the operator ruling recorded as `rf2-0yp7w` —
+> `implementation/ui/` and `implementation/freehand/` return nothing from
+> `git ls-files`. The EP is kept as the record of the donor programme and no work
 > is in flight under it.
 
 ## Abstract

--- a/docs/EP/EP-0032-re-frame-ui-reactivity-and-ownership.md
+++ b/docs/EP/EP-0032-re-frame-ui-reactivity-and-ownership.md
@@ -5,11 +5,14 @@ Type: standards-track
 Created: 2026-07-16
 Resolution: final 2026-07-16
 
-> **Historical record — 2026-07-30.** This EP's programme
+> **Historical record — 2026-08-16.** This EP's programme
 > ([EP-0030](EP-0030-the-compiled-view-substrate-program.md)) was absorbed into
 > Freehand, and Freehand
-> ([EP-0036](EP-0036-the-freehand-view-substrate-programme.md)) is now
-> **withdrawn**; the EP is kept as the record of the donor programme and no work
+> ([EP-0036](EP-0036-the-freehand-view-substrate-programme.md)) was **withdrawn**
+> on 2026-07-30. Both donor substrates were then **removed from the tree** on
+> 2026-08-16 under the operator ruling recorded as `rf2-0yp7w` —
+> `implementation/ui/` and `implementation/freehand/` return nothing from
+> `git ls-files`. The EP is kept as the record of the donor programme and no work
 > is in flight under it. The observation-port contract it graduated into
 > [`spec/006-ReactiveSubstrate.md`](../../spec/006-ReactiveSubstrate.md) is
 > unaffected and still governs — the 2026-07-30 ruling measured invariant 5's

--- a/docs/EP/EP-0033-re-frame-ui-view-evidence.md
+++ b/docs/EP/EP-0033-re-frame-ui-view-evidence.md
@@ -5,11 +5,14 @@ Type: standards-track
 Created: 2026-07-16
 Resolution: accepted 2026-07-11
 
-> **Historical record — 2026-07-30.** This EP's programme
+> **Historical record — 2026-08-16.** This EP's programme
 > ([EP-0030](EP-0030-the-compiled-view-substrate-program.md)) was absorbed into
 > Freehand, and Freehand
-> ([EP-0036](EP-0036-the-freehand-view-substrate-programme.md)) is now
-> **withdrawn**; the EP is kept as the record of the donor programme and no work
+> ([EP-0036](EP-0036-the-freehand-view-substrate-programme.md)) was **withdrawn**
+> on 2026-07-30. Both donor substrates were then **removed from the tree** on
+> 2026-08-16 under the operator ruling recorded as `rf2-0yp7w` —
+> `implementation/ui/` and `implementation/freehand/` return nothing from
+> `git ls-files`. The EP is kept as the record of the donor programme and no work
 > is in flight under it.
 
 ## Abstract

--- a/examples/real-apps/realworld_http/article_editor.cljs
+++ b/examples/real-apps/realworld_http/article_editor.cljs
@@ -71,9 +71,9 @@
    The obvious spelling — replace the whole slice with a fresh
    `(editor-slice slug (draft-from-article article))` — loses every keystroke the
    user made while the GET was still in flight, because entering the editor and
-   typing is faster than a round trip. `FH-CTRL-013` states that seed law for
-   `re-frame.freehand` forms; this app holds its own `:touched` set rather than a
-   freehand form, so it spells the same rule by hand.
+   typing is faster than a round trip. The withdrawn `re-frame.freehand`
+   substrate stated that seed law for its forms (`FH-CTRL-013`); this app holds
+   its own `:touched` set rather than a form, so it spells the same rule by hand.
 
    The seed is LEAFWISE. A field the user has already touched keeps BOTH its
    draft and its baseline, so their text stays on screen AND stays dirty — the

--- a/examples/real-apps/realworld_resources/article_editor.cljs
+++ b/examples/real-apps/realworld_resources/article_editor.cljs
@@ -99,9 +99,9 @@
    The obvious spelling — replace the whole slice with a fresh
    `(editor-slice slug (draft-from-article article))` — loses every keystroke the
    user made while the read was still in flight, because entering the editor and
-   typing is faster than a round trip. `FH-CTRL-013` states that seed law for
-   `re-frame.freehand` forms; this app holds its own `:touched` set rather than a
-   freehand form, so it spells the same rule by hand.
+   typing is faster than a round trip. The withdrawn `re-frame.freehand`
+   substrate stated that seed law for its forms (`FH-CTRL-013`); this app holds
+   its own `:touched` set rather than a form, so it spells the same rule by hand.
 
    The seed is LEAFWISE. A field the user has already touched keeps BOTH its
    draft and its baseline, so their text stays on screen AND stays dirty — the

--- a/implementation/shadow-cljs.edn
+++ b/implementation/shadow-cljs.edn
@@ -824,7 +824,7 @@
                       :infer-externs false}}
 
   ;; rf2-hic-001 — the Hicasso PACKAGE's compile target. Mirrors
-  ;; :node-test-freehand above: the ns-regexp selects
+  ;; :node-test-testbed-support above: the ns-regexp selects
   ;; only `re-frame.hicasso.*` suites, and nothing else in the repo lives
   ;; under that prefix. Those namespaces also match the always-on
   ;; :node-test build's broader `cljs-test$` regex, so the package is
@@ -836,12 +836,13 @@
   ;; :hicasso-bench comment recommends: --config-merge can add a source
   ;; path or an entry to a build that already has the right SHAPE, and
   ;; there is no existing id whose shape is "compile the hicasso package
-  ;; and run its suites". Riding :node-test-freehand would compile the
-  ;; package under the FREEHAND artefact's regexp and name, tying a new
-  ;; artefact's gate to a neighbour's; riding :hicasso-bench would compile
-  ;; the package under the BENCH tree's advanced browser build, which is
-  ;; the very coupling this extraction exists to end. One id, one
-  ;; artefact, matching the two siblings that came before it.
+  ;; and run its suites". Riding the then-live :node-test-freehand would
+  ;; have compiled the package under the FREEHAND artefact's regexp and
+  ;; name, tying a new artefact's gate to a neighbour's; riding
+  ;; :hicasso-bench would compile the package under the BENCH tree's
+  ;; advanced browser build, which is the very coupling this extraction
+  ;; exists to end. One id, one artefact, matching the two donor siblings
+  ;; that came before it.
   ;;
   ;; The compile alone is half the acceptance: it is what proves the
   ;; renamed impl.* graph loads with the bench tree off the classpath.
@@ -864,8 +865,8 @@
   ;; in the bundle when it does — had no artefact to point at.
   ;;
   ;; The entry is `re-frame.hicasso.consumer-app`, which is a small real
-  ;; APPLICATION rather than a require-only stub, for the reason its
-  ;; sibling `:freehand-release` gives: Closure keeps what is reachable
+  ;; APPLICATION rather than a require-only stub, for the reason the
+  ;; departed `:freehand-release` gave: Closure keeps what is reachable
   ;; and an unused require is not, so a namespace that merely required the
   ;; door would DCE to nearly nothing and the bundle would report a cost
   ;; no consumer pays. It reaches a declared view, an ambient read, a
@@ -874,7 +875,7 @@
   ;; adapter, with nothing from the bench tree or from `tools/`. That
   ;; fence is the bead's acceptance and the entry's whole point.
   ;;
-  ;; Shape follows the sibling advanced build :freehand-release: both
+  ;; Shape follows the departed advanced build :freehand-release: both
   ;; settings pinned rather than
   ;; left to `release`'s defaults, so the build says what it is at the
   ;; point a reader is looking. The entry sits under `hicasso/test/` — on
@@ -920,21 +921,24 @@
   ;;   HICASSO_INIT_FN=<ns>/-main HICASSO_OUT_DIR=out/<arm> node .../run.cjs
   ;;
   ;; `run.cjs` passes `--config-merge {:output-dir … :modules {:main
-  ;; {:init-fn …}}}` exactly as `b6_prod_run.cjs` rides `:freehand-release`,
-  ;; so a sibling arm needs NO edit to this file at all. The sequencing law
-  ;; is paid once, here.
+  ;; {:init-fn …}}}` exactly as the Freehand lane's `b6_prod_run.cjs` rode
+  ;; `:freehand-release` before rf2-0yp7w removed both, so a sibling arm
+  ;; needs NO edit to this file at all. The sequencing law is paid once,
+  ;; here.
   ;;
-  ;; WHY A NEW ID RATHER THAN RIDING `:freehand-release`. The b6 driver's
-  ;; trick works because a build id is only a template, and this lane could
-  ;; have merged onto the Freehand release build. It does not, for two
-  ;; reasons: the Freehand programme is withdrawn and its release build has
-  ;; its own gates reading its own `out/` dir (`:freehand-release` is
-  ;; cleaned and rebuilt by `test:freehand-reachability` and
-  ;; `test:freehand-matched`), so a bench run and a gate run would race the
-  ;; same `.shadow-cljs/builds/freehand-release` cache; and the charter's
+  ;; WHY A NEW ID RATHER THAN RIDING `:freehand-release`, decided while that
+  ;; build still existed. The b6 driver's trick worked because a build id is
+  ;; only a template, and this lane could have merged onto the Freehand
+  ;; release build. It did not, for two reasons: the Freehand programme was
+  ;; withdrawn and its release build had its own gates reading its own
+  ;; `out/` dir (`:freehand-release` was cleaned and rebuilt by
+  ;; `test:freehand-reachability` and `test:freehand-matched`), so a bench
+  ;; run and a gate run would have raced the same
+  ;; `.shadow-cljs/builds/freehand-release` cache; and the charter's
   ;; anti-regression fence is explicit that Hicasso does not carry a
   ;; continuity claim to its donors — the measurement lane should not have
-  ;; to borrow a donor's identity to compile.
+  ;; to borrow a donor's identity to compile. The first reason expired with
+  ;; the build; the second is why this id would still be right today.
   ;;
   ;; :advanced with goog.DEBUG false, because HD-012 makes every bar number
   ;; a browser number taken from the artefact a consumer ships. The Spec 009


### PR DESCRIPTION
Slice 3 of `rf2-0yp7w.9`. Three named pockets of surviving donor prose, one of them carrying the mayor's 2026-08-19 00:12 ruling. The bead stays **OPEN** — it is a multi-slice bead and this slice settles seven files, not the bead.

**17 hits adjudicated: 16 repaired, 1 refused.**

## The census corrects the brief again

The dispatch brief carried five hits in `implementation/shadow-cljs.edn`, itself a correction of slice 2's two. **The real number at the base is ELEVEN**, and a twelfth turned up by reading rather than grepping.

```
$ git grep -nF freehand -- implementation/shadow-cljs.edn
131, 827, 839, 868, 877, 923, 927, 931, 932, 933, 934      -> 11
positive control  git grep -cF ':node-test'  -> 44
negative control  git grep -cF 'zzqqxx-nonexistent' -> 0 (exit 1)
```

Same command, same file, same tip the ruling was derived at (`57e45e3d29`). Lines 923–934 are a whole second block — the `:hicasso-bench` measurement-lane rationale — that neither earlier count reached.

**All eleven sit in `;;` comments.** No build id, no `:dev-http` port and no build target is touched, so the STOP condition in the brief does not fire. That is proved from the diff rather than asserted: every changed line in `shadow-cljs.edn` begins with `;;`.

```
$ git diff origin/main...HEAD -- implementation/shadow-cljs.edn \
    | grep -E '^[+-]' | grep -vE '^(\+\+\+|---)' | grep -cvE '^[+-][[:space:]]*;;'
0
```

## What made ten of the eleven wrong

Not that they mention a departed substrate — that alone is never enough. It is that this is **build configuration**, where a named build id is a claim about what the build system contains, and these were in the present tense:

| claim | measured |
|---|---|
| `:node-test-freehand` exists | absent from the `:builds` map |
| `:freehand-release` exists | absent from the `:builds` map |
| `test:freehand-reachability` / `test:freehand-matched` clean and rebuild it | `git grep -cF freehand -- implementation/package.json` = **0** (positive control `hicasso` = 12) |
| `b6_prod_run.cjs` rides it | `git ls-files \| grep -cF b6_prod_run` = **0** (positive control `run.cjs` = 24) |

So the distribution here is deliberately unlike the sibling slices' (slice 1 refused 2 of 2, slice 2 refused 6 of 11). Those swept prose; a stale sentence about a departed substrate is often correct history. This file's ten were live-sounding cross-references into a build system that no longer has those parts, and the one that *was* framed as history was refused.

The repairs are tense and reference corrections, not deletions — the design record survives intact, now readable as history. The precedent is `rf2-7b1ti`'s close reason, which kept `report-changed-surfaces.sh`'s "the jvm-freehand lane this comment used to name" precisely because it was already explicit past tense.

## Per-hit verdicts

### Pocket A — `implementation/shadow-cljs.edn` (sole toucher; hot zone)

| Line | Hit | Verdict | Reason |
|---|---|---|---|
| 131 | `moved that bench tree here from freehand/test/` | **REFUSED** | Explicit past tense, names the bead that did it, and is the live provenance for why `hicasso/test` carries a bench tree at all. Correct history. |
| 827 | `Mirrors :node-test-freehand above` | REPAIRED | The named id is neither above nor anywhere. Pointed at `:node-test-testbed-support`, which *is* directly above (L818) and is identical in shape — same target, same `:main`, an `ns-regexp` selecting one prefix's `-cljs-test$`, and the surrounding prose mirrors L814-817 word for word. |
| 839 | `Riding :node-test-freehand would compile the package…` | REPAIRED | Present conditional offering an alternative that cannot be taken. Past-tensed; the rejected-alternative record survives. |
| 844 | `matching the two siblings that came before it` | REPAIRED | Found by READING, not by the grep — it carries no donor token. Those two were `:node-test-ui` and `:node-test-freehand` (`implementation/scripts/compile-node-test.cjs:84` names both in its measured roster); both are gone, so the count dangles. Now "the two **donor** siblings". |
| 868 | ``for the reason its sibling `:freehand-release` gives`` | REPAIRED | Present-tense sibling that does not exist. The reason itself ("Closure keeps what is reachable and an unused require is not") is stated inline and is untouched. |
| 877 | ``Shape follows the sibling advanced build :freehand-release`` | REPAIRED | Same class; "sibling" → "departed". |
| 923 | ``exactly as `b6_prod_run.cjs` rides `:freehand-release` `` | REPAIRED | Dead at both ends — neither the driver nor the build is in the tree. Kept as history rather than cut, because L927 builds on it ("The b6 driver's trick"); cutting here would orphan that. |
| 927 | ``WHY A NEW ID RATHER THAN RIDING `:freehand-release` `` | REPAIRED | Kept as the rationale heading it is, now marked as decided while that build still existed. |
| 931-934 | ``:freehand-release` is cleaned and rebuilt by `test:freehand-reachability` and `test:freehand-matched`… would race the same `.shadow-cljs/builds/freehand-release` cache`` | REPAIRED | The load-bearing falsehood of the set: a cache race with a build that is never built, named to two npm scripts that do not exist. Past-tensed, and the block now says which of its two reasons expired with the build and which still stands (the charter's anti-regression fence). |

### Pocket B — the two example docstrings

Both read: ``FH-CTRL-013` states that seed law for `re-frame.freehand` forms; this app holds its own `:touched` set rather than a freehand form, so it spells the same rule by hand.`

The brief flagged that this is a CONTRAST and might therefore be correct history. It is not, and the deciding measurement is that **the citation dangles**:

```
$ git grep -nF 'FH-CTRL-013' -- . ':(exclude).beads'
examples/real-apps/realworld_http/article_editor.cljs:74
examples/real-apps/realworld_resources/article_editor.cljs:102
implementation/adapters/reagent/test/re_frame/realworld_resources_cljs_test.cljs:968
```

Three hits, and **all three are citing sites**. Nothing in the tree defines it — `docs/design/freehand/` survives as a frozen record (37 files) and does not carry it. The same holds for every surviving `FH-*` id: `FH-INPUT-003`, `FH-REACT-001/005/006`, `FH-STRUCT-010` are all citations without a definition. A reader told that FH-CTRL-013 "states" the law has nowhere to look.

| File:line | Verdict | Reason |
|---|---|---|
| `examples/real-apps/realworld_http/article_editor.cljs:74-76` | REPAIRED | Tense only. The withdrawn substrate **stated** that law for its forms (id kept in parentheses as provenance); this app holds its own `:touched` set instead. The contrast is preserved, and the rule itself is spelled out in full in the paragraphs directly below, so nothing load-bearing rested on the id. |
| `examples/real-apps/realworld_resources/article_editor.cljs:102-104` | REPAIRED | Identical text, identical repair. |

No test was added or changed — examples are test-free by project rule (rf2-8cevm), and this is a docstring edit.

### Pocket C — the EP banners (executing the ruling)

The inconsistency reproduces exactly as ruled. EP-0030..0033 carried "Historical record — 2026-07-30" recording only the WITHDRAWAL; EP-0034/0035/0036 carry "Historical record — 2026-08-16" recording the withdrawal AND the REMOVAL. All four are now brought to the EP-0034/0035/0036 shape, both events in the order they happened.

| File | Verdict | Reason |
|---|---|---|
| `docs/EP/EP-0030-…:8-12` | REPAIRED | **Verified individually and it did NOT match the other three** — it is the umbrella EP and speaks of "this programme's compiled substrate", with its own "Nothing is in flight under this EP or its siblings EP-0031–EP-0035" close. Edited to fit; that close is preserved verbatim. |
| `docs/EP/EP-0031-…:8-13` | REPAIRED | Removal event added; the banner's own tail wording kept. |
| `docs/EP/EP-0032-…:8-16` | REPAIRED | Same, and its trailing observation-port paragraph (Spec 006 graduated contract "unaffected and still governs") is preserved verbatim. |
| `docs/EP/EP-0033-…:8-13` | REPAIRED | Removal event added. |

The removal claim is measured, not copied from the model banners: `git ls-files implementation/ui` = **0**, `git ls-files implementation/freehand` = **0**, positive control `git ls-files implementation/adapters` = **156**.

**BANNER ONLY, and the diff proves it.** Every hunk lands in the banner block; no body line and no `Status:` / `Type:` / `Created:` / `Resolution:` line is touched, so `check_ep_status_sync.py`'s machine-synced columns cannot be disturbed.

```
$ git diff origin/main...HEAD -- docs/EP/ | grep -cE '^[+-](Status|Type|Created|Resolution):'
0
```

`docs/EP/**` remains archival prose under this bead's own 2026-08-15 ruling. The banner is the one part of an archival record that describes the present, which is why it alone was in scope. EP-0031:31 and its siblings still cite `spec/004D-Freehand-Compiled-Grammar.md` in their bodies; that is body text, deliberately untouched.

## Quality gates

The fast-PR spine did **NOT** run, and no heavyweight gate ran: no `scripts/test-fast-pr.sh`, no shadow-cljs build of any kind, no browser, no Playwright, no npm build, no JVM suite. `worker/workcount-n1b9h` is running a bench-class measurement concurrently and two heavyweight runs wedge rather than fail. Targeted gates only, all foreground, each exit code captured by the invoking shell with the redirect and the `echo $?` on one line, and **all re-run on the final base after rebasing onto `87e5f1e121`**.

| Gate | Covers | Exit |
|---|---|---|
| `python scripts/check_doc_slugs.py` | link targets + heading anchors under `docs/` (so: the four EP banners) | **0** |
| `python scripts/check_readme_links.py --ci` | repo-root markdown + READMEs beside source | **0** |
| `python scripts/check_ep_status_sync.py` | `docs/EP/README.md`'s machine-synced Status columns | **0** |
| `clj-kondo --lint` over both `article_editor.cljs` | the two edited docstrings | **0** |
| EDN structural read of `implementation/shadow-cljs.edn` | the hot-zone file parses | **0** |

**Gate-to-path split, cited rather than re-derived.** `CLAUDE.md` documents it and warns not to nominate by job name: the `verify-readme-links` job runs *both* scripts, and its name reads as though it checks READMEs while the gate that actually does is the other one. So, by path: `check_doc_slugs.py` covers `docs/EP/**` and is the gate for Pocket C. `check_readme_links.py --ci` covers **none** of this PR's changed paths — its own header excludes "markdown BELOW the repo root that is not a README.md" — and was run for completeness only.

**`mkdocs build --strict`: owed but NOT RUNNABLE HERE, and stated rather than skipped quietly.** `mkdocs.yml`'s `exclude_docs` block was read rather than trusted to prose; it holds six trees — `tools/playground/`, `migration/from-re-frame-v1/codemod/`, `migration/reagent-to-hicasso/codemod/`, `design/freehand/`, `design/hicasso/`, `design/retirement/` — and **`docs/EP/` is not among them**, so mkdocs does see these four files. `mkdocs` is not installed on this machine (`command -v mkdocs` → missing), so it was not run. The link and anchor class it would gate over `docs/EP/` is covered by `check_doc_slugs.py`, which ran green and was sabotage-proved below; the residual uncosted class is rendering and nav, and this diff adds no new link, no new heading and no new table.

**`scripts/check_fast_pr_gap.py --list`** (exit 0) reports **96 required checks the fast spine does not run** — cited here for the spine-versus-required-CI gap. It is not a to-do list; most are surface-gated in CI and skip on a diff that does not reach them.

### Sabotage proofs

Each gate over an edited surface was proved to reach THIS worktree by a planted fault, and every restore verified by **three `git hash-object` readings** rather than by reading a diff — because on this repository's CRLF checkouts an unapplied patch and an unchanged file produce the identical diff, which is how slice 2 got two silently no-opped plants and two green sabotage runs (bd memory `crlf-multiline-plant-noops-green`). **Every plant here was anchored to a single newline-free line, and the anchor's uniqueness was asserted before writing** — a plant that would have no-opped aborts instead.

**`check_doc_slugs.py`** — broke one link target on `EP-0031:11`.

```
pre-plant       1266669f8e354b8782654cc003cfbf758e634f67
planted         a1523472b83b450c1631285117bfa60aa2e3ac5a   (differs -> the patch really applied)
post-restore    1266669f8e354b8782654cc003cfbf758e634f67   (== pre-plant)

sabotage run  exit 1 :  BROKEN TARGET: docs\EP\EP-0031-…:11 -> EP-0036-this-target-does-not-exist.md
restored run  exit 0
```

**`clj-kondo`** — malformed a docstring on one line of `realworld_http/article_editor.cljs`, the exact class the gate is nominated for.

```
pre-plant       57b668b78c4420803c9e72f0986cee636f2e3eba   (== the committed blob)
planted         8f10d0da5758ddae9377c35f5098651bcf57324d
post-restore    57b668b78c4420803c9e72f0986cee636f2e3eba

sabotage run  exit 3 :  18 errors, first at article_editor.cljs:86 — the cascade from the
                        early string termination planted at line 76
restored run  exit 0
```

Neither planted fault existed anywhere but this worktree, so a run that had wandered into a sibling checkout would have returned green. That red **is** the discrimination — `check_doc_slugs.py` prints a repo-relative path, which cannot tell two checkouts apart.

**EDN structural check** — carries its own positive and negative controls in one run: the pristine `HEAD` copy passes (exit 0), a copy with its final `}` removed fails (exit 1, "unclosed `{` opened at line 22"), and the subject file passes while printing its own absolute path, which names this worktree.

## Out of fence — named, not touched

Found while working; recorded so the next slice does not re-derive them.

- `implementation/adapters/reagent/test/re_frame/realworld_resources_cljs_test.cljs:968` — the third `FH-CTRL-013` citation, same present tense, same dangling id.
- `implementation/adapters/reagent/test/re_frame/bench/hicasso_narrow_run.cjs:200-206` — carries a near-duplicate of the `shadow-cljs.edn:923-934` block, partly past-tensed already. Bench-class; `worker/workcount-n1b9h` is live in that neighbourhood.
- `implementation/scripts/compile-node-test.cjs:84` — names `node-test-ui` and `node-test-freehand` in a measured roster, **and this one looks like correct history**: it is an explicit record of what was measured before the gate was armed ("measured before arming this"). A later sweep should leave it.
- `docs/design/retirement/freehand-and-ui.md:327` and `implementation/routing/test/re_frame/routing_path_census_test.clj:246` still name `:node-test-freehand`; ~33 files still name `:freehand-release`, most of them the frozen `docs/design/freehand/` and `docs/design/hicasso/` studio records, which `exclude_docs` keeps out of the site and which are durable frozen records by ruling.

Explicitly NOT taken, per fence: `scripts/check-ai-tracking-ratchet.sh` and `CLAUDE.md` (routed to `worker/specres2-c6ka9`, verified holding both), `docs/EP/EP-0034*`–`EP-0038*` (read as the model, unchanged), `docs/EP/README.md`, `docs/EP/EP-template.md`, `docs/release-process.md` (settled by slice 2), and `spec/**`.

Peer holdings were re-derived at start-up and again immediately before the first edit — open PRs with their file lists, `git worktree list`, three-dot diffs on branches without a PR, and `git status --porcelain` inside each live worktree. **No peer holds any file in this PR.** `worker/workcount-n1b9h` was re-verified specifically, since a bench build id living in `shadow-cljs.edn` is exactly what would change that: it holds `implementation/core/test/re_frame/bench/**` and `docs/design/hicasso/studio/**`, not the build config.

The three-dot diff against the merge base (`origin/main...HEAD`) was read for reverts before pushing, before and after the rebase. It is these seven files and nothing else; the seven commits `main` landed underneath touch a disjoint set.
