### PR TITLE
bench(p0): a within-run LEVEL witness for the allocation floor arm (rf2-a233t)

### DIFF
--- a/docs/design/hicasso/studio/the-level-witness-armed-within-one-run.md
+++ b/docs/design/hicasso/studio/the-level-witness-armed-within-one-run.md
@@ -7,7 +7,7 @@ So a figure quoted from this arm out of a single run has been a coin toss betwee
 13–21% apart, and nothing in the rig said so.
 
 Written 2026-08-19 and re-derived 2026-08-20 on `worker/levelwit-a233t`, off
-`9476293ae8b087f1125f9a721a339892a01c7b8b`, which is `origin/main` at the time of
+`f7fb0271ac6f38a1d1979e1fd40d9d843db783b2`, which is `origin/main` at the time of
 writing and therefore an anchor a fresh clone resolves. The three commits between that
 and the page's first base `fcb0afb36d` are tracker checkpoints; no dataset and no bench
 file differs across them, and every figure below was recomputed on this base.
@@ -288,10 +288,16 @@ reds is specific rather than incidental:
   ramp-fallback reading count goes 1 → 99, and the 0.4% tightening control collapses
   60 → 6.
 
-The file was then restored and its content hash compared against the committed object —
-`3dd95e0c268db8b517c802142b2a37de0acbae67` both before the plant and after the restore —
-and the gate re-run green at 9/9. A green run under sabotage would have meant the gate
-was not reading this tree; it was not green.
+The file was then restored, and the restore verified by content hash rather than by eye:
+`git hash-object` reported the identical SHA-1 blob
+`3dd95e0c268db8b517c802142b2a37de0acbae67` before the plant and after it, matching the
+object the index already held. The gate then re-ran green at 9/9. A green run under
+sabotage would have meant the gate was not reading this tree; it was not green.
+
+*(That forty-hex token is a **blob** hash — the content digest of the witness source, not
+a revision of this repository. Nothing resolves it with `git rev-parse`; `git cat-file -t`
+answers `blob`. It is recorded because a diff cannot tell a correct restore from a patch
+that never applied, and a hash can.)*
 
 ## The rig is not touched
 
@@ -341,7 +347,7 @@ arm, not of a build.
 ## Reproduction
 
 From `implementation/`, on this page's base
