### PR TITLE
fix(hicasso): the bench lane's two Node drivers named a deleted build, and one npm script pair could not run (rf2-0yp7w.9.6)

### DIFF
--- a/docs/design/hicasso/production-server-arm.md
+++ b/docs/design/hicasso/production-server-arm.md
@@ -650,7 +650,7 @@ record.
   Nothing detects that skew today.
 - **A build step the programmer owns.** The sidecar bundle is per-application:
   the app's own shadow-cljs build has to produce a server bundle. The spike's is
-  a `:node-script` produced by `--config-merge` over `:freehand-bench-node`,
+  a `:node-script` produced by `--config-merge` over `:hicasso-bench-node`,
   which is a bench convenience and not a shape an application can copy. **And it
   is not only a build**: the bundle has to publish the entry table the JVM's
   identifiers resolve against, so the artefact has a named public surface rather

--- a/implementation/hicasso/test/re_frame/bench/hicasso/compile_gate.cjs
+++ b/implementation/hicasso/test/re_frame/bench/hicasso/compile_gate.cjs
@@ -149,8 +149,9 @@
 // (2026-08-14). No retirement covers this directory: rf2-0yp7w retires
 // `implementation/freehand/` and `implementation/ui/`, and hicasso is the
 // survivor of that ruling — a Reagent adapter, a UIx adapter, and hicasso as
-// re-frame2 native. The sibling coupling in rf2-d19nf is live because
-// Freehand's tree has a scheduled deletion; this one does not, and may never.
+// re-frame2 native. The sibling coupling in rf2-d19nf was live because
+// Freehand's tree had a scheduled deletion, since executed by PR #8322; this
+// directory has none, and may never.
 //
 // WHAT A RELOCATION WOULD NEED, recorded now so the decision is cheap when it
 // is actually due: somewhere to compile from. This gate takes NO new build id

--- a/implementation/hicasso/test/re_frame/bench/hicasso/keywarn_clock_run.cjs
+++ b/implementation/hicasso/test/re_frame/bench/hicasso/keywarn_clock_run.cjs
@@ -9,15 +9,21 @@
 // human framing riding as `;;` comments. See `keywarn_clock.cljs` for what is
 // measured and why a local ablation copy is the right shape for it.
 //
-// ## NO EDIT TO shadow-cljs.edn
+// ## WHICH BUILD ID (rf2-0yp7w.9.6)
 //
-// A `:node-script` compile is what this needs, and the lane's own
-// `:hicasso-bench` is a `:browser` build. Rather than add a build id — HD-017
-// makes that a hot-zone edit to `implementation/shadow-cljs.edn` and therefore
-// a sequenced dispatch — this rides the existing `:freehand-bench-node`
-// `:node-script` id through `--config-merge`, supplying its own `:main` and
-// `:output-to`. Exactly the mechanism `compile_gate.cjs` and `jsfb_build.cjs`
-// use on `:hicasso-bench`; only the borrowed id differs.
+// A `:node-script` compile is what this needs, and the lane's `:hicasso-bench`
+// is a `:browser` build. Rather than add a build id — HD-017 makes that a
+// hot-zone edit to `implementation/shadow-cljs.edn` and therefore a sequenced
+// dispatch — this rode the donor tree's `:freehand-bench-node` `:node-script`
+// id through `--config-merge`, supplying its own `:main` and `:output-to`.
+//
+// PR #8322 deleted that build with the tree, leaving this driver naming a
+// build shadow-cljs does not have, and left no `:node-script` build anywhere
+// in that file to ride instead. So the id below is the lane's OWN, minted
+// beside `:hicasso-bench` and shared with `ssr/driver.cjs` — one id, both of
+// the lane's Node programs, the sequencing law paid once. The `--config-merge`
+// mechanism is unchanged, and is the same one `compile_gate.cjs` and
+// `jsfb_build.cjs` use on `:hicasso-bench`.
 //
 // `compile`, not `release`: the pre-pass exists only where `goog.DEBUG` is
 // true, and a dev compile is the build the figure is ABOUT. The clock refuses
@@ -32,7 +38,7 @@ const path = require('node:path');
 const { shadowBuildVerdict, reportRefusal } = require('./lane_build.cjs');
 
 const IMPL = path.resolve(__dirname, '../../../../..');
-const BUILD_ID = 'freehand-bench-node';
+const BUILD_ID = 'hicasso-bench-node';
 const OUT = 'out/keywarn-clock.js';
 const TAG = 'keywarn-clock';
 

