### PR TITLE
retire(R6 slice 4): the named tail — FH-CTRL-013, the Spec 004 number form, :freehand-release (rf2-0yp7w.9)

### DIFF
--- a/implementation/adapters/reagent/test/re_frame/bench/hicasso_narrow_run.cjs
+++ b/implementation/adapters/reagent/test/re_frame/bench/hicasso_narrow_run.cjs
@@ -201,7 +201,7 @@ const CTL_2 = Number(process.env.HN_CTL_2 || 0.9);
 // landed yet. It has (rf2-2rtt6.2), so the fallback was unreachable code
 // carrying a paragraph of reasoning for a branch that could no longer be
 // taken, and rf2-uhw11 removes both. The donor template was never
-// equivalent anyway: `:freehand-release` is CLEANED AND REBUILT by
+// equivalent anyway: `:freehand-release` was CLEANED AND REBUILT by
 // `test:freehand-reachability` and `test:freehand-matched`, so a bench run
 // and a gate run raced the same `.shadow-cljs/builds/freehand-release`
 // cache — and Closure's renaming for a build compiled fresh differs from

--- a/implementation/adapters/reagent/test/re_frame/realworld_resources_cljs_test.cljs
+++ b/implementation/adapters/reagent/test/re_frame/realworld_resources_cljs_test.cljs
@@ -965,11 +965,12 @@
             a whole-slice `(assoc db :editor (editor-slice …))` that threw the
             keystrokes away — the R-C1 harness case (fitness-harness.md §C.2),
             named MATERIAL by the rf2-y4mgw audit and uncovered by any suite
