### PR TITLE
bench(hicasso): an interaction-to-paint clock on the slice app (rf2-xa8wo)

### DIFF
--- a/implementation/hicasso/test/re_frame/bench/hicasso/lane.cljs
+++ b/implementation/hicasso/test/re_frame/bench/hicasso/lane.cljs
@@ -632,8 +632,69 @@
   value)
 
 ;; ---------------------------------------------------------------------------
+;; Serial promise chains
+;; ---------------------------------------------------------------------------
+
+(defn chain
+  "Fold `xs` into a serial promise chain, threading an accumulator.
+
+  Defined HERE rather than beside the write helpers it was written for,
+  because [[rounds-async!]] below is its second consumer and a var cannot
+  be used above its definition."
+  [init xs f]
+  (reduce (fn [p x] (.then p (fn [acc] (f acc x)))) (js/Promise.resolve init) xs))
+
+;; ---------------------------------------------------------------------------
 ;; Rounds
 ;; ---------------------------------------------------------------------------
+
+(defn- visit-plan
+  "The visits ONE run makes, in execution order, as
+  `{:round :arm :measured?}`.
+
+  THE SCHEDULE IS STATED ONCE, HERE, and both loops below walk it.
+  [[rounds!]] is synchronous and [[rounds-async!]] is not, and the
+  obvious way to write the second is to give it its own nested loops —
+  which would be a second copy of the reflecting order, the warm-up
+  boundary and the round boundary, with nothing holding it in step with
+  the first. This file already prices that shape twice: [[slot-order]]'s
+  `k = 2` degeneracy survived a fix to its own sibling because
+  `b6-harness` held a copy, and [[observe!]]'s missing call was repaired
+  privately in the two hand-rolled loops while the ten apps riding the
+  shared one kept the fault. A plan both loops consume cannot disagree
+  with itself, and `lane-schedule-async-cljs-test` asserts that they do
+  not rather than trusting this paragraph."
+  [arms {:keys [warmup samples] :as _sampling} rounds]
+  (let [k (count arms)]
+    (for [round (range rounds)
+          s     (range (+ warmup samples))
+          j     (slot-order k s)]
+      {:round round :arm (nth arms j) :measured? (>= s warmup)})))
+
+(defn- fresh-readings
+  "One empty reading vector per arm, per round."
+  [arms rounds]
+  (atom (vec (repeat rounds (zipmap (map :id arms) (repeat []))))))
+
+(defn- bank-visit!
+  "Bank one visit's reading — or, for a warm-up visit, record only that it
+  RAN.
+
+  DISCARDED, BUT NOT UNSEEN. A warm-up sample is what the next measured
+  sample actually followed; [[observe!]] carries that across the gap so
+  the guard's `:predecessor` factor stratifies what ran rather than what
+  was banked."
+  [coll readings label {:keys [round arm measured?]} ms]
+  (if measured?
+    (do (collect! coll (label arm) ms)
+        (swap! readings update-in [round (:id arm)] conj ms))
+    (observe! coll (label arm)))
+  nil)
+
+(defn- default-label
+  "An arm names itself to the guard unless the caller says otherwise."
+  [arm]
+  (name (:id arm)))
 
 (defn rounds!
   "Run `rounds` rounds of `sampling` over `arms`, calling
@@ -682,29 +743,60 @@
   bench apps ride this loop and every one of them would inherit the new
   schedule, so the trigger is stated here rather than left to judgement."
   ([arms sampling rounds measure-one!]
-   (rounds! arms sampling rounds measure-one! (fn [arm] (name (:id arm)))))
-  ([arms {:keys [warmup samples] :as _sampling} rounds measure-one! label]
-   (let [k    (count arms)
-         coll (sample-collector)
-         out  (mapv
-                (fn [_round]
-                  (let [acc (atom (zipmap (map :id arms) (repeat [])))]
-                    (dotimes [s (+ warmup samples)]
-                      (doseq [j (slot-order k s)]
-                        (let [arm (nth arms j)
-                              ms  (measure-one! arm)]
-                          (if (>= s warmup)
-                            (do (collect! coll (label arm) ms)
-                                (swap! acc update (:id arm) conj ms))
-                            ;; DISCARDED, BUT NOT UNSEEN. A warm-up sample
-                            ;; is what the next measured sample actually
-                            ;; followed; [[observe!]] carries that across
-                            ;; the gap so the guard's `:predecessor` factor
-                            ;; stratifies what ran rather than what was banked.
-                            (observe! coll (label arm))))))
-                    @acc))
-                (range rounds))]
-     {:readings out :samples (:samples @coll)})))
+   (rounds! arms sampling rounds measure-one! default-label))
+  ([arms sampling rounds measure-one! label]
+   (let [coll     (sample-collector)
+         readings (fresh-readings arms rounds)]
+     (doseq [visit (visit-plan arms sampling rounds)]
+       (bank-visit! coll readings label visit (measure-one! (:arm visit))))
+     {:readings @readings :samples (:samples @coll)})))
+
+(defn rounds-async!
+  "[[rounds!]]'s schedule, driven by a `measure-one!` that answers a
+  PROMISE of the reading rather than the reading. Answers a promise of
+  the same `{:readings :samples}` map.
+
+  ## Why the lane needed this, and what its absence cost
+
+  [[rounds!]] calls `measure-one!` and takes a NUMBER back, so an arm it
+  can schedule is an arm whose whole window closes inside one synchronous
+  call. **A window that ends at a PAINT cannot.** The browser produces the
+  frame after the task returns and the only handle on it is a callback, so
+  every arm this lane could schedule was one bracketed by
+  `react-dom/flushSync` — a commit, and not a paint.
+
+  That is not an accident of what happened to get written. It is the shape
+  the only shared schedule allowed, and it is the reason both of the clock
+  drivers pointed at the package measure a mount:
+  `docs/design/hicasso/product/budgets.md` §4 registers `U1`–`U4` over
+  *latency to visible echo* and *latency to next paint* and records, in
+  those words, that the population is what still blocks them.
+
+  ## It is the same schedule, and that is asserted rather than claimed
+
+  Same [[visit-plan]], same warm-up boundary, same `:predecessor` and
+  `:position` tagging, same answer shape. `lane-schedule-async-cljs-test`
+  runs one deterministic stub through both loops and asserts the banked
+  samples and readings are `=`, so the two cannot drift into two
+  schedules the way [[slot-order]]'s copy once did.
+
+  ## What it does NOT change
+
+  The visits stay SERIAL. [[chain]] starts visit *n+1* only once visit
+  *n*'s promise has resolved, exactly as the synchronous loop makes its
+  next call only once the previous one has returned — so an arm still
+  measures with no sibling running beside it, which is the whole premise
+  the arm-order guard adjudicates under."
+  ([arms sampling rounds measure-one!]
+   (rounds-async! arms sampling rounds measure-one! default-label))
+  ([arms sampling rounds measure-one! label]
+   (let [coll     (sample-collector)
+         readings (fresh-readings arms rounds)]
+     (.then (chain nil (visit-plan arms sampling rounds)
+                   (fn [_ visit]
+                     (.then (js/Promise.resolve (measure-one! (:arm visit)))
+                            (fn [ms] (bank-visit! coll readings label visit ms)))))
+            (fn [_] {:readings @readings :samples (:samples @coll)})))))
 
 (defn normalise
   "One round's raw readings as `{:p50 {id ms} :ratio {id r}}`, every ratio
@@ -1004,11 +1096,6 @@
   exactly one cell, so its probe seq is that cell and nothing else."
   [rotor n]
   [(mod rotor n) (dec n) 0])
-
-(defn chain
-  "Fold `xs` into a serial promise chain, threading an accumulator."
-  [init xs f]
-  (reduce (fn [p x] (.then p (fn [acc] (f acc x)))) (js/Promise.resolve init) xs))
 
 ;; ---------------------------------------------------------------------------
 ;; The positive control