--- a/implementation/hicasso/test/re_frame/bench/hicasso/p0_converge_app.cljs
+++ b/implementation/hicasso/test/re_frame/bench/hicasso/p0_converge_app.cljs
@@ -34,9 +34,11 @@
      round.
   2. **rf2-2rtt6.2 is on main and owns the measurement lane.** HD-017
      gives `:hicasso-bench` and `run.cjs` to that arm; rf2-2rtt6.4's tree
-     rides `:freehand-release`'s compiler settings through a
+     rode `:freehand-release`'s compiler settings through a
      `--config-merge` precisely because the lane had not landed. Running
-     the frontier arm on the lane retires that workaround.
+     the frontier arm on the lane retires that workaround — and rf2-0yp7w
+     since removed that build with the donor tree, so there is no longer
+     anything to ride even if it had not.
   3. **rf2-2rtt6.4 nominated it.** Its own `Open items` names
      rf2-2rtt6.2's set as the convergence target and names its `U-broad`
      row as the closest existing correspondence.

--- a/implementation/hicasso/test/re_frame/bench/hicasso/ssr/driver.cjs
+++ b/implementation/hicasso/test/re_frame/bench/hicasso/ssr/driver.cjs
@@ -11,19 +11,26 @@
 // entry, and neither has a renderer of its own — both call
 // `re-frame.bench.hicasso.ssr.node`'s API through the compiled bundle.
 //
-// ## NO EDIT TO shadow-cljs.edn, deliberately (clause 5)
+// ## WHICH BUILD ID, and why this one is the lane's own (rf2-0yp7w.9.6)
 //
-// The bead says to carry this on existing node-build infrastructure first
-// and mint `:hicasso-ssr-node` only if needed. It is not needed: the build
-// rides `:freehand-bench-node` — the tree's existing `:node-script` — and
-// supplies its own `:main` and `:output-to` through `--config-merge`,
-// exactly as every arm in this lane rides `:hicasso-bench` with its own
-// `:init-fn` and exactly as `b6_prod_run.cjs` rides `:freehand-release`.
-// HD-017 makes a build-id touch a hot-zone, sequenced dispatch; this lane
-// was built so a sibling never has to pay one, and an SSR entry is no
-// more entitled to than an arm is.
+// Clause 5 said to carry this on existing node-build infrastructure first
+// and mint `:hicasso-ssr-node` only if needed, so it rode
+// `:freehand-bench-node` — the donor tree's `:node-script` — supplying its
+// own `:main` and `:output-to` through `--config-merge`, exactly as every
+// arm in this lane rides `:hicasso-bench` with its own `:init-fn`. HD-017
+// makes a build-id touch a hot-zone, sequenced dispatch, and not paying
+// one was the whole point.
 //
-// `:hicasso-bench` — the lane's own id — could NOT serve here: it is a
+// PR #8322 then deleted that build with the tree, and this driver named a
+// build that no longer existed: `npm run ssr:hicasso-bake` failed with
+// `no build with id: :freehand-bench-node` before a line of ClojureScript
+// was read. Nothing was left to ride — after that retirement there is no
+// `:node-script` build anywhere in `implementation/shadow-cljs.edn` — so
+// the id below is the lane's OWN, minted there beside `:hicasso-bench`
+// and shared with `keywarn_clock_run.cjs`, the lane's other Node program.
+// The sequencing law is paid once, for both.
+//
+// `:hicasso-bench` — the lane's browser id — could NOT serve here: it is a
 // `:browser` target, and `renderToString` wants Node's `server.node.js`
 // through Node's own conditional exports.
 //
@@ -36,8 +43,8 @@
 // `:node-script` uses `:js-provider :require`, so there is no shadow-js
 // npm-conversion index — the exact artefact rf2-2rtt6.20 isolated as the
 // carrier — and what is discarded is a plain per-namespace CLJS cache.
-// The cost is a cold `npm run bench:freehand-node` afterwards, which is a
-// manual bench for a withdrawn programme and not a gate.
+// The cost is a cold `keywarn_clock_run.cjs` afterwards — the only other
+// program on this id — which is a hand-run bench and not a gate.
 //
 // ## Warnings are failures, on BOTH sides of the build
 //
@@ -57,7 +64,7 @@ const { shadowBuild } = require('../lane_build.cjs');
 const { resetLaneBuildCache } = require('../../../../../../core/test/re_frame/bench/lane_cache.cjs');
 
 const IMPL = path.resolve(__dirname, '../../../../../..');
