### PR TITLE
spec(006): promote the render-batch law out of the observation-port heading; refuse the retirement (rf2-63t1i)

### DIFF
--- a/spec/006-ReactiveSubstrate.md
+++ b/spec/006-ReactiveSubstrate.md
@@ -1846,7 +1846,7 @@ non-watchable headless site, which guard (1) never reaches). No third mechanism 
 or is needed. A memo table that outlives its slice is a conformance bug (a leak fixture
 pins it).
 
-### Render-batch finalization — the host-checkpoint boundary
+## Render-batch finalization — the host-checkpoint boundary
 
 On the observation-port substrate, the invalidation algorithm's Phase 3
 ([§Invalidation algorithm](#invalidation-algorithm) — "notify subscribers") is realised
@@ -1914,7 +1914,7 @@ unchanged (RULED, rf2-cydkp).
 [009 §Error event catalogue](009-Instrumentation.md#error-event-catalogue) carries the
 category and the reasoning.
 
-#### The second closer — a synchronous host commit must be able to close the window
+### The second closer — a synchronous host commit must be able to close the window
 
 A dirty mark is **constant work**, and it schedules no host render work at all: it records
 the cause, enrols the cell in the open pending window, and arms the microtask. Nothing a


### PR DESCRIPTION
Executes the FIRST of the two ruled commits on rf2-63t1i, and returns a THIRD source-located refusal on the second.

**Landed:** the ruled promotion of the render-batch law out of the observation port's heading.
**Not landed:** the port's retirement — three blockers, two of them new and unruled, one a peer-fence collision.

The ruling ordered promotion first "because promoting first means the deletion never transits a tree where the law is missing". That ordering is exactly why the promotion is landable on its own: it is not a slice of the deletion, it deletes nothing, and it leaves a fully self-consistent tree. The forbidden partial landing is a partial *deletion* that ships green while orphaning `spec/009`'s catalogue. This is the opposite — it removes the blocker that caused refusal #2, permanently, so the next dispatch starts from a safe tree.

## What landed

`spec/006-ReactiveSubstrate.md`, two lines:

- `### Render-batch finalization — the host-checkpoint boundary` → `## …` (H3 → H2)
- `#### The second closer — a synchronous host commit must be able to close the window` → `### …` (H4 → H3, keeping it a child of the promoted section)

Heading text is **byte-identical** on both, so both slugs are preserved. No prose touched — the ruling's "do not 'improve' the wording while promoting it" is honoured literally: the diff contains no non-heading line.

The section was the last subsection of the port's H2 (port H2 `1186` → next H2 `1981`, section at `1849`), so "promote in place" is a pure heading-level change with no text movement.

### Why the law outlives the port (verified, not inherited)

`implementation/core/src/re_frame/frame.cljc:3523` is the docstring of `guard-open-drain!`, a live core production control, and reads `(Spec 006 §Render-batch finalization; Spec 009 §Error event catalogue)`. The same docstring states the guard lives in core because it closes over no view state, "so every substrate whose synchronous flush can publish a render phase reaches THIS one fn".

**Confirmed that citation is ungated**, which is what makes the promotion load-bearing rather than cosmetic. `scripts/check_doc_slugs.py`'s roster is `DEFAULT_ROOTS` plus `tools/*/spec` and never reaches `implementation/**`; `scripts/check_readme_links.py` walks only `README.md` files, repo-root markdown and `.claude/commands/*.md`, so it never opens a `.cljc`. Nothing validates a prose citation inside a docstring — breaking `frame.cljc:3523` would ship green.

### Citations verified still resolving

All six citations of `#render-batch-finalization--the-host-checkpoint-boundary` survive unchanged (`spec/002-Frames.md` x2, `spec/006` x2, `spec/009` x1, `spec/Runtime-Architecture.md` x1), plus the four the ruling named by line: `frame.cljc:3523`, `spec/002-Frames.md:1804` and `:1867`, `spec/Runtime-Architecture.md:162`, `spec/009:2414`.

Checked that nothing keys off `spec/006`'s H2 structure: no table of contents in the file, `spec/README.md` references the document rather than its sections, and the only tool anchoring into `spec/006` (`scripts/check_skill_re_frame2_drift.py`) anchors the adapter-inventory block, not this section.

## Quality gates

Every exit code below is the one **I captured** with an explicit echo of `$?` on the same command line as the redirect — never a harness-reported status. No gate was piped through a filter.

| Gate | Captured exit | Notes |
|---|---|---|
| `python scripts/check_doc_slugs.py` | **0** | The gate for `spec/`. Admissibility per its own docstring: `0` clean, `1` broken link, `2` setup error. |
| `python scripts/check_skill_re_frame2_drift.py` | **0** | Anchors a `spec/006` block. |
| `python scripts/check_readme_links.py --ci` | **0** | Run for completeness; this diff reaches none of its surface. |
| `python scripts/check_fast_pr_gap.py --list` | **0** | Cited below. |

**Sabotage proof that `check_doc_slugs.py` read THIS worktree.** Single-line plant — a multi-line anchor cannot match, because this working tree is **CRLF** while the blob is LF (`core.autocrlf=true`). Changed one existing valid link on `spec/006:1852` to a bogus anchor. Three `git hash-object` readings of the working file:

- pre-plant `c3c39eab64618faa84d84398875b577cc65f887c`
- planted `a43d35f32a31a5ba093861798e0de87d178b1895` (differs, so the patch applied)
- post-restore `c3c39eab64618faa84d84398875b577cc65f887c` (equals pre-plant, so the restore is verified by hash rather than by reading a diff)

The planted run captured exit **1**, with the log naming the broken anchor at `spec/006-ReactiveSubstrate.md:1852` — my line, my file, my tree. The post-restore run captured exit **0**.

**Re-run after rebase.** The branch was rebased onto `468b4b09eb` (a peer's `.claude/commands/mayor-dispatch.md` plus a beads checkpoint — neither touches `spec/`, but `check_readme_links.py` does cover that command file). All three gates were re-run on the final base and captured **0**, **0**, **0** respectively; the diff is still two heading lines and still zero table rows. The pre-rebase green is not being relied on.

**The fast-PR spine was NOT run** (`scripts/test-fast-pr.sh` never invoked) — a bench measurement window was live and heavyweight runs wedge. `scripts/check_fast_pr_gap.py --list` reports **96 required checks the spine does not decide**, so a spine pass would not have been the authority here in any case; CI's `verify-readme-links` job owns both link gates and carries no surface guard.

**Tables verified by hand, as required, since nothing validates spec tables:** this diff changes **zero** table rows. Column counts are trivially unchanged. No table was added, removed or re-columned.

`clj-kondo` was not run: no `.clj` / `.cljc` / `.cljs` file is touched by this diff.

## Why the retirement is NOT in this PR

The ruling and its premises are **re-verified and correct**; I am not revisiting the disposition. Exactly **five** real `:require`s of the port exist tree-wide, all test namespaces, zero under any `src/` — positive control `[re-frame.substrate.spine` returns hits including adapter `src/` requires, so the pattern discriminates and the empty `src/` result is a true empty. `spec/006` does not mandate the port as a substrate obligation.

**My own census reproduces the eleven-page floor exactly**, which is itself worth recording — after five undercounts, this fence is accurate on the axes it measured: **11** spec pages (8 carrying a port spelling, plus `spec/002-Frames.md`, `spec/Runtime-Architecture.md` and `spec/004C-Roots-and-Mount.md` citing only by anchor), **17** src prose sites beyond the port, **26** test namespaces. All sweeps excluded `.beads` and each ran with a positive control.

Three things sit **beyond** that floor.

### Blocker A — "The six frozen invariants" is the same problem the ruling just solved, one section over, and was not ruled

`### The six frozen invariants` (`spec/006:1299-1381`) is inside the port H2 and therefore inside the material slated for deletion. **Invariant 6 is not port-scoped.** It is titled "One notification per cell per render batch — the boundary is the host checkpoint, not drain quiescence and not epoch close", it defines the render batch, it states "**No render count may be inferred from the number of event/frame epochs, nor from the number of drains**", and it retires "one render batch per router drain" as normative — the *same law* this PR just promoted. The two are **mutually referential**: invariant 6 links to the render-batch section twice, and the promoted section cites "invariant 6" **three times**.

Those three citations are **plain prose, not links**, so deleting invariant 6 would leave the section this PR just rescued citing a deleted definition three times — and `check_doc_slugs.py` cannot see it. That is the identical gate gap that produced refusal #2, one layer down.

It is not confined to invariant 6. By the ruling's own test — a law that a core control names as its authority is not port-scoped — two more invariants fail to be port-scoped:

- **Invariant 5** is cited by `implementation/core/src/re_frame/frame.cljc:1710` ("which invariant 5 already prices in") — live core, ungated prose — and by `docs/design/hicasso/architecture.md:146` and `hd-002-adjudication.md:507`. It also names a **live, non-port** test as its pin: `implementation/hicasso/test/re_frame/bench/hicasso/arm1/staged_read_tear_cljs_test.cljs`, present on disk.
- **Invariant 2** is cited by `implementation/core/src/re_frame/subs.cljc:2304` — live core, ungated prose.
- **Invariant 1** is cited from `spec/006:1095`, inside the surviving `## Subscription cache` H2. That one *is* a markdown anchor, so `check_doc_slugs.py` would catch it.

Invariants 1, 3 and 4 genuinely are port-scoped (probe / acquire / release handle mechanics). So this section cannot be promoted wholesale the way render-batch could: it must be **split** — deciding which invariants survive, where they live, and rewording the survivors out of port framing. That is spec authoring on normative material two live core files cite. It is the same kind of question the ruling already accepted was a ruling rather than a worker's call, and it has not been ruled.

### Blocker B — retiring the port strands live core machinery in `subs.cljc` that exists only to serve it

`subs.cljc` is fenced in the brief as a *prose site*. It is not. It carries a port-only apparatus in shipped core:

- `acquire-cache-reaction!` (`:2298`, `^:no-doc`) — **the port is its only caller**. Its five call sites are all in `observation.cljc`. Deleting the port makes it dead code.
- `*acquire-recovery*` (`:710`, `^:dynamic ^:no-doc`) — "bound ONLY by the port's acquire path".
- `record-acquire-recovery!` (`:719`, private) and its recorder calls at the never-cached recovery sites **inside the live `compute-and-cache!` / `build-and-cache!*` build machinery**, which short-circuit when the dynamic var is nil.

Removing this is surgery inside core's subscription build path, not a docstring edit. And it needs a disposition first, because the tree holds a live precedent pointing the **other** way: `spec/009:2414` reasons at length that `guard-open-drain!` is "RETAINED normative surface rather than residue" despite having **no in-repo call sites**, "because the law is core's rather than the retired substrates'". Whether `acquire-cache-reaction!` is residue or a retained core seam is the identical question, already answered once in the opposite direction.

Related and tractable, recorded so it is not rediscovered: the **other** `^:no-doc` seam, `compute-sub-with-memo`, **survives** — `implementation/hicasso/src/re_frame/hicasso/impl/collector.cljs:1180` calls it in shipping source. Only its port-framed docstring needs re-homing.

### Blocker C — the retirement requires editing a live peer's fence

`implementation/core/test/re_frame/bench/read_attribution.clj:176` holds a **real** `:require` of the port. It is an 851-line two-ladder instrument whose `subs` arms are cited by shipping source (`subs.cljc:534`, "measured, `re-frame.bench.read-attribution` arms RC-ATTACH / RC-CAND"), so it must be kept and have its port ladder removed surgically — `arm-port`, `port-plan`, the `port?` branch, the default `RM_SUITE=port`, and roughly thirty lines of report formatting keyed to `PORT`.

That file is inside `implementation/core/test/re_frame/bench/**`, which this brief assigns to peer `worker/armconf-c4hhk` (BENCH-CLASS, holding the machine). Re-derived at start-up and again before writing: `armconf-c4hhk` is a live worktree, and **`worker/workcnt-n1b9h` — a peer the brief does not name — is at this moment holding nine uncommitted files in that exact directory** (`p0_fixture.cljc`, `p0_floor.cljs`, `p0_heap.cljs`, `p0_hicasso.cljs`, `p0_ladder_structural.test.cjs`, `p0_reagent.cljs`, `p0_run.cjs`, `p0_uix.cljs`, plus a new `p0_workcount.cljc`). The retirement cannot be completed without writing into that directory.

One alarm **cleared** here, so the next dispatch need not re-run it: the CLJS sibling `read_attribution_cljs.cljs` needs no surgery. Its own docstring (`:25`) states it "carries no `probe` / observation-port arm", and it has no port `:require` — one prose line, not an arm.

### Two alarms from the ruling, re-confirmed rather than re-litigated

`:adapter/activate-derived-value!` survives (live non-port callers via the spine; only late-bind directory prose staled), and the static override handle is genuinely port-scoped.

### Also confirmed as stated, for the next dispatch's inventory

`observation_schema_extract.clj` parses `(def ObservationOnChangeFailedTags …)` out of `spec/Spec-Schemas.md` and **throws** if absent (`:41`). `observation_render_law_drift_test.clj` reads `re_frame/substrate/observation.cljc` off the classpath and **asserts the URL is non-nil** (`:255`), so it throws on deletion — but note that only **one** of its five deftests is port-scoped; the other four are a repo-wide census defending the *retired per-epoch render law*, i.e. the very law this PR promoted, and its allowlist (`:107`) would need updating as the port's files go. The classifier pair justifies `spec/Spec-Schemas.md`'s `cljs_node_test` arm entirely by the `observation_schema_extract.clj` to `observation_port_cljs_test.cljc` macro edge (`report-changed-surfaces.sh:1428-1438`, `_changed-surfaces.test.cjs:5099-5101`), and the mirror additionally rosters `re-frame.observation-render-law-drift-test` at `:408`.

## Deletion inventory

Nothing deleted. Nothing under `implementation/**` touched. No shim written, no consumer deleted to make a deletion fit, and no peer-held or hot-zone file taken beyond `spec/006` itself.

### Spellings swept, each with a positive control, `.beads` excluded

| Spelling | Files | Control |
|---|---|---|
| `re-frame.substrate.observation` | 23 | `re-frame.substrate.spine` finds 64 files |
| `[re-frame.substrate.observation` (require form) | 5 | same bracket form for the spine returns adapter `src/` requires |
| `re_frame/substrate/observation` (path form) | 1 | covered by the namespace sweep |
| `substrate/observation` | 6 | covered by the namespace sweep |
| `observation port` / `observation-port` (prose) | 53 / 27 | both non-empty, so both discriminate |
| `port-abi-version` | 8 | non-empty |
| `ObservationOnChangeFailedTags` | 7 | non-empty |
| six `:rf.error/observation-*` and `read-after-release` keywords | 5 to 10 each | `:rf.error/flush-in-open-epoch` finds 6 lines |
| anchor `#the-internal-observation-port-adapter-internal` | 14 lines | non-empty |
| anchor `#render-batch-finalization--the-host-checkpoint-boundary` | 6 lines | non-empty |
| anchor `#the-six-frozen-invariants` / `#the-static-override-handle` | 1 / 1 | non-empty |

Union across all spellings: **69 files**.

**A spelling trap worth recording**, since the next dispatch will hit it: the bare word "observation" matches **382 files**, because `spec/015-Data-Classification.md`, `spec/Privacy.md` and the epoch / SSR trees use "observation boundary", "observation streams" and "observation records" for an entirely **unrelated** Spec-015 egress concept. A census on the bare word inflates by roughly 5x. Sweep the port by namespace, anchor and category keyword — never by the English word.

Pre-deletion counts are the table above. Post-deletion counts are not reported because nothing was deleted.
