### PR TITLE
fix(ci): two fail-open gate defects — the SETUP_PATTERNS drift ratchet, and the markdown no link gate opened (rf2-2yorx, rf2-i4nb2)

### DIFF
--- a/scripts/check_fast_pr_gap.py
+++ b/scripts/check_fast_pr_gap.py
@@ -64,12 +64,25 @@ HOW IT DECIDES, and why the failure direction is the safe one.
     installed on this project's Windows checkout reports 0 errors on the line CI
     fails at 2026.04.15, and 10 different errors CI does not).
 
-THE DRIFT RATCHET (`--check`, the default).  A signature in `SPINE_LANES` that
-stops matching any required gate step is a FAILURE: it means the spine still
-claims a lane for a check CI renamed, moved or deleted, and the claim is now
-false.  That is the whole anti-staleness mechanism -- a hand-written list of
-gaps would rot silently, and this territory changed twice on the day the bead was
-filed.
+THE DRIFT RATCHETS (`--check`, the default).  There are TWO, one per hand-written
+constant, because the two constants rot in OPPOSITE directions.
+
+  * A signature in `SPINE_LANES` that stops matching any required gate step is a
+    FAILURE: it means the spine still claims a lane for a check CI renamed, moved
+    or deleted, and the claim is now false.  That is the anti-staleness mechanism
+    for coverage -- a hand-written list of gaps would rot silently, and this
+    territory changed twice on the day the bead was filed.
+
+  * An entry in `SETUP_PATTERNS` that stops matching its call sites is the same
+    rot with the opposite blast radius, and until rf2-2yorx nothing caught it.
+    Toolchain installation gets re-classified as a required GATE, so this map
+    GROWS entries telling a reader to run `npx playwright install` locally as
+    though it were a check -- and no exit code moves.  Measured by planting:
+    reverting the Playwright entry to its pre-`timeout` form took the headline
+    from 96 to 106 while `--check` went on printing 'fast-PR gap map clean'.
+    `SETUP_CANARIES` below is the ratchet for that direction, and it watches the
+    CLASSIFICATION rather than the pattern -- see the comment on that constant
+    for why a per-pattern "matches at least one step" floor does not work here.
 
     python scripts/check_fast_pr_gap.py              audit the map (default)
     python scripts/check_fast_pr_gap.py --list       full report + local commands