-const BUILD_ID = 'freehand-bench-node';
+const BUILD_ID = 'hicasso-bench-node';
 const OUTPUT_TO = 'out/hicasso-ssr-node.js';
 const BUNDLE = path.join(IMPL, OUTPUT_TO);
 const BAKE_DIR = path.join(IMPL, 'out', 'hicasso-ssr-fixtures');

--- a/implementation/shadow-cljs.edn
+++ b/implementation/shadow-cljs.edn
@@ -959,6 +959,63 @@
                       :closure-defines {goog.DEBUG false}}
    :modules {:main {:init-fn re-frame.bench.hicasso.p0-reagent-app/-main}}}
 
+  ;; rf2-0yp7w.9.6 — THE SAME LANE'S NODE PROGRAM ID.
+  ;;
+  ;; `:hicasso-bench` above is the lane's `:browser` shape and cannot serve
+  ;; every driver in it. Two need a PROGRAM under Node instead:
+  ;;
+  ;;   ssr/driver.cjs        `renderToString` resolves `react-dom/server`
+  ;;                         through Node's own conditional exports, which a
+  ;;                         `:browser` build does not take.
+  ;;   keywarn_clock_run.cjs times the key warning's DEV pre-pass, which exists
+  ;;                         only where `goog.DEBUG` is true — the opposite of
+  ;;                         what `:hicasso-bench` pins.
+  ;;
+  ;; Both rode `:freehand-bench-node`, the donor tree's `:node-script`, for the
+  ;; reason recorded in `:hicasso-bench` above: HD-017 makes a build id a hot-
+  ;; zone edit, so riding an existing id was cheaper than minting one. PR #8322
+  ;; then deleted that build with the tree and left both drivers naming a build
+  ;; that does not exist — `no build with id: :freehand-bench-node`, exit 1,
+  ;; before a line of ClojureScript was read. There is now no `:node-script`
+  ;; build anywhere in this file to ride, so the sequencing law is paid here,
+  ;; once, exactly as it was paid once for the browser shape.
+  ;;
+  ;; ONE id for both programs, which is the shape they were already written
+  ;; for: each supplies its own `:main` and `:output-to` through
+  ;; `--config-merge`, and each clears
+  ;; `.shadow-cljs/builds/hicasso-bench-node` first because shadow derives the
+  ;; cache directory from the build id alone, before any merge (rf2-2rtt6.20).
+  ;; The defaults below are the SSR entry, so a bare `shadow-cljs compile
+  ;; hicasso-bench-node` builds something real rather than erroring on a
+  ;; placeholder `:main`.
+  ;;
+  ;; `:infer-externs false`, carried from the departed build and MEASURED here
+  ;; rather than inherited on trust. A `:node-script` build has no browser
+  ;; externs, so Closure cannot resolve a property access on a DOM element and
+  ;; `lane_build.cjs` — which is warnings-fatal — would refuse the build over
+  ;; source these drivers do not own. Re-run at this id with
+  ;; `:infer-externs :auto` merged over it:
+  ;;
+  ;;   [:hicasso-bench-node] Build completed. (192 files, 133 compiled,
+  ;;                                           8 warnings, 10.36s)
+  ;;
+  ;; all eight `:infer-warning`s — four in `core/src/re_frame/substrate/
+  ;; spine.cljs` at 1252, 1577, 1582 and 1874, four more in the lane's own
+  ;; `arm1/mount.cljs`, `front/controlled.cljs` and `front/intent.cljs`. The
+  ;; spine four are the same four `compile_gate.cjs`'s rf2-peorl section
+  ;; records from the DONOR `:node-script` lane, reproduced on this id.
+  ;;
+  ;; A NAME OF ITS OWN, not a donor's. The `:hicasso-bench` note above records
+  ;; the charter's anti-regression fence — Hicasso carries no continuity claim
+  ;; to its donors and the measurement lane should not borrow a donor's
+  ;; identity to compile. That reasoning outlived the build it was written
+  ;; about.
+  :hicasso-bench-node
+  {:target    :node-script
+   :main      re-frame.bench.hicasso.ssr.node/-main
+   :output-to "out/hicasso-bench-node.js"
+   :compiler-options {:infer-externs false}}
+
   ;; rf2-2hrj8 — `:browser-test` is narrowed to DOM-dependent tests only.
   ;; The ns-regexp `-dom-cljs-test$` matches files whose namespace ends in
   ;; `-dom-cljs-test` (i.e. files named `*_dom_cljs_test.cljs`). The


