### PR TITLE
refactor(spec): the manifest sidecar's JVM-only comment cited a deleted macro (rf2-c95do)

### DIFF
--- a/spec/api-manifest-metadata.edn
+++ b/spec/api-manifest-metadata.edn
@@ -204,10 +204,11 @@
  ;; fully, so a var listed here that ever DID acquire a ClojureScript arm
  ;; would appear as a live public with no row and turn the probe RED.
  ;;
- ;; Not every JVM-only var on a covered door needs an entry: `render-static`
- ;; is a `#?(:clj (defmacro …))` and is `:require-macros`-referred, so the
- ;; CLJS analyzer does carry it and it reconciles normally. An entry is
- ;; needed only where the CLJS host has NOTHING.
+ ;; Not every JVM-only var on a covered door needs an entry: a
+ ;; `#?(:clj (defmacro …))` reads as JVM-only in the source but, when it is
+ ;; `:require-macros`-referred, the CLJS analyzer does carry it and it
+ ;; reconciles normally. An entry is needed only where the CLJS host has
+ ;; NOTHING.
  ;;
  ;; Each entry states its justification. Keep it short.
  :jvm-only-classification


### PR DESCRIPTION
## What changed

One comment block in `spec/api-manifest-metadata.edn` (lines 207–211). Nothing else in the file, nothing else in the tree.

`:jvm-only-classification`'s explanatory prose carried a worked example naming `render-static` — a JVM-only var that needs *no* entry, because a `#?(:clj (defmacro …))` that is `:require-macros`-referred is carried by the CLJS analyzer anyway. That var was `re-frame.ui/render-static`, and it went with the `implementation/ui/` tree in the rf2-0yp7w retirement. PR #8580 correctly deleted the live `spec/API.md` clause that named it; this comment survived because the donor-name census could not see it — it retains only the bare var name, with no `re-frame.ui` / `re-frame2-ui` token for a name-shaped grep to catch (the instrument limit rf2-ue4kv was filed on).

### Premise check at source

| Check | Result |
| --- | --- |
| `render-static` under `implementation/`, matched as a fixed string | zero hits (exit 1) |
| Positive control: the same fixed string tree-wide | 10 tracked files — so the empty result above is a true empty, not a bad pattern |
| After this change | 9 files; `spec/api-manifest-metadata.edn` no longer among them |

## Remove vs. replace, and why

**Removed the obsolete example and kept the rule it illustrated**, stated as the class (`a #?(:clj (defmacro …))`) rather than pinned to a named var — because no live var is nameable in its place, and naming one would repeat the fault being fixed.

The reason is source-located rather than editorial. The property the example asserted is *"a JVM-only var **on a covered door** that needs no entry"*, and there are currently **no covered classification doors at all**: `emit-classification-rows` — the sole consumer of `:jvm-only-classification` — has no call site anywhere in the tree outside its own definition (`implementation/scripts/api-manifest/probe/src/re_frame/api_manifest/cljs_publics.clj:126`) and an unused `:refer` in the probe test's `:require-macros`. The probe's `reconcile-rows` is `cljs-only-rows` alone, and the set itself is `#{}`. So a named replacement could only be a var that does *not* in fact sit on a covered door — a fresh instance of exactly the "teaches a surface as current" defect this bead exists to discharge.

