### PR TITLE
ci: annotate the Playwright install guillotine where the runner says nothing (rf2-mul6w)

### DIFF
--- a/.github/scripts/playwright-install-failed.sh
+++ b/.github/scripts/playwright-install-failed.sh
@@ -4,7 +4,7 @@
 #
 # # What this is for
 #
-# Twenty-one CI steps provision browsers with `npx playwright install
+# Seventeen CI steps provision browsers with `npx playwright install
 # --with-deps <browsers>`. When that fails the job dies with a bare
 #
 #     ##[error]Process completed with exit code 1
@@ -22,10 +22,19 @@
 # diff" — see "What the annotation can support" below, which is the correction
 # the merged-PR audit of #8061 reopened this bead for.
 #
-# Every call site is one line:
+# Every call site is one line, in one of TWO shapes. Which one a site takes is
+# decided by ONE question — what its enclosing backstop is — and rf2-mul6w
+# measured the answer rather than guessing it. The default shape carries an
+# in-command deadline:
 #
 #     - name: Install Playwright (Chromium + system deps)
-#       run: npx playwright install --with-deps chromium || "$GITHUB_WORKSPACE/.github/scripts/playwright-install-failed.sh"
+#       run: timeout -k 10 720 npx playwright install --with-deps chromium || "$GITHUB_WORKSPACE/.github/scripts/playwright-install-failed.sh" $?
+#
+# and the three sites that already carry a step-level `timeout-minutes: 5`
+# (`cljs-reagent-slim-bundle-isolation`, `tenant-switcher-testbed-smoke`,
+# `mcp-conformance-re-frame2-pair`) keep the bare form with no `timeout` and no
+# `$?`. "Why there is an in-command deadline" below is the measurement that
+# settles it; do not tidy the two shapes into one.
 #
 # Use the $GITHUB_WORKSPACE-absolute form, not a relative path: several jobs
 # set a `defaults.run.working-directory` (e.g. `implementation`), under which
@@ -33,15 +42,31 @@
 # line as the `npx` — `scripts/check_fast_pr_gap.py` classifies a step as
 # toolchain setup only when EVERY logical line of the body matches one of its
 # `SETUP_PATTERNS`, and the pattern that covers these steps is
-# `^npx playwright install\b`. A separate `echo` line, or a `for` loop, would
-# drop the body out of that set and make the gap map report the job as an
-# UNRUN GATE — a fail-open in the very map the merge criterion consults.
-# Appending `|| <script>` behind the existing command keeps the logical line
-# starting with `npx playwright install`, so nothing reclassifies. It is also
-# what keeps the literal `playwright install --with-deps <browsers>` text that
-# `implementation/scripts/_changed-surfaces.test.cjs` and
-# `tools/template/test/day8/re_frame2_template/release_gate_test.clj` assert
-# on intact, so this change needs no edit outside `.github/`.
+# `^(?:timeout (?:-k \d+ )?\d+ )?npx playwright install\b`. A separate `echo`
+# line, or a `for` loop, would drop the body out of that set and make the gap
+# map report the job as an UNRUN GATE — a fail-open in the very map the merge
+# criterion consults. Appending `|| <script>` behind the existing command keeps
+# the logical line matching, so nothing reclassifies.
+#
+# THE OPTIONAL `timeout` GROUP IN THAT PATTERN AND THE FOURTEEN PREFIXED CALL
+# SITES ARE ONE CHANGE AND MOVE TOGETHER. Either alone lands a tree where the
+# gap map and the workflows disagree: prefix the sites without widening the
+# pattern and fourteen setup steps re-report as unrun gates; widen the pattern
+# without prefixing the sites and the guillotine stays silent. The group is
+# deliberately narrow — a literal `timeout`, an optional `-k <secs>`, one
+# numeric deadline — so it can admit this shape and nothing else.
+#
+# The trailing `$?` is the install's exit status, which `bash` still holds when
+# the right-hand side of a `||` runs. It is the ONLY thing this script learns
+# about the failure, and it distinguishes the two annotations below: 124 is the
+# in-command deadline expiring, anything else is an ordinary nonzero exit.
+#
+# Both shapes keep the literal `playwright install --with-deps <browsers>` text
+# that `implementation/scripts/_changed-surfaces.test.cjs` and
+# `tools/template/test/day8/re_frame2_template/release_gate_test.clj` assert on
+# intact — those are substring and `re-find` assertions, so a prefix does not
+# reach them — and so this change needs no edit outside `.github/` and
+# `scripts/check_fast_pr_gap.py`.
 #
 # # What the annotation can support — and why it no longer says "not this diff"
 #
@@ -88,7 +113,7 @@
 # whichever one the step's working directory sits in:
 #
 #   * `implementation` — `package.json` pins `playwright` to an exact `1.59.1`;
