### PR TITLE
fix(test): honour markdown escaped pipe in the catalogue parser; retire the drifting *Tags totals (rf2-1t0er, rf2-zmpfn)

### DIFF
--- a/implementation/core/test/re_frame/error_catalogue_channel_conformance_test.clj
+++ b/implementation/core/test/re_frame/error_catalogue_channel_conformance_test.clj
@@ -1068,14 +1068,28 @@
   "`[{:category <kw> :tags-cell <string>} …]` for every ACTIVE row of the
   canonical catalogue section. The `:tags` cell is the SIXTH column; `-1` keeps
   trailing empties so a row whose `:tags` cell is BLANK still parses (and so
-  still reds when its schema declares keys)."
+  still reds when its schema declares keys).
+
+  The split skips a BACKSLASH-ESCAPED pipe (rf2-1t0er). `\\|` is how markdown
+  writes a literal pipe inside a table cell, so a cell containing one is
+  correct prose rather than a typo — `:rf.error/infinite-missing-next-page-param`
+  spells its `:next-page-param` contract `(last-page → next-param \\| nil)`.
+  Splitting on it anyway yielded NINE fields where the table has eight and slid
+  every column one place left, so that row's `:tags` cell was read from its
+  `Default :recovery` column. Harmless only by luck: no
+  `InfiniteMissingNextPageParamTags` schema exists to pair with the row, so the
+  mis-read cell was never compared against anything, and the day one is added
+  the pairing arm would diff a recovery sentence against a tag key set. The
+  lookbehind fixes the reader rather than the spec, which is the right side to
+  fix — the escape is valid markdown that any catalogue row may legitimately
+  use."
   ([] (parse-catalogue-tag-rows (slurp spec-009-file)))
   ([text]
    (->> (str/split-lines text)
         (catalogue-section-lines)
         (keep (fn [line]
                 (when-let [[_ cat-str] (re-find catalogue-tag-row-re line)]
-                  (let [cells (str/split line #"\|" -1)]
+                  (let [cells (str/split line #"(?<!\\)\|" -1)]
                     (when (>= (count cells) 7)
                       {:category  (keyword (subs cat-str 1))
                        :tags-cell (str/trim (nth cells 6))})))))

--- a/implementation/core/test/re_frame/error_catalogue_channel_conformance_test.clj
+++ b/implementation/core/test/re_frame/error_catalogue_channel_conformance_test.clj
@@ -880,19 +880,31 @@
 ;; assertion but the wrong KIND of assertion for a coverage question.
 ;;
 ;; Catching it BY NAME would need a total, identity-preserving pairing, and the
-;; two corpora cannot derive one: 22 of the 111 `*Tags` schemas are legitimately
-;; claimed by NO catalogue row (`FxHandledTags`' siblings for non-error ops, and
-;; 12 whose operation 009 never names by any derivation), only 5 schema names
-;; are cited anywhere in 009, and nothing in `implementation/` references a
-;; schema name — so an orphaned schema is indistinguishable from a correctly-
-;; unpaired one without a third authority. The rf2-6tags no-roster ruling
-;; therefore STANDS rather than needing an exception: no orphan allow-list, and
-;; no reading of `implementation/` to discover schema names.
+;; two corpora cannot derive one. A standing minority of the `*Tags` corpus is
+;; legitimately claimed by NO catalogue row, for two different reasons — the
+;; success-path and other non-error siblings of `FxHandledTags`, which an ERROR
+;; catalogue has no row for, and schemas whose operation 009 never names by any
+;; derivation. Barely a handful of schema names are cited anywhere in 009, and
+;; nothing in `implementation/` references a schema name — so an orphaned schema
+;; is indistinguishable from a correctly-unpaired one without a third authority.
+;; The rf2-6tags no-roster ruling therefore STANDS rather than needing an
+;; exception: no orphan allow-list, and no reading of `implementation/` to
+;; discover schema names.
+;;
+;; This paragraph used to quote four raw totals and is deliberately down to none
+;; (rf2-zmpfn). Nothing asserts them, they drift on every schema added or
+;; retired, and three of the four were wrong when re-measured — the unpaired
+;; count, the corpus total, and the count of names 009 cites. Re-derive on
+;; demand instead: `(count (parse-tags-schemas))` for the corpus, and that minus
+;; `(paired-count (parse-catalogue-tag-rows) (parse-tags-schemas))` for the
+;; unpaired population. The argument needs only that the population is
+;; non-empty, never its size.
 ;;
 ;; The answer is the mechanism the ROW side already ships, applied to the
 ;; pairing itself. `tags-column-paired-floor` records the paired COUNT, so a
-;; drop reds without the arm ever knowing WHICH schema went. One integer, not 22
-;; entries: it names no member, so it cannot rot into the hand-maintained roster
+;; drop reds without the arm ever knowing WHICH schema went. One integer, not an
+;; entry per unpaired schema: it names no member, so it cannot rot into the
+;; hand-maintained roster
 ;; the ruling forbids, and the only edit it admits is a deliberate lowering in
 ;; the same commit that removes a pairing.
 ;;
@@ -975,9 +987,11 @@
   schema is a SILENT NARROWING: `HydrationMismatchTags`' adoption keys would
   simply never be diffed against the row, which is coverage lost with nothing
   saying so. The legacy first-`[:map …]`-anywhere reading is retained beside the
-  arms so this reader can only ever WIDEN — measured at the change, all 111
-  `*Tags` schemas but the one edited here are `[:map`-headed, so their key sets
-  are byte-identical either way."
+  arms so this reader can only ever WIDEN — every `*Tags` schema except
+  `HydrationMismatchTags`, the one edited here, is `[:map`-headed, so their key
+  sets are byte-identical either way. Named rather than counted (rf2-zmpfn): the
+  exception is the durable fact, while a corpus total goes stale on the next
+  schema retired, as this line's did."
   [form]
   (let [arm-maps (concat (schema-arm-maps (last form))
                          (->> (tree-seq coll? seq form)
@@ -1011,8 +1025,9 @@
   TOP-LEVEL, not the first `[:map …]` found anywhere, since rf2-zk1xu: a
   two-arm `HydrationMismatchTags` read down to its first arm would validate
   every adoption-tier payload against the HICCUP map and report the shipped
-  schema rejecting events it accepts. For the 110 `[:map`-headed schemas the
-  two readings are the same vector."
+  schema rejecting events it accepts. `HydrationMismatchTags` is the corpus's
+  only non-`[:map`-headed schema, so for every OTHER schema the two readings are
+  the same vector."
   [schema-name]
   (let [text    (slurp spec-schemas-file)
         matcher (re-matcher tags-schema-def-re text)]


### PR DESCRIPTION
Two P4 catalogue-prose beads, both explicitly closable as minutiae. Both were actioned, but **neither landed where its bead expected**, and the reasons are the substance of this PR. Net: one file touched, `spec/009-Instrumentation.md` NOT touched.

## rf2-1t0er — the premise holds, the diagnosis does not

The bead says a **stray unescaped pipe** sits in the `:rf.error/infinite-missing-next-page-param` row, so it parses as 9 fields and its RECOVERY column is read as `:tags`.

The **parse defect is real and reproduced exactly**. Measured at the tip:

```
OLD-SPLIT-FIELDS: 9
OLD-cells[6]: `:fix-registration` — supply a `:next-page-param` fn      <- the RECOVERY column
```

But the pipe is **already markdown-escaped**, so the row renders correctly and is correct prose: it spells the contract `(last-page → next-param \| nil)`, where `\|` is exactly how markdown writes a literal pipe inside a table cell. What is wrong is `parse-catalogue-tag-rows`, which split on a bare pipe pattern and did not honour the escape.

So the fix went into the **reader**, not the spec — the split gained a negative lookbehind for a backslash, one token, at the only pipe-split call site in the file. Rewriting valid markdown to suit a downstream test parser would have left the next author's correctly-escaped cell just as broken, and "the spec is the artefact; the code is downstream" points the same way. It also keeps this PR out of the hot zone entirely — see the fence note below, which matters here.

**By-hand column count**, over the canonical catalogue section. The header is `:operation` / `:op-type` / Channel / Trigger / meaning / Default `:recovery` / `:tags` — 6 columns, which is 8 split fields once the leading and trailing empties are kept:

| | active rows | rows at 8 fields | rows at 9 fields |
|---|---|---|---|
| before | 513 | 512 | **1** |
| after | 513 | **513** | 0 |

Exactly one row was malformed — the one the bead names — and after the fix every row in the table splits to 8, with zero collateral. That row's sixth column moves from the recovery sentence to its real tags cell, `:resource-id` and `:infinite`.

## rf2-zmpfn — worse than the bead said, so the numbers go rather than get corrected

Every figure re-derived from the code that computes it, not from arithmetic:

| quantity | computation | value |
|---|---|---|
| corpus total | `(count (parse-tags-schemas))` | 110 |
| paired | `(paired-count (parse-catalogue-tag-rows) (parse-tags-schemas))` | 93 |
| the pin | `tags-column-paired-floor` | 93 |
| unpaired | corpus minus paired | 17 |
| `[:map`-headed | top-level form of each parsed schema | 109 |
| names 009 cites | distinct `*Tags` tokens in 009 | 4 |

Both drifts the bead predicted are confirmed. PR #8573 retired `HeadMismatchTags`, taking the corpus 111 to 110; and the `22` was **already wrong before that** — 18 at the parent of #8573, 17 now.

The bead named three integers. There were **five**: a fourth in the same sentence ("only 5 schema names are cited anywhere in 009", where the measurement is **4**) and a fifth restatement further down ("One integer, not 22 entries"). Four hand-copied numbers in one paragraph, three of them wrong, none asserted by anything.

That settles the bead's (a)-vs-(b) choice in favour of **(b) for the totals**: they rot on every schema added or retired, no gate can catch them, and the argument they sit in needs only that the unpaired population is non-empty — never its size. The paragraph keeps both **reasons** a schema is legitimately unpaired (durable, and spot-checked: some unclaimed schemas have operations 009 does name, others it never names) and gains a one-line re-derivation recipe in place of the figures. The fabricated `12` sub-split is gone; re-deriving it needs a measurement the test does not expose, and inventing one for a comment would be over-engineering.

The two `[:map`-headedness comments went the **other** way, because there the concrete fact is worth keeping and is not a count: the corpus has exactly **one** non-`[:map`-headed schema and it is `HydrationMismatchTags`, which is `:or`-headed. Naming it says more than "110" did and does not go stale when a schema is retired.

**Deliberately not touched:** the "reports 22 findings" at the non-vacuity corpora is a frozen measurement against the historical files at `ded86cff64`, not the live corpus, so it does not drift.

## Quality gates

| gate | result | exit code I captured |
|---|---|---|
| catalogue conformance ns (control, pre-change) | 28 tests, 177 assertions, 0 failures | **0** |
| same — **sabotage v1** (extra key added to a `:tags` cell) | 28/177, 0 failures — **green** | **0** |
| same — **sabotage v2** (key removed from a `:tags` cell) | 28/177, **2 failures** | **1** |
| same — after the rf2-1t0er fix | 28 tests, 177 assertions, 0 failures | **0** |
| same — after both beads | 28 tests, 177 assertions, 0 failures | **0** |
| same — **re-run on the final rebased base** | 28 tests, 177 assertions, 0 failures | **0** |

The gate is `clojure -M:test -n re-frame.error-catalogue-channel-conformance-test`, run from `implementation/core`. Every exit code above was captured in the same shell as the run, redirect and echo on one command line, never piped through a filter and never taken from a harness report.

**Before/after counts are identical at 28 tests / 177 assertions** — which is precisely what rf2-1t0er demanded as proof the change is a no-op for every existing assertion. A moved count would have meant the malformed row was load-bearing somewhere.

**Planted-fault proof.** The first sabotage came back **green**, which was treated as a reason to stop rather than to proceed: the pairing arm is one-directional (schema keys must be a subset of cell keys), so an *extra* cell key is legal by design and that plant was not discriminating. Re-planted in the correct direction — dropping `:reason` from the `:rf.error/resource-scope-required-from-caller` cell — the gate went **red naming exactly the plant**:

```
[[:rf.error/resource-scope-required-from-caller "ResourceScopeRequiredFromCallerTags" (:reason)]]
```

The fault existed only in this worktree, so a run that had wandered into a sibling checkout would have come back green. Test and assertion counts stayed 28/177 under the plant, confirming it was scoped and aborted no namespace. The restore was verified by the identical **blob** hash `4064577ea0a3f6275554ae1c20a035e3c5031349` before the plant and after the restore, taken against the committed object rather than as a working-file byte digest — and `spec/009-Instrumentation.md` is unmodified in this PR.

**Fast spine: NOT run.** A peer worker was holding a shadow-cljs build, and two heavyweight loads on one box wedge rather than fail. The catalogue conformance namespace is a JVM Clojure test and is the gate that actually reads the changed file, so it was run directly, six times, in the foreground.

**`scripts/check_fast_pr_gap.py --list`: 94 required checks the spine does not run** (exit 0). Green locally is not green in CI.

**Doc-link gates do not apply.** This PR touches one `.clj` file and no markdown, so neither `scripts/check_doc_slugs.py` (roots `docs/`, `spec/`, `skills/`, `migration/`, `tools/*/spec`) nor `scripts/check_readme_links.py --ci` has a surface here. Nothing validates the prose of a Clojure comment, so **the reworded comments were re-read by hand**, and the markdown table column counts in this PR body were counted by hand.

## Fence note for the mayor

Re-derived at start-up and again before the first edit. **`worker/ssrtier-5v0yy` has committed changes to `spec/009-Instrumentation.md`** (2 rows, around lines 1964 and 2010) with no open PR yet — a second hot-zone toucher. This PR no longer touches that file at all, so the collision is moot, but the holder exists and the mayor may want to know.

`worker/implres-5z6bb` had no worktree, branch or commits at either derivation.

**rf2-6tags is fenced behind this PR** and builds on this file. For whoever takes it: the ratchet's existing probe finding (`:rf.error/schema-validation-failure` with `:rf2-6tags/probe-key`) is visible and untouched, `tags-column-paired-floor` is still 93, and the corpus is 110 with 17 unpaired.

Closes rf2-1t0er, rf2-zmpfn.
