### PR TITLE
docs(xray): retire the last live Freehand and re-frame.ui claims in tools/ prose (rf2-0yp7w.9)

### DIFF
--- a/examples/scripts/check-examples-assets.cjs
+++ b/examples/scripts/check-examples-assets.cjs
@@ -319,14 +319,16 @@ const BUILD_OUTPUTS = new Set(['main.js']);
 // is monorepo-STAGED: it is source-only, built from implementation/'s shadow
 // config with a central `:examples/*` build id, and the orchestrator copies
 // _shared into its output dir — so the shared-design-system contract (favicon +
-// OG card + style.css) applies. A standalone scaffold like
-// examples/ui/minimal-counter/ is the opposite: it carries its OWN
-// shadow-cljs.edn / package.json / deps.edn, serves its own host page from
-// resources/public/, and is deliberately NOT on the monorepo classpath (it is
-// "the tree you would have created yourself"). It links none of _shared — nor
-// should it, a minimal user-facing scaffold is not a gallery showcase — and its
-// host-page contract is owned end-to-end by its own scaffold smoke
-// (implementation/freehand/scaffold-smoke). Enumerating it here would force the
+// OG card + style.css) applies. A standalone scaffold is the opposite: it
+// carries its OWN shadow-cljs.edn / package.json / deps.edn, serves its own
+// host page from resources/public/, and is deliberately NOT on the monorepo
+// classpath (it is "the tree you would have created yourself"). It links none
+// of _shared — nor should it, a minimal user-facing scaffold is not a gallery
+// showcase — and its host-page contract is owned end-to-end by its own
+// scaffold smoke. The scaffold this used to name, examples/ui/minimal-counter/,
+// went with the donor tree under rf2-0yp7w, and no standalone scaffold is in
+// the tree today — nothing under examples/ carries its own shadow-cljs.edn — so
+// the rule below is prospective. Enumerating it here would force the
 // gallery chrome onto a page that must stay minimal, so a project root bearing
 // its own shadow-cljs.edn is pruned from this walk (any future standalone
 // scaffold under examples/ is excluded by the same marker, no per-path list).

--- a/tools/xray/spec/008-Embedding-Contract.md
+++ b/tools/xray/spec/008-Embedding-Contract.md
@@ -450,8 +450,8 @@ namespace docstring (see `tools/xray/src/day8/re_frame2_xray/registry.cljs`).
 
 Xray renders pure hiccup, so it can mount only through a host adapter
 whose `:render` slot accepts hiccup render-trees — the **ratom family**
-(stock Reagent, Reagent-slim). The React-hook substrates (UIx, Hicasso,
-and the first-party Freehand and re-frame.ui) share an **element-shaped** `render`
+(stock Reagent, Reagent-slim). The React-hook substrates (UIx,
+Hicasso) share an **element-shaped** `render`
 that hands the tree to React untouched; a hiccup shell mounted there
 reaches React children as raw CLJS data (fn-as-child console.error
 plus an uncaught MapEntry pageerror — rf2-qgfo4). On those hosts the

--- a/tools/xray/spec/008-Embedding-Contract.md
+++ b/tools/xray/spec/008-Embedding-Contract.md
@@ -450,9 +450,9 @@ namespace docstring (see `tools/xray/src/day8/re_frame2_xray/registry.cljs`).
 
 Xray renders pure hiccup, so it can mount only through a host adapter
 whose `:render` slot accepts hiccup render-trees — the **ratom family**