-#     19 of the 21 sites run here, each after an `npm ci` in the same root.
+#     15 of the 17 sites run here, each after an `npm ci` in the same root.
 #   * `docs/tools/playground` — `package.json` asks for `^1.60.0`, and its own
 #     `package-lock.json` resolves `1.60.0`; the two playground smokes run here
 #     (`docs.yml`'s post-merge `build` job and `test.yml`'s `tools-playground`).
@@ -97,7 +122,54 @@
 # rf2-169n (#8065) keys the two browser caches on the two lockfiles separately.
 # The annotation therefore prints `$PWD` and names both locks, leaving the
 # reader one obvious step — match the directory to its lockfile — instead of a
-# caveat that is silently inapplicable in two of twenty-one jobs.
+# caveat that is silently inapplicable in two of seventeen jobs.
+#
+# # Why there is an in-command deadline — and why there is none at three sites
+#
+# `cmd || <handler>` fires the handler on a NON-ZERO EXIT. A step the RUNNER
+# guillotines is killed, not failed, so the handler never runs and this script
+# never speaks. rf2-mul6w measured what the checks page then shows, and the
+# answer is not one thing but two, which is why the remedy is not uniform:
+#
+#   * A STEP-LEVEL `timeout-minutes` GUILLOTINE ALREADY ANNOTATES LEGIBLY. The
+#     runner posts `The action 'Install Playwright chromium (for hermetic
+#     browser preload)' has timed out after 5 minutes.` — read verbatim off
+#     jobs 95959283361 and 95932283494 (2026-08-19). It names the step, so a
+#     reader sees provisioning without opening a log. That is the whole cost
+#     rf2-swos was filed against, and at these three sites it is already paid.
+#
+#   * A JOB-LEVEL `timeout-minutes` GUILLOTINE ANNOTATES NOTHING. Jobs
+#     95959283484 and 95932283700 carry only `The job has exceeded the maximum
+#     execution time of 15m0s` and `The operation was canceled.` — no step, no
+#     cause, and every later step marked `skipped`. Nothing on the checks page
+#     distinguishes this from a wedged gate, and establishing which it was cost
+#     a diagnosis cycle reading the raw log. THAT is the hole the `timeout`
+#     prefix closes, and it is why the fourteen sites whose only backstop is
+#     the job cap take the prefix while the three step-capped ones do not.
+#     Adding a redundant in-command deadline at those three would only thin a
+#     measured margin to restate an annotation the runner already gives.
+#
+# THE 720s VALUE IS DERIVED, NOT ROUND. Measured 2026-08-20 over the 140 most
+# recent completed `test.yml` runs (2026-08-18T05:11Z .. 2026-08-20T10:13Z, all
+# attempts, every step named `Install Playwright*`): 377 non-skipped samples,
+# 370 successes. Those successes are no longer the tight population the cap
+# note in `test.yml` describes — p50 14s, p90 34s, but p95 113s, p99 424s and a
+# MAX OF 621s. Four exceeded 300s and succeeded anyway, purely because they sit
+# at sites with no step cap. So the deadline has to clear 621s or it converts
+# working installs into false reds, which is a worse trade than the one it
+# fixes; and it has to fit inside the tightest enclosing job cap, 15 min at
+# `tools-playground`. 720s does both: 16% clear of the observed worst success,
+# and — since the install step starts at +18s in that job, measured on job
+# 95959283484 — 738s of a 900s budget, leaving the job cap intact as backstop.
+# It also binds on all three cancellations actually observed, at 893s, 895s and
+# 1793s. DO NOT LOWER IT toward the old `p90 21s, max 49s` picture: that
+# population is gone.
+#
+# `-k 10` is the second half of the mechanism. `timeout` sends TERM and then
+# waits; a child that ignores it would hang exactly as before. The KILL ten
+# seconds later bounds that. The orphaned `sudo apt-get` the runner reports
+# terminating is expected and harmless — `npx` dying is what returns 124, and
+# 124 is what makes this script speak.
 #
 # # Why there is no retry loop here — the siblings have one and this does not
 #
@@ -126,10 +198,12 @@
 #     (Chromium + system deps)' has timed out after 5 minutes`, spent entirely
 #     inside the `--with-deps` apt hop fetching 21MB of fonts from
 #     azure.archive.ubuntu.com. The browser download was never reached. Three
-#     of the twenty-one sites carry `timeout-minutes: 5`; an envelope wider
+#     of the seventeen sites carry `timeout-minutes: 5`; an envelope wider
 #     than that cap cannot finish, and a step the runner guillotines never
