### PR TITLE
fix(pair-mcp): list all 33 registry tools in the README, and gate the table against the registry (rf2-664t7)

### DIFF
--- a/scripts/check_readme_inventories.py
+++ b/scripts/check_readme_inventories.py
@@ -16,9 +16,9 @@ matched the enumerated list it introduces.  Examples caught manually:
     (omitting explain-variant); the four category counts summed to 19,
     not the claimed 20.
 
-This script generalises those into two automated checks, driven by a small
-registry (`INVENTORY_REGISTRY` below) so it stays maintainable rather than a
-pile of special-cases:
+This script generalises those into three automated checks, driven by small
+registries (`LAYOUT_CHECKS` / `COUNT_CHECKS` / `NAME_SET_CHECKS` below) so it
+stays maintainable rather than a pile of special-cases:
 
   1. LAYOUT-MAP <-> DISK BIJECTION.  For a README carrying a fenced
      layout/directory-tree block, parse the *top-level* (shallowest-indent)
@@ -33,6 +33,19 @@ pile of special-cases:
      The enumerated list is either a bullet list of backticked code-spans or
      a markdown table whose body rows are counted.
 
+  3. NAME-SET CHECK.  Assert that the first column of a README table equals
+     a name list held OUTSIDE that README — for pair-mcp, the `tools/list`
+     contract snapshot at `test/fixtures/tool-names.json`.
+
+     Check 2 alone cannot see the defect this file was written for.  Its
+     source of truth is the README's OWN table, so a table that has fallen
+     behind its registry while the prose agrees with the table is invisible
+     to it: both numbers match, and both are wrong.  That is exactly how the
+     pair-mcp table drifted twice (24 rows for a 28-tool registry, then 30
+     for 33; rf2-664t7 measured the second).  Check 3 closes it by naming an
+     external source of truth, and it reports WHICH names are missing rather
+     than only that a count differs.
+
 Exit code:
     0  no violations
     1  at least one violation (printed in file:line form)
@@ -46,6 +59,7 @@ Windows dev box and the Linux CI runners.
 from __future__ import annotations
 
 import argparse
+import json
 import re
 import sys
 from dataclasses import dataclass, field
@@ -306,11 +320,11 @@ def count_bullet_code_spans(body: str) -> int:
     return len(re.findall(r"`[^`]+`", body))
 
 
-def count_table_body_rows(lines: list[str]) -> int:
-    """Count body rows of the first markdown pipe-table in *lines*.
+def table_body_rows(lines: list[str]) -> list[str]:
+    """Return the body rows of the first markdown pipe-table in *lines*.
 
     A table is: a header row (``| ... |``), a delimiter row (``|---|---|``),
