### PR TITLE
fix(xray,hicasso): retire three Freehand host rosters in mount.cljs, and re-measure the HS-34 witness comment (rf2-eqq3e, rf2-jtn15)

### DIFF
--- a/implementation/hicasso/test/re_frame/hicasso/client_only_arms_ssr_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/client_only_arms_ssr_cljs_test.cljs
@@ -71,12 +71,20 @@
 
   HS-34 is the *optional routing-integration module*, and there is no
   such module to render. `implementation/hicasso/src/re_frame/hicasso/`
-  holds five optional-module namespaces and routing is not among them;
+  holds six optional-module namespaces and routing is not among them;
   `hicasso/scripts/check_optional_module_reachability.py`'s `MODULES`
-  roster names exactly three (`motion`, `overlay`, `forms`);
-  `docs/design/hicasso/product/naming-ledger.md` row 6 still carries
-  `re-frame.hicasso.routing` as a PROVISIONAL name under an open
-  question; and `docs/design/hicasso/product/invariants.md`'s route-link
+  roster names those same six (`motion`, `overlay`, `native`, `forms`,
+  `server`, `substrate`) — a roster that has GROWN THREE TIMES without
+  admitting routing, so the count evidences the absence more sharply
+  than when this paragraph was written and it read three;
+  `docs/design/hicasso/product/naming-ledger.md` row 6 carries
+  `re-frame.hicasso.routing` as a PROVISIONAL recommendation and NOT
+  under an open question — that ledger's publication note says every
+  row is dispositioned and none is open, and its sibling
+  `naming-packet.md`'s own row 6 glosses the marker in terms,
+  *provisional — the namespace does not exist yet*, a better citation
+  for THERE IS NO MODULE than an open question ever was; and
+  `docs/design/hicasso/product/invariants.md`'s route-link
   row states the move in the FUTURE tense. `h/route-link`
   lives on the core facade today and is witnessed there as HS-40,
   Render, in `facade-roster-ssr-dom-cljs-test`. There is no declaration

--- a/tools/xray/src/day8/re_frame2_xray/mount.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/mount.cljs
@@ -19,13 +19,14 @@
   shell mounts via the adapter the host installed via `(rf/init! ...)`.
 
   That only works on hosts whose `:render` accepts HICCUP render-trees
-  — the ratom family (stock Reagent / reagent-slim). The React-hook
-  substrates (UIx, Freehand) share an ELEMENT-shaped `render`
-  that hands the tree to React untouched, so Xray's hiccup shell cannot
-  mount there; the mount verbs refuse with the `:unsupported-substrate`
-  diagnostic instead of letting raw CLJS data reach React children
-  (rf2-qgfo4 — fn-as-child console.error + uncaught MapEntry pageerror
-  on every UIx template boot). See the substrate gate section below.
+  — the ratom family (stock Reagent / reagent-slim). Every substrate
+  built on the React-hook spine shares an ELEMENT-shaped `render`
+  (`re-frame.substrate.spine/make-react-adapter`) that hands the tree
+  to React untouched, so Xray's hiccup shell cannot mount there; the
+  mount verbs refuse with the `:unsupported-substrate` diagnostic
+  instead of letting raw CLJS data reach React children (rf2-qgfo4 —
+  fn-as-child console.error + uncaught MapEntry pageerror on every UIx
+  template boot). See the substrate gate section below.
 
   ## Production posture
 
@@ -184,10 +185,10 @@
 ;;
 ;; Xray's shell is authored in hiccup (reg-view'd Reagent components), so it
 ;; can only mount through a `:render` slot that accepts hiccup render-trees —