-            until now. The seed is LEAFWISE instead, the same law `FH-CTRL-013`
-            states for freehand forms: a TOUCHED field keeps its own draft AND
-            its own baseline, so the typing survives and stays dirty; every
-            untouched field takes the loaded article's value in both, so the
-            dirty-check still compares against what the server holds."
+            until now. The seed is LEAFWISE instead. The withdrawn
+            `re-frame.freehand` substrate stated that seed law for its forms
+            (`FH-CTRL-013`): a TOUCHED field keeps its own draft AND its own
+            baseline, so the typing survives and stays dirty; every untouched
+            field takes the loaded article's value in both, so the dirty-check
+            still compares against what the server holds."
     (with-new-frame [f (frame/make-anon-frame-record! {:url-bound? true
                                        :fx-overrides {:rf.nav/push-url :rf/no-op}})]
       (rf/dispatch-sync [:auth/store-session {:username "alice" :token "jwt"}] {:frame f})

--- a/skills/re-frame2-improver/spec/design.md
+++ b/skills/re-frame2-improver/spec/design.md
@@ -80,7 +80,7 @@ Commits and PR title/body read as Mike Thompson's work. No `Co-Authored-By` / ge
 | `manual-loading-flags.md` | `assoc :loading? true` / `dissoc` scattered across terminators | Nine States, `spec/Pattern-NineStates.md` |
 | `schemaless-events.md` | Boundary handler ingests untrusted payload with no production boundary validation — no always-on gate (the `:rf.schema/at-boundary` interceptor ref in metadata `:interceptors`, Managed HTTP `:decode`, or equivalent always-on Malli validator); dev-only `:schema` / `reg-app-schema` are not sufficient | Schemas at boundaries, Spec 010 |
 | `imperative-effects.md` | Direct JS / DOM interop inside a `reg-event` handler — effectful *writes* (storage/DOM/dispatch/timers) AND impure *reads* (`Date.now`, `Math.random`, storage reads, sub reads) | Writes → data-only fx (`reg-fx`, `spec/Conventions.md`); impure reads fork on durability — durable writes fold a recorded fact (declared `:rf/time-ms` / event payload / recordable cofx), diagnostics may use an ambient value-returning `reg-cofx` declared via `:rf.cofx/requires` (`cofx.md`; `inject-cofx` removed) |
-| `view-side-hook-state.md` | `reagent/atom` / `useState` holding non-render-local state | Move to `app-db` + `reg-sub`, Spec 004 / `spec/Principles.md` |
+| `view-side-hook-state.md` | `reagent/atom` / `useState` holding non-render-local state | Move to `app-db` + `reg-sub`, `spec/Principles.md` |
 
 ### Deferred catalogue candidates
 


### PR DESCRIPTION
Slice 4 of the R6 prose sweep (rf2-0yp7w.9) — the named tail. Mostly adjudication: **44 sites censused across four pockets, 3 repaired, 21 refused with reasons, 20 handed off.** One new bead filed for a surface no census in this programme has ever seen.

`bd` left **OPEN** — the sweep is not finished, and Pocket B is why.

## The headline: Pocket B is 100× bigger than the brief thought

The brief sent me after **one** dangling `Spec 004` citation and told me to sweep for the number form because "there may be more than this one". There are **102 hits across 55 files**.

`spec/004-Views.md` was deleted by rf2-h89ri. Its census, rf2-v68fz's follow-up and rf2-jcsvn *all* grepped the **filename** (`004-Views`). A citation spelled `Spec 004` is invisible to that pattern — the same "fourth spelling" defect rf2-3l1xe and rf2-g633h recorded for `004D`, recurring one document over.

I repaired the one site inside my fence and filed **rf2-ukkxo** (P2, discovered-from rf2-0yp7w) for the rest, because sweeping it here would have been wrong three times over: it crosses two live peers' surfaces and the `spec/` hot zone; `docs/EP/**` and `docs/design/**` are archival by standing ruling; and **a large subset cannot be re-pointed at all** — rf2-h89ri's close records that `spec/` now "asserts no view contract", naming rf2-ps7ia (still OPEN) as the owner of where a replacement lands. `Spec 004 §Presence`, `§Render-tree primitives` and `§Plain Reagent fns` address sections with no surviving home. That is a ruling, not a worker's call.

A second, older defect rides along: rf2-h89ri measured that `spec/004-Views.md` contained **zero** occurrences of `reg-view`, so every `Spec 004 §reg-view` citation was already false *before* the deletion. It repaired the four it could see; the number-form census shows roughly thirty more standing.

## Per-site verdicts

### Pocket A — `FH-CTRL-013` (census: 3 sites, 3 files)

| File | Line | Verdict | Reason |
|---|---|---|---|
| `examples/real-apps/realworld_http/article_editor.cljs` | 75 | **REFUSED** | Already past tense (slice 3). Correct history. |
| `examples/real-apps/realworld_resources/article_editor.cljs` | 103 | **REFUSED** | Same. |
| `implementation/adapters/reagent/test/re_frame/realworld_resources_cljs_test.cljs` | 968 | **REPAIRED** | Read "the same law `FH-CTRL-013` **states for freehand forms**" — present tense, naming a substrate removed 2026-08-16. Now worded exactly as its two siblings. |

**The id itself STAYS, and that overturns the option the brief left open.** The dangle is confirmed — 3 citing sites, **zero** definitions, positive control `HD-002` returning five definition-shaped sites, and no `FH-*` id defined anywhere in the tree. But it is a **working archaeological key**: the deleted `spec/conformance/freehand/conformance-index.md:112` carries `FH-CTRL-013` in full, and its text ("SEEDS LEAFWISE: every leaf the user edited keeps its draft AND its baseline… a seeded leaf moves baseline and draft together and clears the error its old value carried") confirms exactly what all three docstrings claim. Stripping the id would destroy the only handle by which that wording can be recovered. Precedent applied: rf2-0yp7w.2 ruled FH-* ids **unpointed** in `spec/` — an *address* the reader is expected to follow — while these three are *names* whose target is recoverable by the name.

### Pocket B — bare `Spec 004` (census: 102 hits, 55 files)

| File | Line | Verdict | Reason |
|---|---|---|---|
| `skills/re-frame2-improver/spec/design.md` | 83 | **REPAIRED** | `Move to app-db + reg-sub, Spec 004 / spec/Principles.md` → **DE-ADDRESSED**. Kept the rule, dropped the pointer, invented no home — the treatment rf2-3l1xe/rf2-g633h already ruled. Re-verified at source rather than taken on precedent: `git grep` over `spec/` finds **no** ephemeral/view-side state-placement rule anywhere (positive control: `reg-sub` matches in three spec files), so there is nothing to re-aim at. |
| 54 further files, 101 hits | — | **FILED, NOT SWEPT** | rf2-ukkxo. Out of fence; two live peers; hot zone; and the homeless subset needs rf2-ps7ia's ruling first. |

Bare `Spec 004` under `skills/` and `migration/` is now **zero** (exit 1, positive control `Spec 0NN` firing across five skill files).

### Pocket C — `:freehand-release` (census: 24 hits, **16 files**)

The brief's 16 is confirmed against my own count; the earlier "~33" counted the tracker export. Positive control `:hicasso-bench` fired. **Largely refusals, exactly as predicted.**

| File | Line(s) | Verdict | Reason |
|---|---|---|---|
| `implementation/adapters/reagent/test/re_frame/bench/hicasso_narrow_run.cjs` | 204 | **REPAIRED** | Sole present-tense verb in an otherwise past-tense removed-fallback rationale: "`:freehand-release` **is** CLEANED AND REBUILT by `test:freehand-reachability` and `test:freehand-matched`". All three names are gone — build id absent from the `:builds` map, `implementation/package.json` carries **zero** freehand scripts (control: 12 hicasso). One word; the paragraph is now internally consistent. |
| `implementation/adapters/reagent/test/re_frame/bench/hicasso_narrow_run.cjs` | 200 | **REFUSED** | Already past tense ("the fallback **was** unreachable code"). |
| `TESTING.md` | 69 | **REFUSED** | "Widening **cost** two declarations (`build:freehand-release` …)" — a past-tense record of what a change cost. Verified at source: `check_gate_scheduling.py` no longer carries the declaration and `package.json` has no freehand script, so the sentence claims nothing live. Same class as rf2-v68fz's TESTING.md refusal. |
| `implementation/shadow-cljs.edn` | 869, 878, 925, 929, 934 | **REFUSED ×5** | Slice 3's own repairs, all already past tense ("the **departed** `:freehand-release`", "**before** rf2-0yp7w removed both"). Hot zone; nothing left to do. |
| `docs/design/freehand/studio/**` | 6 files | **REFUSED / OUT OF FENCE** | rf2-0moc4 ruled KEEP, contents untouched. Frozen measurement records naming the build they were taken under is correct history. |
| `docs/design/hicasso/studio/**` | 4 files | **REFUSED / OUT OF FENCE** | Same class; `docs/design/**` is out by standing ruling. |
| `implementation/hicasso/test/re_frame/bench/hicasso/compile_gate.cjs` | 214 | **NOT MINE — handed off** | Inside the live bench peer's declared surface. Reads "the same shape `:freehand-release` **had**" — past tense, probably a refusal. |
| `implementation/hicasso/test/re_frame/bench/hicasso/p0_converge_app.cljs` | 37 | **NOT MINE — handed off** | Same surface. **"rides `:freehand-release`'s compiler settings" — PRESENT TENSE, a real defect.** |
| `implementation/hicasso/test/re_frame/bench/hicasso/ssr/driver.cjs` | 21 | **NOT MINE — handed off** | Same surface. **"exactly as `b6_prod_run.cjs` rides `:freehand-release`" — present tense, and `b6_prod_run.cjs` is not in the tree.** |

### Pocket D — `implementation/scripts/compile-node-test.cjs:84`

| File | Line | Verdict | Reason |
|---|---|---|---|
| `implementation/scripts/compile-node-test.cjs` | 84 | **REFUSED — slice 3's refusal CONFIRMED on my own reading** | It is a dated measurement record and the count is load-bearing: "Every `:node-test`-family lane compiles warning-free today, **measured before arming this**: node-test 2395 files, … node-test-ui 343, node-test-freehand 488, … — 0 warnings in **all seven**." Editing the list falsifies the record — the measurement covered seven lanes, not five — and it is the justification for the zero-warning floor the gate now enforces. Same class as rf2-v68fz's TESTING.md refusal and slice 3's `shadow-cljs.edn:131`. |

## Quality gates

**No heavyweight gate was run.** No `scripts/test-fast-pr.sh`, no shadow-cljs, no browser, no Playwright, no npm build — the bench measurement window was live throughout. Every gate below is a focused checker over a surface this PR actually touches, run **foreground**, exit code captured by the invoking shell on the same command line and quoted from the captured file (never from a harness report).

| Gate | Surface it covers | Captured exit |
|---|---|---|
| `clj-kondo --lint` (edited `.cljs`) | the edited test namespace | **0** (0 errors, 0 warnings) |
| `python scripts/check_doc_slugs.py` | `docs/`, `spec/`, `skills/`, `migration/`, `tools/*/spec` → covers `skills/re-frame2-improver/spec/design.md` | **0** |
| `node --check` (edited `.cjs`) | the edited bench driver | **0** |
| `python scripts/check_fast_pr_gap.py --list` | spine-vs-CI gap | **0** — **96** required checks the spine does not run |

**Gate nominated by PATH, not by job name**, per `CLAUDE.md`: `check_doc_slugs.py` owns `skills/`; `check_readme_links.py --ci` was **not** nominated because this diff touches no repo-root markdown and no README beside source. Neither link gate covers `examples/**` or `implementation/**`, which is why `clj-kondo` and `node --check` carry those two files.

**All three plantable gates sabotage-proved**, each plant anchored to a **single newline-free line** with anchor uniqueness asserted before writing, each restore verified by **three `git hash-object` readings**:

| Gate | Plant | Sabotage exit | pre-plant / planted / post-restore |
|---|---|---|---|
| `clj-kondo` | closing docstring quote removed at the line I edited | **3**, 17 errors | `e6d0a299` / `4289594b` / `e6d0a299` ✓ |
| `check_doc_slugs.py` | broken link target on the row I edited | **1**, naming `design.md:83 -> ../../../spec/NoSuchFile-…` | `8ce64bf2` / `e6bcd237` / `8ce64bf2` ✓ |
| `node --check` | syntax fault at `BASE_BUILD` | **1**, `SyntaxError` naming the plant | `d60aa6f8` / `e8efbec5` / `d60aa6f8` ✓ |

Each fault existed **only in this worktree** — the mayor checkout's blobs were re-read as unchanged after every edit — so the red *is* the discrimination: a run that had wandered into a sibling checkout would have come back green. `check_doc_slugs.py` prints nothing on success and a repo-relative path on failure, so a printed root was never available for it.

Every census in this PR was run with **`.beads/` excluded** and with a **positive control**: `HD-002` for the FH-id definition search, `Spec 004B`/`004C` for the number form, `:hicasso-bench` for the build id, `Spec 0NN` for the skills subset. Every "zero" quoted above is a measured absence, not a broken pattern.

**Verified by hand, since no gate checks it:** the edited markdown row's column count (header 4 pipes, separator 4 pipes, edited row 4 pipes — 3 columns, unchanged), and the anchor targets in the edited prose. The diff adds no link, no heading and no table.

**Re-run on the final base.** The trunk moved under this branch mid-flight (two `chore(beads): checkpoint` commits, `.beads/issues.jsonl` only). Rebased onto `34d6b9c377` and **all three gates re-run there** — `clj-kondo` **0**, `check_doc_slugs.py` **0**, `node --check` **0** — because a pre-rebase green is evidence about a tree that no longer exists.

`git diff origin/main...HEAD` reviewed for reverts against the **new** merge base, three-dot form: 3 files, +8/−7, nothing a sibling landed is undone.

## Risks

Low. Three comment/docstring edits; no executable line changes. The one behavioural-adjacent file (`hicasso_narrow_run.cjs`) took a one-word change inside a `//` comment and re-parses clean.

Closes nothing. rf2-0yp7w.9 stays **open** — see rf2-ukkxo.
