### PR TITLE
fix(catalogue): split the catalogue table on backslash-run parity (rf2-1t0er)

### DIFF
--- a/implementation/core/test/re_frame/error_catalogue_channel_conformance_test.clj
+++ b/implementation/core/test/re_frame/error_catalogue_channel_conformance_test.clj
@@ -1071,6 +1071,55 @@
   inside a link — so the rule is a hardening, not a corpus change."
   #"\[[^\]]*\]\([^)]*\)")
 
+(def ^:private table-delimiter-re
+  "A markdown table COLUMN DELIMITER — a `|` that markdown itself would treat
+  as a cell boundary rather than as content.
+
+  THE RULE IS BACKSLASH-RUN PARITY, not \"is there a backslash in front of it\"
+  (rf2-1t0er). A backslash escapes the character after it, INCLUDING another
+  backslash, so it is the LENGTH of the run immediately before the pipe that
+  decides: an ODD run (`\\|`, `\\\\\\|`) spends its last backslash on the pipe
+  and the pipe is content, while an EVEN run (`\\\\|`, `\\\\\\\\|`) pairs off
+  entirely and the pipe is a bare delimiter. Measured against Python-Markdown's
+  `tables` extension, which is the reference this reader is trying to agree
+  with; `table-delimiter-honours-backslash-run-parity` pins all four.
+
+  WHY THE ESCAPE IS HONOURED AT ALL. `\\|` is how markdown writes a literal
+  pipe inside a cell, so a cell containing one is correct prose rather than a
+  typo — `:rf.error/infinite-missing-next-page-param` spells its
+  `:next-page-param` contract `(last-page → next-param \\| nil)`. Splitting on
+  it yielded NINE fields where the table has eight and slid every column one
+  place left, so that row's `:tags` cell was read from its `Default :recovery`
+  column. Harmless only by luck: no `InfiniteMissingNextPageParamTags` schema
+  exists to pair with the row, so the mis-read cell was never compared against
+  anything, and the day one is added the pairing arm would diff a recovery
+  sentence against a tag key set. Fixing the reader rather than the spec is the
+  right side to fix — the escape is valid markdown that any catalogue row may
+  legitimately use.
+
+  WHY PARITY AND NOT THE SIMPLER `(?<!\\\\)\\|`. That lookbehind reads one
+  character, so it treats EVERY backslash-prefixed pipe as escaped. It happens
+  to be right on the odd runs and is wrong on the even ones, in the direction
+  that HIDES a defect: a cell ending `\\\\` before a pipe really has broken
+  its row into an extra column, and a reader that swallows the delimiter
+  reports the sibling field count and slides its cells silently. That is
+  exactly the blind spot `tags-column-reader-honours-the-escaped-pipe`'s
+  column-alignment invariant exists to catch, so an under-splitting reader
+  disarms the guard rather than merely disagreeing with markdown.
+
+  ZERO-WIDTH ON PURPOSE. The match is the pipe alone: the run in front of it
+  is INSPECTED, never consumed, so the change moves only WHERE columns break
+  and no cell loses a character it used to carry. Consuming the even run
+  instead would leave the preceding cell neither raw (`b\\\\`) nor rendered
+  (`b\\`), which is a third thing that is true of nothing.
+
+  Java's lookbehind needs an obvious maximum length, hence `{0,16}` rather than
+  `*` — thirty-two backslashes in front of one pipe, which no catalogue cell
+  approaches. Beyond that bound the reader falls back to reading the pipe as
+  content, which is the same direction the pre-parity reader erred in, i.e. no
+  worse than the state this replaces."
+  #"(?<=(?<!\\)(?:\\\\){0,16})\|")
+
 (defn- cell-tag-keys
   "The keys a `:tags` cell DOCUMENTS — every back-ticked lone keyword outside a
   markdown cross-reference link (see `markdown-link-re` for why the link goes
@@ -1091,26 +1140,20 @@
   is its only consumer: a row that splits to a different count than its siblings
   has slid its columns, and every cell the arm reads from it is off by one.
 
-  The split skips a BACKSLASH-ESCAPED pipe (rf2-1t0er). `\\|` is how markdown
-  writes a literal pipe inside a table cell, so a cell containing one is
-  correct prose rather than a typo — `:rf.error/infinite-missing-next-page-param`
-  spells its `:next-page-param` contract `(last-page → next-param \\| nil)`.
-  Splitting on it anyway yielded NINE fields where the table has eight and slid
-  every column one place left, so that row's `:tags` cell was read from its
-  `Default :recovery` column. Harmless only by luck: no
-  `InfiniteMissingNextPageParamTags` schema exists to pair with the row, so the
-  mis-read cell was never compared against anything, and the day one is added
-  the pairing arm would diff a recovery sentence against a tag key set. The
-  lookbehind fixes the reader rather than the spec, which is the right side to
-  fix — the escape is valid markdown that any catalogue row may legitimately
-  use."
+  The split is `table-delimiter-re`, which honours markdown's backslash-run
+  parity (rf2-1t0er): the corpus's one escaped-pipe row —
+  `:rf.error/infinite-missing-next-page-param`, whose `:next-page-param`
+  contract reads `(last-page → next-param \\| nil)` — keeps its eight fields,
+  and a row whose cell ends in an EVEN backslash run is reported at the nine
+  fields markdown gives it rather than silently re-joined to eight. See that
+  var for why the parity, and not the presence of a backslash, is the rule."
   ([] (parse-catalogue-tag-rows (slurp spec-009-file)))
   ([text]
    (->> (str/split-lines text)
         (catalogue-section-lines)
         (keep (fn [line]
                 (when-let [[_ cat-str] (re-find catalogue-tag-row-re line)]
-                  (let [cells (str/split line #"(?<!\\)\|" -1)]
+                  (let [cells (str/split line table-delimiter-re -1)]
                     (when (>= (count cells) 7)
                       {:category    (keyword (subs cat-str 1))
                        :tags-cell   (str/trim (nth cells 6))
@@ -2400,3 +2443,76 @@
       (is (empty? (tags-column-findings rows pre-wsopx-schemas))
           "…so the arm greens on a row that documents every key its schema
            declares, instead of redding at the recovery sentence"))))
+
+(deftest table-delimiter-honours-backslash-run-parity
+  (testing "A PURE PARSER FIXTURE for `table-delimiter-re` (rf2-1t0er), fed
+            constructed rows rather than the live corpus — the corpus carries
+            exactly one escaped pipe and no even-backslash run at all, so the
+            even half of the rule is unreachable from it and would be pinned by
+            nothing.
+
+            Markdown decides by the PARITY of the backslash run immediately
+            before the pipe, because a backslash escapes the character after it
+            including another backslash. An ODD run spends its last backslash on
+            the pipe, which is then content; an EVEN run pairs off entirely and
+            the pipe is a bare delimiter. The four cases below are the two rules
+            and their first repeat, checked against Python-Markdown's `tables`
+            extension.
+
+            The pre-parity `#\"(?<!\\\\)\\|\"` read ONE character, so it called
+            every backslash-prefixed pipe escaped: right on the odd runs by
+            luck, wrong on the even ones. That error runs in the direction that
+            HIDES a defect rather than manufacturing one, which is why it is
+            worth fixing in a test file — a row whose cell ends in `\\\\` before
+            a pipe really has broken itself into an extra column, and a reader
+            that swallows the delimiter hands the column-alignment invariant in
+            `tags-column-reader-honours-the-escaped-pipe` a field count matching
+            the row's siblings. The guard then passes a row whose every cell has
+            slid one place left, which is the exact failure it exists to catch."
+    (let [row          (fn [pipe-run]
+                         (str "| `:rf.error/resource-route-plan` | `:error` "
+                              "| diagnostic | A plan step returns `next "
+                              pipe-run " nil`. | `:no-recovery` "
+                              "| `:route-id`, `:reason` |"))
+          parse        (fn [pipe-run]
+                         (first (parse-catalogue-tag-rows
+                                  (catalogue-fixture (row pipe-run)))))
+          fields       #(:field-count (parse %))
+          tags         #(:tags-cell (parse %))
+          tags-col     "`:route-id`, `:reason`"
+          recovery-col "`:no-recovery`"]
+
+      (testing "the CONTROL: no pipe inside a cell at all"
+        (is (= 8 (fields ""))
+            "a six-column row splits to eight fields — the columns plus the
+             empties either side of the leading and trailing pipes")
+        (is (= tags-col (tags ""))
+            "…and the sixth column is where the `:tags` cell is read from"))
+
+      (testing "an ODD run ESCAPES the pipe, so the row keeps its columns"
+        (doseq [[n pipe-run] [[1 "\\|"] [3 "\\\\\\|"]]]
+          (is (= 8 (fields pipe-run))
+              (str n " backslashes before the pipe is an ODD run, so the pipe "
+                   "is CONTENT and the row still has six columns. Splitting on "
+                   "it anyway yields nine fields and slides every cell one "
+                   "place left — the live defect, on "
+                   "`:rf.error/infinite-missing-next-page-param`."))
+          (is (= tags-col (tags pipe-run))
+              (str "…so with " n " backslashes the `:tags` cell is still the "
+                   "TAGS column and not `Default :recovery`."))))
+
+      (testing "an EVEN run leaves the pipe a DELIMITER, so the row gains one"
+        (doseq [[n pipe-run] [[2 "\\\\|"] [4 "\\\\\\\\|"]]]
+          (is (= 9 (fields pipe-run))
+              (str n " backslashes before the pipe is an EVEN run: they escape "
+                   "each other, the pipe is BARE, and markdown gives this row "
+                   "seven columns. Reading eight here is the pre-parity "
+                   "reader — it re-joins a row that has genuinely split, and "
+                   "the column-alignment invariant sees a field count matching "
+                   "the row's siblings on a row whose cells have all slid."))
+          (is (= recovery-col (tags pipe-run))
+              (str "…and the slide is REAL rather than notional: with " n
+                   " backslashes the sixth field is the `Default :recovery` "
+                   "column, so an arm reading `:tags` positionally would diff a "
+                   "recovery value against a tag key set. Reporting nine fields "
+                   "is what lets the alignment invariant convict the row.")))))))

--- a/implementation/core/test/re_frame/error_catalogue_channel_conformance_test.clj
+++ b/implementation/core/test/re_frame/error_catalogue_channel_conformance_test.clj
@@ -1116,9 +1116,12 @@
 
   ZERO-WIDTH ON PURPOSE. The match is the pipe alone: the run in front of it
   is INSPECTED, never consumed, so the change moves only WHERE columns break
-  and no cell loses a character it used to carry. Consuming the even run
-  instead would leave the preceding cell neither raw (`b\\\\`) nor rendered
-  (`b\\`), which is a third thing that is true of nothing.
+  and no cell loses a character it used to carry. The obvious alternative —
+  `(?<!\\\\)(?:\\\\\\\\)*\\|`, which splits at the right places by EATING the
+  even run — would leave a cell reading `b\\\\` in the file as plain `b`:
+  neither the raw text nor the `b\\` a reader sees, but a third string that is
+  neither what the file says nor what markdown renders. This arm harvests from
+  cells verbatim, so raw is the one of the two it wants.
 
   Java's lookbehind needs an obvious maximum length, hence `{0,16}` rather than
   `*` — thirty-two backslashes in front of one pipe, which no catalogue cell

--- a/implementation/core/test/re_frame/error_catalogue_channel_conformance_test.clj
+++ b/implementation/core/test/re_frame/error_catalogue_channel_conformance_test.clj
@@ -1080,9 +1080,16 @@
   backslash, so it is the LENGTH of the run immediately before the pipe that
   decides: an ODD run (`\\|`, `\\\\\\|`) spends its last backslash on the pipe
   and the pipe is content, while an EVEN run (`\\\\|`, `\\\\\\\\|`) pairs off
-  entirely and the pipe is a bare delimiter. Measured against Python-Markdown's
-  `tables` extension, which is the reference this reader is trying to agree
-  with; `table-delimiter-honours-backslash-run-parity` pins all four.
+  entirely and the pipe is a bare delimiter.
+
+  Measured against Python-Markdown 3.10's `tables` extension, the reference
+  this reader is trying to agree with. Rendering `| one | two<run>| three |`
+  under a five-column header — wide enough that a short row is padded rather
+  than TRUNCATED, which is what makes the split visible at all — gives two
+  cells for runs of one and three (`two| three`, `two\\| three`: the pipe is
+  content) and three for runs of two and four (`two\\`, `two\\\\` then
+  `three`: the pipe is a delimiter and the surviving backslashes are the run
+  halved). `table-delimiter-honours-backslash-run-parity` pins all four.
 
   WHY THE ESCAPE IS HONOURED AT ALL. `\\|` is how markdown writes a literal
   pipe inside a cell, so a cell containing one is correct prose rather than a
@@ -2446,18 +2453,22 @@
 
 (deftest table-delimiter-honours-backslash-run-parity
   (testing "A PURE PARSER FIXTURE for `table-delimiter-re` (rf2-1t0er), fed
-            constructed rows rather than the live corpus — the corpus carries
-            exactly one escaped pipe and no even-backslash run at all, so the
-            even half of the rule is unreachable from it and would be pinned by
-            nothing.
+            constructed rows rather than the live corpus, because the corpus
+            cannot reach half the rule. Spec 009 carries eleven escaped pipes
+            across nine lines and EVERY ONE is a run of exactly one — only the
+            catalogue row for
+            `:rf.error/infinite-missing-next-page-param` is in this reader's
+            section at all — and the file holds no even-length run anywhere. So
+            the even half of the rule is unreachable from the corpus and would
+            be pinned by nothing.
 
             Markdown decides by the PARITY of the backslash run immediately
             before the pipe, because a backslash escapes the character after it
             including another backslash. An ODD run spends its last backslash on
             the pipe, which is then content; an EVEN run pairs off entirely and
             the pipe is a bare delimiter. The four cases below are the two rules
-            and their first repeat, checked against Python-Markdown's `tables`
-            extension.
+            and their first repeat, checked against Python-Markdown 3.10's
+            `tables` extension.
 
             The pre-parity `#\"(?<!\\\\)\\|\"` read ONE character, so it called
             every backslash-prefixed pipe escaped: right on the odd runs by


### PR DESCRIPTION
Closes the second half of `rf2-1t0er`, per the merged-PR audit of #8576.

## Half 1 was already present at my base

The audit's first complaint — "no assertion pins the new behavior" — was
delivered by **PR #8583 (`rf2-6tags`)**, commit `4b9e029c88`, which was already
on `main` when this branch was cut. I found it as
`tags-column-reader-honours-the-escaped-pipe` in the same file: the live
escaped-pipe row's `:tags` cell pinned to `:resource-id, :infinite`, a
column-alignment invariant over every active row, and a synthetic escaped-pipe
row driven end to end through the arm's verdict. My baseline run measured
**29 tests / 184 assertions**, exactly the figure that PR reported. Nothing here
duplicates it.

## The parity rule

`parse-catalogue-tag-rows` split on `#"(?<!\\)\|"`. That lookbehind reads
exactly **one** character, so it calls every backslash-prefixed pipe escaped.
Markdown decides by the **parity** of the backslash run immediately before the
pipe, because a backslash escapes the character after it including another
backslash — an **odd** run spends its last backslash on the pipe, which is then
content; an **even** run pairs off entirely and the pipe is a bare delimiter.

The rule now lives in a named `table-delimiter-re` — the file's existing idiom
for a regex worth explaining, alongside `tags-cell-key-re` and
`markdown-link-re`:

```clojure
#"(?<=(?<!\\)(?:\\\\){0,16})\|"
```

It is **zero-width on purpose**. The run in front of the pipe is inspected,
never consumed, so only *where* columns break changes and no cell loses a
character it used to carry. The alternative `(?<!\\)(?:\\\\)*\|` is equally
parity-correct on the field count but eats the even run, delivering a cell
written `b\\` as plain `b` — neither the file's text nor markdown's rendered
`b\`. This arm harvests back-ticked keywords verbatim and never renders, so raw
is the one of the two it wants. Java's lookbehind needs an obvious maximum
length, hence `{0,16}` (thirty-two backslashes) rather than `*`; past that bound
the reader reads the pipe as content, which is the direction the old reader
erred in anyway.

### The audit said four cases were wrong. It is two, and which two matters

Re-derived rather than taken on trust. The one-character lookbehind is **right
on the odd runs by luck** and wrong only on the even ones:

| backslash run | markdown | old one-character lookbehind | new `table-delimiter-re` |
|---|---|---|---|
| 1 | pipe is content | content — correct | content — correct |
| 2 | pipe is a **delimiter** | content — **wrong** | delimiter — correct |
| 3 | pipe is content | content — correct | content — correct |
| 4 | pipe is a **delimiter** | content — **wrong** | delimiter — correct |

Naming which two matters because the error runs in the direction that **hides**
a defect rather than manufacturing one. A cell ending in two backslashes before
a pipe really has broken its row into an extra column; a reader that swallows
that delimiter hands half 1's column-alignment invariant a field count matching
the row's siblings, and the guard then passes a row whose every cell has slid
one place left — the exact failure it exists to catch. Under-splitting **disarms
the guard**, it does not merely disagree with markdown.

### Verified against the reference myself

The audit cited a local Python-Markdown probe; this re-derives it on
Python-Markdown 3.10, `tables` extension. Rendering a row whose middle cell ends
in a backslash run before a pipe gives **two** cells for runs of 1 and 3 (the
pipe is content) and **three** cells for runs of 2 and 4 (the pipe is a
delimiter) — parity, exactly, and the surviving backslashes are the run halved.

One trap worth recording: under a **three**-column header every run renders
three cells, because Python-Markdown pads and truncates rows to the header. A
count-based reading of that says "content" for all four runs — the right answer
for the odd runs, the wrong one for the even, reached by measuring the header
instead of the row. A five-column header pads without truncating and the split
is visible.

## The fixture

`table-delimiter-honours-backslash-run-parity` is a **pure parser fixture**: it
feeds `parse-catalogue-tag-rows` constructed rows through the existing
`catalogue-fixture` helper, not the live spec file. It has to be constructed,
because the corpus cannot reach half the rule — Spec 009 carries eleven escaped
pipes across nine lines, **every one a run of exactly one**, no even-length run
anywhere in the file, and only the
`:rf.error/infinite-missing-next-page-param` row is inside the section this
reader scopes to.

Both directions, each checked twice — the field count, and the cell `:tags` is
actually read from:

- a no-pipe **control** (8 fields, `:tags` at column six);
- runs of **1 and 3** — 8 fields, `:tags` still the tags column;
- runs of **2 and 4** — 9 fields, and `:tags` demonstrably reads the
  `Default :recovery` column, which is what makes the alignment invariant
  convict the row.

That census itself needed a control, and earned it: the shell-quoted `grep -F`
I reached for first reported the *same nine lines* for a one-backslash and a
two-backslash pattern, because the quoting stripped a backslash before grep saw
it. Recounted with a scanner that reports the run length before every pipe, run
first against constructed lines of known run length so a zero could not pass as
a clean result.

## Non-vacuity control

The audit's complaint about half 1 was precisely that reverting the fix stayed
green, so this change is held to that standard.

Reverting `table-delimiter-re` to the old one-character lookbehind and
re-running:

```
Ran 30 tests containing 194 assertions.
4 failures, 0 errors.          exit 1
```

The four are **exactly the even runs** — both assertions at run 2 and both at
run 4: the field count comes back 8 where 9 is correct, and the `:tags` cell
comes back as the tags column where the recovery column is correct. The odd
runs, the control, and all of half 1 stay green, which is the measured statement
of "right on the odd runs by luck".

The plant was **scoped**: namespace and assertion counts were unchanged at
30/194 across the sabotage run, so nothing aborted early and the suite it was
proving did run. The restore was verified against the committed object by the
identical blob hash `5527d7f23c643fcc52547c0dd2200b358ca25426` before the plant
and after it, not by reading a diff.

This plant is also the tree-verification: the runner prints no root banner, and
the old regex existed only in this worktree, so a run that had wandered into a
sibling checkout would have come back green.

## Counts

| | tests | assertions |
|---|---|---|
| base (half 1 already present) | 29 | 184 |
| after this change | **30** | **194** |

## Verified by hand, because no gate reaches it

- **The docstring's claim about what the split does** — all four run lengths
  re-derived against Python-Markdown 3.10 as above, and the `{0,16}` bound
  probed at its edge: runs of 30 and 32 split, a run of 34 falls back to reading
  the pipe as content, which is what the docstring says.
- **Table column counts.** The fixture's constructed rows are 6 columns,
  matching `catalogue-fixture`'s 6-column header and its separator row — except
  the even-run rows, which are deliberately 7 and are the defect under test. The
  two tables in this PR body are 4 columns and 3 columns, header, separator and
  every body row alike.
- Every backslash rendering in the new docstrings was read back at its Clojure
  string value.

## Quality gates

| gate | command | exit code (captured) |
|---|---|---|
| catalogue conformance — baseline, before any edit | `clojure -M:test -n re-frame.error-catalogue-channel-conformance-test` (from `implementation/core`) | **0** — 29 tests / 184 assertions |
| catalogue conformance — after the change | same | **0** — 30 tests / 194 assertions |
| catalogue conformance — **sabotage**, old regex restored | same | **1** — 4 failures / 0 errors, 30 tests / 194 assertions |
| catalogue conformance — after restore, re-verified | same | **0** — 30 / 194 |
| catalogue conformance — **re-run on the final rebased base** | same | **0** — 30 / 194 |

Exit codes are the ones this worker captured itself with an explicit `echo` of
the runner's own status on the same command line as the redirect, not any number
the harness reported about the same runs.

**The fast-PR spine did not run at all**, and is not required of this dispatch.
The targeted gate above is the only one I ran directly. No browser or
shadow-cljs build was started. For the spine-versus-required-CI gap generally,
`scripts/check_fast_pr_gap.py --list` reports **94 required checks the spine does
not run** — that is a fact about the spine, not a census of what I ran.

Gates were re-run on the final base after rebasing. The three-dot diff against
the merge base removes only this branch's own predecessor text — the docstring
paragraph relocated into `table-delimiter-re` and the old split line — so
nothing a sibling landed is reverted.

Scope: `implementation/core/test/re_frame/error_catalogue_channel_conformance_test.clj`
only. `spec/009-Instrumentation.md` is untouched — the audit ruled that fixing
the downstream reader rather than valid spec prose is the correct side, and
`rf2-zmpfn` stays closed.
