### PR TITLE
docs(hicasso): src comments state the present contract, and the retained-inventory ledger is ruled a measured surface (rf2-ww5at)

### DIFF
--- a/implementation/hicasso/src/re_frame/hicasso/impl/boundary.cljs
+++ b/implementation/hicasso/src/re_frame/hicasso/impl/boundary.cljs
@@ -66,7 +66,7 @@
   silent trap has a second door. [[report!]] is `(cond (vector? …) …
   (fn? …) … :else nil)`, so `{:on-error :app/boundary-failed}` — a bare
   intent keyword, which is what somebody writes who has not yet noticed
-  intents are vectors here — swallowed every caught error and returned
+  intents are vectors here — would swallow every caught error and return
   nil.
 
   ### Why the shape is refused HERE and not in `report!`
@@ -84,7 +84,7 @@
   ordinary course of loading the page, rather than on the first failure.
   By the time [[report!]] runs, `:on-error` is nil, a vector or a
   function, and its last arm means *no `:on-error` was declared* — which
-  is what it now says.
+  is what it says.
 
   ### Why a throw from `render` is acceptable when one from `report!` is not
 

--- a/implementation/hicasso/src/re_frame/hicasso/impl/codec.cljs
+++ b/implementation/hicasso/src/re_frame/hicasso/impl/codec.cljs
@@ -1720,11 +1720,11 @@
 ;;
 ;; **The trap has a second door, and `:slots` is not it.** A declaration
 ;; carries TWO rosters, and `host-entry`'s reserved skip sits above both
