### PR TITLE
test(catalogue): pin the escaped-pipe row and the catalogue's column alignment (rf2-6tags)

### DIFF
--- a/implementation/core/test/re_frame/error_catalogue_channel_conformance_test.clj
+++ b/implementation/core/test/re_frame/error_catalogue_channel_conformance_test.clj
@@ -1080,10 +1080,16 @@
         (re-seq tags-cell-key-re (str/replace cell markdown-link-re " "))))
 
 (defn- parse-catalogue-tag-rows
-  "`[{:category <kw> :tags-cell <string>} …]` for every ACTIVE row of the
-  canonical catalogue section. The `:tags` cell is the SIXTH column; `-1` keeps
-  trailing empties so a row whose `:tags` cell is BLANK still parses (and so
-  still reds when its schema declares keys).
+  "`[{:category <kw> :tags-cell <string> :field-count <int>} …]` for every
+  ACTIVE row of the canonical catalogue section. The `:tags` cell is the SIXTH
+  column; `-1` keeps trailing empties so a row whose `:tags` cell is BLANK still
+  parses (and so still reds when its schema declares keys).
+
+  `:field-count` is how many fields the split yielded — the evidence for WHICH
+  column the `:tags` cell was taken from, carried out of the one reader rather
+  than recovered by a second one. `tags-column-reader-honours-the-escaped-pipe`
+  is its only consumer: a row that splits to a different count than its siblings
+  has slid its columns, and every cell the arm reads from it is off by one.
 
   The split skips a BACKSLASH-ESCAPED pipe (rf2-1t0er). `\\|` is how markdown
   writes a literal pipe inside a table cell, so a cell containing one is
@@ -1106,8 +1112,9 @@
                 (when-let [[_ cat-str] (re-find catalogue-tag-row-re line)]
                   (let [cells (str/split line #"(?<!\\)\|" -1)]
                     (when (>= (count cells) 7)
-                      {:category  (keyword (subs cat-str 1))
-                       :tags-cell (str/trim (nth cells 6))})))))
+                      {:category    (keyword (subs cat-str 1))
+                       :tags-cell   (str/trim (nth cells 6))
+                       :field-count (count cells)})))))
         vec)))
 
 (defn- pascal
@@ -2320,3 +2327,76 @@
                         "| **RETIRED.** … | — | — |")))]
       (is (empty? rows) "a struck row does not parse as a tags row")
       (is (empty? (tags-column-findings rows pre-wsopx-schemas))))))
