### PR TITLE
spec: retire HeadMismatchTags, the schema of a row struck in May (rf2-zk1xu)

### DIFF
--- a/spec/Spec-Schemas.md
+++ b/spec/Spec-Schemas.md
@@ -2160,12 +2160,24 @@ A schema and its catalogue row are **co-edited**, and a conformance test holds t
    [:final-redirect :any]
    [:frame          {:optional true} :keyword]])
 
-(def HeadMismatchTags
-  [:map
-   [:category    :keyword]
-   [:server-hash :any]
-   [:client-hash :any]
-   [:head-id     {:optional true} :keyword]])
+;; RETIRED (rf2-zk1xu): `HeadMismatchTags` is gone, three months after the row it
+;; typed. It was registered for `:rf.warning/head-mismatch`, whose `:tags` column
+;; read exactly `:server-hash`, `:client-hash`, `:head-id`; that row was STRUCK
+;; (rf2-4o1c.4) when head mismatch was folded INTO `:rf.ssr/hydration-mismatch`
+;; and discriminated by `:failing-id` `:rf.ssr/head-mismatch` — a VALUE on that
+;; row, not a category of its own. The schema outlived its row as canonical-
+;; looking prose no catalogue category, emitter or spec consumer claimed.
+;;
+;; NOTHING REPLACES IT, and nothing should. A head mismatch reaches the trace
+;; through `verify-hydration!` — host-attributed today, runtime-attributed if the
+;; post-v1 follow-on lands, per
+;; [011 §Mismatch detection — head](011-SSR.md#mismatch-detection--head) — so its
+;; `:tags` are the hiccup arm of `HydrationMismatchTags` below, and `:head-id`
+;; was never reachable on either path: `verify-hydration!` accepts only
+;; `:first-diff-path` / `:failing-id` / `:server-hash`. The head's own shipped
+;; channel, `:rf/head-hash` (plus the `data-rf-head-hash` wire attribute), is a
+;; HYDRATION-PAYLOAD channel, not a trace one — it never rides `:tags`, so it
+;; needs no `*Tags` schema at all.
 
 (def HydrationMismatchTags
   ;; TWO DISJOINT ARMS UNDER ONE CATEGORY. `:rf.ssr/hydration-mismatch` is the
@@ -2186,8 +2198,8 @@ A schema and its catalogue row are **co-edited**, and a conformance test holds t
   ;; sub-arm is the SAME shape: it is discriminated by `:failing-id`
   ;; `:rf.ssr/head-mismatch` and nothing else — `verify-hydration!` accepts only
   ;; `:first-diff-path` / `:failing-id` / `:server-hash` opts, so no `:head-id`
-  ;; can reach this category's tags. (`HeadMismatchTags` above types a
-  ;; head-model channel of its own and is not this category's schema.)
+  ;; can reach this category's tags — the retirement note directly above records
+  ;; where that key came from and why no schema declares it any more.
   ;;
   ;; ADOPTION TIER — `re-frame.substrate.spine/native-hydration-reporter` and
   ;; `re-frame.hicasso.impl.mount/hydration-reporter` emit through plain


### PR DESCRIPTION
Discharges the bounded remainder the PR #8562 merged-PR audit reopened `rf2-zk1xu` for.

## Outcome: RETIRED, with the producer question answered at source

The audit asked for one of two things — retire the stale `HeadMismatchTags` schema, or identify and document the real channel and producer it models. **There is no such channel**, and the history says why, so it is retired.

**Provenance, measured.** `HeadMismatchTags` was registered on 2026-05-09 by `a6b8ea8ecf` ("register ~65 missing :tags schemas in Spec-Schemas", rf2-mmn5) — a bulk *one schema per category enumerated in 009 §Error categories* pass. Its category was the then-live catalogue row `:rf.warning/head-mismatch`, whose Tags column at that commit read **exactly** `:server-hash`, `:client-hash`, `:head-id` — the schema's key set. Two days later `942e123a83` (2026-05-11, rf2-4o1c.4) **struck that row**, folding head mismatch into `:rf.ssr/hydration-mismatch` discriminated by `:failing-id :rf.ssr/head-mismatch`. The row went; the schema did not. It is orphaned residue of a deleted row, not a forward declaration.

**Why no producer can be named — including under the deferred work.** A head mismatch reaches the trace through `verify-hydration!`: host-attributed today through the generic `:failing-id` seam, runtime-attributed *if* the post-v1 follow-on lands (`spec/011-SSR.md` §Mismatch detection — head, and 011's deferred table, which records runtime-side head attribution as a `:post-v1` **untracked note**). On **both** paths the emitted event is `:rf.ssr/hydration-mismatch`, already modelled by `HydrationMismatchTags`' hiccup arm — so `HeadMismatchTags` would still be wrong after the deferred work ships. `:head-id` was never reachable on either path: `verify-hydration!` accepts only `:first-diff-path` / `:failing-id` / `:server-hash`, the same measurement #8562 used to strike `:head-id` from the 009 row.

**The head's own shipped channel is not a trace channel.** `:rf/head-hash` (plus the `data-rf-head-hash` wire attribute) has shipped, but it is a **hydration-payload** channel — it is typed in this same file on `:rf/hydration-payload` (`spec/Spec-Schemas.md:3904`), whose existing comment already states that a host attributes a head-only mismatch as `:rf.ssr/head-mismatch` through the `:failing-id` seam and that runtime-side attribution is a post-v1 follow-on. It never rides `:tags`, so it needs no `*Tags` schema.

## The change

`spec/Spec-Schemas.md` only. 20 insertions / 8 deletions, one file.

1. The `HeadMismatchTags` def is replaced by a `RETIRED (rf2-zk1xu)` note in the established house form used by `PlainFnUnderNonDefaultFrameOnceTags` and `DispatchFromAsyncCallbackFellThroughTags` in this file — what it typed, which commit struck the row, and what supersedes it.
2. #8562's parenthetical inside `HydrationMismatchTags` — which called the orphan "a head-model channel of its own", the very claim this audit rejected — is re-pointed at that note.

`:head-id` is **not** put back on `:rf.ssr/hydration-mismatch`; #8562's emitted-shape correction stands untouched.

**No `spec/009-Instrumentation.md` edit is required and none is made.** A tree-wide census (`git grep -F HeadMismatchTags -- :!.beads`) returned two hits before this change — the def and #8562's comment — and one after: the retirement note naming its own subject. 009 never cited the schema, and its `:rf.ssr/hydration-mismatch` row already says there is no `:head-id` tag on this category.

The `*Tags` corpus goes **111 → 110**. The pairing is untouched: the retired schema was one of the unpaired ones, so `paired-count` is unchanged and `tags-column-paired-floor` (93) needs no edit.

## Quality gates

| Gate | Captured exit | Result |
|---|---|---|
| `implementation/core`: `clojure -M:test -n re-frame.error-catalogue-channel-conformance-test` | **0** | 28 tests / 177 assertions, 0 failures, 0 errors |
| `scripts/check_doc_slugs.py` | **0** | no broken anchors |
| `scripts/check_fast_pr_gap.py --list` | **0** | 94 required checks the fast spine does not run |

Every exit code above is the one **I** captured with an explicit echo of the runner's status into a per-worktree, per-attempt `.exit` file, on the same command line as the redirect — never a harness-reported number. Both gates were re-run on the **final rebased base** (`ba1b085d31`); the numbers above are from those final runs.

**`scripts/test-fast-pr.sh` was deliberately NOT run.** A peer holds a live allocation-measurement window, and the brief directs the cheap checkers plus the one targeted catalogue arm instead. So the fast spine did not run at all — the CI gap above is the honest statement of what is still undecided locally.

### Planted-fault proofs

Both plants were restored, and each restore was verified by the identical **blob** hash `f80190d87d1d39f364963da8ab42df8b14f33048` computed against the committed object (this checkout translates line endings, so a plain byte digest would misreport a correct restore).

**Catalogue arm — red, discriminating.** `:client-hash` → `:client-hazh` in `HydrationMismatchTags`' hiccup arm, the same def this PR edits: captured exit **1**, **6 failures** naming `:client-hash`. Scope control: the planted run still reported **28 tests / 177 assertions**, identical to the clean control, so the plant did not abort any namespace.

**Doc-slugs gate — red, discriminating, and a finding.** The first plant broke the anchor in the retirement note this PR adds (`#mismatch-detection--head` → `#mismatch-detection--haed`): the gate came back **green, exit 0**. That is not a pass — it means **`check_doc_slugs.py` does not read markdown links inside fenced code blocks**, so this PR's entire diff is invisible to it. A second plant, in Spec-Schemas.md *prose* (`#per-category-tags-schemas` → `#per-category-tags-schemaz`, line 851), came back **exit 1** naming `spec/Spec-Schemas.md:851 -> #per-category-tags-schemaz`. That red proves the gate read **this** worktree's copy of the file — the fault existed only here, so a run that had wandered into a sibling tree would have returned green — and pins the invisibility as fence-scoped rather than tree-scoped.

### Verified by hand (nothing automated covers it)

- **Table column counts: not applicable, and verified so.** This diff touches **zero** table rows — filtering the diff's changed lines for a pipe character returns **0**. Every changed line is a `;;` comment inside the existing fenced block. The one 009 catalogue row in scope (`:rf.ssr/hydration-mismatch`, 009 line 2013, 6 columns) is **unmodified**.
- **The one link in the new note, since the gate cannot see it.** `[011 §Mismatch detection — head](011-SSR.md#mismatch-detection--head)` — the heading exists at `spec/011-SSR.md:1258`, and the byte-identical target is already cited from *prose* at `spec/009-Instrumentation.md:1068` and `:2013` and at `spec/Spec-Schemas.md:3904`, where `check_doc_slugs.py` does validate it and is green.
- **Schema count**, by direct count of the schema-def line pattern: 111 before, **110** after.
- **Census positive control**: the fixed-string grep that underwrites "only two occurrences" was run against the pre-change tree, where it found both — so the search can find the string it now reports as reduced to one.

## Recorded, not swept

Two siblings found in passing. Neither is actioned; `spec/009-Instrumentation.md` is one-toucher hot zone and both files sit outside this PR's fence.

1. **`spec/009-Instrumentation.md:2392`** (`:rf.error/infinite-missing-next-page-param`) still carries a stray pipe inside a cell, so it parses as 9 fields. Pre-existing, already recorded on the bead by the previous worker, and explicitly out of scope for this dispatch. It looks trivially safe to fix, but 009 is hot zone and a wider diff costs the next toucher — **say the word and I will take it as its own one-line PR.**
2. **`implementation/core/test/re_frame/error_catalogue_channel_conformance_test.clj` lines 883 and 978** cite "22 of the 111 `*Tags` schemas" and "all 111 `*Tags` schemas". These are dated prose measurements in comments — nothing asserts them. The `111` becomes `110` with this PR, but the `22` is **already stale at the tip, independently of this change**: `tags-column-paired-floor` is 93 against 111 schemas, so the unpaired population is 18, not 22 (17 after this PR). Correcting them properly needs a measurement of the sub-buckets the same sentence names, which is scope this PR should not grow — flagged for a follow-up ruling rather than fixed here.