-#     prints its annotation at all. There, a wider loop is not merely useless
-#     but actively worse than what it replaces.
+#     reaches this script at all. There, a wider loop is not merely useless
+#     but actively worse than what it replaces. At the other fourteen the
+#     in-command deadline is what an outer loop would have to be sized
+#     under, not the job cap.
 #
 # Playwright's own knobs were preferred to hand-rolling, per the brief, and
 # both were checked at source and rejected on measurement, not on taste:
@@ -169,9 +243,21 @@
 # Exit status stays a plain 1, as in `install-clojure-cli.sh` and
 # `resolve-clojure-deps.sh`: the annotation is the machine-readable carrier
 # the checks API exposes, and a bespoke code would be a second convention with
-# no consumer.
+# no consumer. That is this script's OWN exit, not the install's -- the
+# install's arrives as $1 and only chooses which title to print.
 #
 set -euo pipefail
+
+# $1 is the install's exit status where the call site passes it (see the header).
+# 124 is `timeout` expiring; a site with no in-command deadline passes nothing,
+# and an absent argument is not evidence of anything, so it degrades to the
+# general title rather than guessing.
+status="${1:-}"
+
+if [ "${status}" = "124" ]; then
+  echo "::error title=Playwright browser install TIMED OUT — no gate ran::npx playwright install did not finish inside its in-command deadline in ${PWD}, and was killed. This step provisions the browser, so the gate this job exists to run never started: the red reports PROVISIONING and carries no verdict on the code under test. A HEALTHY INSTALL HERE IS SECONDS, NOT MINUTES — measured over the 140 most recent test.yml runs to 2026-08-20, p50 14s and p90 34s, with the slowest success of 370 at 621s. Exceeding the deadline therefore means the install was not merely slow but stalled, and the two stalls measured under rf2-swos both need a DIFFERENT RUNNER rather than more time: a slow azure.archive.ubuntu.com apt hop under --with-deps, sustained at ~52 kB/s against 18.9 MB/s on a healthy run; and a Google Cloud Storage 403 'this service is not available in your location' on the Chrome-for-Testing bucket that cdn.playwright.dev redirects to, scoped to this runner's egress IP. So the remedy is a re-run. BEFORE RE-RUNNING, check whether this PR touches a provisioning input, because a diff can cause this too — the browser arguments on the npx playwright install line (each extra engine is another download), the deadline itself, the step's working-directory or env or download host, the runner image or setup-node or cache inputs (a busted cache key turns a cache hit into a cold ~120 MB fetch), this script, or the Playwright pin in the lockfile of the root shown above: implementation/package-lock.json pins 1.59.1, docs/tools/playground/package-lock.json pins 1.60.0. If it touches any of them, read this step's raw log first."
+  exit 1
+fi
 
 echo "::error title=Playwright browser install failed — no gate ran::npx playwright install exited nonzero in ${PWD}. This step provisions the browser, so the gate this job exists to run never started: the red reports PROVISIONING and carries no verdict on the code under test. WHICH KIND of failure it is depends on the diff, and this script cannot tell you — it is the || branch of the install and sees neither the diff nor the install's output. BEFORE RE-RUNNING, check whether this PR touches a provisioning input: the browser arguments on the npx playwright install line, the step's working-directory or env or download host, the runner image or setup-node or cache inputs, this script itself, or the Playwright pin in the lockfile of the root shown above — implementation/package-lock.json pins 1.59.1, docs/tools/playground/package-lock.json pins 1.60.0. If it touches any of them, read this step's raw log first: a diff-caused install failure lands here looking exactly like an outage. If it touches none of them, this is infrastructure and the remedy is a re-run, which lands on a different runner. Playwright already retries the download five times internally (playwright-core browserFetcher.js), and both modes measured under rf2-swos need a different runner rather than more attempts: a Google Cloud Storage 403 'this service is not available in your location' on the Chrome-for-Testing bucket that cdn.playwright.dev redirects to, scoped to this runner's egress IP; and a slow azure.archive.ubuntu.com apt hop under --with-deps."
 exit 1

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -349,7 +349,7 @@ jobs:
       - name: Install Playwright (Chromium + system deps)
         if: github.event_name != 'pull_request'
         working-directory: docs/tools/playground
-        run: npx playwright install --with-deps chromium || "$GITHUB_WORKSPACE/.github/scripts/playwright-install-failed.sh"
+        run: timeout -k 10 720 npx playwright install --with-deps chromium || "$GITHUB_WORKSPACE/.github/scripts/playwright-install-failed.sh" $?
 
       - name: Smoke the built bundles under headless Chromium
         if: github.event_name != 'pull_request'

--- a/.github/workflows/expensive-tests.yml
+++ b/.github/workflows/expensive-tests.yml
@@ -80,7 +80,7 @@ jobs:
             ${{ runner.os }}-playwright-
 
       - name: Install Playwright (Chromium + system deps)
