### PR TITLE
bench(p0): the HEAP row's control goes every-round; the CLOCK row keeps overlap (rf2-egdaq)

### DIFF
--- a/implementation/core/test/re_frame/bench/p0_app.cljs
+++ b/implementation/core/test/re_frame/bench/p0_app.cljs
@@ -467,11 +467,39 @@
   was published as a bare ratio nothing adjudicated.
 
   The adjudication is the LANE's, not a second copy: [[lane/control-verdict]]
-  is what the freehand P0 arms already publish their controls under, and
-  what it DECIDES is not this namespace's to change (rf2-egdaq, which is
-  open, is the ruling on whether that decision tightens). Read its
-  docstring before quoting `:ok?`: the rule is range OVERLAP, not
-  every-round-inside.
+  is what this arm publishes its controls under, and what it DECIDES is not
+  this namespace's to change. Read its docstring before quoting `:ok?`: the
+  rule is range OVERLAP, not every-round-inside.
+
+  ## And OVERLAP is the right rule HERE, which is not true of the heap row
+  ## (rf2-egdaq, settled)
+
+  The lane spells a second rule — [[lane/control-verdict-strict]], every
+  round inside the band — and `re-frame.bench.p0-heap` moved this driver's
+  OTHER row onto it. This row stays on overlap, on measurement rather than
+  on inertia. THIS CONTROL IS A CLOCK RATIO. `control-round!` reads two
+  mount times and divides them, and on the M2 and bulk-broad rows those
+  times are one to three of Chrome's 100 µs `performance.now()` quanta —
+  which is a floor the ratio lands on, not a defect the arm has. The
+  2026-07-31 ruling measured what strict would cost: over rf2-6i0i2's
+  eighty controls, 80 of 80 pass under overlap and 64 of 80 under strict,
+  every miss LOW, every miss on one of the two coarse-leg rows, four of
+  them missing by 0.0014 on a two-quantum floor — while M1 and narrow,
+  measured on 20-plus quanta legs, pass strict 40 times out of 40. A rule
+  that refuses a fifth of its controls by landing on the clock quantum is
+  measuring RESOLUTION, not correctness.
+
+  The heap row is not exempted from strict by precedent; it is outside
+  this exemption's reason. Its control is a dense array read in BYTES off
+  CDP's heap counter, with no quantum for a low round to sit on. The two
+  rows differ in their INSTRUMENT, so they differ in their rule.
+
+  **And nothing is lost by keeping overlap here**, because the record
+  below carries `[:control :per-round]` — the rounds themselves, not a
+  summary of them. That is what let the eighty-control ensemble be
+  re-adjudicated from published data without re-running a window, and it
+  is what lets the ruling be revisited the same way if the batched window
+  it named as its own trigger ever lands on this row.
 
   Answers a flat JS object because a driver reading `verify.ok?` off a
   `clj->js` map sees `undefined` — every gate green while every gate was

--- a/implementation/core/test/re_frame/bench/p0_heap.cljs
+++ b/implementation/core/test/re_frame/bench/p0_heap.cljs
@@ -1301,28 +1301,77 @@
                                                       {:tolerance tolerance})))
              ;; ONE expression of the positive-control rule too, and it is
              ;; the LANE's. The driver owns the collector, so it is the
