### PR TITLE
docs(hicasso): describe the studio index's real typographic roles (rf2-e7m4r)

### DIFF
--- a/docs/design/hicasso/studio/README.md
+++ b/docs/design/hicasso/studio/README.md
@@ -16,11 +16,17 @@ left it.
 
 **This index is exempt from the repository's GDS README restyle** (PR #8529),
 for the same reason the restyle already kept evidence identifiers and ISO window
-dates on the bench data pages it points at. The bold and the italics here mark
-verdict status — REFUTED, WITHDRAWN, SUPERSEDED, UNRESOLVED, NOT-COMPARABLE, and
-the standing labels a row carries — rather than emphasising prose, so stripping
-them changes what a row asserts. The numerals are measured figures with units.
-And the prose immediately to the left of a commit hash is what
+dates on the bench data pages it points at. The bold and the italics here do
+several jobs, and only reading the row tells them apart. Both mark verdict and
+status — REFUTED, WITHDRAWN, SUPERSEDED, UNRESOLVED, NOT-COMPARABLE, and the
+standing labels a row carries. Bold also carries the load-bearing finding a row
+exists to assert, and the figures it turns on. Italics also carry notation,
+where the slant is the symbol rather than stress — variables like `*r*` and
+`*2D*`, sample sizes like `*(n=8)*`. The rest is ordinary prose emphasis, most
+of it contrastive: `*inside*` rather than beside, `*what*` rather than
+`*where*`. A mechanical restyle tells none of these apart, and stripping a
+verdict changes what a row asserts. The numerals are measured figures with
+units. And the prose immediately to the left of a commit hash is what
 `scripts/check_provenance_pins.py` classifies that hash by, so rewording around
 one moves it between citation classes.
 


