### PR TITLE
docs(retire): record the docs/design/freehand/ KEEP ruling on the authority page (rf2-72vvj)

### DIFF
--- a/docs/design/retirement/freehand-and-ui.md
+++ b/docs/design/retirement/freehand-and-ui.md
@@ -21,11 +21,11 @@ plan's deletions — has been overtaken and must not be re-cited: `docs/design/f
 ruled `rf2-0moc4` on 2026-08-18. The record of that ruling is in
 [§What is in each phase](#what-is-in-each-phase) below, beside the R6 surface list that used to
 imply otherwise.** The separation stands on the readability reason alone, which is enough.
-`docs/design/retirement/`
-is a new sibling of `design/freehand/` and `design/hicasso/`, added to `mkdocs.yml`'s
-`exclude_docs` the same way they are: a working design record, tracked and greppable, not a page
-of the built site. `scripts/check_doc_slugs.py` still validates its links and anchors, and that
-checker runs unconditionally in `test.yml`'s `verify-readme-links` job.
+
+`docs/design/retirement/` is a new sibling of `design/freehand/` and `design/hicasso/`, added to
+`mkdocs.yml`'s `exclude_docs` the same way they are: a working design record, tracked and
+greppable, not a page of the built site. `scripts/check_doc_slugs.py` still validates its links and
+anchors, and that checker runs unconditionally in `test.yml`'s `verify-readme-links` job.
 
 ## The census, re-taken
 
@@ -389,10 +389,10 @@ as an instruction to delete has misread it twice.
 anchors its measurement numbers to the frozen studio tree — `docs/design/hicasso/studio/README.md`
 records that `docs/design/freehand/studio/` "is frozen and is never extended", which is a statement
 about the tree's role, not merely about its contents. Deleting the design tree would pull that
-measurement baseline out from under a live evidence chain. That coupling is measured rather than asserted: deleting the
-37 files takes `scripts/check_doc_slugs.py` to **exit 1 with four broken targets**, all four inbound
-from `docs/design/hicasso/` — `hd-002-adjudication.md:158` and `:566` pointing at
-`../freehand/studio/bulk-rerender-where-the-time-goes.md`, and `product/requirements-mine.md:15`
+measurement baseline out from under a live evidence chain. That coupling is measured rather than
+asserted: deleting the 37 files takes `scripts/check_doc_slugs.py` to **exit 1 with four broken
+targets**, all four inbound from `docs/design/hicasso/` — `hd-002-adjudication.md:158` and `:566`
+pointing at `../freehand/studio/bulk-rerender-where-the-time-goes.md`, and `product/requirements-mine.md:15`
 and `:108` pointing at `../../freehand/studio/fitness-harness.md`. Two dispatches two days apart
 derived that same figure independently.
 

--- a/docs/design/retirement/freehand-and-ui.md
+++ b/docs/design/retirement/freehand-and-ui.md
@@ -14,9 +14,14 @@ kept as evidence and is no part of this plan — is [`donor-surfaces.md`](donor-
 
 ## Why this page is not in `docs/design/freehand/`
 
-The obvious home is the withdrawn programme's own design tree — but that tree is one of the things
-this plan deletes, and a plan filed inside its own demolition site stops being readable at exactly
-the moment someone needs to check whether the demolition was complete. `docs/design/retirement/`
+The obvious home is the withdrawn programme's own design tree, and a plan filed inside its own
+subject stops being readable at exactly the moment someone needs to check whether the demolition
+was complete. **The stronger reason first given here — that the design tree was itself one of this
+plan's deletions — has been overtaken and must not be re-cited: `docs/design/freehand/` is KEPT,
+ruled `rf2-0moc4` on 2026-08-18. The record of that ruling is in
+[§What is in each phase](#what-is-in-each-phase) below, beside the R6 surface list that used to
+imply otherwise.** The separation stands on the readability reason alone, which is enough.
+`docs/design/retirement/`
 is a new sibling of `design/freehand/` and `design/hicasso/`, added to `mkdocs.yml`'s
 `exclude_docs` the same way they are: a working design record, tracked and greppable, not a page
 of the built site. `scripts/check_doc_slugs.py` still validates its links and anchors, and that
@@ -367,11 +372,40 @@ were re-measured immediately before the cut rather than inherited: external `FH-
 `check_doc_slugs.py` and `check_readme_links.py` both exited 0 afterwards. R5's own bead
 (rf2-0yp7w.8) closes as absorbed rather than being dispatched as a second corpus deletion.
 
-**R6** is the remaining ~237 prose files: `docs/design/freehand/`, the `docs/api` pages, `docs/skills`,
+**R6** is the remaining ~237 prose files: `docs/design/freehand/` — **in scope for editing and never
+for deletion; see the ruling immediately below** — the `docs/api` pages, `docs/skills`,
 `skills/re-frame2-ui/` entire, `mkdocs.yml`'s nav, the root `README.md`/`CHANGELOG.md`/`AGENTS.md`/
 `CLAUDE.md` mentions, `spec/Conventions.md`'s Freehand section and `:rf.adapter/*` row,
 `spec/006-ReactiveSubstrate.md`'s adapter table, `spec/API.md`'s rows, `spec/Ownership.md`, and the
 ~80 comment and docstring lines left in `core/src`, `ssr/src`, `ssr-ring/src` and `tools/xray/src`.
+
+**`docs/design/freehand/` is KEPT — ruled `rf2-0moc4` on 2026-08-18, after two workers in
+succession refused an instruction to delete it.** Its 37 tracked files stay where they are with
+their contents untouched. Appearing in the R6 list above means only that they are edited for stale
+status like any other prose surface; it has never meant they are removed, and a sweep that reads it
+as an instruction to delete has misread it twice.
+
+**The deciding reason is the hicasso coupling.** `docs/design/hicasso/` is itself ruled kept, and it
+anchors its measurement numbers to the frozen studio tree — `docs/design/hicasso/studio/README.md`
+records that `docs/design/freehand/studio/` "is frozen and is never extended", which is a statement
+about the tree's role, not merely about its contents. Deleting the design tree would pull that
+measurement baseline out from under a live evidence chain. That coupling is measured rather than asserted: deleting the
+37 files takes `scripts/check_doc_slugs.py` to **exit 1 with four broken targets**, all four inbound
+from `docs/design/hicasso/` — `hd-002-adjudication.md:158` and `:566` pointing at
+`../freehand/studio/bulk-rerender-where-the-time-goes.md`, and `product/requirements-mine.md:15`
+and `:108` pointing at `../../freehand/studio/fitness-harness.md`. Two dispatches two days apart
+derived that same figure independently.
+
+Two further facts stand behind the ruling, neither of them the deciding one. `docs/EP/EP-0036` —
+which the EP paragraph below rules is kept — states under §Design-record posture that the tree "is a
+durable, frozen supporting record" which "remains after spec graduation", so deleting it would make
+a kept EP false. And `mkdocs.yml`'s `exclude_docs` already holds `design/freehand/` out of the
+published site, so keeping the tree costs the docs build nothing.
+
+**One support the ruling originally leaned on has since lapsed, and citing it now would be wrong.**
+It rested partly on 11 markdown links from `spec/004-Views.md` that `check_doc_slugs.py` validated
+on every PR; that file has since been deleted and those links went with it. Nothing about the
+hicasso coupling depends on it, so the ruling stands unchanged on the four links above.
 
 **`docs/EP/EP-0030` through `EP-0036` are historical programme records and this plan does not
 delete them.** A withdrawn programme's EP is the reason the withdrawal is legible; deleting it


### PR DESCRIPTION
## What and why

`docs/design/retirement/freehand-and-ui.md` is named by `donor-surfaces.md` as **the authority**
for the `re-frame.freehand` / `re-frame.ui` retirement programme. It listed `docs/design/freehand/`
among R6's ~237 in-scope prose files and recorded **nothing** about the KEEP ruling. A reader
consulting the named authority therefore got the superseded answer, and the correct one was
reachable only by finding a closed bead.

Two dispatches in succession read that listing as an instruction to delete the tree and refused,
each re-deriving the same evidence from scratch. This PR writes the ruling down where the next
sweep will meet it. **It records a decision already taken; it does not take one, and it deletes
nothing.**

## Premises checked at source (all held)

| Claim | Verified |
|---|---|
| `rf2-0moc4` ruled KEEP on 2026-08-18 | Yes — `bd show`: *"RULED (a) KEEP — `docs/design/freehand/` stays, contents untouched"*, and its point 3 names the hicasso coupling as **the deciding reason** |
| The passage is "around L370" | **L370 exactly**, in `### What is in each phase`. The ruling's own text cites "line 305" — that had drifted, as the brief warned |
| A **second** superseded claim, not in the brief | **L17–18** also said *"that tree is one of the things this plan deletes"*. Corrected too |
| Tree is 37 tracked files | Yes — `git ls-files docs/design/freehand \| wc -l` = 37 |
| Four inbound hicasso links, at the cited lines | Yes — `hd-002-adjudication.md:158`, `:566`; `product/requirements-mine.md:15`, `:108`. **Re-verified on the final rebased base**, since an incoming commit touched `docs/design/hicasso/` |
| Both link targets still exist | Yes |
| `mkdocs.yml` `exclude_docs` holds the tree out of the site | Yes |
| The `spec/004-Views.md` support has lapsed | Yes — `git ls-files spec/004-Views.md` returns nothing; the file is gone |
| `docs/EP/EP-0036` already asserts the tree remains | **Yes — needs nothing, changed nothing.** See below |

### `docs/EP/EP-0036` needed no change

`docs/EP/EP-0036-the-freehand-view-substrate-programme.md` is already correct on both counts. Its
2026-08-16 historical-record banner states the design record *"is not affected — `docs/design/freehand/`
remains a durable frozen record ... re-affirmed by the `rf2-0moc4` ruling of 2026-08-18"*, and its
§Design-record posture still carries the durable-frozen-record statement the ruling quotes. **No edit
made there.**

## What changed

One file, two regions of prose. No table was added or altered.

- **L17–23** — the "Why this page is not in `docs/design/freehand/`" rationale no longer claims the
  plan deletes the tree. The lapsed reason is flagged as overtaken rather than silently dropped, and
  cross-links to the new record.
- **L375–380** — the R6 surface list now says `docs/design/freehand/` is *in scope for editing and
  never for deletion*.
- **L382 onward** — the new passage: the ruling, its **deciding** reason (the hicasso coupling) with
  the measurement, the two **supporting** facts marked as supporting, and the one support that has
  **lapsed** flagged so it is not re-cited.

## Quality gates

**1. `scripts/test-fast-pr.sh` did NOT run.** The diff is one Markdown file under
`docs/design/retirement/`, and the machine is carrying a bench-class allocation window on another
branch, so no heavyweight suite was started.

**2. Targeted gates run directly, with exit codes captured by this worker's own shell** (redirect and
`echo $?` on one command line; never piped, never read from the harness):

| Gate | Captured exit |
|---|---|
| `python scripts/check_doc_slugs.py` (clean, pre-rebase) | **0** |
| `python scripts/check_doc_slugs.py` (**broken-link plant**) | **1** |
| `python scripts/check_doc_slugs.py` (**broken-anchor plant**) | **1** |
| `python scripts/check_doc_slugs.py` (final, **post-rebase**) | **0** |
| `python scripts/check_readme_links.py --ci` (final, **post-rebase**) | **0** |

`docs/` is one of `check_doc_slugs.py`'s `DEFAULT_ROOTS` (read at source, `scripts/check_doc_slugs.py:93`),
so it is the gate for this path.

**Which tree the gate read, proved by planted fault.** The gate prints no root banner, so the
discriminating route was the red. Two plants, both at lines this PR is already editing:

- A link to `./retkeep-72vvj-plant-no-such-file.md` — a filename that exists in no other checkout.
  The gate returned **exit 1**, `BROKEN TARGET: docs\design\retirement\freehand-and-ui.md:409 -> ./retkeep-72vvj-plant-no-such-file.md`.
  A run that had wandered into a sibling worktree would have come back green.
- The new cross-link's anchor mangled to `#what-is-in-each-phase-retkeep-plant`. **Exit 1**,
  `BROKEN ANCHOR: ...:22`. This was planted specifically to prove the one novel construct in the
  diff — an intra-page anchor link — is actually gated rather than assumed to be.

**Both restores verified by hashing, not by reading a diff.** The file carries the identical blob
hash `3bc59e5cb2308009439846390856a45589f9cd47` before the first plant and after each restore.

**3. Gates deliberately NOT nominated, checked at source rather than assumed:**

- **`mkdocs build --strict` does not reach this file.** `mkdocs.yml`'s `exclude_docs` block lists
  `design/retirement/` (alongside `design/freehand/` and `design/hicasso/`), read at source.
- **`scripts/check_provenance_pins.py` does not reach this file.** Its `DEFAULT_ROOT` is
  `docs/design/hicasso` (`scripts/check_provenance_pins.py:247`); this page is under
  `docs/design/retirement/`.

**4. Fast-spine versus required CI.** `python scripts/check_fast_pr_gap.py --list` reports
**94 required checks the fast spine does not run**, under the three required contexts
`All required checks passed` (test.yml), `Lint required` (lint.yml) and `Docs required` (docs.yml).
Since the spine did not run here at all, that whole gap plus the spine's own contents is undecided
locally — CI decides it. The two gates above were run directly for that reason.

## Verified by hand, because nothing gates prose

- **Anchors.** One anchor link is added, `#what-is-in-each-phase`, resolving to the existing
  `### What is in each phase` heading in the same file. Machine-checked by the gate and additionally
  proved gated by the anchor plant above. No heading was added, renamed or removed, so no existing
  anchor moved.
- **Tables.** **No table added, removed or edited** — both changed regions are prose paragraphs.
  Column counts in the page's existing tables are untouched.
- **Quotations.** Every quoted string was copied from its source, not recalled:
  `docs/design/hicasso/studio/README.md:13` for *"is frozen and is never extended"*, and
  `docs/EP/EP-0036-...:300–302` for *"durable, frozen supporting record"* / *"remains after spec
  graduation"*.
- **Reflow.** The second commit only re-wraps the new passage to the page's width; no wording change.

## Fence

Re-derived at start-up and again before the first edit, from `gh pr list --state open --json number,headRefName,files`
and a `git status --porcelain` sweep of every worker worktree: **no open PR and no peer worktree
touches `docs/design/retirement/` or `docs/EP/EP-0036*`.** This PR touches one file, in neither the
hot zone nor any peer's surface. `docs/design/hicasso/` and `docs/design/freehand/` were **read only**.