-        run: npx playwright install --with-deps chromium || "$GITHUB_WORKSPACE/.github/scripts/playwright-install-failed.sh"
+        run: timeout -k 10 720 npx playwright install --with-deps chromium || "$GITHUB_WORKSPACE/.github/scripts/playwright-install-failed.sh" $?
 
       # rf2-wh5to — the eleven gates below used to be ONE unnamed
       # `set -euo pipefail` step. That structure is why the
@@ -337,7 +337,7 @@ jobs:
 
       - name: Install Playwright chromium (for the emitted browser proofs)
         working-directory: implementation
-        run: npx playwright install --with-deps chromium || "$GITHUB_WORKSPACE/.github/scripts/playwright-install-failed.sh"
+        run: timeout -k 10 720 npx playwright install --with-deps chromium || "$GITHUB_WORKSPACE/.github/scripts/playwright-install-failed.sh" $?
 
       - name: Run template emitted-app smoke
         env:
@@ -426,7 +426,7 @@ jobs:
 
       - name: Install Playwright chromium (for hermetic browser preload)
         working-directory: implementation
-        run: npx playwright install --with-deps chromium || "$GITHUB_WORKSPACE/.github/scripts/playwright-install-failed.sh"
+        run: timeout -k 10 720 npx playwright install --with-deps chromium || "$GITHUB_WORKSPACE/.github/scripts/playwright-install-failed.sh" $?
 
       - name: Run re-frame2-pair live conformance suite (hermetic)
         run: npm run test:re-frame2-pair-live-hermetic-suite

--- a/.github/workflows/template-release.yml
+++ b/.github/workflows/template-release.yml
@@ -217,7 +217,7 @@ jobs:
 
       - name: Install Playwright chromium (for the emitted browser proofs)
         working-directory: implementation
-        run: npx playwright install --with-deps chromium || "$GITHUB_WORKSPACE/.github/scripts/playwright-install-failed.sh"
+        run: timeout -k 10 720 npx playwright install --with-deps chromium || "$GITHUB_WORKSPACE/.github/scripts/playwright-install-failed.sh" $?
 
       # rf2-ek857f F1 — RF2_TEMPLATE_RUN_EMITTED_TESTS=1 flips the
       # behavioural emitted-app tier ON (default-off for the local fast

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1691,7 +1691,7 @@ jobs:
       # Do not move this step out of `implementation`, and do not reorder it
       # before `npm ci`.
       - name: Install pinned Chromium + Firefox + WebKit
-        run: npx playwright install --with-deps chromium firefox webkit || "$GITHUB_WORKSPACE/.github/scripts/playwright-install-failed.sh"
+        run: timeout -k 10 720 npx playwright install --with-deps chromium firefox webkit || "$GITHUB_WORKSPACE/.github/scripts/playwright-install-failed.sh" $?
 
       - name: I15 three-engine controlled-input gate
         run: npm run test:hicasso-controlled
@@ -1801,7 +1801,7 @@ jobs:
       # this step out of `implementation`, and do not reorder it before
       # `npm ci`.
       - name: Install pinned Chromium + Firefox + WebKit
-        run: npx playwright install --with-deps chromium firefox webkit || "$GITHUB_WORKSPACE/.github/scripts/playwright-install-failed.sh"
+        run: timeout -k 10 720 npx playwright install --with-deps chromium firefox webkit || "$GITHUB_WORKSPACE/.github/scripts/playwright-install-failed.sh" $?
 
       - name: HMR contract gate — 36 real shadow reloads in three engines
         run: npm run test:hicasso-hmr
@@ -3470,7 +3470,7 @@ jobs:
             ${{ runner.os }}-playwright-
 
       - name: Install Playwright (Chromium + system deps)
-        run: npx playwright install --with-deps chromium || "$GITHUB_WORKSPACE/.github/scripts/playwright-install-failed.sh"
+        run: timeout -k 10 720 npx playwright install --with-deps chromium || "$GITHUB_WORKSPACE/.github/scripts/playwright-install-failed.sh" $?
 
       - name: Compile :browser-test, serve, and run Playwright runner
         run: npm run test:browser
@@ -3611,7 +3611,7 @@ jobs:
             ${{ runner.os }}-playwright-
 
       - name: Install Playwright (Chromium + system deps)
-        run: npx playwright install --with-deps chromium || "$GITHUB_WORKSPACE/.github/scripts/playwright-install-failed.sh"
+        run: timeout -k 10 720 npx playwright install --with-deps chromium || "$GITHUB_WORKSPACE/.github/scripts/playwright-install-failed.sh" $?
 
       # Production-mode CLJS smoke for `:rf.schema/at-boundary`
       # (Spec 010 §Production builds, rf2-r2uh / rf2-84e9). Compiles
@@ -3675,7 +3675,7 @@ jobs:
             ${{ runner.os }}-playwright-
 
       - name: Install Playwright (Chromium + system deps)
