### PR TITLE
fix(xray): the activate-derived-value! comment names the spine, not a host roster (rf2-u2fm4)

### DIFF
--- a/tools/xray/src/day8/re_frame2_xray/settings/effects.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/settings/effects.cljs
@@ -641,9 +641,10 @@
         ;;
         ;; `interop/activate-derived-value!` is the substrate's own "put
         ;; this derived value on your push path" op: a no-op on hosts that
-        ;; are push-based from birth (the React-hook spine — UIx) and
-        ;; on plain-atom, and idempotent on an already-capturing reaction. It
-        ;; runs FIRST so the seed below reads a settled node.
+        ;; are push-based from birth (the React-hook spine wires one watch
+        ;; per source at construction) and on plain-atom, and idempotent on
+        ;; an already-capturing reaction. It runs FIRST so the seed below
+        ;; reads a settled node.
         (interop/activate-derived-value! reaction)
         ;; Seed the baseline from the reaction's CURRENT value before
         ;; `add-watch` — the reaction may hold issues that predate this


### PR DESCRIPTION
Closes rf2-u2fm4.

## What changed

One comment, in `tools/xray/src/day8/re_frame2_xray/settings/effects.cljs`.

```diff
-        ;; are push-based from birth (the React-hook spine — UIx) and
-        ;; on plain-atom, and idempotent on an already-capturing reaction. It
-        ;; runs FIRST so the seed below reads a settled node.
+        ;; are push-based from birth (the React-hook spine wires one watch
+        ;; per source at construction) and on plain-atom, and idempotent on
+        ;; an already-capturing reaction. It runs FIRST so the seed below
+        ;; reads a settled node.
```

## Which of the two fix shapes, and why

The audit offered a minimal fix (name UIx *and* Hicasso) and a durable one
(name the structural spine with no copied host roster). **Taken: the durable
one**, for three reasons.

1. **The roster is the defect, not its contents.** This bead was filed because
   the roster named Helix after Helix was removed at S7/W13; it was reopened
   once when the repair left the roster still stale; it was reopened a second
   time because the repaired roster is *incomplete*. Three failures, one cause.
   A membership list copied into a comment must be revisited every time the host
   set moves, and nothing gates it — no gate reads comment text, which is why
   this got to three.
2. **The replacement says MORE, not less.** `— UIx` asserted membership and
   asked the reader to trust it. *"the React-hook spine wires one watch per
   source at construction"* gives the **mechanism**, which is the actual reason
   the op is a no-op there. A reader who knows the mechanism can classify any
   host, including ones that do not exist yet.
