### PR TITLE
fix(xray): the L3 tab inventory in code and Conventions names the registry, not a stale six (rf2-gui26)

### DIFF
--- a/tools/xray/spec/Conventions.md
+++ b/tools/xray/spec/Conventions.md
@@ -245,17 +245,22 @@ locks the bare-`Panel` convention.
    `EventDetailPanel` on the JS side is the adapter's idiom, not a
    CLJS-side spelling the convention propagates.
 
-5. **The split is consistent across all six panels.** Renaming one
-   would force renaming all six; the per-panel facade shape (per
-   §Panel facade + leaf split above) is uniform precisely because
-   the leaf-view symbol name is uniform.
+5. **The split is consistent across every registered panel.**
+   Renaming one would force renaming all of them; the per-panel
+   facade shape (per §Panel facade + leaf split above) is uniform
+   precisely because the leaf-view symbol name is uniform. The set
+   is the registry's, not a literal — one `Panel` reg-view per id in
+   `panel-registry/tab-ids-for-mode :dynamic` (enumerated in point 1
+   above), so a tab added or retired never leaves a count behind.
 
 **Consequence.** New panels added under
 `tools/xray/src/day8/re_frame2_xray/panels/<panel>/` MUST follow
 the convention: a single public reg-view named `Panel` in the
 facade, no verbose `<Panel>Panel` rename. Hosts addressing a panel
-do so via tab-key dispatch (the shell's `case`), never by importing
-the `Panel` symbol directly.
+do so via tab-key dispatch (the shell's `tab-by-id :dynamic` registry
+lookup — the literal `case` this replaced is gone per rf2-2moh1, as
+point 1 above records), never by importing the `Panel` symbol
+directly.
 
 ## Mount conventions
 

--- a/tools/xray/src/day8/re_frame2_xray/registry.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/registry.cljs
@@ -887,8 +887,10 @@
 
     ;; ---- 4-layer chrome events (spec/018) -------------------------
 
-    ;; L3 tab bar — flip the active tab. Six valid ids:
-    ;; :epoch :app-db :views :trace :machines :routing
+    ;; L3 tab bar — flip the active tab. The valid ids are whatever
+    ;; `panel-registry/tab-ids-for-mode :dynamic` currently holds (the
+    ;; JVM-portable mirror of that set is `focus/valid-panels`), so
+    ;; this event has no literal inventory to keep in step.
     ;; Registry-driven; a new tab requires only a reg-l4-tab! call.
     ;; Issues surface inline in the Epoch panel, via the L2 event-row
     ;; pink-wash, and via the auto-open-on-error signal — there is no

--- a/tools/xray/src/day8/re_frame2_xray/shell.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/shell.cljs
@@ -2464,10 +2464,11 @@
                                      " ease-out forwards")}}
       ;; rf2-2moh1 — registry-driven panel mount. Each tab's per-panel
       ;; `install!` declares `:panel <view-fn>` via
-      ;; `panel-registry/reg-l4-tab!`; the previous case-switch over
-      ;; `{:event :app-db :views :trace :machines :routing}` is
-      ;; replaced by a lookup against `tab-by-id :dynamic`. The six
-      ;; tabs and their per-panel view fns each live colocated with
+      ;; `panel-registry/reg-l4-tab!`; the case-switch this replaced
+      ;; enumerated `{:event :app-db :views :trace :machines :routing}`
+      ;; — a literal that went stale on every tab added or retired.
+      ;; A lookup against `tab-by-id :dynamic` has no inventory to keep
+      ;; in step: EVERY registered tab's view fn lives colocated with
       ;; the panel's own subs / events / fxs in `panels/<panel>.cljs`
       ;; rather than the panel-cum-shell coupling the literal case-
       ;; switch encoded.


### PR DESCRIPTION
Closes rf2-gui26.

## What this is

The bead reported three SIX-tab Dynamic-L3 rosters in `tools/xray` code comments. **All three of its named sites were already correct at the tip** — they landed via PR #8440 (merged 2026-08-17). This PR fixes the sites a re-derived census found instead.

The live Dynamic L3 roster is **ten**, verified at source in `focus.cljc` `valid-panels`, which mirrors `panel-registry/tab-ids-for-mode :dynamic`:

`:epoch :app-db :views :trace :machines :routing :resources :derivation-graph :module-view :hicasso`

## The salvage branch — already merged, nothing carried forward

`salvage/xrayroster-2` (`66bacb2f6a`, containing `cfd881ec7a`) is **fully upstream**. Established by patch-equivalence, not ancestry, because this repo rebase-merges:

```
$ git cherry origin/main origin/salvage/xrayroster-2
- cfd881ec7a0e21463ccefd8aff8510900b151448
- 66bacb2f6a857e94013fdde9142fc7b09566e0de
```