### PR DESCRIPTION
Closes rf2-e7m4r (the AUDIT REOPEN scope only; the bead's original items are merged and untouched).

## What the audit claimed, and what the measurement says

PR #8557 added a durable exemption to `docs/design/hicasso/studio/README.md` asserting that the page's bold and italics "mark verdict status ... rather than emphasising prose". The audit called that universal claim false and cited 26 single-asterisk italic spans.

**The audit's figure reproduces exactly.** At #8557's merge commit `98f198c96e` the page carries **26** single-asterisk italic spans. On today's `origin/main` it carries **28** — PR #8555 added one table row on 2026-08-20 carrying two more (`*r*`, `*r+1*`). All ten words the audit sampled — *what*, *exactly*, *and*, *inside*, *where*, *can*, *mean*, *ratio*, *cheaper*, *worse* — are present and are ordinary emphasis. The claim is false.

**It is not rescued by scoping to bold either.** Of 403 bold spans, 46 contain a verdict or status token and 85 are a bare measured figure with units; the remaining 273 are emphasis on the row's load-bearing finding.

**Repair shape taken: shape 1 — describe the actual roles.** Shape 2, restyling "only the ordinary emphasis", would touch 20 of 28 italic spans and 273 of 403 bold spans. That is the blanket rewrite the audit forbids, wearing a smaller name. Shape 1 is also the honest one: the page genuinely uses these marks for several jobs, so no re-wording of a one-job claim can be true.

**The exemption still stands, on better footing.** It now rests where it really sits — a mechanical pass cannot tell the roles apart, and stripping a verdict changes what a row asserts. The other two grounds are untouched and verified intact: numerals as measured figures with units, and provenance-pin classification keyed to the prose immediately left of a hash.

**No counts are written into the page.** A durable exemption that pins a census invites exactly this bead's second life — the figure moved 26 -> 28 in one day.

## The near-miss on this file

PR #8555 was flagged as about to delete this paragraph. Read at the merge base: #8555 landed as `59425d8bea` with **+1 / -0** on this file, adding one table row and leaving the exemption paragraph intact. The revert did not happen. This branch's own merge-base diff (`origin/main...HEAD`, three-dot) is 11 insertions / 5 deletions confined to the exemption paragraph, and reverts nothing.

## Italic-span census, classified

28 single-asterisk spans on the base tree, fenced blocks and inline code masked:

| Role | Count | Instances |
|---|---|---|
| Verdict / status label | 2 | *indistinguishable* (L39), *anchored, awaiting a second reading* (L121) |
| Notation — variables | 4 | *r*, *r+1* (L124); *D*, *2D* (L140) |
| Notation — sample size | 2 | *(n=8)*, *(n=6)* (L136) |
| Ordinary prose emphasis | 20 | *inside*, *required*, *established*, *exactly*, *can*, *and*, *mean*, *bulk*, *inside*, *worse*, *rises*, *cheaper*, *registered*, *by construction*, *literalness*, *composition*, *entails*, *what*, *where*, *ratio* |

**Census completeness is arithmetic, not judgement.** The page has 1,668 asterisks outside code spans; 403 bold spans x 4 + 28 italic spans x 2 = 1,612 + 56 = 1,668 exactly. Nothing is unaccounted for. The page uses no `_underscore_` italics, no `<em>` and no `<i>`.

**Positive control on the census scanner:** a synthetic `*positivecontrol*` span appended to a copy of the page took the total from 28 to 29 and was reported by name. A zero from this scanner is a checked zero.

**Positive control on the "trunk did not touch my file" search:** the same `git log <range> -- <path>` form that returned empty for `393cb24370..origin/main` returns `59425d8bea` for `98f198c96e..393cb24370`. The empty result is real.

## After the edit

Census re-run on the edited page: **28** spans, unchanged. Bold: **403**, unchanged. The illustrative examples in the new prose are written in code spans, so the edit adds and removes no emphasis marks anywhere on the page (asterisks outside code spans: 1,668 before, 1,668 after; 12 added inside code spans).

## Quality gates

| Gate | Exit code I captured |
|---|---|
| `python scripts/check_doc_slugs.py` | **0** |
| `python scripts/check_provenance_pins.py --changed-since origin/main` | **0** |
| `python scripts/check_readme_links.py --ci` (informational) | **0** |
| `python scripts/check_fast_pr_gap.py --list` | **0** |

Every code above is the one captured by `echo $?` into a per-worktree, per-attempt `.exit` file on the same command line as the redirect, re-run on the final rebased base. No gate was piped through a filter.

**Planted-fault result.** `check_doc_slugs.py` prints nothing on success, so the tree-verification route here is the plant. A broken link target was planted in the paragraph under edit; the gate returned **exit 1** and named it precisely:

```
BROKEN TARGET: docs\design\hicasso\studio\README.md:9 -> ../product/decision-brief-PLANTED-typoclaim.md
```

The fault existed only in this worktree, so a run that had wandered into a sibling checkout would have come back green. Restored and verified by the identical **blob** hash `48c064f138db75971fe5bac3828515b799c103fd` before and after, against the committed object, with `git status --porcelain` empty.

**Second, independent tree signal.** `check_provenance_pins.py --changed-since origin/main` reported `0 pages inspected` before the edit and `1 page inspected, 12 cited pins - 12 landed, 0 stranded, 0 unresolvable, 0 foreign; 0 findings` after it. It saw this worktree's change. The edited paragraph contains no hex token, so it creates no citation and moves no hash between classes.

**`scripts/test-fast-pr.sh` did NOT run, deliberately.** The surface is one markdown file under `docs/design/hicasso/`; no CLJS, JVM, browser or build gate reaches it, and the spine's documentation tier is classifier-gated. `python scripts/check_fast_pr_gap.py --list` heads **94** required checks the spine does not decide.

**`mkdocs build --strict` is not the gate for this path.** `mkdocs.yml`'s `exclude_docs` block lists `design/hicasso/` at line 37, read at source. `check_readme_links.py --ci` does not reach this file either — it is under a docs-gate root — and it is reported above only as a clean informational run.

## By-hand checks the gates do not perform

**Table column counts, before and after.** The page carries exactly one table, starting at L102 (L108 after the edit): 50 rows — 1 header (`| Page | Phase | What it settles |`), 1 delimiter (`|---|---|---|`), 48 body rows. Every row is **3** columns, header and delimiter included, with pipes inside code spans masked. Identical before and after; the edit touches only prose above the table.

**Anchors and links.** The edit adds no link and no heading, and removes none. All heading anchors on the page are unchanged. Line widths in the rewritten paragraph are 69-80 characters, matching the file. CRLF endings preserved throughout.