--- a/implementation/hicasso/test/re_frame/bench/hicasso/lane_schedule_async_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/bench/hicasso/lane_schedule_async_cljs_test.cljs
@@ -1,0 +1,158 @@
+(ns re-frame.bench.hicasso.lane-schedule-async-cljs-test
+  "ONE SCHEDULE, TWO LOOPS (rf2-xa8wo).
+
+  [[re-frame.bench.hicasso.lane/rounds-async!]] exists because a window
+  that ends at a PAINT cannot close inside one synchronous call, and
+  [[re-frame.bench.hicasso.lane/rounds!]] takes a number back. It is a
+  second driver over the same plan, and the failure mode of a second
+  driver is the one this lane has already paid for twice: `slot-order`'s
+  `k = 2` degeneracy survived a fix to its own sibling because
+  `b6-harness` held a copy of the rule, and `lane/observe!`'s missing call
+  was repaired privately in two hand-rolled loops while the ten apps
+  riding the shared one kept the fault.
+
+  So the two loops are not argued to agree. They are RUN AGAINST EACH
+  OTHER, on one deterministic stub, and the banked samples and readings
+  are asserted `=`.
+
+  ## Why the stub answers its own execution index
+
+  The same reason `lane-schedule-cljs-test`'s does, and deliberately the
+  same stub shape: a value that encodes WHERE IN THE TRUE EXECUTION
+  SEQUENCE the call happened turns *did the two loops visit the arms in
+  the same order?* into an equality over recorded data, with no second
+  model of `slot-order` to be wrong in the same way as the first.
+
+  ## Anti-vacuity
+
+  [[the-two-loops-really-do-visit-something]] runs first. Two empty
+  answers are `=` and would carry the whole file green over a
+  `rounds-async!` that measured nothing at all — which is exactly what a
+  promise chain that dropped its tail would produce."
+  (:require [cljs.test :refer-macros [async deftest is testing]]
+            [re-frame.bench.hicasso.lane :as lane]))
+
+(def ^:private sampling
+  "`lane-schedule-cljs-test`'s numbers, carried rather than chosen: this
+  file's claim is invariant to them, and matching its sibling keeps the
+  two readable side by side."
+  {:warmup 3 :samples 6})
+
+(def ^:private rounds 5)
+
+(def ^:private arm-counts
+  "Every arm count this lane's harnesses run at, plus the four
+  `slice-echo-clock-app` runs. `2` is in for its own sake: `slot-order`
+  drops the reflection at `k = 2` because it cancels the rotation, and a
+  loop that walked the plan wrongly would be most likely to show it at
+  the degenerate count."
+  [2 4 5 7 8])
+
+(defn- arms [n]
+  (mapv (fn [i] {:id (keyword (str "arm-" i))}) (range n)))
+
+(defn- sync-run
+  "`rounds!` over `n` arms, answering `{:samples :readings :truth}` where
+  `truth` is every execution in order — warm-up and measured alike."
+  [n]
+  (let [truth (atom [])
+        out   (lane/rounds! (arms n) sampling rounds
+                            (fn [arm]
+                              (let [i (count @truth)]
+                                (swap! truth conj (name (:id arm)))
+                                i)))]
+    (assoc out :truth @truth)))
+
+(defn- async-run
+  "`rounds-async!` over the same stub, one microtask late so the answer is
+  a genuine promise rather than a value in promise clothing.
+
+  `:overlaps` counts visits that began while another was still in flight.
+  A loop that fanned the plan out with `Promise.all` would produce the
+  same readings and be a different instrument entirely — every arm
+  measuring beside its siblings, which is the premise the arm-order guard
+  adjudicates under."
+  [n]
+  (let [truth    (atom [])
+        in-fl    (atom 0)
+        overlaps (atom 0)]
+    (.then (lane/rounds-async! (arms n) sampling rounds
+                               (fn [arm]
+                                 (when (pos? @in-fl) (swap! overlaps inc))
+                                 (swap! in-fl inc)
+                                 (let [i (count @truth)]
+                                   (swap! truth conj (name (:id arm)))
+                                   (.then (js/Promise.resolve nil)
+                                          (fn [_] (swap! in-fl dec) i)))))
+           (fn [out] (assoc out :truth @truth :overlaps @overlaps)))))
+
+;; ---------------------------------------------------------------------------
+;; Anti-vacuity, first
+;; ---------------------------------------------------------------------------
+
+(deftest the-two-loops-really-do-visit-something
+  (testing "Two empty answers are `=`. Unless the async loop actually
+           executes the whole plan, every equality below is an assertion
+           about nothing."
+    (async done
+      (let [n 4]
+        (.then (async-run n)
+               (fn [a]
+                 (is (= (* rounds (+ (:warmup sampling) (:samples sampling)) n)
+                        (count (:truth a)))
+                     "every visit in the plan ran")
+                 (is (= (* rounds (:samples sampling) n) (count (:samples a)))
+                     "and the measured ones were banked")
+                 (done)))))))
+
+;; ---------------------------------------------------------------------------
+;; The claim
+;; ---------------------------------------------------------------------------
+
+(deftest the-async-loop-walks-the-synchronous-loops-plan
+  (testing "Same visits, same order, same warm-up boundary — asserted
+           over the recorded execution rather than re-derived from
+           `slot-order`, which would be a second copy of the rule under
+           test."
+    (async done
+      (.then
+        (lane/chain nil arm-counts
+                    (fn [_ n]
+                      (.then (async-run n)
+                             (fn [a]
+                               (let [s (sync-run n)]
+                                 (is (= (:truth s) (:truth a))
+                                     (str "arm count " n ": the true execution order"))
+                                 (is (= (:samples s) (:samples a))
+                                     (str "arm count " n ": every banked sample, with its "
+                                          ":predecessor and :position"))
+                                 (is (= (:readings s) (:readings a))
+                                     (str "arm count " n ": the per-round readings")))
+                               nil))))
+        (fn [_] (done))))))
+
+(deftest the-async-loop-keeps-the-visits-serial
+  (testing "`chain` starts a visit only once the previous one has
+           resolved, so an arm still measures with no sibling running
+           beside it."
+    (async done
+      (.then (async-run 5)
+             (fn [a]
+               (is (zero? (:overlaps a))
+                   "no visit began while another was still in flight")
+               (done))))))
+
+(deftest a-plain-value-from-measure-one-is-accepted
+  (testing "`js/Promise.resolve` on the arm's answer, so a caller whose
+           window happens to close synchronously — a floor arm, a plumb
+           tare — needs no wrapper of its own."
+    (async done
+      (let [as (arms 3)]
+        (.then (lane/rounds-async! as sampling rounds (fn [_] 1.0))
+               (fn [{:keys [samples readings]}]
+                 (is (= (* rounds (:samples sampling) 3) (count samples)))
+                 (is (every? (fn [round]
+                               (every? (fn [[_ xs]] (= (:samples sampling) (count xs)))
+                                       round))
+                             readings))
+                 (done)))))))