The pattern itself is still live in the tree (`re-frame.core`'s registration macros are `#?(:clj (defmacro …))` at e.g. `implementation/core/src/re_frame/core.cljc:777`, self-`:require-macros`-referred at lines 170–186), which is why the *rule* is worth keeping — but `re-frame.core` is not a probe-covered door, so it cannot honestly carry the sentence's "on a covered door".

The paragraph earns its place: the surrounding prose defines the key as covering a var "defined under `#?(:clj …)` with NO ClojureScript arm at all", and this paragraph is the warning that a `defmacro` *looks* like exactly that and is not. That is the trap a maintainer would fall into, and it is not said anywhere else in the block.

## Manifest semantics unchanged

Comment-only. `:jvm-only-classification` is still `#{}`; no entries added; the block was not restructured (the `;;` separators at 206 and 212 and the closing "Each entry states its justification" line are untouched). This is **verified, not asserted** — see the gate below, which parses the file the way `gen.clj` lines 220–221 do and requires the parsed value to be *identical* to `origin/main`'s.

## Census accounting, re-derived at this tip

The audit's correction is confirmed by independent measurement rather than quoted. The corrected pattern uses `([^x]|$)` so the bare `re-frame2-ui` does not match `re-frame2-uix` — UIx is a live, first-class, actively supported adapter.

| Point | Matching lines |
| --- | --- |
| Parent of #8580's API.md commit (pre-edit classification population) | **72** |
| #8580's head (`351184d606`) | **71** |
| This branch's tip | **71** |
| `origin/main` | **71** |

So **71 is the post-edit tip count and 72 was the pre-edit population** — as the audit stated. This change does not move the number, which is the point: `render-static` never matched that pattern, which is precisely why the census could not see this residue.

Nine `spec/` files still carry a match (`spec/API.md` left the roster with #8580). Those are the sweep's classification surface, already dispositioned by the merged slice — untouched here.

## Quality gates

| Gate | Command | Exit code (captured by me) |
| --- | --- | --- |
| Sidecar EDN + semantics (control, final base) | `bb gate-sidecar-manifest.clj <root> origin/main` | **0** |
| Same gate, sabotaged: `;;` stripped from a line this branch introduced | as above | **1** |
| Same gate, sabotaged: `:jvm-only-classification` made non-empty | as above | **1** |

The two sabotage runs failed with, respectively, `FAIL[working-tree]: not valid EDN — Invalid leading character:` and both semantic arms firing at once (`parsed value DIFFERS from origin/main` plus `:jvm-only-classification is no longer the empty set`).

The gate reads `spec/api-manifest-metadata.edn` with `clojure.edn/read` over a `java.io.PushbackReader` — the same call the real consumer makes at `implementation/scripts/api-manifest/src/re_frame/api_manifest/gen.clj` lines 220–221 — and asserts (1) it parses, (2) its parsed value equals `origin/main`'s, and (3) `:jvm-only-classification` is still `#{}`.

**Which tree the gate read** was verified by both available routes: it prints `GATE_ROOT` / `GATE_FILE` naming this worktree, *and* the planted faults reddened it — a fault that exists only in this checkout, so a run that had wandered into a sibling worktree would have come back green. Each restore was verified by hashing the bytes against the committed object rather than by reading a diff: the identical blob hash `66bee76d9681c91a99bf21c2002598a1ee696bcd` before each plant and after each restore. Each plant asserted its anchor matched exactly once, so a silently no-op patch could not masquerade as a passing sabotage.

### Gates NOT run, and why

- **`scripts/check_doc_slugs.py` was not run, and its green would not have meant anything here.** Its `_iter_markdown` selects files with `rglob("*.md")`, so it never opens an `.edn` file. Reporting it as coverage of this change would be a wrong-gate nomination.
- **`scripts/check_readme_links.py --ci` likewise** — its three rosters are markdown, not `.edn`.
- **The fast-PR spine (`scripts/test-fast-pr.sh`) did not run at all.** For the fast-spine-versus-required-CI gap see `scripts/check_fast_pr_gap.py --list` — that is a fact about the *spine*, not a census of what ran here. The targeted gate run directly is the one tabled above, and it is the only automated check that reaches this file's content locally.
- **No heavyweight load was started.** The full `api-manifest` CI job and its projection checks are this file's CI surface and will run on this PR — `spec/api-manifest-metadata.edn` is on the `lint.yml` `detect` surface list, so the job is triggered by this diff. It was deliberately not run locally: other workers hold the machine, and a comment-only edit proven semantically identical to `origin/main` cannot move its result.

### Verified by hand

- **Prose read back by hand.** The replacement sentence parses, keeps its subject, and still teaches the one-directional rule's scope — that an entry is needed only where the CLJS host has *nothing*, and that a `:require-macros`-referred `defmacro` is not such a case despite reading as `#?(:clj …)`-only in source.
- **Block structure checked by hand**: every line still carries its `;;`, the blank `;;` separators bounding the paragraph are intact, and the following `:jvm-only-classification` / `#{}` pair is unchanged.
- The three markdown tables in this PR body were column-counted by hand.
- The merge-base diff (three-dot, against the point this branch left the trunk) was read before pushing: one file, one hunk, entirely this change. Nothing a sibling landed is reverted.

## Out of scope, recorded so nobody re-chases it

- `tools/xray/test/day8/re_frame2_xray/panels_e2e/static_machines_panel_e2e_cljs_test.cljs` names `render-static`. Different tree, different fence — flagged, not touched.
- `spec/004C-Roots-and-Mount.md` line 254 carries `(ui/render-static root-form)` inside a present-tense "full host-tier signature set" fence, alongside `ui/create-root` / `ui/render!` / `ui/hydrate-root` / `ui/unmount!`. That is the whole `re-frame.ui` host-tier block rather than a stray name, and 004C was inside #8580's classification slice, so it is a judgement already made — flagged for the mayor, not reopened here. `spec/011-SSR.md` line 894 and `spec/004B-UI-Tree-and-Conversion.md` line 498 are explicit past-tense tombstones and are correct as they stand.
