### PR TITLE
docs(retire): sweep retired-substrate residue from implementation source comments (rf2-0yp7w.9)

### DIFF
--- a/implementation/core/src/re_frame/trace.cljc
+++ b/implementation/core/src/re_frame/trace.cljc
@@ -590,10 +590,8 @@
   1. THE EMIT SITE DIDN'T ALREADY SUPPLY ONE. `:frame` under `tags` is
      authoritative wherever the site stamps it: a `:rf.frame/created`
      for a dynamically constructed frame B is tagged `{:frame B}` while
-     the ambient frame is still A (rf2-7eel71), and the `:rf.ui`
-     cross-frame carried-op warning deliberately names its two frames
-     `:origin-frame` / `:ambient-frame` and carries no bare `:frame` at
-     all. This fn only supplies the tag; it never overrides one.
+     the ambient frame is still A (rf2-7eel71). This fn only supplies
+     the tag; it never overrides one.
 
   2. THE EMIT IS CORRELATED TO A RUN — its tags carry a
      `:rf.trace/dispatch-id`. Spec 009 is explicit that


### PR DESCRIPTION
One sub-surface of rf2-0yp7w.9: **source comments and docstrings under `implementation/**/src/` plus the `implementation/adapters` READMEs**, and nothing else. Sibling slices hold `docs/design/freehand/**` + `skills/**`; `spec/**`, `tools/**`, `docs/**` and every `test/` tree are out of scope here.

The net change is **one docstring**. Most of what the bead's census counted is either already-correct prose, a deliberate tombstone, or a frozen source that cannot be edited. Those are findings, not omissions, and they are set out below.

## Census, re-derived at HEAD

The bead's counts were measured 2026-08-15, before PR #8485 landed. Re-derived with two independent patterns, each with a positive control so an empty result means "nothing there" rather than "wrong pattern", and every sweep run with `-- ':!.beads'`:

| directory | files | lines |
|---|---|---|
| `implementation/core/src` | 2 | 2 |
| `implementation/ssr/src` | 1 | 2 |
| `implementation/ssr-ring/src` | 0 | 0 |
| `implementation/routing/src` | 0 | 0 |
| `implementation/hicasso/src` | 4 | 10 |
| `implementation/adapters/**/README.md` | **0** | **0** |

Two corrections to the bead:

- **The adapters READMEs are clean.** The bead's "3 files / 7 lines" under `implementation/adapters` are all under `implementation/adapters/reagent/test/**` and `uix/test/**` — a `test/` tree, out of this slice. Verified with a positive control on the glob itself (`adapter` matches 90 lines across the 5 READMEs), so the zero is a real zero rather than a mis-typed pathspec.
- **`core/src` has 2 hits, not 1.** The bead's pattern `re-frame\.ui[^-]` does not match the `:rf.ui` keyword spelling. The broader pattern found `trace.cljc:593` — and that is the one genuine residue in the whole slice.

A dead-*path* / dead-*namespace* sweep (`implementation/freehand`, `implementation/ui`, `re-frame.freehand`, `re-frame.ui`, fixed-string) closes the census: every remaining hit is in `slot.cljc` or `ssr/ui_tree.cljc`, both handled below.

Note that `:rf.ui/*` is a **live** keyword namespace — the UI-tree data contract that `re-frame.ssr` and the Hicasso test-kit both read (`:rf.ui/tree-version`, `:rf.ui/opaque`, `:rf.ui/property-props`). It is not residue and was not swept.

## The one change

`implementation/core/src/re_frame/trace.cljc` — `stamp-frame`'s condition-1 docstring gave two illustrations of "the emit site didn't already supply a `:frame`". The second named the `:rf.ui` cross-frame carried-op warning. `spec/009-Instrumentation.md` records `:rf.warning/cross-frame-carried-op` as **RETIRED** — "emitted only by the compiled `re-frame.ui` view substrate, retired and removed with that artefact (rf2-0yp7w)".

Checked for a live emit to rename it to: `:origin-frame` / `:ambient-frame` appears only in the retired warning's schema in `spec/Spec-Schemas.md` and in an unrelated `test_support.cljc` fixture option (EP-0002). There is no live emit of that shape, so there is no name to swap in and the clause is dead rather than merely misnamed.

**Dropped the clause, kept the explanation.** The live `:rf.frame/created` example and the governing sentence both survive, so condition 1 is still illustrated and still reasoned — not reduced to a bare fact.

## What was deliberately NOT changed

Four hits match the greps but are load-bearing. Deleting them is the failure mode the bead warns about.

1. **`core/src/re_frame/substrate/adapter.cljc:27`** — `:rf.adapter/ui`, `:rf.adapter/freehand` "stay reserved and are never recycled, per the Conventions tombstone rule". This is a live **tombstone**: it exists precisely *because* those members are retired. Deleting it would license recycling the keywords.

2. **`ssr/src/re_frame/ssr/ui_tree.cljc:42-43`** — already correctly reframed. It explains that the DOM-conversion tables were once a verbatim copy of `re-frame.ui.rules` / `re-frame.ui.semantic`, then states: "**That substrate has been retired (rf2-0yp7w), so these tables are now the ORIGINALS and the pin is gone.**" That is the live explanation for why these rows are authoritative and why no pin guards them. Textbook "explains a live mechanism by contrasting with the retired substrate".

