### PR TITLE
docs(retire): correct four live-tense claims about the removed donor substrates (rf2-5z6bb)

### DIFF
--- a/implementation/hicasso/lint-fixtures/negative.cljs
+++ b/implementation/hicasso/lint-fixtures/negative.cljs
@@ -134,8 +134,9 @@
    [:button props]
    [:a {:href "/help"} "Help"]
    ;; An <a> with NO href is not a link and not focusable, so it needs no
-   ;; accessible name. The tag set and this condition are the compiled
-   ;; substrates' (`re-frame.ui.compiler.a11y`), not invented here.
+   ;; accessible name. The tag set and this condition were inherited from
+   ;; this project's retired compiled-view substrate
+   ;; (`re-frame.ui.compiler.a11y`, gone with rf2-0yp7w), not invented here.
    [:a {:name "section-3"}]
    [:a {:class "anchor-target"}]])
 

--- a/implementation/hicasso/resources/clj-kondo.exports/day8/re-frame2-hicasso/hooks/re_frame/hicasso.clj
+++ b/implementation/hicasso/resources/clj-kondo.exports/day8/re-frame2-hicasso/hooks/re_frame/hicasso.clj
@@ -344,8 +344,11 @@
 
 (def ^:private naming-attributes
   "The attributes that give an element an accessible name on their own.
-  The same three the compiled substrates' a11y pass names
-  (`re-frame.ui.compiler.a11y`, `:rf.ui.compile/a11y-missing-accessible-name`)."
+  The same three this project's retired compiled-view substrate named in its
+  a11y pass (`re-frame.ui.compiler.a11y`,
+  `:rf.ui.compile/a11y-missing-accessible-name`) — inherited from it rather
+  than invented here. That substrate went with rf2-0yp7w; the rule it agreed
+  with is what stayed."
   #{:aria-label :aria-labelledby :title})
 
 (defn- needs-an-accessible-name?

--- a/implementation/hicasso/scripts/check_optional_module_reachability.py
+++ b/implementation/hicasso/scripts/check_optional_module_reachability.py
@@ -110,8 +110,10 @@ in full and called itself "the DEPENDENCY-GRAPH half of that sentence"
 while asking only the module question.  Each file was right about
 itself; the clause was measured by neither.  So it is measured here
 now, in TWO ARMS, which is the shape
-`implementation/scripts/check-ui-adapter-isolation.cjs` already uses
-for the same claim about `re-frame2-ui`:
+`implementation/scripts/check-ui-adapter-isolation.cjs` used for the
+same claim about `re-frame2-ui`.  That gate is gone -- it retired with
+the compiled-view substrate it guarded (rf2-0yp7w.4), so do not go
+looking for it; what survives it is the two-arm shape itself:
 
   1. **SOURCE** — no namespace under `src/` requires UIx.  Read off
      `:require` forms by the same parser the module rows use, so the

--- a/implementation/hicasso/test/re_frame/hicasso/examples/navigation/conduct_dom_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/examples/navigation/conduct_dom_cljs_test.cljs
@@ -73,8 +73,11 @@
   **Prefetch.** `re-frame.routing` warms a destination from all three
   credible-intent positions (`:on-mouse-enter` / `:on-focus` /
   `:on-touch-start`, the closed class `re-frame.routing.link/
-  prefetch-intent-keys` holds), and `re-frame.ui.route-link-dom-cljs-test`
-  drives them with real DOM events. Hicasso's own `h/route-link` DECLINES
+  prefetch-intent-keys` holds), and `re-frame.route-link-cljs-test`
+  drives each of them — with a SYNTHETIC event, not a real DOM one: the
+  suite that drove them through the browser retired with the compiled-view
+  substrate (rf2-0yp7w), so no browser-level witness survives it.
+  Hicasso's own `h/route-link` DECLINES
   `:prefetch` outright in v0 and fails loud at the link site
   (`:rf.error/hicasso-route-link-prefetch-declined`), so there is nothing
   on this application's surface to witness. Admitting the key is a


### PR DESCRIPTION
R6 slice of `rf2-0yp7w.9`, fenced to `implementation/`. **The classification was the job**, and it came out close to the parent bead's own ratio: of **27 in-fence files** carrying a hit, **23 are correct as they stand** and **4 asserted a current fact about a surface that no longer exists**.

## Census, re-run at the tip

```
git grep -lI -E 're-frame\.(ui|freehand)|re-frame2-ui([^x]|$)|re-frame2-freehand' -- implementation ':!.beads'
```

**34 files raw → 27 in fence** after the three hard exclusions (5 bench-tree files, the catalogue conformance test, `_changed-surfaces.test.cjs`). The brief's hours-old figure of 26 had already rotted by one.

**The corrected regex earns its keep on this surface.** Measured here: bare `re-frame2-ui` matches **11** files; `re-frame2-ui([^x]|$)` matches **3**. Eight of eleven were `re-frame2-uix`, which is first-class and live.

## The 4 changed

| File | Why it was residue |
|---|---|
| `implementation/hicasso/test/re_frame/hicasso/examples/navigation/conduct_dom_cljs_test.cljs` | Claimed `re-frame.ui.route-link-dom-cljs-test` "drives them with real DOM events". **That namespace does not exist**, so this was a false coverage claim used to justify not testing prefetch here. Re-pointed at the surviving witness `re-frame.route-link-cljs-test`, which drives all three intent positions with a **synthetic** event — and says plainly that no browser-level witness survived the substrate. The "nothing here to witness" argument is untouched: it rests on Hicasso declining `:prefetch`, not on the other suite. |
| `implementation/hicasso/scripts/check_optional_module_reachability.py` | Cited `implementation/scripts/check-ui-adapter-isolation.cjs` as the gate whose two-arm shape it copies, in the present tense. **That script was deleted with the substrate** (`ef3131f4a2`). Marked gone so nobody goes looking; the two-arm shape is what survives it. |
| `implementation/hicasso/resources/clj-kondo.exports/day8/re-frame2-hicasso/hooks/re_frame/hicasso.clj` | `naming-attributes`' docstring cited `re-frame.ui.compiler.a11y` in the present tense as the authority for the attribute set. |
| `implementation/hicasso/lint-fixtures/negative.cljs` | The same a11y claim, same present tense, in the fixture comment. |

The last two are one claim in three places, and **the third — the sibling `README.md` in the same clj-kondo export — was already corrected to "retired"**. This is a consistency repair inside one artefact, not invented work.

**Every provenance name is kept.** Only the tense is corrected, so the record of where each rule came from survives. Three of the four still match the census on purpose; only `conduct_dom_cljs_test.cljs` leaves it, because there the dead namespace was replaced by a live one.

## The 23 left alone, and why

**Live ABI — the `ssr` trio the bead flagged. Verdict: LIVE, confirmed at source, left alone.**

- `implementation/ssr/src/re_frame/ssr/ui_tree.cljc` — `:rf.ui/tree-version` is the root gate of the tree ABI `re-frame.ssr/emit-ui-tree` consumes, validated before any traversal. The `re-frame.ui.rules` mention is already-corrected prose: *"That substrate has been retired (rf2-0yp7w), so these tables are now the ORIGINALS and the pin is gone."*
- `implementation/ssr/test/re_frame/ssr/emit_ui_tree_cljs_test.cljc` — same, already corrected in the same words.
- `implementation/ssr/test/re_frame/ssr/root_manifest_cljs_test.cljc` — an explicit *"WHAT USED TO BE HERE AND IS NOT"* tombstone. Deleting it destroys exactly the record a reader needs.

Renaming or scrubbing any of these would break a shipped surface, not tidy a dead one.

**Already-corrected prose (retirement stated in the immediate context)** — `adapters/reagent/.../realworld_resources_cljs_test.cljs` (x2, one an explicit "TRIMMED, NOT DELETED" tombstone), `hicasso/test_kit/src/re_frame/hicasso/test.cljs` (x2), `routing/test/re_frame/routing_path_census_test.clj`, `hicasso/scripts/check_budget_ledger.py`, `scripts/_browser-dom-lane-partition.test.cjs` (x2), `scripts/_navigation-ceiling-policy.test.cjs`, `scripts/_reagent-slim-smoke-policy.test.cjs`, `scripts/api-manifest/probe/.../cljs_probe.cljc`.

**Changelogs and provenance ledgers (past-event narratives)** — `core/test/.../capture_frame_reincarnation_sink_route_cljs_test.cljc`, `core/test/.../frame_destroyed_subscribe_devtrace_identity_cljs_test.cljc`, `scripts/_preflight-xray-package.test.cjs` (x2), `scripts/_rewrite-local-root-coord.test.cjs` (x2), `scripts/_rigorous-local-inventory.test.cjs`, `scripts/api-manifest/src/.../doc_api_check.clj`.

The line I drew: a **past-event narrative** ("#6516 fixed...", "that block went with...") is a record and stays; a **current normative or coverage assertion** resting on a surface that is gone is residue and was fixed. Marking every historical PR narrative in the corpus would be gold-plating.

**Deliberate negative fixtures** — `scripts/_adapter-smoke-filter.test.cjs` (x2) is the sharpest: it asserts the retired `ui/testbed` and `ui-testbed` filter shapes select **nothing, and in particular never fall through onto UIx**. That is a live guard against exactly the `ui-testbed`/`uix-testbed` near-collision this programme keeps tripping over. `scripts/_preflight-story-package.test.cjs` pins a rule the shipped script still carries (see below).

**Synthetic parser fixtures** — `scripts/api-manifest/test/.../api_md_check_test.clj` (~45 hits) and `.../doc_api_check_test.clj` (~11). Both are hand-built input to pure functions (`parse-var-rows`, `coverage-problems`); the namespace strings are arbitrary test data and neither reads the real `API.md`. Renaming them is churn with live assertions attached.

**A frozen manifest is a record** — `implementation/hicasso/frozen-sources.edn`'s `:forbidden-import-prefixes ["re-frame.bench." "re-frame.freehand."]` is a live config value forbidding an import. Dropping the retired prefix weakens a guard for no gain, and the file's own comment says prose naming these is deliberate.

## The three exclusions, classified but untouched

1. **Bench trees** (5 files) — `rf2-0yp7w.9.6` owns them and `worker/pctile-xa8wo` was live in that tree.
2. **`core/test/.../error_catalogue_channel_conformance_test.clj`** — held by `worker/specmin-cluster`. Read only: all 4 hits are tombstones ("both were removed on 2026-08-16", "went with them"). Correct as-is; the holder need not act.
3. **`scripts/_changed-surfaces.test.cjs`** — HOT ZONE, one-toucher with `.github/scripts/report-changed-surfaces.sh`. **Not edited, as instructed.** Read only: 6 of its 7 hits are changelog comments and correct. Line 4017 (*"re-frame.ui now ships REAL DOM tests"*) is stale present tense, but it is a comment in a file that moves in one commit with the shell script or not at all. Reported, not touched.

## Findings outside this fence (reported, not fixed)

1. **`implementation/routing/test/re_frame/routing_conduct_dom_cljs_test.cljs:38-44` is HALF-corrected and now self-contradictory.** It says the three intent positions *"are driven with REAL DOM events in **the retired compiled tier's** route-link DOM suite"* and then declines to test them here because *"rebuilding that here would add a second copy of a covered proof."* If the tier retired, the proof is not covered — the justification inverts. Someone swapped the namespace for a phrase without re-reading the argument. **Invisible to this census** (the `re-frame.ui` name was already scrubbed), which is worth noting for the programme: scrubbing a name can hide a live defect from the very regex hunting it.
2. **`implementation/scripts/serve-and-run-browser-tests.cjs:360`** cites `check-ui-adapter-isolation.cjs` as an "established convention" — the same deleted script. Also invisible to the census (names the file, not a namespace).
3. **`.github/scripts/preflight-story-package.sh:130-134`** still carries a live `EXTRA_HINT` for `("day8", "re-frame2-ui")`. The rule is now vestigial — the coordinate cannot leak because it does not exist — but it is **one-toucher** with the in-fence `_preflight-story-package.test.cjs`, which pins that exact string. They move together or not at all.

## Quality gates

Box was busy at start (a peer's 3 GB node run, started 76 s earlier); **no heavyweight run was started concurrently**, and `scripts/test-fast-pr.sh` was not run.

| Gate | Covers | Captured exit |
|---|---|---|
| `python hicasso/scripts/check_optional_module_reachability.py --self-test && ...` | the edited `.py` | **0** |
| `python hicasso/scripts/check_lint_export.py --self-test && ...` | `negative.cljs` **and** the clj-kondo hook | **0** |
| `check_freeze.py`, `check_complaint_catalogue.py`, `check_facade_inventory.py` (+ self-tests) | hicasso invariants, no collateral | **0** |
| Reader parse (`clojure.tools.reader`, `:features #{:cljs}`) | the edited `.cljs` docstring | **0** (31 top-level forms) |

Every number above is the one **captured in the same shell as the runner** (`> log 2>&1; echo "CAPTURED_EXIT=$?"`), never piped through a filter and never taken from a harness report.

### Planted-fault proofs — four, each restored and hash-verified

None of these gates prints its root, so the red **is** the discrimination: the fault existed only in this worktree, so a run that had wandered into a sibling checkout would have come back green.

1. **Reachability gate** — promoted `day8/re-frame2-uix` into `hicasso/deps.edn`'s production `:deps`. Captured exit **1**, naming the map and pointing at the `:test` alias. Restored to the identical **blob** hash `4da8620a29d84e17a49cd926dbce62315a9bd00b`.
2. **Lint-export gate, fixture arm** — flipped `[:a {:name "section-3"}]` to `[:a {:href "/section-3"}]`, **at the very lines whose comment this PR edits**. Captured exit **1**, red at `negative.cljs:140:4` naming `nameless-interactive-element`. Restored to the identical **blob** hash `25e252da8f1dbf913e6e0f4865d2e97b172b71da`.
3. **Lint-export gate, hook arm** — dropped `:title` from `naming-attributes`, **the exact def whose docstring this PR edits**, proving the gate loads and executes that file. Captured exit **1**, red at `negative.cljs:129:4`. Restored to the identical **blob** hash `189d97e4d235414c9258f040a5e873bbefd43566`.
4. **Reader parse** — inserted an unescaped double quote at the edited docstring line. Captured exit **1**, red at line 77. Restored to the identical **blob** hash `3f6957aaa1b9df23e104c1081cd6499e48766896`.

Each plant was scoped to one assertion, and the clean runs before and after report the same check counts (6 checks, 12 self-test rows), so nothing was silently skipped.

### What did NOT run locally, and who owns it

**`npm run test:browser` did not run here.** `conduct_dom_cljs_test.cljs` is selected by `:browser-test` (`.*-dom-cljs-test$`); the gate is compound (`shadow-cljs compile browser-test && node scripts/serve-and-run-browser-tests.cjs`) and its compile half is the one that covers a docstring edit — but this worktree has **no `node_modules`**, and junctioning the mayor's is the operation that has twice emptied it. That risk is not worth taking for a change of prose inside an existing string literal, so **CI's browser lane is the gate for this file** and must be green before merge. The reader parse above is a local check of the only failure mode the edit can actually cause, with a planted fault to prove it bites.

### Fast-spine gap

`python scripts/check_fast_pr_gap.py --list` → **94 required checks the spine does not run** ("Green here is not green in CI"), across `test.yml`, `lint.yml` and `docs.yml`.

### Verified by hand

- The four edited hunks are prose only — no code, no symbols, no behaviour.
- Markdown table column counts in this body checked by hand.
- Post-edit census re-run: 33 files (34 → 33; only `conduct_dom_cljs_test.cljs` leaves, as intended).
- Rebased onto `2c777440b7` and **all gates re-run on the final base**, all still exit 0. The three-dot diff against the merge base is exactly these four files — nothing a sibling landed would be reverted.

Closes rf2-5z6bb.