-`9476293ae8b087f1125f9a721a339892a01c7b8b`. Nothing here opens a browser; the whole
+`f7fb0271ac6f38a1d1979e1fd40d9d843db783b2`. Nothing here opens a browser; the whole
 control is a read over committed JSON and takes a few seconds.
 
 ```bash

--- a/docs/design/hicasso/studio/the-level-witness-armed-within-one-run.md
+++ b/docs/design/hicasso/studio/the-level-witness-armed-within-one-run.md
@@ -1,0 +1,391 @@
+# The level witness, armed within one run
+
+Seat: MEASUREMENT RECORD, EP-0039. Bead `rf2-a233t` — the floor arm is multi-modal and
+**both modes certify**. The leg witness asks whether a window's legs are alike, and in
+both modes they are; it has nothing to say about which of two levels a window sits at.
+So a figure quoted from this arm out of a single run has been a coin toss between levels
+13–21% apart, and nothing in the rig said so.
+
+Written 2026-08-19 and re-derived 2026-08-20 on `worker/levelwit-a233t`, off
+`9476293ae8b087f1125f9a721a339892a01c7b8b`, which is `origin/main` at the time of
+writing and therefore an anchor a fresh clone resolves. The three commits between that
+and the page's first base `fcb0afb36d` are tracker checkpoints; no dataset and no bench
+file differs across them, and every figure below was recomputed on this base.
+
+**NO RUNS WERE TAKEN FOR THIS PAGE.** Every figure below is re-derived from datasets
+already committed to this repository. That is not a shortcut: the bead's claim was that
+the witness is computable from data already recorded, and taking a window would have
+tested a different claim. The one thing a new window could have added — more elevated
+readings — the corpus already supplies forty of.
+
+## The answer, first
+
+**THE WITNESS IS ARMED. It is a refusal, it exits non-zero, and its control passes.**
+
+`implementation/hicasso/test/re_frame/bench/hicasso/alloc_level_witness.cjs` compares,
+per segment and inside one run, the level the run **settled** at against the level it
+**started** at, and refuses when the step exceeds **5% of the run's own starting level**.
+
+Run over **every admissible floor run this repository has committed** — 101 records
+across four corpora and four substrate revisions — it refuses **exactly the 40 elevated
+runs and no others**: zero false refusals, zero misses.
+
+**And the definition turned out to be the finding.** The bead warned that the normal
+band depends on how the step is defined and told this page to pin a definition before
+setting a threshold. It does more than depend on it. The definition `rf2-77gz8`'s
+re-analysis quoted — one round against one round, −43 to +158 B normal against
+3,912–3,948 B in the mode — **does not separate the populations at all** on the larger
+corpus. Its normal band reaches **+2,312 B** while its elevated band descends to
+**+860 B**: they overlap by 1,452 B. A bound set from the quoted figures would have
+refused legitimate runs, which is the expensive failure this arm was told to avoid.
+
+## What was re-derived before anything was sized on it
+
+`rf2-c4hhk`'s headline was taken as a claim, not a finding, and recomputed from its
+committed datasets under its own declared estimator — the median, over certified windows
+at round index ≥ 6, of that window's `legMedian`, per segment; elevated when either
+segment's estimator is at or above 21,000 B/write; admissible when
+`controlVerdict.ok === true` and `verification.unverified === 0`.
+
+| Quantity | `rf2-c4hhk` reported | Re-derived here |
+|---|---|---|
+| Admissible readings | 69 of 70 | **69** |
+| Elevated readings | 37 | **37** |
+| ARMED | 18 of 34 | **18 of 34** |
+| UNARMED | 19 of 35 | **19 of 35** |
+| Records with no `alloc` object | `armed-25` | **`armed-25`, and only that one** |
+
+Every figure reproduces. `armed-25` is excluded and named rather than replaced, exactly
+as that page states: Chromium failed to launch, no window was measured, and the driver
+wrote a 118-byte record carrying `generatedAt`, `build` and `initFn` and nothing else,
+then **exited 1 — the same code as all sixty-nine good runs**.
+
+**THE EXIT CODE IS NOT THE VERDICT FOR THIS RUNNER.** `p0_run.cjs --only alloc` exits
+non-zero as a matter of course: it exits on any refused window and on any collection
+falling inside a measured one, and both are routine at this page. All seventy of
+`rf2-c4hhk`'s runs exited 1 and all twenty of `rf2-77gz8`'s did. **The expected exit code
+of a healthy run of this runner is 1.** Admissibility is read off the record's own
+fields, and the witness reads the same fields rather than a status code.
+
+## The definition, pinned
+
+Stated before any threshold was chosen, and it is the whole of the design:
+
+| Half | Statistic | Window |
+|---|---|---|
+| **AFTER** | median of `legMedian` over **certified** windows | round index **≥ 6** |
+| **BEFORE** | **minimum** of `legMedian` over **certified** windows | rounds **1–5** |
+| **STEP** | `AFTER − BEFORE`, per segment | — |
+
+**AFTER is not a new quantity.** It is the published estimator, verbatim — the one
+`rf2-77gz8` pre-registered and `rf2-c4hhk` carried unchanged. The witness therefore
+adjudicates exactly the number the records quote, which is the only number a level gate
+has any business gating.
+
+**BEFORE is a minimum, and the asymmetry is deliberate.** The error available to an
+early round is one-signed: those rounds carry warm-up allocation the settled rounds do
+not, so an early window can read above the run's floor and cannot read below it. A
+window reading below its cohort would already have been refused by the leg witness — *"a
+leg BELOW its cohort is a leg something removed bytes from, and nothing in the work unit
+removes bytes; the collector does"* — so a certified window is not available to be
+spuriously low. The minimum of the certified early windows is therefore the best estimate
+of the level the run started at, and a median over as few as one or two windows is not:
+**five runs read a NEGATIVE step under the median form, the worst at −1,014 B**, every
+one of them a normal run with a single inflated early round inside a two-window median.
+
+Named, because a count is not checkable and a list is. Each row is that run's certified
+rounds 1–3 — two windows in every case, which is what makes one inflated round decisive:
+
+| Run | Segment | Certified r1–3 | Step under the median form |
+|---|---|---|---|
+| `alloc-c4hhk/unarmed-35` | `uix-subs` | r1 21,688 · r3 19,420 | **−1,014 B** |
+| `alloc-77gz8/run20` | `uix-subs` | r2 19,930 · r3 19,444 | −147 B |
+| `workcount-n1b9h/run6` | `reagent-subs` | r1 19,316 · r2 19,004 | −60 B |
+| `alloc-9jrhi/bisect-3-b` | `reagent-subs` | r1 19,586 · r2 19,256 | −43 B |
+| `workcount-n1b9h/run2` | `reagent-subs` | r1 19,610 · r3 19,208 | −31 B |
+
+Under the pinned minimum every one of these reads its lower window and steps positive.
+
+Round 0 is outside the window: it is the prime round and is uncertified in every run in
+the corpus.
+
+**Rounds 4–5 are inside the BEFORE window even though they are the transition**, because
+a minimum cannot be raised by them and the coverage is free. Measured over every
+admissible run, the BEFORE minimum came from rounds 1–3 in **201 of 202 segment-halves**
+— the ramp is never the lowest certified window when a pre-ramp one exists. The one half
+where it is, `alloc-c4hhk/armed-03`'s `reagent-subs`, has *none* of rounds 1–3 certified;
+under a rounds-1–3 window that run has no BEFORE at all and the witness must refuse a
+run whose level is not elevated. Under this window it is scored, at +0.494%, and
+certifies.
+
+That fallback is disclosed rather than hidden. When it happens on an elevated run it
+sits *between* the levels and so **understates** the step — it biases toward missing a
+mode run, never toward refusing a normal one. Forcing every elevated run in the corpus to
+that worst case, 38 of 40 still exceed the bound and two would slip. `beforeFromRamp` is
+set on any reading scored that way, and **no elevated run in the corpus is one**.
+
+## The bands, under every definition the corpus has used
+
+Each definition scored over the same admissible runs, taking each run's worst segment.
+The byte band and the fraction band are each the minimum and maximum over that
+population, so the two extremes need not come from the same run.
+
+| Definition | Normal (n=60) | Elevated (n=40) | Gap | Undefined on |
+|---|---|---|---|---|
+| **`min(cert r1–5)` → `median(cert r≥6)` — PINNED** | 96..194 B · 0.494–1.015% | 2,616..3,984 B · 13.766–21.070% | **+2,422 B** | 1 run |
+| `median(cert r1–3)` → `median(cert r≥6)` | 96..168 B · 0.494–0.887% | 2,616..3,948 B · 13.516–20.840% | +2,448 B | 2 runs |
+| `median(cert r1–3)` → `median(cert r4–6)` | 90..896 B · 0.456–4.653% | 1,655..4,083 B · 8.634–21.553% | +759 B | 1 run |
+| `cert r3` → `cert r4`, one round each | 80..**2,312** B · 0.411–12.228% | **860**..4,946 B · 4.428–26.026% | **−1,452 B (OVERLAP)** | 95 runs |
+
+**The bottom row is the finding this page owes the bead.** It is the form whose bands the
+bead quoted from `rf2-77gz8`, and on 101 runs rather than 27 it is not a discriminator:
+its normal population reaches 12.2% while its elevated population descends to 4.4%. It is
+also undefined on at least one segment in **95** of the 101 admissible runs and on both
+segments in **16** of them, because a single round is not always certified — a definition
+that cannot be evaluated is not a gate.
+
+The `median(r4–6)` row separates but keeps only 759 B of gap, because rounds 4–5 sit in
+its AFTER half where they belong to neither level.
+
+The pinned form and the `median(r1–3)` form are within 26 B of each other on gap. The
+pinned one is chosen for **coverage** — it scores one more run — and for the negative-step
+argument above, not for width.
+
+## The bound
+
+**5% of the run's own BEFORE level**, which is about 950 B at this arm's level.
+
+It is a **fraction rather than a byte count** so that it carries no constant tied to this
+plan's roots and cells: a plan sitting at a different level is gated at the same relative
+strictness, and no one has to remember to re-derive a threshold when the level moves.
+
+| | Value | Distance from the bound |
+|---|---|---|
+| Largest step the normal population has produced | **1.015%** (192 B, `alloc-c4hhk/unarmed-06`) | bound is **4.9×** above it |
+| Largest normal step in bytes | **194 B** (`alloc-9jrhi/bisect-7`) | — |
+| Smallest step the elevated population has produced | **13.766%** (2,616 B, `alloc-c4hhk/armed-18`) | bound is **2.75×** below it |
+| Largest elevated step | **21.070%** (3,984 B, `alloc-9jrhi/bisect-1`) | — |
+
+Nothing was fitted. The number is one twentieth; the corpus was consulted only to check
+that both populations sit far from it, and it is biased toward the loose side because a
+refusal that fires on a legitimate run is the expensive error here.
+
+### The bound does not depend on the mode's rate
+
+`rf2-6kxub` measured the elevated mode at **0%, 10% and 53% across three windows at one
+revision**, on one instrument, with both arms moving together. A witness calibrated
+against an assumed rate would be calibrated against that unstable number.
+
+**This one is not, and the independence is structural rather than lucky.** Every quantity
+above is a comparison inside a single run, between two windows of that run's own rounds.
+No step is compared against another run, no threshold is derived from how often the mode
+appears, and no count of runs enters the rule. A window of one run and a window of
+seventy are adjudicated identically, and a window taken on a day when the mode never
+appears is scored by the same rule as one taken on a day when it appears in half the
+runs. The rate governs *how often the witness fires*; it does not enter *when* it fires.
+
+## The decision: a refusal, not a recorded verdict
+
+The bead asks which of two this becomes — a **refusal** that exits non-zero like the leg
+witness, or a **recorded verdict** that gates only what may be quoted — and frames the
+trade honestly: the arm's figures are load-bearing for the published allocation series,
+so a refusal firing on a legitimate run is expensive, while a verdict nobody reads is
+useless.
+
+**It is a refusal.** Three things decide it, and the first is the one that actually moves
+the argument.
+
+**A recorded verdict is what already exists, and it is what failed.** Every byte this
+witness reads was already in the record. The per-window certificate was already computed,
+already written, already carried in every dataset — and both modes still certified, and
+figures from this arm were still quoted out of single runs. That is the defect the bead
+is named for. Adding a second advisory number to a record that already contained the
+answer is not a fix; it is the same failure with more provenance.
+
+**The expensive-refusal worry is about a gate inside the rig, and this is not one.** A
+refusal that fires wrongly *during a bench window* costs a re-run: ninety minutes of
+browser time, a fresh box, and a plan that has to be re-declared. This refusal fires over
+a **written record**, after the fact, from a command that takes seconds. A false refusal
+here costs a re-read and an argument, not a window. That asymmetry is what makes the
+strict form affordable, and it is a direct consequence of the bead's own constraint that
+the witness be analysis-side.
+
+**And the false-refusal rate is measured rather than assumed.** Zero, over 100 scored runs
+across four corpora and four substrate revisions, with the bound sitting 4.9× above the
+worst normal step the corpus has ever produced. The bead's "expensive" is a real cost
+attached to a rate, and the rate is the part that was unknown when the bead was filed. It
+is no longer unknown.
+
+### What would change this
+
+Stated now, so it is a prediction rather than a defence:
+
+- **An intermediate level.** The bound is blind between 1.015% and 13.766%. The corpus
+  contains nothing there, and the two-population model is what licences a hard threshold.
+  A run that settles in that gap falsifies the model, and the right response is to widen
+  the record — not to nudge the bound until the awkward run passes.
+- **A single false refusal on a run that is demonstrably not elevated.** One is enough to
+  reopen this, because the whole cost argument above rests on a rate of zero.
+- **The ramp-fallback hole biting.** Two of forty elevated runs would slip if their
+  rounds 1–3 all failed to certify. None does today. If one ever does, the fallback needs
+  closing rather than disclosing.
+- **A second instrument.** Every figure here comes from one rig, unchanged since
+  `408dfb0aa8`. If the arm is ever measured another way and the levels do not reproduce,
+  this witness is measuring the instrument and not the arm.
+
+`rf2-6kxub` is deliberately **not** on that list. The mode's rate swinging 0% → 10% → 53%
+changes how often this fires; it does not change whether the rule is right, because no
+quantity in the rule is derived from a rate.
+
+## The control
+
+The claim that licences arming this at all is that the bound refuses exactly the elevated
+runs and nothing else. Every dataset it rests on is committed, so it is re-derived by
+`alloc_level_witness.test.cjs` on every run of that gate rather than asserted here once.
+
+| Corpus | Records | Inadmissible | Scored | Elevated | Refused | False refusals | Misses | Not computable |
+|---|---|---|---|---|---|---|---|---|
+| `alloc-c4hhk` | 70 | 1 | 69 | 37 | 37 | **0** | **0** | 0 |
+| `alloc-77gz8` | 20 | 1 | 19 | 2 | 2 | **0** | **0** | 0 |
+| `alloc-9jrhi` | 8 | 1 | 6 | 1 | 1 | **0** | **0** | 1 |
+| `workcount-n1b9h` | 6 | 0 | 6 | 0 | 0 | **0** | **0** | 0 |
+| **Total** | **104** | **3** | **100** | **40** | **40** | **0** | **0** | **1** |
+
+Within `alloc-c4hhk` the refusals split **18 of 34 armed** and **19 of 35 unarmed** — the
+same split the arming window reported, which is the expected result of a witness that
+reads levels and is blind to which bundle produced them.
+
+**The three inadmissible records, named.** `alloc-c4hhk/armed-25` carries no `alloc`
+object. `alloc-77gz8/run12` and `alloc-9jrhi/bisect-5` fail their positive control. Each
+is excluded by the record's own criteria, not by this witness, and each is reported
+rather than skipped.
+
+**The one run that cannot be scored**, `alloc-9jrhi/pilot-rounds6`, is a six-round pilot.
+It has no round ≥ 6, so **the published estimator does not exist for it either**;
+refusing it and quoting nothing from it are the same statement, and the refusal carries
+its own code (`level-window`) so it is never confused with a level step.
+
+### The controls that show the gate bites
+
+A gate nobody has watched cross its own threshold is a gate nobody has watched. Both
+directions are asserted in the test:
+
+- Loosened to **25%**, the witness refuses **nothing** and all 40 elevated runs become
+  misses.
+- Tightened to **0.4%**, it refuses **all 60** normal runs.
+- At the shipped bound, one byte past 5% refuses and exactly 5% certifies.
+
+And a planted mutation shows the gate reaches the code it claims to. Turning BEFORE's
+minimum into a maximum — one character, `<` to `>`, at the `reduce` that picks the lowest
+certified early window — takes the gate from **9/9 to 3/9**, and every one of the six
+reds is specific rather than incidental:
+
+- the two fixtures that pin the minimum fail *by name* — "certified ramp rounds do not
+  raise BEFORE" and "one inflated early round does not raise BEFORE";
+- `alloc-c4hhk/armed-13` and `alloc-9jrhi/bisect-1` become **newly-missed elevated runs**,
+  which is the failure the bound exists to prevent;
+- the refusal count falls 40 → 38, the worst normal step inverts to −216 B, the
+  ramp-fallback reading count goes 1 → 99, and the 0.4% tightening control collapses
+  60 → 6.
+
+The file was then restored and its content hash compared against the committed object —
+`3dd95e0c268db8b517c802142b2a37de0acbae67` both before the plant and after the restore —
+and the gate re-run green at 9/9. A green run under sabotage would have meant the gate
+was not reading this tree; it was not green.
+
+## The rig is not touched
+
+Nothing under `implementation/core/test/re_frame/bench/` is modified, and nothing this
+page adds is compiled into the bundle the arm builds. The witness reads committed records
+and never writes one.
+
+That is a requirement rather than a convenience. **No bench file has changed since
+`408dfb0aa82ee97aee47753660b05ae99d8fab0f`**, which is what lets `rf2-6kxub` compare rates
+across three windows and what lets `rf2-c4hhk` claim its window ran the instrument that
+produced the `alloc-77gz8` datasets. A witness soldered into `p0_run.cjs` would end that
+constancy and would put a gate inside the rig whose invariance the published series rests
+on.
+
+| File | Blob at this page's base | Blob at `rf2-c4hhk`'s base |
+|---|---|---|
+| `core/test/re_frame/bench/p0_run.cjs` | `ce6363ff774d8049c07b58513d708687a73e937e` | `ce6363ff774d8049c07b58513d708687a73e937e` |
+| `core/test/re_frame/bench/p0_heap.cljs` | `5e174327ac17feac2f46ccbdf2bc4f89accf624f` | `5e174327ac17feac2f46ccbdf2bc4f89accf624f` |
+| `core/test/re_frame/bench/p0_workcount.cljc` | `033f00470c380a17664a1dabffa0768f0e22c671` | `033f00470c380a17664a1dabffa0768f0e22c671` |
+| `core/test/re_frame/bench/p0_fixture.cljc` | `1f066a05365e9f47b76b887a3d98e7cd8a9152e8` | `1f066a05365e9f47b76b887a3d98e7cd8a9152e8` |
+| `core/test/re_frame/bench/p0_floor.cljs` | `3a14ff96414f9a77a7612f56181444155b582620` | `3a14ff96414f9a77a7612f56181444155b582620` |
+
+Every one is byte-identical to the table on
+[Does arming the census move the high level?](does-arming-the-census-move-the-high-level.md).
+
+## The corpus this was calibrated against
+
+All datasets are committed under
+`implementation/hicasso/test/re_frame/bench/hicasso/data/`. The plan is identical across
+every one of them — `P0_ALLOC_PLAN=floor`, `P0_ALLOC_WRITE=all`, `P0_ROOTS=4`,
+`P0_ALLOC_CELLS=6`, `P0_ALLOC_ROUNDS=18`, so B = 24 — except the six-round pilot noted
+above. Every figure is a browser figure: `:advanced`, real Chromium under playwright,
+`--enable-precise-memory-info`, in-page `performance.memory.usedJSHeapSize` sampled at
+every leg boundary. The runtime is the one each record carries; no run was re-taken.
+
+| Corpus | Records | Substrate revision(s) | Census |
+|---|---|---|---|
+| `alloc-c4hhk/` | 70 | `4a1537cb717dc6660aa449642f198a2cc970c93b` | 35 armed, 35 unarmed, strictly alternating |
+| `alloc-77gz8/` | 20 | `4a1537cb717dc6660aa449642f198a2cc970c93b` | all armed |
+| `alloc-9jrhi/` | 8 | `4a1537cb71`, `a158c40288`, `48c715f97c`, `9d20be1d00`, and `88411ed803` for the two named `head` runs | unarmed |
+| `workcount-n1b9h/` | 6 | `4a1537cb717dc6660aa449642f198a2cc970c93b` for runs 3–6; runs 1–2 were taken at that page's own HEAD, which its record does not pin and neither does its dataset | all armed |
+
+That the witness holds across every substrate revision the corpus contains, and across
+both census arms, is worth stating: the levels it discriminates are a property of the
+arm, not of a build.
+
+## Reproduction
+
+From `implementation/`, on this page's base
+`9476293ae8b087f1125f9a721a339892a01c7b8b`. Nothing here opens a browser; the whole
+control is a read over committed JSON and takes a few seconds.
+
+```bash
+# the full corpus control, printing the bands and every exclusion by name
+node hicasso/test/re_frame/bench/hicasso/alloc_level_witness.cjs --corpus
+
+# the fixtures alone
+node hicasso/test/re_frame/bench/hicasso/alloc_level_witness.cjs --self-test
+
+# fixtures plus the corpus control plus the loosen/tighten mutation proofs
+node hicasso/test/re_frame/bench/hicasso/alloc_level_witness.test.cjs
+
+# one run, or a window's worth: exits non-zero on any refusal
+node hicasso/test/re_frame/bench/hicasso/alloc_level_witness.cjs \
+  hicasso/test/re_frame/bench/hicasso/data/alloc-77gz8/run09-a4a1537cb71.json
+```
+
+`run09` is the worked example the bead cites. It prints:
+
+```text
+;;   reagent-subs   before     18950 @r 1 (n=4)  after     21632 (n=10)  step   +2682 B   14.153%
+;;   uix-subs       before     19372 @r 2 (n=4)  after     22072 (n=10)  step   +2700 B   13.938%
+;;   REFUSED [level-step] reagent-subs: settled at 21632 B/write against 18950 B/write …
+```
+
+## What this does not settle
+
+- **It does not explain the mode.** Nothing here says what the elevated level *is*. The
+  witness refuses a contaminated reading; it does not diagnose one. `rf2-6kxub` holds the
+  open question of what the rate depends on.
+- **It does not gate a run at the moment it is taken.** The refusal is over a written
+  record, so a window still has to invoke it. That is the deliberate cost of leaving the
+  rig alone, and the invocation is one line.
+- **It is not registered in the fast-PR spine.** `alloc_level_witness.test.cjs` follows
+  `clock_witness.test.cjs`'s shape exactly and belongs in `test:script-helpers`, but that
+  list lives in `implementation/package.json`, outside this change's fence. Filed as
+  `rf2-zu82n`; until it lands, the gate runs by name.
+- **The ramp fallback is a real hole, bounded rather than closed.** A segment whose
+  rounds 1–3 all fail to certify is scored from a ramp round and its step is understated.
+  No elevated run in the corpus is scored that way, and two of forty would slip if one
+  were. The reading is marked; it is not repaired.
+- **The bound rests on 40 elevated readings, 37 of them from one window on one day.**
+  `rf2-6kxub` established that the rate is not a property of the revision, so the
+  *levels* seen in that window may not be the only ones the arm has. A fourth level at
+  +96 B on `new` is already recorded there; it is far inside the refusal region, but a
+  level between 1.015% and 13.766% would be invisible to this bound and nothing here
+  excludes one.

--- a/implementation/hicasso/test/re_frame/bench/hicasso/alloc_level_witness.cjs
+++ b/implementation/hicasso/test/re_frame/bench/hicasso/alloc_level_witness.cjs
@@ -52,7 +52,7 @@
 // removes bytes; the collector does" — so a certified window is not available
 // to be spuriously low. The minimum of the certified early windows is
 // therefore the best estimate of the level the run started at, and a median
-// over as few as one or two windows is not: four runs read a NEGATIVE step
+// over as few as one or two windows is not: FIVE runs read a NEGATIVE step
 // under the median form, the worst at -1,014 B, every one of them a normal run
 // with a single inflated early round inside a two-window median.
 //
@@ -185,9 +185,10 @@ function median(xs) {
 }
 
 // PER-SEGMENT, NOT PER-ROUND. A round holds one window per segment and the
-// levels are page-global — rf2-c4hhk found the offset identical on both
-// segments in 34 of 37 elevated runs — but the two segments sit at different
-// absolute levels (19,100 against 19,540), so they are never pooled.
+// levels are page-global — in all 37 of `alloc-c4hhk`'s elevated runs BOTH
+// segments are elevated, never one alone — but the two segments sit at
+// different absolute levels (19,100 against 19,540), so they are never pooled.
+// A run is refused on EITHER segment's step rather than on the pair agreeing.
 function segmentsOf(alloc) {
   const out = new Map();
   for (const round of alloc.perRound || []) {

--- a/implementation/hicasso/test/re_frame/bench/hicasso/alloc_level_witness.cjs
+++ b/implementation/hicasso/test/re_frame/bench/hicasso/alloc_level_witness.cjs
@@ -1,0 +1,547 @@
+'use strict';
+// THE FLOOR ARM'S WITHIN-RUN LEVEL WITNESS — rf2-a233t.
+//
+//     node hicasso/test/re_frame/bench/hicasso/alloc_level_witness.cjs <dataset.json>...
+//     node hicasso/test/re_frame/bench/hicasso/alloc_level_witness.cjs --corpus
+//     node hicasso/test/re_frame/bench/hicasso/alloc_level_witness.cjs --self-test
+//
+// ## THE DEFECT THIS REFUSES
+//
+// The floor arm is MULTI-MODAL. Most runs settle at 19,100 / 19,540 B per
+// write; some settle 2,532 B higher, and one level 3,792 B higher has been
+// seen. `rf2-c4hhk`'s seventy-run window established that the levels are real
+// — an armed run and an unarmed run trace the elevated ramp byte for byte —
+// and `rf2-77gz8` established that the work count is identical across them, so
+// neither the instrument nor different-work-per-write explains the step.
+//
+// BOTH MODES STILL CERTIFY. The leg witness in `p0_run.cjs` asks whether a
+// window's legs are ALIKE, and in both modes they are: an elevated window is
+// six legs of 21,632 B, as internally consistent as six legs of 19,100 B. It
+// has nothing to say about WHICH of two levels the window sits at. So the
+// runner passes an elevated window without remark, and any figure quoted from
+// this arm out of a single run is a coin toss between two levels 13-21% apart.
+//
+// ## THE RULE
+//
+// A run that is at one level is at that level THROUGHOUT. The elevated mode is
+// not a run that starts high — it is a run that starts at the low level, steps
+// over rounds 4-5, and settles high. So the two populations are separated
+// inside a single run's own data, and no second run and no new instrument are
+// needed to tell them apart:
+//
+//   BEFORE(seg) = MINIMUM of `legMedian` over CERTIFIED windows at rounds 1-5
+//   AFTER(seg)  = MEDIAN  of `legMedian` over CERTIFIED windows at round >= 6
+//   STEP(seg)   = AFTER - BEFORE
+//
+//   REFUSE when STEP(seg) > BOUND x BEFORE(seg) for any segment.
+//
+// ## WHY THOSE TWO STATISTICS, WHICH IS NOT A SYMMETRY
+//
+// AFTER is not a new quantity: it is the PUBLISHED ESTIMATOR, verbatim — the
+// median over certified windows at round index >= 6, per segment, declared in
+// `rf2-77gz8`'s pre-registration and carried unchanged by `rf2-c4hhk`. The
+// witness therefore adjudicates exactly the number the records quote, which is
+// the only number a level gate has any business gating.
+//
+// BEFORE is a MINIMUM rather than a median, and the asymmetry is the point.
+// The error available to an early round is ONE-SIGNED: those rounds carry
+// warm-up allocation the settled rounds do not, so an early window can read
+// ABOVE the run's floor and cannot read below it. A window that read below its
+// cohort would already have been refused by the leg witness — "a leg BELOW its
+// cohort is a leg something removed bytes from, and nothing in the work unit
+// removes bytes; the collector does" — so a certified window is not available
+// to be spuriously low. The minimum of the certified early windows is
+// therefore the best estimate of the level the run started at, and a median
+// over as few as one or two windows is not: four runs read a NEGATIVE step
+// under the median form, the worst at -1,014 B, every one of them a normal run
+// with a single inflated early round inside a two-window median.
+//
+// Round 0 is outside the window because it is the prime round and is
+// uncertified in every run in the corpus.
+//
+// ## WHY ROUNDS 4-5 ARE IN THE WINDOW WHEN THEY ARE THE TRANSITION
+//
+// Because a minimum cannot be raised by them, and coverage is free. MEASURED
+// over every committed admissible run: the BEFORE minimum came from rounds 1-3
+// in 201 of 202 segment-halves — the ramp is never the lowest certified window
+// when a pre-ramp one exists — so including rounds 4-5 changes no reading. The
+// one half where it does is `alloc-c4hhk/armed-03`'s `reagent-subs`, where
+// NONE of rounds 1-3 certified. Under a rounds-1-3 window that run has no
+// BEFORE at all and the witness must refuse a run whose level is not elevated;
+// under this window it is scored, at +0.494%, and certifies.
+//
+// THE COST, STATED AND MEASURED. When a segment's rounds 1-3 all fail to
+// certify, BEFORE falls back to a ramp round, which sits BETWEEN the levels on
+// an elevated run and so SHRINKS its step. That biases toward missing a mode
+// run, never toward refusing a normal one. Forcing every elevated run in the
+// corpus to that worst case, 38 of 40 still exceed the bound and two would
+// slip — so the degradation is real, it is one-sided in the safe direction for
+// false refusals, and it is DISCLOSED rather than hidden: `beforeFromRamp` is
+// set on any segment scored that way, and no elevated run in the corpus is.
+//
+// ## THE TWO OTHER DEFINITIONS THE CORPUS HAS USED, AND WHY NEITHER IS PINNED
+//
+// The difference is entirely about whether a ramp round is allowed inside a
+// LEVEL's window, and it is worth about 2.4 kB of separation. Scored over the
+// same 100 admissible runs, taking each run's worst segment:
+//
+//   | definition                                | normal band  | mode band     |
+//   |-------------------------------------------|--------------|---------------|
+//   | min(cert r1-5) -> median(cert r>=6) PINNED |   96..194 B  | 2,616..3,984 B|
+//   | median(r1-3) -> median(r>=6)               |   96..168 B  | 2,628..3,948 B|
+//   | median(r4-6) - median(r1-3)                |   90..896 B  | 1,655..4,083 B|
+//   | r4 - r3, one round against one round       |   80..2,312 B|   860..4,946 B|
+//
+// THE LAST ONE DOES NOT SEPARATE THE POPULATIONS AT ALL. It is the form
+// `rf2-77gz8`'s re-analysis quoted as -43 to +158 B normal against 3,912-3,948
+// B in the mode, and on the larger corpus its normal band reaches +2,312 B
+// while its mode band descends to +860 B — they OVERLAP by 1,452 B. A bound
+// set from that quoted band would have refused legitimate runs. It is also
+// undefined on 16 of the 101 admissible runs, because one round is not always
+// certified. The median(r4-6) form separates but leaves only 759 B of gap,
+// because rounds 4-5 are in the AFTER half where they belong to neither level.
+//
+// ## WHY THE TEST IS ONE-SIDED
+//
+// A NEGATIVE step is not this defect and is not gated. The gate exists to stop
+// an elevated PUBLISHED figure, and the published figure is AFTER: a run whose
+// early rounds read above its settled level publishes the lower number, which
+// is the correct one. Under the pinned estimator no admissible run in the
+// corpus produces a negative step at all, so the rule costs nothing here; it
+// is one-sided because of what the gate is FOR, not because of what the corpus
+// happened to show.
+//
+// ## THE BOUND, AND WHERE IT COMES FROM
+//
+// BOUND = 5% of the run's own BEFORE level (~950 B at this arm's level).
+//
+// It is a fraction rather than a byte count so that it carries no constant
+// tied to this plan's roots and cells, and so a plan that moves the level does
+// not silently move the gate with it. Measured over every committed admissible
+// floor run — 100 scored runs across four revisions and four corpora:
+//
+//   normal population   n=60    0.494% .. 1.015%   (96 .. 194 B)
+//   elevated population n=40   13.766% .. 21.070%  (2,616 .. 3,984 B)
+//
+// 5% sits 4.9x above the largest step the normal population has ever produced
+// and 2.75x below the smallest the mode has. Nothing was fitted: the number is
+// one twentieth, and the corpus was consulted only to check that both
+// populations sit far from it.
+//
+// THE BOUND DOES NOT DEPEND ON THE MODE'S RATE, which matters because that
+// rate is not stable — `rf2-6kxub` measured 0%, 10% and 53% across three
+// windows at ONE revision. Nothing here is sized against a rate: the witness
+// scores each run against that run's own earlier rounds, so a window of one
+// run and a window of seventy are adjudicated identically, and a window taken
+// on a day when the mode never appears is scored by the same rule as one taken
+// on a day when it appears in half the runs.
+//
+// ## WHAT IT REFUSES
+//
+//   * `level-step`   — a segment's settled level is more than BOUND above its
+//                      own pre-transition level. The run is in the elevated
+//                      mode and its figures must not be quoted.
+//   * `level-window` — a segment has no certified window in one of the two
+//                      halves. There is then no settled level to certify, and
+//                      — since AFTER is the published estimator — no figure to
+//                      quote either.
+//   * `no-alloc`     — the record carries no `alloc` object. `rf2-c4hhk`'s
+//                      `armed-25` is the corpus example: Chromium failed to
+//                      launch, nothing was measured, and the driver still
+//                      exited 1.
+//   * `inadmissible` — the positive control failed or a read-back went
+//                      unverified. Reported, and the level is not adjudicated.
+//
+// ## WHY THIS IS ANALYSIS-SIDE, AND NOT A CHANGE TO THE RUNNER
+//
+// `implementation/core/test/re_frame/bench/` has not changed since
+// `408dfb0aa8`. Every dataset in `alloc-77gz8`, `alloc-c4hhk` and
+// `workcount-n1b9h` was produced by that one instrument, and `rf2-6kxub` leans
+// on exactly that when it compares rates across windows. A witness computable
+// from data ALREADY RECORDED costs that constancy nothing; the same witness
+// soldered into `p0_run.cjs` would end it, and would put a gate inside the rig
+// whose invariance the published series rests on. So this file reads records
+// and never writes one, and the bundle the arm compiles is untouched.
+
+const fs = require('node:fs');
+const path = require('node:path');
+
+// The pinned windows and the bound. Exported so a caller can re-score the
+// corpus under a different definition without editing this file — the record
+// in docs/design/hicasso/studio/ does exactly that to build the table above.
+const BEFORE_ROUNDS = [1, 5];
+const BEFORE_PRE_RAMP_MAX = 3; // rounds above this are the transition; see the header
+const AFTER_ROUND_MIN = 6;
+const LEVEL_STEP_BOUND = 0.05;
+const HIGH_MODE_FLOOR_B = 21000; // rf2-77gz8's classification criterion, for reporting only
+
+function median(xs) {
+  if (!xs.length) return null;
+  const s = [...xs].sort((a, b) => a - b);
+  const m = s.length >> 1;
+  return s.length % 2 ? s[m] : (s[m - 1] + s[m]) / 2;
+}
+
+// PER-SEGMENT, NOT PER-ROUND. A round holds one window per segment and the
+// levels are page-global — rf2-c4hhk found the offset identical on both
+// segments in 34 of 37 elevated runs — but the two segments sit at different
+// absolute levels (19,100 against 19,540), so they are never pooled.
+function segmentsOf(alloc) {
+  const out = new Map();
+  for (const round of alloc.perRound || []) {
+    for (const arm of Object.values(round.arms || {})) {
+      const seg = arm.segment;
+      if (!out.has(seg)) out.set(seg, []);
+      out.get(seg).push({ round: round.round, legMedian: arm.legMedian, certified: arm.certified === true });
+    }
+  }
+  return out;
+}
+
+const inWindow = (rows, lo, hi) =>
+  rows.filter((r) => r.certified && typeof r.legMedian === 'number' && r.round >= lo && r.round <= hi);
+
+// ADMISSIBILITY IS THE RECORD'S, NOT THE EXIT CODE'S. `--only alloc` exits
+// non-zero as a matter of course — it exits on any refused window and on any
+// collection inside a measured one, and both are routine at this page. All
+// seventy of rf2-c4hhk's runs exited 1, including the one that measured
+// nothing. The two run-level gates are the positive control and the read-back
+// verification; the per-window certificate is inside the estimator above.
+function admissibility(alloc) {
+  const reasons = [];
+  if (!alloc || typeof alloc !== 'object') {
+    return { ok: false, reasons: ['the record carries no `alloc` object at all'] };
+  }
+  if (alloc.controlVerdict?.ok !== true) reasons.push('the positive control did not adjudicate ok (`controlVerdict.ok`)');
+  if (alloc.verification?.unverified !== 0) reasons.push(`${alloc.verification?.unverified} read-back(s) went unverified`);
+  return { ok: reasons.length === 0, reasons };
+}
+
+function adjudicate(record, { bound = LEVEL_STEP_BOUND } = {}) {
+  const faults = [];
+  const fault = (code, message) => faults.push({ code, message });
+  const alloc = record && record.alloc;
+
+  if (!alloc) {
+    fault(
+      'no-alloc',
+      'the record carries no `alloc` object: nothing was measured. A driver that fails to open a page still writes a record and still ' +
+        'exits 1, so this is invisible in the exit code and obvious here.'
+    );
+    return { ok: false, admissible: false, faults, segments: [], bound };
+  }
+
+  const adm = admissibility(alloc);
+  if (!adm.ok) {
+    for (const r of adm.reasons) fault('inadmissible', `${r} — the run is excluded and named, and its level is not adjudicated.`);
+    return { ok: false, admissible: false, faults, segments: [], bound };
+  }
+
+  const segments = [];
+  for (const [seg, rows] of segmentsOf(alloc)) {
+    const beforeRows = inWindow(rows, BEFORE_ROUNDS[0], BEFORE_ROUNDS[1]);
+    const afterRows = inWindow(rows, AFTER_ROUND_MIN, Infinity);
+    const lowest = beforeRows.length ? beforeRows.reduce((a, b) => (b.legMedian < a.legMedian ? b : a)) : null;
+    const before = lowest ? lowest.legMedian : null;
+    const after = median(afterRows.map((r) => r.legMedian));
+    const s = {
+      segment: seg,
+      before,
+      after,
+      beforeRound: lowest ? lowest.round : null,
+      beforeFromRamp: lowest ? lowest.round > BEFORE_PRE_RAMP_MAX : false,
+      nBefore: beforeRows.length,
+      nAfter: afterRows.length,
+      step: before === null || after === null ? null : after - before,
+      fraction: before === null || after === null || before === 0 ? null : (after - before) / before,
+      elevated: after !== null && after >= HIGH_MODE_FLOOR_B,
+    };
+    segments.push(s);
+
+    if (before === null || after === null) {
+      const half = before === null ? `rounds ${BEFORE_ROUNDS[0]}-${BEFORE_ROUNDS[1]}` : `rounds >= ${AFTER_ROUND_MIN}`;
+      fault(
+        'level-window',
+        `${seg}: no certified window in ${half}, so this segment has no level to compare. AFTER is the published estimator, so a run ` +
+          'missing it has no figure to quote either — refusing is the same statement as "nothing was certified here".'
+      );
+      continue;
+    }
+    if (s.fraction > bound) {
+      fault(
+        'level-step',
+        `${seg}: settled at ${after} B/write against ${before} B/write before the transition — a step of +${s.step} B ` +
+          `(${(s.fraction * 100).toFixed(3)}%), past the ${(bound * 100).toFixed(0)}% bound (+${Math.round(bound * before)} B). ` +
+          "The run changed level mid-window, so its settled figure is one of two modes and must not be quoted as the arm's."
+      );
+    }
+  }
+
+  if (!segments.length) fault('level-window', 'the record carries no per-round arm windows at all.');
+
+  return { ok: faults.length === 0, admissible: true, faults, segments, bound };
+}
+
+function format(v, label) {
+  const out = [];
+  out.push(`;; ${label || 'run'} — within-run LEVEL witness (rf2-a233t)`);
+  for (const s of v.segments) {
+    const step = s.step === null ? '—' : `${s.step >= 0 ? '+' : ''}${s.step} B`;
+    const pct = s.fraction === null ? '—' : `${(s.fraction * 100).toFixed(3)}%`;
+    out.push(
+      `;;   ${s.segment.padEnd(14)} before ${String(s.before ?? '—').padStart(9)} @r${String(s.beforeRound ?? '-').padStart(2)} (n=${s.nBefore})` +
+        `  after ${String(s.after ?? '—').padStart(9)} (n=${s.nAfter})  step ${step.padStart(9)}  ${pct.padStart(8)}` +
+        (s.beforeFromRamp ? '  [BEFORE fell back to a ramp round — the step is understated]' : '')
+    );
+  }
+  if (v.ok) {
+    out.push(`;;   CERTIFIED: every segment holds its level across the transition, within ${(v.bound * 100).toFixed(0)}%.`);
+  } else {
+    for (const f of v.faults) out.push(`;;   REFUSED [${f.code}] ${f.message}`);
+  }
+  return out.join('\n');
+}
+
+// --- the corpus control, as a function rather than as prose ------------------
+//
+// The claim the bound rests on is that it refuses EXACTLY the elevated runs and
+// nothing else. That claim is checkable against every dataset this repository
+// has committed, so it is checked rather than asserted, and
+// `alloc_level_witness.test.cjs` runs it on every fast-PR spine. Classification
+// is rf2-77gz8's criterion — either segment's published estimator at or above
+// 21,000 B/write — which is INDEPENDENT of the step this witness measures.
+
+const CORPORA = ['alloc-c4hhk', 'alloc-77gz8', 'alloc-9jrhi', 'workcount-n1b9h'];
+
+function scoreCorpus({ dataDir = path.join(__dirname, 'data'), corpora = CORPORA, bound = LEVEL_STEP_BOUND } = {}) {
+  const rows = [];
+  for (const corpus of corpora) {
+    const dir = path.join(dataDir, corpus);
+    if (!fs.existsSync(dir)) continue;
+    for (const file of fs.readdirSync(dir).filter((f) => f.endsWith('.json')).sort()) {
+      const record = JSON.parse(fs.readFileSync(path.join(dir, file), 'utf8'));
+      const v = adjudicate(record, { bound });
+      rows.push({
+        corpus,
+        run: file.replace(/\.json$/, ''),
+        admissible: v.admissible,
+        elevated: v.segments.some((s) => s.elevated),
+        refused: !v.ok,
+        codes: [...new Set(v.faults.map((f) => f.code))],
+        verdict: v,
+      });
+    }
+  }
+  const scored = rows.filter((r) => r.admissible);
+  const notComputable = scored.filter((r) => r.codes.includes('level-window'));
+  const stepped = scored.filter((r) => !r.codes.includes('level-window'));
+  const falsePositives = stepped.filter((r) => !r.elevated && r.codes.includes('level-step'));
+  const misses = stepped.filter((r) => r.elevated && !r.codes.includes('level-step'));
+  const band = (elev) => {
+    const xs = stepped.filter((r) => r.elevated === elev).map((r) => ({
+      pct: Math.max(...r.verdict.segments.map((s) => s.fraction)),
+      b: Math.max(...r.verdict.segments.map((s) => s.step)),
+    }));
+    if (!xs.length) return { n: 0 };
+    return {
+      n: xs.length,
+      minPct: Math.min(...xs.map((x) => x.pct)), maxPct: Math.max(...xs.map((x) => x.pct)),
+      minB: Math.min(...xs.map((x) => x.b)), maxB: Math.max(...xs.map((x) => x.b)),
+    };
+  };
+  return {
+    rows,
+    scored: scored.length,
+    inadmissible: rows.filter((r) => !r.admissible),
+    elevated: scored.filter((r) => r.elevated).length,
+    refusedForStep: scored.filter((r) => r.codes.includes('level-step')).length,
+    degraded: stepped.filter((r) => r.verdict.segments.some((s) => s.beforeFromRamp)),
+    falsePositives, misses, notComputable,
+    normal: band(false), mode: band(true), bound,
+  };
+}
+
+// --- fixtures ---------------------------------------------------------------
+//
+// Synthetic, so the refusals can be seen without opening a browser and without
+// reading 20 MB of committed JSON. The corpus control above is the other half.
+
+function synth({
+  before = 19004, after = 19100, rounds = 18,
+  certifyBefore = [1, 2, 3], certifyRamp = false, certifyAfter = true,
+  segments = ['reagent-subs', 'uix-subs'],
+} = {}) {
+  const perRound = [];
+  for (let round = 0; round < rounds; round++) {
+    const arms = {};
+    for (const segment of segments) {
+      const isRamp = round === 4 || round === 5;
+      const preRamp = round >= 1 && round <= 3;
+      const legMedian = preRamp ? before : isRamp ? Math.round((before + after) / 2) : after;
+      arms[`${segment}|grid/floor`] = {
+        segment,
+        legMedian,
+        certified: preRamp ? certifyBefore.includes(round) : isRamp ? certifyRamp : round >= AFTER_ROUND_MIN && certifyAfter,
+      };
+    }
+    perRound.push({ round, arms });
+  }
+  return { alloc: { controlVerdict: { ok: true }, verification: { unverified: 0 }, rounds, perRound } };
+}
+
+function selfTest() {
+  const checks = [];
+  const check = (name, ok) => checks.push({ name, ok });
+  const has = (v, code) => v.faults.some((f) => f.code === code);
+
+  // 1. THE NORMAL POPULATION. The corpus's own low level and the largest
+  //    settling movement it has ever produced both certify.
+  {
+    check('a flat run certifies', adjudicate(synth({ before: 19004, after: 19004 })).ok);
+    check('the corpus low level (19,004 -> 19,100, +96 B) certifies', adjudicate(synth({ before: 19004, after: 19100 })).ok);
+    check('the largest settling step ever measured (+194 B) certifies', adjudicate(synth({ before: 19184, after: 19378 })).ok);
+    check('the largest settling FRACTION ever measured (1.015%) certifies', adjudicate(synth({ before: 18908, after: 19100 })).ok);
+  }
+
+  // 2. THE DEFECT. Both elevated levels in the corpus, and the least-marginal
+  //    elevated run there is.
+  {
+    const nu = adjudicate(synth({ before: 19004, after: 21632 })); // +2,628 B, the `new` level
+    check('the +2,532 level REFUSES', !nu.ok && has(nu, 'level-step'));
+    const hi = adjudicate(synth({ before: 18944, after: 22892 })); // +3,948 B, the `high` level
+    check('the +3,792 level REFUSES', !hi.ok && has(hi, 'level-step'));
+    const marginal = adjudicate(synth({ before: 19016, after: 21632 })); // +2,616 B, the smallest in the corpus
+    check('the smallest elevated step in the corpus REFUSES', !marginal.ok && has(marginal, 'level-step'));
+  }
+
+  // 3. THE BOUND IS WHERE IT SAYS IT IS. Exactly at 5% certifies; a byte past
+  //    refuses. A gate nobody has watched cross its own threshold is a gate
+  //    nobody has watched.
+  {
+    check('a step of exactly the bound certifies', adjudicate(synth({ before: 20000, after: 21000 })).ok);
+    const over = adjudicate(synth({ before: 20000, after: 21001 })); // 5.005%
+    check('one byte past the bound REFUSES', !over.ok && has(over, 'level-step'));
+  }
+
+  // 4. ONE-SIDED. A run whose early rounds read high publishes the LOWER
+  //    number, so it is not this defect and is not gated.
+  {
+    check('a large NEGATIVE step certifies — the published figure is the lower one', adjudicate(synth({ before: 20554, after: 19540 })).ok);
+  }
+
+  // 5. EITHER SEGMENT REFUSES THE RUN. The levels are page-global, but a
+  //    witness that needed both to agree would pass the 3-in-37 that do not.
+  {
+    const one = synth({ before: 19004, after: 19100 });
+    for (const round of one.alloc.perRound) {
+      if (round.round >= AFTER_ROUND_MIN) round.arms['uix-subs|grid/floor'].legMedian = 22072;
+    }
+    const v = adjudicate(one);
+    check('one elevated segment refuses the whole run', !v.ok && has(v, 'level-step'));
+    check('and the certified segment is still reported', v.segments.find((s) => s.segment === 'reagent-subs').step === 96);
+  }
+
+  // 6. A HALF WITH NO CERTIFIED WINDOW IS A REFUSAL, NOT A PASS. The silent
+  //    failure this replaces is a witness that computes a step from an empty
+  //    window and reports NaN as "within bound".
+  {
+    const noBefore = adjudicate(synth({ certifyBefore: [], certifyRamp: false }));
+    check('an empty BEFORE window REFUSES', !noBefore.ok && has(noBefore, 'level-window'));
+    const noAfter = adjudicate(synth({ rounds: 6 })); // the 6-round pilot's shape
+    check('a run with no round >= 6 REFUSES', !noAfter.ok && has(noAfter, 'level-window'));
+    const nb = adjudicate(synth({ certifyBefore: [], certifyRamp: false })).segments[0];
+    check('and it reports the empty half rather than a NaN step', nb.step === null && nb.nBefore === 0);
+  }
+
+  // 7. BEFORE IS A MINIMUM, so the transition cannot raise it. This is the
+  //    whole of what lets rounds 4-5 sit in the window, and a mutation that
+  //    turns it into a mean or a median must be visible.
+  {
+    const ramp = adjudicate(synth({ before: 19004, after: 19100, certifyRamp: true }));
+    check('certified ramp rounds do not raise BEFORE', ramp.ok && ramp.segments[0].before === 19004 && ramp.segments[0].beforeRound <= 3);
+    const r = synth({ before: 19004, after: 19100, certifyBefore: [1, 2, 3] });
+    r.alloc.perRound[2].arms['reagent-subs|grid/floor'].legMedian = 21688; // one inflated early round
+    const v = adjudicate(r);
+    check('one inflated early round does not raise BEFORE', v.ok && v.segments.find((s) => s.segment === 'reagent-subs').before === 19004);
+    const r0 = synth({ before: 19004, after: 19100 });
+    r0.alloc.perRound[0].arms['reagent-subs|grid/floor'] = { segment: 'reagent-subs', legMedian: 1, certified: true };
+    check('round 0 is outside the window even when certified and lowest', adjudicate(r0).segments.find((s) => s.segment === 'reagent-subs').before === 19004);
+  }
+
+  // 8. THE RAMP FALLBACK IS DISCLOSED. When rounds 1-3 give nothing the run is
+  //    still scored, and the reading is marked as understating its step.
+  {
+    const v = adjudicate(synth({ before: 19004, after: 19100, certifyBefore: [], certifyRamp: true }));
+    check('a segment with only ramp rounds is scored rather than refused', v.ok);
+    check('and it is marked beforeFromRamp', v.segments.every((s) => s.beforeFromRamp === true));
+    check('an ordinary reading is NOT marked beforeFromRamp', adjudicate(synth()).segments.every((s) => s.beforeFromRamp === false));
+  }
+
+  // 9. ADMISSIBILITY IS READ OFF THE RECORD. The exit code is not a criterion
+  //    and neither is the absence of one.
+  {
+    const noAlloc = adjudicate({ generatedAt: 'x', build: 'hicasso-bench' });
+    check('a record with no `alloc` object REFUSES', !noAlloc.ok && has(noAlloc, 'no-alloc'));
+    const badControl = synth();
+    badControl.alloc.controlVerdict.ok = false;
+    const bc = adjudicate(badControl);
+    check('a failed positive control is INADMISSIBLE, not certified', !bc.ok && has(bc, 'inadmissible'));
+    const unverified = synth({ before: 19004, after: 21632 });
+    unverified.alloc.verification.unverified = 2;
+    const uv = adjudicate(unverified);
+    check('an unverified read-back is INADMISSIBLE and the level is not adjudicated', !uv.ok && has(uv, 'inadmissible') && !has(uv, 'level-step'));
+  }
+
+  // 10. THE BOUND IS A FRACTION OF THE RUN'S OWN LEVEL, so a plan sitting at a
+  //     different level is gated at the same relative strictness.
+  {
+    check('a tenfold level with the same relative step certifies', adjudicate(synth({ before: 190040, after: 191000 })).ok);
+    check("a tenfold level with the mode's relative step REFUSES", !adjudicate(synth({ before: 190040, after: 216320 })).ok);
+  }
+
+  return { checks };
+}
+
+// --- CLI --------------------------------------------------------------------
+
+function main(argv) {
+  const args = argv.slice(2);
+  if (args.includes('--self-test')) {
+    const { checks } = selfTest();
+    const bad = checks.filter((c) => !c.ok);
+    for (const c of checks) console.log(`${c.ok ? 'ok  ' : 'FAIL'} ${c.name}`);
+    console.log(`;; ${checks.length - bad.length}/${checks.length} fixtures pass`);
+    return bad.length ? 1 : 0;
+  }
+  if (args.includes('--corpus')) {
+    const r = scoreCorpus();
+    console.log(`;; corpus control — bound ${(r.bound * 100).toFixed(0)}% of each run's own BEFORE level`);
+    console.log(`;;   admissible ${r.scored}   scored ${r.normal.n + r.mode.n}   elevated ${r.elevated}   refused-for-step ${r.refusedForStep}`);
+    console.log(`;;   FALSE POSITIVES ${r.falsePositives.length}   MISSES ${r.misses.length}   not-computable ${r.notComputable.length}   ramp-fallback readings ${r.degraded.length}`);
+    console.log(`;;   normal n=${r.normal.n}  ${r.normal.minB}..${r.normal.maxB} B  ${(r.normal.minPct * 100).toFixed(3)}%..${(r.normal.maxPct * 100).toFixed(3)}%`);
+    console.log(`;;   mode   n=${r.mode.n}  ${r.mode.minB}..${r.mode.maxB} B  ${(r.mode.minPct * 100).toFixed(3)}%..${(r.mode.maxPct * 100).toFixed(3)}%`);
+    for (const row of r.inadmissible) console.log(`;;   EXCLUDED ${row.corpus}/${row.run} — ${row.codes.join(', ')}`);
+    for (const row of r.notComputable) console.log(`;;   NOT COMPUTABLE ${row.corpus}/${row.run}`);
+    for (const row of r.degraded) console.log(`;;   RAMP FALLBACK ${row.corpus}/${row.run} (elevated=${row.elevated})`);
+    return r.falsePositives.length || r.misses.length ? 1 : 0;
+  }
+  const files = args.filter((a) => !a.startsWith('--'));
+  if (!files.length) {
+    console.error('usage: alloc_level_witness.cjs [--self-test] [--corpus] <dataset.json>...');
+    return 2;
+  }
+  let bad = 0;
+  for (const f of files) {
+    const v = adjudicate(JSON.parse(fs.readFileSync(f, 'utf8')));
+    console.log(format(v, path.basename(f)));
+    if (!v.ok) bad++;
+  }
+  return bad ? 1 : 0;
+}
+
+if (require.main === module) process.exit(main(process.argv));
+
+module.exports = {
+  adjudicate, format, selfTest, scoreCorpus, admissibility, segmentsOf, median,
+  BEFORE_ROUNDS, BEFORE_PRE_RAMP_MAX, AFTER_ROUND_MIN, LEVEL_STEP_BOUND, HIGH_MODE_FLOOR_B, CORPORA,
+};