-             ;; driver that reads `predicted` against the measured range —
-             ;; and until rf2-95s5b it printed that pair as a bare ratio
-             ;; nothing adjudicated. `lane/control-verdict` is what the
-             ;; freehand P0 arms already publish their controls under; what
-             ;; it DECIDES is not this namespace's to change (rf2-egdaq),
-             ;; and its docstring states the rule it applies — range
-             ;; OVERLAP, not every-round-inside.
+             ;; driver that states `predicted` against this row's own
+             ;; per-round readings — and until rf2-95s5b it printed that
+             ;; pair as a bare ratio nothing adjudicated.
+             ;;
+             ;; THE RULE IS `lane/control-verdict-strict`, EVERY ROUND
+             ;; INSIDE THE BAND (rf2-egdaq). It used to be the lane's
+             ;; overlap rule, which asks only that the measured RANGE meet
+             ;; the band — and on a counter this precise that is not a
+             ;; weaker gate, it is an absent one. This control's whole
+             ;; purpose is to catch a collector that has stopped seeing
+             ;; transient garbage, and the shape that failure takes is a
+             ;; round reading ~0 B. Under overlap, one round at 0 B beside
+             ;; five good ones PASSES: `min` 0 is below the roof and `max`
+             ;; ~4,700,000 is above the floor, so the range meets the band
+             ;; and a good round vouches for a dead one. Under this rule
+             ;; that round is named and the run is refused.
+             ;;
+             ;; AND THE COARSE-LEG CARVE-OUT DOES NOT REACH HERE. The
+             ;; 2026-07-31 ruling keeps overlap for legs sitting within a
+             ;; few of Chrome's 100 µs `performance.now()` quanta, where a
+             ;; low round is the clock rather than a defect, and names a
+             ;; window whose legs clear the quantum as its own revisit
+             ;; trigger. This leg is not a clock leg at all: a dense array
+             ;; of unboxed doubles read in BYTES off CDP's heap counter,
+             ;; predicted 4,700,000 B and typically published inside
+             ;; [4,699,074 – 4,700,974], ±0.02% of it. There is no quantum
+             ;; to sit on, so the exemption has nothing to exempt — and the
+             ;; ruling's own revisit trigger, a window whose legs clear the
+             ;; quantum, is met by a leg that was never on one in the first
+             ;; place. `re-frame.bench.p0-app`'s control IS a clock
+             ;; ratio and stays on overlap under that same ruling; the two
+             ;; rows of this driver are adjudicated by different rules
+             ;; because they are measured by different instruments.
+             ;;
+             ;; RE-ADJUDICATING THE PUBLISHED SERIES COSTS NOTHING, and the
+             ;; published records settle it without re-running a window: a
+             ;; stated [min–max] whose two ends both sit inside the band
+             ;; bounds EVERY round inside it. Across this row's published
+             ;; series the widest excursion either way is 4,690,838 B —
+             ;; 0.195% below a prediction gated at ±25% — so every heap row
+             ;; ever published is `ok` under this rule too. The tightening
+             ;; buys teeth for the next run, not a revision of the last one.
+             ;;
+             ;; The answer carries `:per-round` so a later reader can
+             ;; re-adjudicate under either rule WITHOUT re-running the
+             ;; window — the durability hole rf2-egdaq's audit of PR #8326
+             ;; found, and the reason the aggregate shape is gone from
+             ;; this call rather than merely tightened.
              ;;
              ;; A flat literal `#js` answer, never `clj->js`: that would
              ;; render `:ok?` as the key `"ok?"` and a driver reading
              ;; `v.ok` would see `undefined` — the control green for ever
              ;; because nothing could read it. The same trap `mount!`
-             ;; already carries the scar from.
-             :controlVerdict (fn [predicted measured slack]
-                               (let [m (js->clj measured :keywordize-keys true)
-                                     v (lane/control-verdict
-                                         predicted
-                                         (select-keys m [:min :max :mean])
-                                         slack)]
-                                 #js {:ok    (boolean (:ok? v))
-                                      :why   (:why v)
-                                      :slack (:slack v)}))
+             ;; already carries the scar from, and it is why `:outside`
+             ;; is built as flat `#js` objects one level down too.
+             :controlVerdict (fn [predicted per-round slack]
+                               (let [vs (vec (js->clj per-round))
+                                     v  (lane/control-verdict-strict predicted vs slack)]
+                                 #js {:ok       (boolean (:ok? v))
+                                      :rule     (name (:rule v))
+                                      :why      (:why v)
+                                      :slack    (:slack v)
+                                      :stated   (boolean (:stated? v))
+                                      :band     (into-array (:band v))
+                                      :perRound (into-array vs)
+                                      :outside  (into-array
+                                                  (map (fn [o]
+                                                         #js {:round    (:round o)
+                                                              :measured (:measured o)
+                                                              :offBy    (:off-by o)})
+                                                       (:outside v)))}))
              :guardSelfTest  (fn [] (pr-str (guard/self-test)))
              ;; The fan-out sweep's two doors, and both of them are RULES
              ;; rather than arithmetic, so both live here rather than in a

--- a/implementation/core/test/re_frame/bench/p0_run.cjs
+++ b/implementation/core/test/re_frame/bench/p0_run.cjs
@@ -88,8 +88,11 @@
 //   1. the arm-order guard's self-test, in the page, before anything is
 //      measured — exit 1 (clock) / the page refuses to install (heap);
 //   2. `N unverified of M` — clock and heap, exit 1 on any nonzero count;
