### PR TITLE
docs(hicasso): the work-census instrument pin names an object that exists (rf2-ymwjc)

### DIFF
--- a/docs/design/hicasso/studio/the-work-count-is-a-constant-and-the-mode-did-not-reproduce.md
+++ b/docs/design/hicasso/studio/the-work-count-is-a-constant-and-the-mode-did-not-reproduce.md
@@ -83,7 +83,7 @@ otherwise draw a conclusion from.
 
 | File | Blob at this page's base |
 |---|---|
-| `core/test/re_frame/bench/p0_workcount.cljc` | `1787bc0053772c6bd72c3b665db8e8f9be87b2cd` |
+| `core/test/re_frame/bench/p0_workcount.cljc` | `033f00470c380a17664a1dabffa0768f0e22c671` |
 
 The other rig files carry the census call sites and the recording; the census's
 own semantics are wholly in the blob above.


### PR DESCRIPTION
Fixes rf2-ymwjc.

The "Instrument revision" table on *The work count is a constant, and the mode did not reproduce* pinned `p0_workcount.cljc` at `1787bc0053772c6bd72c3b665db8e8f9be87b2cd`. `git cat-file -t` on that token returns *could not get object info* — it is in no clone. That table is the only thing telling a future reader **which** instrument produced the workcount datasets, so a pin nobody can resolve still *looks* pinned: the rf2-owq6p failure mode, one level down.

One occurrence, one token. **Diff is 1 file, 1 insertion, 1 deletion** against the merge base (`origin/main...HEAD`, three-dot).

## The corrected pin, and how it was derived

Not copied from the bead — derived four independent ways, all agreeing on `033f00470c380a17664a1dabffa0768f0e22c671`:

| Derivation | Result |
|---|---|
| `git rev-parse 157f97d67d:implementation/core/test/re_frame/bench/p0_workcount.cljc` (the authored branch commit) | `033f0047…` |
| `git rev-parse 408dfb0aa8:…` (the rebase-merged commit, confirmed an ancestor of `origin/main`) | `033f0047…` |
| `git rev-parse origin/main:…` (tip) | `033f0047…` |
| `git ls-tree 408dfb0aa8 …` and `git ls-files -s …` (index) | `100644 blob 033f0047…` |

A pin that merely *resolves* is not necessarily *correct*, so the object was also opened rather than just resolved: `git cat-file -t` says `blob`, `git cat-file -s` says 7690 bytes, and `git cat-file -p` begins `(ns re-frame.bench.p0-workcount "EP-0038 P0 — the WORK CENSUS: …")`. It is the right file, not merely a reachable one.

## Quality gates

Every exit code below was captured with an explicit echo of the runner's own status on the same command line, redirected to a per-worktree, per-attempt log. Nothing was piped through a filter.

| Gate | Command | Exit |
|---|---|---|
| Provenance pins | `python scripts/check_provenance_pins.py` | **0** |
| Doc slugs / anchors | `python scripts/check_doc_slugs.py` | **0** |
| Fast-PR gap listing | `python scripts/check_fast_pr_gap.py --list` | **0** |

**`check_provenance_pins.py` does NOT red on this defect, and that is the point of the bead.** The gate separates commits from digests by CONTEXT, never by asking git — its own docstring gives the reason, and it is a good one: the stranded pins are precisely the objects a fresh clone lacks, so "git has never heard of this" and "this is a content digest" are the same observation from inside a checkout, and a resolvability-based classifier would call every stranded pin a digest and pass a corpus of entirely broken pins, silently, in CI. Here both context rules fire toward *digest* — a file path in a code span is a digest word, and the enclosing `| File | Blob at this page's base |` header makes the table a blob table top to bottom. **An unresolvable blob is outside its population by design, not by oversight.** No change was made to the gate.

That was measured, not assumed. With the defect **restored** the gate exits **0**; the working file at that moment hashed `84642097399cfb479310980a7d3d81bbe38e80e5`, byte-identical to the object committed at `HEAD`, so the plant demonstrably applied.

**Proof the gate read this tree**, three readings against the committed object:

| Reading | `git hash-object` of the page | Gate |
|---|---|---|
| pre-plant (fixed) | `dfa809ec8c5052a64a06990965ee4052dec7b65a` | 0 |
| planted — `4a5cbfea87` to `4a5cbfea99` on line 7, a single newline-free anchor | `d1eb4e4f86bbe979d5c7f868063d4a50a8a32fb7` | **1** |
| post-restore | `dfa809ec8c5052a64a06990965ee4052dec7b65a` | 0 |

Pre-plant differs from planted, so the patch applied; post-restore equals pre-plant exactly, so the restore is byte-exact. Under the plant the gate named the file, the line and the token: `…the-work-count-is-a-constant-and-the-mode-did-not-reproduce.md:7  4a5cbfea99 [UNRESOLVABLE]`. A commit-classed token was chosen deliberately — a blob-classed or over-40-character plant would have come back green because the gate *excluded* it, not because it passed.

