### PR TITLE
docs(mayor-method): call a restore hash a blob hash so a provenance checker cannot read it as a pin (rf2-nmmlh)

### DIFF
--- a/docs/the-mayor-method/dispatch-prompt-template.md
+++ b/docs/the-mayor-method/dispatch-prompt-template.md
@@ -798,13 +798,20 @@ reads clean too**, because "unchanged" and "not attempted" are the same diff. Th
 plant that silently no-ops makes the sabotage run come back green, so the worker reports a guard that fired when
 nothing was ever broken — a false proof of a real guard, which is worse than no proof.
 
-Hash the file before the plant and compare after the restore. Three cautions:
+Hash the file before the plant and compare after the restore. Four cautions:
 
 * **On a checkout whose line endings are translated, use version control's own content hash against the committed
   object, not a plain byte digest of the working file.** A checkout during a rebase can rewrite the working file
   after you hashed it, so a plain digest reports a *correct* restore as failed. A false "restore failed" is not
   merely noise: the worker's next move is to doubt the whole sabotage result, and the sabotage result is the
   deliverable.
+* **When you write that hash down, call it a *blob* hash in the words immediately before the token.** A content
+  hash is forty hex characters, indistinguishable from a commit id, and the prose carrying it is commit-flavoured
+  by construction — "identical before the plant and after it, against the committed object". A provenance checker
+  that classifies each hex token by the *nearest* description on its left reads "committed", files the token as a
+  citation of a commit that exists nowhere, and reds a gate over the one sentence in the record that describes its
+  own evidence. "The identical blob hash `<token>`" costs a word and settles it; the correct word further left
+  loses to whatever sits closer.
 * **Anchor a patch to a single line.** One worker's multi-line anchor matched nothing, with no error and no edit,
   and only the hash caught it.
 * **A hash proves the SOURCE changed, not that the runtime ever saw it.** One worker planted a one-line fault and


### PR DESCRIPTION
Closes rf2-nmmlh.

## The collision

Two of this project's own rules collide, and the collision recurs for every worker who edits a page under
`docs/design/hicasso/`.

The restore-hashing cautions in `docs/the-mayor-method/dispatch-prompt-template.md` — pasted into every editing
dispatch — tell the worker to verify a planted-fault restore with version control's own content hash against the
committed object, and to record that hash as evidence. `scripts/check_provenance_pins.py` extracts every 40-hex
token on a changed page under `docs/design/hicasso/` and classifies it as a cited authored head unless a digest
word is nearest on its left; an unclassifiable token is a finding by design, so the gate fails toward refusal.

A restore-verification hash is a SHA-1 blob hash, and the prose the caution produces is commit-flavoured by
construction. `committed` is a commit word, `hash` is a digest word but sits further left, nearest wins, and the
token is read as a pin that resolves to no commit.

## Premise verified at source

The bead's claim was checked against the script rather than taken on trust, and it holds exactly as described.

* `_DIGEST_WORDS` (`scripts/check_provenance_pins.py:291`) matches `blob|digest|sha-?256|fnv|checksum|hash`;
  `_COMMIT_WORDS` (`:294`) matches `commit|authored|…|committed|…`.
* `classify()` (`:561`) collects every left-context signal, sorts by end offset, and takes the last — nearest wins,
  and a tie goes to the PIN reading. Left context is the token's own line prefix plus up to `_LEFT_LINES = 2` whole
  lines above, stopping at a blank line or the start of its own table row. A digest word within
  `_RIGHT_APPOSITION = 14` characters to the right also demotes the token.
* Driven directly against `classify()` with the three phrasings, from a throwaway probe outside the tree:
  * `…verified by hashing the bytes against the committed object: <sha>` → `is_pin=True`, reason
    `commit word 'commit' nearest on the left` — the collision, reproduced.
  * `…the SHA-1 blob hash <sha> was identical` → `is_pin=False`, `digest word 'hash' nearest on the left`.
  * The corpus phrasing that PR #8536 landed, with `blob` ending the line above the token → `is_pin=False`,
    `digest word 'blob' nearest on the left`.
* The concrete instance is real: `git cat-file -t 3dd95e0c268db8b517c802142b2a37de0acbae67` returns `blob`, and
  `docs/design/hicasso/studio/the-level-witness-armed-within-one-run.md` already carries the workaround.