-    then N body rows.  Returns N (body rows only).
+    then N body rows.  Returns the body rows only (stripped), in order.
     """
     rows: list[str] = []
     in_table = False
@@ -331,7 +345,31 @@ def count_table_body_rows(lines: list[str]) -> int:
                 seen_delim = True
             continue
         rows.append(line)
-    return len(rows)
+    return rows
+
+
+def count_table_body_rows(lines: list[str]) -> int:
+    """Count body rows of the first markdown pipe-table in *lines*."""
+    return len(table_body_rows(lines))
+
+
+def table_first_column_names(lines: list[str]) -> list[str]:
+    """Extract the first column of each body row as a bare name.
+
+    The idiom these tables use is a leading backticked code-span —
+    ``| `discover-app` | ... | ... |``.  Returns the span's text with the
+    backticks stripped; a row whose first cell carries no code-span yields
+    its stripped text, so a malformed row surfaces as a mismatch rather
+    than vanishing.
+    """
+    names: list[str] = []
+    for row in table_body_rows(lines):
+        # ``| a | b |`` splits to ['', ' a ', ' b ', ''] — cell 1 is first.
+        cells = row.split("|")
+        first = cells[1].strip() if len(cells) > 1 else ""
+        m = re.search(r"`([^`]+)`", first)
+        names.append(m.group(1) if m else first)
+    return names
 
 
 # ---------------------------------------------------------------------------
@@ -447,12 +485,65 @@ COUNT_CHECKS: tuple[CountCheck, ...] = (
         claim_re=r"\*\*Write\*\*\s*\((\d+)(?:,[^)]*)?\)",
         counter=_count_bullet_after,
     ),
-    # pair-mcp — prose 'twenty-eight ... ops' vs Tool-surface table rows.
+    # pair-mcp — prose '33 ... ops' vs Tool-surface table rows.  The numeral
+    # group admits BOTH forms this module's docstring promises: a digit run
+    # and an English number word.  It was word-only (``[a-z\-]+``) until
+    # rf2-664t7, which is narrower than ``parse_numeral`` accepts and than
+    # the contract advertises — so when the GDS restyle rewrote 'thirty' to a
+    # digit (rf2-aw1ez) the count did not become wrong, it became UNREADABLE,
+    # and the check reported 'claim pattern not found' rather than a
+    # mismatch.  Widening here is not loosening the gate: the count is still
+    # compared, and ``parse_numeral`` still rejects a non-numeral.
     CountCheck(
         readme="tools/re-frame2-pair-mcp/README.md",
         label="prose tool count vs Tool-surface table",
-        claim_re=r"exposes the ([a-z\-]+)\s+re-frame2-pair",
+        claim_re=r"exposes the (\d+|[a-z\-]+)\s+re-frame2-pair",
         counter=_count_named_table("Tool surface"),
+    ),
+)
+
+
+@dataclass(frozen=True)
+class NameSetCheck:
+    """A README table's first column <-> an external JSON name list.
+
+    The COUNT check above compares a prose claim against the README's own
+    table, so a table that has fallen behind its registry is INVISIBLE to
+    it — prose and table agree with each other while both under-list the
+    source of truth.  That is exactly how the pair-mcp table drifted twice
+    (24 rows for a 28-tool registry, then 30 for 33; rf2-664t7), and this
+    check is what closes it: the table is compared against a name list
+    OUTSIDE the README.
+    """
+
+    readme: str           # repo-relative README path
+    label: str            # human label for diagnostics
+    section: str          # heading whose table carries the names
+    source_json: str      # repo-relative JSON file holding the truth
+    json_key: str         # key in that file whose value is the name list
+    source_note: str = ""  # why that file is the source of truth
+
+
+NAME_SET_CHECKS: tuple[NameSetCheck, ...] = (
+    # pair-mcp Tool-surface table <-> the tools/list contract snapshot.
+    #
+    # WHY THIS FIXTURE AND NOT registry.cljs.  `tool-names.json` is the
+    # canonical `tools/list` snapshot shared by the stdio round-trip test
+    # and the cross-server MCP conformance harness (rf2-drke0), and
+    # `test/stdio-roundtrip.js` asserts it equals the names a LIVE
+    # `tools/list` returns.  So it already tracks `registry/tools` under
+    # test, and gating on it keeps this script stdlib-only and free of any
+    # coupling to ClojureScript source layout — no regex over `.cljs`.
+    NameSetCheck(
+        readme="tools/re-frame2-pair-mcp/README.md",
+        label="Tool-surface table vs the tools/list contract snapshot",
+        section="Tool surface",
+        source_json="tools/re-frame2-pair-mcp/test/fixtures/tool-names.json",
+        json_key="names",
+        source_note=(
+            "the tools/list snapshot pinned against a live server by "
+            "tools/re-frame2-pair-mcp/test/stdio-roundtrip.js"
+        ),
     ),
 )
 
@@ -543,6 +634,61 @@ def _run_count_check(repo_root: Path, chk: CountCheck) -> list[Violation]:
     return []
 
 
+def _run_name_set_check(repo_root: Path, chk: NameSetCheck) -> list[Violation]:
+    path = repo_root / chk.readme
+    if not path.is_file():
+        return [Violation(chk.readme, 0, f"README not found: {path}")]
+    src = repo_root / chk.source_json
+    if not src.is_file():
+        return [Violation(chk.readme, 0,
+                          f"{chk.label}: source of truth not found: {src}")]
+    try:
+        payload = json.loads(src.read_text(encoding="utf-8"))
+    except (ValueError, OSError) as exc:
+        return [Violation(chk.readme, 0,
+                          f"{chk.label}: could not read {chk.source_json}: {exc}")]
+    expected_list = payload.get(chk.json_key) if isinstance(payload, dict) else None
+    if not isinstance(expected_list, list) or not expected_list:
+        return [Violation(chk.readme, 0,
+                          f"{chk.label}: {chk.source_json} has no non-empty "
+                          f"{chk.json_key!r} list")]
+
+    text = path.read_text(encoding="utf-8", errors="replace")
+    sec = _section_body(text, chk.section)
+    if sec is None:
+        return [Violation(chk.readme, 0,
+                          f"{chk.label}: section {chk.section!r} not found")]
+    start_line, body = sec
+    listed = table_first_column_names(body.splitlines())
+    if not listed:
+        return [Violation(chk.readme, start_line,
+                          f"{chk.label}: no table body rows under "
+                          f"{chk.section!r}")]
+
+    expected = set(expected_list)
+    actual = set(listed)
+    violations: list[Violation] = []
+    missing = sorted(expected - actual)
+    extra = sorted(actual - expected)
+    if missing:
+        violations.append(Violation(
+            chk.readme, start_line,
+            f"{chk.label}: table is MISSING {len(missing)} name(s) present in "
+            f"{chk.source_note or chk.source_json}: {', '.join(missing)}"))
+    if extra:
+        violations.append(Violation(
+            chk.readme, start_line,
+            f"{chk.label}: table lists {len(extra)} name(s) absent from "
+            f"{chk.source_note or chk.source_json}: {', '.join(extra)}"))
+    dupes = sorted({n for n in listed if listed.count(n) > 1})
+    if dupes:
+        violations.append(Violation(
+            chk.readme, start_line,
+            f"{chk.label}: table repeats {len(dupes)} name(s): "
+            f"{', '.join(dupes)}"))
+    return violations
+
+
 def check(repo_root: Path, verbose: bool = False) -> list[Violation]:
     """Run every registered check; return the flat list of violations."""
     violations: list[Violation] = []
@@ -558,6 +704,12 @@ def check(repo_root: Path, verbose: bool = False) -> list[Violation]:
         if verbose and not vs:
             sys.stderr.write(
                 f"  OK  count:  {chk.readme} — {chk.label}\n")
+        violations.extend(vs)
+    for chk in NAME_SET_CHECKS:
+        vs = _run_name_set_check(repo_root, chk)
+        if verbose and not vs:
+            sys.stderr.write(
+                f"  OK  names:  {chk.readme} — {chk.label}\n")
         violations.extend(vs)
     return violations
 
@@ -650,6 +802,40 @@ def _run_self_tests(verbose: bool = False) -> int:
     expect("not-a-number", parse_numeral("frame"), None)
     expect("twenty", parse_numeral("twenty"), 20)
 
+    # The pair-mcp claim pattern must admit BOTH numeral forms the module
+    # docstring promises (rf2-664t7).  It was word-only, so the GDS restyle's
+    # digit rewrite made the count unreadable rather than wrong (rf2-aw1ez) —
+    # the check reported 'claim pattern not found' and stopped comparing.
+    _pair_claim = next(c.claim_re for c in COUNT_CHECKS
+                       if c.readme.endswith("re-frame2-pair-mcp/README.md"))
+
+    def _claim(text: str):
+        m = re.search(_pair_claim, text)
+        return m.group(1) if m else None
+
+    expect("pair-claim-word",
+           _claim("exposes the thirty-three re-frame2-pair ops"), "thirty-three")
+    expect("pair-claim-digit",
+           _claim("exposes the 33 re-frame2-pair ops"), "33")
+    expect("pair-claim-wraps-newline",
+           _claim("exposes the 33\nre-frame2-pair ops"), "33")
+    # Widened, not loosened: a non-numeral still reaches parse_numeral and is
+    # still rejected there, so the gate keeps its teeth.
+    expect("pair-claim-non-numeral-rejected",
+           parse_numeral(_claim("exposes the many re-frame2-pair ops") or ""),
+           None)
+
+    # first-column name extraction backing the NameSetCheck (rf2-664t7)
+    named = [
+        "| MCP tool | What |",
+        "|---|---|",
+        "| `discover-app` | x |",
+        "| `read-ui`      | y |",
+        "| plain-text     | z |",
+    ]
+    expect("table-first-col", table_first_column_names(named),
+           ["discover-app", "read-ui", "plain-text"])
+
     # layout top-level dir extraction — root label + indented entries
     blk = FencedBlock(open_line=1, lines=[
         "testbeds/",
@@ -724,6 +910,51 @@ def _run_self_tests(verbose: bool = False) -> int:
             (base / d).mkdir()
         expect("disk-dirs-skips-build-artefacts",
                _disk_dirs(base), {"core", "adapters"})
+
+    # NameSetCheck end-to-end (rf2-664t7) — the regression this check exists
+    # for is a table that under-lists its registry while the PROSE agrees
+    # with the table, which the count check cannot see by construction.
+    with tempfile.TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        (root / "tools").mkdir()
+        chk = NameSetCheck(
+            readme="tools/R.md", label="T", section="Tool surface",
+            source_json="tools/names.json", json_key="names")
+
+        def _write(rows: list[str]) -> None:
+            (root / "tools" / "R.md").write_text(
+                "# T\n\n## Tool surface\n\n| A | B |\n|---|---|\n"
+                + "".join(f"| `{r}` | x |\n" for r in rows),
+                encoding="utf-8")
+
+        (root / "tools" / "names.json").write_text(
+            '{"names": ["alpha", "beta", "gamma"]}', encoding="utf-8")
+
+        _write(["alpha", "beta", "gamma"])
+        expect("nameset-in-sync", _run_name_set_check(root, chk), [])
+
+        _write(["alpha", "beta"])
+        vs = _run_name_set_check(root, chk)
+        expect("nameset-missing-count", len(vs), 1)
+        expect("nameset-missing-names", "gamma" in vs[0].message, True)
+
+        _write(["alpha", "beta", "gamma", "delta"])
+        vs = _run_name_set_check(root, chk)
+        expect("nameset-extra-count", len(vs), 1)
+        expect("nameset-extra-names", "delta" in vs[0].message, True)
+
+        _write(["alpha", "beta", "gamma", "gamma"])
+        vs = _run_name_set_check(root, chk)
+        expect("nameset-duplicate", any("repeats" in v.message for v in vs), True)
+
+        # A missing / unreadable source of truth must be a VIOLATION, never a
+        # silent pass — an absent fixture is no verdict, not a green one.
+        _write(["alpha", "beta", "gamma"])
+        missing_src = NameSetCheck(
+            readme="tools/R.md", label="T", section="Tool surface",
+            source_json="tools/nope.json", json_key="names")
+        expect("nameset-absent-source-is-violation",
+               len(_run_name_set_check(root, missing_src)), 1)
 
     if failures:
         sys.stderr.write(f"\n{failures} self-test failure(s).\n")

--- a/tools/re-frame2-pair-mcp/README.md
+++ b/tools/re-frame2-pair-mcp/README.md
@@ -11,13 +11,14 @@ back-compat, but new sessions should prefer the MCP server.
 ## What it is
 
 A Node-based stdio JSON-RPC server (written in ClojureScript, compiled
-via shadow-cljs to a single `.js` file) that exposes the thirty
+via shadow-cljs to a single `.js` file) that exposes the 33
 re-frame2-pair ops listed in `registry/tools` as MCP tools (the
-read/inspect/action ops —
-including the operating-frame trio `set-operating-frame` /
-`reset-operating-frame` / `get-operating-frame` (rf2-zomfq) — plus the
-two write tools `restore-epoch` / `replace-app-db`, which are gated behind
-`--allow-writes`). The authoritative ordered catalogue is `registry/tools`
+read/inspect/action ops — including the operating-frame trio
+`set-operating-frame` / `reset-operating-frame` / `get-operating-frame`
+(rf2-zomfq) and the three read-only `re-frame.hicasso.tool` evidence
+reads `read-mounted-boundaries` / `read-read-attribution` /
+`explain-render` — plus the two write tools `restore-epoch` /
+`replace-app-db`, which are gated behind `--allow-writes`). The authoritative ordered catalogue is `registry/tools`
 ([`src/re_frame2_pair_mcp/tools/registry.cljs`](src/re_frame2_pair_mcp/tools/registry.cljs));
 the table below mirrors it. AI agents (Claude Code, Cursor, Copilot) launch it
 as a subprocess; one active nREPL socket is reused and replaced when
@@ -49,6 +50,9 @@ cljs-eval compile.
 | `read-sub`     | _(new — no bash equivalent)_ | Validated one-shot subscription read (rf2-3bu3d.7) — the #1 read on any re-frame2 app. Prefer over raw `eval-cljs @(subscribe …)`: the `sub` arg is EDN-parsed and the sub-id validated against the live `:sub` registrar (unknown id → `:reason :unknown-id` with `:nearest`, never a silent nil), and the value is elided / privacy-gated server-side. |
 | `read-dom`     | _(new — no bash equivalent)_ | View-plane read (rf2-nfjil): query the **rendered DOM** by CSS selector and return matched count + per-node `{:tag :text :attrs}`. Answers "did the UI update?" / "what's on screen now?" — the read-plane counterpart to the data-plane reads. Pairs with `dispatch {:await-render true}` for a deterministic dispatch → settle → read-dom observe. |
 | `read-ui`      | _(new — no bash equivalent)_ | The typed `ui/read` op (rf2-3bu3d.1) — given a view-id / point / CSS selector, return the **rendered subtree** plus the re-frame2 **entity** that produced it (source-coord + `:subs-read`), in one round-trip. Rides the view↔DOM map (`data-rf-view`) so it answers "what does this show, and what produced it?" with zero testids. Read-only. |
+| `read-mounted-boundaries` | _(new — no bash equivalent)_ | Every Hicasso boundary **mounted right now** — the first of the three read-only `re-frame.hicasso.tool` evidence reads. Per boundary its `:key`, the `:instances` holding that key, the `:frame`, `:read-orders`, and the `:reads` it holds (each with `:sub-id`, a projected `:query` and the cell's `:epoch` — **never** the value the read returned). No arg, deliberately: the question is what is mounted. A boundary is keyed by its **read set**, the only identity this runtime retains — it mints no boundary id, so two boundaries reading the same set are indistinguishable and `:instances` counts them; `:view` / `:source` are `:unknown` by design, not a gap awaiting closure. An empty roster says only that no boundary holds a live read edge right now. Read-only, versioned (`:schema`). |
+| `read-read-attribution` | _(new — no bash equivalent)_ | The **reverse edge**: which boundaries read each subscription. Per subscription its `:sub-id`, projected `:query`, `:frame-id`, the cell's `:epoch`, the `:fan-out` and the distinct `:readers` — keyed identically to `read-mounted-boundaries`, so the two rosters join with no correlation step. No arg. The one read that is **exact without qualification**: every cell's reader array is maintained by the same commit and cleanup that acquire and release the reference. Also the way in when you can name a subscription but need the boundary — start here and take the `:key` onward to `explain-render`. A key nothing holds is absent rather than present with zero readers. |
+| `explain-render` | _(new — no bash equivalent)_ | Which of a boundary's reads **moved most recently**, and which retained runs *could* have driven it. Folds Spec 009's retained event window at read time (retention is `:rf.trace/events-retained`) and keeps no history of its own. No arg; spans every mounted boundary. **Two halves, never blended.** Proven: `:latest-reads` names the reads standing at the boundary's `:peak-epoch`, and `:snapshot` is the exact sum React compares. Uncorrelated: the commit seam records no cascade id, so `:cause` is `:unknown` **structurally** — not occasionally, not fixable with a bigger ring — and `:candidates` are retained runs offered as **leads**; do not present one as the cause. `:loss {:reason :uncorrelated}` means the search ran (so `:candidates []` is an honest survey); `:cap` means the window was empty and `:candidates` is `:unknown`. |
 | `record`       | _(new — no bash equivalent)_ | First-class **signal recorder** (rf2-zo4b9): install a read-only rAF observer over a heterogeneous signal-set (`:app-db` path, `:sub`, `:dom`, `:focus`), return immediately with a `:recording-id`, and let a human interact. Records each *change* (deduped) until a `stop` condition (`:ms` / `:changes` / `:pred`) trips. The canonical move for intermittent / human-in-the-loop bugs. Read-only by construction. |
 | `read-recording`| _(new — no bash equivalent)_ | Read back a recording's change-log (rf2-zo4b9), paired with `record`. `drain` returns-and-clears the buffer (poll→consume→repeat live-watch); `stop` tears the recording down after reading. |
 | `watch-until`  | _(new — no bash equivalent)_ | Block until a data **predicate** over a signal-set holds (rf2-zo4b9) — the blocking counterpart to `record` ("wait until focus lands on the modal" / "wait until `[:upload :status]` flips to `:done`"). Server-polls a cheap runtime read on a ~100ms cadence until the condition trips or `timeout-ms` (default 30000) elapses. |


### PR DESCRIPTION
Closes rf2-664t7.

Both of the bead's findings were re-tested at source before any edit, and **both hold exactly**.

## The census — the bead's "under by 3" is exact

Re-derived at `origin/main` HEAD from the source of truth, not from the README being fixed:

| Source | Count |
|---|---|
| `registry/tools` in `src/re_frame2_pair_mcp/tools/registry.cljs` | 33 |
| `test/fixtures/tool-names.json` (`tools/list` contract snapshot) | 33 |
| `conformance_test.cljs` corpus docstring ("33 today") | 33 |
| README `## Tool surface` table body rows (before) | **30** |

Independently confirmed against a **live server**, after the fact: the `MCP conformance tools/re-frame2-pair-mcp (rf2-cum40)` job on this PR logs `tools/list -> 33 tools advertised: …`, and that advertised name-set is **identical** to the registry census above. The three names added here (`explain-render`, `read-mounted-boundaries`, `read-read-attribution`) each appear in that run's own `OK tools/call <name>` lines, so they are real advertised tools that belonged in the table. Four sources now agree at 33: registry, fixture, live `tools/list`, and the table.

Set difference, not just a count: the table was missing exactly `explain-render`, `read-mounted-boundaries` and `read-read-attribution` — the three read-only `re-frame.hicasso.tool` evidence reads — with **no extras** and no duplicates. The registry and fixture name-sets are identical.

Pre-existing on main; not caused by the GDS restyle in #8529.

## Finding 2 — the pattern really does reject numerals

```
'exposes the thirty re-frame2-pair'        -> 'thirty'
'exposes the thirty-three re-frame2-pair'  -> 'thirty-three'
'exposes the 33 re-frame2-pair'            -> None      <-- the defect
```

Confirmed end-to-end, not just in isolation: writing the digit form into the README with the old pattern still in place reproduced rf2-aw1ez's CI failure **verbatim** in this worktree —

```
prose tool count vs Tool-surface table: claim pattern not found (/exposes the ([a-z\-]+)\s+re-frame2-pair/)
```

The count did not become wrong, it became *unreadable*: the check stopped comparing entirely.

## What changed

1. **The three missing rows + the prose claim** (now `33`). The digit form is what the GDS house style wanted and what change 2 makes legal, so the fix is self-demonstrating.
2. **Widened the pair-mcp `claim_re`** from `([a-z\-]+)` to `(\d+|[a-z\-]+)`. This is not loosening the gate — the module docstring already promises both forms ("N may be a digit run or an English number word"), `parse_numeral` already accepts both, and a non-numeral still reaches `parse_numeral` and is still rejected. Only this one check was word-only.
3. **Took the bead's optional step 3, via a better source than the bead proposed.** The bead weighed regexing `:name "…"` out of the `.cljs` and worried it would couple the gate to source layout. It does not have to: `test/fixtures/tool-names.json` is the `tools/list` contract snapshot that `test/stdio-roundtrip.js` asserts against a **live** server, so it already tracks the registry under test. Gating on it keeps the script stdlib-only, never shelling out, with no coupling to ClojureScript source layout.

### Why step 3 was worth taking

Findings 1 and 2 alone would have left the bead able to reopen. The count check's source of truth is *the README's own table*, so a table that has fallen behind its registry **while the prose agrees with the table** is invisible to it — both numbers match and both are wrong. That is not hypothetical: it is how this exact table drifted **twice** (24 rows for a 28-tool registry, recorded in the checker's own docstring; then 30 for 33, this bead).

Proven directly. Reproducing that precise shape — row deleted *and* prose lowered to 32, so prose and table agree — gives:

```
OK  count:  tools/re-frame2-pair-mcp/README.md — prose tool count vs Tool-surface table
1 README inventory violation(s) found:
  tools/re-frame2-pair-mcp/README.md:36
      Tool-surface table vs the tools/list contract snapshot: table is MISSING 1 name(s)
      present in the tools/list snapshot ...: explain-render
```

The old check reports **OK** on the bug that shipped; only the new one catches it. It also names *which* tool is missing rather than only that a count differs.

## Quality gates

All run from this worktree, foreground, each exit code captured explicitly by the invoking shell (never a harness-reported number, never through a pipe):

| Gate | Exit |
|---|---|
| `python scripts/check_readme_inventories.py --verbose` | **0** |
| `python scripts/check_readme_inventories.py --self-test --verbose` | **0** (28 self-tests pass) |
| `python scripts/check_readme_links.py --ci` | **0** |
| `python scripts/check_doc_slugs.py` | **0** (not required here — see below) |

**Gate nominated by path, not by job name.** `check_doc_slugs.py`'s roots are `docs`/`spec`/`skills`/`migration` plus a `tools/*/spec` tier; `tools/re-frame2-pair-mcp/README.md` is a README beside source and sits under none of them. Verified by measurement rather than by reading the source: with a broken link target planted in that README, `check_doc_slugs.py` **exited 0 and named nothing**, while `check_readme_links.py --ci` exited 1 naming the planted target exactly. `check_readme_links.py --ci` is the gate for this file. No `tools/*/spec` path was touched.

**Fast spine:** not run. `scripts/check_fast_pr_gap.py --list` (exit 0) derives the 96 required CI checks the spine does not run — that is a fact about the spine, not a census of what I ran. What I ran is the four gates above, directly. This is the honest coverage claim: the *complete* consumer set of the changed script is two invocations in `.github/workflows/test.yml` and the same two in `scripts/test-fast-pr.sh` (`--verbose` and `--self-test --verbose`) — both of which are in the table above, so CI runs nothing against this script that I did not. The two `implementation/ssr-node` references to it are prose comments, not executions.

**MCP conformance / pair-mcp node suite:** not run locally, and cannot be affected by this diff — two files, a README and a Python CI script; no CLJS source, no descriptor, no fixture is touched. Both jobs nevertheless triggered in CI on this PR and both passed, which is where the live `tools/list -> 33` cross-check above comes from.

**Full CI on this PR: 33 checks SUCCESS, 55 skipped, 0 failures**, including `Node tools/re-frame2-pair-mcp (shadow-cljs :server-test)` and `MCP conformance tools/re-frame2-pair-mcp (rf2-cum40)`.

### Teeth, proven by planted faults

Every plant was restored and each restore verified by **content hash** against the pre-plant object (`git hash-object`), not by reading a diff:

- Deleted one table row → new check red, naming `explain-render`.
- Deleted the row *and* lowered the prose to match → count check **green**, new check red (the blind spot above).
- Reverted `claim_re` to word-only → `--self-test` red on `pair-claim-digit` and `pair-claim-wraps-newline`, so the fix is **ratcheted** and a future revert cannot pass silently.
- Broken link target → `check_readme_links.py --ci` red naming it; `check_doc_slugs.py` green.

README restored `0aa8251e…` → `0aa8251e…`; script restored `fd6ab23f…` → `fd6ab23f…`. Both byte-identical.

### Hand verification (no gate covers this)

The deliverable is a table, and **nothing in CI validates markdown prose, tables, rendering or nav** — link targets and anchors are the whole of what the link gates check. So I verified the table structure by hand and confirmed the checker I used for it bites (it catches a 2-column row):

- **Column counts: all 35 pipe-rows have exactly 3 columns** (1 header + 1 delimiter + 33 body), histogram `{3: 35}` — no row over- or under-splits.
- **Alignment:** delimiter row `|---|---|---|` is well-formed and 3 columns, matching the header `MCP tool | Bash-shim equivalent | What it does`.
- Every body row starts and ends with `|`; first column of every row is a bare backticked code-span; **33 unique names, no duplicates**.
- New rows placed in **registry order** (after `read-ui`, before `record`), matching the table's existing convention of mirroring `registry/tools` — the README states the table mirrors it.
- No literal unescaped `|` inside any cell.

Also updated the module docstring, which said "two automated checks" and would otherwise have shipped stale at three.

### Rebase

Rebased onto `origin/main` after two tracker-checkpoint commits landed mid-work (neither touched either file). **All gates above were re-run on the final base** — the numbers quoted are from the rebased tree, not the pre-rebase one. Diff against the merge base is exactly the two intended files and reverts nothing.

## Not done, deliberately

The four `story-mcp` count checks are digit-only (`(\d+)`), the mirror of the narrowness fixed here — neither form honours the docstring's "either form" promise. They are green, in a different README, and outside this bead's fence, so I left them. Noting it as an observation, not filing it as work.