-        run: npx playwright install --with-deps chromium || "$GITHUB_WORKSPACE/.github/scripts/playwright-install-failed.sh"
+        run: timeout -k 10 720 npx playwright install --with-deps chromium || "$GITHUB_WORKSPACE/.github/scripts/playwright-install-failed.sh" $?
 
       # Production-mode CLJS elision smokes:
       #   - rf2-2zdu: re-frame.trace/emit! must NOT fire under :advanced +
@@ -4035,7 +4035,7 @@ jobs:
             ${{ runner.os }}-playwright-
 
       - name: Install Playwright (Chromium + system deps)
-        run: npx playwright install --with-deps chromium || "$GITHUB_WORKSPACE/.github/scripts/playwright-install-failed.sh"
+        run: timeout -k 10 720 npx playwright install --with-deps chromium || "$GITHUB_WORKSPACE/.github/scripts/playwright-install-failed.sh" $?
 
       # rf2-9grp6 — narrow scope. The orchestrator at
       # implementation/adapters/scripts/serve-and-run-adapter-smokes.cjs supports a
@@ -4139,7 +4139,7 @@ jobs:
             ${{ runner.os }}-playwright-
 
       - name: Install Playwright (Chromium + system deps)
-        run: npx playwright install --with-deps chromium || "$GITHUB_WORKSPACE/.github/scripts/playwright-install-failed.sh"
+        run: timeout -k 10 720 npx playwright install --with-deps chromium || "$GITHUB_WORKSPACE/.github/scripts/playwright-install-failed.sh" $?
 
       # PR-smoke tier (rf2-wa3oo + rf2-og36y). The full feature-load +
       # full Xray matrix + Story static-export sweep sat on the critical
@@ -4405,15 +4405,29 @@ jobs:
       # here. Measured 2026-08-13, and every claim below is from a CI log or
       # from `playwright-core` at the pinned version, not from taste:
       #
-      #   * THE CAP IS NOT TIGHT. 183 samples of this step across 2026-08-10
-      #     to 2026-08-13 (every `Install Playwright*` step of the last ~46
-      #     completed test.yml runs): 183 successes, 0 failures, min 10s,
-      #     p50 13s, p90 21s, max 49s. The 300s cap is 6.1x the observed
-      #     worst case. Raising it re-widens the open-ended window the cap
-      #     exists to bound — the rf2-e6enf failure above, where four PRs
-      #     (#2304/#2311/#2316/#2324) each sat 15-75+ min on a wedged
-      #     apt/dpkg lock and blocked the merge queue. That trade is a
-      #     regression, not a fix.
+      #   * THE CAP IS STILL CLEAR OF THIS SITE, BUT THE HEADROOM IS NOT WHAT
+      #     IT WAS, AND THE OLD NUMBER HERE WAS STALE. The 2026-08-13 reading
+      #     was 183 samples, 183 successes, 0 failures, p50 13s, p90 21s,
+      #     max 49s — "6.1x the observed worst case". Re-derived 2026-08-20
+      #     over the 140 most recent completed test.yml runs (2026-08-18T05:11Z
+      #     .. 2026-08-20T10:13Z, ALL attempts, every `Install Playwright*`
+      #     step): 377 non-skipped samples, 370 successes, 7 non-successes.
+      #     The successes have grown a long tail — p50 14s and p90 34s still,
+      #     but p95 113s, p99 424s, MAX 621s, and four of the 370 finished
+      #     ABOVE 300s. Every one of those four sits at a job with no step
+      #     cap; across the three step-capped sites the worst success is 164s
+      #     over 80 samples, so this cap is 1.8x its own site's worst case
+      #     rather than 6.1x. That is clear, not comfortable, and the trend is
+      #     the thing to watch: re-derive before quoting, do not carry the
+      #     number forward.
+      #
+      #     rf2-g3lv's conclusion is UNCHANGED by that. Raising the cap
+      #     re-widens the open-ended window it exists to bound — the rf2-e6enf
+      #     failure above, where four PRs (#2304/#2311/#2316/#2324) each sat
+      #     15-75+ min on a wedged apt/dpkg lock and blocked the merge queue.
+      #     That trade is a regression, not a fix. But the 1.8x is now close
+      #     enough that it is a judgement for Mike rather than an arithmetic
+      #     certainty, and rf2-mul6w files it as such rather than acting on it.
       #
       #   * THE APT HOP IS ALREADY MINIMAL. On ubuntu-24.04 the hop reports
       #     `0 upgraded, 9 newly installed, 0 to remove` — invariant across
@@ -4448,15 +4462,32 @@ jobs:
       #     anyway. A hit skips the DOWNLOAD; this failure is in the apt hop,
       #     which runs either way.
       #