@@ -120,8 +133,12 @@ MIN_SPINE_CHECKERS = 10
 # is the defect this file exists to prevent, so the list stays narrow.
 # ---------------------------------------------------------------------------
 SETUP_PATTERNS = (
-    r"^npm ci$",
-    r"^npm install$",
+    # Long flags only, no package argument and no chaining: `npm install
+    # --no-audit --no-fund` is how two required jobs install their deps, while
+    # `npm install some-package && npm run build` must stay a GATE.  The bare
+    # `^npm install$` this replaces missed both flag-bearing call sites, which
+    # rf2-2yorx's canary ratchet found reported as unrun required checks.
+    r"^npm (?:ci|install)(?: --[a-z][a-z-]*)*$",
     r"^pip install\b",
     # Written both bare and quoted across the workflows
     # (`"$GITHUB_WORKSPACE/.github/scripts/install-clojure-cli.sh"`), so the
@@ -151,6 +168,64 @@ SETUP_PATTERNS = (
     r"^clj-kondo --version$",
 )
 _SETUP_RE = tuple(re.compile(p) for p in SETUP_PATTERNS)
+
+
+# ---------------------------------------------------------------------------
+# THE SETUP RATCHET (rf2-2yorx).  A witness for SETUP_PATTERNS drift, standing on
+# the far side of the classification it watches.
+#
+# WHY NOT A FLOOR ON THE PATTERNS THEMSELVES.  The obvious guard -- "every
+# SETUP_PATTERNS entry must match at least one required step" -- was measured
+# against the known-WRONG answer and does not catch it.  Three of the thirteen
+# required Playwright installs are still written bare, so the pre-`timeout`
+# pattern goes on matching those three; a floor of one stays GREEN while the
+# other ten silently become gates.  A guard tested only on the passing case is
+# not a guard.
+#
+# WHAT THIS CHECKS INSTEAD.  A required GATE step whose EVERY line is nothing but
+# toolchain installation was misclassified, whatever the reason -- a pattern that
+# drifted off its call sites, or a call-site shape SETUP_PATTERNS never had.
+# These canaries name a TOOL where SETUP_PATTERNS names a CALL SHAPE, and being
+# loose is exactly what makes them an independent witness: a canary written tight
+# enough to drift in step with the entry it watches would witness nothing.
+#
+# The whole-body rule from `is_setup` is kept, and it is what holds the false
+# positives at zero: `npm ci` followed by `npm run build` mixes installation with
+# a build, so it stays a gate and is not flagged.  Keep the clj-kondo canaries
+# pinned to the INSTALLER shapes -- a bare `clj-kondo` canary would match the
+# lint gate itself and red on a correct map.
+# ---------------------------------------------------------------------------
+SETUP_CANARIES = (
+    r"\bnpm (?:ci|install)\b",
+    r"\bpip install\b",
+    r"install-clojure-cli\.sh",
+    r"\bnpx playwright install\b",
+    r"\bapt-get\b",
+    r"clj-kondo/releases/download/",
+    r"\bunzip\b.*clj-kondo",
+    r"\bsudo install\b.*clj-kondo",
+    r"^clj-kondo --version$",
+)
+_CANARY_RE = tuple(re.compile(p) for p in SETUP_CANARIES)
+
+
+def misclassified_setup(step: "Step") -> list[str]:
+    """The canaries hit by a step whose every line is nothing but installation.
+
+    Empty for any body that mixes installation with something else, which is the
+    direction this file has always guarded: hiding a gate inside a setup step is
+    worse than over-reporting one.
+    """
+    lines = [ln.strip() for ln in join_continuations(step.run or "") if ln.strip()]
+    if not lines:
+        return []
+    hits: set[str] = set()
+    for line in lines:
+        matched = [c for c, rx in zip(SETUP_CANARIES, _CANARY_RE) if rx.search(line)]
+        if not matched:
+            return []
+        hits.update(matched)
+    return sorted(hits)
 
 
 # ---------------------------------------------------------------------------
@@ -722,6 +797,23 @@ class GapMap:
                     f"in SPINE_LANES -- or the parser broke."
                 )
 
+        # The other rot direction: setup re-classified as a gate (rf2-2yorx).
+        for path, job in self.required:
+            for step in job.gate_steps:
+                hits = misclassified_setup(step)
+                if not hits:
+                    continue
+                self.problems.append(
+                    f"{path}: `{job.job_id}` step \"{step.name}\" is reported as a "
+                    f"required GATE, but every line of its body is toolchain "
+                    f"installation ({', '.join(hits)}). No SETUP_PATTERNS entry "
+                    f"recognises this call site any more, so the gap map now lists an "
+                    f"installer as a check the spine does not run, and tells a reader "
+                    f"to reproduce it locally. That inflation moves no exit code on "
+                    f"its own -- this is the ratchet that makes it move (rf2-2yorx). "
+                    f"Re-anchor the SETUP_PATTERNS entry to this call site."
+                )
+
         if len(self.spine_checkers) < MIN_SPINE_CHECKERS:
             self.problems.append(
                 f"only {len(self.spine_checkers)} `python scripts/check_*.py` "
@@ -1152,6 +1244,67 @@ def run_self_tests(verbose: bool) -> int:
         any("expected at least" in p and SPINE in p for p in empty.problems),
     )
 