So the gate's designed escape works and needs no gate change to be usable. This PR takes the bead's option (a) —
one caution in the brief, at the source — and nothing else. `scripts/check_provenance_pins.py` is untouched;
`_DIGEST_WORDS` is not widened.

## The change

One bullet added to the restore-hashing cautions, where the hash instruction already lives, and the list's count
word moved from "Three" to "Four". The method tree is the generic layer, so the sentence names the mechanism
without naming this repository's script, tree or constant: a content hash is forty hex characters that a
provenance checker classifying by the nearest description on its left will read as a commit id, so call it a
*blob* hash in the words immediately before the token.

## Quality gates

**1. Did `scripts/test-fast-pr.sh` run at all?** No. The diff is one markdown page in `docs/`, and the gate that
covers that path was run directly, with a planted-fault control.

**2. Targeted gates, exit codes captured by this worker** (redirect and `echo $?` on one command line; the numbers
below are the ones that shell wrote, not any figure reported about the run):

| Run | Command | Captured exit |
| --- | --- | --- |
| 1 | `python scripts/check_doc_slugs.py --verbose` (baseline, edit committed) | 0 — `744 markdown files across 11 roots`, `no broken links.` |
| 2 | `python scripts/check_doc_slugs.py` (sabotage) | 1 |
| 3 | `python scripts/check_doc_slugs.py` (restored) | 0 |
| 4 | `python scripts/check_doc_slugs.py --verbose` (restored) | 0 — `no broken links.` |
| 5 | `python -m mkdocs build --strict` (site dir outside the tree) | 0 — built in 36.08s |

`docs` is one of `check_doc_slugs.py`'s `DEFAULT_ROOTS`, so it is the link-and-anchor gate for this path.
`mkdocs.yml`'s `exclude_docs` block was read at source before nominating the site build: it excludes
`tools/playground/`, the two codemod trees, `design/freehand/`, `design/hicasso/` and `design/retirement/` —
`the-mayor-method/` is not among them, and the build log lists `the-mayor-method/dispatch-prompt-template.md`
among the pages it rendered. `scripts/check_readme_links.py --ci` is not nominated: no `.claude/commands/*.md`,
no README and no repo-root markdown is touched by this diff.

**Which tree did the gate read?** `check_doc_slugs.py` prints per-root file counts, not a checkout root, so the
proof is the red from a planted fault. A single-line-anchored broken link target was planted in the bullet this PR
adds; run 2 came back exit 1 naming it — `BROKEN TARGET: docs\the-mayor-method\dispatch-prompt-template.md:813 ->
./no-such-page-restorehash.md`. That fault existed in this branch's checkout and nowhere else, so a run that had
wandered into another tree would have come back green.

**Restore verified by hashing the bytes, not by reading a diff** — and written the way this PR now prescribes: the
blob hash `0e1b3d9cd75c04af025f6d4fbc902004b6fb44e4` was identical before the plant and after the restore, matching
the object the index already held, while the planted state hashed
`0695cbbd0ad14995c604922d8cf7a897c2502e07` — so the plant genuinely applied rather than silently no-opping.

**3. Fast-spine versus required-CI gap.** Derived by `scripts/check_fast_pr_gap.py --list` (read only; that script
is being edited by a live peer). It reports **96 required checks the fast spine does not run**, under the three
required contexts `All required checks passed` (test.yml), `Lint required` (lint.yml) and `Docs required`
(docs.yml). The spine did not run here at all, so the whole of that surface is CI's to decide. Of note for this
diff: `test.yml`'s `verify-readme-links` job runs `check_doc_slugs.py` unconditionally on every PR, and `docs.yml`
runs the MkDocs build with staging steps a local build does not perform.

**Verified by hand, because nothing gates it.** No headings, no markdown links and no table rows are added or
changed by this diff, so there are no new anchors or link targets to check and no table column counts to count.
Checked by eye instead: the list's count word now reads "Four" and the block holds four bullets; the new bullet
wraps at 115 columns, matching its neighbours; the only inline code span added is `<token>`, a placeholder that
renders literally inside backticks. The merge-base diff (`origin/main...HEAD`) is eight added lines and one
changed word, reverting nothing a sibling landed.