3. **`hicasso/src/.../impl/slot.cljc:37, 62, 73, 82`** — **REFUSED, and this is the correct outcome.** Line 37 is in a **frozen source**: `implementation/hicasso/frozen-sources.edn` row 242-243 pins `bench "front/slot.cljc"` to `package "src/re_frame/hicasso/impl/slot.cljc"`, and the freeze gate reconstructs the file line by line from the donor. A docstring is a string and a string is code, so editing that line reds MOVED. The other three hits are the *sanctioned repair* already made under **rf2-o9yo4** — an inserted comment note that says `implementation/freehand` on purpose, and whose closing line reads "if you arrived here from a grep for `freehand`, this is the answer". Sweeping it would delete the answer to the very grep that found it.

4. **`hicasso/src/.../forms.cljs:37`, `impl/intent.cljs:241`, `impl/route_link.cljs:18, 39, 44, 153`** — Freehand as a **design lineage**, not as code.

   This turns on a distinction worth recording: `implementation/freehand/` (the code) is gone, but **`docs/design/freehand/` is live** — 37 tracked files including a complete decision record D001 to D022. So `forms.cljs`'s citation of `docs/design/freehand/decisions/D016-buffered-and-revision-controls.md` resolves to a real file, and `route_link.cljs`'s "From Freehand (taken)" / "(Declined:" bullets are one arm of a three-donor comparative design record (routing / Freehand / Replicant) whose donor is still readable. These reference a design record that exists, not "a namespace that no longer exists". Left intact.

## Quality gates

1. **`scripts/test-fast-pr.sh` did NOT run.** The machine is running a bench-class allocation window (`worker/armsched-rs8q6`), and two heavyweight gates on one box wedge rather than fail. The diff is one docstring, so the full spine is not the proportionate gate — the targeted gates below prove what this change can actually break.

2. **Targeted gates, exit codes captured by me** (redirect plus `echo $?` on one command line, never piped through a filter):

   | gate | exit | result |
   |---|---|---|
   | `clojure -M -e "(require 're-frame.trace) ..."` (in `implementation/core`) | **0** | `:LOADED-OK true` |
   | `clj-kondo --lint implementation/core/src/re_frame/trace.cljc` | **0** | 0 errors, 0 warnings |

   The namespace load is the authoritative proof: a docstring edit can only break the file by unbalancing the string or the enclosing form, and a successful compile-and-resolve excludes both. **The clj-kondo pass is corroborating only, not authoritative** — the local binary is v2025.10.23 while CI pins 2026.04.15, and per `check_fast_pr_gap.py`'s own note a differently-versioned local pass proves nothing about the pinned job.

3. **Tree verification — planted fault, both gates red.** Confirmed both gates read *this* worktree rather than a sibling's: planted a string-terminating quote at line 593, the exact line edited (single-line anchor; content hash changed from `49930d6b...` to `6608b75c...`, so the patch demonstrably applied rather than silently no-opping).

   - `clj-kondo` → **exit 3**, `trace.cljc:597:7: error: Invalid character ... found while reading keyword`
   - namespace load → **exit 1**, `Syntax error reading source at (re_frame\trace.cljc:597:39)`

   Both named the edited file. The fault existed only in this worktree, so a run that had wandered into a sibling checkout would have come back green. Restored and **verified by content hash, not by reading a diff**: `git hash-object` back to `49930d6bd39b3dad1e197d195881bd1b7927bd66`, byte-identical to pre-plant, zero plant residue. Both gates re-run green afterwards (exit 0 / exit 0).

4. **`check_readme_links.py --ci` is not nominated, because no README is touched.** It *is* the right gate for `implementation/adapters/**/README.md` — those sit outside `check_doc_slugs.py`'s `docs` / `spec` / `skills` / `migration` plus `tools/*/spec` roots, where that script exits 0 on a broken link — but the census found zero residue in them, so this diff presents no surface for it. `check_doc_slugs.py` is likewise not the gate here: `implementation/**` is outside its roots entirely.

5. **Fast-spine-versus-required-CI gap**, derived solely via `scripts/check_fast_pr_gap.py --list` (exit 0): **94 required checks the spine does not run** — steps inside jobs the spine does run, plus 40 `test.yml` jobs, 4 `lint.yml` jobs and 1 `docs.yml` job with no spine lane at all. Most are surface-gated and skip on a diff that does not reach them; the claim is only that none of them is decided locally.

6. **Rebased onto a moved trunk, and every gate re-run on the final base.** The trunk advanced 8 commits while this was in flight (base `065c5f9a95` → `e59b3716bd`). Nothing touched `trace.cljc`, and the rebase was clean with the file's content hash unchanged at `49930d6b...` — but re-deriving the gap on the final base **changed the number**, from 96 to 94, because `35137eca3d` ("red the fail-open where a drifted `SETUP_PATTERNS` entry inflates the gap map", rf2-2yorx) landed in the interval and de-inflated section (A) by two. The figure quoted above is the post-rebase one; section (B) is unchanged at 40 / 4 / 1. Post-rebase re-runs: `clj-kondo` exit **0**, namespace load exit **0** (`:LOADED-OK`), gap script exit **0**.

7. **Prose verified by hand.** Nothing validates prose, so I read the rewritten docstring back in full. The surviving sentence — "...a `:rf.frame/created` for a dynamically constructed frame B is tagged `{:frame B}` while the ambient frame is still A (rf2-7eel71). This fn only supplies the tag; it never overrides one." — is grammatical, complete, and still supports the "TWO conditions" numbered structure that follows it. No tables were touched, so no column counts are affected. One file changed, 2 insertions, 4 deletions; the merge-base (three-dot) diff was read before pushing to confirm nothing a sibling landed is reverted.

Does not close rf2-0yp7w.9 — sibling slices remain.
