### PR TITLE
fix: three donor residues the name-shaped census cannot see (rf2-ue4kv)

### DIFF
--- a/.github/scripts/preflight-story-package.sh
+++ b/.github/scripts/preflight-story-package.sh
@@ -128,10 +128,6 @@ MISSING_HINT = {
 # reach the published jar. Seeing one here means an alias leaked into
 # :deps.
 EXTRA_HINT = {
-    ("day8", "re-frame2-ui"):
-        " re-frame2-ui NEVER PUBLISHES — it is in-tree donor code, consumed"
-        " by :local/root and test-only, so it must stay under Story's :test"
-        " alias, never in the published :deps.",
     ("day8", "re-frame2-epoch"):
         " The epoch artefact is test-only for Story (both consumers read"
         " the late-bound facade) — it must stay under the :test alias.",

--- a/implementation/routing/test/re_frame/routing_conduct_dom_cljs_test.cljs
+++ b/implementation/routing/test/re_frame/routing_conduct_dom_cljs_test.cljs
@@ -37,11 +37,16 @@
 
   **Prefetch.** All three positions of the closed intent class
   (`re-frame.routing.link/prefetch-intent-keys` — `:on-mouse-enter` /
-  `:on-focus` / `:on-touch-start`) are driven with REAL DOM events in
-  the retired compiled tier's route-link DOM suite (rf2-2n3p, PR #8017), which also
-  carries an assertion that reds the moment the class grows. Rebuilding
-  that here would add a second copy of a covered proof and a second thing
-  to keep in step with the law.
+  `:on-focus` / `:on-touch-start`) are exercised by
+  `re-frame.route-link-cljs-test`, but SYNTHETICALLY: it reads the handler
+  off the rendered attrs map and calls it, rather than firing a browser
+  gesture at a mounted anchor, and it names the three positions literally
+  instead of reading the class. The suite that drove them through the real
+  DOM, and the roster assertion that pinned its gestures against the class,
+  both retired with the compiled-view substrate (rf2-0yp7w), and nothing
+  replaced either. So this paragraph records a GAP rather than declining a
+  covered proof: no browser-level witness of prefetch survives on any
+  surface, and this file does not supply one.
 
   ## The URL is borrowed, and given back
 

--- a/implementation/scripts/_preflight-story-package.test.cjs
+++ b/implementation/scripts/_preflight-story-package.test.cjs
@@ -246,13 +246,13 @@ test('an empty <version> fails — an incomplete GAV is unresolvable', () => {
 });
 
 test('a leaked test-only dependency fails with a pointed hint', () => {
-  // re-frame2-ui NEVER PUBLISHES (in-tree donor code) and lives under Story's
-  // :test alias. Seeing it in the published pom means the alias leaked into :deps.
-  const deps = [...THIRD_PARTY, ...inRepoDeps(), dep('day8', 're-frame2-ui', VERSION)];
+  // re-frame2-epoch is test-only for Story and lives under its :test alias.
+  // Seeing it in the published pom means the alias leaked into :deps.
+  const deps = [...THIRD_PARTY, ...inRepoDeps(), dep('day8', 're-frame2-epoch', VERSION)];
   expectFail(
     makeFixture({ pom: pomWith(deps) }),
     'leaked test-only dep',
-    /UNEXPECTED DIRECT dependency day8\/re-frame2-ui.*NEVER PUBLISHES/s,
+    /UNEXPECTED DIRECT dependency day8\/re-frame2-epoch.*test-only for Story/s,
   );
 });
 

--- a/implementation/scripts/serve-and-run-browser-tests.cjs
+++ b/implementation/scripts/serve-and-run-browser-tests.cjs
@@ -357,8 +357,9 @@ async function run() {
 }
 
 // rf2-u0cy4: guard the real launch behind require.main. Matches the
-// established convention (e.g. check-ui-adapter-isolation.cjs's
-// `--self-test`). Production invocation is always `node
+// established convention (e.g. run-hicasso-native-ime-witness.cjs, the
+// sibling that pairs a `--self-test` with the same guard). Production
+// invocation is always `node
 // scripts/serve-and-run-browser-tests.cjs ...` (require.main === module is
 // always true there), so this changes nothing about how the two production
 // browser gates run this file.


### PR DESCRIPTION
Three donor residues the R6 census cannot see, because in each the donor **name** was scrubbed and the surrounding **claim** was left standing. A name-shaped regex returns all three as clean forever.

All three were re-verified at the tip before editing, and again after a rebase onto `ddbf404453`.

---

## 1. `routing_conduct_dom_cljs_test.cljs` — self-contradictory and load-bearing

The "What this file deliberately does not witness" section declined to witness prefetch on the strength of a proof it called, in one breath, **"the retired compiled tier's route-link DOM suite"** and, in the next, extant. Both cannot hold. Measured, the second is the false half.

**Does the prefetch coverage it cites exist anywhere today? No — not the coverage it describes.** Three separate claims, each checked at source:

| Claim in the prose | Verdict | Evidence |
|---|---|---|
| "driven with REAL DOM events" | **FALSE** | The real-DOM suite was `implementation/ui/test/re_frame/ui/route_link_dom_cljs_test.cljs` (rf2-2n3p, PR #8017), deleted with `implementation/ui/` in `ef3131f4a2`. No file matching `implementation/**/*dom_cljs_test.cljs` drives a prefetch intent through a DOM event today. |
| "carries an assertion that reds the moment the class grows" | **FALSE** | That roster assertion pinned the deleted fixture's gestures against `prefetch-intent-keys` and went with it. The surviving suite contains **zero** references to `prefetch-intent-keys`. |
| "a second copy of a covered proof" | **MISLEADING** | Coverage does survive, in `re-frame.route-link-cljs-test`, but it is **synthetic**: `fire-intent!` reads the handler off the rendered attrs map and calls it. No gesture reaches a mounted anchor. Its position list is a literal `doseq`, so a grown class is silently under-tested rather than red. |

**Repair, prose only:** re-pointed at the live suite, labelled synthetic, and the paragraph now records a **gap** rather than declining a covered proof. This matches the repair PR #8577 made to the Hicasso navigation witness, which carried the same scrubbed-name residue.

**Coverage question, referred rather than actioned** (per the bead's scope note — a coverage gap is not a residue sweep):

- No browser-level prefetch witness survives on any surface.
- No roster assertion pins the surviving test's positions against `prefetch-intent-keys`.
- Relevant to sizing it: rf2-2n3p's *motivating* risk has died. That bead existed because `re-frame.ui/route-link` wrote the three positions out **literally**, so a position added to the class reached some surfaces and missed others. That donor is gone, and `link.cljc`'s `prefetch-intent-attrs` now maps over `prefetch-intent-keys` as the one enumeration (rf2-7g4qn). What remains uncovered is narrower: whether React attaches the three handlers under the real event names, and the literal position list in the surviving test.

The bead is left **OPEN** with this recorded.

## 2. `serve-and-run-browser-tests.cjs` — a cited exemplar that does not exist

The comment above the `require.main === module` guard justified itself by pointing at "the established convention (e.g. `check-ui-adapter-isolation.cjs`'s `--self-test`)".

`implementation/scripts/check-ui-adapter-isolation.cjs` was deleted in `ef3131f4a2` — confirmed independently by `git show --name-status` (status `D` on that path) and by its absence from `git ls-files`. A reader who goes looking for the convention finds no file, and cannot tell whether the convention or the citation is the thing that rotted.

**Re-pointed at `run-hicasso-native-ime-witness.cjs`**, which is the live exemplar of exactly the pairing this comment is about: it is the only other script under `implementation/scripts/` carrying **both** a `--self-test` mode and a `require.main === module` guard, and its self-test is wired into `test:script-helpers`, so the convention it exemplifies is executed rather than merely asserted. Comment-only; no behaviour changes.

## 3. `preflight-story-package.sh` + its pinning test — one commit

The `EXTRA_HINT` entry keyed `("day8", "re-frame2-ui")` is present tense about a removed tree: *"it is **in-tree donor code**, **consumed** by `:local/root` and test-only"*. `implementation/ui/` was deleted in `ef3131f4a2`, so there is no in-tree donor code to consume and the coordinate cannot reach Story's pom by any route.

**The pairing is real, and was measured rather than assumed.** The suite's `a leaked test-only dependency fails with a pointed hint` row was the **only** row exercising the extra-dependency path at all, and it pinned the hint verbatim:

```js
/UNEXPECTED DIRECT dependency day8\/re-frame2-ui.*NEVER PUBLISHES/s
```

So removing the script's entry alone would have reddened the suite on the next run. Demonstrated directly in the sabotage below.

**Repair:** retire the dead entry — not reword it — but retiring it alone would have taken the extra-dependency path's only test with it. The test is instead **re-pointed** at `("day8", "re-frame2-epoch")`, a live test-only Story dependency with a live hint of the same shape. Net: one dead branch removed, and the surviving pin now covers a hint that can actually fire. Both files in **one commit**.

---

## Quality gates

The box was held by another worker's measurement window, so **no heavyweight gate was run** — no `scripts/test-fast-pr.sh`, no shadow-cljs build, no browser or Playwright run.

**The fast spine did NOT run.** `scripts/check_fast_pr_gap.py --list` reports **94** required checks the spine does not run; none of the three gates below is decided by it, and CI owns the rest.

| Gate | Scope | Captured exit |
|---|---|---|
| `node scripts/_preflight-story-package.test.cjs` (from `implementation/`) | item 3 — the suite that invokes the real shell script | **0** — 10 passed |
| `node scripts/_serve-and-run-cli.test.cjs` (from `implementation/`) | item 2 — spawns and module-loads the edited script | **0** — 5 passed |
| Clojure reader parse, `:read-cond :allow` | item 1 — proxy for the compile gate | **0** — `READ OK forms= 38` |

Every exit code above is the one **I** captured, by redirecting to a log and echoing the runner's own status to a file on one command line in one shell — never a harness-reported number. All were re-run on the final base after the rebase.

**Item 1's real gate was NOT run.** `implementation/routing/test/` is on the `node-test` build's source paths, so `npm run test:cljs` is the compile gate that reaches this file. It is a cold shadow-cljs compile and the box was busy, so it was not run; the reader parse above is a proxy that proves the docstring is balanced and the file still reads, not that it compiles. **CI owns the real compile.** The edit is confined to a docstring string literal.

### Planted-fault proofs — each gate proved to read THIS worktree

Each plant was anchored to a single line, in the region being edited, and each restore verified against the committed object by git blob hash rather than by reading a diff.

1. **`_serve-and-run-cli.test.cjs`** — planted a doubled brace on `if (require.main === module) {`, the line the edited comment describes. Captured exit **1**; failure was a `SyntaxError: Unexpected end of input` naming the script **at this worktree's absolute path**. Restored; the identical blob hash `ee209fc38bf05f9c5cd7b99ac560f718d0e499d8` before the plant and after it.

2. **`_preflight-story-package.test.cjs`** — the decisive one. Renamed the `("day8", "re-frame2-epoch")` key in the **shell script** and ran the **node suite**. Captured exit **1**, `1 of 10 failed`: the shell script still detected the unexpected dependency but emitted it **without the hint**, exactly as predicted. This proves three things at once — the node suite executes the shell script in this worktree, the one-toucher coupling is real in the load-bearing direction (a shell-only change reds the suite), and the plant was **scoped**: the other 9 rows still ran, and both runs report 10 tests. Restored; the identical blob hash `d4c4ad5230b32d387ce7ed2f0e398d722ef6eaa1`. Re-run after restore: exit **0**, 10 passed.

3. **Reader parse** — injected a quote-and-paren pair into the docstring sentence being edited. Captured exit **1**, `Invalid token: proof:` — a token that exists only in this worktree's version of the file, so a run that had wandered into a sibling checkout would have come back green. Restored; the identical blob hash `08d4cce2416ce01d3d58e22d3dce71925d8f4928`. Re-run after restore: exit **0**, `forms= 38`.

One plant **silently failed to apply** on the first attempt — an end-of-line-anchored regex against a CRLF-terminated file matched nothing, with no error. Caught by checking the match count before running the gate, not afterwards. A green sabotage run there would have read as "the control does not bite".

### Gates that do NOT reach these files

`scripts/check_doc_slugs.py` and `scripts/check_readme_links.py --ci` validate markdown link targets and anchors. All four changed files are `.cljs`, `.cjs` and `.sh` — outside the docs gate's roots and outside all three of the README gate's rosters. Neither is the gate for this change, and neither was nominated.

### By hand

- The two tables in this PR body have consistent column counts; no markdown was added to any committed file.
- Merge-base diff (`origin/main...HEAD`) read before pushing: exactly the four fenced files, 17 insertions / 15 deletions, nothing a sibling landed is reverted.
- Fence re-derived at start-up and before the first edit: no open PR touches any of the four files.
- Repo-wide sweep for any other pin on the removed `EXTRA_HINT`: none. The remaining `re-frame2-ui` hits are either the live **`re-frame2-uix`** adapter (a different artefact) or historical prose in `docs/EP/` and `CHANGELOG.md`, all outside this fence.

Closes nothing — rf2-ue4kv stays open on item 1's referred coverage question.
