### PR TITLE
docs(method) + test(routing): the translated-line-ending plant class, and a prefetch roster pin (rf2-pmw4g, rf2-3u16e)

### DIFF
--- a/docs/the-mayor-method/dispatch-prompt-template.md
+++ b/docs/the-mayor-method/dispatch-prompt-template.md
@@ -798,7 +798,7 @@ reads clean too**, because "unchanged" and "not attempted" are the same diff. Th
 plant that silently no-ops makes the sabotage run come back green, so the worker reports a guard that fired when
 nothing was ever broken — a false proof of a real guard, which is worse than no proof.
 
-Hash the file before the plant and compare after the restore. Four cautions:
+Hash the file before the plant and compare after the restore. Five cautions:
 
 * **On a checkout whose line endings are translated, use version control's own content hash against the committed
   object, not a plain byte digest of the working file.** A checkout during a rebase can rewrite the working file
@@ -814,6 +814,12 @@ Hash the file before the plant and compare after the restore. Four cautions:
   loses to whatever sits closer.
 * **Anchor a patch to a single line.** One worker's multi-line anchor matched nothing, with no error and no edit,
   and only the hash caught it.
+* **A pattern anchored at the end of a line matches nothing where line endings are translated** — a carriage
+  return sits between the text and the line ending, so the anchor never reaches the text. This defeats a
+  single-line anchor exactly as readily as a multi-line one, so the caution above does not cover it. And the
+  detector here is cheaper and earlier than the hash: **read the match count before you run the gate.** Zero is
+  unambiguous and free, where the hash convicts a no-op plant only after a whole gate run has been spent, and
+  convicts it as a signal the worker still has to interpret.
 * **A hash proves the SOURCE changed, not that the runtime ever saw it.** One worker planted a one-line fault and
   its live witness came back green. The hashes differed, so the plant had genuinely applied and the rule above
   reported success — but the file was not in the host build's module graph, so the watcher never noticed the edit

--- a/implementation/routing/test/re_frame/route_link_cljs_test.cljs
+++ b/implementation/routing/test/re_frame/route_link_cljs_test.cljs
@@ -29,6 +29,10 @@
             ;; rf2-qwm0a: listener / buffer surface lives in re-frame.trace.tooling.
             [re-frame.trace.tooling :as trace-tooling]
             [re-frame.routing :as routing]
+            ;; rf2-3u16e: the credible-intent position class is pinned against
+            ;; its one published definition, so this file's literal cannot
+            ;; silently fall behind it.
+            [re-frame.routing.link :as link]
             [re-frame.adapter.reagent :as reagent-adapter]
             [re-frame.test-support :as test-support]))
 