-      # One real gap stays open and is deliberately not patched here: a step
-      # the runner guillotines on `timeout-minutes` is killed rather than
-      # failing, so the `|| playwright-install-failed.sh` handler never runs
-      # and this mode prints no "no gate ran" annotation. Moving the cap into
-      # the command (`timeout 270 npx playwright install …`) would fix that,
-      # but it breaks `scripts/check_fast_pr_gap.py`'s `^npx playwright
-      # install\b` setup pattern and would fail-open the gap map — see the
-      # header of .github/scripts/playwright-install-failed.sh. At 0 failures
-      # in 183 samples that trade is not worth taking.
+      # THE GAP THIS COMMENT USED TO LEAVE OPEN IS NOW CLOSED ELSEWHERE, AND
+      # THIS SITE IS ONE OF THE THREE THAT DELIBERATELY DOES NOT TAKE THE FIX
+      # (rf2-mul6w). A step the runner guillotines on `timeout-minutes` is
+      # killed rather than failing, so the `|| playwright-install-failed.sh`
+      # handler never runs. The old note said moving the cap into the command
+      # would fix that but would fail-open `scripts/check_fast_pr_gap.py`'s
+      # `^npx playwright install\b` setup pattern, and declined the trade at
+      # "0 failures in 183 samples". Both halves have moved. The rate is no
+      # longer zero — 5 install stalls in 377 samples in the window above, all
+      # on 2026-08-19, two of which reddened `main` — and the pattern now
+      # carries a narrow optional `timeout` group, so widening it fails nothing
+      # open. Fourteen sites therefore run `timeout -k 10 720 npx playwright
+      # install … || <handler> $?`.
+      #
+      # This site keeps the bare form because the gap is not open HERE, and
+      # that was measured rather than assumed. A step-cap guillotine already
+      # posts `The action 'Install Playwright (Chromium + system deps)' has
+      # timed out after 5 minutes` — verbatim from job 95932283494 — which
+      # names the step, so a reader sees provisioning without opening a log.
+      # It is the JOB-cap guillotine that says nothing usable: jobs
+      # 95959283484 and 95932283700 carry only `The job has exceeded the
+      # maximum execution time of 15m0s` and `The operation was canceled.`,
+      # with every later step `skipped`. Adding a redundant in-command
+      # deadline here would thin the 1.8x margin above to restate an
+      # annotation the runner already gives. See the header of
+      # .github/scripts/playwright-install-failed.sh for the full derivation.
       - name: Install Playwright (Chromium + system deps)
         timeout-minutes: 5
         run: npx playwright install --with-deps chromium || "$GITHUB_WORKSPACE/.github/scripts/playwright-install-failed.sh"
@@ -5117,7 +5148,7 @@ jobs:
 
       - name: Install Playwright chromium (for the emitted browser proofs)
         working-directory: implementation
-        run: npx playwright install --with-deps chromium || "$GITHUB_WORKSPACE/.github/scripts/playwright-install-failed.sh"
+        run: timeout -k 10 720 npx playwright install --with-deps chromium || "$GITHUB_WORKSPACE/.github/scripts/playwright-install-failed.sh" $?
 
       # tools/template is a deps-new template (rf2-dolpf §2; clj-new
       # body dropped in §2.5 / rf2-40vmd) — its tests
@@ -6073,7 +6104,7 @@ jobs:
             ${{ runner.os }}-playwright-playground-
 
       - name: Install Playwright (Chromium + system deps)
-        run: npx playwright install --with-deps chromium || "$GITHUB_WORKSPACE/.github/scripts/playwright-install-failed.sh"
+        run: timeout -k 10 720 npx playwright install --with-deps chromium || "$GITHUB_WORKSPACE/.github/scripts/playwright-install-failed.sh" $?
 
       # Build BOTH bundles from source — the committed esbuild bootstrap
       # (playground.js + playground.css) and the untracked, generated