--- a/implementation/hicasso/test/re_frame/bench/hicasso/alloc_level_witness.cjs
+++ b/implementation/hicasso/test/re_frame/bench/hicasso/alloc_level_witness.cjs
@@ -88,7 +88,7 @@
 //   | definition                                | normal band  | mode band     |
 //   |-------------------------------------------|--------------|---------------|
 //   | min(cert r1-5) -> median(cert r>=6) PINNED |   96..194 B  | 2,616..3,984 B|
-//   | median(r1-3) -> median(r>=6)               |   96..168 B  | 2,628..3,948 B|
+//   | median(r1-3) -> median(r>=6)               |   96..168 B  | 2,616..3,948 B|
 //   | median(r4-6) - median(r1-3)                |   90..896 B  | 1,655..4,083 B|
 //   | r4 - r3, one round against one round       |   80..2,312 B|   860..4,946 B|
 //
@@ -97,8 +97,10 @@
 // B in the mode, and on the larger corpus its normal band reaches +2,312 B
 // while its mode band descends to +860 B — they OVERLAP by 1,452 B. A bound
 // set from that quoted band would have refused legitimate runs. It is also
-// undefined on 16 of the 101 admissible runs, because one round is not always
-// certified. The median(r4-6) form separates but leaves only 759 B of gap,
+// undefined on at least one segment in 95 of the 101 admissible runs, and on
+// BOTH segments in 16 of them, because one round is not always certified —
+// a definition that cannot be evaluated is not a gate. The median(r4-6) form
+// separates, but leaves only 759 B of gap against this form's 2,422 B,
 // because rounds 4-5 are in the AFTER half where they belong to neither level.
 //
 // ## WHY THE TEST IS ONE-SIDED