**Not nominated, and verified at source:** `mkdocs build --strict` does **not** cover this path. `mkdocs.yml` sets `docs_dir: docs` and its `exclude_docs` block lists `design/hicasso/` (alongside `design/freehand/`, `design/retirement/`, `tools/playground/` and the two codemod trees), so `docs/design/hicasso/**` is off the site.

**The fast-PR spine did not run.** `scripts/check_fast_pr_gap.py --list` places this surface under `docs.yml`, job **"Provenance pins"**, step *"Check provenance pins on changed pages"* — a docs workflow job, not a spine tier. No heavyweight gate was run at all: no spine, no shadow-cljs, no browser, no npm build. None covers a one-token markdown edit.

**Verified by hand, because nothing gates it:** the "Instrument revision" table's column counts are header 2, separator 2, body row 2 — consistent. Prose, tables and rendering are outside every gate above.

## Unresolvable-pin sweep — the class, not the instance

Extracted every **exactly-40-lowercase-hex** token from all tracked markdown, with `.beads/` excluded (a ~15 MB database export that matches almost everything), and asked `git cat-file -t` for each. The regex is bounded by negative hex lookaround on both sides so a 64-character SHA-256 document digest cannot contribute a 40-character substring.

**971 files · 300 distinct tokens · 449 occurrences → 223 blobs, 59 commits, 1 tree, and 17 unresolvable.**

*Controls, because a search returning zero is not a check that passed:* the extractor was run against something it must find and located the known-bad token (`True`); the resolver returned `blob` rc=0 for the known-good replacement; and it returned rc≠0 for a synthetic all-zero token, so it can say *no*.

**Of the 17, exactly one is a defect — the one repaired here.** The other sixteen do not resolve *by design*, in four classes:

| Class | Tokens | Why it cannot resolve |
|---|---|---|
| External repository commits | `247fafa2…` (krausest/js-framework-benchmark), `b463a97a…` (athensresearch/athens), `71bf92b4…` (district0x/memefactory), `a3c30943…` (day8/re-frame-10x), `2b835032…` (day8/clein, a `:git/sha` dep) | Objects of *other* repositories; several are cited with their github.com commit URLs |
| Sabotage-plant content hashes | `a3d28cb0…`, `ff8ceed0…`, `7fbc629c…`, `d7f4272f…`, `7c4659d2…`, `91ef67b8…` | The "Under the plant" column of a plant/restore control. A hash that *changed* is the evidence the plant applied; the planted state is never committed, and each row's baseline and restored hashes do resolve |
| Toggled-arm content hashes | `5b4f4e06…`, `6468c2aa…`, `a832fafb…`, `eca40a01…` | The B arm of an A/B ladder — one line removed or commented out in the working tree. In every one of these tables the A-arm blob on the row above resolves and the B-arm blob does not, which is exactly the expected signature |
| Not a git object at all | `a53d3c8e…` | A `git patch-id --stable` value, explicitly labelled as such |

The seventeenth token is cited **twice**. It is repaired in the instrument table here, and deliberately **left standing** on `the-second-mode-a-pre-registered-twenty-run-window.md:186`, where the broken token is the *subject* of a paragraph reporting this very finding — quoting it verbatim is what makes that record true, and that page belongs to another bead besides.

**A supplementary pass** covered abbreviated pins, since the same class exists one level down: 7–12 hex characters inside a code span, across the gate's own corpus root (`docs/design/hicasso`, its `DEFAULT_ROOT`). **131 files · 362 distinct tokens · 811 occurrences → 298 commits, 62 blobs, 2 unresolvable** — and neither is a defect: `165e7fdea6` is described on its own line as a *"modified `arm1/runtime.cljs`"*, and `83b865f8` is an 8-character FNV render-tree hash the page itself names as such. Controls again: the extractor found a known abbreviated pin, and the resolver rejected a bogus one.

## No new gate is proposed

The sweep is the argument against one. A resolvability check over 40-hex tokens would fire on **sixteen legitimate records** and zero real defects beyond this one — it would be noise from its first run and disabled within a week, which is precisely the reasoning the bead and the gate's docstring already set out. The corpus is in good shape: every commit-classed pin in it resolves, which is what `check_provenance_pins.py` enforces and it is working. This was a single mistyped token, and it is now correct.

## Risks

Low. One token in one table cell in a design record excluded from the built site; no code, no spec, no gate touched. The residual risk is that `033f0047…` is the blob at the *merge* commit while the page says "at this page's base" — those are the same object here, confirmed at the authored commit, the merged commit and `origin/main` alike, so the distinction does not bite.
