### PR TITLE
refactor(retire): re-point the last four 'Spec 004' citations in core.cljc (rf2-kz7ve)

### DIFF
--- a/implementation/core/src/re_frame/core.cljc
+++ b/implementation/core/src/re_frame/core.cljc
@@ -739,7 +739,7 @@
   (computed ids, library generation, Form-3 / `create-class` bodies)
   where the `reg-view` macro's defn-shape doesn't fit. Optional metadata
   is merged with any pending source-coords from a wrapping `reg-view`.
-  Per Spec 004 §reg-view*."
+  Per Spec 001 §Allowed forms of the middle slot."
   ([id render-fn]
    (reg-view* id {} render-fn))
   ([id metadata render-fn]
@@ -768,7 +768,7 @@
 (defn view
   "Runtime-lookup handle for a registered view. Returns the registered
   render fn (or nil if not registered) — call with the view's invocation
-  args to yield the hiccup tree. Per Spec 004 §Calling a registered view."
+  args to yield the hiccup tree. Per Spec 001 §`(re-frame.core/view id)`."
   [id]
   (when-let [meta (registrar/lookup :view id)]
     (:handler-fn meta)))
@@ -780,7 +780,8 @@
      on sym), auto-injects lexical `dispatch` / `subscribe` bound to the
      surrounding frame, defs the symbol and registers under the id.
      For runtime registration with computed ids or non-defn bodies, use