--- a/implementation/hicasso/test/re_frame/bench/hicasso/alloc_level_witness.test.cjs
+++ b/implementation/hicasso/test/re_frame/bench/hicasso/alloc_level_witness.test.cjs
@@ -1,0 +1,152 @@
+#!/usr/bin/env node
+'use strict';
+// THE LEVEL WITNESS'S FIXTURES AND ITS CORPUS CONTROL, IN A GATE — rf2-a233t.
+//
+//     node hicasso/test/re_frame/bench/hicasso/alloc_level_witness.test.cjs
+//
+// `alloc_level_witness.cjs` decides whether a floor run held ONE level across
+// its own transition. Two things are checked here and they answer different
+// questions.
+//
+// THE FIXTURES answer "does the rule do what its header says": they are
+// synthetic, they cross the bound in both directions, and they live in the
+// module so any caller runs them.
+//
+// THE CORPUS CONTROL answers the only question that licences ARMING the thing:
+// does this bound refuse EXACTLY the elevated runs and nothing else? That is
+// not a claim to be written in a record and left there — every dataset it
+// rests on is committed, so it is re-derived here on every run of this gate.
+// The counts below are therefore PINNED: a committed dataset that changes, a
+// bound that drifts, or an estimator that is quietly redefined all turn this
+// red rather than turning a published table wrong.
+//
+// WHY THE EXACT COUNTS AND NOT JUST "no false positives". A witness that
+// stopped scoring runs — an estimator typo that emptied every window, say —
+// would report zero false positives with perfect honesty. So the population
+// sizes are asserted beside the verdict, which is the same reason
+// `clock_witness.test.cjs` asserts its own fixture count has not shrunk.
+
+const assert = require('node:assert');
+
+const witness = require('./alloc_level_witness.cjs');
+
+const tests = [];
+const test = (name, fn) => tests.push([name, fn]);
+
+// --- the module's own fixtures ----------------------------------------------
+
+test('every fixture in alloc_level_witness.cjs passes', () => {
+  const { checks } = witness.selfTest();
+  const bad = checks.filter((c) => !c.ok).map((c) => c.name);
+  assert.deepStrictEqual(bad, [], `failing fixtures: ${bad.join(', ')}`);
+  assert.ok(checks.length >= 25, `the fixture set shrank to ${checks.length}; it had 26`);
+});
+
+// --- the corpus control -----------------------------------------------------
+
+let corpus = null;
+const scored = () => (corpus ??= witness.scoreCorpus());
+
+test('the bound refuses every elevated run in the committed corpus', () => {
+  const r = scored();
+  assert.deepStrictEqual(
+    r.misses.map((m) => `${m.corpus}/${m.run}`),
+    [],
+    'an elevated run was not refused — the bound is too loose'
+  );
+});
+
+test('and it refuses no run that is not elevated', () => {
+  const r = scored();
+  assert.deepStrictEqual(
+    r.falsePositives.map((m) => `${m.corpus}/${m.run}`),
+    [],
+    'a normal run was refused — a false refusal on this arm is expensive'
+  );
+});
+
+test('the populations are the ones the bound was set against', () => {
+  const r = scored();
+  // 101 admissible records; 100 carry both halves on at least one segment.
+  assert.strictEqual(r.scored, 101, 'the admissible population changed');
+  assert.strictEqual(r.normal.n + r.mode.n, 100, 'the scored population changed');
+  assert.strictEqual(r.mode.n, 40, 'the elevated population changed');
+  assert.strictEqual(r.normal.n, 60, 'the normal population changed');
+  assert.strictEqual(r.refusedForStep, 40, 'the refusal count no longer equals the elevated count');
+});
+
+test('the two populations are still separated by the margin the bound rests on', () => {
+  const r = scored();
+  assert.strictEqual(r.normal.minB, 96);
+  assert.strictEqual(r.normal.maxB, 194);
+  assert.strictEqual(r.mode.minB, 2616);
+  assert.strictEqual(r.mode.maxB, 3984);
+  // The bound sits between them with room on both sides. These are the two
+  // numbers the bound was chosen against; if either moves, re-derive it.
+  assert.ok(r.normal.maxPct < r.bound, `the worst normal step ${r.normal.maxPct} reached the bound ${r.bound}`);
+  assert.ok(r.mode.minPct > r.bound, `the least elevated step ${r.mode.minPct} fell under the bound ${r.bound}`);
+  assert.ok(r.bound / r.normal.maxPct > 4, 'less than 4x of margin above the normal population');
+  assert.ok(r.mode.minPct / r.bound > 2.5, 'less than 2.5x of margin below the elevated population');
+});
+
+test('the runs the corpus itself excludes are excluded here, and named', () => {
+  const r = scored();
+  assert.deepStrictEqual(
+    r.inadmissible.map((x) => `${x.corpus}/${x.run}`).sort(),
+    [
+      // Chromium failed to launch; the record has no `alloc` object at all and
+      // the driver still exited 1. rf2-c4hhk committed it as its own evidence.
+      'alloc-c4hhk/armed-25-a4a1537cb71',
+      'alloc-77gz8/run12-a4a1537cb71',
+      'alloc-9jrhi/bisect-5-a-4a1537cb71-replicate',
+    ].sort()
+  );
+  assert.deepStrictEqual(
+    r.notComputable.map((x) => `${x.corpus}/${x.run}`),
+    // A 6-round pilot: there is no round >= 6, so the PUBLISHED estimator does
+    // not exist for it either. Refusing it and quoting nothing from it are the
+    // same statement.
+    ['alloc-9jrhi/pilot-rounds6-head-88411ed803']
+  );
+});
+
+test('exactly one reading falls back to a ramp round, and it is not an elevated one', () => {
+  const r = scored();
+  assert.strictEqual(r.degraded.length, 1);
+  assert.strictEqual(r.degraded[0].run, 'armed-03-a4a1537cb71');
+  assert.strictEqual(r.degraded[0].elevated, false);
+});
+
+// --- the mutation proof -----------------------------------------------------
+//
+// The checks above all run the SHIPPED bound. This one reaches past it: a gate
+// that cannot be shown to bite is a gate nobody has watched. Loosening the
+// bound past the elevated population must let elevated runs through, and
+// tightening it under the normal population must start refusing normal ones.
+// If either fails, the separation being claimed is not there.
+
+test('a bound loosened past the mode stops refusing elevated runs', () => {
+  const loose = witness.scoreCorpus({ bound: 0.25 });
+  assert.strictEqual(loose.refusedForStep, 0, 'a 25% bound still refused something');
+  assert.strictEqual(loose.misses.length, 40, 'the elevated runs did not become misses');
+});
+
+test('a bound tightened under the normal population starts refusing normal runs', () => {
+  const tight = witness.scoreCorpus({ bound: 0.004 });
+  assert.strictEqual(tight.falsePositives.length, 60, 'a 0.4% bound did not refuse the whole normal population');
+});
+
+// --- runner -----------------------------------------------------------------
+
+let failed = 0;
+for (const [name, fn] of tests) {
+  try {
+    fn();
+    console.log(`ok   ${name}`);
+  } catch (e) {
+    failed++;
+    console.error(`FAIL ${name}\n     ${e.message}`);
+  }
+}
+console.log(`;; ${tests.length - failed}/${tests.length} checks pass`);
+process.exit(failed ? 1 : 0);


