### PR TITLE
docs: close PR #8529's README scope claim, and refuse the api-docs regeneration (rf2-e7m4r, rf2-jzv5x)

### DIFF
--- a/docs/design/hicasso/studio/README.md
+++ b/docs/design/hicasso/studio/README.md
@@ -14,6 +14,16 @@ studio at `docs/design/freehand/studio/` is frozen and is never extended** — i
 is the predecessor programme's record and it stays exactly as its own programme
 left it.
 
+**This index is exempt from the repository's GDS README restyle** (PR #8529),
+for the same reason the restyle already kept evidence identifiers and ISO window
+dates on the bench data pages it points at. The bold and the italics here mark
+verdict status — REFUTED, WITHDRAWN, SUPERSEDED, UNRESOLVED, NOT-COMPARABLE, and
+the standing labels a row carries — rather than emphasising prose, so stripping
+them changes what a row asserts. The numerals are measured figures with units.
+And the prose immediately to the left of a commit hash is what
+`scripts/check_provenance_pins.py` classifies that hash by, so rewording around
+one moves it between citation classes.
+
 ## What a page in here owes its reader
 
 The measurement discipline in [validation.md](../validation.md) is binding, and

--- a/examples/_shared/README.md
+++ b/examples/_shared/README.md
@@ -60,7 +60,7 @@ contract:
 </div>
 ```
 
-`structure.css` lays this out as two columns on wider viewports, with the host
+`structure.css` lays this out as 2 columns on wider viewports, with the host
 width controlled by `--rf-xray-inline-width` (560px by default). At 900px and
 below it stacks the host beneath the app, removes the host's fixed minimum
 width, and caps its height so the panel scrolls internally. These rules only

--- a/tools/story/testbeds/counter_with_stories/README.md
+++ b/tools/story/testbeds/counter_with_stories/README.md
@@ -93,7 +93,7 @@ recipe forwards in production. The substrate is always-on: it
 survives `:advanced` + `goog.DEBUG=false` where the trace surface
 DCEs because event-emit is the production observability surface. The
 demo's registration is intentionally ungated so visitors can see
-the listener fire; production deployments and the registration
+the listener fire; production deployments gate the registration
 with `(not ^boolean re-frame.interop/debug-enabled?)` per the
 chapter-22 recipe.
 


### PR DESCRIPTION
Closes rf2-e7m4r. Also carries the finding for rf2-jzv5x, which needs no code change.

## rf2-e7m4r — PR #8529's scope claim, closed

The restyle itself is sound; its scope claim was incomplete. Re-derived at the landed commit `b22a0fef4c`: 133 tracked `README.md` files, 106 changed, 27 unchanged, of which 25 match a declared exclusion. The two that match none are settled here, one each way — because an unlisted file is not automatically a file that should change.

**`docs/design/hicasso/studio/README.md` — declared exempt.** The declaration goes in the page itself, beside the editorial rule it already carries for its own tree (the Freehand-studio freeze), because that is where the next person to touch this tree will read it and there is no other maintained in-tree scope statement to amend. Four reasons, each measured:

- its 381 bold spans mark verdict status — REFUTED, WITHDRAWN, SUPERSEDED, UNRESOLVED, NOT-COMPARABLE, "τ untouched", "No slope is published" — rather than emphasising prose. GDS's no-bold rule does not reach them, and stripping them changes what a row asserts.
- its numerals are measured figures with units and its dates are ISO evidence windows. PR #8529 already kept exactly these on the hicasso bench data pages under "Deliberate keeps", and this index is the index to those pages.
- the prose immediately left of each of its 12 provenance hashes is what `scripts/check_provenance_pins.py` classifies them by, so a prose restyle moves hashes between citation classes on a page nobody meant to change.
- it is the live index that takes a new table row per landed record page, and is being extended right now. A 381-site rewrite collides with every page in flight — the same reason `docs/design/hicasso/product/README.md` was excluded.

**`examples/_shared/README.md` — restyled.** It is an ordinary README beside source in the exact class the restyle covered, nothing pins its prose, and it was simply missed. The delta measured smaller than the audit described, and the honest report is that the audit overstated it: no bold or italics (0 spans), no Latin abbreviations (0), sentence-case headings, British spelling, and bullet punctuation already matching what the restyle produced elsewhere. What remained was one word-form numeral, and it moves. Heading words are untouched, so every slug is stable — which also keeps `examples/scripts/check-examples-assets.cjs`'s error messages, which cite this README's sections by name, still pointing at real sections.

**The malformed sentence** at `tools/story/testbeds/counter_with_stories/README.md:96` loses its missing verb. The debug-enabled gating rule is preserved and was verified against two sources rather than inferred: `spec/009-Instrumentation.md` (consumer SHOULD belt-and-braces `(when (not ^boolean re-frame.interop/debug-enabled?) …)` registration) and the testbed's own recipe comment in `elision_demo.cljs`.

The pair-MCP inventory defect #8529 disclosed is rf2-664t7's and is not touched here.

## rf2-jzv5x — a refusal, on two independent grounds

The count re-derives exactly: `docs/api/re-frame.core.md` carries 1 hit for the retired-substrate pattern, at line 845, with `.beads` excluded. Neither premise that follows from it holds.

**It is not a generated file.** Nothing in the api-manifest chain writes into `docs/api/`. The chain's only `spit` is `gen.clj:430`, which writes `spec/api-manifest.edn`. `doc_api_check.clj` *reads* `docs/api/` as a projection to validate against that manifest — its scope table at line 84 lists `docs/api/` as an input tree, and its success line is "OK: docs/api page+member coverage in sync". `lint.yml` puts `docs/api/**` on a `paths:` filter for the same reason. So `docs/api/*.md` are hand-authored prose checked against a generated manifest, not output of it. There is no generator to run, and the bead's instruction to run one has no referent.

**The hit is not residue.** The sentence reads: "`:rf.adapter/ui` and `:rf.adapter/freehand` stay reserved and are never recycled, but the two donor view substrates were removed on 2026-08-16 and nothing produces either value now." That is already past-tensed, already dated to the removal, and it is the reserved-kind catalogue rather than a live reference to a removed surface. It agrees with three independent sources: the live docstring at `implementation/core/src/re_frame/substrate/adapter.cljc:27` carries the same clause almost word for word; `spec/006-ReactiveSubstrate.md:2808` states it normatively as "retired kinds, still reserved"; and `rf2-0yp7w.9` lists the set under DO NOT DELETE, with `rf2-wtznc` closed on the reading that the member is a defensive denylist entry on the footing `:rf.adapter/helix` has held since its own adapter was removed. `docs/design/retirement/donor-surfaces.md` reaches the same disposition independently.

Deleting it would remove a correct, current statement and re-open a disposition that has already been ruled twice. No edit made.

## Quality gates

**`scripts/test-fast-pr.sh` did not run.** A bench-class allocation window holds the machine, and two heavyweight runs on one box wedge rather than fail. The surface here is three markdown lines plus one paragraph, and the gates below are the ones that decide it.

Gates run directly, each foreground, each redirected to its own log with the runner's own exit code echoed on the same command line. These are the exit codes captured from the runners themselves, on the final rebased base:

| Gate | Captured exit |
|---|---|
| `python scripts/check_doc_slugs.py` | 0 |
| `python scripts/check_readme_links.py --ci` | 0 |
| `python scripts/check_provenance_pins.py` | 0 (136 pages, 0 findings) |
| `python scripts/check_fast_pr_gap.py --list` | 0 (94 required checks the spine does not run) |

**Both link gates ran, because neither one alone decides this diff.** Nominated by path, not by job name: `docs/` is one of `check_doc_slugs.py`'s `DEFAULT_ROOTS` and covers the studio README, while the other two files are READMEs beside source and belong to `check_readme_links.py --ci`. The split was proved in both directions by planted faults rather than assumed:

- a broken link target planted in `docs/design/hicasso/studio/README.md` turned `check_doc_slugs.py` red at exit 1, naming `docs/design/hicasso/studio/README.md:24` — while `check_readme_links.py --ci` stayed at exit 0 on the same fault.
- a broken link target planted in `examples/_shared/README.md` turned `check_readme_links.py --ci` red at exit 1, naming `examples/_shared/README.md:63` — while `check_doc_slugs.py` stayed at exit 0 on the same fault.
- a third plant in `tools/story/testbeds/counter_with_stories/README.md` turned `check_readme_links.py --ci` red naming line 96, confirming that file is inside its surface too.

The reds also prove which tree each gate read: the faults existed only in this worktree, so a run that had wandered into a sibling checkout would have come back green.

All three restores were verified by hashing the bytes, not by reading a diff. Each file returned to the identical blob hash it carried before its plant — the identical blob hashes `df204e6940b505dc3f5c0dd8faf7e0db6021c1c5`, `1f7b09cca1b1c37104fd3fbfb75bb228ececff2c` and `d06831ab90da46bcf7e83605d3d74fa1226b9c70`, all three of them content digests of working files rather than citations of any revision — and a sweep for plant residue returns nothing.

**`mkdocs build --strict` is the wrong gate here, checked at source rather than assumed.** `mkdocs.yml`'s `exclude_docs` block lists `design/hicasso/`, so the studio README is invisible to the build; and `docs_dir` is `docs`, so `examples/_shared/` and `tools/story/testbeds/` were never candidates for exclusion in the first place.

**Nothing validates this markdown's prose or its table column counts, so both were checked by hand.** The diff touches no heading line and no table row — verified by grepping the merge-base diff for heading-shaped and row-shaped lines, both empty — so every anchor and every column count on all three pages is unchanged. The added paragraph on the studio README introduces no markdown link and no 40-hex token. The one-token change in `examples/_shared/README.md` and the one-word change in the story testbed README are both mid-sentence in body prose.

The merge-base diff was read for reverts before pushing (`git diff origin/main...HEAD`): 12 insertions, 2 deletions, three files, nothing another branch has touched.