+
+(deftest tags-column-reader-honours-the-escaped-pipe
+  (testing "THE LIVE ROW, PINNED (rf2-6tags, per the PR #8562 audit). rf2-1t0er
+            taught `parse-catalogue-tag-rows` to skip a backslash-escaped pipe,
+            but pinned the repair in PROSE ONLY — no assertion moved, so
+            reverting the lookbehind today runs the whole namespace GREEN. That
+            is the same shape of blind spot this arm exists to close, one level
+            down: a gate that does not OBSERVE the cell it adjudicates cannot
+            tell which column it adjudicated.
+
+            `:rf.error/infinite-missing-next-page-param` is the corpus's one
+            escaped-pipe row — it spells its `:next-page-param` contract
+            `(last-page → next-param \\| nil)` — so it is the positive fixture.
+            Under the pre-rf2-1t0er reader the row split to NINE fields, every
+            column slid one place left, and this cell was read from the
+            `Default :recovery` column, harvesting `:fix-registration` and
+            `:next-page-param` as though the row had documented them."
+    (let [cell (catalogue-tags-cell :rf.error/infinite-missing-next-page-param)]
+      (is (some? cell)
+          "the escaped-pipe row still parses as an active catalogue row — if it
+           was renamed or retired, move this pin to whichever row now carries a
+           `\\|`, since the reader property is what is under test")
+      (is (= #{:resource-id :infinite} (cell-tag-keys cell))
+          (str "the escaped-pipe row's `:tags` cell reads as the TAGS column. "
+               "Harvested " (pr-str (sort (cell-tag-keys cell))) " from "
+               (pr-str cell) ". `:fix-registration` / `:next-page-param` here "
+               "means the split stopped honouring the escape and the cell came "
+               "from `Default :recovery`; anything else means the row's tags "
+               "changed legitimately — update this pin in that commit."))))
+
+  (testing "THE COLUMN-ALIGNMENT INVARIANT, which is what generalises the pin
+            past one row. Every active row of a markdown table has the same
+            number of columns, so every row must split to the same field count;
+            a row that does not has slid, and EVERY cell the arm reads from it
+            is off by one. Derived from the corpus's own rows — there is no
+            column literal here to go stale, and no second parser: the count
+            rides out of `parse-catalogue-tag-rows` on `:field-count`."
+    (let [rows  (parse-catalogue-tag-rows)
+          modal (->> rows (map :field-count) frequencies (apply max-key val) key)
+          slid  (->> rows
+                     (remove #(= modal (:field-count %)))
+                     (mapv (juxt :category :field-count)))]
+      (is (seq rows)
+          "the catalogue parsed to a non-empty row set — otherwise the
+           invariant below holds vacuously")
+      (is (empty? slid)
+          (str "active catalogue rows that split to a different field count "
+               "than their " modal "-field siblings, so their `:tags` cell is "
+               "read from the wrong column: " (pr-str slid) ". Escape a literal "
+               "pipe inside a cell as `\\|` — and if the escape is already "
+               "there, the READER is at fault, not the row (rf2-1t0er)."))))
+
+  (testing "NON-VACUITY, against the reader defect itself: a synthetic row whose
+            Trigger cell carries an escaped pipe must still reach the arm's
+            VERDICT through its real `:tags` cell. Under the pre-rf2-1t0er
+            reader this row's cell is the `Default :recovery` sentence, so the
+            keys-set diff would convict a clean row of omitting all five keys
+            its schema declares — a red naming the wrong column, for a reason
+            unrelated to the change in front of the author."
+    (let [rows (parse-catalogue-tag-rows
+                 (catalogue-fixture
+                   (str "| `:rf.error/resource-route-plan` | `:error` | diagnostic "
+                        "| A plan step returns `next \\| nil`. | `:no-recovery` "
+                        "| `:route-id`, `:reason`, `:frame`, `:contributor`, "
+                        "`:plan-cause` |")))]
+      (is (= [:rf.error/resource-route-plan] (mapv :category rows))
+          "the escaped-pipe row parses")
+      (is (= #{:route-id :reason :frame :contributor :plan-cause}
+             (cell-tag-keys (:tags-cell (first rows))))
+          "…from its `:tags` column, not from `Default :recovery`")
+      (is (empty? (tags-column-findings rows pre-wsopx-schemas))
+          "…so the arm greens on a row that documents every key its schema
+           declares, instead of redding at the recovery sentence"))))


### PR DESCRIPTION
## What this is, and what the brief's premise turned out to be

The brief asked for the Tags-column keys-set diff arm to be built. **It was already built** — `6035062599 core/test: grow the 009 ratchet by a Tags-column keys-set diff (rf2-6tags)` landed it, and five later commits under this same bead hardened it (whole-`:operation` pairing, the link-text rule, the `SchemaValidationFailureTags` pairing, the paired-count floor, the shrink-only baseline). The non-vacuity proof the brief asks for is likewise already in the suite, at `tags-column-arm-reds-on-its-motivating-defect`. Nine Tags-column deftests ship today. The premise does not hold, and re-deriving the arm would have duplicated it.

What *had not* shipped is the pin the bead's most recent audit note ordered, and that is what this PR lands.

The PR #8562 audit told rf2-6tags to "repair the parser … **and pin the existing infinite-pagination row as the positive fixture so the real Tags cell is observed**". PR #8576 (rf2-1t0er) did the repair — a negative lookbehind so the split skips a backslash-escaped pipe — but pinned it **in prose only**. Its own commit message says "No existing assertion changes", and the measurement bears that out: reverting the lookbehind to the pre-repair `#"\|"` runs all 28 tests / 177 assertions **green**.

So the reader that decides *which column the Tags arm adjudicates* was itself unratcheted. That is this bead's own thesis one level down — a gate whose coverage never reaches the place where drift accumulates keeps reporting green over it.

## The arm — one deftest, three testings

**The live row, pinned**, as the audit ordered. `:rf.error/infinite-missing-next-page-param` is the corpus's one escaped-pipe row (it spells its `:next-page-param` contract `(last-page → next-param \| nil)`), so its `:tags` cell must harvest `:resource-id`, `:infinite`. Under the pre-repair reader the row split to nine fields, every column slid one place left, and the cell was read from `Default :recovery` — harvesting `:fix-registration` and `:next-page-param` as though the row had documented them.

**The column-alignment invariant**, which generalises the pin past one row. Every active row of a markdown table has the same column count, so a row splitting to a different field count than its siblings has slid, and every cell the arm reads from it is off by one. It is derived from the corpus's own rows: no column literal to go stale, **and no second catalogue parser** (the bead forbids one) — the count rides out of the existing reader on a new `:field-count` key. No new vocabulary, no new script, no hand-maintained roster: the two sources are the two files both existing gates already parse.

**Non-vacuity against the reader defect**, in-suite. A synthetic row carrying an escaped pipe must reach the arm's *verdict* through its real `:tags` cell. Under the pre-repair reader that row's cell is the recovery sentence, so the keys-set diff convicts a clean row of omitting all five keys its schema declares — a red naming the wrong column, for a reason unrelated to the change in front of the author.

## Quality gates

**Gate: `re-frame.error-catalogue-channel-conformance-test`** (`clojure -M:test -n …` from `implementation/core`). Foreground, exit code captured in the same shell as the redirect, quoted from that capture.

| run | result | exit (captured) |
|---|---|---|
| control, before any edit | 28 tests / 177 assertions, 0 failures | `0` |
| after the arm | 29 tests / 184 assertions, 0 failures | `0` |
| sabotage (pre-repair reader) | 29 tests / 184 assertions, **4 failures** | `1` |
| post-rebase, final base | 29 tests / 184 assertions, 0 failures | `0` |

**+1 test, +7 assertions.** Seven is the right number: two pin the live row (that it still parses at all, and that its harvested key set is the tags column), two carry the alignment invariant (a non-empty row set, so it cannot hold vacuously, plus the invariant itself), and three carry the synthetic reader property end to end — the row parses, its cell is the tags cell, and the *arm's verdict* on it is clean.

**Planted-fault proof, and it doubles as the arm's own non-vacuity proof.** The fault is not hand-written: it is the pre-repair reader recovered verbatim from `git show 7d2dad1e7a^`, i.e. `#"\|"` in place of `#"(?<!\\)\|"`. It is a *removal* of a guard, which is the shape this file's pairing arm actually discriminates on. Restoring it reds exactly and only the new deftest, 4 of its 7 assertions, each naming the real failure mode:

- the live row harvests `#{:fix-registration :next-page-param}` instead of `#{:resource-id :infinite}`
- the alignment invariant names the offender: `[[:rf.error/infinite-missing-next-page-param 9]]`
- the synthetic row's cell reads `#{:no-recovery}`
- and `tags-column-findings` falsely convicts that clean row of `:missing #{:route-id :reason :frame :contributor :plan-cause}`

The other 28 tests stayed green throughout the sabotage — which is the measurement proving the pre-repair state was genuinely unpinned before this arm, and it is the discrimination that the run read *this* worktree: the fault existed only here, so a run that had wandered elsewhere would have come back green. Restore verified against the committed object by the identical **blob** hash `8ab3f25f65a929db8b810175bf074b0e0fdaac5f`, taken before the plant and after the restore (the planted intermediate hashed `1d116ddc40812da5931caaa24f85f6e8096207db`, so the plant did apply rather than silently no-op).

**Non-vacuity against the pre-rf2-wsopx catalogue state** — the proof the bead makes mandatory. The historical corpus was **recovered from history, not hand-constructed**: `git show 344c5f7e09^:spec/009-Instrumentation.md` and `git show 344c5f7e09^:spec/Spec-Schemas.md`, where `344c5f7e09` is the rf2-wsopx fix commit. Driving the shipped arm's own functions over those two texts:

```
PRE-WSOPX CORPUS  rows: 489  schemas: 111
PRE-WSOPX field-count frequencies: {8 489}
PRE-WSOPX findings: 24
SCHEMA ResourceRoutePlanTags: (:category :cause :contributor :nav-token :plan-cause :reason :resource-id :route-id)
MOTIVATING-DEFECT FINDING: {:category :rf.error/resource-route-plan, :schema "ResourceRoutePlanTags", :missing [:contributor :plan-cause]}
prefetched rows in pre-wsopx catalogue: 0
```

The arm reds on the exact defect that motivated the bead — `:plan-cause` and `:contributor` missing from that row — and the bead's other claim checks out too: `:rf.route/prefetched` appeared **zero** times in the catalogue at that commit. The historical corpus has no escaped-pipe row (`{8 489}`, uniform), which is the expected result and not a gap: the alignment arm added here is orthogonal to the wsopx defect, and each is proved against its own motivating instance.

**Corpus figures, re-derived at this base rather than trusted** (matching PR #8576's report): catalogue header 6 columns / 8 split fields, **513 active rows, all 513 at 8 fields**. #8576 removed the stale hand-copied totals from this file's prose in favour of a re-derivation recipe, so there was no number in the file to update, and this PR adds none.

**Fast spine: NOT run.** `worker/bisect-9jrhi` holds the box for a measurement window, and the brief forbids a second heavyweight load — two on one machine wedge rather than fail. The conformance namespace is a JVM Clojure test and is the one run this change needs; no JVM was in flight when it started (checked `tasklist`). No shadow-cljs, browser, Playwright or npm build was run. `scripts/check_fast_pr_gap.py --list` reports **94 required checks the fast spine does not run**, and CI decides all of them.

Change is confined to one file, `implementation/core/test/re_frame/error_catalogue_channel_conformance_test.clj`. `spec/009-Instrumentation.md` and `spec/Spec-Schemas.md` were read, never edited. The merge-base diff (`origin/main...HEAD`) is 86 insertions / 6 deletions in that one file, and the six deletions are the docstring header and map literal this PR rewrites — nothing a sibling landed is reverted.

**Rebased past PR #8580** (`ddbf404453`, which edits `spec/009-Instrumentation.md` — a file this arm reads), and the gate was re-run on that final base: **29 tests / 184 assertions, 0 failures, captured exit `0`**. The corpus census was re-derived there too and is unchanged — header 6 columns / 8 fields, 513 active rows, all 513 at 8. The merge-base diff is still the same one file.