### PR DESCRIPTION
Closes rf2-a233t. Arms the within-run LEVEL witness for the hicasso allocation floor arm.

## The defect

The floor arm is multi-modal, and **both modes certify**. The leg witness in `p0_run.cjs`
asks whether a window's legs are *alike*, and in both modes they are — an elevated window
is six legs of 21,632 B, as internally consistent as six legs of 19,100 B. It has nothing
to say about *which* of two levels the window sits at. So a figure quoted from this arm
out of a single run has been a coin toss between levels 13–21% apart.

## The rule

Per segment, inside one run: compare the level the run **settled** at against the level it
**started** at, and refuse when the step exceeds **5% of the run's own starting level**.

- **AFTER** — median of `legMedian` over certified windows at round ≥ 6. This is the
  *published estimator, verbatim*, so the witness adjudicates exactly the number the
  records quote.
- **BEFORE** — **minimum** of `legMedian` over certified windows at rounds 1–5. A minimum,
  not a median, because early-round error is one-signed and a median over one or two
  windows reads negative on five corpus runs (worst −1,014 B).

Over **101 admissible runs** across four corpora and four substrate revisions it refuses
**exactly the 40 elevated runs**: zero false refusals, zero misses.

## The two premises the bead flagged — both re-derived, one corrected

**"the high population is now n=3" was stale, and the replacement number holds.**
Re-derived independently from the committed `alloc-c4hhk/` datasets (70 tracked files),
not taken from the prior report: **37 of 69 admissible, 18 of 34 armed, 19 of 35 unarmed**
— reproducing the reported figures exactly.