+    # THE SETUP RATCHET (rf2-2yorx), the other rot direction.  Its unit shape
+    # first: the whole-body rule is what keeps it off correct maps.
+    def _step(body: str) -> Step:
+        return parse_workflow(
+            "jobs:\n  a:\n    steps:\n      - name: s\n        run: |\n"
+            + "".join(f"          {ln}\n" for ln in body.splitlines()),
+            "f.yml",
+        )["a"].steps[0]
+
+    check(
+        "a body that is nothing but an installer is flagged as misclassified setup",
+        misclassified_setup(_step("npx playwright install --with-deps chromium")) != [],
+    )
+    check(
+        "a body MIXING an installer with a build is NOT flagged (it is a real gate)",
+        misclassified_setup(_step("npm ci\nnpm run build")) == [],
+    )
+    check(
+        "the clj-kondo canaries do not match the lint gate itself",
+        misclassified_setup(
+            _step("clj-kondo --parallel --fail-level error --lint implementation")
+        ) == [],
+    )
+
+    # ... and then against the answer that is known WRONG.  The fixture has no
+    # Playwright call sites, so the corpus has to be the REAL workflows: revert
+    # the Playwright entry to its pre-`timeout` form -- exactly the drift measured
+    # under rf2-mul6w, which took the headline 96 -> 106 at exit 0 -- and require
+    # the ratchet to red.  A guard exercised only on the passing case is untested,
+    # and the per-pattern floor this replaced passes that case while failing this
+    # one: three call sites are still written bare, so the reverted pattern goes
+    # on matching them.
+    global SETUP_PATTERNS, _SETUP_RE
+    _live_patterns, _live_res = SETUP_PATTERNS, _SETUP_RE
+    try:
+        SETUP_PATTERNS = tuple(
+            r"^npx playwright install\b" if "playwright" in p else p
+            for p in SETUP_PATTERNS
+        )
+        _SETUP_RE = tuple(re.compile(p) for p in SETUP_PATTERNS)
+        drifted = load(REPO_ROOT)
+    finally:
+        SETUP_PATTERNS, _SETUP_RE = _live_patterns, _live_res
+
+    _drift_problems = [p for p in drifted.problems if "toolchain installation" in p]
+    check(
+        "THE MEASURED FAIL-OPEN: the pre-`timeout` Playwright pattern now REDS",
+        len(_drift_problems) > 0
+        and all("npx playwright install" in p for p in _drift_problems),
+    )
+    check(
+        "a floor of one match per pattern would NOT have caught it (the control)",
+        sum(
+            1
+            for _path, job in drifted.required
+            for s in job.steps
+            if s.run and s.is_setup and "playwright install" in s.command
+        )
+        > 0,
+    )
+
     _pin = _KONDO_PIN_RE.search(
         "curl -fsSL -o /tmp/clj-kondo.zip https://github.com/clj-kondo/clj-kondo"
         "/releases/download/v2026.04.15/clj-kondo-2026.04.15-linux-static-amd64.zip")
@@ -1187,6 +1340,15 @@ def run_self_tests(verbose: bool) -> int:
     # Against the REAL repo: the map builds clean and reports a non-trivial gap.
     real = load(REPO_ROOT)
     check("real repo: the gap map has no problems", real.problems == [])
+    check(
+        # The negative half of the sabotage above: the same ratchet, same corpus,
+        # patterns unmolested, must be SILENT. Without this the red proves only
+        # that the arm fires, not that it discriminates.
+        "real repo: no required gate step is misclassified toolchain setup",
+        not any(
+            misclassified_setup(s) for _p, j in real.required for s in j.gate_steps
+        ),
+    )
     check("real repo: >= 60 required jobs discovered", len(real.required) >= 60)
     check("real repo: at least one PARTIAL job (the item-3 class)", len(real.partial) >= 1)
     check(

--- a/scripts/check_fast_pr_gap.py
+++ b/scripts/check_fast_pr_gap.py
@@ -84,6 +84,8 @@ constant, because the two constants rot in OPPOSITE directions.
     CLASSIFICATION rather than the pattern -- see the comment on that constant
     for why a per-pattern "matches at least one step" floor does not work here.
 
+MODES.
+
     python scripts/check_fast_pr_gap.py              audit the map (default)
     python scripts/check_fast_pr_gap.py --list       full report + local commands
     python scripts/check_fast_pr_gap.py --brief      the digest the spine prints

--- a/scripts/check_readme_links.py
+++ b/scripts/check_readme_links.py
@@ -35,10 +35,26 @@ authority and scheduling, not on findings:
       guard), where the docs gate is documentation-surface-gated.  Root
       markdown gets the stronger of the two lanes for free.
 
