### PR TITLE
docs: two bounded prose corrections on docs/design (rf2-9neqq, rf2-72vvj)

### DIFF
--- a/docs/design/hicasso/product/dispositions.md
+++ b/docs/design/hicasso/product/dispositions.md
@@ -257,10 +257,11 @@ against the tree.** Until 2026-08-14 HS-23, HS-31, HS-32, HS-34 and HS-35 — an
 nothing, so `rf2-2ius2` rewrote each cell to say who owned it if anyone did and **no live owner** where nobody did.
 `rf2-cfriw` then took note 3 below at its word and server-rendered the four that still owed a witness, and **only one of
 the four turned out to be an ordinary unproved refusal.** HS-35 owes no witness at all — the condition in its own name
-failed. HS-34 has no module to refuse: the namespace has not been built and its name is still an open ledger row.
-HS-31 and HS-32 do not refuse on any path — both emit their live surface into the server bytes, and HS-32's anchored
-door does not reach Render either, though `rf2-9zz0y` has since discharged the first of the five clauses it owes and
-that cell records which. HS-23 alone carries a real declaration-source refusal, and only on
+failed. HS-34 has no module to refuse: the namespace has not been built, and its name is a *provisional* default on a
+ledger row that is dispositioned rather than open. HS-31 and HS-32 do not refuse on any path — both emit their live
+surface into the server bytes, and HS-32's anchored door does not reach Render either, though `rf2-9zz0y` has since
+discharged the first of the five clauses it owes and that cell records which.
+HS-23 alone carries a real declaration-source refusal, and only on
 one of the three routes an author has. The operative column is still the upgrade slot and the route out of it is still
 [2.4](#24-the-default-rule-and-how-a-row-is-upgraded)'s; what changed is that the slot no longer has a standing owner,
 so a row leaves Client-only when some *live* bead proves it.

--- a/docs/design/retirement/freehand-and-ui.md
+++ b/docs/design/retirement/freehand-and-ui.md
@@ -399,8 +399,9 @@ are the frozen evidence surface, and the `docs/design/hicasso/studio/README.md` 
 the next paragraph goes on to say the studio "stays exactly as its own programme left it". All
 four of the inbound links measured below land inside it. Its numbers, evidence ids and window
 dates are the baseline a live chain cites, so revising them is not a prose fix but an edit to
-another programme's evidence. **So, in one line: outside `studio/`, correct stale status and
-broken links and add nothing; inside `studio/`, nothing; delete nothing anywhere.**
+another programme's evidence. **So, in one line: outside `studio/`, correct stale status, broken
+links, factual errors and contradictions with rulings — all four of the EP-0036 classes quoted
+above, and no fifth — and add nothing; inside `studio/`, nothing; delete nothing anywhere.**
 
 **The deciding reason is the hicasso coupling.** `docs/design/hicasso/` is itself ruled kept, and it
 anchors its measurement numbers to the frozen studio tree — `docs/design/hicasso/studio/README.md`


### PR DESCRIPTION
Two bounded prose corrections on `docs/design/**`, one per bead. Both premises were re-measured at source before editing; both held.

## rf2-9neqq — `dispositions.md` §1.2 agrees with the HS-34 cell

§1.2 read *"HS-34 has no module to refuse: the namespace has not been built and its name is still an open ledger row."* That last clause is the exact claim PR #8564 (`rf2-453hd`) corrected one section down, inside HS-34's own §2.1 cell — the prose in §1.2 was never swept with the cell, so the two disagreed inside one file.

Re-measured at source rather than inherited from the bead:

- `naming-ledger.md:5` — *"Every row below is now dispositioned and none is open"*
- `naming-ledger.md:26` — row 6's status is `applied (default, rf2-hic-065)`
- `naming-packet.md:38` — *"Zero rows are left open."*
- `naming-packet.md:78` — row 6 glossed *"provisional — the namespace does not exist yet"*

§1.2 now says the name is a *provisional* default on a ledger row that is dispositioned rather than open. **The finding is untouched:** HS-34 still has no module to refuse, because the namespace has not been built. Nothing outside that one sentence changed except the paragraph's own line wrapping, which had to reflow to absorb it.

## rf2-72vvj — the R6 one-liner carries all four EP-0036 correction classes

Governed by the newest audit note (#8563, 2026-08-21), which is later than #8550's by its own stamp. Its bounded ask, and only it.

The paragraph above the imperative quotes EP-0036's four allowed corrections and calls that quote *"the whole of R6's permission here"*. The final operative line then permitted only two of them — stale status and broken links — leaving a worker to guess whether correcting a factual error or a contradiction with a ruling outside the studio was allowed. That is the same class of ambiguity the passage exists to remove.

The one-liner now enumerates all four and bounds them explicitly: *"correct stale status, broken links, factual errors and contradictions with rulings — all four of the EP-0036 classes quoted above, and no fifth — and add nothing"*. The four-part bound is verified at `docs/EP/EP-0036-the-freehand-view-substrate-programme.md:305`: *"Correct stale status, broken links, factual errors, and contradictions with rulings; do not grow it into a second API manual or tracker."*

**Preserved, verbatim and deliberately:** the no-growth rule (`add nothing`), the absolute `studio/` freeze (`inside studio/, nothing`), no deletion anywhere (`delete nothing anywhere`), and every one of #8563's landed reconciliations and measurements. The diff is 2 lines out to 3 and touches nothing else. `rf2-0moc4` is **not** re-ruled.

## Quality gates

**Which gate, and why not the obvious one.** `mkdocs build --strict` is **not** the gate for either file, confirmed by reading `mkdocs.yml` rather than by assertion: its `exclude_docs` block (lines 32–38) lists `design/hicasso/` and `design/retirement/` among the six trees kept out of the site. The gate that does cover both is `scripts/check_doc_slugs.py`, whose `DEFAULT_ROOTS` include `docs/`.

| Gate | Invocation | Exit code I captured |
|---|---|---|
| `check_doc_slugs.py` | `python scripts/check_doc_slugs.py` (after both commits) | **0** |
| `check_provenance_pins.py` | `python scripts/check_provenance_pins.py --changed-since origin/main --verbose` | **0** |

Both numbers are from `echo $?` on the runner's own command line, redirect and echo in one shell — not from any harness-reported status. Every log and exit file was written under a per-worktree, per-attempt name.

`check_provenance_pins.py` reports `1 page inspected, 5 cited pins — 4 landed, 0 stranded, 1 unresolvable, 0 foreign; 1 accompanied in scope; 0 findings`. The one unresolvable token is pre-existing at `dispositions.md:157` and is accompanied in its own block by `93f3040ea0`; my edit writes no hex token at all. The page count also confirms the gate's root: it inspects the hicasso page and not the retirement one, which is outside its corpus.

**Planted-fault proof — run twice, once per file.** `check_doc_slugs.py` prints nothing on success, so it offers no root banner; the tree-verification route available is the red from a planted fault. In each case the plant was a single-line, uniquely-anchored broken link target placed **at a line this PR itself edits**, with the anchor asserted to match exactly once so a silent no-op was impossible:

- `dispositions.md` — gate exit **1**, `BROKEN TARGET: docs\design\hicasso\product\dispositions.md:261 -> no-such-page-docsfour.md`
- `freehand-and-ui.md` — gate exit **1**, `BROKEN TARGET: docs\design\retirement\freehand-and-ui.md:404 -> no-such-page-docsfour-r6.md`

Neither fault existed in any other checkout, so a run that had wandered into a sibling worktree would have come back green. Both restores were verified by hashing the bytes against the committed object rather than by reading a diff — `dispositions.md` back to the identical blob hash `d9bb07e63607b1af39a0a6dcb482499b5c196e30`, `freehand-and-ui.md` back to the identical blob hash `a5dc862aef63fe6a5e4a46549ed206136cc7d869` — and the gate ran green again afterwards (exit **0**, empty log) with `git status` clean.

**By hand, because no gate reads prose, tables or rendering.** Counted over the three-dot diff against the merge base: changed lines containing a table pipe — **0**; changed lines containing a markdown link — **0**; changed lines that are headings — **0**. So this PR mints no anchor, breaks no anchor, and alters no table's column count; both files' tables are byte-identical to `origin/main`. The two changed passages are plain prose, and I read each in place afterwards to confirm the paragraph still parses as one sentence sequence.

**Fast spine: did NOT run.** No JVM, shadow-cljs, browser, Playwright or npm gate was run either — none of them covers a `docs/design/**` prose edit, and a peer holds an allocation measurement window on this machine. The cheap Python checkers above are the whole of what applies.

**Gap:** `python scripts/check_fast_pr_gap.py --list` derives **94** required checks the fast spine does not run. Since the spine did not run at all here, the honest coverage statement is that the two targeted gates above are what this change has been decided by locally, and CI's three required contexts — `All required checks passed`, `Lint required`, `Docs required` — decide the rest.

**Rebase check, and the gates re-run on the FINAL base.** The trunk moved under this branch while it was in flight (`ba1b085d31`, a beads checkpoint, touching neither of my files), so the branch was rebased onto it and **both gates were re-run afterwards** rather than resting on a pre-rebase green: `check_doc_slugs.py` exit **0** with an empty log, `check_provenance_pins.py --changed-since origin/main` exit **0** with `0 findings`, both captured the same way as above. The three-dot diff against the merge base was then read for what it would revert — 2 files, 8 insertions, 6 deletions, identical to the pre-rebase figures and all of them mine. Nothing a sibling landed is undone.

Closes rf2-9neqq. Closes rf2-72vvj.