-;; the ratom family (stock Reagent / reagent-slim). The React-hook substrates
-;; (UIx, the first-party Freehand) share the spine's ELEMENT-shaped
-;; `render` (`re-frame.substrate.spine/make-render`): it hands the tree to
-;; React untouched, so the hiccup vector reaches React as an iterable of raw
+;; the ratom family (stock Reagent / reagent-slim). Every substrate built on
+;; the React-hook spine shares its ELEMENT-shaped `render`
+;; (`re-frame.substrate.spine/make-render`): it hands the tree to React
+;; untouched, so the hiccup vector reaches React as an iterable of raw
 ;; CLJS values — the component fn becomes a Fragment child ("Functions are
 ;; not valid as a React child … frame_provider") and the props map's
 ;; MapEntries throw UNCAUGHT ("Objects are not valid as a React child
@@ -900,8 +901,8 @@
   for the rationale.
 
   If the substrate adapter is absent, returns nil so preload retry can
-  wait. If the installed adapter is a React-element substrate (UIx /
-  Freehand — kinds whose `:render` cannot take the hiccup
+  wait. If the installed adapter is a React-element substrate (a kind in
+  `react-element-render-kinds`, whose `:render` cannot take the hiccup
   shell, rf2-qgfo4), returns the `:unsupported-substrate` diagnostic and
   logs one `console.warn` without mounting. If the layout host is
   missing, returns an inspectable diagnostic map and logs


### PR DESCRIPTION
Two stale-prose beads of the same class, in different trees. Both were filed by
workers who found the site outside their own fence and recorded rather than
swept, and both were flagged as possible triage-closes.

- **rf2-eqq3e** — three present-tense Freehand host rosters in `mount.cljs`.
- **rf2-jtn15** — the HS-34 comment block in a Hicasso SSR witness file.

Every premise was re-measured at the merge base before acting, and every search
was run once against something it should find. **Both beads are fixed rather
than closed**; the reasoning for not treating rf2-jtn15 as minutiae is below.
Two premises turned out to be understated rather than wrong, and one further
site was found and deliberately *not* swept.

## rf2-eqq3e — mount.cljs (commit 1)

**All three premises hold, and one is understated.**

`tools/xray/src/day8/re_frame2_xray/mount.cljs` carried three present-tense
host rosters naming Freehand, a tree PR #8322 removed on 2026-08-16
(`git ls-files implementation/freehand/` returns nothing; the same query
against `implementation/hicasso/` returns 593, which is that search's positive
control). The file already contradicted them at `:215-216`, which says in terms
that Xray no longer reads a Freehand host at all.

**The `open!` docstring is the sharp one, as filed.** It is the direct source
twin of the `tools/xray/spec/011-Launch-Modes.md` sentence that PRs #8525 and
#8554 repaired. The spec half now reads `UIx / Hicasso`; the docstring still
read `UIx / Freehand`, so the same sentence had been disagreeing with itself
across two files since that repair landed.

**Understated premise: all THREE rosters omitted Hicasso, not two.** Each read
`(UIx, Freehand)` or `(UIx / Freehand)`. Both faults rf2-u2fm4 was reopened
for, three times over rather than twice, in one file.

### Fix shape, per site

Ruled one file over by rf2-u2fm4's resolution in PR #8565: name the structural
property, not a host roster. I read all three sites before applying it, since a
launch-mode table is not a mechanism sentence — but all three here **are**
mechanism sentences, so all three de-roster rather than having their membership
corrected.

| Site | Was | Now |
|---|---|---|
| ns docstring | `The React-hook substrates (UIx, Freehand) share an ELEMENT-shaped :render` | `Every substrate built on the React-hook spine shares an ELEMENT-shaped :render`, citing `spine/make-react-adapter` |
| gate comment | `The React-hook substrates (UIx, the first-party Freehand) share the spine's ELEMENT-shaped :render` | `Every substrate built on the React-hook spine shares its ELEMENT-shaped :render`, citing `spine/make-render` |
| `open!` docstring | `a React-element substrate (UIx / Freehand — kinds whose :render cannot take the hiccup shell)` | `a React-element substrate (a kind in react-element-render-kinds, whose :render cannot take the hiccup shell)` |

The first two name the property, so membership follows from the spine rather
than from a list. That matches the canonical roster-free form already in the
tree at `re-frame.substrate.observation/build-node-handle!` and in
`tools/xray/spec/016-Auxiliary-Panels.md`, and it is what #8565 converged on.

The third names the property **and points at the one place membership actually
lives** — this file's own `react-element-render-kinds` def. The sibling
`open-overlay!` docstring immediately below was already roster-free, so this
restores internal consistency as well as agreement with the spec. The duplicate
roster is deleted rather than re-synchronised, which is the part that stops the
recurrence: no gate reads comment text, so a second roster can only ever drift.

Both cited symbols were verified live: `spine/make-render` and
`spine/make-react-adapter` exist in `re-frame/substrate/spine.cljs`.

**Deliberately untouched, per the bead:** the `:211-216` tombstone rationale and
the `:239` reserved-kind set. Both are correct as historical and defensive
references, and both are refusals rather than oversights.

## rf2-jtn15 — the HS-34 witness comment (commit 2)

**All three claims hold. Fixed rather than closed as minutiae** — the bead
raised that option and the stance allows it, but this block's entire rhetorical
strength is that each of four sources is *checkable*, and two of the four had
moved. A reader who checks the first source finds six where the comment
promises three, and reads a correct finding as wrong. That is a comment
actively undermining the conclusion it exists to support, in the witness file
that documents an ABSENT witness — precisely the artefact the `rf2-hic-064`
Phase 6 audit will re-derive. It is cheap, and it is the same repair
`dispositions.md`'s HS-34 cell already received in #8564.

| Claim | Comment said | Measured at merge base |
|---|---|---|
| `MODULES` roster | exactly three (`motion`, `overlay`, `forms`) | **six** — `motion`, `overlay`, `native`, `forms`, `server`, `substrate` |
| naming-ledger row 6 | a provisional name **under an open question** | row 6 is `applied (default, rf2-hic-065)`; the ledger's publication note reads *every row below is now dispositioned and none is open* |
| source namespaces | **five** optional-module namespaces | **six**, matching the roster exactly |

**The finding gets sharper, not weaker.** Routing is absent from a roster that
has grown three times without admitting it — `native` (rf2-b3gy) and `server`
(rf2-2a0ju) on 2026-08-14, `substrate` (rf2-hvr5h) on 2026-08-18. And the
comment now cites `naming-packet.md`'s own row 6 gloss, *provisional — the
namespace does not exist yet*, which says the thing directly where "under an
open question" said something the ledger denies.

**The finding itself was re-verified, not inherited:** there is no
`re-frame.hicasso.routing` namespace anywhere under `implementation/` (anchored
`^(ns re-frame.hicasso.routing` grep, exit 1, run against an ns that does exist
as the positive control), and `invariants.md`'s route-link row still states the
move in the future tense.

**One deliberate wording constraint.** This block sits inside the ns
**docstring**, not a `;;` comment, so a bare `"` around the gloss would
terminate the string. It is carried in the file's existing `*italic*`
convention instead, as `dispositions.md` does. The file's double-quote count is
unchanged at 302 either side of the edit, which is the check for that.

### Recorded, not swept — a fifth site of the same claim

`docs/design/hicasso/product/dispositions.md` §1.2 still reads *"HS-34 has no
module to refuse: the namespace has not been built and **its name is still an
open ledger row**"*. That is the same claim #8564 corrected in the HS-34 cell of
the same file, left standing in the prose section below it. **Not touched here**
— that file is another worker's surface and the brief scoped it read-only. Worth
a bead.

## Quality gates

**What covers these surfaces: nothing cheap, measured rather than assumed.**

- `tools/xray/src/**/*.cljs` — every classifier arm matching it routes to a
  heavyweight family, and all four pure-Python checkers miss it:
  `check_doc_slugs.py`'s roots stop at `tools/*/spec`, `check_readme_links.py`
  covers markdown, `check_retired_composition_vocab.py` scans `.md` only, and
  `check_skill_xray_tab_inventory_drift.py` reads `panels/`.
- `implementation/hicasso/test/**` — covered only by whatever compiles that
  namespace, i.e. the CLJS suite. A docstring-only edit reaches no assertion.

**`scripts/test-fast-pr.sh` was NOT run, deliberately.** Both changes are
comment and docstring text with no executable form moved, so a heavyweight
compile or browser gate would burn the machine to re-prove a claim the
equivalence check establishes directly.
`python scripts/check_fast_pr_gap.py --list` heads
**`REQUIRED CHECKS THIS SPINE DOES NOT RUN (94)`**, captured exit **0** (re-run
on the final base after rebase; still 94).

**No plant is possible and none was invented** — no gate in this repository
reads comment text, so a fault planted in the changed lines could not go red.
The substitute is #8565's: prove the reader-visible code is byte-identical.

### The equivalence check

A string- and char-literal-aware Clojure lexer splits each file into
`code | string | comment` spans and emits two projections: the **code skeleton**
(comments stripped, every string literal replaced by a fixed placeholder) and
the ordered **string-literal census**.

**Comment-stripping alone would have proved nothing here, and this is the one
substantive deviation from #8565's recipe.** Three of the four edited sites are
**docstrings**, which are `:doc` metadata strings rather than comments — a
string-aware comment stripper leaves them standing by construction. So the
check is comment-stripping *plus* a string census: the skeleton carries the
claim (no form moved), and the census identifies exactly which literals moved
and confirms each is a docstring.

Exit codes I captured myself, each with the redirect and the `echo` on one
command line, and **all re-run on the final base after the rebase**:

| Check | Result | Exit |
|---|---|---|
| lexer self-test — 8 cases | 8/8 PASS | **0** |
| `mount.cljs` base vs branch — code skeleton | **identical** | **0** |
| `client_only_arms_ssr_cljs_test.cljs` base vs branch — code skeleton | **identical** | **0** |
| controls on `mount.cljs` (4) | ALL PASS | **0** |
| controls on the HS-34 file (3 + desync guard) | ALL PASS | **0** |

Lexer self-test cases: `;` inside a string, `\;` and `\"` as character
literals, an escaped quote inside a string, a plain line comment, plus the
three discrimination properties (docstring change invisible to the skeleton,
visible in the census; form change visible to the skeleton).

Controls, run against the **real files** rather than fixtures:

| Control | Expectation | Result |
|---|---|---|
| `mount.cljs` — form mutation (`:ok? true` → `:ok? false`) | must be DETECTED | skeleton moved |
| `mount.cljs` — arity mutation (`[]` → `[x]`) | must be DETECTED | skeleton moved |
| `mount.cljs` — comment-text mutation | must NOT be detected | skeleton and census both unmoved |
| `mount.cljs` — docstring-text mutation | skeleton blind, census sighted | skeleton unmoved, exactly 1 literal moved |
| HS-34 file — `deftest` name mutation | must be DETECTED | skeleton moved |
| HS-34 file — `:require` vector mutation | must be DETECTED | skeleton moved |
| HS-34 file — docstring-text mutation | skeleton blind, census sighted | skeleton unmoved, exactly 1 literal moved |
| HS-34 file — lexer desync guard | every lexed literal terminates | 133/133 PASS |

The desync guard is there because the HS-34 file carries **302 double quotes**
and long prose docstrings containing `"` inside `;;` comments — the case where
a naive lexer silently mis-pairs and reports a confident, wrong answer.

**One control failed open and was caught.** The first attempt at the
`mount.cljs` form control used an anchor matching **twice**; the harness
reports `ANCHOR MATCHED 2 TIMES — CONTROL INVALID` rather than over-applying
silently. Re-anchored on a verified-unique form. (This is the "a plant that
never applied reads clean" trap, caught by counting rather than by diffing.)

### Results

- `mount.cljs`: skeleton **byte-identical**; 105 string literals both sides;
  exactly **2** differ, indices 0 and 41 — the ns docstring and `open!`'s
  docstring, precisely the two sites edited. The `;;` gate comment shows as a
  comment-stripped difference with no skeleton difference, as it should.
- HS-34 file: skeleton **byte-identical**; 133 literals both sides; exactly
  **1** differs, index 0 — the ns docstring, the only site edited.

### By-hand verification

Checked by hand and reported here, since no gate reads any of it:

- **Delimiters balanced.** `mount.cljs` `()` 765/765, `[]` 149/149, `{}` 44/44,
  `"` 234 (unchanged). Parens went 766 → 765 because the removed roster
  `(UIx, the first-party Freehand)` was a balanced pair *inside a comment*; the
  count stays balanced and the skeleton is unmoved. HS-34 file: `()` 288/288,
  `[]` 118/118, `{}` 43/43, `"` 302 — **every count unchanged**.
- **Line width.** `mount.cljs`: longest added line 76, in the `;;` block whose
  neighbours run 74–76; longest added docstring line 72. HS-34 file: longest
  added line 70, against a docstring region whose max is 73 and a file max of
  78. No line exceeds its file's prevailing width.
- **Line endings preserved, no flip.** Working files CRLF-only on both
  (`mount.cljs` 1441 → 1442, HS-34 511 → 519, bare-LF 0 in each); committed
  blobs LF-only on both sides, matching their bases. Verified on the **staged
  blob**, so the comparison is between the bytes that actually land rather than
  the smudged working copy.
- **No trailing whitespace introduced.**
- **No mojibake**: 41 correct U+2014 em-dashes in the HS-34 file, zero U+FFFD.
- **Merge-base diff read for reverts** (`origin/main...HEAD`, three-dot): the
  branch touches exactly two files, `13/5` and `14/13`. Nothing a sibling
  landed is reverted. The trunk touched neither of my two files nor any of my
  cited sources while I worked, so the measurements above are still true of it.

Runtime behaviour does not move in either commit.