-The root roster is GIT-TRACKED and NON-RECURSIVE (see `_iter_root_markdown`),
-so it cannot grow into `implementation/`, `tools/`, `node_modules` or any
-generated tree, and an untracked scratch file dropped at the repo root
-cannot red the gate on an author's machine (the rf2-k30r7 lesson).
+NON-README MARKDOWN BESIDE SOURCE IS THE SAME SURFACE AGAIN (rf2-i4nb2), and
+for the same three reasons.  `implementation/SECURITY.md` is cited from the root
+`README.md`, carries 36 relative targets including cross-file anchors into
+`spec/`, renders on GitHub — and was covered by NOTHING.  It is not a README, so
+`_iter_readmes` never saw it; it has a `/` in its path, so `_iter_root_markdown`
+dropped it; it is outside DEFAULT_ROOTS, so the docs gate never opened it.  A
+broken target planted in it returned exit 0 from BOTH gates.  Eight documents
+sat in that hole, the two `tools/mcp-conformance/` vocabularies among them,
+which `spec/Conventions.md` and `spec/Tool-Pair.md` cite normatively.
+
+`_iter_source_markdown` closes it and needs NO new exclusion to do so: the
+existing `_is_excluded` already refuses the gate fixture trees, the docs-gate
+roots and `tools/*/spec/`.  What it must NOT take, and why, is written on that
+function; the self-test asserts each refusal rather than only the membership.
+
+All three rosters are GIT-TRACKED, so an untracked scratch file dropped anywhere
+in the tree cannot red the gate on an author's machine while CI, running on a
+clean clone, stays green (the rf2-k30r7 lesson).  The root roster is
+additionally NON-RECURSIVE (see `_iter_root_markdown`), so it cannot grow into
+`implementation/`, `tools/`, `node_modules` or any generated tree.
 
 What this validates per file:
 
@@ -329,25 +345,77 @@ def _iter_root_markdown(repo_root: Path) -> Iterable[Path]:
             yield path
 
 
-def _iter_scanned(repo_root: Path) -> Iterable[Path]:
-    """Yield every file this gate validates: the README corpus plus root markdown.
+def _iter_source_markdown(repo_root: Path) -> Iterable[Path]:
+    """Yield every GIT-TRACKED non-README markdown file beside source (rf2-i4nb2).
 