3. **It converges on the canonical statement this comment already cites.**
   Three lines above, the same comment block points at
   `re-frame.substrate.observation/build-node-handle!` as "the canonical
   statement of this order". That comment reads *"a no-op for hosts already
   push-based from birth (the React-hook spine wires one watch per source at
   construction)"* — roster-free, and now matched verbatim. Xray's own
   `spec/016-Auxiliary-Panels.md` uses the same roster-free form ("a no-op on
   adapters already push-based from birth").

The new sentence is true of Hicasso without naming it:
`re-frame.hicasso.substrate` stands on `re-frame.substrate.spine`, whose
`make-derived-value` "wires ONE WATCH PER SOURCE at construction", and it says
in terms that on this spine the activation "is a routed no-op".

**Not touched, deliberately.** The `:rf.adapter/helix` refusal and tombstone,
the reserved-kind set, and every historical Helix reference. This is a comment;
runtime behaviour is unchanged.

## The second site was already discharged

`tools/xray/spec/011-Launch-Modes.md:470` now reads
`(UIx / Hicasso — hosts whose :render cannot take the hiccup shell…)`.
A fixed-string case-insensitive grep for `helix` across `tools/xray/` returns
**0 hits across the whole tool** — the spec half of this bead needs no edit, so
this PR touches no markdown.

## A third site of the same class — RECORDED, not swept

Per the scope fence, recorded on rf2-u2fm4 rather than fixed here.
`tools/xray/src/day8/re_frame2_xray/mount.cljs` carries three present-tense
React-element host rosters naming **Freehand**, a substrate retired and removed
by #8322:

| Line | Text | Fault |
|---|---|---|
| 23 | `The React-hook substrates (UIx, Freehand) share an ELEMENT-shaped render` | names a removed substrate; omits Hicasso |
| 188 | `(UIx, the first-party Freehand) share the spine's ELEMENT-shaped render` | same |
| 903-904 | `a React-element substrate (UIx / Freehand — kinds whose :render cannot take the hiccup shell, rf2-qgfo4)` | the direct source counterpart of `011-Launch-Modes.md:470`, which #8525/#8554 repaired to `(UIx / Hicasso — …)` and left this one behind |

`mount.cljs:211-216` and `:239` — the defensive tombstone and the reserved-kind
set that includes `:rf.adapter/helix` and `:rf.adapter/freehand` — are **correct
as they stand** and are not part of that finding.

## Quality gates

**`scripts/test-fast-pr.sh` was NOT run, deliberately.** The dispatch reserved
the machine for a concurrent worker running five heavyweight gate families
sequentially, and forbade shadow-cljs, browser/Playwright, npm build and JVM
runs. `python scripts/check_fast_pr_gap.py --list` heads **94** — the number of
required CI checks that spine does not decide — so a spine pass would not have
been the authority here regardless.

**What covers `tools/xray/src/`, and what does not.** Every arm of
`.github/scripts/report-changed-surfaces.sh` that classifies a `.cljs` file
under `tools/xray/src/` routes it to a heavyweight family:

| Classifier arm | Gate family | Cheap? |
|---|---|---|
| `is_story_xray_runtime_path` (:281) | browser / Playwright | no |
| `is_story_xray_node_test_path` (:316) | CLJS node-test (shadow-cljs) | no |
| `is_story_xray_dom_test_path` fan-in (:423) | DOM CLJS suite | no |
| `examples_compile` (:596) | shadow-cljs release compile | no |
| tools story/xray arm (:1857) | tools JVM, mcp-conformance, template-expensive | no |

**Nothing cheap covers this path**, and I checked rather than assumed. The four
pure-Python scripts that mention `tools/xray` all miss this file:
`check_doc_slugs.py` roots reach `tools/*/spec` but not `tools/*/src`;
`check_readme_links.py --ci` covers markdown beside source, not `.cljs`, and its
roster excludes `tools/*/spec` besides; `check_retired_composition_vocab.py`
scans `.md` only, under `docs/core`, `docs/api`, `docs/EP`, `spec`, `skills` and
`tools/*/spec`; `check_skill_xray_tab_inventory_drift.py` reads
`tools/xray/src/day8/re_frame2_xray/panels/`, not `settings/`. Per the dispatch,
that is the reported outcome, not a gap to be closed by running a heavy gate.

**No fault was planted, and there was nothing for one to prove.** No gate in
this repository reads comment text, so a plant in the changed lines could not
turn any gate red, and a plant outside them would be testing a different change.
Saying so plainly is the honest report.

**What I verified by hand instead.** For a comment-only edit the conclusive
check is that the compiler sees nothing new, so I proved exactly that: strip
every `;`-to-EOL comment (string-literal and char-literal aware) from
`origin/main`'s copy of the file and from the branch copy, and compare. **Both
reduce to the identical 445 lines of reader-visible code.** The checker carries
its own controls in both directions — mutating a real form
(`reaction` to `reaction2`) is detected, mutating comment text
(`wires one watch` to `WIRES ONE WATCH`) is not — so a `True` here is
discriminating rather than vacuous. Run after the rebase, against the final base
`d98b6222f3`. **Captured exit code: 0** (redirect and the exit-code echo on one
command line, in one shell; the number quoted is the one I captured, not one
reported about the run).

Also checked by hand: all 7 changed diff lines match a leading-comment pattern
(`;;` after optional whitespace); delimiter counts are unchanged across the file
(round 343/343, square 69/69, curly 13/13, double-quote 126); no line exceeds 80
columns; CRLF endings preserved with no line-ending flip (the diff is 3 lines
out, 4 in, not a whole-file rewrite); and the two prose tables above were counted
by hand — 3 columns by 4 rows, and 3 columns by 6 rows, headers included.

**Positive control on the searches.** The audit's phrase "push-from-birth" does
not appear in the target file — the file says **"push-based from birth"** — so a
search for the former returns zero on a file that plainly contains the idea, and
that zero would read as "the audit is stale, close it". Every grep underwriting a
claim here was a fixed-string grep, and was run once against something it should
find.

## Tree verification

The edit was confirmed present in the worker worktree and **absent from the
mayor checkout**, which still holds the pre-edit text — both trees read, not one.
The worker-worktree guard ran and exited 0.