Both `-`. Confirmed independently: PR #8440 is `MERGED`, and `main` carries `cfd881ec7a`'s exact replacement text at both sites (`shell.cljs` "The strip is whatever `panel-registry/tabs-for-mode :dynamic` has registered"; `palette/events.cljs` "Panel ids in `palette-panels` are not a frozen list at all"). **Nothing was replayed from the salvage branch, and the branch is untouched.**

## The three sites fixed

| Site | Was | Now |
|---|---|---|
| `src/…/registry.cljs:890` | `Six valid ids: :epoch :app-db :views :trace :machines :routing` — enumerated six of ten, and directly contradicted the line beneath it ("Registry-driven; a new tab requires only a reg-l4-tab! call") | Numeral-free; names `panel-registry/tab-ids-for-mode :dynamic` and its JVM-portable mirror `focus/valid-panels` |
| `src/…/shell.cljs:2469` | "The six tabs and their per-panel view fns each live colocated…" — a present-tense count of ten tabs | Numeral-free ("EVERY registered tab's view fn…"). The historical case-switch enumeration on the line above is **kept**: it names `:event`, the retired Event/Handler tab, and is accurate *as history* |
| `spec/Conventions.md:248` | "consistent across all six panels… would force renaming all six" | Numeral-free, registry-derived. There are exactly **ten** `rf/reg-view Panel` declarations under `panels/`, one per roster id — counted |

Also in `Conventions.md`: the Consequence paragraph said hosts address panels "via tab-key dispatch (the shell's `case`)". That `case` was replaced by a `tab-by-id :dynamic` registry lookup in rf2-2moh1 — and **point 1 of the same section already says so**, so the section contradicted itself. Corrected.

Per the bead's own FIX guidance, every repair is **numeral-free and names the source of truth**, so none of them can go stale on the next tab added or retired.

## The census — and the sixes deliberately LEFT

A `six`/`Six`/`SIX` grep over `tools/xray` (excluding `.beads`, a full-database export that matches almost anything) returns ~70 hits, the large majority legitimate. The discriminator is whether the "six" refers to the **Dynamic L3 tab roster**. Cross-checked with a roster-tail census — enumerations carrying `:machines :routing` but missing `:resources` / `:derivation-graph` / `:module-view` / `:hicasso` — which is the reliable method here, since these comments carry no `9` and no `nine` and are invisible to any numeric census.

The roster-tail census returned exactly five hits. Two were the genuine staleness fixed above. The other three are correct:

- `focus.cljc:125` and `focus_cljs_test.cljs:140` — the real `valid-panels` def and its test, both wrapping to a second line that carries the tail.
- `panel_gallery_inventory_smoke_cljs_test.cljs:154` — `galleried-dynamic-tabs`, deliberately six.

**Classification of the two sites flagged as unclassified:**

- **`shell.cljs:2469` — GENUINELY STALE.** Fixed above. Its neighbouring enumeration on 2468 is history and was kept.
- **`panel_gallery_inventory_smoke_cljs_test.cljs:138` — LEGITIMATE, left alone.** "the six CORE L4 lenses" is a code-enforced partition, not a roster count: the same file defines `galleried-dynamic-tabs` (six) and a documented-exclusion set (Resources · Graph · Frames · Hicasso, four), and the test asserts the two **exactly partition** `focus/valid-panels`. 6 + 4 = 10. Its own comment says "walks all ten live tabs".

Other sixes left, by reason:

- **Hicasso genuinely has six views** — `panels/hicasso.cljs:4,498,515,520,522`, `hicasso_helpers.cljc:262,557,561`, `registry.cljs:1317`, `README.md:62`, `deps.edn:46`, `feature_matrix/scenarios.cjs:63`, and the Hicasso tests. Six *sub-views of one tab*; unrelated to the tab roster.
- **Historical records of a deleted six-key map** — `theme/tokens.cljc:754`, `theme/tokens_cljs_test.cljc:204`, `theme/var_resolution_cljs_test.cljs:106`. Correct as written.
- **The panel-gallery's six-core partition** — `testbeds/panel_gallery/core.cljs:7,20,33,47,172` and `panel_views.cljs:4,23`. Same partition as the smoke test; `core.cljs:47` explicitly says "ten L4 tabs … this gallery covers the six core lenses". `panel_views.cljs:4` is a bead-provenance chain about the historical 6-tab shape.
- **Different subjects entirely** — six-domino cascade (`managed_fx_template.cljs`, `l2_counter_inc_row`), six trace columns (`trace.cljs:22`, `trace_helpers.cljc:17`), six `:rf.egress/profile` members (`config.cljc:621`, `local_render.cljc:16`), six 'No X' placeholder cards (`app_db_diff_*`), the six-fn Resources override seam (`resources.cljs:1191,1357`), six restore-failure rows (`runtime.cljs:1453,1464`), six modal surfaces (`theme/a11y.cljs`), six settings-picker options (`settings/view.cljs:285`), six-level nesting fixtures (`edn_inspector`, `panel_gallery` fixtures), six runner decks (`machine_epochs`, `runner/core.cljs`).
- **`spec/007-UX-IA.md:129`** — "the Figma export fixed the first six; the cohesive-sub-domain tabs were appended after" is accurate history, and the sentence it sits in already reads "**Ten** Dynamic tabs".