-;; of them, so `{:callbacks {:constructor :event}}` was the identical
-;; silent mint — the audit of the fix above found it still standing.
-;; [[refuse-callback-position!]] is the callback half, asked of the same
-;; canonical name by the same predicate, and it rides the id that arm
-;; already had. Two rosters, two arms, one question.
+;; of them, so `{:callbacks {:constructor :event}}` is the identical
+;; silent mint through the other roster. [[refuse-callback-position!]] is
+;; the callback half, asked of the same canonical name by the same
+;; predicate, and it rides the id that arm already had. Two rosters, two
+;; arms, one question.
 
 (defn- slot-key-name
   "The prop name a `:slots` entry spells, or nil when the entry cannot
@@ -2771,7 +2771,7 @@
   uncamelCased, so the slot still carries the prefix to test.
 
   The roster is this repo's own, not a guess: the `reagent-slim` adapter
-  narrowed exactly this seam after an audit and shipped this same set
+  narrows exactly this seam to this same set
   (`adapters/reagent-slim/IMPL-SPEC.md` §7.2, `DESIGN-RATIONALE.md` §5)."
   #{"className" "id" "role"})
 
@@ -2841,9 +2841,9 @@
   the rule underneath an installed Reagent codebase and the warning is
   that migration's safety-net (DESIGN-RATIONALE §5: \"the warning exists
   for the case we did not audit\"). Hicasso has no such codebase to
-  protect, and after this change a keyword at a host prop is the CORRECT
-  and taught spelling of HD-011's flagship case — warning on the happy
-  path is a nag, not a diagnostic. The guide teaches the rule instead."
+  protect, and a keyword at a host prop is the CORRECT and taught
+  spelling of HD-011's flagship case — warning on the happy path is a
+  nag, not a diagnostic. The guide teaches the rule instead."
   [slot v]
   (cond
     (fn? v)                       v

--- a/implementation/hicasso/src/re_frame/hicasso/impl/inventory.cljs
+++ b/implementation/hicasso/src/re_frame/hicasso/impl/inventory.cljs
@@ -52,7 +52,17 @@
   boundary, on exactly the rung being measured, in the direction that
   flatters this arm. Filed here it over-counts in the coincident-sequence
   case, which is the direction a candidate's own instrument should err
-  in."
+  in.
+
+  **The `:what` strings are DATA, held byte-for-byte against the measured
+  table.** Thirteen of the fourteen are identical to
+  `re-frame.bench.hicasso.arm1.runtime/retained-inventory`'s, and the
+  fourteenth — `:react/use-context` — differs only by the namespace the
+  copy renamed. That tree is the artefact the heap ladders were read off,
+  so a ladder is compared against these rows on the assumption they still
+  say what the measurement said. Rewriting one for its prose silently
+  moves the baseline a published row was taken against; whoever needs one
+  changed re-measures rather than re-words."
   []
   {:per-boundary
    [{:token :registration

--- a/implementation/hicasso/src/re_frame/hicasso/impl/overlay.cljs
+++ b/implementation/hicasso/src/re_frame/hicasso/impl/overlay.cljs
@@ -324,8 +324,8 @@
 
   A superset on purpose, narrowed by [[tab-stop?]] and then ORDERED by
   [[sequential-tab-stops]]. On its own it answers *which elements are
-  candidates*, which is not the same question as *where Tab goes*, and
-  the gap between the two is what the audit of #8071 measured."
+  candidates*, which is not the same question as *where Tab goes*; the
+  gap between the two is what [[sequential-tab-stops]] exists to close."
   (str "a[href],area[href],button,input,select,textarea,summary,"
        "iframe,object,embed,audio[controls],video[controls],"
        "[contenteditable],[tabindex]"))
@@ -439,8 +439,8 @@
   ## What this models, and what it does not
 
   It models the two places sequential order departs from document order
-  inside an ordinary panel, both of which the audit of #8071 measured
-  choosing the wrong edge:
+  inside an ordinary panel, each of which sends a document-order answer
+  to the wrong edge:
 
   - a named radio group is ONE stop ([[one-stop-per-radio-group]]);
   - a positive `tabindex` sorts ahead of every `tabindex=0`, ascending,

--- a/implementation/hicasso/src/re_frame/hicasso/native.cljc
+++ b/implementation/hicasso/src/re_frame/hicasso/native.cljc
@@ -473,9 +473,9 @@
   here rather than reimplemented, because one policy concept with two
   implementations is the shape a second copy gets subtly wrong — the
   `useSyncExternalStore` triple is compared by identity and a fresh
-  closure per render re-subscribes every island on every render. Audit
-  #7839 asked for the two-value matrix and no second policy mechanism;
-  this is the first half taken by not building the second.
+  closure per render re-subscribes every island on every render. The
+  two-value matrix is the whole of the policy surface, and there is no
+  second policy mechanism behind it.
 
   So the hook answers `false` while React is producing server bytes AND
   again on hydration's first client pass, and `true` afterwards and on

--- a/implementation/hicasso/src/re_frame/hicasso/tool.cljs
+++ b/implementation/hicasso/src/re_frame/hicasso/tool.cljs
@@ -390,10 +390,10 @@
   and this read is complete for it. What the empty does NOT establish is
   that nothing is retained above — an Activity-hidden subtree that has
   released its reads leaves the same empty census as an unmounted one, and
-  only a later re-subscribe distinguishes them, retrospectively (audit
-  #7792). Read the other way round, a row here is not proof the boundary
-  is on SCREEN: a Suspense-fallback-hidden subtree stays subscribed and
-  stays in this roster.
+  only a later re-subscribe distinguishes them, retrospectively. Read the
+  other way round, a row here is not proof the boundary is on SCREEN: a
+  Suspense-fallback-hidden subtree stays subscribed and stays in this
+  roster.
 
   Everything this read does not know is in `:naming` and `:host`, which
   are projections of their own with their own bases and their own losses —


### PR DESCRIPTION
Closes the `implementation/hicasso/src/**` residue left after #8535, and rules the one
open question that slice explicitly left owed. **Comments and docstrings only — no
behaviour surface in the diff at all.**

## What the census actually said

#8535 did the bulk of `src/`, and it did it well: the shapes that sweep targets are
already at zero here. Re-derived on this branch's base, `.beads` excluded, each pattern
run against the whole repo as a positive control so an empty result means *nothing there*
rather than *wrong pattern*:

| shape | before | after | repo-wide control |
|---|---|---|---|
| PR / issue numbers `#NNNN` | 4 | **0** | 631 files |
| `audit` narration | 7 | **1** (a quotation, see below) | 706 files |
| ISO dates `YYYY-MM-DD` | 0 | 0 | 752 files |
| `rf2-hic-NNN` | 0 | 0 | 240 files |
| `AUSEST` timestamps | 0 | 0 | 68 files |
| bead ids `rf2-xxxxx` | 9 | 9 (both fenced, see below) | 3208 files |

A broad journey-word sweep (`used to`, `formerly`, `previously`, `superseded`,
`reopened`, `historically`, `originally`, `the old`, `has since`, …) returned 104 raw hits
and, on reading every one, no further targets: they are domain vocabulary — an *old
revision*, a *superseded incarnation*, a *previously-focused element* — not journey
narration. One is a refusal string (`impl/intent.cljs`, "It used to succeed silently
under ") which is machine-read text the complaint-catalogue gate round-trips, and is
fenced.

## What was rewritten — 8 sentences, 6 files

Each drops the provenance attribution and keeps the constraint it carried.

- **`impl/overlay.cljs`** — `tab-stop-selector` and `sequential-tab-stops`. Both cited
  "the audit of #8071 measured". The first now points at the var that closes the gap
  rather than at the PR that found it; the second states *what goes wrong* (a
  document-order answer lands on the wrong edge) instead of *who noticed*.
- **`impl/codec.cljs`** — the second-door comment above `slot-key-name` (`was the
  identical silent mint — the audit of the fix above found it still standing` → present
  tense, "through the other roster"); `html-attr-slots` (`narrowed … after an audit and
  shipped` → `narrows … to`, **keeping the two live `adapters/reagent-slim/` citations**);
  `host-prop-value` (drops `after this change`).
- **`impl/boundary.cljs`** — the shape-trap sentence moves from `swallowed every caught
  error and returned nil` to `would swallow … and return nil`, which is the same
  constraint stated as what breaks if the guard is removed; and `which is what it now
  says` → `which is what it says`.
- **`native.cljc`** — `mint-server-gate`. `Audit #7839 asked for the two-value matrix and
  no second policy mechanism` → the matrix *is* the whole policy surface and there is no
  second mechanism. The constraint (one policy concept, one implementation) is the point
  of the paragraph and is untouched.
- **`tool.cljs`** — `read-mounted-boundaries` drops a trailing `(audit #7792)`.

## What was deliberately KEPT, and why

- **`impl/slot.cljc` — SOURCE-LOCATED REFUSAL.** It is the single surviving row in
  `hicasso/frozen-sources.edn`, pinned by sha256 at 109 lines. Four of the nine remaining
  bead ids are its. This was not assumed: a one-word docstring fault was planted there and
  `check_freeze.py` went **red on exactly that line**, printing the donor and package
  strings side by side; the file was then restored and the gate returned to exit 0. Its
  comments cannot be touched until the frozen-row retirement lands, which the bead already
  fences as a separate ruled change.
- **`impl/inventory.cljs`'s five `:what` bead references — RETAINED, exception recorded.**
  This is the bead's acceptance criterion 3. `retained-inventory` returns **runtime data**,
  not comments: suites read the map, `shapes/bulk_dom_cljs_test.cljs` prints a row in an
  assertion message, and design records cite rows by token name. Measured rather than
  argued: **13 of the 14 `:what` strings are byte-identical** to
  `test/re_frame/bench/hicasso/arm1/runtime.cljs`'s — the measured bench donor this sweep
  fences out — and the 14th (`:react/use-context`) differs only by the namespace the copy
  renamed. `docs/design/hicasso/studio/reads-per-boundary-heap-ladder.md` §Provenance
  names that very string as the only difference between its whole-tree measurement anchor
  and the `origin/main` it was taken against. Re-wording a row here silently moves a
  baseline a published row was read against. The exception is now recorded in the
  `retained-inventory` docstring, where the next sweep meets it before touching the table.
  (All five cited beads are closed, so none is a live obligation pointer — they are
  provenance for evidence CI does not reproduce.)
- **The one surviving `audit` token**, `impl/codec.cljs:2843`, is a **quotation** of
  `adapters/reagent-slim/DESIGN-RATIONALE.md` §5 — "the warning exists for the case we did
  not audit" — inside quote marks and byte-identical. It cites a live document; it is not
  this codebase's journey.
- **Every runtime string.** Zero changed, and that is what makes the control decisive.

## Pinned prose — checked, none blocked an edit

Every distinctive sentence was grepped repo-wide before rewriting. Three test files carry
similar prose (`overlay_focus_dom_cljs_test.cljs`, `native_ssr_dom_cljs_test.cljs`,
`tool_reads_cljs_test.cljs`) but each is **its own docstring prose**, not a regex against
this source — nothing slurps these files and asserts on their text. `check_bundle_isolation.cjs`
pins `premise` strings from three of the edited files, but those premises are code tokens
(`"rf2:hicasso-native-tier"`, `:rf.error/hicasso-native-slot-collision`), not prose, and
are untouched. No sentence had to be left in place.

## Mechanical verification

The identity control reuses **the repo's own reader** — `code_only` from
`hicasso/scripts/check_naming_census.py` — rather than a second parser:

- **code identity: IDENTICAL**, on both forms. Whitespace-collapsed *and* as a list of
  3863 non-blank lines. The two-form check is deliberate: a collapsed compare cannot see a
  code line merged into its neighbour by a paragraph re-wrap.
- **string inventory: 1452 strings, count unchanged in every file**; 8 differ, and a
  docstring-position classifier (third element of the immediately-enclosing `ns`/`def…`
  form) reports **all 8 as DOCSTRING, 0 as RUNTIME**.
- The control was proven to bite before being believed: a plant of one code token plus one
  runtime string reddened all three axes, and the restore was verified by **the identical
  blob hash** against the committed object rather than by reading a diff.

## Quality gates

1. **`scripts/test-fast-pr.sh` — NOT run.** The diff is comments and docstrings in one
   package, and a peer is holding a bench-class allocation window on this box; two
   heavyweight gates wedge rather than fail. The targeted gates below cover the surface.
2. **Targeted gates, foreground, exit codes captured by the running shell** (redirect and
   `echo $?` on one command line — never a pipeline, whose status is its last filter's).
   All re-run on the **final rebased base** after the trunk moved 7 commits:

   | gate | exit |
   |---|---|
   | `check_freeze.py --self-test` + `check_freeze.py` + `check_optional_module_reachability.py` (×2) + `check_complaint_catalogue.py` (×2) + `check_budget_ledger.py` (×2) | **0** |
   | `check_example_fence_coverage.py` (×2) + `check_facade_inventory.py` (×2) + `check_guide_samples.py` (×2) | **0** |
   | `test:hicasso-lint` (`check_lint_export.py --self-test` + `check_lint_export.py`) | **0** |
   | `npx shadow-cljs compile :node-test-hicasso` | **0** (549 files, 0 warnings) |

   Together the first three rows are the whole of `npm run test:hicasso-invariants`, run
   as two foreground phases rather than one detached call — the chain splits cleanly and
   both halves fit well inside the runtime ceiling, so nothing was backgrounded and no
   orphan could write to a log a restart was reusing.

   `check_complaint_catalogue.py` round-trips every refusal string and `check_facade_inventory.py`
   pins the public surface; both green independently corroborates the zero-runtime-string
   claim.

   **Tree verification.** The compile prints its config path and it names this worker's
   worktree, so that gate demonstrably read this tree and not a sibling's. The freeze gate
   is silent about its root, so it took the other route: the planted `slot.cljc` fault
   exists only here, and the gate went red on it.

3. **Fast-spine-versus-required-CI gap**, derived via `scripts/check_fast_pr_gap.py --list`
   (the one path for this): **94 required checks the spine does not run**, across the three
   required contexts `All required checks passed` (test.yml), `Lint required` (lint.yml) and
   `Docs required` (docs.yml). Most are surface-gated and skip on a diff that does not reach
   them; the claim is only that none of them is decided locally. Relevant to this diff:
   test.yml's `CLJS (shadow-cljs :node-test)` job carries a **Hicasso release build
   (`:advanced`, `goog.DEBUG` false)** step that the spine does not run, and the local
   `:node-test-hicasso` compile above is not a substitute for it.

4. **Nothing validates prose.** Every rewritten sentence was read by hand in the final
   merge-base diff and confirmed to read as a sentence, in the present tense, still
   carrying the constraint its predecessor carried. The one table added to a docstring was
   checked for column counts. `scripts/check_doc_slugs.py` is **not** nominated: its roots
   are `docs`, `spec`, `skills`, `migration` and `tools/*/spec`, and `implementation/**` is
   outside `docs_dir` entirely.

5. **Merge-base revert check.** `git diff origin/main...HEAD` (three-dot) reviewed for what
   it would undo: six files, `+33/−23`, all of them this branch's own rewrites. None of the
   7 commits the trunk gained touches `implementation/hicasso/src`, and the base tree hash
   for that directory is unchanged, so the captured baseline is still the baseline.

## Scope

`implementation/hicasso/src/**` only. `implementation/hicasso/test/**` is untouched — the
non-bench half landed in #8543 and the bench half is measured evidence. `frozen-sources.edn`
is untouched.

**rf2-ww5at is NOT closed by this PR.** `src/` was not its whole remaining scope: the bead
was reopened for the non-bench `test/` slice, and acceptance criteria 1 and 2 belong to
that dispatch. Criterion 3 — the `inventory.cljs` `:what` ruling — is discharged here.