-    Deduplicated by resolved path, because the repo-root `README.md` is a
-    member of both rosters.
+    THE GAP THIS CLOSES.  `implementation/SECURITY.md` is cited from the repo
+    root `README.md` and carries 36 relative targets, several of them cross-file
+    anchors into `spec/`.  It was covered by NOTHING: not by `check_doc_slugs.py`
+    (outside DEFAULT_ROOTS), and not here either, because `_iter_readmes` wants
+    the name `README.md` and `_iter_root_markdown` drops anything with a `/` in
+    it.  A broken target planted in it returned exit 0 from both gates.  Seven
+    more documents sat in the same hole -- `examples/TESTING.md`,
+    `implementation/adapters/TESTING.md`, the mutually-linked reagent-slim
+    design trio, and the two `tools/mcp-conformance/` vocabularies that
+    `spec/Conventions.md` and `spec/Tool-Pair.md` cite normatively.
+
+    NO NEW EXCLUSION WAS NEEDED, which is the measurement that settled the
+    scope.  `_is_excluded` already drops everything a wider roster must not
+    take: `_test_fixtures` (137 files of deliberately-broken markdown that exist
+    to be flagged -- covering them would red this gate permanently), the
+    docs-gate roots, and `tools/*/spec/` -- which is what keeps the four
+    `tools/*/spec/findings/` design records out.  Those four were measured, not
+    assumed: they carry 33 stale relative targets between them (`../spec/…` from
+    inside `tools/xray/spec/findings/` resolves to `tools/xray/spec/spec/…`),
+    exactly the link rot that `check_doc_slugs.py`'s `findings` exclusion --
+    "excludes exploratory work" -- exists to leave alone.
+
+    The one addition this roster makes beyond the eight is
+    `.../_shared/README_with_ssr.md`, a template payload whose sibling
+    `.../root/README.md` this gate ALREADY walks under the same `_MUSTACHE_RE`
+    guard.  Taking it is the consistent answer, and it is clean today.
+
+    GIT-TRACKED, NOT A FILESYSTEM WALK, for the rf2-k30r7 reason `_iter_root_markdown`
+    records: an author's untracked scratch note must not red a gate that CI runs
+    on a clean clone.
+    """
+    commands = {p.resolve() for p in _iter_command_files(repo_root)}
+    for rel in _git_ls_files(repo_root, "*.md"):
+        if "/" not in rel:
+            continue                      # _iter_root_markdown's roster
+        path = repo_root / rel
+        if path.name == "README.md":
+            continue                      # _iter_readmes' roster
+        if _is_excluded(path, repo_root):
+            continue
+        if not path.is_file():
+            # Tracked but absent mid-rename; the index still lists it.
+            continue
+        # The mayor-loop command files are the THIRD arm's surface (rf2-1yy75),
+        # where they are scanned for path-shaped REFERENCES rather than anchors.
+        # They carry no headings and no markdown links, so taking them here
+        # would find nothing and double-scan seven files -- measured: zero
+        # findings either way.
+        if path.resolve() in commands:
+            continue
+        yield path
+
+
+def _iter_scanned(repo_root: Path) -> Iterable[Path]:
+    """Yield every file this gate validates for links and anchors.
+
+    Three rosters: the README corpus, repo-root markdown (rf2-znup0) and
+    non-README markdown beside source (rf2-i4nb2).  Deduplicated by resolved
+    path, because the repo-root `README.md` is a member of the first two.
     """
     seen: set[Path] = set()
-    for path in _iter_readmes(repo_root):
-        ap = path.resolve()
-        if ap in seen:
-            continue
-        seen.add(ap)
-        yield path
-    for path in _iter_root_markdown(repo_root):
-        ap = path.resolve()
-        if ap in seen:
-            continue
-        seen.add(ap)
-        yield path
+    for roster in (_iter_readmes, _iter_root_markdown, _iter_source_markdown):
+        for path in roster(repo_root):
+            ap = path.resolve()
+            if ap in seen:
+                continue
+            seen.add(ap)
+            yield path
 
 
 # --------------------------------------------------------------------------
@@ -1131,11 +1199,101 @@ def _run_self_tests(verbose: bool = False) -> int:
             "gate while tracked command files stay covered\n"
         )
 
+    # rf2-i4nb2 — the beside-source roster, asserted against the real tree.
+    # Membership is only half of it: what makes this roster safe is what it
+    # REFUSES, and each refusal below is a measured one rather than a taste.
+    live_root = Path(__file__).resolve().parent.parent
+    source_roster = {
+        p.relative_to(live_root).as_posix() for p in _iter_source_markdown(live_root)
+    }
+    must_hold = (
+        # The originating instance: cited from the root README, 36 relative
+        # targets, and no gate opened it before this roster existed.
+        ("implementation/SECURITY.md" in source_roster,
+         "the beside-source roster lost implementation/SECURITY.md"),
+        # Fixture trees are deliberately-broken markdown. Covering them reds the
+        # gate on a correct tree, permanently.
+        (not any(p.startswith("scripts/_test_fixtures/") for p in source_roster),
+         "a gate fixture reached the beside-source roster"),
+        # Exploratory design records: 33 stale targets between the four of them,
+        # left alone on the same standing decision that excludes `ai/`.
+        (not any("/findings/" in p for p in source_roster),
+         "an exploratory findings/ document reached the beside-source roster"),
+        # The third arm's surface -- scanned for path-shaped references, not
+        # anchors. Taking them here would double-scan seven files.
+        (not any(p.startswith(".claude/commands/") for p in source_roster),
+         "a mayor-loop command file is double-covered"),
+        # Rosters must stay disjoint: the other two own these.
+        (not any(p.rsplit("/", 1)[-1] == "README.md" or "/" not in p
+                 for p in source_roster),
+         "the beside-source roster overlaps the README or root-markdown roster"),
+    )
+    for ok, message in must_hold:
+        if not ok:
+            sys.stderr.write(f"self-test FAIL: {message}\n")
+            failures += 1
+    if all(ok for ok, _ in must_hold) and verbose:
+        sys.stderr.write(
+            "self-test PASS: the beside-source roster takes the navigated "
+            f"documents ({len(source_roster)}) and refuses fixtures, findings/ "
+            "and the command files\n"
+        )
+
+    # ... and the same causality tooth the two rosters above carry: an untracked
+    # scratch note beside source must be poisonous to a walk and absent from the
+    # tracked roster. CI runs on a clean clone; an author's scratch must not red
+    # it here (rf2-k30r7).
+    src_scratch = live_root / "implementation" / "i4nb2_untracked_scratch.md"
+    try:
+        src_scratch.write_text(
+            "# Untracked scratch\n\n"
+            "[a link nobody tracked](i4nb2-no-such-file.md)\n",
+            encoding="utf-8",
+        )
+        scratch_is_poisonous = not (
+            live_root / "implementation" / "i4nb2-no-such-file.md"
+        ).exists()
+        walk_roster = {
+            p.name for p in (live_root / "implementation").glob("*.md")
+        }
+        tracked_roster = {
+            p.relative_to(live_root).as_posix()
+            for p in _iter_source_markdown(live_root)
+        }
+    finally:
+        src_scratch.unlink(missing_ok=True)
+
+    if not (scratch_is_poisonous and src_scratch.name in walk_roster):
+        sys.stderr.write(
+            "self-test FAIL: the beside-source scratch fixture is not actually "
+            "poisonous to a walk-based roster, so the tracking tooth proves "
+            f"nothing (broken-target={scratch_is_poisonous}, "
+            f"in-walk={src_scratch.name in walk_roster})\n"
+        )
+        failures += 1
+    elif f"implementation/{src_scratch.name}" in tracked_roster:
+        sys.stderr.write(
+            "self-test FAIL: an untracked scratch note beside source reached "
+            "the beside-source roster\n"
+        )
+        failures += 1
+    elif "implementation/SECURITY.md" not in tracked_roster:
+        sys.stderr.write(
+            "self-test FAIL: the beside-source roster lost a tracked document "
+            "while excluding the untracked one\n"
+        )
+        failures += 1
+    elif verbose:
+        sys.stderr.write(
+            "self-test PASS: an untracked scratch note beside source cannot red "
+            "the gate while tracked beside-source markdown stays covered\n"
+        )
+
     if failures:
         sys.stderr.write(f"\n{failures} self-test failure(s).\n")
         return 1
     if verbose:
-        sys.stderr.write(f"all {len(cases) + 3} self-tests passed.\n")
+        sys.stderr.write(f"all {len(cases) + 5} self-tests passed.\n")
     return 0
 
 


### PR DESCRIPTION
Two same-surface CI-gate beads. Both premises were treated as claims and re-measured at source; one of them changed the conclusion.

## rf2-2yorx — a drifted `SETUP_PATTERNS` entry fails `check_fast_pr_gap.py` OPEN

**Reproduced before changing anything.** Reverting the Playwright entry to its pre-`timeout` form took `--check`'s headline from **96 to 106** while it went on printing `fast-PR gap map clean` at **exit 0**; `--self-test` and `--list` also exited 0. Ten toolchain installs were silently reclassified as required GATES, each carrying a reproduce command telling a reader to run `npx playwright install` locally.

**The fix the bead sketched does not work, and the measurement says so.** A per-pattern "matches at least one required step" floor stays GREEN under that exact drift: **3 of the 13** required Playwright installs are still written bare, so the reverted pattern goes on matching them while the other ten become gates. A discriminator only ever tested on the passing case is untested — so this one was exercised against the answer that is known wrong before being trusted.

**What landed instead** watches the classification rather than the pattern. `SETUP_CANARIES` names a TOOL where `SETUP_PATTERNS` names a CALL SHAPE, and a required GATE step whose *every* line is nothing but toolchain installation is a problem — a pattern that drifted off its call sites, or a call-site shape the patterns never had. The whole-body rule from `is_setup` is kept, so `npm ci` followed by `npm run build` stays a gate.

Post-fix, the identical plant exits **1** with 10 problems naming each drifted call site.

**The new arm immediately found two LIVE instances of the same class**: both `npm install --no-audit --no-fund` steps ("Install implementation deps (for playwright)", "Install fixture deps (shadow-cljs)") were being reported as required checks the spine does not run. `^npm install$` widens to long-flag form — no package argument, no chaining — and the map loses exactly those two false entries.

## rf2-i4nb2 — markdown covered by neither link gate

**Re-derived against the bead's figures; three of the four moved.**

| | bead's claim | measured | why |
|---|---|---|---|
| tracked `.md` (minus `.beads`) | 977 | **977** | confirmed |
| `check_doc_slugs.py` roster | 747 | **744** | four `tools/*/spec/findings/` docs excluded by name |
| `check_readme_links.py --ci` | 138 | **76** | 138 counted every README; 62 sit under the docs-gate roots and are deliberately excluded — the two rosters are DISJOINT by construction |
| orphaned | 128 | **150** | follows from the above |

**But 137 of the 150 are gate test fixtures.** `scripts/_test_fixtures/**` is deliberately-broken markdown the gates' own self-tests consume; covering it is not gold-plating but wrong, and `_test_fixtures` is already an exclusion here. Four more are `tools/*/spec/findings/` design records — measured, not assumed: **33 stale relative targets** between them (`../spec/012-Routing.md` from inside `tools/xray/spec/findings/` resolves to `tools/xray/spec/spec/…`), exactly the exploratory link rot the standing `findings` exclusion exists to leave alone. Covering them would red main on day one.

**That leaves 13, of which 8 are unambiguously navigated** — cited from elsewhere and carrying cross-references someone follows:

- `implementation/SECURITY.md` — cited from the root `README.md`, 36 relative targets incl. cross-file anchors into `spec/`
- `examples/TESTING.md` — 14 inbound citations, 18 relative targets
- `implementation/adapters/TESTING.md`
- `implementation/adapters/reagent-slim/{DESIGN-RATIONALE,FORM-3,IMPL-SPEC}.md` — a mutually-linked trio, each cited from outside
- `tools/mcp-conformance/{NAMING,TOKEN-BUDGETS}.md` — cited **normatively** from `spec/Conventions.md` and `spec/Tool-Pair.md`

**The widening needs no new exclusion.** `_is_excluded` already refuses fixtures, the docs-gate roots and `tools/*/spec/`. The roster is git-tracked, so an untracked scratch note cannot red a gate CI runs on a clean clone. It takes one file beyond the eight — a template payload whose sibling this gate already walks under the same mustache guard — and it is clean today, so this lands green and stands as a ratchet.

**Arming checked, which is the rf2-v7fui trap the bead names.** `verify-readme-links` carries no `if:` and no surface guard, `test.yml`'s PR trigger is deliberately unfiltered, and the job sits in `all-required-passed`'s `needs`. Adding the roster to `check_doc_slugs.py` instead would have repeated the exact defect.

**Explicitly left uncovered, and why that is acceptable:** the 137 fixtures (covering them reds a correct tree), and the 4 `findings/` records (a standing decision, and 33 findings deep). Nothing else — the template payload is now covered rather than excluded, because its sibling already was.

## Quality gates

Cheap, plantable Python checkers — the gates ARE the deliverable here, so each was run and each was sabotaged.

Captured exit codes, all re-run on the **final rebased base** (`f2c344bcef`), each redirect and echo on one command line:

| command | exit |
|---|---|
| `python scripts/check_fast_pr_gap.py` | 0 |
| `python scripts/check_fast_pr_gap.py --self-test` | 0 |
| `python scripts/check_fast_pr_gap.py --list` | 0 |
| `python scripts/check_readme_links.py --ci` | 0 |
| `python scripts/check_readme_links.py --self-test` | 0 |
| `python scripts/check_doc_slugs.py` | 0 |
| `python scripts/check_doc_slugs.py --self-test` | 0 |
| `python scripts/check_workflow_yaml.py` | 0 |
| `python scripts/check_workflow_job_timeouts.py` | 0 |
| `python scripts/check_ci_reproduce_commands.py` | 0 |

**Planted faults, each verified to red naming exactly what was planted, then restored and the restore hashed against the committed object** (`git hash-object` vs `git rev-parse HEAD:<path>`, not a diff):

1. Pre-`timeout` Playwright pattern in `SETUP_PATTERNS` — pre-fix `--check` **exit 0** (96 to 106); post-fix **exit 1**, 10 problems naming each call site. Restore hash `f5253687…` matched.
2. Broken link target appended to `implementation/SECURITY.md` — widened gate **exit 1** naming `implementation/SECURITY.md:269`; the **pre-change gate exited 0** on the identical fault (run from `git show HEAD:` to get a true control), and `check_doc_slugs.py` still exits 0. Restore hash `57ee944f…` matched.
3. Self-test refusals sabotaged in-process: neutering `_is_excluded` reds with *"a gate fixture reached the beside-source roster"* and *"an exploratory findings/ document reached the beside-source roster"*; dropping the command-file skip reds with *"a mayor-loop command file is double-covered"*.

**`--list` before/after.** Not byte-identical, deliberately, and the whole diff is the two false entries the new ratchet found:

```
< REQUIRED CHECKS THIS SPINE DOES NOT RUN (96)
> REQUIRED CHECKS THIS SPINE DOES NOT RUN (94)
<   step "Install implementation deps (for playwright)"
<     $ cd implementation && npm install --no-audit --no-fund
<   step "Install fixture deps (shadow-cljs)"
<     $ cd skills/re-frame2-pair/tests/fixture && npm install --no-audit --no-fund
```

Both are toolchain setup, inspected in `test.yml` to confirm no gate is hidden — a narrowing, in the correct direction, not a fail-open. `docs.yml`'s `npm ci ; npm run build` correctly remains a gate. Post-rebase `--list` is byte-identical to the pre-rebase one.

**Fast-spine-vs-required-CI gap:** `python scripts/check_fast_pr_gap.py --list` — 94 required checks this spine does not run. That is a fact about the SPINE, not a census of what was run here.

**Did I run the fast spine?** No. The diff is two pure-Python gate scripts and touches no workflow, no CLJS and no JVM artefact; the targeted gates above are the controls for it, and each was proven to reach this worktree by a planted fault rather than by a printed banner.

**Verified by hand, since no gate checks prose or tables:** anchors and table column counts in this body, and the `--list` excerpt against the captured logs.