A companion check for staleness in the other direction — a `nine`/`9`-tab claim now that the roster is ten — returned **zero** hits.

## Spec obligation

`tools/xray/spec/**` **did need a change**, and it is in this PR: `Conventions.md` (above). `018-Event-Spine.md` was checked and needs nothing — it already teaches the ten-tab bar (row 10 is Hicasso), and its three remaining sixes are the Hicasso sub-views, the six trace-type chips, and an explicitly-labelled "earlier 6-tab aspiration" retirement note.

## Quality gates

Behaviour is unchanged — all three edits are comments/prose. No runtime code was touched.

**Ran locally, in this worktree, each exit code captured from the runner's own shell (never a pipeline, never the harness's report), and each re-run on the FINAL post-rebase base:**

| Gate | Exit | Notes |
|---|---|---|
| `python scripts/check_doc_slugs.py` | **0** | Covers `tools/*/spec` via `_iter_markdown`'s tools tier — the gate for the `Conventions.md` edit |
| `node scripts/compile-node-test.cjs node-test out/node-test.js` | **0** | 1990 files, 0 warnings. Compiles `../tools/xray/src` + `../tools/xray/test` per `shadow-cljs.edn` |
| `node out/node-test.js` | **0** | **11854 tests, 60048 assertions, 0 failures, 0 errors** |
| `node scripts/serve-and-run-xray-feature-gate.cjs --smoke` | **0** | **4 scenarios, 0 failures, 9 matrix rows covered** |

`scripts/test-fast-pr.sh` was **not** run; the four targeted gates above were run directly instead.

**Both gates proven to read THIS worktree, by both available routes:**

- *Root banner* — the shadow-cljs run prints `config: …\re-frame2-worktrees\xrayroster\implementation\shadow-cljs.edn`.
- *Planted fault, `check_doc_slugs.py`* — a broken anchor added to the `Conventions.md` paragraph this PR edits took the gate to **exit 1** with `BROKEN ANCHOR: tools\xray\spec\Conventions.md:255 -> ./018-Event-Spine.md#rf2-gui26-planted-fault-no-such-anchor`. Restored; exit 0 again.
- *Planted fault, CLJS* — an undeclared symbol planted at the `registry.cljs` line this PR edits took the compile to **exit 1** naming the absolute path in this worktree: `…\re-frame2-worktrees\xrayroster\tools\xray\src\day8\re_frame2_xray\registry.cljs:890` / `Use of undeclared Var …/rf2-gui26-planted-fault-undefined-symbol`. Restored; exit 0 again.

Both faults existed only in this worktree, so a run that had wandered into a sibling checkout would have come back green. Both restores were verified by **content hash against the committed object** (`git hash-object` == `git rev-parse HEAD:<path>`), not by reading a diff, and the post-restore suite reported the **same 11854/60048 counts** as the control — confirming the plant was scoped and suppressed no namespaces.

`scripts/check_fast_pr_gap.py --list` (exit **0**) enumerates the 96 required CI checks the fast spine does not decide. That is a fact about the spine, not a census of what was run here.

`npm run test:xray-feature-gate` is **armed** by this diff — `.github/scripts/report-changed-surfaces.sh` reports `story_xray_browser=true` and `cljs_browser=true`, since any change under `tools/xray/src` arms it regardless of whether it is a comment. Its PR-smoke tier was therefore run here, green (table above). It exceeded the foreground runtime ceiling, so it was detached and polled to completion within the turn on both its log and its exit-code file; the quoted **0** is its own runner's captured code. It too printed this worktree's root, serving from `…\re-frame2-worktrees\xrayroster\implementation\out\xray-feature-gate`. The `http-server exited unexpectedly` line after the verdict is the teardown of the static server, and follows the `0 failures` result rather than preceding it. The **full** (non-smoke) tier remains CI's.

**Verified by hand** (no gate reaches a code comment, which is the bead's own point): the ten-member roster read at source in `focus.cljc`; the ten `rf/reg-view Panel` declarations counted under `panels/`; every "six" classified individually against the roster-tail census; the `Conventions.md` numbered list still runs 1–5 with point 5's cross-reference to point 1 resolving; no table column counts changed (no tables were edited).

Diffed against the merge base in the three-dot form before pushing: three files, this PR's own edits only, nothing reverted.