--- a/implementation/hicasso/test/re_frame/bench/hicasso/slice_echo_clock_app.cljs
+++ b/implementation/hicasso/test/re_frame/bench/hicasso/slice_echo_clock_app.cljs
@@ -1,0 +1,601 @@
+(ns re-frame.bench.hicasso.slice-echo-clock-app
+  "THE SLICE'S INTERACTION-TO-PAINT CLOCK — one discrete interaction,
+  through to the paint that follows it, on the witness application
+  `U1`–`U4` are stated over (rf2-xa8wo, deliverable 2).
+
+      HICASSO_INIT_FN=re-frame.bench.hicasso.slice-echo-clock-app/-main \\
+      HICASSO_OUT_DIR=out/hicasso-slice-echo \\
+      HICASSO_PORT=8137 \\
+        node implementation/hicasso/test/re_frame/bench/hicasso/run.cjs
+
+  NO NEW BUILD ID, and that is checked rather than assumed. `run.cjs`
+  takes its entry from `HICASSO_INIT_FN` and rides `:hicasso-bench`, the
+  id the whole lane already shares, so this arm costs
+  `implementation/shadow-cljs.edn` — an HD-017 hot-zone file — nothing.
+
+  ## THE WINDOW, WHICH IS THE WHOLE POINT OF THIS FILE
+
+  Every other clock on this lane brackets its operation with
+  `react-dom/flushSync` and stops when the commit returns. That is a
+  MOUNT OR A COMMIT AND NOT A PAINT, and `docs/design/hicasso/product/
+  budgets.md` §4 says so in terms: the estimands `U1`–`U4` are registered
+  over *latency to visible echo*, *latency to next paint*,
+  *operation latency* and *per-frame latency*, and §9.3 calls them
+  *slice-app user-visible gates*. A `p95` taken over a commit and
+  published against a line written about a paint is worse than no `p95`,
+  because it is quotable.
+
+  [[window!]] is the repair. It starts the clock immediately before a real
+  DOM event, and stops it in the first task AFTER the browser has produced
+  and painted the frame that carries the echo:
+
+      t0 ──▶ dispatchEvent ──▶ [React's discrete lane commits] ──▶ t-commit
+             │
+             └─▶ requestAnimationFrame ──▶ [the frame's rendering steps:
+                     the callback runs BEFORE style, layout and paint, and
+                     is where this file READS THE ECHO OUT OF THE DOM]
+                     │
+                     └─▶ setTimeout 0 ──▶ the first task after that frame's
+                             rendering lifecycle ──▶ t-paint
+
+  `requestAnimationFrame` runs before paint, so a callback registered
+  there is not enough on its own; the `setTimeout` inside it lands in the
+  first task after that frame's rendering lifecycle has run. This is the
+  standard after-paint idiom and the lane already relies on it in three
+  places (`clock-app`, `hd8-clock-app`, `shapes.census-clock-app`) for
+  exactly this reason.
+
+  **Three things carry the claim that this window reaches a paint, and
+  none of them is a sentence in this docstring.**
+
+  1. THE MECHANISM. The reading cannot be taken at all unless a frame's
+     rendering steps run: the promise resolves from a `setTimeout` queued
+     inside a `requestAnimationFrame` callback, so a window in which the
+     browser produced no frame produces no reading — it hangs, and
+     `run.cjs`'s sentinel kills the run. A `flushSync` window crosses no
+     frame boundary and would answer instantly.
+  2. THE ECHO, CHECKED PER SAMPLE. The typed character, or the flipped
+     checkbox, is read out of the DOM INSIDE those rendering steps —
+     before style, layout and paint — so a verified sample is one whose
+     painted frame carried the echo. It banks into `lane/tally` and
+     `lane/assert-verified!` refuses the run at `N unverified of M`.
+  3. THE POSITIVE CONTROL, which is the discriminating one and is
+     described next.
+
+  Every reading is also published DECOMPOSED — `:commit`, `:to-raf`,
+  `:raf-to-paint` — so a reader can see how much of a window closed
+  inside the DOM event and how much of it is the browser's rendering
+  lifecycle. A rig that had reverted to a commit-bounded window would
+  show the first of those three and nothing else.
+
+  ## THE POSITIVE CONTROL IS INVISIBLE TO THE WINDOW IT REPLACES
+
+  `:ctl-blocked` is `:keystroke` plus a busy-wait of [[blocked-ms]]
+  milliseconds on the main thread, spent AFTER React's commit has returned
+  and BEFORE the browser can produce a frame. Its prediction is additive
+  and needs no model of the application: **the window must lengthen by
+  exactly [[blocked-ms]]**.
+
+  What makes it the right control here rather than a generic one is where
+  the injected cost sits. A commit-bounded window would not see one
+  millisecond of it — the block begins after the commit it stops at — so
+  a rig that had quietly reverted to measuring a commit reports a control
+  that predicted [[blocked-ms]] and measured nothing. The control
+  therefore adjudicates the INSTRUMENT'S WINDOW and not merely its
+  sensitivity.
+
+  It is adjudicated under `lane/control-verdict-strict` — every round
+  inside the band — and not under the overlap rule, because these legs are
+  tens of milliseconds and nowhere near the 100 µs clamp Chrome puts on
+  `performance.now()`. `lane/control-verdict`'s own docstring names that exactly: a
+  batched window lifting the legs clear of the quantum is the condition
+  under which the strict rule is the one to use.
+
+  ## WHAT THIS FILE PUBLISHES, AND WHAT IT DELIBERATELY DOES NOT
+
+  It publishes `{:n :min :max :p50 :p95 :p99}` per arm, the guard's
+  verdict, the control's verdict, and the runtime label — and it compares
+  none of them to anything.
+
+  **There is no threshold in this file, no band around a latency, and no
+  pinned figure.** `U1`'s one-60-Hz-frame line, `U2`'s 50 ms `p95` and
+  100 ms `p99`, `U3`'s 100 ms — none of them appears here, and none of
+  them should. Reading this instrument against those lines is a separate
+  quiet-box window (`rf2-85og2` gate 1), and an instrument that carried
+  the line it is meant to be read against would be an instrument nobody
+  could re-adjudicate. The only pass/fail this file makes are the two
+  INSTRUMENT-INTEGRITY verdicts above, and `budgets.md` §2's rule holds
+  for both: they are structural, not distributional.
+
+  ## THE ROWS, AND WHICH ESTIMANDS THEY CAN AND CANNOT SERVE
+
+      :idle-frame   no interaction at all — the settle and nothing else.
+                    The FLOOR of any paint-bounded window on this box: what
+                    a reading costs when the application does no work.
+                    Without it a `p95` cannot be read, because the frame
+                    boundary is in every other row too.
+
+      :keystroke    one character typed over the last one in the editor's
+                    title field. `U1`'s estimand — *latency to visible
+                    echo* on a controlled update — and an instance of
+                    `U2`'s.
+
+      :toggle       a real click on the published checkbox. `U2`'s
+                    estimand — *latency to next paint* for an ordinary
+                    discrete interaction — on a second event path
+                    (`click`/`change` rather than `input`).
+
+      :ctl-blocked  the positive control described above.
+
+  **`U3` AND `U4` ARE NOT SERVED BY THIS ROW SET, and that is stated
+  rather than left to be discovered.** `U3` is *operation latency* for a
+  BROAD operation — a route change, a reset, a save reply — which needs
+  its own preparation outside the window, because the route the editor
+  rows type into is the route a navigation row would leave. `U4` is
+  *per-frame latency* under dragging or animation, which is not one
+  interaction through to one paint at all: it is a run of consecutive
+  frames, and its estimator is a distribution over frame intervals rather
+  than over window lengths. Both want another driver on [[window!]]'s
+  mechanism; neither is this one.
+
+  ## THE POPULATION IS THE SLICE APPLICATION, MOUNTED THROUGH ITS OWN DOOR
+
+  [[boot!]] calls `h/mount!` with the slice's own `[views/app {}]` and the
+  same two `:initial-events` its `-main` passes, differing only in which
+  route it opens on — which is data the application already takes. Nothing
+  here reaches under `re-frame.hicasso.impl.*`, nothing rebuilds a view,
+  and no interaction is simulated by dispatching an event: every reading
+  starts at a DOM event on a node the application rendered.
+
+  ## THE SCRIPTED KEYSTROKE GOES THROUGH THE PROTOTYPE'S OWN SETTER
+
+  `(set! (.-value node) v)` does NOT work, and the failure is silent.
+  React installs an instance-level property descriptor on every controlled
+  input to track its value; assigning through it updates React's tracked
+  value, so the `input` event that follows is seen as a no-op change and
+  the handler never runs. Writing through the descriptor captured off
+  `HTMLInputElement.prototype` leaves the tracker stale, which is what
+  makes the event a real one.
+  `examples.per-keystroke-dom-cljs-test` carries the same capture for the
+  same reason.
+
+  Owner: rf2-xa8wo."
+  (:require [re-frame.adapter.uix :as uix-adapter]
+            [re-frame.bench.hicasso.lane :as lane]
+            [re-frame.core :as rf]
+            [re-frame.hicasso :as h]
+            [re-frame.hicasso.examples.slice.events :as slice-events]
+            [re-frame.hicasso.examples.slice.routes :as slice-routes]
+            [re-frame.hicasso.examples.slice.views :as slice-views]))
+
+;; ---------------------------------------------------------------------------
+;; The knobs — every one of them a SCHEDULE knob, never a line
+;; ---------------------------------------------------------------------------
+
+(def article-slug
+  "The seeded article the editor opens on. Any of `db/seed`'s seven would
+  do; this one is the slug `flow-dom-cljs-test` already navigates to, so
+  a reader comparing the two is comparing one page."
+  "intents")
+
+(def sampling
+  "Per-round warm-up and measured counts.
+
+  `:warmup 8` is `rf2-h904p`'s value and is carried rather than chosen:
+  `lane/rounds!`'s docstring records that it puts the +27% step this lane
+  sees after a site's sixth execution inside the warm-up. `:samples 12`
+  is the same file's figure. **A tail quantile over 12 is mostly
+  interpolation** — `lane/quantile`'s docstring prices exactly that — so
+  the run that reads this instrument will want more, and raising these
+  two is how it gets them."
+  {:warmup 8 :samples 12})
+
+(def rounds
+  "Rounds per run. Five is the lane's standard and what `across-rounds`
+  and `control-verdict-strict` are shaped for."
+  5)
+
+(def blocked-ms
+  "How long `:ctl-blocked` blocks the main thread after the commit and
+  before the frame.
+
+  Chosen against the FRAME INTERVAL rather than by taste. A paint-bounded
+  window is quantised by the display's rendering opportunities — roughly
+  16.7 ms at 60 Hz — so an injected cost much smaller than one frame can
+  be absorbed by the quantisation entirely and would make a control that
+  fails for the clock rather than for the instrument. 50 ms is three
+  frames, which is far enough clear of the grid that the control's band
+  can be set from the quantisation and still be narrow."
+  50.0)
+
+(def control-slack
+  "The half-width of `:ctl-blocked`'s band, as a fraction of
+  [[blocked-ms]].
+
+  Derived, not tuned. Each round's adjudicated figure is a DIFFERENCE of
+  two per-round medians, and each of those two carries at most one
+  rendering interval of quantisation, so the difference can sit up to two
+  intervals — about 33 ms — from [[blocked-ms]] in the worst case before
+  anything is wrong with the instrument. `0.5` of 50 ms is ±25 ms on the
+  MEDIAN of twelve samples, where the per-sample quantisation has largely
+  averaged out; it is deliberately generous, because the claim the control
+  makes is THE INSTRUMENT SEES THE INJECTED COST, not THE MODEL IS EXACT."
+  0.5)
+
+(def rotor
+  "The characters `:keystroke` types, in turn. Rotating rather than fixed
+  so a page left stale by a window that closed too early cannot pass the
+  echo check by carrying the PREVIOUS sample's character."
+  "abcdefghijklmnopqrstuvwxyz")
+
+;; ---------------------------------------------------------------------------
+;; State — one mounted slice, and the counters that adjudicate it
+;; ---------------------------------------------------------------------------
+
+(defonce ^:private !state
+  (atom {:container   nil
+         :handle      nil
+         :base-title  nil
+         :tick        0
+         :echo-tally  nil
+         :aux         {}}))
+
+(defn- next-tick! []
+  (:tick (swap! !state update :tick inc)))
+
+(defn verification
+  "`{:writes M :unverified N}` over every window taken since the last
+  [[boot!]] — warm-up visits included, because a verification is worth
+  more the more of them there are. Exposed so the DOM self-test can read
+  the same counter [[take-plan!]] adjudicates."
+  []
+  (lane/tally-value (:echo-tally @!state)))
+
+;; ---------------------------------------------------------------------------
+;; The glass
+;; ---------------------------------------------------------------------------
+
+(def ^:private pristine-input-value-setter
+  "`HTMLInputElement.prototype`'s own `value` setter, captured lazily.
+
+  A `delay` and not a `def` of the setter itself: this namespace's top
+  level runs wherever it is loaded, and `js/HTMLInputElement` does not
+  exist on the node lane."
+  (delay (.-set (js/Object.getOwnPropertyDescriptor
+                  js/HTMLInputElement.prototype "value"))))
+
+(defn- set-native-value! [node v]
+  (.call @pristine-input-value-setter node v))
+
+(defn- node-at [sel]
+  (some-> (:container @!state) (.querySelector sel)))
+
+(defn- title-field [] (node-at "#slice-title"))
+(defn- published-box [] (node-at "#slice-published"))
+
+;; ---------------------------------------------------------------------------
+;; The window
+;; ---------------------------------------------------------------------------
+
+(defn after-paint
+  "A promise that resolves in the first task AFTER the browser has
+  produced and painted the next frame.
+
+  Used OUTSIDE every window, to let the page settle between operations."
+  []
+  (js/Promise. (fn [resolve]
+                 (js/requestAnimationFrame (fn [] (js/setTimeout resolve 0))))))
+
+(defn window!
+  "ONE reading: `interact!` — a real DOM event on the mounted slice —
+  through to the paint that follows it.
+
+  Answers a promise of
+
+      {:ms              t-paint - t0    the reading, and the estimand
+       :commit-ms       t-commit - t0   how much of it closed inside the
+                                        DOM event — the whole of what a
+                                        `flushSync` window would have seen
+       :to-raf-ms       t-raf - t0      through to the frame's rendering
+                                        steps beginning
+       :raf-to-paint-ms t-paint - t-raf style, layout, paint, and the task
+                                        hop out of the rendering lifecycle
+       :echo            whatever `observe-at-frame` answered, read INSIDE
+                        those rendering steps and therefore before paint}
+
+  The three-way decomposition is published rather than derived later
+  because it is what a reader needs to interpret a tail quantile on this
+  window: `:commit-ms` is the application's own work, and everything
+  above it is the browser's rendering lifecycle plus the wait for a
+  rendering opportunity — which is QUANTISED by the display's refresh and
+  is in every row, including [[idle-plan]]'s.
+
+  `t0` is taken immediately before `interact!`. A real user's latency
+  starts at the input device rather than at `dispatchEvent`, and that
+  segment belongs to the user agent rather than to the application;
+  `PerformanceEventTiming` would carry it, at a `duration` rounded up to
+  the nearest 8 ms, which is coarser than the whole of what `U1` is stated
+  over. The omission is therefore deliberate and is a floor on the
+  reading, never a ceiling.
+
+  `after-commit!`, when a plan supplies one, runs after `t-commit` has
+  been read and before the frame is asked for. It is the seam the positive
+  control occupies, and it is a real one: effects, other listeners and
+  layout reads all run there in an ordinary application, inside the user's
+  wait and outside anything a `flushSync` window can see.
+
+  A throw anywhere inside REJECTS rather than escaping. An exception
+  raised in a `requestAnimationFrame` or `setTimeout` callback would
+  otherwise leave this promise unsettled for ever and the run would die on
+  `run.cjs`'s twenty-minute sentinel wearing a timeout's face."
+  [{:keys [interact! after-commit! observe-at-frame]}]
+  (js/Promise.
+    (fn [resolve reject]
+      (try
+        (let [t0 (lane/now-ms)]
+          (interact!)
+          (let [t-commit (lane/now-ms)]
+            (when after-commit! (after-commit!))
+            (js/requestAnimationFrame
+              (fn []
+                (try
+                  (let [t-raf (lane/now-ms)
+                        echo  (observe-at-frame)]
+                    (js/setTimeout
+                      (fn []
+                        (try
+                          (let [t-paint (lane/now-ms)]
+                            (resolve {:ms              (- t-paint t0)
+                                      :commit-ms       (- t-commit t0)
+                                      :to-raf-ms       (- t-raf t0)
+                                      :raf-to-paint-ms (- t-paint t-raf)
+                                      :echo            echo}))
+                          (catch :default e (reject e))))
+                      0))
+                  (catch :default e (reject e)))))))
+        (catch :default e (reject e))))))
+
+;; ---------------------------------------------------------------------------
+;; The arms
+;; ---------------------------------------------------------------------------
+
+(defn- idle-plan
+  "The floor. No interaction at all — what one settle costs when the
+  application does nothing. `:echo` is `:n/a` and banks as verified,
+  because there is no echo to be late."
+  [_]
+  {:interact!        (fn [] nil)
+   :observe-at-frame (fn [] {:verified? true :echo :n/a})})
+
+(defn- keystroke-plan
+  "One character typed OVER the last one, so the field's length — and
+  therefore the work — is the same at every sample.
+
+  A user typing over a selection produces exactly this: the control's
+  value moves first, the `input` event fires second. Appending instead
+  would grow the title by one character per sample and make a run's last
+  readings a different amount of work from its first, which is precisely
+  the ramp the guard's `:position` factor exists to catch."
+  [_]
+  (let [field (title-field)
+        want  (str (:base-title @!state)
+                   (nth rotor (mod (next-tick!) (count rotor))))]
+    {:interact!        (fn []
+                         (set-native-value! field want)
+                         (.dispatchEvent field (js/Event. "input" #js {:bubbles true})))
+     :observe-at-frame (fn []
+                         (let [got (.-value field)]
+                           {:verified? (= want got) :echo got}))}))
+
+(defn- toggle-plan
+  "A real click on the published checkbox.
+
+  `HTMLElement.click()` and not a synthesised `change`: the user agent's
+  activation behaviour flips `checkedness` WITHOUT going through the
+  JavaScript property setter React tracks, which is what leaves React's
+  tracked value stale and makes the change a real one."
+  [_]
+  (let [box  (published-box)
+        want (not (.-checked box))]
+    {:interact!        (fn [] (.click box))
+     :observe-at-frame (fn []
+                         (let [got (.-checked box)]
+                           {:verified? (= want got) :echo got}))}))
+
+(defn- busy-wait!
+  "Block the main thread for `ms`. A spin and not a `setTimeout`, because
+  the control has to occupy the interval the window is measuring rather
+  than yield it."
+  [ms]
+  (let [end (+ (lane/now-ms) ms)]
+    (loop [] (when (< (lane/now-ms) end) (recur)))))
+
+(defn- blocked-plan
+  "[[keystroke-plan]] plus [[blocked-ms]] of blocked main thread on
+  [[window!]]'s `after-commit!` seam.
+
+  WHERE THE COST SITS IS THE CONTROL. Injecting it inside `interact!`
+  would put it before `t-commit`, where a `flushSync` window would see
+  every millisecond of it and the control would prove only that the
+  instrument can measure a busy loop. On the seam it lands strictly
+  between the commit and the frame — invisible to the window this one
+  replaces, and fully inside this one."
+  [state]
+  (assoc (keystroke-plan state) :after-commit! (fn [] (busy-wait! blocked-ms))))
+
+(def arms
+  "The measured arms, floor first so it leads the schedule."
+  [{:id :idle-frame  :plan idle-plan}
+   {:id :keystroke   :plan keystroke-plan}
+   {:id :toggle      :plan toggle-plan}
+   {:id :ctl-blocked :plan blocked-plan :control? true}])
+
+;; ---------------------------------------------------------------------------
+;; Sampling
+;; ---------------------------------------------------------------------------
+
+(defn- bank-aux!
+  "Record one sample's structural parts.
+
+  The decomposition is kept per arm because the control's claim is about
+  WHERE in the window the injected cost lands, and that cannot be
+  re-derived from `:ms` afterwards. Warm-up samples bank here too — a
+  verification is worth more the more of them there are, and the count
+  published beside the tally says how many."
+  [arm-id {:keys [commit-ms to-raf-ms raf-to-paint-ms echo]}]
+  (let [t (:echo-tally @!state)]
+    (swap! t (fn [{:keys [of bad]}]
+               {:of  (inc of)
+                :bad (if (:verified? echo) bad (inc bad))})))
+  (swap! !state update-in [:aux arm-id]
+         (fn [a] (-> (or a {:commit [] :to-raf [] :raf-to-paint []})
+                     (update :commit conj commit-ms)
+                     (update :to-raf conj to-raf-ms)
+                     (update :raf-to-paint conj raf-to-paint-ms))))
+  nil)
+
+(defn measure-one!
+  "One sample of `arm`, as a promise of its `:ms`.
+
+  The arm's plan is built OUTSIDE the window — reading the node, deciding
+  what the echo must be — so nothing but the interaction and the frame is
+  inside it."
+  [arm]
+  (.then (window! ((:plan arm) !state))
+         (fn [r] (bank-aux! (:id arm) r) (:ms r))))
+
+;; ---------------------------------------------------------------------------
+;; Boot
+;; ---------------------------------------------------------------------------
+
+(defn boot!
+  "Mount the slice into `container` on `frame-id`, opened on the article
+  route, and answer a promise of the mounted handle.
+
+  Two settles, both outside every window: React's commit and the initial
+  events' drain are not the same tick, and the base title is read off the
+  glass rather than copied out of `db/seed` — a copy here would be a
+  second authority that a change to the seed would silently falsify.
+
+  INSTALLING THE ADAPTER AND LEAVING REACT'S `act` ENVIRONMENT ARE NOT
+  DONE HERE. Both are process-wide and belong to whoever owns the process:
+  [[-main]] owns the bench page and does both, while the DOM self-test
+  runs inside a shared browser bundle where a sibling suite's adapter and
+  `act` flag have to survive it, so it installs its own through
+  `re-frame.test-support`'s reset fixture and restores the flag itself."
+  [container frame-id]
+  (let [handle (h/mount! container
+                         {:frame          frame-id
+                          :initial-events [[::slice-events/seed]
+                                           [:rf.route/navigate
+                                            {:to     slice-routes/article
+                                             :params {:slug article-slug}}]]}
+                         [slice-views/app {}])]
+    (swap! !state assoc
+           :container container
+           :handle handle
+           :tick 0
+           :aux {}
+           :echo-tally (lane/tally))
+    (-> (after-paint)
+        (.then (fn [_] (after-paint)))
+        (.then (fn [_]
+                 (let [field (title-field)]
+                   (when (nil? field)
+                     (throw (ex-info (str "the slice mounted but its editor did not: "
+                                          "#slice-title is not on the page, so there is "
+                                          "no controlled field to type into")
+                                     {:rf.error/id ::editor-absent
+                                      :slug        article-slug})))
+                   (swap! !state assoc :base-title (.-value field))
+                   handle))))))
+
+(defn teardown!
+  "Take this root down and drop the container. Exposed because the DOM
+  self-test mounts and unmounts around each of its rows."
+  []
+  (let [{:keys [container handle]} @!state]
+    (when handle (h/unmount! handle))
+    (when (and container (.-parentNode container))
+      (.removeChild (.-parentNode container) container))
+    (swap! !state assoc :container nil :handle nil :base-title nil)
+    nil))
+
+;; ---------------------------------------------------------------------------
+;; The run
+;; ---------------------------------------------------------------------------
+
+(defn- readings-by-arm [readings]
+  (reduce (fn [m round]
+            (reduce-kv (fn [m id xs] (update m id (fnil into []) xs)) m round))
+          {}
+          readings))
+
+(defn control-per-round
+  "One adjudicated figure per round: the difference between
+  `:ctl-blocked`'s median and `:keystroke`'s, in milliseconds.
+
+  A DIFFERENCE and not a ratio, because the prediction is additive — the
+  control injects a duration, not a multiple — and pairing each round with
+  its own denominator is what `control-verdict-strict` asks for."
+  [readings]
+  (mapv (fn [round]
+          (lane/round4 (- (:p50 (lane/summarise (get round :ctl-blocked)))
+                          (:p50 (lane/summarise (get round :keystroke))))))
+        readings))
+
+(defn take-plan!
+  "Take the plan, publish the record, and adjudicate the two
+  instrument-integrity verdicts. Answers a promise.
+
+  Order matters and is the lane's: the record is published BEFORE
+  `assert-verified!` can throw, so an operator reading a failed run has
+  the evidence on the console rather than only the refusal."
+  []
+  (.then
+    (lane/rounds-async! arms sampling rounds measure-one!)
+    (fn [{:keys [readings samples]}]
+      (let [by-arm  (readings-by-arm readings)
+            control (lane/control-verdict-strict blocked-ms
+                                                 (control-per-round readings)
+                                                 control-slack)
+            verdict (lane/guard! samples "slice interaction-to-paint")]
+        (lane/record! :slice-echo
+                      {:window     :interaction-to-paint
+                       :population {:app   're-frame.hicasso.examples.slice
+                                    :route :article
+                                    :slug  article-slug}
+                       :schedule   (assoc sampling :rounds rounds)
+                       :summary    (into {} (map (fn [[id xs]] [id (lane/summarise xs)])) by-arm)
+                       :structure  (into {}
+                                         (map (fn [[id {:keys [commit to-raf raf-to-paint]}]]
+                                                [id {:commit       (lane/summarise commit)
+                                                     :to-raf       (lane/summarise to-raf)
+                                                     :raf-to-paint (lane/summarise raf-to-paint)}]))
+                                         (:aux @!state))
+                       :control    control
+                       :guard      (select-keys verdict [:refuse? :contaminated?
+                                                         :unchecked? :tolerance])
+                       :echo       (lane/tally-value (:echo-tally @!state))
+                       :runtime    (lane/runtime-label)
+                       :note       (str "No line is applied to any figure above. U1-U4 are "
+                                        "read against this instrument in their own quiet-box "
+                                        "window, not here.")})
+        (set! (.-HICASSO_GUARD_REFUSED js/window) (boolean (:refuse? verdict)))
+        (set! (.-HICASSO_CONTROL_FAILED js/window) (not (:ok? control)))
+        (lane/assert-verified! (:echo-tally @!state) "slice interaction-to-paint")
+        nil))))
+
+(defn ^:export -main []
+  (rf/init! uix-adapter/adapter)
+  (lane/leave-act-environment!)
+  (if-not (lane/self-test!)
+    (lane/fail! (str "the arm-order self-test failed — the copy of the schedule "
+                     "rule this app is about to rely on no longer behaves like "
+                     "the one the .cjs drivers use, so nothing may be measured"))
+    (-> (boot! (or (js/document.getElementById "app") (lane/fresh-container!))
+               ::frame)
+        (.then (fn [_] (take-plan!)))
+        (.catch (fn [e] (lane/fail! (lane/describe-throw "slice-echo-clock-app" e))))
+        (.then (fn [_] (lane/done!)))))
+  nil)

--- a/implementation/hicasso/test/re_frame/bench/hicasso/slice_echo_clock_app.cljs
+++ b/implementation/hicasso/test/re_frame/bench/hicasso/slice_echo_clock_app.cljs
@@ -74,7 +74,9 @@
   milliseconds on the main thread, spent AFTER React's commit has returned
   and BEFORE the browser can produce a frame. Its prediction is additive
   and needs no model of the application: **the window must lengthen by
-  exactly [[blocked-ms]]**.
+  [[blocked-ms]]**, to within the one rendering interval the browser's
+  frame grid rounds it to — see [[control-slack]], where the band is
+  derived from that interval rather than tuned to a measurement.
 
   What makes it the right control here rather than a generic one is where
   the injected cost sits. A commit-bounded window would not see one
@@ -109,11 +111,14 @@
 
   ## THE ROWS, AND WHICH ESTIMANDS THEY CAN AND CANNOT SERVE
 
-      :idle-frame   no interaction at all — the settle and nothing else.
-                    The FLOOR of any paint-bounded window on this box: what
-                    a reading costs when the application does no work.
-                    Without it a `p95` cannot be read, because the frame
-                    boundary is in every other row too.
+      :idle-frame   no interaction at all — the frame and nothing else.
+                    The FLOOR of any paint-bounded window on this box: the
+                    wait for the next rendering opportunity, which every
+                    other row pays too and which no application work can
+                    remove. Without it a tail quantile on the rows above
+                    cannot be read, because a `p95` at the floor and a
+                    `p95` twice it are different findings and the figure
+                    alone does not say which.
 
       :keystroke    one character typed over the last one in the editor's
                     title field. `U1`'s estimand — *latency to visible
@@ -212,14 +217,23 @@
   "The half-width of `:ctl-blocked`'s band, as a fraction of
   [[blocked-ms]].
 
-  Derived, not tuned. Each round's adjudicated figure is a DIFFERENCE of
-  two per-round medians, and each of those two carries at most one
-  rendering interval of quantisation, so the difference can sit up to two
-  intervals — about 33 ms — from [[blocked-ms]] in the worst case before
-  anything is wrong with the instrument. `0.5` of 50 ms is ±25 ms on the
-  MEDIAN of twelve samples, where the per-sample quantisation has largely
-  averaged out; it is deliberately generous, because the claim the control
-  makes is THE INSTRUMENT SEES THE INJECTED COST, not THE MODEL IS EXACT."
+  Derived from the frame grid, not tuned to a measurement.
+
+  Both arms start at the same phase ([[measure-one!]]'s alignment), so
+  each round's adjudicated figure is a difference of two windows that each
+  end at the first rendering opportunity at or after their own work. The
+  injected duration therefore reaches the difference ROUNDED to the grid,
+  never exactly: the block does not add to the wait the unblocked arm
+  pays, it SUBSUMES it and leaves whatever is left of the interval it
+  landed inside. So the difference sits within one rendering interval —
+  about 16.7 ms at 60 Hz — of [[blocked-ms]], in either direction, with
+  nothing wrong with the instrument.
+
+  `0.5` of 50 ms is ±25 ms, which covers that interval with room for a
+  grid that is not exactly 60 Hz. It is deliberately generous, because the
+  claim the control makes is THE INSTRUMENT SEES THE INJECTED COST, not
+  THE MODEL IS EXACT — and a control tightened until it only just passes
+  is a control tuned to the box it was written on."
   0.5)
 
 (def rotor
@@ -459,10 +473,54 @@
 
   The arm's plan is built OUTSIDE the window — reading the node, deciding
   what the echo must be — so nothing but the interaction and the frame is
-  inside it."
+  inside it.
+
+  ## EVERY WINDOW STARTS AT THE SAME POINT IN THE FRAME GRID
+
+  [[after-paint]] runs first, OUTSIDE the reading, so the clock always
+  starts in the first task after a paint. Without it this instrument
+  cannot produce a reportable figure at all, and the arm-order guard says
+  so rather than the author noticing.
+
+  **A paint-bounded window is PREDECESSOR-DEPENDENT BY CONSTRUCTION.** Its
+  length is dominated by the wait for the browser's next rendering
+  opportunity, and those sit on a grid — so how long a sample waits
+  depends on where in that grid the PREVIOUS sample left the clock. An arm
+  that follows `:ctl-blocked`, which spans three intervals and ends with a
+  frame already overdue, waits almost nothing; the same arm following
+  `:keystroke`, which ends just after a paint, waits a whole interval. The
+  first run of this instrument measured exactly that: `:idle-frame` read a
+  full interval after `:keystroke` and zero after `:ctl-blocked`, ranges
+  disjoint, and the guard REFUSED.
+
+  That is a fault in the ARM and not in the guard's tolerance, which is
+  not the arm's to move. Aligning every window to the grid is the repair:
+  the phase is then a constant of the instrument rather than a property of
+  whatever ran before.
+
+  ## WHAT THE ALIGNMENT COSTS THE ESTIMAND, STATED RATHER THAN HIDDEN
+
+  A real user's interaction arrives at a uniformly random phase in the
+  grid; this one always arrives at the same phase, immediately after a
+  paint, which is the phase with the LONGEST wait to the next rendering
+  opportunity. So a reading taken here is the conservative end of the
+  phase distribution — for a `p95` or `p99` latency line, the end that
+  cannot flatter the application.
+
+  The alternative is to randomise the phase deliberately, with a delay
+  drawn uniformly from one interval before `t0`. That reproduces the
+  user's phase distribution and is guard-clean for the same reason
+  alignment is (an independent draw is not a predecessor effect), at the
+  cost of needing far more samples to resolve a tail. **It is not built.**
+  What would warrant building it: a reading whose `p95` sits close enough
+  to a line that the difference between the worst phase and the mean phase
+  decides it — at which point the honest answer is the user's
+  distribution, not this one's."
   [arm]
-  (.then (window! ((:plan arm) !state))
-         (fn [r] (bank-aux! (:id arm) r) (:ms r))))
+  (.then (after-paint)
+         (fn [_]
+           (.then (window! ((:plan arm) !state))
+                  (fn [r] (bank-aux! (:id arm) r) (:ms r))))))
 
 ;; ---------------------------------------------------------------------------
 ;; Boot

--- a/implementation/hicasso/test/re_frame/bench/hicasso/slice_echo_window_dom_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/bench/hicasso/slice_echo_window_dom_cljs_test.cljs
@@ -1,0 +1,340 @@
+(ns re-frame.bench.hicasso.slice-echo-window-dom-cljs-test
+  "THE INSTRUMENT'S OWN SELF-TEST (rf2-xa8wo, deliverable 2).
+
+  `slice-echo-clock-app` measures one discrete interaction on the slice
+  application through to the paint that follows it. This file asks
+  whether it does, and it is a CORRECTNESS test of the instrument rather
+  than a benchmark: **no assertion here is a line on a latency**, no
+  figure is published, and nothing is compared to `U1`–`U4`.
+
+  ## The one inequality that carries the whole claim
+
+  [[the-window-extends-past-the-commit-by-the-injected-cost]] is the
+  discriminating row, and it is worth reading before the others.
+
+  Every clock this lane had before this one stops when the commit returns.
+  The control arm spends `blocked-ms` on the main thread STRICTLY BETWEEN
+  the commit and the frame, so a commit-bounded window sees none of it and
+  a paint-bounded window sees all of it. The assertion is therefore
+
+      (>= (- :ms :commit-ms) blocked-ms)
+
+  which reads *at least `blocked-ms` of this window lies after the point
+  the old window stopped*. It is flake-proof in the direction a shared CI
+  runner can move it: a busy loop that spins for `blocked-ms` takes at
+  least that long, and load can only make the left-hand side larger. That
+  is why the row is stated as a floor over an injected duration rather
+  than as a band around a measured one — a band would be a threshold in a
+  correctness gate, which is exactly the thing this bead refuses to add.
+
+  ## What is NOT asserted, deliberately
+
+  The positive control's own verdict. `control-verdict-strict` adjudicates
+  a difference of per-round medians, and adjudicating it here would mean
+  running the full schedule on a shared runner and then believing the
+  answer — a latency threshold in a PR gate by another name. Its
+  ARITHMETIC is pinned below on synthetic readings, where it cannot flake;
+  its VERDICT belongs to the quiet-box run.
+
+  ## Runtime
+
+  The DOM rows need a real browser and carry the `-dom-cljs-test` suffix
+  so `:browser-test` runs them; each degrades to a stated skip under
+  `:node-test`, which is the posture every other `*-dom` suite in this
+  tree keeps. The pure rows run on both."
+  (:require [cljs.test :refer-macros [async deftest is testing use-fixtures]]
+            [re-frame.adapter.uix :as uix-adapter]
+            [re-frame.bench.hicasso.lane :as lane]
+            [re-frame.bench.hicasso.slice-echo-clock-app :as clock]
+            [re-frame.hicasso.examples.slice.routes :as slice-routes]
+            [re-frame.test-support :as test-support]))
+
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture
+    {:adapter       uix-adapter/adapter
+     :ambient-frame nil
+     ;; The MAP shape, because every DOM row is `async`: `cljs.test` refuses
+     ;; an async test under a fn-form fixture and ABORTS THE WHOLE NAMESPACE
+     ;; — silently as far as the row is concerned, and taking every suite
+     ;; scheduled after it in the same bundle with it. `examples.slice.
+     ;; flow-dom-cljs-test` carries the same three keys for the same reason.
+     :async?        true
+     :init-fn       (fn []
+                      ;; React's `act` queue is not the browser's scheduler,
+                      ;; and every reading this instrument takes is taken
+                      ;; outside it — `lane/leave-act-environment!`'s own
+                      ;; argument, applied to the suite that drives it.
+                      (set! (.-IS_REACT_ACT_ENVIRONMENT js/globalThis) false)
+                      ;; The reset restores the registrar to a baseline
+                      ;; captured when THIS FORM was evaluated, which is
+                      ;; before `slice.routes` finished loading — so the
+                      ;; route the instrument navigates to would not exist.
+                      (slice-routes/register!))}))
+
+(def ^:private off-browser
+  "no DOM on this runtime — every claim below is a real mount, a real DOM
+  event and a real frame, and :browser-test is where they are asked")
+
+(defn- browser? []
+  (and (exists? js/document) (some? js/document) (some? (.-body js/document))))
+
+(defn- skip! [why]
+  (is true (str "a mounted React root needs a real DOM — " why)))
+
+;; ---------------------------------------------------------------------------
+;; One mounted slice, torn down again
+;; ---------------------------------------------------------------------------
+
+(defonce ^:private !frame-n (atom 0))
+
+(defn- fresh-frame-id []
+  (keyword "re-frame.bench.hicasso.slice-echo-window-dom-cljs-test"
+           (str "frame-" (swap! !frame-n inc))))
+
+(defn- with-mounted-slice
+  "Mount the slice through the instrument's own [[clock/boot!]], run
+  `f` — which answers a promise — and tear the root down afterwards
+  whatever happened.
+
+  A FRESH frame id per mount, because a suite that mounts several times
+  in one process would otherwise hand `h/mount!` a frame that already
+  holds the previous row's `app-db`, and the seeded article's title —
+  which the keystroke row types over — would be whatever the last row
+  left there."
+  [f]
+  (let [container (lane/fresh-container!)]
+    (-> (clock/boot! container (fresh-frame-id))
+        (.then (fn [_] (f)))
+        (.then (fn [v] (clock/teardown!) v)
+               (fn [e] (clock/teardown!) (throw e))))))
+
+(defn- plan-for [arm-id]
+  (:plan (first (filter #(= arm-id (:id %)) clock/arms))))
+
+(defn- one-window
+  "One reading from `arm-id`'s plan, built and taken the way
+  [[clock/measure-one!]] builds and takes it."
+  [arm-id]
+  (clock/window! ((plan-for arm-id) nil)))
+
+(defn- fail-async [done]
+  (fn [e]
+    (is false (str "the instrument threw rather than answering a reading: " e))
+    (done)))
+
+;; ---------------------------------------------------------------------------
+;; The mount
+;; ---------------------------------------------------------------------------
+
+(deftest the-instrument-mounts-the-slice-and-finds-its-editor
+  (testing "The population is the slice application on its article route,
+           reached through `h/mount!` with the application's own initial
+           events. If the editor is not on the page there is no controlled
+           field to type into and every row below is meaningless."
+    (if-not (browser?)
+      (skip! off-browser)
+      (async done
+        (-> (with-mounted-slice
+              (fn []
+                (let [field (js/document.querySelector "#slice-title")]
+                  (is (some? field) "the editor's title field is on the page")
+                  (is (seq (.-value field))
+                      "and it is showing the seeded article's title")
+                  (is (some? (js/document.querySelector "#slice-published"))
+                      "as is the published checkbox the toggle row clicks"))
+                (js/Promise.resolve nil)))
+            (.then (fn [_] (done)) (fail-async done)))))))
+
+(deftest tearing-down-takes-the-root-off-the-page
+  (testing "So a suite that mounts twice is not measuring two slices."
+    (if-not (browser?)
+      (skip! off-browser)
+      (async done
+        (-> (with-mounted-slice (fn [] (js/Promise.resolve nil)))
+            (.then (fn [_]
+                     (is (nil? (js/document.querySelector "#slice-title"))
+                         "the editor is gone once the root is unmounted")
+                     (done))
+                   (fail-async done)))))))
+
+;; ---------------------------------------------------------------------------
+;; The window
+;; ---------------------------------------------------------------------------
+
+(deftest a-keystroke-window-reaches-a-frame-carrying-its-own-echo
+  (testing "The reading resolves at all — which it can only do once a
+           frame's rendering steps have run — and the character was
+           already in the DOM when they did, so the frame that was painted
+           is the frame that shows it."
+    (if-not (browser?)
+      (skip! off-browser)
+      (async done
+        (-> (with-mounted-slice
+              (fn []
+                (.then (one-window :keystroke)
+                       (fn [{:keys [ms commit-ms to-raf-ms raf-to-paint-ms echo]}]
+                         (is (:verified? echo)
+                             "the typed character was on the glass inside the frame's
+                              rendering steps, before style, layout and paint")
+                         (is (= (.-value (js/document.querySelector "#slice-title"))
+                                (:echo echo))
+                             "and it is still there afterwards")
+                         (is (<= commit-ms to-raf-ms ms)
+                             "the decomposition is ordered: commit, then the frame's
+                              rendering steps, then the task after the paint")
+                         (is (<= 0 raf-to-paint-ms)
+                             "with the rendering lifecycle after the callback, not before")
+                         (is (> ms commit-ms)
+                             "so the window is strictly longer than the commit-bounded
+                              one every other clock on this lane takes")))))
+            (.then (fn [_] (done)) (fail-async done)))))))
+
+(deftest a-toggle-window-reaches-a-frame-carrying-its-own-echo
+  (testing "The second discrete path — `click`/`change` on a checkbox
+           rather than `input` on a text field — through the same window."
+    (if-not (browser?)
+      (skip! off-browser)
+      (async done
+        (-> (with-mounted-slice
+              (fn []
+                (.then (one-window :toggle)
+                       (fn [{:keys [echo ms commit-ms]}]
+                         (is (:verified? echo)
+                             "the checkbox had flipped by the frame's rendering steps")
+                         (is (> ms commit-ms)
+                             "and this window too runs past the commit")))))
+            (.then (fn [_] (done)) (fail-async done)))))))
+
+(deftest the-window-extends-past-the-commit-by-the-injected-cost
+  (testing "THE DISCRIMINATING ROW. `:ctl-blocked` spends
+           `clock/blocked-ms` on the main thread strictly between the
+           commit and the frame. A commit-bounded window sees none of it;
+           this one must see all of it.
+
+           A floor over an injected duration, never a band around a
+           measured one — load can only make the left-hand side larger."
+    (if-not (browser?)
+      (skip! off-browser)
+      (async done
+        (-> (with-mounted-slice
+              (fn []
+                (.then (one-window :ctl-blocked)
+                       (fn [{:keys [ms commit-ms echo]}]
+                         (is (>= (- ms commit-ms) clock/blocked-ms)
+                             (str "at least " clock/blocked-ms "ms of the window lies "
+                                  "after the point a flushSync window stops"))
+                         (is (:verified? echo)
+                             "and the blocked frame still carried the echo")))))
+            (.then (fn [_] (done)) (fail-async done)))))))
+
+;; ---------------------------------------------------------------------------
+;; The instrument end to end, at a schedule small enough for a PR gate
+;; ---------------------------------------------------------------------------
+
+(deftest the-whole-schedule-runs-and-every-echo-verifies
+  (testing "`lane/rounds-async!` drives all four arms over the real
+           application, and the echo tally reads `0 unverified of M` with
+           M the whole plan — warm-up visits included, since they bank
+           their verification too.
+
+           The schedule is TINY here and the module's own is not: this row
+           asks whether the instrument runs, and a run that reads it wants
+           `clock/sampling` and `clock/rounds`."
+    (if-not (browser?)
+      (skip! off-browser)
+      (async done
+        (let [sampling {:warmup 1 :samples 2}
+              rounds   1]
+          (-> (with-mounted-slice
+                (fn []
+                  (.then (lane/rounds-async! clock/arms sampling rounds clock/measure-one!)
+                         (fn [{:keys [readings samples]}]
+                           (is (= (* rounds (:samples sampling) (count clock/arms))
+                                  (count samples))
+                               "every measured visit was banked for the guard")
+                           (is (= rounds (count readings)))
+                           (is (every? (fn [round]
+                                         (= (count clock/arms) (count round)))
+                                       readings)
+                               "and every arm has a reading in every round")
+                           (is (= {:writes (* rounds
+                                              (+ (:warmup sampling) (:samples sampling))
+                                              (count clock/arms))
+                                   :unverified 0}
+                                  (clock/verification))
+                               "0 unverified of M — every window, warm-up included,
+                                reached a frame that carried its own echo")))))
+              (.then (fn [_] (done)) (fail-async done))))))))
+
+;; ---------------------------------------------------------------------------
+;; The control's arithmetic, where it cannot flake
+;; ---------------------------------------------------------------------------
+
+(deftest the-control-adjudicates-a-difference-of-per-round-medians
+  (testing "Pinned on synthetic readings rather than on a run. The
+           prediction is ADDITIVE — the control injects a duration, not a
+           multiple — so what each round contributes is
+           `p50(:ctl-blocked) - p50(:keystroke)` in milliseconds."
+    (let [readings [{:keystroke [10.0 12.0 14.0] :ctl-blocked [60.0 62.0 64.0]}
+                    {:keystroke [20.0 20.0 20.0] :ctl-blocked [69.0 70.0 71.0]}]]
+      (is (= [50.0 50.0] (clock/control-per-round readings))
+          "each round pairs its own two medians")
+      (let [v (lane/control-verdict-strict clock/blocked-ms
+                                           (clock/control-per-round readings)
+                                           clock/control-slack)]
+        (is (:ok? v) "a control that saw exactly what it predicted passes")
+        (is (= :every-round (:rule v))
+            "under the strict rule — these legs are tens of milliseconds and
+             nowhere near the 100 microsecond clock clamp the overlap rule exists
+             for")))))
+
+(deftest the-control-refuses-a-window-that-did-not-see-the-injection
+  (testing "Anti-vacuity for the row above. A commit-bounded window would
+           see none of the injected cost, so its per-round differences
+           would sit at zero — and the control has to say so."
+    (let [readings [{:keystroke [10.0 12.0 14.0] :ctl-blocked [10.0 12.0 14.0]}
+                    {:keystroke [20.0 20.0 20.0] :ctl-blocked [20.0 21.0 20.0]}]
+          v        (lane/control-verdict-strict clock/blocked-ms
+                                                (clock/control-per-round readings)
+                                                clock/control-slack)]
+      (is (not (:ok? v))
+          "an instrument that cannot see a change its own arithmetic predicts
+           cannot be trusted with an unpredicted one")
+      (is (= 2 (count (:outside v)))
+          "and both rounds are named rather than merely counted"))))
+
+;; ---------------------------------------------------------------------------
+;; The knobs, and the reasoning behind the one that is not a schedule knob
+;; ---------------------------------------------------------------------------
+
+(deftest the-injected-control-duration-clears-the-frame-grid
+  (testing "`blocked-ms` is chosen against the display's rendering
+           interval and not by taste. A paint-bounded window is quantised
+           by the rendering opportunities the browser offers — about
+           16.7 ms at 60 Hz — so an injection much smaller than one frame
+           can be absorbed by the quantisation entirely, and a control
+           that fails for the clock is not a control."
+    (is (>= clock/blocked-ms (* 2.0 16.7))
+        "at least two rendering intervals at 60 Hz")
+    (let [{:keys [band predicted]} (lane/control-verdict-strict
+                                     clock/blocked-ms
+                                     [clock/blocked-ms]
+                                     clock/control-slack)]
+      (is (= clock/blocked-ms predicted)
+          "the control predicts the injected duration itself — an additive
+           prediction that needs no model of the application")
+      (is (<= (first band) clock/blocked-ms (second band))
+          "and its band is centred on it"))))
+
+(deftest the-arm-roster-is-the-four-rows-the-file-documents
+  (testing "The namespace docstring names four rows and says which
+           estimands they can and cannot serve. A fifth added silently
+           would leave that prose describing an instrument that no longer
+           exists — the drift class this lane keeps paying for."
+    (is (= [:idle-frame :keystroke :toggle :ctl-blocked] (mapv :id clock/arms))
+        "floor first, so it leads the schedule")
+    (is (= [:ctl-blocked] (mapv :id (filter :control? clock/arms)))
+        "and exactly one of them is a control")
+    (is (pos? (:warmup clock/sampling)))
+    (is (pos? (:samples clock/sampling)))
+    (is (pos? clock/rounds))))


### PR DESCRIPTION
Deliverable 2 of `rf2-xa8wo`: a driver whose measurement window is **one discrete interaction through to the paint that follows it**, on the slice application. **No reading taken, no threshold, no band, no pinned figure.**

Deliverable 1 was re-verified at the tip before anything else — `lane/quantile` interpolates linearly at `h = (n-1)q`, `summarise` answers `{:n :min :max :p50 :p95 :p99}`, `lane_quantile_cljs_test` witnesses both the nearest-rank discrimination and the `:p50` agreement — and left alone.

## The path discrepancy in the bead, resolved at source

The bead's description says `implementation/hicasso/test/re_frame/hicasso/examples/` and its later comment says `implementation/hicasso/examples/`. **The description is right.** `implementation/hicasso/examples/` does not exist; the witness applications (`slice`, `editor`, `grid`, `ledger`, `forms`, `navigation`, `todo`, `typeahead`) live under `implementation/hicasso/test/re_frame/hicasso/examples/`.

## What was actually blocking, and it was not only the estimator

`lane/rounds!` calls `measure-one!` and takes a NUMBER back, so an arm it can schedule is one whose whole window closes inside a synchronous call. **A window that ends at a paint cannot** — the browser produces the frame after the task returns and the only handle on it is a callback. So every arm this lane could schedule was one bracketed by `react-dom/flushSync`, which is why both landed drivers measure a commit. That is the shape the only shared schedule allowed, not a coincidence of what got written.

## What landed

**`lane/rounds-async!`** — `rounds!`'s schedule with the return type widened to a promise. Both loops now walk one private `visit-plan`, so the reflecting order, the warm-up boundary and `observe!`'s predecessor tagging cannot become two copies (`slot-order`'s `k = 2` degeneracy and `observe!`'s missing call are both recorded instances of that). `lane_schedule_async_cljs_test` runs one deterministic stub through both loops and asserts the banked samples, the readings and the true execution order are `=` at arm counts 2/4/5/7/8, that the visits stay serial, and that a plain value from `measure-one!` is accepted. `chain` moved above `rounds!` unchanged so the async loop can use it. `lane_schedule_cljs_test` is the regression net over the refactor and is green.

**`slice_echo_clock_app.cljs`** — the driver. It mounts the slice through `h/mount!` with the application's own `:initial-events`, differing only in which route it opens on. The window runs from a real DOM event through `requestAnimationFrame` then `setTimeout 0`, the first task after that frame's rendering lifecycle; the echo is read out of the DOM **inside** the rAF callback, before style, layout and paint, and banks into `lane/tally` with `assert-verified!` refusing at *N unverified of M*. Every reading is published decomposed — `:commit`, `:to-raf`, `:raf-to-paint` — so a reader can see how much of a window closed inside the DOM event.

Four rows: `:idle-frame` (the floor — the wait for the next rendering opportunity, which no application work can remove), `:keystroke` (U1's *latency to visible echo*), `:toggle` (U2's *latency to next paint*, on the `click`/`change` path), `:ctl-blocked` (the control). **U3 and U4 are named as NOT served**, with what each would need.

**`slice_echo_window_dom_cljs_test.cljs`** — the self-test. A correctness test of the instrument: no assertion is a line on a latency.

**No new build id.** It rides `HICASSO_INIT_FN` and `:hicasso-bench`; `implementation/shadow-cljs.edn` is untouched. Verified by building it that way.

## How the window is established to reach a PAINT rather than a mount

1. **The mechanism.** The reading resolves from a `setTimeout` queued inside a `requestAnimationFrame` callback, so a window in which the browser produced no frame produces no reading at all. A `flushSync` window crosses no frame boundary and answers instantly.
2. **The echo, per sample.** Read inside the frame's rendering steps, before paint, so a verified sample is one whose painted frame carried the echo.
3. **The positive control, which is the discriminating one.** `:ctl-blocked` spends 50 ms on the main thread **strictly between the commit and the frame** — on `window!`'s `after-commit!` seam. A commit-bounded window sees none of it. The DOM self-test's `the-window-extends-past-the-commit-by-the-injected-cost` asserts `(>= (- ms commit-ms) blocked-ms)`: a floor over an injected duration, never a band around a measured one, so load can only move it the safe way.

## The finding the rig produced, and the repair

The instrument's first run under `:advanced` **refused**, and not for load. A paint-bounded window is **predecessor-dependent by construction**: its length is dominated by the wait for the next rendering opportunity, those sit on a grid, and how long a sample waits depends on where in that grid the previous sample left the clock. The arm-order guard measured exactly that — `:idle-frame` read a full rendering interval after `:keystroke`, which ends just after a paint, and zero after `:ctl-blocked`, which spans three intervals and ends with a frame already overdue, ranges disjoint; `:toggle` carried the same contrast.

**The guard's tolerance was not moved.** The repair is in the ARM, one line in `measure-one!`: settle to a fresh frame outside the reading, so the clock always starts in the first task after a paint. Both consequences are stated at source rather than left to be found — the alignment reports the **conservative end** of the phase distribution (a real interaction arrives at a uniformly random phase; this one always at the phase with the longest wait), and the injected block **subsumes** the wait rather than adding to it, which is what `control-slack`'s band is derived from.

## Quality gates

Every exit code below is the one **I** captured with the redirect and the `echo` on one command line, never a harness report. All runs foreground; the compound lanes were split into build and run halves so each fitted the ceiling.

| Gate | Exit |
|---|---|
| `node hicasso/test/re_frame/bench/hicasso/compile_gate.cjs` (`test:hicasso-compile`) | **0** — 154 namespaces, zero warnings |
| `:advanced` release build of the driver via `lane_build.cjs`, as `run.cjs` builds it | **0** — 0 warnings |
| `npx shadow-cljs compile browser-test` | **0** |
| `node scripts/serve-and-run-browser-tests.cjs` (`test:browser`) | **0** — 1029 tests, 5775 assertions, 0 failures |
| `node scripts/compile-node-test.cjs node-test out/node-test.js` | **0** |
| `node out/node-test.js` (`test:cljs`) | **0** — 11868 tests, 60087 assertions, 0 failures |
| `node scripts/_browser-dom-lane-partition.test.cjs` | **0** — 2 passed |
| `npm run test:hicasso-invariants` | **0** |
| `python scripts/check_fast_pr_gap.py --list` | **0** — **94 required checks the spine does not run** |

**The fast spine did NOT run** (`scripts/test-fast-pr.sh` was not invoked); the two lanes that cover this diff were run directly instead, plus the compile gate that auto-covers every `.cljs` under the bench tree.

**Planted-fault proof, both lanes, both scoped to one assertion so nothing aborted a namespace:**

- **Browser lane.** `(>= (- ms commit-ms) clock/blocked-ms)` widened by a factor of 1000 in `slice_echo_window_dom_cljs_test.cljs`. Recompiled (2 files compiled, so the runtime observed the plant), ran: **exit 1**, `FAIL in (the-window-extends-past-the-commit-by-the-injected-cost)` at `slice_echo_window_dom_cljs_test.cljs:223:30`. The fault existed only in this worktree, so a run that had wandered into a sibling's would have come back green. Restored and verified by the identical **blob** hash `5926d9d8a7ae9d2bd3ff833457643686989f1e9f` before the plant and after it (planted: `46d597d30f412715e00557a8d4f8c4ae59f67b20`, so the patch genuinely applied), taken against the committed object rather than as a byte digest.
- **Node lane.** One count assertion in `lane_schedule_async_cljs_test.cljs`. Recompiled (2 files), ran: **exit 1**, `FAIL in (a-plain-value-from-measure-one-is-accepted)` at `lane_schedule_async_cljs_test.cljs:153:22`. Restored and verified by the identical **blob** hash `ec543132df5500c2c786a03ae40782c6ac0230c1`.

Both gates also print their root, and both named this worktree.

**Rebased onto `origin/main` (26 commits) and every gate above re-run on the final base.** `main` never touched `lane.cljs`. The merge-base diff (`origin/main...HEAD`, three-dot) is exactly these four files, 1214 insertions and 28 deletions, and all 28 deletions are this branch's own `rounds!` body and the moved `chain` — nothing a sibling landed is reverted.

**Prose, anchors and tables verified by hand:** no markdown is touched by this diff, so neither `check_doc_slugs.py` nor `check_readme_links.py --ci` has a surface here, and no table was added or edited anywhere.

Closes rf2-xa8wo.