-(stock Reagent, Reagent-slim). The React-hook substrates (UIx,
-Hicasso) share an **element-shaped** `render`
-that hands the tree to React untouched; a hiccup shell mounted there
+(stock Reagent, Reagent-slim). The React-hook substrates (UIx, Hicasso)
+share an **element-shaped** `render` that hands the tree to React
+untouched; a hiccup shell mounted there
 reaches React children as raw CLJS data (fn-as-child console.error
 plus an uncaught MapEntry pageerror — rf2-qgfo4). On those hosts the
 mount verbs (`open!`, `open-overlay!`, `popout!`, and therefore the

--- a/tools/xray/spec/011-Launch-Modes.md
+++ b/tools/xray/spec/011-Launch-Modes.md
@@ -467,8 +467,8 @@ load. It MAY schedule a bounded adapter-ready retry. Once the adapter
 is ready, it MUST find the configured layout host and mount the shell
 there. If the host is missing, it MUST emit the diagnostic described in
 §Layout host contract and leave the app running. If the installed
-adapter is a React-element substrate (UIx / Hicasso / Helix / Freehand /
-re-frame.ui — hosts whose `:render` cannot take the hiccup shell, per
+adapter is a React-element substrate (UIx / Hicasso / Helix — hosts
+whose `:render` cannot take the hiccup shell, per
 [`008-Embedding-Contract.md`](./008-Embedding-Contract.md) §Adapter
 resolution), it MUST refuse the mount with the
 `:unsupported-substrate` diagnostic (status API + one `console.warn`)

--- a/tools/xray/spec/011-Launch-Modes.md
+++ b/tools/xray/spec/011-Launch-Modes.md
@@ -467,8 +467,8 @@ load. It MAY schedule a bounded adapter-ready retry. Once the adapter
 is ready, it MUST find the configured layout host and mount the shell
 there. If the host is missing, it MUST emit the diagnostic described in
 §Layout host contract and leave the app running. If the installed
-adapter is a React-element substrate (UIx / Hicasso / Helix — hosts
-whose `:render` cannot take the hiccup shell, per
+adapter is a React-element substrate (UIx / Hicasso / Helix — hosts whose
+`:render` cannot take the hiccup shell, per
 [`008-Embedding-Contract.md`](./008-Embedding-Contract.md) §Adapter
 resolution), it MUST refuse the mount with the
 `:unsupported-substrate` diagnostic (status API + one `console.warn`)

--- a/tools/xray/spec/021-Dynamic-Panel-Designs.md
+++ b/tools/xray/spec/021-Dynamic-Panel-Designs.md
@@ -835,13 +835,15 @@ entry in `tools/xray/testbeds/feature_matrix/scenarios.cjs`, and the canonical
 covered-row count pin in `coverage_matrix_metadata_test.clj` — because the
 PR-smoke run is derived from those entries rather than from a fixed list, and
 because that scenario was the sole claimant of its matrix row. The deck's
-SOURCE (`tools/xray/testbeds/freehand_views/`) stays until the Freehand tree
-deletion, because it is inseparable from its `:testbeds/freehand-views` build
+SOURCE (`tools/xray/testbeds/freehand_views/`) waited for the Freehand tree
+deletion, because it was inseparable from its `:testbeds/freehand-views` build
 id and port-8036 `:dev-http` entry in top-level
-`implementation/shadow-cljs.edn`: deleting the source alone leaves a build
-compiling a tree that is not there.
+`implementation/shadow-cljs.edn`: deleting the source alone would have left a
+build compiling a tree that is not there. **The second pass has landed**
+(rf2-0yp7w) — source, build id and port went together, and nothing under
+`tools/xray/testbeds/` or `implementation/shadow-cljs.edn` names the deck now.
 [`017-Test-Coverage-Matrix.md`](017-Test-Coverage-Matrix.md) carries the
-remaining checklist.
+artefact-by-artefact record.
 
 One asserted fact OUTLIVES the deck and is worth naming, because it is the
 only browser-level proof that `:adapter/activate-derived-value!` holds end to

--- a/tools/xray/spec/027-Hicasso-Evidence.md
+++ b/tools/xray/spec/027-Hicasso-Evidence.md
@@ -481,11 +481,14 @@ is rf2-hic-024's.
 The dependency points one way only: `tools/xray` → `implementation/hicasso`.
 Nothing under `implementation/` may `:require` anything under `tools/`.
 
-**Release note.** `implementation/hicasso/deps.edn` carries no `:clein/build`
-yet (rf2-hic-008 owns release wiring), so `day8/re-frame2-hicasso` is the
-second in-repo coordinate `.github/scripts/preflight-xray-package.sh` refuses
-to find in a published pom, beside `day8/re-frame2-freehand`. That refusal is
-correct and is not a mechanical fix.
+**Release note — CLOSED.** This edge was once Xray's unpublishable coordinate:
+`implementation/hicasso/deps.edn` carried no `:clein/build`, so
+`.github/scripts/preflight-xray-package.sh` refused to find
+`day8/re-frame2-hicasso` in a published pom. rf2-gra70 answered it by
+publishing the artefact — `deps.edn` now carries the `:clein/build` alias — and
+the refusal is gone. What replaces it is an ordering obligation rather than
+nothing; see
+[`docs/release-process.md`](../../../docs/release-process.md).
 
 ---
 
@@ -575,9 +578,10 @@ surface in `feature_matrix/scenarios.cjs` is a Hicasso host, so a populated arm
 in the shell sweep needs a new deck, a new `implementation/shadow-cljs.edn`
 build id and a new `:dev-http` port — the shape rf2-6pohj built for the Views
 panel. That cost is why there is no staged Hicasso host, and it is not a reason
-against the DOM row above. If that deck is ever wanted its moment is the
-Freehand tree deletion, because `testbeds/freehand-views` existed solely to
-give the Views panel a populated roster, those panel sections have now retired
-(`021-Dynamic-Panel-Designs.md` §3.4.1, rf2-l86mm), and the deck's build id,
-port and scenario slot free up together with the tree. This tab is the survivor
-of that disposition, not a casualty of it.
+against the DOM row above. If that deck is ever wanted, its moment has arrived:
+`testbeds/freehand-views` existed solely to give the Views panel a populated
+roster, those panel sections retired
+([`021-Dynamic-Panel-Designs.md`](021-Dynamic-Panel-Designs.md) §3.4.1,
+rf2-l86mm), and the deck's build id, port and scenario slot freed up with the
+Freehand tree (rf2-0yp7w). This tab is the survivor of that disposition, not a
+casualty of it.

--- a/tools/xray/spec/027-Hicasso-Evidence.md
+++ b/tools/xray/spec/027-Hicasso-Evidence.md
@@ -487,8 +487,7 @@ Nothing under `implementation/` may `:require` anything under `tools/`.
 `day8/re-frame2-hicasso` in a published pom. rf2-gra70 answered it by
 publishing the artefact — `deps.edn` now carries the `:clein/build` alias — and
 the refusal is gone. What replaces it is an ordering obligation rather than
-nothing; see
-[`docs/release-process.md`](../../../docs/release-process.md).
+nothing; see [`docs/release-process.md`](../../../docs/release-process.md).
 
 ---
 

--- a/tools/xray/spec/Principles.md
+++ b/tools/xray/spec/Principles.md
@@ -131,11 +131,7 @@ Xray ships **zero bytes** in production. The trace bus, the epoch
 history, the schema validation, the registrar trace emit — all
 gated on `re-frame.interop/debug-enabled?` (alias of `goog.DEBUG`).
 Production builds (`:advanced` + `goog.DEBUG=false`) elide all of it.
-That includes the view-evidence reads themselves: `re-frame.freehand.tool`
-nil-gates every read on `re-frame.interop/debug-enabled?`, and the
-current-occurrence index it reads is written only from call sites inside the
-same gate — so a production build allocates no index because nothing reaches
-the atom for Closure to keep it alive for. The advanced gate executes a
+The advanced gate executes a
 private-state assertion in addition to bundle sentinels. Its second advanced
 build deliberately creates and mutates a renamed `cacheline*` atom and must
 fail the runtime assertion, proving this specific evidence-state oracle still

--- a/tools/xray/spec/Principles.md
+++ b/tools/xray/spec/Principles.md
@@ -131,8 +131,8 @@ Xray ships **zero bytes** in production. The trace bus, the epoch
 history, the schema validation, the registrar trace emit — all
 gated on `re-frame.interop/debug-enabled?` (alias of `goog.DEBUG`).
 Production builds (`:advanced` + `goog.DEBUG=false`) elide all of it.
-The advanced gate executes a
-private-state assertion in addition to bundle sentinels. Its second advanced
+The advanced gate executes a private-state
+assertion in addition to bundle sentinels. Its second advanced
 build deliberately creates and mutates a renamed `cacheline*` atom and must
 fail the runtime assertion, proving this specific evidence-state oracle still
 has teeth after minification; it is not a


### PR DESCRIPTION
R6 slice 5 of the Freehand / re-frame.ui retirement prose sweep (rf2-0yp7w.9).

Six sites repaired, all of them prose that named a removed substrate **in the
present tense**. Everything else the census turned up on this fence is HISTORY
or DELIBERATE and is deliberately untouched — a dead library named in a record
of its own death is not a live reference.

## The census, re-derived at trunk tip

The brief's pattern returned **196 files**; re-run here it returns the same 196
before my edits, 193 after. **But the pattern over-counts by 22 files**, and the
mechanism is worth recording: `re-frame2-ui` matches inside `re-frame2-uix`, so
the whole live, first-class **UIx adapter** — `day8/re-frame2-uix` — is swept up
as donor residue. Anchoring it (`re-frame2-ui([^x]|$)`) gives the real figure:

| Pattern | Files |
|---|---|
| brief's, at my base | 196 |
| corrected (uix false positive removed) | 174 |
| corrected, at HEAD after this change | 171 |

Controls: `hicasso` returns 966 files (the pattern reaches the tree); a nonsense
token returns 0; `re-frame.uix` / `re_frame.uix` return 0 files, so `re-frame\.ui`
carries no equivalent prefix trap.

`.beads` excluded throughout, plus the four ruled-KEEP trees
(`docs/design/freehand`, `docs/design/hicasso`, `docs/EP`, `docs/design/retirement`).

## The split on my fence

Of the corrected 174, **34 fell inside this dispatch's fence**. Adjudicated:

| Class | Files | Disposition |
|---|---|---|
| RESIDUE | 7 | **6 repaired here**; the 7th is held by a live worker (below) |
| HISTORY | 23 | retirement records, changelog entries, provenance notes, past-tense rationale |
| DELIBERATE | 4 | negative tests and skill criteria that name the donors *on purpose* |

Six of those 34 are held by a live worker's branch and were left alone whatever
their class; they are named under *Held or fenced* below.

### RESIDUE — the six repairs

* **`tools/xray/spec/008-Embedding-Contract.md` §Adapter resolution** — listed
  "the first-party Freehand and re-frame.ui" among the live React-hook
  substrates. That sentence drives a normative MUST-refuse.
* **`tools/xray/spec/011-Launch-Modes.md`** — the same enumeration, inside the
  preload's `MUST refuse the mount` clause: `UIx / Hicasso / Helix / Freehand /
  re-frame.ui`.
* **`tools/xray/spec/Principles.md` §Production elision** — explained the
  elision of the view-evidence reads *through* `re-frame.freehand.tool`'s
  nil-gating. Those reads retired with their substrate (021 §3.4.1) and the
  namespace is gone, so the paragraph explained the elision of nothing.
* **`tools/xray/spec/021-Dynamic-Panel-Designs.md` §3.4.1** — "The deck's SOURCE
  … **stays until** the Freehand tree deletion". Measured at tip: `git ls-files
  tools/xray/testbeds/freehand_views` returns **0** (control: `tools/xray/testbeds`
  returns 40); `implementation/shadow-cljs.edn` names neither `freehand-views`
  nor port `8036` (control: 74 `testbeds/` hits, 31 `803x` ports).
* **`tools/xray/spec/027-Hicasso-Evidence.md`** — two sites. The **Release note**
  claimed `implementation/hicasso/deps.edn` "carries no `:clein/build` yet", so
  `preflight-xray-package.sh` still refuses `day8/re-frame2-hicasso` "beside
  `day8/re-frame2-freehand`". **Both halves are false**: that `deps.edn` carries
  `:clein/build` at line 169 and says "PUBLISHED, as of rf2-gra70" at line 42;
  the script's own comment records the Freehand edge deleted and Hicasso
  published; `docs/release-process.md` carries the closed record. The second
  site future-tensed a deletion that has landed.
* **`examples/scripts/check-examples-assets.cjs`** — the standalone-scaffold
  rationale cited `examples/ui/minimal-counter/` and
  `implementation/freehand/scaffold-smoke` in the present tense. `examples/ui`
  was deleted by `c951808b47` (rf2-0yp7w.6) and nothing under `examples/`
  carries its own `shadow-cljs.edn`, so the rule is prospective. The **rule is
  unchanged**; only the dead exemplar is re-tensed.

### DELIBERATE — named on purpose, kept

`tools/re-frame2-pair-mcp/test/…/hicasso_tool_test.cljs` and `…/hicasso_wire_test.cljs`
assert the donor spellings are **absent** (`(is (not (str/includes? form "freehand")))`,
`(doseq [donor ["re-frame.freehand" "re-frame.ui.tool"]] …)`);
`skills/reagent-migration/evals/evals.json` and `…/spec/authoring-prompt.md`
grade against carrying a Freehand spelling across. Stripping the name breaks the
check.

### HISTORY — the twenty, in one line

`CLAUDE.md`, `TESTING.md`, `CHANGELOG.md`, `docs/release-process.md`,
`implementation/README.md`, both `article_editor.cljs` docstrings, the two
hicasso READMEs, the whole `migration/reagent-to-hicasso/codemod` trio,
`skills/reagent-migration/spec/{design,inputs}.md`,
`tools/story/spec/015`, `tools/story/src/…/late_bind.cljc`,
`tools/template/spec/DESIGN-RATIONALE.md`, `tools/xray/spec/014` and `018`, and
the surviving past-tense body of `021` and `027`. Every one is past-tense and
correct; several are load-bearing provenance (the codemod's classpath rationale,
`frozen-sources.edn`'s `:forbidden-import-prefixes` still barring
`re-frame.freehand.`, verified present at line 235).

### A false positive worth naming

`docs/api/re-frame.core.md:845` lists `:rf.adapter/freehand` and `:rf.adapter/ui`.
That is **not** residue and needs no bead: it is a faithful generated rendering
of a DELIBERATE reserved-kind row, sourced from
`implementation/core/src/re_frame/substrate/adapter.cljc:27` ("stay reserved and
are never [reused]") and pinned by `spec/006` §2808 and `spec/Conventions.md:103`.
No hand-edit, and the generator was not run.

## Held or fenced — reported, not touched

* **`tools/xray/spec/017-Test-Coverage-Matrix.md`** carries the one real
  remaining residue on this fence: its §freehand-views section still says "The
  remaining six go quietly stale, and they travel with the FREEHAND TREE
  DELETION" and tables six artefacts as pending. **All six have landed** —
  measured individually above and in `implementation/scripts/dev-testbed.cjs:93`,
  `implementation/README.md` and `.github/workflows/test.yml:4165`. Held by
  `worker/cites-ukkxo` (PR #8523).
* Repo-root **`README.md`** — declared CONTENDED mid-dispatch. It carries **no
  donor residue**: its only match is line 187, `day8/re-frame2-uix`, i.e. the
  false positive above. Nothing to route.
* `tools/xray/spec/018`, `tools/story/spec/017-Testing-Story.md`,
  `tools/story/src/…/presence.cljc` (PR #8523), `CHANGELOG.md`
  (`worker/rosters-ye64v`), `skills/reagent-migration/evals/evals.json`
  (`worker/skillmig-4zkbd`) — all HISTORY or DELIBERATE on inspection; nothing owed.
* `spec/**` (10 files), `.github/**` (9), `scripts/**` (9),
  `implementation/**` (95) — fenced out. `scripts/check_jvm_lane_rosters.py:82`
  was checked and is DELIBERATE: it explains why the `BASELINE` dict is empty.
* **`implementation/hicasso/test/re_frame/bench/hicasso/**` — a live remainder,
  filed as its own bead.** Fenced out (live allocation window). Re-measured
  here, and it is **worse than the bead recorded**: `ssr/driver.cjs:60` is not
  prose but `const BUILD_ID = 'freehand-bench-node'`, and that build id is
  absent from `implementation/shadow-cljs.edn` (control `hicasso-bench`: 5 hits)
  while the file is wired live from `implementation/package.json:28-29`.

## Quality gates

**The fast-PR spine did NOT run, and no heavyweight gate of any kind ran** — a
live allocation measurement window holds this machine, and two heavyweight gates
on one box wedge rather than fail. No shadow-cljs, no browser, no npm build, no
JVM gate. `python scripts/check_fast_pr_gap.py --list` reports **96 required
checks the spine does not run**; that is a fact about the spine, not a census of
what I ran. What I ran, foreground, each alone, exit code captured by the
invoking shell on the same command line and quoted from the captured file:

| Gate | Command | Captured exit |
|---|---|---|
| doc link/anchor targets | `python scripts/check_doc_slugs.py` | **0** |
| README + root markdown links | `python scripts/check_readme_links.py --ci` | **0** |
| JS syntax | `node --check examples/scripts/check-examples-assets.cjs` | **0** |
| spine gap listing | `python scripts/check_fast_pr_gap.py --list` | **0** |

Gates nominated **by path**, never by job name. `check_doc_slugs.py`'s
`DEFAULT_ROOTS` was read at source — `("docs", "spec", "skills", "migration")`
plus the `tools/<tool>/spec` special case — so it covers the five
`tools/xray/spec/` edits. `check_readme_links.py --ci` is **not** nominated by
path for this diff (no repo-root markdown, no README beside source, no
`.claude/commands/`); it was run anyway and is green.

**All four were re-run on the final base after rebasing onto `f585a80719`**, and
again after the reflow commit. The pre-rebase greens are not the ones quoted.

### Sabotage proof

Both plantable gates proved they read **this** worktree. Each plant was anchored
to a **single newline-free line I was already editing**, with anchor uniqueness
asserted before writing, and each restore verified by `git hash-object` against
the committed blob:

* `check_doc_slugs.py` → **exit 1**, naming
  `027-Hicasso-Evidence.md:491 -> ../../../docs/PLANTED-NO-SUCH-FILE-…`.
  Pre-plant `f63a2733…` → post-plant `9e767980…` → post-restore `f63a2733…`,
  equal to `HEAD:tools/xray/spec/027-Hicasso-Evidence.md`.
* `node --check` → **exit 1**, `SyntaxError: Unexpected identifier 'its'` at
  line 323, and the path it printed named this worktree. Pre-plant `5102474c…`
  → post-plant `1a03ba00…` → post-restore `5102474c…`, equal to the committed
  blob.

Each fault existed only here, so the red **is** the discrimination — a run that
had wandered into a sibling checkout would have come back green.
`check_doc_slugs.py` prints nothing on success, so no root-banner route was
available for it.

### What nothing checks

Nothing validates this markdown's prose, tables, rendering or nav, so verified
by hand: **no table row and no heading is changed by this diff** (`git diff
origin/main...HEAD | grep -cE '^\+.*\|.*\|'` → 0; changed heading lines → 0), so
no column count moved and no anchor could break. The one link added
(`../../../docs/release-process.md`) and the one bare mention converted to a
link (`021-Dynamic-Panel-Designs.md`) are both covered by `check_doc_slugs.py` —
proved reachable by the planted red above. `mkdocs build --strict` does not
reach `tools/*/spec` at all: `docs_dir` is `docs`, so those files were never
candidates for `exclude_docs`.

The `examples/scripts/check-examples-assets.cjs` change is entirely inside a
comment block; `node --check` covers its syntax, and **no cheap gate covers the
comment's prose**. Its only gate is the classifier-selected `examples_compile`
lane, which is heavyweight and did not run. Verified by hand that the comment
still reads correctly and that the pruning rule it justifies is unchanged.

No source docstring under `tools/**` was touched.

### Revert check

`git diff origin/main...HEAD` (three-dot, against the **merge base**, not the
tip) was read end to end for anything this push would undo. It reverts nothing:
the only landing between my base and `origin/main` was
`docs/design/hicasso/product-kind-census.md`, which this diff does not touch.