-//   3. the positive control — clock and heap, adjudicated by
-//      `lane/control-verdict` and exit 1 when it is not `ok`;
+//   3. the positive control — clock and heap, exit 1 when it is not `ok`.
+//      The two rows are adjudicated by DIFFERENT rules of the lane's, and
+//      which one applies is a property of the instrument: the clock row by
+//      `lane/control-verdict` (overlap), the heap row by
+//      `lane/control-verdict-strict` (every round). See below;
 //   4. the arm-order verdict over the samples — exit 2, figures not
 //      quotable.
 //
@@ -99,13 +102,51 @@
 // (2)'s denominator rather than counted as verified, and (3) is the gate
 // they answer to instead. See `p0-harness/mount-sample!`.
 //
-// `lane/control-verdict` is the lane's shared rule and WHAT IT DECIDES IS
-// NOT THIS DRIVER'S TO CHANGE: rf2-egdaq is the open ruling on whether it
-// tightens from range-overlap to every-round-inside. Read its docstring
-// before quoting `:ok?`. Both of this driver's controls pass under either
-// reading — heap 4,700,317 B [4,699,074–4,700,974] against a predicted
-// 4,700,000 B, clock 1.8381x [1.8182–1.8548] against a predicted 1.9975x
-// with ±25% slack — so wiring them in changed no published figure.
+// TWO CONTROL RULES, ONE PER ROW, AND THE INSTRUMENT PICKS (rf2-egdaq).
+// The lane spells both and neither is this driver's to invent. What this
+// driver decides is only which of them each row is entitled to, and it
+// decides that on what the row's control leg is MADE OF:
+//
+//   - the CLOCK row (`re-frame.bench.p0-app`) keeps `lane/control-verdict`,
+//     the overlap rule. Its control is a ratio of two mount times, and on
+//     the M2 and bulk-broad rows those times are one to three of Chrome's
+//     100 µs `performance.now()` quanta. The 2026-07-31 ruling measured
+//     what strict would cost there over rf2-6i0i2's eighty controls: 80 of
+//     80 pass under overlap and 64 of 80 under strict, every miss LOW and
+//     every miss on a coarse-leg row, while the two rows measured on 20-plus
+//     quanta legs pass strict 40 times out of 40. A rule that refuses a
+//     fifth of its controls by landing on the clock quantum is measuring
+//     RESOLUTION, not correctness. Overlap stands here.
+//   - the HEAP row (`re-frame.bench.p0-heap`) takes
+//     `lane/control-verdict-strict`, every round inside the band. Its
+//     control is a dense array of 587,500 unboxed doubles read in BYTES off
+//     CDP's heap counter — 4,700,000 B predicted, and a typical published
+//     range is [4,699,074 – 4,700,974], ±0.02%. There is no quantum for a
+//     low round to sit on, so the carve-out above has nothing to exempt,
+//     and the ruling's own revisit trigger — a window whose legs clear the
+//     quantum — is met by a leg that was never on one.
+//
+// AND ON THIS ROW OVERLAP IS NOT A WEAKER GATE, IT IS AN ABSENT ONE. The
+// failure the heap control exists to catch is a collector that has stopped
+// seeing transient garbage, and its shape is a round reading ~0 B. Under
+// overlap one such round beside five good ones passes — `min` 0 sits under
+// the roof, `max` 4,700,000 over the floor, so the range meets the band.
+// Under strict that round is NAMED and the run is refused.
+//
+// NO PUBLISHED ROW IS RE-ADJUDICATED BY THIS, because none needs to be. The
+// published ranges are what settle it without re-running anything: a range
+// whose `min` and `max` both sit inside the band bounds EVERY round inside
+// it, and across this row's published series the widest excursion either way
+// is 4,690,838 B — 0.195% below a prediction gated at ±25%, better than two
+// orders of magnitude inside. So the strict verdict of every heap row ever
+// published is `ok`, and the tightening buys teeth for the next run rather
+// than a revision of the last one. That is what makes this row's half of
+// rf2-egdaq settleable by a worker at all; the CLOCK row's half was not,
+// which is why it went to the operator and was ruled on 2026-07-31.
+//
+// Read the two docstrings before quoting `:ok?` — each answer carries the
+// `:rule` that decided it precisely so a record cannot be read under the
+// other one.
 
 'use strict';
 