### PR DESCRIPTION
## What this is

`rf2-0yp7w.9.6` — the R6 sweep's last pocket, the hicasso bench tree. One site in it was **executable**, and it falsified the programme's standing "EXECUTABLE RESIDUE: NONE" finding for two files rather than one.

## The headline: two broken entry points

`ssr/driver.cjs:60` and `keywarn_clock_run.cjs:35` both carried

```js
const BUILD_ID = 'freehand-bench-node';
```

a live constant passed to `shadowBuild` / `shadowBuildVerdict`, riding the donor tree's `:node-script` through `--config-merge`. Each file's header said in as many words that not minting an id was the point: HD-017 makes a build id a hot-zone, sequenced dispatch.

**PR #8322 deleted that build with the tree.** Read from the failure rather than inferred — `npm run ssr:hicasso-bake` at the base of this branch:

```
[hicasso-ssr] building the SSR node entry -> out/hicasso-ssr-node.js
shadow-cljs - config: .../implementation/shadow-cljs.edn
no build with id: :freehand-bench-node
{:build-id :freehand-bench-node, :known-builds #{...}}
ExceptionInfo: no build with id: :freehand-bench-node
[hicasso-ssr] BUILD REFUSED — shadow-cljs exited 1
```

exit 1, before a line of ClojureScript was read. `ssr:hicasso-serve` takes the same `build()` call on the same constant and failed identically. `keywarn_clock_run.cjs` has **no npm script** — derived, not assumed: `grep -F keywarn implementation/package.json` exits 1, and its own header documents the direct `node hicasso/test/re_frame/bench/hicasso/keywarn_clock_run.cjs` invocation.

## Why `:hicasso-bench-node` and not a rename onto something existing

A rename that merely makes the constant resolve is not the repair, and the three candidates were each ruled out at source:

| candidate | why not |
|---|---|
| `:hicasso-bench` | `:target :browser`. `renderToString` wants Node's `server.node.js` through Node's own conditional exports (driver.cjs's own header says so), and `node.cljs`'s docstring depends on `:node-script` semantics — "emits a program, runs `:main` on load" — where a `:browser` module has `:modules`/`:init-fn` and no `:main`/`:output-to`. It also pins `goog.DEBUG` false, the opposite of the dev pre-pass the keywarn clock times, and that clock "refuses to run under a production build rather than reporting a zero". |
| a `:node-test` build | wrong shape: driven by `:ns-regexp` over a test corpus, not a program entry. |
| any other `:node-script` | **there is none.** `grep -n ":node-script" implementation/shadow-cljs.edn` returns nothing — the retirement took the last one. |

So the sequencing law is paid here, once, and this PR is the one-toucher for `implementation/shadow-cljs.edn` this tick. `:hicasso-bench-node` is a `:node-script` minted beside `:hicasso-bench` and **shared by both programs**, which is the "one build id, N programs (rf2-2rtt6.20)" shape both drivers were already written for — each merges its own `:main`/`:output-to` and each clears the shared cache first. Its name is the lane's own rather than a donor's, which is the reasoning `:hicasso-bench`'s existing note in that file already records: the charter's anti-regression fence, under which Hicasso carries no continuity claim to its donors.

`:infer-externs false` is carried from the departed build and **measured here rather than trusted**. With `:infer-externs :auto` merged over the new id:

```
[:hicasso-bench-node] Build completed. (192 files, 133 compiled, 8 warnings, 10.36s)
```

All eight are `:infer-warning`s — four in `core/src/re_frame/substrate/spine.cljs` at 1252, 1577, 1582 and 1874, which are the **same four** `compile_gate.cjs`'s rf2-peorl section records from the donor `:node-script` lane, reproduced on this id; four more in the lane's own `arm1/mount.cljs`, `front/controlled.cljs` and `front/intent.cljs`. `lane_build.cjs` is warnings-fatal, so without the setting the build is red on arrival over source these drivers do not own. That measurement is now recorded in the build's comment.

### Both programs verified end to end on the new id

- `npm run ssr:hicasso-bake` — `Build completed. (192 files, 191 compiled, 0 warnings)`, 9 fixtures baked.
- `npm run ssr:hicasso-serve -- --port 8139` — live `HTTP/1.1 200`, `x-hicasso-ssr-frame: :hicasso.ssr/request-1`, 1686 bytes.
- `node .../keywarn_clock_run.cjs` — 0 warnings, table printed, exit 0. Its run also shows the shared-cache clear firing against the new id.

## The prose sites, all re-measured at tip

| site | verdict |
|---|---|
| `ssr/driver.cjs:14-24` | **rewritten.** The "NO EDIT TO shadow-cljs.edn, deliberately" heading became false the moment this PR minted an id; it now records what was ridden, why it went, and why the new id is the lane's own. |
| `ssr/driver.cjs:39` | **fixed.** `npm run bench:freehand-node` does not exist; the cold-cache cost is now `keywarn_clock_run.cjs`, the only other program on this id. |
| `ssr/driver.cjs:21` — `b6_prod_run.cjs` rides `:freehand-release` | **dropped.** rf2-0yp7w.9.3 established that file is not in the tree, and the clause was a redundant second analogy beside the `:hicasso-bench` one, which is live and kept. |
| `keywarn_clock_run.cjs:12-20` | **rewritten**, same reason as driver.cjs's header. |
| `p0_converge_app.cljs:37` | **re-tensed.** "rides `:freehand-release`'s compiler settings" becomes "rode", with a clause noting the build went with the donor tree. The passage's own next sentence already said this file retires that workaround. |
| `compile_gate.cjs:153` | **re-tensed, not deleted.** "Freehand's tree has a scheduled deletion; this one does not" — the deletion landed (PR #8322). The contrast the sentence draws is still the point and is preserved. |

## Refusals

**The two settled ones, confirmed and not re-litigated:**

- `compile_gate.cjs:214` — "the same shape `:freehand-release` **had**". Already past tense and correct as it stands.
- `compile_gate.cjs:179-182, 204, 376` — a measurement record of what the retired gate covered: a nineteen-row roster, seventeen freehand arms, and the `freehand-release` versus `ui-bench` warning comparison. The **count** is load-bearing; editing the list would falsify the record. Same class as `implementation/scripts/compile-node-test.cjs:84`. This PR in fact *depends* on that record — the `ui-bench` row is what predicted the `:infer-warning` problem the new build's setting avoids, and re-measuring it reproduced the spine four exactly.

**Classified conservatively and refused** — the R6 sweep's measured shape is that most donor mentions are the retirement record doing its job:

- `README.md:76` — "`frozen-sources.edn`'s `:forbidden-import-prefixes` bars `re-frame.bench.` and `re-frame.freehand.`". **Verified true at source**: line 235 of that file still lists both. A live guard, accurately described.
- `README.md:92` — "Hicasso **had** 2 contemporaries … and both **were** retired and removed." Already past tense.
- `arm1/boundary.cljs:62-66, 171` — cite `re-frame.freehand.error-react`'s generation counter and its `^js`-tagging discipline as the provenance of two decisions in this file. Neither claims the donor is in the tree; both are lineage records, and re-tensing them would risk the record's meaning for no gain.
- `arm1/mount.cljs:181`, `hd8_rows.cljs:52/449/2050`, `hd8_witnesses.cljs:21-28/454/490`, `hd8_run.cjs:72`, `lane.cljs:12-27`, `front/intent.cljs`, `front/route_link.cljs`, `front/slot.cljc:37`, `ssr/entry.cljs:100`, `shapes/route_link_dom_cljs_test.cljs:30`, `keywarn_elision_run.cjs:29`, `arm1/ambient_refusal_cljs_test.cljs` — all historical or lineage prose. Unchanged.

**Census closing the executable claim.** `git grep -nE "BUILD_ID\s*=" -- implementation/hicasso/test/re_frame/bench/hicasso/` returns 18 sites. The two fixed here were the only ones naming a build that does not exist; every other one is `hicasso-bench`, which does. After this PR the five surviving `freehand-bench-node` strings in the tree are all past-tense record, or a verbatim quote of the error message above.

## One premise on the bead was STALE, checked and reported

The bead records `tools/xray/spec/017-Test-Coverage-Matrix.md` §The freehand-views deck as still saying "The remaining six go quietly stale". **Measured at tip: already trued up** — the section now reads "All six have now landed, across three commits rather than one", and rows 1, 2, 3, 5, 6 and 8 are each marked DONE with the landing pass named. PR #8523 carried it. **Not touched by this PR**: out of scope and already correct.

## The one site outside the bead's stated fence

`docs/design/hicasso/production-server-arm.md:653` names the same constant. It is **carried in this PR** — one line, and no open PR or live worktree holds that file — because re-pointing the constant while leaving that line would make the tree contradict itself in the same instant.

## Quality gates

| gate | command | exit code I captured |
|---|---|---|
| SSR bake (the real one) | `npm run ssr:hicasso-bake` | **0** — `192 files, 191 compiled, 0 warnings`, 9 fixtures |
| SSR serve | `npm run ssr:hicasso-serve -- --port 8139` plus `curl` | **0** (curl) — `HTTP/1.1 200`, 1686 B |
| keywarn clock | `node hicasso/test/re_frame/bench/hicasso/keywarn_clock_run.cjs` | **0** — `73 files, 72 compiled, 0 warnings` |
| externs negative probe | the same id with `:infer-externs :auto` merged | **0** exit, **8 warnings** — the refusal this setting prevents |
| syntax | `node --check` over `driver.cjs`, `keywarn_clock_run.cjs`, `compile_gate.cjs` | **0** |
| lint | `clj-kondo --lint p0_converge_app.cljs` | **0** — 0 errors, 0 warnings |
| doc links and anchors | `python scripts/check_doc_slugs.py` | **0** |
| hicasso provenance pins | `python scripts/check_provenance_pins.py --changed-since origin/main` | **0** — 1 page inspected, 0 findings |
| test-lane bijection | `python scripts/check_test_lane_bijection.py` | **0** — 1589 files, 44 lanes |
| shadow-cljs.edn readers | `compile_gate.test.cjs`, `lane_build.test.cjs`, `ssr/bake_bytes.test.cjs`, `dev-testbed.test.cjs`, `_rigorous-local-inventory.test.cjs`, `_changed-surfaces.test.cjs`, plus eight more `scripts/_*.test.cjs` that parse that file on the first pass | **0** |

Every number above is the exit code captured by the shell that ran the gate — redirect and `echo $?` on one command line — never one reported about the run by anything else. All were **re-run on the final rebased base** (`5737aa60c7`), after PR #8582 landed `alloc_heap_trajectory.cjs` into this same tree, a file this PR does not touch.

**Tree verification, both routes.** `shadow-cljs` prints its config path, and every run named this branch's checkout rather than a sibling's. For the two silent gates a fault was planted at a line already being edited:

- `node --check` — an unbalanced `(((` on `driver.cjs`'s `BUILD_ID` line went **red, exit 1**, `SyntaxError: Unexpected token ';'` at line 67. Restored to the identical **blob** hash `af3a3007041047e7a02f3606a2e885207f1302c4`, taken against the committed object.
- `check_doc_slugs.py` — a broken link target planted in `production-server-arm.md` prose went **red, exit 1**, `BROKEN TARGET: ...production-server-arm.md:654`. Restored to the identical **blob** hash `dd92a442e62054c5a45de560cc8dd3b72796bdab`, and the gate went green again afterwards.

Both faults existed only in this worktree, so a run that had wandered into a sibling's would have come back green.

`check_provenance_pins.py --changed-since` reported "1 page inspected", which is this branch's one changed corpus page; an unchanged tree would have inspected 0.

**What I did NOT run, stated plainly.** The fast-PR spine (`scripts/test-fast-pr.sh`) did **not** run at all; the targeted gates above ran directly. `scripts/check_fast_pr_gap.py --list` names the fast-spine-versus-required-CI gap, which is a fact about the spine and not a census of this PR. `npm run test:hicasso-compile`, the lane's heavyweight `:advanced` gate, was not run: the only change to `compile_gate.cjs` is a two-line comment, `node --check` and that file's own `compile_gate.test.cjs` cover it, and CI's `cljs` job runs it. `scripts/check_readme_links.py --ci` was not run — no README or source-adjacent markdown is touched.

**Checked by hand, because no gate reaches it.** `mkdocs build --strict` is not nominated: `mkdocs.yml`'s `exclude_docs` keeps `docs/design/**` out of the site. Nothing validates prose, tables, rendering or nav. I read the changed markdown bullet in context — prose inside an existing bullet, with no table row, heading, anchor or link added or moved, so no column count changed on any table in this diff. The one markdown table this PR sits near, `p0_converge_app.cljs`'s four-row witness table in a docstring, is untouched: the edit is three lines above it in the numbered list. The comment prose in each `.cjs` header was re-read end to end after editing, since a rewritten header is exactly the kind of change a syntax check cannot see.