@@ -445,13 +449,25 @@
 (deftest prefetch-intent-dispatches-on-each-credible-intent-position
   (testing "hover, focus and touch-start each warm the link's own destination"
     (rf/reg-route :route/article {:params [:map [:slug :string]]} "/articles/:slug")
-    (doseq [pos [:on-mouse-enter :on-focus :on-touch-start]]
-      (let [{:keys [dispatched source installed?]}
-            (fire-intent! {:to :route/article :params {:slug "x"} :prefetch :intent} pos)]
-        (is installed? (str pos " is installed on a :prefetch :intent link"))
-        (is (= [:rf.route/prefetch {:to :route/article :params {:slug "x"}}] dispatched)
-            (str pos " dispatched the address-only prefetch event"))
-        (is (= :router source) "routing-substrate attribution")))))
+    (let [positions [:on-mouse-enter :on-focus :on-touch-start]]
+      ;; ROSTER PIN (rf2-3u16e). The positions stay written out, because naming
+      ;; them is what tells a reader which gestures this file exercises — but a
+      ;; literal alone fails CLOSED: `prefetch-intent-attrs` maps over
+      ;; `link/prefetch-intent-keys`, so a position added to that class would be
+      ;; installed correctly, go untested here, and nothing would say so.
+      ;; Iterating the class instead would absorb the new position silently and
+      ;; would not red either; only pinning the two against each other does.
+      (is (= (set link/prefetch-intent-keys) (set positions))
+          (str "the credible-intent class has changed to "
+               (pr-str link/prefetch-intent-keys)
+               " — extend this test's positions to match it"))
+      (doseq [pos positions]
+        (let [{:keys [dispatched source installed?]}
+              (fire-intent! {:to :route/article :params {:slug "x"} :prefetch :intent} pos)]
+          (is installed? (str pos " is installed on a :prefetch :intent link"))
+          (is (= [:rf.route/prefetch {:to :route/article :params {:slug "x"}}] dispatched)
+              (str pos " dispatched the address-only prefetch event"))
+          (is (= :router source) "routing-substrate attribution"))))))
 
 (deftest a-link-without-prefetch-installs-no-intent-handlers
   (testing "a passive link installs NONE of the three positions, so a caller's


### PR DESCRIPTION
Two independent beads on disjoint surfaces, one commit each.

---

## rf2-pmw4g (P3) — the plant-verification cautions miss the translated-line-ending class

`docs/the-mayor-method/dispatch-prompt-template.md` only. One caution added to the list under
**Verify a restore by hashing the bytes, never by reading a diff**, plus the lead-in count corrected
from "Four cautions" to "Five".

**Premise re-derived before writing anything, because the bead itself invited a refusal here.** The
list's third caution is *"Anchor a patch to a single line. One worker's multi-line anchor matched
nothing, with no error and no edit, and only the hash caught it."* That is the same failure — a plant
that no-ops — reached by a different mechanism, with a different detector. An end-of-line-anchored
pattern against a carriage-return-terminated line is exactly one line and still matches nothing, so
that caution does not reach this class. Searched the whole file for `match count`, `carriage`,
`line endings`, `anchor`: the only hits are the paragraph noting that a rewrite flipping line endings
reads clean, the hash caution, and the single-line-anchor caution. Neither the mechanism nor the
detector appears anywhere in the file. **The premise holds and the caution was written.**

Both halves the bead asked for are in, the second being the more valuable:

1. the **mechanism** — a carriage return sits between the text and the line ending, so the anchor never
   reaches the text;
2. the **detector** — read the match count *before* running the gate. Zero is unambiguous and free,
   where the hash convicts a no-op plant only after a whole gate run has been spent, and convicts it as
   a signal the worker still has to interpret.

Register held to the generic method tree: no repository names, tracker ids, change numbers, paths, tool
names or operating-system mechanics. "Where line endings are translated" is the register the first
caution in that same list already uses. The list was not restructured and nothing else in the file was
touched; the lead-in count moved because it is a count and four bullets became five.

The detector is not just documented here, it was used — both plants below had their match count read
before the gate ran.

---

## rf2-3u16e (P4) — no roster assertion pinned the prefetch position class

`implementation/routing/test/re_frame/route_link_cljs_test.cljs` only. One assertion.

**The claim re-derived at `origin/main` HEAD rather than trusted, and it HOLDS.** Across every tracked
file, `prefetch-intent-keys` appears in source at its definition, at the late-bound seam that publishes
it, and inside `prefetch-intent-attrs` which maps over it — and in *no test's code anywhere*. The two
remaining mentions under a test tree are prose in doc comments. The surviving suite
`re-frame.route-link-cljs-test` wrote the three positions out as a literal `doseq` and did not require
the defining namespace at all.

**A measurement that contradicts the fix the bead literally proposed, and it matters.** The bead asks for
the `doseq` to be *derived from* `prefetch-intent-keys` "so the suite reds when the class grows". It
would not red. `prefetch-intent-attrs` already maps over the same class, so a position added there is
installed correctly and a derived `doseq` would simply iterate one more time, pass, and say nothing. What
produces the ratchet is pinning the two against each other. That is also what the deleted original did —
it kept its fixture's own gestures and pinned them against the class — so this restores the shape that
was lost rather than inventing one.

So the literal stays, which also answers the bead's own "is it harder to read" escape hatch: naming the
three gestures is what tells a reader which ones this file exercises, and the pin sits directly above
them with a message that names the new class membership and says what to do about it.

**The gap is one-sided; no Hicasso edit.** The brief flagged a second `route_link_cljs_test.cljs` under
`implementation/hicasso/test/` as possibly the model or possibly a second place to edit. It is neither.
Hicasso's `h/route-link` **declines** `:prefetch` outright in v0 (`:rf.error/hicasso-route-link-prefetch-declined`)
and references `prefetch-intent-keys` in no source file at all — its own suite enumerates prefetch
*values*, not positions. There is no position list on that surface to pin.

**Not built, deliberately.** The sibling referral "no browser-level prefetch witness survives anywhere"
was already rejected on the record. No browser witness was added, no new namespace, no new script, no
roster file.

---

## Quality gates

| Gate | Command | Exit code I captured |
|---|---|---|
| doc slugs — control | `python scripts/check_doc_slugs.py` | **0** |
| doc slugs — sabotage | same, broken link target planted in the new bullet | **1** |
| doc slugs — restored | same | **0** |
| doc slugs — **re-run on final base after rebase** | same | **0** |
| routing probe — control | `clojure -M <probe> <test file>` | **0** |
| routing probe — sabotage | same, fourth key planted into the published class | **1** |
| routing probe — restored | same | **0** |
| routing probe — **re-run on final base after rebase** | same | **0** |

Every number above was captured by `echo "EXIT=$?"` on the same command line as the redirect, in one
shell. Nothing was piped through a filter, and no harness-reported number is quoted anywhere.

### What the routing probe is, and why it is not the CLJS suite

The real gate for `re-frame.route-link-cljs-test` is `npm run test:cljs` — `compile-node-test.cjs` plus
the node run, a cold shadow-cljs compile. **I did not run it, and CI owns it.** Two measured reasons:

* the machine was held. A shadow-cljs `hicasso-bench-node` compile was running out of a *different*
  worker's checkout — traced through the process tree from the JVM to the sibling worktree's own
  `shadow-cljs` runner, not inferred. It had started eleven seconds earlier, read off the system clock
  rather than guessed. It had finished by the time this branch was ready to push, but by then the second
  reason stood alone;
* this worktree carries no `implementation/node_modules`. Running the suite means junctioning it at the
  primary checkout's real one, which is the link whose removal has twice emptied that real directory. For
  a two-line assertion on a P4 test-side ratchet, creating that link is the disproportionate risk, not the
  unrun gate.

So the probe stands in, and it is narrower than the suite by design. It does two things in a fresh JVM:
reader-parses the edited test file (29 forms — a syntax fault in the restructured `deftest` would fail
here), and evaluates the new assertion's exact predicate against the **real published class**, loaded from
the same `.cljc` source the CLJS build reads.

What that leaves for CI: whether the file *compiles as ClojureScript*. The one new thing that could fail
is the added require of the defining namespace — and a sibling `-cljs-test` namespace in the same
directory already requires it under the same `node-test` build, so it resolves on the classpath the suite
will actually run on.

### Which tree the gates read

Neither gate prints a root banner — the doc-slugs gate's green log is empty — so the root-banner route is
not on offer for either, and the proof is the planted fault in both cases.

* **doc slugs.** Match count read *before* the plant (the anchor matched exactly 1 line) and after (1
  occurrence of the planted target), so the plant was not a silent no-op. The gate came back red naming
  exactly what was planted, in the new bullet:
  `BROKEN TARGET: docs/the-mayor-method/dispatch-prompt-template.md:820 -> ./no-such-page-twosmall.md`.
  Restore verified by the identical **blob** hash `1ec99efaf6272451b793c5c4f242f7d19618fab4` before the
  plant and after it, against the object committed on this branch.
* **routing probe.** A fourth key was planted into the published class on a single-line anchor, match
  count 1 before and 1 after. The probe went red, and the plant is visible in its *output* as well as its
  exit code — it printed the class carrying the planted key, which is positive evidence the runtime
  observed the plant rather than serving a stale compile. Restore verified by the identical **blob** hash
  `eace9a3af762f79e5e7c6f0dcf574a2f5e9419f2`. Nothing outside this branch's two files remains changed.

Both planted tokens existed only in this worktree, so a run that had wandered into a sibling checkout
would have come back green. The plants were scoped: the probe's form count was 29 on every arm, and the
class plant was one key on one line, restored inside the same command that re-ran the gate.

### Not run

The fast-PR spine (`scripts/test-fast-pr.sh`) **did not run at all**. `scripts/check_fast_pr_gap.py --list`
reports 94 required checks that spine does not run — that is a fact about the spine, not a census of what
ran here. The gates run directly are the eight rows in the table above and nothing else.
`mkdocs build --strict` was not run; `docs/the-mayor-method` is not in `mkdocs.yml`'s `exclude_docs`, so CI
owns it. `npm run test:cljs` was not run, for the two reasons above.

### Verified by hand, because no gate reaches it

The link gates check link targets and heading anchors and nothing else — no prose, no tables, no
rendering, no nav.

* The new caution was read against its four neighbours for voice and register, and against the generic
  tree's rule that it carry no repository, tracker, path, tool or operating-system specifics.
* The list lead-in count now matches the bullet count (five).
* No heading, no anchor and no table was touched anywhere in the diff, in either file.
* The new bullet's back-reference ("the caution above") resolves to the single-line-anchor caution
  immediately preceding it, and the following caution's own "the rule above" still resolves to the
  hash-the-file lead-in, which the insertion did not move.
* The three-dot diff against the merge base was read for what it would revert before pushing: two files,
  30 insertions, 8 deletions, all of it this branch's own. The trunk gained one unrelated commit while this
  work was in flight; both gates were re-run on the final base after rebasing onto it.

### Fence

Re-derived at start-up and again before the first edit, from open changes, every worker branch's
three-dot diff against the trunk, and every sibling worktree's uncommitted status. **No branch and no
worktree, committed or uncommitted, touches either of this change's two files** — nor the definition file
the second plant borrowed and restored.
