### PR TITLE
docs(xray): re-tense 017's freehand-views retirement rows — all six have landed (rf2-w2hlv)

### DIFF
--- a/tools/xray/spec/017-Test-Coverage-Matrix.md
+++ b/tools/xray/spec/017-Test-Coverage-Matrix.md
@@ -316,31 +316,35 @@ rf2-l86mm, because that is the change that makes them red:
 | 4 | the `freehand-views populated Views roster` scenario and its `STAGED_SURFACES` entry in `tools/xray/testbeds/feature_matrix/scenarios.cjs` | rf2-l86mm | **DONE.** The PR-smoke run is derived from these entries rather than from a fixed list, so leaving them standing while the panel goes reds the smoke gate against a section that no longer renders |
 | 7 | the canonical covered-row pin in `coverage_matrix_metadata_test.clj` | rf2-l86mm | **DONE — 13 → 12.** This scenario was the sole claimant of the retired `Mounted view reads (Freehand tool door, rf2-7gth0)` matrix row, so removing that row without moving the pin fails `coverage_matrix_metadata_test` |
 
-The remaining six go quietly stale, and they travel with the FREEHAND TREE
-DELETION rather than with the panel — because rows 2 and 3 are in top-level
-`implementation/shadow-cljs.edn`, rows 5 and 6 in `implementation/`, and row 8
-in `.github/workflows/`, none of which the panel pass holds. Row 1 waits with
-them rather than going early: deleting the deck's source while its build id
-survives leaves a build compiling a tree that is not there, which is a worse
-state than either end of the move.
+The remaining six went quietly stale rather than red, and they travelled with
+the FREEHAND TREE DELETION rather than with the panel — because rows 2 and 3
+are in top-level `implementation/shadow-cljs.edn`, rows 5 and 6 in
+`implementation/`, and row 8 in `.github/workflows/`, none of which the panel
+pass held. Row 1 waited with them rather than going early: deleting the deck's
+source while its build id survived would have left a build compiling a tree
+that is not there, which is a worse state than either end of the move. **All
+six have now landed**, across three commits rather than one — rows 1, 2 and 3
+with the tree deletion itself (rf2-0yp7w.6), rows 5 and 6 with the
+config-residue sweep that followed it (rf2-puwyb), and row 8 with the
+smoke-tier re-costing (rf2-ano54):
 
-| # | Artefact | The retirement pass | If left behind |
+| # | Artefact | Pass | State |
 |---|---|---|---|
-| 1 | `tools/xray/testbeds/freehand_views/` — `core.cljs` and `index.html` | delete the tree | dead source under a build id that is also going; its `re-frame.freehand` require dies with the tree either way |
-| 2 | the `:testbeds/freehand-views` build in `implementation/shadow-cljs.edn` | delete the build map | a build compiling a deleted tree |
-| 3 | its port-8036 `:dev-http` entry in `implementation/shadow-cljs.edn` | delete the entry, freeing the 803x slot | a served root that no longer exists |
-| 5 | the `DEV_HTTP` entry and the port-band comment in `implementation/scripts/dev-testbed.cjs` | delete both | the launcher advertises a URL for a build id shadow-cljs no longer knows — silently, because the drift guard in `dev-testbed.test.cjs` runs shadow-cljs → `DEV_HTTP` and never the reverse |
-| 6 | the build→URL row in `implementation/README.md` | delete the row | a documented testbed nobody can start |
-| 8 | the PR-smoke enumeration in `.github/workflows/test.yml` | drop the deck from the named list: 5 scenarios → 4, 4 staged surfaces → 3, 4 bundles → 3, and 12 → 11 in the nightly sweep | a comment naming a scenario that no longer exists |
+| 1 | `tools/xray/testbeds/freehand_views/` — `core.cljs` and `index.html` | rf2-0yp7w.6 | **DONE — tree deleted.** Dead source under a build id that was going with it; its `re-frame.freehand` require died with the tree either way |
+| 2 | the `:testbeds/freehand-views` build in `implementation/shadow-cljs.edn` | rf2-0yp7w.6 | **DONE — build map deleted.** Left standing it would have been a build compiling a deleted tree |
+| 3 | its port-8036 `:dev-http` entry in `implementation/shadow-cljs.edn` | rf2-0yp7w.6 | **DONE — entry deleted, and the 803x slot is free again.** Left standing it would have served a root that no longer exists |
+| 5 | the `DEV_HTTP` entry and the port-band comment in `implementation/scripts/dev-testbed.cjs` | rf2-puwyb | **DONE — entry deleted; the port-band comment re-tensed rather than deleted, and it now records 8036 as free again.** Left standing, the launcher would have advertised a URL for a build id shadow-cljs no longer knows — silently, because the drift guard in `dev-testbed.test.cjs` runs shadow-cljs → `DEV_HTTP` and never the reverse |
+| 6 | the build→URL row in `implementation/README.md` | rf2-puwyb | **DONE — row deleted.** Left standing it would have documented a testbed nobody can start |
+| 8 | the PR-smoke enumeration in `.github/workflows/test.yml` | rf2-ano54 | **DONE — 5 scenarios → 4, 4 staged surfaces → 3, 4 bundles → 3, and 12 → 11 in the nightly sweep.** Left standing it would have named a scenario that no longer exists |
 
 Beyond the eight, three re-reads rather than removals. The dated aggregate
 costings in `implementation/scripts/serve-and-run-xray-feature-gate.cjs` and in
 this document's own opening move with row 8's numbers, but neither names the
 deck and both already carry the date they were measured, so re-date them rather
 than treat them as breakage.