**The band depends on the definition, so the definition is pinned first.** All four
candidate definitions scored over the same runs:

| Definition | Normal (n=60) | Elevated (n=40) | Gap |
|---|---|---|---|
| `min(cert r1–5)` → `median(cert r≥6)` — **PINNED** | 96..194 B | 2,616..3,984 B | **+2,422 B** |
| `median(cert r1–3)` → `median(cert r≥6)` | 96..168 B | 2,616..3,948 B | +2,448 B |
| `median(cert r1–3)` → `median(cert r4–6)` | 90..896 B | 1,655..4,083 B | +759 B |
| `cert r3` → `cert r4`, one round each | 80..**2,312** B | **860**..4,946 B | **−1,452 B (OVERLAP)** |

**The bottom row is the finding.** It is the form whose bands the bead quoted from
rf2-77gz8 (−43 to +158 B normal against 3,912–3,948 B). On 101 runs rather than 27 it
**does not separate the populations at all** — a bound set from those quoted figures would
have refused legitimate runs. It is also undefined on ≥1 segment in 95 of 101 runs.

**The bound does not depend on the mode's rate** (rf2-6kxub: 0%, 10%, 53% at one
revision). No quantity in the rule is derived from a rate — every comparison is inside a
single run, so a window of one run and a window of seventy are adjudicated identically.