@@ -137,10 +178,13 @@ const CONTROL_DOUBLES = Number(process.env.P0_CONTROL_DOUBLES || 587500);
 const CONTROL_PREDICTED = CONTROL_DOUBLES * 8;
 const HEAP_TOLERANCE = Number(process.env.P0_HEAP_TOLERANCE || 0.25);
 const CLOCK_TIMEOUT_MS = Number(process.env.P0_CLOCK_TIMEOUT_MS || 30 * 60 * 1000);
-// How far a positive control's measured range may sit from the prediction
-// its own arithmetic made and still count as THE INSTRUMENT HAS SIGNAL.
-// Generous on purpose — the claim being gated is not that the model is
-// exact. `lane/control-verdict` applies it; this driver only carries it.
+// How far a positive control's reading may sit from the prediction its own
+// arithmetic made and still count as THE INSTRUMENT HAS SIGNAL. Generous on
+// purpose — the claim being gated is not that the model is exact. ONE slack
+// for both rows; what differs between them is not the width of the band but
+// WHAT HAS TO SIT INSIDE IT — the range on the clock row, every round on the
+// heap row (see the two rules at the head of this file). Both rules apply
+// it; this driver only carries it.
 const CONTROL_SLACK = Number(process.env.P0_CONTROL_SLACK || 0.25);
 
 const ONLY = (() => {
@@ -741,15 +785,24 @@ async function heapPass(
   );
 
   // THE CONTROL IS ADJUDICATED, not printed. `predicted` is 8 bytes a
-  // double, fixed before the run; the measured range is this row's own
-  // per-round readings. The rule is `lane/control-verdict`'s, the same one
-  // the freehand P0 arms publish under — this driver states the pair and
-  // reads the answer, and it does so HERE because the page has to still be
-  // open for the rule to be the lane's rather than a JavaScript copy of it.
-  const ctlStat = stat(rounds.map((r) => r.control.measuredCdp));
+  // double, fixed before the run; the readings are this row's own, ONE PER
+  // ROUND. The rule is `lane/control-verdict-strict`'s — every round inside
+  // the band, not merely the range meeting it (rf2-egdaq) — and this driver
+  // states the pair and reads the answer HERE because the page has to still
+  // be open for the rule to be the lane's rather than a JavaScript copy.
+  //
+  // THE PER-ROUND ARRAY IS WHAT CROSSES, and an aggregate cannot stand in
+  // for it. A `{min, max, mean}` summary has already thrown away which
+  // round was which, so the rule it is handed to can only ask about the
+  // range; handing over the rounds is what lets the answer name the one
+  // that missed. It is also what makes the answer re-adjudicable later
+  // without re-running the window — the hole rf2-egdaq's audit of PR #8326
+  // found on three runs that had recorded only the summary.
+  const ctlPerRound = rounds.map((r) => r.control.measuredCdp);
+  const ctlStat = stat(ctlPerRound);
   const controlVerdict = await page.evaluate(
-    ([p, m, s]) => window.P0H.controlVerdict(p, m, s),
-    [CONTROL_PREDICTED, { min: ctlStat.min, max: ctlStat.max, mean: ctlStat.mean }, CONTROL_SLACK]
+    ([p, v, s]) => window.P0H.controlVerdict(p, v, s),
+    [CONTROL_PREDICTED, ctlPerRound, CONTROL_SLACK]
   );
 
   const extra = analyse ? await analyse(page, rounds, plan) : {};
@@ -786,6 +839,10 @@ async function heapPass(
         doubles: CONTROL_DOUBLES,
         predictedBytes: CONTROL_PREDICTED,
         measured: ctlStat,
+        // The rounds themselves, beside the summary of them. A record that
+        // keeps only the summary cannot be re-adjudicated under the other
+        // rule, which is the durability half of rf2-egdaq.
+        perRound: ctlPerRound,
         slack: CONTROL_SLACK,
         verdict: controlVerdict,
       },
@@ -3935,6 +3992,45 @@ function ladderStructuralFailures(row) {
   return out;
 }
 
+// THE HEAP ROW'S POSITIVE CONTROL, PRINTED ONCE (rf2-egdaq). All three heap
+// summaries below publish the same control taken the same way, and they used
+// to say so in three copies that had to be edited together — which is how two
+// of them could have kept naming the overlap rule after the row had stopped
+// using it. A published record that names the wrong adjudicator is worse than
+// one that names none: it invites a reader to apply the other rule's reading
+// to a number it never adjudicated.
+//
+// The verdict NAMES ITS OWN RULE (`verdict.rule`) rather than this printer
+// asserting one, for that same reason — the string comes from the answer.
+function printHeapControl(row) {
+  const c = row.control.measured;
+  console.log(
+    `;; positive control: predicted ${CONTROL_PREDICTED} B  |  measured ${Math.round(c.mean)} B ` +
+      `[${Math.round(c.min)}–${Math.round(c.max)}]  (ratio ${(c.mean / CONTROL_PREDICTED).toFixed(4)})`
+  );
+  const v = row.control.verdict;
+  console.log(
+    `;;   VERDICT (lane/control-verdict-strict, rule ${v.rule}, ` +
+      `slack ±${(row.control.slack * 100).toFixed(0)}%): ${v.ok ? 'OK' : 'FAILED'}`
+  );
+  console.log(`;;     ${v.why}`);
+  console.log(';;     (the shared rule words its figures with an "x"; this control\'s unit is BYTES)');
+  // EVERY ROUND, PASS OR FAIL. The rule adjudicates per round, so a record
+  // that printed only the range would be quoting a summary the rule did not
+  // read — and the rounds are what a later reader needs to re-adjudicate
+  // under the other rule without re-running the window.
+  const per = row.control.perRound || [];
+  if (per.length) {
+    console.log(`;;     rounds: ${per.map((x) => Math.round(x)).join(', ')} B`);
+  }
+  for (const o of v.outside || []) {
+    console.log(
+      `;;     OUTSIDE round ${o.round}: ${Math.round(o.measured)} B, ` +
+        `off by ${(o.offBy * 100).toFixed(2)}% of the prediction`
+    );
+  }
+}
+
 function summariseLadder(row, structuralFailures) {
   const B = row.plan[0].arms[0].boundaries;
   console.log('\n;; ==== P0 RETAINED HEAP — THE READS LADDER (rf2-2rtt6.34) ====');
@@ -3945,16 +4041,7 @@ function summariseLadder(row, structuralFailures) {
   console.log(`;; ${row.rounds} rounds. Reads walk ${LADDER_RUNGS.join('/')}; Q = E on every rung`);
   console.log(';; (distinct-query, the mandatory worst-case witness — every read its own key).');
   console.log(';; Q is COUNTED off the frame\'s own sub-cache on every mount, not asserted.');
-  const ctlA = row.control.measured;
-  console.log(
-    `;; positive control: predicted ${CONTROL_PREDICTED} B  |  measured ${Math.round(ctlA.mean)} B ` +
-      `[${Math.round(ctlA.min)}–${Math.round(ctlA.max)}]  (ratio ${(ctlA.mean / CONTROL_PREDICTED).toFixed(4)})`
-  );
-  console.log(
-    `;;   VERDICT (lane/control-verdict, slack ±${(row.control.slack * 100).toFixed(0)}%): ` +
-      `${row.control.verdict.ok ? 'OK' : 'FAILED'}`
-  );
-  console.log(`;;     ${row.control.verdict.why}`);
+  printHeapControl(row);
   console.log(`;; verification: ${row.verification.unverified} unverified of ${row.verification.mounts} mounts`);
   for (const d of row.verification.detail || []) console.log(`;;   UNVERIFIED ${d}`);
 
@@ -4121,17 +4208,7 @@ function summariseClock(c) {
 function summariseHeap(row) {
   console.log('\n;; ==== P0 RETAINED HEAP — bytes per boundary ====');
   console.log(`;; ${row.roots} roots held per arm; list=${row.perRoot.list} rows, grid=${row.perRoot.grid} cells`);
-  const ctlA = row.control.measured;
-  console.log(
-    `;; positive control: predicted ${CONTROL_PREDICTED} B  |  measured ${Math.round(ctlA.mean)} B ` +
-      `[${Math.round(ctlA.min)}–${Math.round(ctlA.max)}]  (ratio ${(ctlA.mean / CONTROL_PREDICTED).toFixed(4)})`
-  );
-  console.log(
-    `;;   VERDICT (lane/control-verdict, slack ±${(row.control.slack * 100).toFixed(0)}%): ` +
-      `${row.control.verdict.ok ? 'OK' : 'FAILED'}`
-  );
-  console.log(`;;     ${row.control.verdict.why}`);
-  console.log(';;     (the shared rule words its figures with an "x"; this control\'s unit is BYTES)');
+  printHeapControl(row);
   console.log(`;; verification: ${row.verification.unverified} unverified of ${row.verification.mounts} mounts`);
   console.log(';;   (a mount is verified on TWO read-backs: the boundary elements it produced,');
   console.log(";;    and the unique query keys the frame's sub-cache is holding — B and Q)");
@@ -4195,16 +4272,7 @@ function summariseFanout(row) {
   );
   console.log(`;; ${row.rounds} rounds. Q is COUNTED off the frame's own sub-cache on every mount,`);
   console.log(';; not asserted by the plan — an unstamped or mis-stamped rung is an unverified mount.');
-  const ctlA = row.control.measured;
-  console.log(
-    `;; positive control: predicted ${CONTROL_PREDICTED} B  |  measured ${Math.round(ctlA.mean)} B ` +
-      `[${Math.round(ctlA.min)}–${Math.round(ctlA.max)}]  (ratio ${(ctlA.mean / CONTROL_PREDICTED).toFixed(4)})`
-  );
-  console.log(
-    `;;   VERDICT (lane/control-verdict, slack ±${(row.control.slack * 100).toFixed(0)}%): ` +
-      `${row.control.verdict.ok ? 'OK' : 'FAILED'}`
-  );
-  console.log(`;;     ${row.control.verdict.why}`);
+  printHeapControl(row);
   console.log(`;; verification: ${row.verification.unverified} unverified of ${row.verification.mounts} mounts`);
   for (const d of row.verification.detail || []) console.log(`;;   UNVERIFIED ${d}`);
 


### PR DESCRIPTION
## What this is

`rf2-egdaq` (P2, audit). The bead's DESCRIPTION is stale in two ways and its newest
mayor note says so; both were re-derived at the tip before anything was touched.

**Premise 1 — dead paths. HOLDS.** The description names
`implementation/freehand/test/re_frame/bench/hicasso/{lane,hd8_rows}.cljs`.
`git ls-files implementation/freehand/` returns **0** at the tip. Both files live under
`implementation/hicasso/test/re_frame/bench/hicasso/` now.

**Premise 2 — the strict rule already exists and is adopted. HOLDS.**
`lane/control-verdict-strict` is at `lane.cljs:1100`, beside the loose `control-verdict`
at `:1017`; `amp_merge_clock_app.cljs:1048` and `direct_return_clock_app.cljs:432` call it.
`docs/design/hicasso/decisions.md:1615-1624` records the ruling and its carve-out.

**Premise 3 — "the P0 ALLOCATION arms still call the loose rule". PARTLY. It is one clock
arm and one allocation arm, and they do not get the same answer.** That is the finding.

## (a) The verdict: SPLIT — one arm changes, one is REFUSED at source

`p0_app.cljs` is **not** an allocation arm. Its `control-round!` (`:198`) is documented as
"**The clock's positive control** for this round" and reads `(get-in (h/normalise readings
:control-1x) [:ratio :control-2x])` — a ratio of two mount **times**. `verification-totals`
calls its rows "**clock rows**". So the Chrome-clamp carve-out does not merely "transfer" to
it: **the carve-out was ruled ON it.**

`docs/design/hicasso/studio/p0-converged-witness-set.md:1379-1409` re-adjudicated **80
controls** from rf2-6i0i2's balanced ensemble, and its four rows — M1 mount, M2 mount, bulk
broad, bulk narrow — are exactly `p0_app.cljs`'s `published-rows`. Result: **80 of 80 pass
under overlap, 64 of 80 under strict.** Every miss is LOW; every miss lands on the two rows
whose control leg is **one to three of Chrome's 100 microsecond `performance.now()` quanta**;
M1 and narrow, on 20-plus-quantum legs, pass strict **40 of 40**. Strict would refuse M2 in 6
runs of 10 and bulk broad in 6 of 10 on a page where every other gate is green.

**So `p0_app.cljs:482` keeps `lane/control-verdict`, and the reasoning is now written into
`adjudicate`'s docstring** in place of the stale pointer to "rf2-egdaq, which is open".

`p0_heap.cljs` **is** the allocation arm the brief's argument fits, and it goes strict. Its
control is a dense JS array of 587,500 unboxed doubles read in **bytes** off CDP's heap
counter, predicted 4,700,000 B. No quantum, so the carve-out has nothing to exempt — the
ruling's own revisit trigger ("a window whose legs clear the quantum") is met by a leg that
was never on one.

**And on this row overlap is not a weaker gate, it is an absent one.** `p0_run.cjs:1010`
names the failure the control exists to catch: "A retention instrument reads both control
figures as ZERO." Under overlap a round reading **0 B** beside five good ones **passes** —
`(and (<= min hi) (>= max lo))` with `min` 0 under the roof and `max` ~4,700,000 over the
floor. Under `control-verdict-strict` that round is named and the run is refused. That is
HD-008's argument landing on a row where it has real teeth.

## The published series: re-adjudicated from what is committed, and NOTHING flips

No window was run. A published range whose **both ends** sit inside the band bounds every
round inside it, so the committed records answer the question directly. Every P0 heap control
published, against a band of 3,525,000 – 5,875,000 B:

| page | published range (B) | worst end |
|---|---|---|
| `p0-uix-on-subs-frontier-arm.md:333` | 4,699,074 – 4,700,974 | −0.020% |
| `heap-fan-out-sweep.md:224-225` (x2) | 4,699,074 – 4,700,974 | −0.020% |
| `reads-per-boundary-heap-ladder.md:234` | 4,698,960 – 4,701,088 | −0.022% |
| `reads-per-boundary-heap-ladder.md:237` | 4,694,914 – 4,701,024 | −0.108% |
| `reads-per-boundary-heap-ladder.md:1158` | 4,690,838 – 4,700,872 | **−0.195%** |
| `reads-per-boundary-heap-ladder.md:2858` | 4,699,042 – 4,700,872 | −0.020% |
| `the-c1-anchor-on-the-package-arm.md:209` (x3) | 4,698,928 – 4,700,936 / 4,699,042 – 4,700,872 | −0.023% |

Widest excursion anywhere: **4,690,838 B, 0.195% below a prediction gated at ±25%** — better
than two orders of magnitude inside. **Every heap row ever published is `ok` under the strict
rule too.** The tightening buys teeth for the next run, not a revision of the last one.

## The change

- `p0_heap.cljs` — `:controlVerdict` takes **one value per round** and calls
  `lane/control-verdict-strict`. The flat `#js` answer grows `rule`, `stated`, `band`,
  `perRound` and `outside` (itself flat `#js` objects one level down, for the `clj->js`
  scar the file already carries).
- `p0_run.cjs` — hands over `rounds.map(r => r.control.measuredCdp)` instead of a
  `{min,max,mean}` summary, and keeps `control.perRound` in the record. **An aggregate cannot
  be re-adjudicated afterwards** — the durability hole this same bead's audit of PR #8326
  found on three runs.
- `p0_run.cjs` — the three heap summaries (`summariseLadder`, `summariseHeap`,
  `summariseFanOut`) printed the same control block in three copies, which is how two of them
  could have gone on naming the overlap rule after the row stopped using it. One
  `printHeapControl`, taking the rule's name **from the verdict** rather than asserting one.
  It prints every round and names any that sat outside the band.
- `p0_app.cljs` — no behaviour change. The docstring now records why overlap is right *here*,
  and that `[:control :per-round]` is already in the record, so the ruling stays revisitable
  from published data if the batched window it named ever lands on this row.

## Not touched, deliberately

- **`lane.cljs` is read-only for this dispatch** (peer `worker/pctile-xa8wo`). Nothing here
  needed an edit to it: both rules already exist and this change only picks between them.
- **`rf2-z143r`'s fence** (apportioning the 2.4 microsecond cost) — not entered.
- `p0_run.cjs:3511`'s **allocation-window** control is a different rule (an absolute-error
  test on a *mean*), not `lane/control-verdict`. Out of this bead's scope; noted on the bead.
- **No caller-pin test added.** The repo's existing `lane_control_strict_cljs_test` pins that
  the two rules stay two; it does not pin any caller's choice, not even the clock apps'. A
  source-grep pin asserting "this call site says -strict" is the nag-diagnostic class the
  project stance rejects. Recorded on the bead as a deliberate non-addition.

## Quality gates

Both gates run **foreground**, with the redirect and the `echo` of the runner's own exit code
on **one command line in one shell**; the numbers below are the ones I captured, never the
harness's.

| gate | invoked from | exit I captured |
|---|---|---|
| `node core/test/re_frame/bench/p0_ladder_structural.test.cjs` (in `npm run test:script-helpers`) | `implementation/` | **0** — `96 passed` |
| `node hicasso/test/re_frame/bench/hicasso/compile_gate.cjs` (`npm run test:hicasso-compile`) | `implementation/` | **0** — `151 namespaces compiled with zero warnings`; `456 files, 455 compiled, 0 warnings, 23.08s` |

**Why these two.** `test:hicasso-compile` is the only warnings-fatal compile that reaches
`implementation/core/test/re_frame/bench/*.cljs`: `compile_gate.cjs:353` rosters
`re-frame.bench.p0-app` explicitly, and `p0_app.cljs:68` requires `re-frame.bench.p0-heap`,
so both edited namespaces are in its graph. `TESTING.md:22` states the same. Neither
`:node-test` (`cljs-test$`) nor `:browser-test` (`-dom-cljs-test$`) selects them and nothing
test-shaped requires them, so `npm run test:cljs` does **not** reach this surface.
`p0_ladder_structural.test.cjs` requires `p0_run.cjs` as a module, so it is the cheap gate on
the `.cjs` half.

**Planted-fault proof, both gates — each red on a fault that existed only in this worktree,
each restored and verified by hashing the bytes against the committed object.**

1. `p0_run.cjs`: replaced `const c = row.control.measured;` in `printHeapControl` with an
   unbalanced call. Gate **exit 1**, `SyntaxError: missing ) after argument list` at
   `...implementation/core/test/re_frame/bench/p0_run.cjs:4004`. Restored, and the **blob**
   hash `8170875b337702818ade2b2e6cf1682536ee1342` is identical before the plant and after
   it; re-ran green, `96 passed`, exit 0.
2. `p0_heap.cljs`: wrapped the strict call in `(planted-fault-rf2-egdaq ...)`. Gate **exit
   1**, `BUILD REFUSED — :hicasso-bench compiled with 1 warning(s)`, `WARNING #1 —
   :undeclared-var`, `Use of undeclared Var re-frame.bench.p0-heap/planted-fault-rf2-egdaq`
   at line 1356 — it names the edited namespace, so the gate demonstrably reaches it.
   Restored, and the **blob** hash `f0e94a302e539a685c57cde049f90afd4b2823ac` is identical
   before and after; re-ran green, exit 0.

Both plants were scoped to one line each, so neither could abort a suite ahead of the rows it
was meant to prove — the namespace count was 151 and the assertion count 96 on every green
run, before and after. Both gates also printed their own root banner naming this worktree, so
the two tree-verification routes agree rather than resting on one.

**Both gates were re-run on the FINAL rebased base.** The trunk moved during the work; the
branch was rebased onto `origin/main` and no commit in the interval touched
`implementation/core/test/re_frame/bench/`. The merge-base three-dot diff
(`origin/main...HEAD`) is exactly these three files, so nothing here reverts a sibling's
landing.

**The fast spine did NOT run** (`scripts/test-fast-pr.sh`). It is heavier than this surface
needs and this dispatch was held off heavy runs; the two targeted gates above were run
directly instead. Per `scripts/check_fast_pr_gap.py --list`, the spine does not decide **94**
required checks in any case — the three required contexts are `All required checks passed`
(test.yml), `Lint required` (lint.yml) and `Docs required` (docs.yml), and green on the spine
is not green in CI.

**No measurement window was taken.** No P0 bench, no release build, no browser, no Playwright.
The whole of this is adjudication code plus a re-adjudication computable from committed
records.

**Verified by hand, because no gate covers it:** the arithmetic in the table above (each
published range against 3,525,000 – 5,875,000 B), and the column counts of both tables in this
body (3 columns and 7 body rows in the first; 3 columns and 2 body rows in the second).

## Left OPEN for the operator

`rf2-egdaq` is **not closed**. An operator-facing records question is written up on the bead
and needs Mike, not a worker.