-     `reg-view*`. Per Spec 004 §reg-view."
+     `reg-view*`. Per Spec 001 §Allowed forms of the middle slot and
+     Conventions §`reg-view` auto-id derivation rule."
      {:arglists '([sym args body+] [sym docstring args body+])}
      [sym & more]
      (rvm/expand-reg-view (meta &form)
@@ -1452,7 +1453,8 @@
 (defn capture-frame
   "Return a frame api — the keystone affordance for
   carrying a frame into closures and across async boundaries. Per Spec
-  002 §capture-frame and Spec 004 §Affordance for plain fns.
+  002 §capture-frame and Cross-Spec-Interactions §10 Plain Reagent fn
+  under a `frame-provider`.
 
   Two arities:
     (capture-frame)           — capture the ambient frame


### PR DESCRIPTION
Repairs the last four number-form citations of the deleted `spec/004-Views.md` (rf2-kz7ve), in the one file PR #8523 refused because a peer branch appeared to hold it.

**Fence:** `implementation/core/src/re_frame/core.cljc`, one file, docstring text only. `spec/**` is held by a peer (rf2-ik0g6) and untouched here.

## The fence, re-verified rather than inherited

The bead was fenced because `worker/armconf-c4hhk` read as holding this file. Re-derived at dispatch: the three-dot diff `origin/main...<branch>` for **every** live worker branch returns **zero** `implementation/core/src/re_frame/core.cljc` paths — all ten branches checked, not just that one. The fence is genuinely clear.

## Census and controls

Re-derived at `origin/main`, not taken from the brief.

| scope | pattern | hits |
|---|---|---|
| this file, anchored `Spec 004` (excl. `004B`/`004C`/`004D`) | 4 | 742, 771, 783, 1455 |
| this file, **unanchored** bare `004` | 4 | identical set — no `004B`/`004C` here, so no over-count risk |
| `implementation/core/src/` siblings | 0 | nothing to report or leave |
| tree-wide, `.beads` excluded | 32 | 4 mine + 28 declared |

- **Positive control** `Spec 004[BCD]` → **43** hits. The pattern discriminates.
- **Wrapping pass.** A line-wrapped citation defeats a flat search. Checked with `Spec\r?\n\s*004` (CRLF-aware — the file carries 2937 CRLF and zero bare LF). **Zero** wrapped target hits, and its **positive control fired**: 3 wrapped `Spec\r?\n` citations exist in this file, all of *other* specs (002 ×2, 009). So the zero is a real zero, not a broken pattern.
- **`.beads` excluded** throughout (`':!.beads'`), it being a whole-database export.
- Filename form `004-Views` → 0 in this file.

## All four are CATEGORY 1 — the cited section never existed

Verified at source against the deleted blob `3e43b19235^`. `spec/004-Views.md` was 2831 lines titled *"Views — the common Freehand contract"*, and it is a **different API surface entirely** — `v/defview`, `v/markup`, `v/sub`:

| string | occurrences in the deleted doc |
|---|---|
| `reg-view` | **0** |
| `reg-view*` | **0** |
| `Calling a registered view` | **0** |
| `Affordance for plain fns` | **0** |
| `view` (positive control) | **141** lines |

So these four citations were **false before the deletion**, not broken by it. This confirms and extends rf2-h89ri's finding 1.

`Affordance for plain fns` also appears **nowhere live** in the tree — the sole tree-wide occurrence was the citation itself.

## Per-site verdicts

| line | subject | cat | verdict | home, verified at source |
|---|---|---|---|---|
| 742 | `reg-view*` plain-fn surface | 1 | RE-POINT | `spec/001-Registration.md:55` §Allowed forms of the middle slot — states verbatim that `reg-view` is "the **only registration that ships as a defn-shape macro**" and that "the plain-fn surface for runtime / programmatic registration is `reg-view*`" |
| 771 | runtime-lookup handle | 1 | RE-POINT | `spec/001-Registration.md:258` §`` `(re-frame.core/view id)` `` — "the runtime-lookup handle for a view registered under `id`… returns the registered render fn… or `nil`", matching the docstring near-verbatim |
| 783 | `reg-view` macro (multi-subject) | 1 | RE-POINT ×2 | `001:55` §Allowed forms (defn-shape grammar) **+** `spec/Conventions.md:1590` §`` `reg-view` auto-id derivation rule `` — which carries `id = (keyword (str *ns*) (str sym))` and the `^{:rf/id …}` override verbatim, i.e. exactly this docstring's two specific claims |
| 1455 | `capture-frame` for plain fns | 1 | RE-POINT | `spec/Cross-Spec-Interactions.md:115` §10 Plain Reagent fn under a `frame-provider` — enumerates `(rf/capture-frame frame-id)` locked to a named frame as a shape that works for deliberately unregistered code, which is what this docstring's 2-arity is |

Consistent with the rf2-ik0g6 ruling (001 carries the grammar and the handle; 002 retained where already named). At 1455 the live `002 §capture-frame` half is retained; only the dead half moves. At 783, 002 is *not* already named, so none was added.

**Two divergences from the dispatch brief, both resolved in favour of source.**

1. The brief nominated `000-Vision §Plain Reagent fns under non-default frames` for site 1455; the **bead** and PR #8523 both nominate `Cross-Spec-Interactions §10`. Both sections genuinely carry the claim in near-duplicate prose, so either would be defensible — the bead governs, and §10 is the better fit because it is keyed on the plain-fn-under-`frame-provider` interaction that the 2-arity answers.
2. The bead's parenthetical read "`Conventions.md` §Render-tree shape vs runtime lookup (the reg-view auto-id derivation rule)", conflating two adjacent sections. At source these are **distinct**: §Render-tree shape vs runtime lookup is `Conventions.md:1612`, while the auto-id derivation rule is its own section at **`Conventions.md:1590`**, titled `` `reg-view` auto-id derivation rule ``. Cited the precise one — which is also how PR #8523's own table spells it.

## Quality gates

Every number below was captured with an explicit `echo $?` on the **same command line** as the redirect, never a harness-reported value. No pipelines. All four re-run on the final rebased base (merge-base now equals `origin/main`).

| gate | command | captured exit |
|---|---|---|
| clj-kondo | `clj-kondo --lint implementation/core/src/re_frame/core.cljc` | **2** |
| doc slugs (control) | `python scripts/check_doc_slugs.py` | **0** |
| readme links (control) | `python scripts/check_readme_links.py --ci` | **0** |
| fast-PR gap | `python scripts/check_fast_pr_gap.py --list` | **0** |

- **clj-kondo exit 2 is warnings-only:** `errors: 0, warnings: 20`. Those 20 are pre-existing unresolved-symbol findings on facade re-export vars. Reproduced on unmodified `HEAD` content: **warnings 20, identical**. (The HEAD baseline also reports `errors: 1`, which is purely the scratch-path artefact `Namespace name does not match file name` from linting outside the source tree — not a content finding.)
- **Gate-reaches-my-tree, proven by planted fault.** clj-kondo prints no root banner, so the discriminating route is the red. Planted a single-line, CRLF-anchored fault at **line 742 — a line this PR edits** — removing the docstring's closing quote. The anchor was asserted to match exactly once, and the working-file hash **changed** (`8b13433d…` → `9f3b28ca…`), so the plant was not a silent no-op. Gate went **RED: exit 3, `errors: 16`** (from 0), the cascade beginning immediately downstream of the plant — positive evidence the linter observed the planted bytes, not a cached parse. The fault existed only in this worktree, so a run that had wandered into a sibling checkout would have returned exit 2 / errors 0.
- **Restore verified by hashing against the committed object**, not by reading a diff: `git hash-object` read **three times**, all `8b13433d8d19d44f3e3af080e085a5d6fe85a919` = `git rev-parse HEAD:<path>`. Zero plant markers remain; `git status` clean. Post-restore re-run returned to **exit 2, errors: 0, warnings: 20**.
- **`check_doc_slugs.py` is a CONTROL, not coverage.** `DEFAULT_ROOTS` read at source (`scripts/check_doc_slugs.py:93`) is `("docs", "spec", "skills", "migration")` plus a `tools/<tool>/spec` tier. `implementation/` is on **none** of them, so it walks nothing in this diff and its 0 says nothing about this change.
- **`check_readme_links.py --ci` is likewise a control** — it owns repo-root markdown, READMEs beside source, and `.claude/commands/*.md`. This diff touches none.
- **The fast-PR spine did NOT run**, deliberately: a bench allocation window has been holding this machine, two heavyweight runs wedge rather than fail, and this diff is docstring prose with no code path. No shadow-cljs, no browser, no npm build, no JVM suite. `check_fast_pr_gap.py --list` reports the **96** required checks the spine does not run.

### Coverage gap, stated plainly

**No gate covers this change.** Nothing validates a prose citation inside a `.cljc` docstring: `check_doc_slugs.py` does not reach `implementation/`, and these are prose, not markdown links, so nothing resolves them even where it does read. The warrant for each re-point is the at-source verification tabulated above — every home was opened and read, and every line number in the verdict table was checked — not a gate. clj-kondo only proves no edit slipped outside a docstring.

Verified by hand: this file's local citation style is `Per Spec NNN §Section` for numbered specs and a bare `Conventions §…` / `Cross-Spec-Interactions §N` for the rest — line 1090 already carries `Cross-Spec-Interactions §2`, so the new spellings match their neighbours. Table column counts in this body checked by hand.

## Revert check

`git diff --name-only origin/main...HEAD` (three-dot, against the **merge base**) returns exactly one path, 6 insertions / 4 deletions, and every changed line is citation text. Nothing a sibling landed is undone. This check is not ceremonial on this file — the branch that previously appeared to hold it swept 23 `implementation/core/src/` files into one commit via `git checkout <rev> -- <path>`, which stages as well as writes.

## Risks

Low. Docstring text only; no code path, no assertion text, no test expectation, no public surface change.

After this, every remaining `Spec 004` string in the tree (28 hits) is a declared refusal or exclusion: `docs/EP/**` (17) and `docs/design/**` (3) on the standing rf2-v68fz ruling, `TESTING.md:304` (1) same, `auto_inject_form2_cljs_test.cljs` (3) deliberately RE-TENSED verbatim quotations, `api_md_check_test.clj:450` (1) refused as synthetic parser-test input, and 3 in `spec/` held by the peer bead.