## The decision: refusal, not a recorded verdict

**A refusal**, exiting non-zero. Reasoning, with what would reverse it, in the studio
record. In short: a recorded verdict is *what already existed and what failed* — every
byte this reads was already in the record and both modes still certified. The bead's
"expensive false refusal" worry attaches to a gate inside the rig; this one fires over a
**written record** in seconds, so a false refusal costs a re-read, not a 90-minute window.
And the false-refusal rate is measured at zero over 100 scored runs with 4.9× margin.

Reversal conditions are stated as predictions: an intermediate level (the bound is blind
between 1.015% and 13.766%), any single false refusal, the ramp-fallback hole biting, or
a second instrument failing to reproduce the levels.

## Scope: analysis-side, no bench run taken

The bead's constraint — *"computable from data ALREADY recorded … must not alter the
bundle the arm compiles"* — is met. **No browser window was opened and no run was taken.**
Nothing under `implementation/core/test/re_frame/bench/` is touched; all five bench blobs
are byte-identical to rf2-c4hhk's base, and that directory is unchanged since `408dfb0aa8`
— which is precisely what lets rf2-6kxub compare rates across windows.

## Inherited work, and what I did with each

This branch was stranded twice. Disposition of what the second worker left uncommitted:

- **`alloc_level_witness.cjs` (modified, uncommitted)** — **KEPT.** Two header
  corrections; both independently verified correct (mode band min under the
  `median(r1–3)` form is 2,616 B not 2,628 B; the one-round form is undefined on ≥1
  segment in 95 of 101 runs and on both in 16).