--- a/scripts/check_fast_pr_gap.py
+++ b/scripts/check_fast_pr_gap.py
@@ -128,7 +128,17 @@ SETUP_PATTERNS = (
     # trailing quote is optional -- a missed quote here re-reports the Clojure
     # installer as an unrun gate in all twenty-three JVM jobs.
     r"install-clojure-cli\.sh[\"']?$",
-    r"^npx playwright install\b",
+    # The `timeout` prefix is OPTIONAL and its shape is pinned tight (rf2-mul6w).
+    # Fourteen of the seventeen Playwright installs carry an in-command deadline
+    # -- `timeout -k 10 720 npx playwright install ...` -- because a step the
+    # RUNNER guillotines is killed rather than failed, so its `|| <handler>` arm
+    # never runs and the checks page carries no verdict at all.  Without this
+    # optional group those fourteen bodies stop matching, drop out of the setup
+    # set, and get reported as UNRUN GATES: a fail-open in the very map the merge
+    # criterion consults.  Keep the group narrow -- a literal `timeout`, an
+    # optional `-k <secs>`, one numeric deadline -- so it can admit nothing but
+    # this shape.  See .github/scripts/playwright-install-failed.sh.
+    r"^(?:timeout (?:-k \d+ )?\d+ )?npx playwright install\b",
     r"^sudo apt-get\b",
     r"^apt-get\b",
     # The clj-kondo installer step (lint.yml). It fetches the pinned release


### PR DESCRIPTION
Closes rf2-mul6w.

`npx playwright install … || playwright-install-failed.sh` fires the handler only on a **non-zero exit**. A step the runner guillotines on `timeout-minutes` is *killed, not failed*, so the handler never runs and the job carries no verdict on the code under test.

## The premise was half right, and the half that was wrong changes the fix

The bead describes one defect. Measured against the checks API, it is **two**, with different severities — and that is what decided the shape of this change.

| enclosing backstop | sites | what the checks page actually says |
|---|---|---|
| step-level `timeout-minutes: 5` | 3 | `The action 'Install Playwright (Chromium + system deps)' has timed out after 5 minutes.` — **names the step** |
| job-level `timeout-minutes` | 14 | `The job has exceeded the maximum execution time of 15m0s` + `The operation was canceled.` — **names nothing**, every later step `skipped` |

Read verbatim from jobs `95959283361` / `95932283494` (step cap) and `95959283484` / `95932283700` (job cap).

So at the three step-capped sites a reader already sees provisioning without opening a log — the cost rf2-swos was filed against is already paid there. It is the **job-cap** guillotine that says nothing usable, and all three cancellations in the measured window landed there, each burning its job's entire budget first (893s, 895s, 1793s).

**Fourteen job-capped sites therefore take an in-command deadline; the three step-capped ones keep the bare form**, where a redundant deadline would only thin a measured margin to restate an annotation the runner already gives.

```
run: timeout -k 10 720 npx playwright install --with-deps chromium || "$GITHUB_WORKSPACE/.github/scripts/playwright-install-failed.sh" $?
```

## Re-derived rate — against the written "0 failures in 183 samples"

Recounted from scratch, not carried forward. Window: the **140 most recent completed `test.yml` runs**, 2026-08-18T05:11Z .. 2026-08-20T10:13Z, **all attempts** (`filter=all`, so a green re-run does not erase the incident it replaced), every step named `Install Playwright*`.

- **377** non-skipped samples, **370** successes, **7** non-successes → **1.86%**.
- Of the 7, **5 are genuine install stalls** (312s, 313s, 893s, 895s, 1793s), all on 2026-08-19, two of which reddened `main` → **1.33%**. The other 2 are whole-run supersession cancels at 11s and 15s, counted but not attributable to this step.

The written trade declined this fix at "0 failures in 183 samples". **It is no longer zero**, so the trade has flipped and the comment is corrected in place.

### A second stale claim in the same comment block, corrected

The block also asserts *"THE CAP IS NOT TIGHT … p50 13s, p90 21s, max 49s. The 300s cap is 6.1x the observed worst case."* That population is gone. The 370 successes now run **p50 14s, p90 34s, p95 113s, p99 424s, max 621s**, and **four finished above 300s**. All four sit at jobs with no step cap; across the three step-capped sites the worst success is 164s over 80 samples, so that cap is **1.8x** its own site's worst case, not 6.1x.

Raising it is out of scope here and rf2-g3lv's reasoning for not raising it still stands on its own terms, so this PR **corrects the numbers and leaves the cap untouched**. Filed as **rf2-5h2t8** for Mike.

## Why 720s is derived, not round

It has to clear the worst *successful* install or it converts working installs into false reds — a worse trade than the one it fixes — and it has to fit inside the tightest enclosing job cap.

- Observed worst success **621s** → 720s is 16% clear.
- Tightest job cap is **15 min** (`tools-playground`), and the install starts at **+18s** there (measured on job `95959283484`), so 738s of a 900s budget: **the job cap survives as backstop**.
- It binds on **all three** cancellations observed (893s / 895s / 1793s).

`-k 10` is the second half: `timeout` sends TERM and then waits, so a child that ignores it would hang exactly as before.

## The gap map: pattern and call sites move in ONE commit

`scripts/check_fast_pr_gap.py` classifies a step as toolchain setup only when **every** logical line matches a `SETUP_PATTERNS` entry, and `is_setup` uses an `^`-anchored pattern, so a `timeout ` prefix drops the body out of that set. The pattern gains a deliberately narrow optional group — a literal `timeout`, an optional `-k <secs>`, one numeric deadline:

```python
r"^(?:timeout (?:-k \d+ )?\d+ )?npx playwright install\b",
```

**Proof it neither fails open nor drops a site: `--list` is BYTE-IDENTICAL before and after** (360 lines, `REQUIRED CHECKS THIS SPINE DOES NOT RUN (96)` both sides), diffed against the pristine trunk baseline.

That identity is only meaningful with a control, so both directions were **planted**:

| plant | result |
|---|---|
| revert the pattern, leave the 14 sites prefixed | map inflates **96 → 106**; the 10 required install steps re-listed as **unrun gates**, each with a reproduce command — the exact fail-open the old comment feared |
| swap one site's prefix for `nice -n 5 ` | map inflates **96 → 97**; the widened pattern **rejects** a non-`timeout` prefix, so it is still narrow |

**One finding from that first plant is worth flagging: `check_fast_pr_gap.py` exited 0 in the fail-open state.** The drift ratchet covers `SPINE_LANES`, not `SETUP_PATTERNS`, so a stale setup pattern silently inflates the map and nothing in CI reds. Filed as **rf2-2yorx**; not fixed here, because adding a ratchet arm is a separate change to the same hot-zone file.

## The mechanism was verified by running it, not by assertion

A simulated hang against the real handler:

```
timeout -k 10 2 sleep 60 || .github/scripts/playwright-install-failed.sh $?
→ ::error title=Playwright browser install TIMED OUT — no gate ran::…
→ step exit 1   (RED — where today the step is killed and says nothing)
```

Also exercised: ordinary non-zero exit through a prefixed site (general title), and a **bare** site passing no argument at all (general title, no `set -u` explosion — `${1:-}` handles the three unprefixed sites).

## Nothing outside `.github/` and the gap map needed to change

`implementation/scripts/_changed-surfaces.test.cjs` and `tools/template/test/day8/re_frame2_template/release_gate_test.clj` assert on the literal install text, but via `indexOf` / `re-find` — substring searches a prefix cannot reach. Verified: all **17** sites still carry `playwright install --with-deps chromium`, both three-engine sites still carry `… chromium firefox webkit`, `npm ci` still precedes the install in both hicasso jobs, and a negative control (`--with-deps opera`) returns 0 so the search discriminates.

## Quality gates

Captured exit codes, each from the runner's own shell, re-run on the **final rebased base** (`origin/main` @ `5961c76213`; nothing touched `.github/**` or the gap map on the trunk since the branch point, and the three-dot merge-base diff is exactly these six files — no revert risk).

| gate | exit |
|---|---|
| `python scripts/check_fast_pr_gap.py --list` | **0** (byte-identical to trunk baseline) |
| `python scripts/check_fast_pr_gap.py` | **0** |
| `python scripts/check_fast_pr_gap.py --self-test` | **0** |
| `python scripts/check_fast_pr_gap.py --brief` | **0** |
| `python scripts/check_workflow_yaml.py` | **0** |
| `python scripts/check_workflow_job_timeouts.py --self-test` | **0** |
| `python scripts/check_workflow_job_timeouts.py` | **0** |
| `python scripts/check_gate_scheduling.py` | **0** |
| `python scripts/check_ci_reproduce_commands.py` | **0** |
| `node implementation/scripts/_changed-surfaces.test.cjs` | **0** (292 passed) |
| `node implementation/scripts/_mcp-conformance-install-policy.test.cjs` | **0** (5 passed) |
| `bash -n .github/scripts/playwright-install-failed.sh` | **0** |

Each of the three workflow-reading gates was proved to read *this* tree by a planted fault, then restored and the restore verified by hashing against the committed object (not by reading a diff):

- gap map → planted pattern revert and a `nice -n 5` prefix (above)
- job-cap ratchet → planted an uncapped job; **exit 1**, naming it
- workflow YAML → planted an unclosed flow sequence; **exit 1** at line 3475

*(A first YAML plant — an unbalanced quote appended to a plain scalar — returned 0 because that is still valid YAML. A bad plant, not a gate failure; re-planted with a genuinely malformed node.)*

**What I did NOT run:** the fast-PR spine (`scripts/test-fast-pr.sh`) was not run — its documentation tier is classifier-gated and this diff is workflow/CI, so the targeted gates above are the covering set. `scripts/check_readme_links.py --ci` was not run because **no `.md` changed**, under `.github/` or anywhere else. `scripts/check_doc_slugs.py` would be the wrong nomination for this surface in any case — its roots are `docs`, `spec`, `skills`, `migration` and `tools/*/spec`.

Separately, and as a fact about the **spine** rather than a census of this run, `scripts/check_fast_pr_gap.py --list` derives **96 required checks that `scripts/test-fast-pr.sh` does not run** — including `cljs-browser`, `adapter-testbed-smokes`, `tools-playground` and `mcp-conformance-re-frame2-pair`, i.e. four of the jobs whose install lines this PR edits. Those are decided in CI only.
