### PR TITLE
docs(retire): sweep config/root-markdown/migration for Freehand residue - 1 correction, 55 reasoned keeps (rf2-0yp7w.9)

### DIFF
--- a/migration/reagent-to-hicasso/codemod/README.md
+++ b/migration/reagent-to-hicasso/codemod/README.md
@@ -301,11 +301,16 @@ extracted rule landed at `implementation/freehand/test/…/bench/hicasso/front/
 slot.cljc`; `rf2-hic-001` then moved the runtime into `implementation/hicasso/`,
 and `frozen-sources.edn` pins the two files byte-for-byte under the rename. Both
 therefore answer identically today, which is precisely why the pin has to
-name one: Freehand is retired, its tree goes, and a codemod whose only classpath
-entry sat inside it would go red — `-M:test` and `-M:run` alike — the day that
-happened, in a tool whose whole job is to run after the retirement. The path is
+name one: Freehand was retired and its tree deleted (`rf2-0yp7w`, 2026-08-16),
+and a codemod whose only classpath entry had sat inside it would have gone red
+— `-M:test` and `-M:run` alike — on the day of that cut, in a tool whose whole
+job is to run after the retirement. The path is
 `implementation/hicasso/src`, and `shared_rule_test.clj` fails on a rule loaded
-from the bench tree as loudly as on one copied into `src/`.
+from the bench tree as loudly as on one copied into `src/`. That cut re-homed the
+prototype rather than deleting it, so the twin this deliberately does NOT read is
+now `implementation/hicasso/test/re_frame/bench/hicasso/front/slot.cljc` — both
+copies still exist, which is what keeps the guard load-bearing rather than
+vestigial.
 
 Reagent's own key function is a second rule and does live here, in
 `donor.clj` — but written as the shared rule plus its two named deltas (a string


### PR DESCRIPTION
## What this is

One slice of `rf2-0yp7w.9` — the **configuration, root-markdown and migration** sub-surfaces of the Freehand/re-frame.ui prose sweep. Do not close `rf2-0yp7w.9`; other sub-surfaces remain.

**The headline is a refusal.** 55 of the 56 pattern hits in this slice are **correct as they stand** and were kept, with reasons below. One file lagged and was corrected.

## Census (re-derived, not inherited)

`git grep -cEi 'freehand|re-frame\.ui[^-a-z]|re_frame\.ui|re-frame2-ui[^x]' -- <path> ':!.beads'`, re-run on the final rebased base:

| file | hits | verdict |
|---|---|---|
| `TESTING.md` | 43 | KEEP all |
| `mkdocs.yml` | 7 | KEEP all |
| `CHANGELOG.md` | 2 | KEEP both |
| `CLAUDE.md` | 1 | KEEP |
| `docs/release-process.md` | 2 | KEEP both |
| `migration/reagent-to-hicasso/codemod/deps.edn` | 4 | KEEP all |
| `migration/reagent-to-hicasso/codemod/test/.../shared_rule_test.clj` | 3 | KEEP all |
| `migration/reagent-to-hicasso/codemod/README.md` | 2 | **corrected** |

Positive control on the same command shape: `reagent` returns 4 in `README.md`. Independent control: `git ls-files implementation/ui implementation/freehand` returns 0 rows, so the trees really are gone. `migration/from-re-frame-v1/README.md` carries **zero** hits and was not touched.

## The one change

`migration/reagent-to-hicasso/codemod/README.md` explained the codemod's classpath choice in **anticipatory tense** — "Freehand is retired, its tree goes ... the day that happened" — and left a reader believing the prototype twin it deliberately does *not* read still sat under `implementation/freehand/`, a path that no longer exists.

Its two siblings already carry the correction, and this file was the one that lagged:

- `deps.edn`: "rf2-0yp7w P0 then re-homed the PROTOTYPE too ... the twin this deliberately does NOT read is now at `implementation/hicasso/test/.../front/slot.cljc`"
- `shared_rule_test.clj`: "rf2-0yp7w P0 RE-HOMED the twin ... so both copies still exist and the namespace guard below is load-bearing rather than vestigial"

The edit past-tenses the cut and states where the twin now lives. **No decision changes**: the classpath still points at `implementation/hicasso/src`, the shipped door. Verified at source that both slot files exist and that `frozen-sources.edn` still pins `front/slot.cljc`.

## Why the other 55 stayed

- **`CLAUDE.md` (1)** — the single hit *is* the retirement note itself, the paragraph telling every future agent these trees are gone and that surviving references are residue. The most load-bearing mention in the repository. Untouched.
- **`CHANGELOG.md` (2)** — a changelog that no longer mentions a retired artefact lies about what happened. One hit records why `day8/re-frame2-ui` will never exist; the other is release-ordering history explaining the *live* `xray-v*`-after-`v*` obligation.
- **`mkdocs.yml` (7)** — six are rationale comments; the seventh is the `exclude_docs` entry for `design/freehand/`, and that tree is ruled **KEEP** (rf2-0moc4, re-affirmed on main during this PR by rf2-72vvj). **No hit is a nav entry**, so there is no residue here. Separately verified that all 185 nav `.md` targets resolve, accounting for `mkdocs_hooks.py` staging `migration/` and `spec/` into `docs_dir`.
- **`docs/release-process.md` (2)** — one is the live normative statement of the release artefact set, explaining why an artefact a reader might expect is absent; the other is closed-obligation history explaining the live ordering obligation that replaced it.
- **`migration/.../deps.edn` (4) and `shared_rule_test.clj` (3)** — all in comments and a `testing` docstring that explain *live* design decisions. The live `:paths` value is `../../../implementation/hicasso/src`; no dead path. `shared_rule_test.clj`'s comment explains why its guard is spelled by namespace (`re_frame/bench/`) rather than by the old `/implementation/freehand/` tree address — deleting it invites the slack guard back.
- **`TESTING.md` (43)** — **the premise that these are "the bulk of the job and most likely genuine residue" does not hold; the file was already swept.** Every mention is either a past-tense record of the retirement with the live consequence stated, or a reusable rule whose subject happened to be the retired substrate. Measured rather than eyeballed: of 41 gate tokens named in the file, 12 are absent from `implementation/package.json`, and **every one appears inside an explicitly past-tense retirement sentence** — for example "`test:ui-warm-watch` retired with its artefact ... a gate leaving by the front door rather than a hole reopening", and "The two Freehand release-bundle probes that used to sit here retired with their artefact". The `Retirement order for the Freehand CI lanes` section states its own keep-rationale: "ALL STAGES HAVE LANDED. This section is now a RECORD, not a plan ... kept because the *method* outlived the subject." Deleting it would destroy a reusable CI-retirement methodology, and relocating it was not available — `docs/design/retirement/freehand-and-ui.md` is held by a live peer (PR #8550).

One apparent gap was a false positive in my own checker rather than a finding: `test:re-frame2-pair-live-hermetic-suite` is defined in `tools/mcp-conformance/package.json`, not `implementation/package.json`.

## Out of scope, and one item of remaining work

`docs/api/re-frame.core.md` carries a hit and is **generated** by the api-manifest chain. It was not hand-edited. **Remaining work for another slice: it needs a regeneration through its own chain**, which was outside this slice's fence.

`spec/**`, `docs/design/**`, `docs/EP/**`, `skills/**`, `implementation/**` and `tools/**` belong to other slices and were not touched.

## Quality gates

**Nominated by path, not by job name.** Both link gates run in `test.yml`'s job displayed as *"Verify markdown link slugs — READMEs + the docs/spec/skills/migration corpus"*.

1. **`scripts/test-fast-pr.sh` did NOT run.** The diff is one prose file in `migration/`. The spine's documentation tier is classifier-gated, and the gates that actually cover this surface were run directly instead. A bench-class allocation window was live on the machine; these are cheap Python checkers plus one small JVM suite, none of which contends with it.

2. **Targeted gates, with exit codes I captured myself** (redirect plus an explicit `echo` of the runner's own status on one command line, never piped through a filter), re-run on the final base after rebasing onto `e67567a163`:

| gate | exit |
|---|---|
| `scripts/check_doc_slugs.py` | **0** |
| `scripts/check_readme_links.py --ci` | **0** |
| `clojure -M:test` in `migration/reagent-to-hicasso/codemod` (the one surface the classifier arms: `migration_hicasso_codemod=true`) | **0** — 54 tests, 490 assertions, 0 failures |

**Both gates were proved to read this worktree by planted faults, and the plants also settle which gate owns which path:**

- A broken target planted in the edited file made `check_doc_slugs.py` go **red (exit 1)**, naming `migration\reagent-to-hicasso\codemod\README.md:311 -> ./rf2-planted-does-not-exist.md`, while `check_readme_links.py --ci` stayed **green (exit 0)** on that same fault.
- A broken target planted in root markdown (`TESTING.md`) made `check_readme_links.py --ci` go **red (exit 1)**, while **`check_doc_slugs.py` exited 0 on the same broken link** — the fail-open on repo-root markdown, reproduced here.

Both restores were verified by hashing against the committed object rather than by reading a diff: the identical blob hash `3864304c74919a9824dd184351c1a7c3e19192e5` for the codemod README before the plant and after it, and the identical blob hash `c0b79579f6ef696de7c6a682e001dc9a72a22f49` for `TESTING.md`. `git status --porcelain` was empty after each restore.

3. **`mkdocs build --strict` is NOT nominated, and that is settled at source.** `mkdocs.yml` was not edited (all 7 hits kept), so there is no nav change; and the one file this PR does change sits under `exclude_docs`' `migration/reagent-to-hicasso/codemod/` entry, so the MkDocs build never sees it.

4. **Fast-spine-versus-required-CI gap**: `scripts/check_fast_pr_gap.py --list` reports **94 required checks the spine does not run**. Cited as the one path for that derivation rather than enumerated by hand.

**Verified by hand, since nothing validates prose, tables or rendering:** the edited paragraph was re-wrapped to the file's 73-81 character hard wrap, matching its neighbours; the only changed file contains no table; and the two tables in this PR body are 3-column and 2-column with matching separator rows.