- **`the-level-witness-armed-within-one-run.md` (untracked)** — **KEPT, with corrections.**
  Every figure re-derived independently; all reproduced except one off-by-one, now fixed.

Corrections I made on top:

- **`four runs read a NEGATIVE step` → `five`** (both files). Independently measured: five
  segment readings across five distinct runs. The five are now **named in a table** so the
  claim is checkable rather than merely counted.
- **Replaced a citation of another page's "34 of 37 offset identical" statistic** with what
  this page derives: all 37 elevated `alloc-c4hhk` runs carry **both** segments elevated.
  (I reproduce 33 of 37 for the cited quantity; rather than litigate a ±1 in another page's
  number, this page now cites only what it measures.)
- **Rebased onto `9476293ae8`** and updated the record's base anchor; re-verified every
  figure and all five bench blob hashes on the final base.
- **Filed `rf2-zu82n`** for spine registration, which the record promised as a follow-up
  but which did not exist.

## Quality gates

**Ran locally, foreground, exit codes captured from the runner's own shell:**

| Gate | Captured exit |
|---|---|
| `node …/alloc_level_witness.test.cjs` (primary gate) | **0** — 9/9 checks |
| `node …/alloc_level_witness.cjs --corpus` | **0** — 0 false positives, 0 misses |
| `node …/alloc_level_witness.cjs --self-test` | **0** — 26/26 fixtures |
| `python scripts/check_doc_slugs.py` (gate for `docs/design/hicasso/studio/**`) | **0** |
| `python scripts/check_provenance_pins.py --self-test --verbose` | **0** — 68/68 |
| `python scripts/check_provenance_pins.py --changed-since origin/main --verbose` | **0** — 13 cited pins, 13 landed, 0 findings |

**I did NOT run the fast-PR spine.** `scripts/check_fast_pr_gap.py --list` derives the 96
required CI checks the spine does not run — that is a fact about the spine, not a census
of what I ran. The targeted gates above are what I ran directly.

`mkdocs build --strict` is **deliberately not nominated**: `mkdocs.yml`'s `exclude_docs`
keeps `docs/design/**` out of the site, so its green would decide nothing.
`check_readme_links.py --ci` is likewise not the gate for this path.

**Both gates proven to bite, in this worktree:**

- **Witness gate** — planted `<` → `>` at the `reduce` picking BEFORE's minimum. Gate went
  **9/9 → 3/9**, naming the two minimum-pinning fixtures *by name* and listing
  `alloc-c4hhk/armed-13` and `alloc-9jrhi/bisect-1` as newly-missed elevated runs; refusal
  count 40 → 38. Restored and hash-compared against the committed object
  (`3dd95e0c268db8b517c802142b2a37de0acbae67` before and after); re-ran green 9/9.
- **Doc gate** — planted a broken link target. Gate went **red naming this file at line
  318**; the fault existed only in this worktree, so a run reading a sibling tree would
  have come back green. Restored, hash-compared
  (`4c9bb4fc100a63c664fc14829d21128cc73b026d` before and after), re-ran exit 0.

**Verified BY HAND, because no gate checks prose, tables or numbers:**

- **All 8 markdown tables column-consistent** — header, separator and every body row
  checked programmatically per table (3, 3, 4, 5, 3, 9, 3, 4 columns). No mismatches.
- **Every numeric claim re-derived** by a script written independently of the witness
  module, so the witness is not marking its own homework: admissibility (101/3), the
  per-corpus control table, both population bands, all four definition rows, the
  `201 of 202` BEFORE-provenance count, the `38 of 40` ramp worst case, and each extreme's
  attributed run (`unarmed-06`, `bisect-7`, `armed-18`, `bisect-1`).
- **All five bench blob hashes** verified against the record's table on the final base.
- **The `run09` worked example** reproduced verbatim.
- One link target resolves.

Note for anyone extending this: `legWorstDeviation` is a **fraction** (`worst / legMedian`,
`p0_run.cjs:2093`), not a percentage. Neither artefact here cites it, but reading it as a
percent understates by 100×.

## The `Provenance pins` red, and why the fix is the gate's own escape

The first push reddened `Provenance pins` (and `Docs required`, its rollup — `MkDocs
build` and the slug gate were both green). Not a provenance defect: the token at
line 292 was the **SHA-1 blob hash** recorded to verify the sabotage restore.
`git cat-file -t 3dd95e0c268db8b517c802142b2a37de0acbae67` answers `blob`.

The mechanism is narrower than "a blob hash and a commit SHA look alike", and the gate
said so itself: *"commit word `commit` nearest on the left"*. `check_provenance_pins.py`
classifies each 40-hex token by the **nearest** left-context word — `_DIGEST_WORDS`
(`blob|digest|sha-?256|fnv|checksum|hash`) against `_COMMIT_WORDS` (`commit|authored|
landed|committed|…`). My sentence read *"compared against the committed object"*: `hash`
was present but `committed` sat nearer, so the token flipped to PIN, resolved to no
commit, and became a finding. The gate is behaving exactly as designed — it fails toward
refusal because, from inside any checkout, a stranded pin and a content digest are the
same observation.

**So there was an escape and I used it rather than rewording around the gate.** Naming
the token a `blob` puts a digest word nearest, which is the gate's designed mechanism.
The evidence survives **verbatim** — full hash, both readings, the restore claim intact
and still checkable — and the token stops being extracted as a citation at all: cited
pins go **14 → 13, all landed, 0 findings**. A parenthetical now states outright that it
is a blob and not a revision, which is the durable half: it tells the next reader what
the token is instead of relying on one adjacent word.

Proven discriminating on the final base: re-planting the original wording
(`blob` → `committed object`) reds the gate again naming this file at line 293; restored,
green. Base anchor refreshed to the current `origin/main` (`f7fb0271ac`), and the cited
blob hash re-verified unchanged across the rebase.

**Filed `rf2-nmmlh` (P3)** for the collision itself — the gate-mechanics rule tells every
worker to hash a restore, and every such hash is a 40-hex string on a changed
`docs/design/hicasso/` page. The escape works but is discoverable only by reading a
2,300-line script, so the likely fix is one line in the dispatch brief, not a gate change.
I did not touch `scripts/`; it is outside this fence.

## Fence

`implementation/hicasso/test/re_frame/bench/hicasso/alloc_level_witness*` and
`docs/design/hicasso/studio/**`. Re-derived at start-up and before the first edit: the
only other open PR (#8535) is confined to `implementation/hicasso/src/**`, and no other
worktree is dirty inside this fence. Rebased twice onto a moving trunk (now
`f7fb0271ac`); neither intervening merge touched this surface, and all gates above were
re-run on the final base. The diff against the merge base is **three added files, 1,099
insertions, zero deletions and zero modifications** — nothing to revert, and no `.beads`
path.