-[`027-Hicasso-Evidence.md`](027-Hicasso-Evidence.md) records that this deck's
-build id, port and scenario slot free up together at rf2-hic-062 — still true
-of rows 1, 2 and 3. And the reactively-driven repaint the scenario asserted
+[`027-Hicasso-Evidence.md`](027-Hicasso-Evidence.md) tracks this deck's build
+id, port and scenario slot as freeing up together — rows 1, 2 and 3 have now
+freed all three. And the reactively-driven repaint the scenario asserted
 (rf2-2t126) was the only browser-level proof that
 `:adapter/activate-derived-value!` holds end to end in a real DOM, while
 `re-frame.hicasso.impl.collector` calls that hook as well as the Freehand


### PR DESCRIPTION
Closes rf2-w2hlv.

`tools/xray/spec/017-Test-Coverage-Matrix.md` tabled six freehand-views
artefacts as pending work travelling with "the FREEHAND TREE DELETION", while
the sibling passage in `021-Dynamic-Panel-Designs.md` §3.4.1 (re-tensed by the
still-open #8525) describes that deck as retired. A coverage matrix is exactly
the document a reader consults for this answer, so the two disagreeing mattered.

## The census — re-derived, not inherited

The routed claim ("all six have landed") arrived second-hand, so I re-derived
each row individually at `origin/main` HEAD in my own worktree. **Six of six
confirmed** — the premise holds.

| # | Artefact | Measurement at HEAD | Landed in |
|---|---|---|---|
| 1 | `tools/xray/testbeds/freehand_views/` | `git ls-files` → 0 tracked files; absent on disk | `c951808b47` (rf2-0yp7w.6) |
| 2 | `:testbeds/freehand-views` build | 0 hits for `freehand-views` in `implementation/shadow-cljs.edn` | `c951808b47` (rf2-0yp7w.6) |
| 3 | port-8036 `:dev-http` entry | 0 hits for `8036` in `implementation/shadow-cljs.edn`; band now runs 8030–8035 | `c951808b47` (rf2-0yp7w.6) |
| 5 | `dev-testbed.cjs` `DEV_HTTP` entry + port-band comment | entry absent from the `DEV_HTTP` map; comment re-tensed, not deleted | `98a35fece5` (rf2-puwyb) |
| 6 | build→URL row in `implementation/README.md` | 0 hits for `freehand-views` and for `8036` | `98a35fece5` (rf2-puwyb) |
| 8 | PR-smoke enumeration in `.github/workflows/test.yml` | now reads 4 scenarios / 3 staged surfaces / 3 bundles "instead of 11", with a tombstone naming rf2-l86mm | `ede7ddf357` (rf2-ano54) |

Every zero-result search above was run once against a control that it should
find (`panel_gallery` → 22 files; `panel-gallery` → 9 hits in `shadow-cljs.edn`
and 2 in `implementation/README.md`; `DEV_HTTP` → 6 hits), so none of these is
a wrong pattern answering "no matches" in the voice of "nothing is wrong".

**Row 5 landed by a different route than its row prescribed**, and the row now
says so. The row said "delete both". The `DEV_HTTP` entry was indeed deleted,
but the port-band comment was **re-tensed into a tombstone** recording 8036 as
free again (rf2-puwyb) rather than removed — which is the better outcome for a
port-allocation table, and worth stating rather than papering over.

## Scope

Re-tensed the six rows and the two sentences carrying the same pendingness: the
paragraph introducing the table, and the `027-Hicasso-Evidence.md`
cross-reference whose "still true of rows 1, 2 and 3" directly asserted those
rows had not landed. No restructure, no re-audit of other rows, **021 untouched**.

The table's column headers moved from `The retirement pass | If left behind` to
`Pass | State`, matching the sibling table eight lines above it in the same
section — the document's own established form for landed artefacts. Column
count is unchanged at 4, and each row's "if left behind" rationale is preserved
inside the `State` cell, exactly as rows 4 and 7 do it.

One incidental correction inside a sentence already being re-tensed: it cited
`rf2-hic-062` as 027's pin for the slot freeing up. `rf2-hic-062` does not
appear in `027-Hicasso-Evidence.md`, nor anywhere under `tools/xray/spec/`
except that one sentence. Rather than restate an unsupported pin I dropped it;
the surviving clause is true of 027 both at HEAD and as #8525 rewrites it.

## Fence

`tools/xray/spec/017-Test-Coverage-Matrix.md` only — one file. The bead's fence
was PR #8523 (`worker/cites-ukkxo`), which I re-derived as **MERGED**
(`86c91ed49b`), so the file was free. Re-derived `gh pr diff 8525 --name-only`:
017 is **not** among its six paths, so no overlap with that open PR.

## Quality gates

The heavy spine did **not** run and was not run deliberately: a live allocation
measurement window holds this machine, and two heavyweight runs on one box wedge
rather than fail. No `scripts/test-fast-pr.sh`, no shadow-cljs, no browser or
Playwright, no npm build, no JVM gate. This diff is one markdown file, so none
of those covers it in any case. Gates run directly, each foregrounded with its
exit code captured in the same shell (never piped, never taken from a harness
report):

| Gate | Command | Captured exit |
|---|---|---|
| Doc slugs (covers this path) | `python scripts/check_doc_slugs.py` | **0** |
| Doc slugs, sabotage control | `python scripts/check_doc_slugs.py` (fault planted) | **1** (expected red) |
| Doc slugs, re-run on final base | `python scripts/check_doc_slugs.py` | **0** |
| README links (control only) | `python scripts/check_readme_links.py --ci` | **0** |

**Why `check_doc_slugs.py` covers `tools/xray/spec/`, read at source.** Its
`DEFAULT_ROOTS` is `("docs", "spec", "skills", "migration")` — which does *not*
include `tools`. Coverage comes from the **second tier** in `_iter_markdown`
(line 713): after appending each `DEFAULT_ROOTS` entry, it walks
`TOOLS_ROOT = "tools"` and, for every child directory, appends `tool / "spec"`
as a root if it exists. `tools/xray/spec` is therefore a root in its own right,
and `017-Test-Coverage-Matrix.md` is reached by that root's `rglob("*.md")`.

**Proof the gate read THIS worktree.** The gate prints no root banner, and its
green run emits an empty log — a shape indistinguishable from a walk of nothing.
So I proved reach by a planted fault: I changed this file's `027` link target to
`027-Hicasso-Evidence-SABOTAGE-w2hlv.md`, a single-line anchor. The gate went
**red, exit 1**, naming exactly what was planted:

```
BROKEN TARGET: tools\xray\spec\017-Test-Coverage-Matrix.md:345 -> 027-Hicasso-Evidence-SABOTAGE-w2hlv.md
```

That fault existed only in this worktree, so a run that had wandered into a
sibling checkout would have come back green. Restore was verified by **content
hash against the committed object** rather than by reading a diff:
`git hash-object` returned `d245311198d2eba05fe1d14327e42c6ccc3fd747` both
before the plant and after the restore, identical to `git rev-parse
HEAD:tools/xray/spec/017-Test-Coverage-Matrix.md`, with `git status --porcelain`
empty.

**`check_readme_links.py --ci` is a control and its green means nothing here.**
Its surface is repo-root markdown, READMEs beside source, and
`.claude/commands/*.md`. `tools/xray/spec/` is on none of those, so it exits 0
on this diff whatever the diff contains.

**Nothing validates this file's prose, table arithmetic or column counts**, so I
checked by hand. Every table row in the section — both tables, all 12 lines
including headers and separators — carries exactly 5 pipes / 4 columns,
counted mechanically over lines 291–360 and eyeballed. No cell contains a bare
`|`. The `→` characters in rows 5 and 8 are preserved verbatim.

For the gap between this local set and the required CI set, see
`scripts/check_fast_pr_gap.py --list` (96 required checks the spine does not
run). That listing is a fact about the spine, not a census of what I ran — what
I ran is the four rows above.

## Rebase

The trunk moved twice under this branch. Rebased onto the final base
`7a03af8822` and **re-ran both gates there** (rows 3 and 4 above) rather than
resting on a pre-rebase green. The only intervening trunk commit was a beads
checkpoint touching `.beads/issues.jsonl` alone — my file was untouched by it.
Read the three-dot diff `origin/main...HEAD` before pushing: every deleted line
is one of my own re-tensed originals, so this reverts nothing a sibling landed.
