### PR TITLE
docs(hicasso): three measurement-lane beads — control census, cluster carrier, mode rate (rf2-0gjqi, rf2-csca8, rf2-6kxub)

### DIFF
--- a/docs/design/hicasso/studio/the-cluster-follows-the-mode-and-the-third-arm-is-still-missing.md
+++ b/docs/design/hicasso/studio/the-cluster-follows-the-mode-and-the-third-arm-is-still-missing.md
@@ -1,0 +1,336 @@
+# The cluster follows the mode, and the third arm is still missing
+
+Seat: RE-ANALYSIS RECORD, EP-0038. Bead `rf2-csca8`, which asks which of three
+properties carries the ~1,050–1,224 B cluster that
+[the rider follows the position, not the substrate](the-rider-follows-the-position-not-the-substrate.md)
+filed rather than chased: the uix SUBSTRATE, the POSITION in the round, or the
+segment-order MODE.
+
+**No allocation window was taken for this page, and no rig file was edited.**
+Every figure is re-derived from datasets already committed under
+`implementation/hicasso/test/re_frame/bench/hicasso/data/`. The analysis was run
+against the tree at commit `a51138e93b`, and the extraction it rests on is
+`alloc_position_confound.cjs` at the identical blob
+`cd1a80711ca1846cc6e4c5cfece0bbc6ad673164`.
+
+**τ was not moved, in either direction.** No gate, band, threshold, budget or
+tolerance on this rig was widened, narrowed or touched, and nothing here reads
+one.
+
+## The answer, first
+
+**The MODE carries it. Position is refuted, substrate is associated but not
+necessary — and the rig change the bead asks for is STILL REQUIRED, because the
+one property that survives is the one the committed corpus cannot separate.**
+
+| arm of the question | verdict | the counts it rests on | Fisher, two-sided |
+|---|---|---|---|
+| POSITION | **REFUTED** | `parity` uix pos0 8 of 747 against pos1 3 of 724 | `p` = 0.2254 |
+| SUBSTRATE | **ASSOCIATED, NOT NECESSARY** | `parity` uix 11 of 1,471 against reagent 2 of 1,588 | `p` = 0.0102 |
+| MODE | **CONFIRMED** | `fixed` uix pos1 8 of 38 against `parity` uix pos1 3 of 724 | `p` = 2.67e-9 |
+
+- **The position refutation now rests on 1,471 windows instead of 43**, which is
+  the whole of what this page adds to it. The earlier read reached the same
+  verdict from the three paired `parity` runs alone — 1 of 20 against 1 of 23,
+  `p` = 1.0 — and that reproduces here exactly. It was right, and it was right
+  on 2.9% of the evidence available.
+- **"Not one reagent window lands in the band" does not survive the widening.**
+  On 1,588 `parity` reagent windows, two land in the bead's band and fifteen
+  land in the wider one the bead states its comparison in. The substrate
+  ASSOCIATION survives and is now properly powered; the NECESSITY claim does not.
+- **The mode contrast is the strongest thing on this page and the least
+  matched.** Against the whole committed `parity` corpus it is `p` = 2.67e-9;
+  against the three `parity` runs taken in the same session, on the same box, on
+  the same revision, interleaved with the `fixed` runs, it is **`p` = 0.1344**.
+  Both are stated below and neither is dropped.
+
+## The two bands are not one question
+
+This is the methodological finding, and it has to come before the census because
+every number after it depends on which band is meant.
+
+`rf2-csca8` names **two** bands. It defines the cluster by its observed extremes,
+**1,050–1,224 B**, and it states its `parity` comparison in a wider
+**1,000–1,300 B**. On three runs those two choices agreed. On the full committed
+corpus they do not, and the disagreement is not a rounding artefact — **the wide
+band admits a second and different term.**
+
+The evidence is the leg ordinal. Every floor window has six work legs, so an
+in-band excess can be indexed by which leg carried it:
+
+| mode \| segment \| position | in-band legs by ordinal, 0 → 5 | total |
+|---|---|---|
+| `fixed` \| `uix-subs` \| pos1 | 2, 1, 0, 2, 6, **0** | 11 |
+| `parity` \| `uix-subs` \| pos0 | 0, 1, 2, 0, 2, **43** | 48 |
+| `parity` \| `reagent-subs` \| pos0 | 11, 9, 0, 2, 0, **0** | 22 |
+| `parity` \| `uix-subs` \| pos1 | 1, 2, 5, 17, 2, **1** | 28 |
+
+**`parity | uix-subs | pos0`'s in-band legs are the LAST leg of the window, 43
+times out of 48. The `fixed` cluster never lands there, not once in 11.** Two
+populations that disagree that completely about which leg carries them are not
+being counted by one criterion, and the split shows in the magnitudes too: of
+the 45 `parity | uix-subs | pos0` windows the wide band catches, only **8** sit
+inside the bead's own 1,050–1,224.
+
+So a last-leg term of its own lives at `parity` position 0, and the wide band
+sweeps it in. **This page therefore reports both bands everywhere and takes the
+bead's own 1,050–1,224 as primary**, because that is the band the cluster was
+defined by. Under the wide band the position verdict INVERTS — 45 of 747 against
+3 of 724, `p` = 8.82e-11 — and that inversion is a fact about the last-leg term,
+not about the cluster.
+
+**The last-leg term is not named here and is not this bead's.** It is recorded
+so the band choice is legible, and because a later reader pooling the `parity`
+corpus for any purpose will meet it.
+
+## The corpus
+
+| corpus | runs | segment order | control slot |
+|---|---|---|---|
+| `segorder-rs8q6/fixed-{1,2,3}` | 3 | `fixed` | `first` |
+| `segorder-rs8q6/parity-{1,2,3}` | 3 | `parity` | `first` |
+| `alloc-c4hhk` | 69 | `parity` | `first` |
+| `alloc-77gz8` | 20 | `parity` | `first` |
+| `alloc-9jrhi` | 8 | `parity` | `first` |
+| `ctrlslot-rs8q6` | 9 | `parity` | `first`, `last`, `mid` |
+| `workcount-n1b9h` | 6 | `parity` | `first` |
+
+118 runs, 4,224 arm windows, **3,308 collection-free** on `falls === 0`. Every
+run is `P0_ALLOC_PLAN=floor`, `P0_ALLOC_WRITE=all`, `P0_ROOTS=4`, B = 24, six
+writes, one instrument — checked rather than assumed, because a pooled census
+over unlike units would be meaningless and the byte band is absolute.
+
+**168 windows are in the corpus and out of the position tables.** Under
+`controlSlot` `last` and `mid` the three control windows do not precede position
+0, so "position 0" stops naming the same event; the six non-`first`
+`ctrlslot-rs8q6` runs are excluded from every position figure and the reader
+prints the count it dropped.
+
+## The census
+
+Worst leg per window, over the window's own leg median, collection-free windows,
+`controlSlot = first`:
+
+| mode | segment | position | windows | in 1,000–1,300 | rate | in 1,050–1,224 | rate |
+|---|---|---|---|---|---|---|---|
+| `fixed` | `reagent-subs` | 0 | 43 | 0 | 0.0% | 0 | 0.0% |
+| `fixed` | `uix-subs` | 1 | 38 | **8** | **21.1%** | **8** | **21.1%** |
+| `parity` | `reagent-subs` | 0 | 675 | 15 | 2.2% | 2 | 0.3% |
+| `parity` | `reagent-subs` | 1 | 913 | 0 | 0.0% | 0 | 0.0% |
+| `parity` | `uix-subs` | 0 | 747 | 45 | 6.0% | 8 | 1.1% |
+| `parity` | `uix-subs` | 1 | 724 | 3 | 0.4% | 3 | 0.4% |
+
+**The `fixed` cell is twenty times the rate of any `parity` cell in the bead's
+own band**, and it is the only cell above 1.1%.
+
+### The null arm
+
+Over **37,680 collection-free control legs** across all 118 runs, the count in
+the 1,000–1,300 B band is **zero**. The controls run the same window machinery,
+the same sampler and the same round schedule as the arms and dispatch nothing,
+so a term found in them would be the instrument's rather than the arm's. It is
+not there, in either band.
+
+### And a control on the reader itself
+
+Re-derived from the 14 committed `parity` runs the previous record published:
+**387 collection-free windows, 182 / 205 by position, 101 + 11 rider legs.**
+Those are that record's figures to the digit, which is what says this page's
+window extraction has not drifted from the one the earlier counts were taken
+with.
+
+## The three-way question, arm by arm
+
+### POSITION — refuted, and now with power behind it
+
+Within `parity` the segment order reverses on odd rounds, so **uix occupies both
+positions**: 747 windows at position 0 and 724 at position 1. That is the
+position arm the bead believed unavailable, and it is already in the tree.
+
+| comparison | band 1,050–1,224 | band 1,000–1,300 |
+|---|---|---|
+| `parity` uix, pos0 against pos1 | 8/747 vs 3/724, `p` = 0.2254 | 45/747 vs 3/724, `p` = 8.82e-11 |
+| `parity` reagent, pos0 against pos1 | 2/675 vs 0/913, `p` = 0.1805 | 15/675 vs 0/913, `p` = 2.44e-6 |
+
+**Under the bead's own band there is no position effect on 1,471 uix windows.**
+Under the wide band there is a very large one, and the ordinal table above says
+what it is: the last-leg term, which sits at position 0 and is not the cluster.
+
+### SUBSTRATE — associated, not necessary
+
+| comparison | band 1,050–1,224 | band 1,000–1,300 |
+|---|---|---|
+| `parity` pooled, uix against reagent | 11/1,471 vs 2/1,588, `p` = 0.0102 | 48/1,471 vs 15/1,588, `p` = 5.31e-6 |
+| `parity` pos0 only, uix against reagent | 8/747 vs 2/675, `p` = 0.1126 | 45/747 vs 15/675, `p` = 3.21e-4 |
+
+uix carries the term about eight times as often as reagent does. **But reagent
+carries it.** Two windows in the bead's band and fifteen in the wider one, out
+of 1,588. On the 89 reagent windows the earlier read had, the expected count in
+the bead's band is 0.11 — so seeing none of them was the likeliest single
+outcome and says nothing about necessity. **A zero in a small sample is not an
+impossibility result**, and that is the whole of the correction here.
+
+### MODE — confirmed, and stated at two strengths
+
+| baseline | counts | Fisher, two-sided |
+|---|---|---|
+| whole committed `parity` corpus, uix at pos1 | 8/38 vs 3/724 | **`p` = 2.67e-9** |
+| the three same-session `parity` runs, uix at pos1 | 8/38 vs 1/23 | **`p` = 0.1344** |
+
+The first is 724 windows across 112 runs, many sessions, several dates and
+several revisions. The second is 23 windows taken on one box in one session
+interleaved with the `fixed` runs themselves. **They are matched on different
+things and neither dominates**: the wide baseline has the power and carries
+session, date and revision as uncontrolled terms; the same-session baseline
+controls all three and has almost no power.
+
+The honest reading is that the mode contrast is large, is the only arm that
+survives, and is **not yet established at a matched baseline**. A replication of
+the `fixed` arm at higher n against same-session `parity` is what would settle
+its size, and that is an allocation window rather than an analysis.
+
+The negative control on the same contrast: `reagent` at position 0, `fixed`
+against `parity`, reads **0 of 43 against 2 of 675, `p` = 1.0**. Reagent does not
+move with the mode. Whatever the mode does, it does to uix.
+
+## Why the rig change is still needed
+
+The bead names its discriminator: *a fixed run with the segment order REVERSED
+(uix leading), which `p0_run.cjs` does not currently offer.* **That remains the
+right instrument, and the reason it is needed has changed rather than gone away.**
+
+The bead's stated reason was that no position arm existed. That reason is
+superseded — `parity` supplies uix at both positions, 1,471 windows of it, and
+this page uses exactly that. But it supplies it **under `parity`**, and the one
+finding that survived is that something about `fixed` is what carries the term.
+Inside `fixed` the confound is untouched:
+
+- Under `fixed` the order never moves, so **uix is always position 1 and reagent
+  is always position 0**. Substrate and position are perfectly confounded there,
+  in all 81 `fixed` windows.
+- So `fixed` uix pos1 at 21.1% is consistent with two readings this corpus
+  cannot separate: *uix under `fixed`*, or *second-driven under `fixed`*.
+- A `parity` comparison cannot decide between them, because it is the `fixed`
+  mode that the effect is attached to.
+
+**A `fixed` run with the order reversed puts uix at position 0 while holding the
+mode constant, and it is the only arrangement that does.** If the cluster follows
+uix to position 0, the carrier is the substrate under `fixed`; if it stays at
+position 1 with reagent now in it, the carrier is the slot. Nothing already
+committed answers that, and nothing can, because no committed run drives `fixed`
+in the other order.
+
+### What it costs, since this page sizes it rather than making it
+
+Measured against `p0_run.cjs` at blob
+`1be8e793d070b9b4797503d40e5798b2fb7b325e`. **Three lines**, and no reader,
+schema or record change:
+
+| what | where | change |
+|---|---|---|
+| the mode roster | `p0_run.cjs:1717` | one more name in `ALLOC_SEG_ORDERS` |
+| the order itself | `p0_run.cjs:1821`–`:1824` | one branch in `allocSegmentOrder`, returning the reversed plan every round |
+| the preflight refusal | `p0_run.cjs:2582`–`:2585` | **nothing** — it already interpolates `ALLOC_SEG_ORDERS.join(' \| ')`, so a new name is refused by name for free |
+
+The record already carries `segOrder` per run and `segments` per round, and both
+readers group on the field rather than recomputing a parity rule, so a third
+mode is read correctly by everything that exists without being taught about.
+
+**This page does not make that change.** `p0_run.cjs` is shared with `rf2-fk6pj`
+and `rf2-onozm`, which want their own arms in the same file; it is one-toucher,
+and bundling is the mayor's call rather than this bead's.
+
+## What the earlier read got wrong, and one thing it did not
+
+**The "8 of 38 versus 9 of 38" is an ESTIMATOR difference and neither count is an
+error.** "Worst leg" has two readings, and they part on exactly one window in the
+corpus. `fixed-2` round 4 `uix-subs` has leg excesses **0, −12, 0, −4,324,
++1,056, 0**. Read as *the excess furthest from the cohort median in either
+direction* — which is `legWorstDeviation` re-derived, and the reading the
+previous record publishes — that window's worst leg is **−4,324 B** and it is out
+of band. Read as *the largest excess above the median* it is **+1,056 B** and it
+is in. Eight and nine are the same census under the two readings, and
+`alloc_position_confound.cjs` has pinned both since it was written. **A record
+quoting one of them owes the reader which**, and this reader prints both columns
+so the choice cannot be silent.
+
+That leg is worth its own sentence. **A leg 4,324 B BELOW its cohort is a leg
+something removed bytes from, and nothing in the work unit removes bytes — the
+collector does.** The window carries `falls === 0` all the same, so the falls
+gate did not see it. That is a bound on the gate, recorded here and not acted on:
+no gate was changed and none is proposed.
+
+**And the bead's own title is wrong, as its filer suspected.** "Seen only under
+the fixed segment order" does not hold: the term appears under `parity` three
+times at uix position 1 and eight more at uix position 0 within the bead's band,
+out of 1,471 windows. It is **rarer** under `parity` by a factor of about twenty,
+not absent.
+
+## What is not concluded
+
+- **No mechanism is named.** Nothing here says what the term is, only what it
+  travels with. The `fixed` mode drives the same two segments in the same order
+  every round where `parity` alternates them; which consequence of that matters
+  is untested.
+- **The mode contrast is not established at a matched baseline.** `p` = 2.67e-9
+  against 112 pooled runs, `p` = 0.1344 against the three that share its session.
+  Nothing here chooses between those, and the second is the one that controls
+  what the first does not.
+- **Three `fixed` runs is three.** 81 windows, one box, one session, one
+  revision. Every `fixed` figure on this page rests on them.
+- **The last-leg term at `parity` position 0 is described and not chased.** Its
+  ordinal signature is published above because it decides the band question; its
+  identity is nobody's yet.
+- **The falls gate's blind spot is recorded, not remedied.** One window with a
+  −4,324 B leg passed it. No gate, band or tolerance was touched, and widening or
+  narrowing one is not proposed in either direction.
+- **`rf2-e9wr`'s refusal to pin τ stands**, and `rf2-rs8q6`'s fence against
+  discharging any of this by widening τ is restated rather than relaxed.
+
+## Reproduction
+
+Every measured figure on this page — every window and leg count, byte value,
+rate, ordinal and `p` — is re-derived from the committed records by:
+
+```bash
+node implementation/hicasso/test/re_frame/bench/hicasso/alloc_cluster_carrier.cjs --corpus
+```
+
+and the same-session subset, which is the only place this page's `p` = 0.1344
+comes from, by:
+
+```bash
+node implementation/hicasso/test/re_frame/bench/hicasso/alloc_cluster_carrier.cjs \
+  implementation/hicasso/test/re_frame/bench/hicasso/data/segorder-rs8q6/*.json
+```
+
+That reader imports its window extraction from `alloc_position_confound.cjs`
+rather than restating it, so the two records cannot drift about what a window is,
+and it re-derives that record's published 387 / 182 / 205 / 101 + 11 as a control
+on itself. Its fixtures run under `--self-test`.
+
+### The statistic, and the convention it is taken under
+
+Every `p` on this page is **Fisher's exact test, two-sided**, by the conventional
+definition: the sum of the probabilities of every table whose probability is no
+greater than the observed table's.
+
+**Fisher rather than the two-proportion `z` the neighbouring record publishes,
+and the reason is the data.** Several cells here carry zero or one success, where
+the normal approximation is not defined — `alloc_position_confound.cjs` returns
+`null` for exactly that case rather than a number. No `z` is quoted anywhere on
+this page, and the two conventions must not be read across.
+
+The two-sided convention is named because doubling the smaller tail is the other
+common one and it disagrees on asymmetric margins, which every margin here is.
+The reader's fixtures pin the tea-tasting table at 0.4857, `[[0,5],[5,0]]` at
+2/252 and `[[1,0],[0,1]]` at exactly 1, so a change to the convention reds rather
+than drifting.
+
+### What that command does NOT print
+
+Three kinds of number here are not figures of the runs: the **corpus table's
+configuration** (`P0_ALLOC_PLAN`, `P0_ROOTS`, B, the write count) — that is how
+the runs were taken, not something read out of them; the **seat, bead and blob
+identifiers**; and the **rig sizing table**, which is read off `p0_run.cjs` and
+not off any dataset. Everything else on the page comes out of the command.

--- a/docs/design/hicasso/studio/the-eight-signs-are-one-block.md
+++ b/docs/design/hicasso/studio/the-eight-signs-are-one-block.md
@@ -6,6 +6,15 @@ property of the two writes or an artefact. Written 2026-08-18 on
 `worker/armfloor-0gjqi`, written off `4cf5680a82` and rebased onto
 `2a48dc2109`.
 
+**Corrected 2026-08-21 under the merged-PR audit of #8458, and no window was
+taken for the correction either.** The audit found one sentence in *And how
+large one has been measured to be* false as written: it said every `alloc-9jrhi`
+dataset carried a passing positive control, where one of the eight refuses. The
+census, the quoted control values and the `4a1537cb71` row are corrected there
+and the estimator is now named. **No figure on this page moved** — the
+correction excludes a run whose medians were the middle entry of the row it
+sits in, so the spread it is quoted for is unchanged.
+
 **No allocation window was taken for this page.** Nothing here is a new
 measurement. Every figure below is either re-derived from a committed dataset,
 re-derived from a figure already published on
@@ -179,25 +188,48 @@ and 928 B/write on `uix-subs`.** To flip the smallest cell takes 524 and 188.
 
 Re-derived here, first-hand, from the eight committed `alloc-9jrhi` datasets.
 Population: the floor arm's certified windows. Statistic: the median of
-`rise/W` across the rounds that certified, per segment per run — the same shape
+`rise/W` across the rounds that certified, per segment per run, where W is the
+run's six non-prime writes (`writes`, not `windowWrites`) — the same shape
 of estimator the source page uses, applied to the floor rather than to
 `arm − floor`. Instrument revision: each dataset's own, named in its filename;
-every one carries `writeSelector: "all"`, plan `floor`, B = 24, `unverified: 0`
-and a passing positive control (`perDouble` 8.081, `differential` 8.001).
+every one carries `writeSelector: "all"`, plan `floor`, B = 24 and
+`unverified: 0`.
+
+**Seven of the eight passed their positive control; one refused, and it is
+excluded from the spread below.** `bisect-5-a-4a1537cb71-replicate` carries
+`controlVerdict.ok: false` — `perDouble` 12.303 and `differential` 15.039
+against a predicted 8 B/double. The seven that passed read `perDouble` 8.081
+(six runs) and 8.083 (`pilot-rounds6`), `differential` 8.001 (five runs), 7.913
+(`bisect-6`) and 8.004 (`pilot-rounds6`).
 
 | `implementation/core/src` revision | runs | `reagent-subs` medians | `uix-subs` medians | spread |
 |---|---|---|---|---|
-| `4a1537cb71` | 3 | 22,984 / 19,236 / 19,132 | 23,468 / 19,736 / 19,556 | **3,852 / 3,912 B/write** |
+| `4a1537cb71` | 2 admissible, 1 refused | 22,984 / (19,236) / 19,132 | 23,468 / (19,736) / 19,556 | **3,852 / 3,912 B/write** |
 | `88411ed803` | 2 | 19,429 / 19,427 | 20,107 / 21,752 | 2 / **1,645 B/write** |
 | `a158c40288` | 1 | 19,430 | 20,146 | — |
 | `48c715f97c` | 1 | 19,418 | 19,954 | — |
 | `9d20be1d00` | 1 | 19,470 | 19,683 | — |
 
-**Three runs at one revision, one write, one page, one instrument, and their
-certified floor medians span 3,852 and 3,912 B/write.** Both exceed the 2,472
-and 928 B/write that would reverse every sign on the corresponding segment. Two
-runs at HEAD span 1,645 B/write on `uix-subs`, which still exceeds `uix-subs`'
-928.
+The parenthesised entries are the refused run's, kept in the row so the census
+is legible and excluded from the spread. **The exclusion does not move the
+figure**, and the reason is arithmetic rather than lucky: the refused run's
+medians are the MIDDLE entry of each `4a1537cb71` row, so the two admissible
+runs were already the endpoints the spread was taken between.
+
+**Two admissible runs at one revision, one write, one page, one instrument, and
+their certified floor medians span 3,852 and 3,912 B/write.** Both exceed the
+2,472 and 928 B/write that would reverse every sign on the corresponding
+segment. Two runs at HEAD span 1,645 B/write on `uix-subs`, which still exceeds
+`uix-subs`' 928.
+
+**A refused control does not weaken this sub-finding, and stating why is the
+point of keeping the run on the page rather than deleting it.** The argument
+here is that the floor's between-run spread is LARGE — larger than the offset
+that would flip every sign — so an inadmissible run can only ever be argued to
+have inflated it. It did not: dropping it leaves 3,852 and 3,912 unchanged.
+Read the other way, one run in eight failing a control that predicts a constant
+8 B/double is itself a fact about this instrument's between-run behaviour, and
+it is recorded here as one.
 
 These re-derived spreads run slightly above `rf2-77gz8`'s exact 3,792 B because
 the estimators differ and the difference is stated rather than reconciled: that
@@ -205,6 +237,15 @@ bead quotes the two steady-state LEVELS a bimodal run sits at, where this median
 pools a run's certified rounds across a within-run step. **Both are correct
 answers to different questions**, and this page uses the median because it is the
 shape of estimator the disputed cells were computed with.
+
+Which is now measurable rather than asserted, and it is the reason the estimator
+is named at the top of this section. Taking the median of `legMedian` over the
+same certified rounds instead of `rise/W`, the two admissible `4a1537cb71` runs
+read 22,892 / 23,332 and 19,100 / 19,540 — a spread of **3,792 and 3,792
+B/write**, `rf2-77gz8`'s figure to the byte and the same number on both
+segments. So the two estimators disagree by about 60-120 B on a level and by
+about 100 B on a spread, and the residual gap to `rf2-77gz8` is the estimator
+and not a third quantity.
 
 ## The shape of the residual argues the other way
 

--- a/docs/design/hicasso/studio/the-mode-rate-tracks-elapsed-session-time.md
+++ b/docs/design/hicasso/studio/the-mode-rate-tracks-elapsed-session-time.md
@@ -1,0 +1,237 @@
+# The mode rate tracks elapsed session time — and the bisect's one high run does not follow
+
+Seat: RE-ANALYSIS RECORD, EP-0038. Bead `rf2-6kxub`, which asks why three
+windows at one revision, on one instrument, with the same plan and the same
+estimator produced three incompatible rates for the elevated floor mode.
+
+**No allocation window was taken for this page, and no rig file was edited.**
+Every figure is re-derived from datasets already committed under
+`implementation/hicasso/test/re_frame/bench/hicasso/data/`. The analysis was run
+against the tree at commit `a51138e93b`.
+
+**τ was not moved, in either direction.** No gate, band, threshold, budget or
+tolerance was widened, narrowed or touched. The 21,000 B/write high-mode
+criterion used throughout is `rf2-77gz8`'s, carried unchanged through
+[does arming the census move the high level](does-arming-the-census-move-the-high-level.md);
+it is a LABEL on an already-measured bimodal population and not a gate — nothing
+passes or fails on it and no run is refused by it.
+
+## The answer, first
+
+**The rate tracks how long the session had been running, and the association is
+real but weaker than a quartile cut makes it look. It does NOT explain the
+bisect's high run, and it does NOT discharge `rf2-9jrhi`.**
+
+- **The three rates reproduce exactly**, and so does the finding that they are
+  not an arming effect: 0 of 6, 2 of 20, 37 of 69 = 53.6%, with 18 of 34 armed
+  against 19 of 35 unarmed. Both arms moved together, which is what an
+  environment term does and an arming term does not.
+- **Session duration orders them**: 8.2 min → 0%, 19.7 min → 10%, 88.3 min →
+  53.6%. That relation is four points once the bisect is added and it is
+  described, not fitted.
+- **Within the long session the gradient is real but modest.** The
+  boundary-free rank test gives **one-tail `p` = 0.0198**. A quartile cut gives
+  0.0054 — and that figure moves eightfold, 0.0210 to 0.0025, across a two-run
+  choice of where the cut falls. **The cut is a choice; quote the rank test.**
+- **THE BOUND, and it is the half that must not be lost.** The bisect session's
+  single high run sits at **+3.6 minutes, second of eight** in a 14.9-minute
+  session. The gradient says an early run is where a high is LEAST likely, so
+  **elapsed time does not explain this run**. `rf2-9jrhi`'s open question —
+  whether the second mode is revision-dependent — is **not** discharged by
+  anything here, and the two questions stay separate.
+
+## The census
+
+Statistic: the median of `legMedian` over each run's CERTIFIED floor windows,
+per segment. A run is HIGH when either segment reads at or above 21,000 B/write.
+
+| session | runs | high | rate | minutes | inadmissible |
+|---|---|---|---|---|---|
+| `workcount-n1b9h` | 6 | 0 | 0.0% | 8.2 | — |
+| `alloc-9jrhi` | 8 | 1 | 12.5% | 14.9 | — |
+| `alloc-77gz8` | 20 | 2 | 10.0% | 19.7 | — |
+| `alloc-c4hhk` | 69 | 37 | **53.6%** | 88.3 | `armed-25-a4a1537cb71` |
+
+`armed-25` carries no `alloc` block at all, so it holds no reading. It is named
+as inadmissible rather than dropped silently and **is never counted low** —
+counting it low would move the headline rate, and a dataset with no reading is
+not a reading of zero.
+
+**Not an arming effect.** `alloc-c4hhk` alternated armed and unarmed runs
+strictly: **18 of 34 armed (52.9%) against 19 of 35 unarmed (54.3%)**. An arming
+term would have separated them. This reproduces `rf2-c4hhk`'s own result and is
+restated here only because it is the first thing the rate question has to
+exclude.
+
+## Duration orders the sessions
+
+| session | minutes | rate |
+|---|---|---|
+| `workcount-n1b9h` | 8.2 | 0.0% |
+| `alloc-9jrhi` | 14.9 | 12.5% |
+| `alloc-77gz8` | 19.7 | 10.0% |
+| `alloc-c4hhk` | 88.3 | 53.6% |
+
+**Four sessions, monotone but for one inversion at 14.9 against 19.7 minutes,
+where the two rates are 12.5% and 10% on 8 and 20 runs.** No test is offered on
+this table and none should be: four points, three of them at durations that are
+also three different clock times on two different dates, and the rates carry
+sampling error of their own. It is stated as an ORDERING and not as a fit.
+
+**The bisect is on this table rather than beside it**, which matters twice over.
+Its rate fits the duration relation perfectly well. Its internal ordering, below,
+does not fit the within-session gradient at all. Those are two different claims
+about the same eight runs and this page keeps them apart.
+
+## Within the long session, which is the only unconfounded arm
+
+`alloc-c4hhk` is 69 runs on one box, at one revision, in one continuous session.
+A comparison inside it holds revision, box, date and instrument fixed, which no
+comparison ACROSS the sessions can. It is the only arm here that separates
+elapsed time from everything elapsed time is otherwise confounded with.
+
+### The quartile figure, and why this page does not lead with it
+
+An earlier read quoted a one-tailed hypergeometric on the first quarter:
+P(at most 5 high among the first 19 of 69, given 37 high overall) = 0.0054. That
+reproduces exactly. **But it turns on where the quarter is cut**, and the cut is
+a choice rather than a measurement:
+
+| first `k` runs | high | one-tail `p` |
+|---|---|---|
+| 17 | 5 | 0.0210 |
+| 18 | 5 | 0.0109 |
+| **19** | 5 | **0.0054** |
+| 20 | 5 | 0.0025 |
+| 34 (half) | 15 | 0.0934 |
+
+**An eightfold move across a two-run choice, and a first-half/second-half split
+gives 0.093.** Any of those cuts is defensible and none is pre-registered. A
+figure that mobile should not be the one a record leads with.
+
+### The figure to quote instead
+
+**Mann-Whitney rank-sum on each run's position in the session, high against low.
+There is no cut point to choose.**
+
+> U = **763** against a null mean of 592, z = 2.058, **one-tail `p` = 0.0198**.
+> Mean position 39.6 for the 37 high runs against 29.7 for the 32 low ones.
+
+One-tailed, and deliberately: the question asked is whether the EARLY runs read
+low, which has a direction. The normal approximation is used for the tail at
+n = 37 against 32, far past where it bites, and the exact U is printed beside it
+so the approximation can be checked rather than trusted.
+
+**So the within-session gradient is real at about `p` = 0.02, not `p` = 0.005.**
+It is an association of moderate strength on a single session.
+
+## The three rates stop being incompatible — conditionally
+
+Read against the long session's own EARLY rate rather than its pooled rate, the
+two short sessions are unremarkable. Read against the pooled rate, one of them is
+extreme. One-tailed binomial, P(at most the observed count):
+
+| reference rate | `workcount-n1b9h`, 0 of 6 | `alloc-77gz8`, 2 of 20 |
+|---|---|---|
+| early prefix, 5 of 19 = 26.3% | 0.160 | 0.072 |
+| pooled, 37 of 69 = 53.6% | 0.0099 | **5.89e-5** |
+
+**That contrast is the whole of the claim.** Against 53.6%, `alloc-77gz8`'s 2 of
+20 is a 1-in-17,000 event and the three sessions genuinely do contradict each
+other. Against 26.3% — the rate the long session itself ran at while it was as
+young as the short ones were when they ended — nothing needs explaining.
+
+**This is conditional and it is not a test.** The reference rate is taken from
+the same data the gradient was found in, so the second row is not an independent
+confirmation of the first. What it establishes is consistency: one within-session
+gradient plus ordinary sampling accounts for all three observations, where three
+properties of three revisions is not needed.
+
+## The bound, stated at length because it is the half a summary loses
+
+`alloc-9jrhi` is the corpus that should break the elapsed-time account, and it
+partly does.
+
+| elapsed | run | level, `reagent-subs` | mode |
+|---|---|---|---|
+| +0.0 min | `pilot-rounds6-head-88411ed803` | 19,256 | low |
+| **+3.6 min** | **`bisect-1-a-4a1537cb71`** | **22,892** | **HIGH** |
+| +5.7 min | `bisect-2-m-a158c40288` | 19,386 | low |
+| +7.3 min | `bisect-3-b-48c715f97c` | 19,378 | low |
+| +9.4 min | `bisect-4-p-9d20be1d00` | 19,054 | low |
+| +11.3 min | `bisect-5-a-4a1537cb71-replicate` | 19,108 | low |
+| +13.2 min | `bisect-6-a-4a1537cb71-replicate2` | 19,100 | low |
+| +14.9 min | `bisect-7-head-88411ed803` | 19,378 | low |
+
+**The single high run is the SECOND of eight, at +3.6 minutes of a 14.9-minute
+session.** Under the within-`c4hhk` gradient — 27.8% in the first quarter against
+52.9-68.8% after — an early run is precisely where a high run is least likely.
+So one of two things is true, and this page does not choose between them: the
+gradient is noisy at n = 1, or something else is also in play.
+
+### What that means for `rf2-9jrhi`, exactly
+
+`rf2-9jrhi` has an open question — **whether the second mode is
+revision-dependent**, standing at n = 1. It would have been discharged here had
+the bisect's high run landed LATE in its session, because then position-in-session
+would have been confounded with revision and that record's flat verdict would
+have needed re-reading.
+
+**It landed early. So the question is untouched**, and the RATE (this bead) and
+the mode's REVISION-DEPENDENCE (`rf2-9jrhi`) do not collapse into one another.
+Nothing on this page should be cited as bearing on the second. See
+[the bisect is flat and the floor has a second mode](the-bisect-is-flat-and-the-floor-has-a-second-mode.md).
+
+## Two corrections to the earlier read
+
+- **The bisect's high run is the SECOND-earliest of eight, not the third.** The
+  earlier note's own ordered list has `pilot-rounds6` at +0.0 and `bisect-1-a` at
+  +3.6, which makes it second; the prose beside that list said third. The
+  direction of the bound is unaffected — second is, if anything, earlier — but
+  the figure is corrected.
+- **The quarter boundaries were 19 / 18 / 17 / 15 there and 18 / 18 / 17 / 16
+  here**, because equal-elapsed-time quarters and equal-count quarters do not
+  cut the same session the same way. Both partition all 69 runs and both find 37
+  high; the quarter rates read 26.3 / 66.7 / 58.8 / 66.7 under the first and
+  27.8 / 66.7 / 52.9 / 68.8 under the second. **That the two disagree at all is
+  the reason this page leads with a test that has no boundary.**
+
+## What is not concluded
+
+- **No mechanism is named.** Thermal state, V8 tier accumulation and heap
+  fragmentation over a long session all survive this equally. An association with
+  elapsed time is not a cause.
+- **Across the three sessions, duration is confounded with date and clock time.**
+  `workcount-n1b9h` opened at 11:23, `alloc-77gz8` at 13:52 and `alloc-c4hhk` at
+  23:54, and the last ran past midnight. Only the within-`alloc-c4hhk` arm is
+  free of that, and it is one session.
+- **One session is one session.** The whole gradient rests on `alloc-c4hhk`; the
+  other three corpora are too short to carry an internal trend and are not asked
+  to.
+- **The bead's SECOND move is not made here.** Recording the Chromium build
+  string, the box's load at window open and the elapsed time since the previous
+  run is a change to `implementation/core/test/re_frame/bench/p0_run.cjs` — hot,
+  one-toucher, and shared with `rf2-fk6pj`, `rf2-csca8` and `rf2-onozm`. It needs
+  no window and it is the mayor's to bundle.
+- **The LEVELS are not in question and were not re-opened.** `rf2-c4hhk`
+  established that arming moves neither, and the level values reproduce to the
+  byte. This page is about the RATE only.
+
+## Reproduction
+
+Every measured figure on this page — every rate, duration, `p`, rank statistic
+and byte level — is re-derived from the committed records by:
+
+```bash
+node implementation/hicasso/test/re_frame/bench/hicasso/alloc_mode_rate_session.cjs
+```
+
+It launches nothing, reads no rig file and writes nothing. Its fixtures run under
+`--self-test` and pin the bound hardest of all — that the bisect's high run is
+second of eight and in the early half — because that is the half a write-up is
+most likely to lose.
+
+The fixtures also **discriminate rather than restate**: they require the prefix
+sweep to move at least fourfold across the cut, and require the boundary-free
+rank test to come out WEAKER than the best cut. A change that made the quartile
+figure look robust would red them.

--- a/implementation/hicasso/test/re_frame/bench/hicasso/alloc_cluster_carrier.cjs
+++ b/implementation/hicasso/test/re_frame/bench/hicasso/alloc_cluster_carrier.cjs
@@ -1,0 +1,528 @@
+'use strict';
+// WHAT CARRIES THE ~1,000-1,300 B CLUSTER — rf2-csca8, read off the committed
+// floor corpus and nothing else.
+//
+//     node hicasso/test/re_frame/bench/hicasso/alloc_cluster_carrier.cjs <dataset.json>...
+//     node hicasso/test/re_frame/bench/hicasso/alloc_cluster_carrier.cjs --corpus
+//     node hicasso/test/re_frame/bench/hicasso/alloc_cluster_carrier.cjs --self-test
+//
+// ## THE QUESTION
+//
+// `rf2-rs8q6` filed rather than chased a SECOND term: under
+// `P0_ALLOC_SEG_ORDER=fixed` the second-driven arm window of a round — which
+// under that mode is always `uix-subs` — carries a cluster of windows whose
+// worst leg sits around 1,050-1,224 B over the window's own leg median.
+// `rf2-csca8` asks which of THREE properties carries it: the uix SUBSTRATE, the
+// POSITION in the round, or the segment-order MODE itself.
+//
+// Under `fixed` those three are confounded exactly as position and substrate
+// were before that mode was landed: position 0 is always `reagent-subs` and
+// position 1 is always `uix-subs`. So a `fixed` run alone cannot separate them.
+//
+// ## WHY THIS READER EXISTS RATHER THAN A ONE-OFF DERIVATION
+//
+// `alloc_position_confound.cjs` already extracts the window stream, the leg
+// cohorts and the control arm, and already cross-checks each round's stated
+// segment and window order against the keys the round actually filled. This
+// reader IMPORTS that extraction rather than restating it, so the two records
+// cannot drift about what a window is. What it adds is the three-way census and
+// its exact test.
+//
+// ## THE STATISTIC, AND WHY THIS READER PRINTS TWO OF THEM
+//
+// The bead's population is "collection-free windows whose WORST LEG sits in the
+// band" — one statistic per window, not a leg count. But "worst leg" has two
+// readings and they do not agree on this corpus:
+//
+//   SIGNED-FURTHEST   the excess furthest from the cohort median in EITHER
+//                     direction. This is `legWorstDeviation` re-derived, and it
+//                     is the reading `alloc_position_confound.cjs` publishes.
+//   LARGEST-POSITIVE  the largest excess ABOVE the cohort median.
+//
+// They differ on exactly one window in the `segorder-rs8q6` corpus, and that
+// one window is the whole of the reported "8 of 38 versus 9 of 38": `fixed-2`
+// round 4 `uix-subs` has excesses [0, -12, 0, -4324, +1056, 0]. Its furthest
+// excess is -4,324 B, so signed-furthest puts it out of band; its largest
+// positive excess is +1,056 B, so largest-positive puts it in. NEITHER COUNT IS
+// AN ERROR. A record quoting one of them must say which, and this reader prints
+// both side by side so the choice cannot be silent.
+//
+// The -4,324 B leg is itself worth the sentence: a leg BELOW its cohort is a
+// leg something removed bytes from, and nothing in the work unit removes bytes
+// — the collector does. That window passed the falls gate (`falls === 0`) all
+// the same, which is a bound on the gate and not a defect in this reader.
+//
+// ## THE POPULATION, AND THE TWO RESTRICTIONS ON IT
+//
+// `plan=floor` allocation records, collection-free windows only (`falls === 0`)
+// — the same restriction the previous records used, INDEPENDENT OF tau.
+// Nothing here reads, moves or is calibrated against tau in either direction.
+//
+// And `controlSlot === 'first'` wherever the position index is read, because
+// under `last` and `mid` the three control windows do not precede position 0
+// and "position 0" stops naming the same event. The nine `ctrlslot-rs8q6` runs
+// are therefore in the corpus and out of the position tables; the report says
+// so rather than dropping them silently.
+//
+// ## WHAT THIS IS NOT
+//
+// It is not a gate. No run passes or fails on it, no threshold here is a
+// budget, and it launches nothing — it is a reader over records that already
+// exist, exactly as `alloc_position_confound.cjs` and `alloc_level_witness.cjs`
+// are.
+
+const fs = require('node:fs');
+const path = require('node:path');
+
+const {
+  windowsOf,
+  controlLegsOf,
+  excesses,
+  worstExcessSignedB,
+  ridersOf,
+} = require('./alloc_position_confound.cjs');
+
+// The band, verbatim from `rf2-csca8`'s own comparison: "1 of 23 in the same
+// 1,000-1,300 B band". It is a DESCRIPTION of an already-measured population,
+// not a threshold anything is adjudicated against — widening or narrowing it
+// changes what this reader counts and refuses nothing either way.
+const BAND_LO_B = 1000;
+const BAND_HI_B = 1300;
+
+// The bead's own narrower quotation — the observed extremes of the cluster it
+// found, "1,050-1,224 B". Reported beside the band above so that the published
+// `8 of 38` is re-derivable under the exact bounds it was published with.
+const OBSERVED_LO_B = 1050;
+const OBSERVED_HI_B = 1224;
+
+// --- the two readings of "worst leg" ---------------------------------------
+
+const largestPositiveB = (w) => {
+  const e = excesses(w);
+  if (!e.length) return null;
+  return Math.max(...e);
+};
+
+const STATISTICS = {
+  'signed-furthest': worstExcessSignedB,
+  'largest-positive': largestPositiveB,
+};
+
+const inBand = (b, lo, hi) => b !== null && b >= lo && b <= hi;
+
+// --- Fisher's exact test ----------------------------------------------------
+//
+// TWO-SIDED, by the conventional definition: the sum of the probabilities of
+// every table at least as extreme as the observed one, where "at least as
+// extreme" means "of probability no greater than the observed table's". That
+// convention is named because the other common one — doubling the smaller tail
+// — disagrees on asymmetric margins, and every margin here is asymmetric.
+//
+// Fisher rather than a two-proportion z, and the reason is the data: several
+// cells here are 0 or 1 successes, where the normal approximation the z rests
+// on is not defined (`alloc_position_confound.cjs` returns `null` for exactly
+// that case). The z scores that reader publishes are NOT reproduced here and
+// nothing on this page is stated in them.
+
+const LOG_FACTORIAL = [0];
+function logFactorial(n) {
+  for (let i = LOG_FACTORIAL.length; i <= n; i++) {
+    LOG_FACTORIAL[i] = LOG_FACTORIAL[i - 1] + Math.log(i);
+  }
+  return LOG_FACTORIAL[n];
+}
+
+function tableProbability(a, b, c, d) {
+  return Math.exp(
+    logFactorial(a + b) +
+      logFactorial(c + d) +
+      logFactorial(a + c) +
+      logFactorial(b + d) -
+      logFactorial(a + b + c + d) -
+      logFactorial(a) -
+      logFactorial(b) -
+      logFactorial(c) -
+      logFactorial(d)
+  );
+}
+
+function fisherExactTwoSided(a, b, c, d) {
+  if (a + b === 0 || c + d === 0 || a + c === 0 || b + d === 0) return 1;
+  const n = a + b + c + d;
+  const row1 = a + b;
+  const col1 = a + c;
+  const observed = tableProbability(a, b, c, d);
+  // A strict `<=` on floating point drops tables that are equiprobable with the
+  // observed one by symmetry, which is how a two-sided p silently becomes
+  // one-sided on a balanced margin. The tolerance is what keeps them in.
+  const ceiling = observed * (1 + 1e-9);
+  let p = 0;
+  const lo = Math.max(0, col1 - (n - row1));
+  const hi = Math.min(row1, col1);
+  for (let x = lo; x <= hi; x++) {
+    const q = tableProbability(x, row1 - x, col1 - x, n - row1 - col1 + x);
+    if (q <= ceiling) p += q;
+  }
+  return Math.min(1, p);
+}
+
+// --- the census -------------------------------------------------------------
+
+const CELL_KEY = (w) => `${w.segOrder}|${w.segment}|pos${w.position}`;
+
+function analyse(datasets) {
+  const all = datasets.flatMap((d) => windowsOf(d.data, d.id));
+  const clean = all.filter((w) => w.falls === 0);
+  // The position index only names the same event under `first`. See the header.
+  const positional = clean.filter((w) => w.controlSlot === 'first');
+  const otherSlots = clean.length - positional.length;
+
+  const out = {
+    windows: all.length,
+    collectionFree: clean.length,
+    positional: positional.length,
+    excludedOtherSlot: otherSlots,
+    runs: [...new Set(all.map((w) => w.runId))].length,
+    modes: [...new Set(all.map((w) => w.segOrder))].sort(),
+    byStatistic: {},
+  };
+
+  for (const [name, statistic] of Object.entries(STATISTICS)) {
+    const hit = (w, lo = BAND_LO_B, hi = BAND_HI_B) =>
+      inBand(statistic(w), lo, hi);
+
+    const cells = {};
+    for (const w of positional) {
+      const k = CELL_KEY(w);
+      cells[k] = cells[k] || { key: k, segOrder: w.segOrder, segment: w.segment, position: w.position, windows: 0, band: 0, observed: 0, values: [] };
+      cells[k].windows++;
+      if (hit(w)) {
+        cells[k].band++;
+        cells[k].values.push({ run: w.runId, round: w.round, bytes: statistic(w) });
+      }
+      if (hit(w, OBSERVED_LO_B, OBSERVED_HI_B)) cells[k].observed++;
+    }
+
+    // Which LEG carries the in-band excess. This is what shows the pooled
+    // parity population is not one term: see the report's own note.
+    const ordinals = {};
+    for (const w of positional) {
+      const k = CELL_KEY(w);
+      ordinals[k] = ordinals[k] || [0, 0, 0, 0, 0, 0];
+      excesses(w).forEach((b, ordinal) => {
+        if (!inBand(b, BAND_LO_B, BAND_HI_B)) return;
+        while (ordinals[k].length <= ordinal) ordinals[k].push(0);
+        ordinals[k][ordinal]++;
+      });
+    }
+
+    const pick = (mode, segment, position) =>
+      positional.filter(
+        (w) =>
+          (mode === null || w.segOrder === mode) &&
+          (segment === null || w.segment === segment) &&
+          (position === null || w.position === position)
+      );
+    // THE COMPARISONS ARE RUN UNDER BOTH BANDS, and that is load-bearing
+    // rather than generous. The wide 1,000-1,300 B band is the one the bead
+    // states its parity comparison in; the narrow 1,050-1,224 B band is the
+    // one it defines the CLUSTER by. On this corpus they do not answer the
+    // same question, because the wide band admits a second and different term
+    // — see the ordinal table, where `parity | uix-subs | pos0`'s in-band legs
+    // sit at the LAST leg ordinal and the `fixed` cluster's never do. A record
+    // that quoted one band without the other would read as having settled
+    // something it had not.
+    const bands = [
+      { name: `${BAND_LO_B}-${BAND_HI_B}`, lo: BAND_LO_B, hi: BAND_HI_B },
+      { name: `${OBSERVED_LO_B}-${OBSERVED_HI_B}`, lo: OBSERVED_LO_B, hi: OBSERVED_HI_B },
+    ];
+    const comparisons = {};
+    for (const band of bands) {
+      const inThis = (w) => inBand(statistic(w), band.lo, band.hi);
+      const count = (ws) => ({ k: ws.filter(inThis).length, n: ws.length });
+      const compare = (label, a, b) => {
+        const x = count(a);
+        const y = count(b);
+        return { label, a: x, b: y, p: fisherExactTwoSided(x.k, x.n - x.k, y.k, y.n - y.k) };
+      };
+      comparisons[band.name] = [
+        compare('POSITION  | parity, uix-subs, pos0 vs pos1', pick('parity', 'uix-subs', 0), pick('parity', 'uix-subs', 1)),
+        compare('POSITION  | parity, reagent-subs, pos0 vs pos1', pick('parity', 'reagent-subs', 0), pick('parity', 'reagent-subs', 1)),
+        compare('POSITION  | fixed, pos0 vs pos1 (substrate-confounded)', pick('fixed', null, 0), pick('fixed', null, 1)),
+        compare('SUBSTRATE | parity pos0, uix vs reagent', pick('parity', 'uix-subs', 0), pick('parity', 'reagent-subs', 0)),
+        compare('SUBSTRATE | parity pooled, uix vs reagent', pick('parity', 'uix-subs', null), pick('parity', 'reagent-subs', null)),
+        compare('MODE      | uix at pos1, fixed vs parity', pick('fixed', 'uix-subs', 1), pick('parity', 'uix-subs', 1)),
+        compare('MODE      | reagent at pos0, fixed vs parity', pick('fixed', 'reagent-subs', 0), pick('parity', 'reagent-subs', 0)),
+      ];
+    }
+
+    out.byStatistic[name] = {
+      cells: Object.values(cells).sort((p, q) => p.key.localeCompare(q.key)),
+      ordinals,
+      comparisons,
+    };
+  }
+
+  // THE NULL ARM. The control windows run the same machinery, the same sampler
+  // and the same round schedule as the arms and dispatch nothing, so a term
+  // found in them would be the instrument's and not the arm's.
+  const controlLegs = datasets
+    .flatMap((d) => controlLegsOf(d.data, d.id))
+    .flatMap((c) => (c.legs || []).map((x) => x - c.legMedian));
+  out.control = {
+    legs: controlLegs.length,
+    band: controlLegs.filter((b) => inBand(b, BAND_LO_B, BAND_HI_B)).length,
+  };
+
+  // AND THE READER'S OWN CONTROL: the published 14-run parity figures. If this
+  // reader's window extraction has drifted, these move.
+  const published = clean.filter((w) => /^(workcount-n1b9h|alloc-9jrhi)\//.test(w.runId));
+  out.readerControl = {
+    windows: published.length,
+    pos0: published.filter((w) => w.position === 0).length,
+    pos1: published.filter((w) => w.position === 1).length,
+    riderLegsPos0: published.filter((w) => w.position === 0).flatMap(ridersOf).length,
+    riderLegsPos1: published.filter((w) => w.position === 1).flatMap(ridersOf).length,
+  };
+
+  return out;
+}
+
+// --- printing ---------------------------------------------------------------
+
+const rate = (k, n) => (n ? `${((100 * k) / n).toFixed(1)}%` : 'n/a');
+const pStr = (p) => (p >= 0.001 ? p.toFixed(4) : p.toExponential(2));
+
+function report(a) {
+  const L = [];
+  L.push('THE ~1,000-1,300 B CLUSTER, AND WHAT CARRIES IT (rf2-csca8)');
+  L.push('');
+  L.push(`runs ${a.runs} | arm windows ${a.windows} | collection-free ${a.collectionFree} | ` +
+    `in the position tables ${a.positional} (excluded, controlSlot != first: ${a.excludedOtherSlot})`);
+  L.push(`segment-order modes present: ${a.modes.join(', ')}`);
+  L.push('');
+  L.push(`READER CONTROL — the published 14-run parity figures: ${a.readerControl.windows} collection-free ` +
+    `windows, ${a.readerControl.pos0} / ${a.readerControl.pos1} by position, ` +
+    `${a.readerControl.riderLegsPos0} + ${a.readerControl.riderLegsPos1} rider legs.`);
+  L.push('  (published: 387 windows, 182 / 205, 101 + 11)');
+  L.push('');
+  L.push(`NULL ARM — control legs ${a.control.legs}, of which in the ${BAND_LO_B}-${BAND_HI_B} B band: ${a.control.band}`);
+  L.push('');
+
+  for (const [name, s] of Object.entries(a.byStatistic)) {
+    L.push(`=== worst leg read as ${name.toUpperCase()} ===`);
+    L.push('');
+    L.push(`  ${'mode | segment | position'.padEnd(34)}${'windows'.padStart(9)}${`in ${BAND_LO_B}-${BAND_HI_B}`.padStart(14)}${'rate'.padStart(8)}${`in ${OBSERVED_LO_B}-${OBSERVED_HI_B}`.padStart(14)}`);
+    for (const c of s.cells) {
+      L.push(`  ${c.key.replace(/\|/g, ' | ').padEnd(34)}${String(c.windows).padStart(9)}${String(c.band).padStart(14)}${rate(c.band, c.windows).padStart(8)}${String(c.observed).padStart(14)}`);
+    }
+    L.push('');
+    L.push('  IN-BAND LEGS BY ORDINAL (a leg count, not a window count):');
+    for (const c of s.cells) {
+      const o = s.ordinals[c.key] || [];
+      L.push(`    ${c.key.replace(/\|/g, ' | ').padEnd(34)}[${o.join(', ')}]`);
+    }
+    L.push('');
+    for (const [band, cmps] of Object.entries(s.comparisons)) {
+      L.push(`  FISHER EXACT, TWO-SIDED — band ${band} B:`);
+      for (const cmp of cmps) {
+        L.push(`    ${cmp.label.padEnd(52)}${`${cmp.a.k}/${cmp.a.n}`.padStart(9)} vs ${`${cmp.b.k}/${cmp.b.n}`.padEnd(9)} p = ${pStr(cmp.p)}`);
+      }
+      L.push('');
+    }
+  }
+  return L;
+}
+
+// --- the self-test ----------------------------------------------------------
+//
+// Synthetic fixtures for the machinery, and a pin on the committed corpus for
+// the figures a record quotes. The synthetic half is what makes the pins
+// DISCRIMINATING rather than merely restating: the two worst-leg readings are
+// required to DISAGREE on the window that separates them, and Fisher is
+// required to miss the values the two-proportion z would give.
+
+const synthWindow = (segment, legs, extra = {}) => ({
+  segment,
+  arm: 'grid/floor',
+  rung: 'floor',
+  falls: 0,
+  legs,
+  legMedian: legs.slice().sort((x, y) => x - y)[legs.length >> 1],
+  certified: true,
+  ...extra,
+});
+
+function synthDataset(segOrder, rounds) {
+  return {
+    alloc: {
+      plan: { name: 'floor', arms: true, rungs: false, fits: false },
+      segOrder,
+      controlSlot: 'first',
+      boundaries: 24,
+      perRound: rounds.map((r, i) => ({
+        round: i,
+        controls: { idle: { falls: 0, legs: [100, 100, 100], legMedian: 100 } },
+        arms: r,
+      })),
+    },
+  };
+}
+
+function selfTest() {
+  const checks = [];
+  const ok = (name, pass) => checks.push([pass, name]);
+
+  // --- Fisher, against values computable by hand --------------------------
+  // The 2x2 [[1,0],[0,1]] is the smallest table with both margins fixed at 1;
+  // every table is as extreme as every other, so p = 1 exactly.
+  ok('fisher: [[1,0],[0,1]] is p = 1', Math.abs(fisherExactTwoSided(1, 0, 0, 1) - 1) < 1e-12);
+  // Tea-tasting, the canonical worked example: 3/4 against 1/4 gives 0.4857.
+  ok('fisher: the tea-tasting table gives 0.4857', Math.abs(fisherExactTwoSided(3, 1, 1, 3) - 0.485714285714) < 1e-9);
+  // 0 of 5 against 5 of 5 is the extreme table on balanced margins: p = 1/126.
+  ok('fisher: [[0,5],[5,0]] is 2/252', Math.abs(fisherExactTwoSided(0, 5, 5, 0) - 2 / 252) < 1e-12);
+  ok('fisher: an empty margin returns 1 rather than NaN', fisherExactTwoSided(0, 0, 3, 4) === 1);
+  // The 1/20-vs-1/23 cell the earlier triage read as "no position effect".
+  ok('fisher: 1/20 against 1/23 is p = 1', Math.abs(fisherExactTwoSided(1, 19, 1, 22) - 1) < 1e-9);
+  // AND IT DISCRIMINATES: the same counts under a pooled two-proportion z give
+  // z = -0.0699, which is not a p-value at all and must not be mistaken for one.
+  ok('fisher: 9/38 vs 2/43 reproduces 0.0204 and not the z', Math.abs(fisherExactTwoSided(9, 29, 2, 41) - 0.0204) < 5e-4);
+
+  // --- the two worst-leg readings, and the window that separates them ------
+  // `fixed-2` round 4's excess vector, verbatim.
+  const separator = synthWindow('uix-subs', [19872, 19860, 19872, 15548, 20928, 19872]);
+  ok('worst leg: signed-furthest takes the -4,324 B leg', worstExcessSignedB(separator) === -4324);
+  ok('worst leg: largest-positive takes the +1,056 B leg', largestPositiveB(separator) === 1056);
+  ok('worst leg: the two readings disagree about the band', inBand(largestPositiveB(separator), BAND_LO_B, BAND_HI_B) && !inBand(worstExcessSignedB(separator), BAND_LO_B, BAND_HI_B));
+
+  // --- the census, on a dataset whose answer is known by construction ------
+  const planted = synthDataset('fixed', [
+    { 'reagent-subs|grid/floor': synthWindow('reagent-subs', [1000, 1000, 1000, 1000, 1000, 1000]), 'uix-subs|grid/floor': synthWindow('uix-subs', [1000, 1000, 1000, 1000, 2280, 1000]) },
+    { 'reagent-subs|grid/floor': synthWindow('reagent-subs', [1000, 1000, 1000, 1000, 1000, 1000]), 'uix-subs|grid/floor': synthWindow('uix-subs', [1000, 1000, 1000, 1000, 1000, 1000]) },
+  ]);
+  const a = analyse([{ id: 'planted-1', data: planted }]);
+  const cells = a.byStatistic['largest-positive'].cells;
+  const uix = cells.find((c) => c.key === 'fixed|uix-subs|pos1');
+  const reagent = cells.find((c) => c.key === 'fixed|reagent-subs|pos0');
+  ok('census: the planted uix window is counted at position 1', uix && uix.band === 1 && uix.windows === 2);
+  ok('census: the unplanted reagent windows are not counted', reagent && reagent.band === 0 && reagent.windows === 2);
+  // AND THE TWO BANDS ARE DISCRIMINATED: +1,280 B is inside 1,000-1,300 and
+  // outside the bead's quoted 1,050-1,224, so a reader that collapsed the two
+  // bands would report `observed` as 1 here.
+  ok('census: the +1,280 B plant is in the band and outside the observed range', uix && uix.observed === 0);
+
+  // --- the falls gate is respected ----------------------------------------
+  const collected = synthDataset('fixed', [
+    { 'reagent-subs|grid/floor': synthWindow('reagent-subs', [1000, 1000, 1000, 1000, 1000, 1000]), 'uix-subs|grid/floor': synthWindow('uix-subs', [1000, 1000, 1000, 1000, 2100, 1000], { falls: 1 }) },
+  ]);
+  const b = analyse([{ id: 'planted-2', data: collected }]);
+  const bUix = b.byStatistic['largest-positive'].cells.find((c) => c.key === 'fixed|uix-subs|pos1');
+  ok('falls gate: a collection-carrying window is out of the population', !bUix);
+
+  // --- the committed corpus, pinned -------------------------------------
+  // These are the figures a record quotes. They are pinned as literals so that
+  // a change to the extraction reds here rather than drifting into prose.
+  let corpusFiles = [];
+  try {
+    corpusFiles = corpus();
+  } catch (e) {
+    corpusFiles = [];
+  }
+  if (corpusFiles.length) {
+    const c = analyse(corpusFiles.map(load).filter(isFloorAlloc));
+    ok('corpus: the reader control reproduces the published 387 / 182 / 205', c.readerControl.windows === 387 && c.readerControl.pos0 === 182 && c.readerControl.pos1 === 205);
+    ok('corpus: the reader control reproduces the published 101 + 11 rider legs', c.readerControl.riderLegsPos0 === 101 && c.readerControl.riderLegsPos1 === 11);
+    ok('corpus: the null arm carries nothing in the band', c.control.band === 0);
+    const find = (stat, key) => c.byStatistic[stat].cells.find((x) => x.key === key);
+    ok('corpus: fixed|uix|pos1 reads 8 of 38 signed-furthest', (find('signed-furthest', 'fixed|uix-subs|pos1') || {}).band === 8);
+    ok('corpus: fixed|uix|pos1 reads 9 of 38 largest-positive', (find('largest-positive', 'fixed|uix-subs|pos1') || {}).band === 9);
+    ok('corpus: fixed|reagent|pos0 reads 0 of 43', (find('signed-furthest', 'fixed|reagent-subs|pos0') || {}).band === 0);
+    ok('corpus: parity|uix|pos0 reads 45 of 747', (find('signed-furthest', 'parity|uix-subs|pos0') || {}).band === 45 && find('signed-furthest', 'parity|uix-subs|pos0').windows === 747);
+    ok('corpus: parity|uix|pos1 reads 3 of 724', (find('signed-furthest', 'parity|uix-subs|pos1') || {}).band === 3 && find('signed-furthest', 'parity|uix-subs|pos1').windows === 724);
+    ok('corpus: parity|reagent|pos0 reads 15 of 675 — the substrate NECESSITY claim fails here', (find('signed-furthest', 'parity|reagent-subs|pos0') || {}).band === 15 && find('signed-furthest', 'parity|reagent-subs|pos0').windows === 675);
+    ok('corpus: parity|reagent|pos1 reads 0 of 913', (find('signed-furthest', 'parity|reagent-subs|pos1') || {}).band === 0);
+    // The ordinal structure, which is what bounds the pooled parity result.
+    const ord = c.byStatistic['signed-furthest'].ordinals;
+    ok('corpus: parity|uix|pos0 in-band legs sit at ordinal 5 (43 of 48)', ord['parity|uix-subs|pos0'][5] === 43);
+    ok('corpus: fixed|uix|pos1 carries NO in-band leg at ordinal 5', ord['fixed|uix-subs|pos1'][5] === 0);
+
+    // THE PUBLISHED p-VALUES, and the pin DISCRIMINATES between the two bands
+    // rather than restating one of them: the position verdict FLIPS across
+    // them, which is the whole methodological finding of the record.
+    const cmp = (stat, band, label) =>
+      c.byStatistic[stat].comparisons[band].find((x) => x.label.startsWith(label));
+    const wideP = cmp('signed-furthest', `${BAND_LO_B}-${BAND_HI_B}`, 'POSITION  | parity, uix').p;
+    const narrowP = cmp('signed-furthest', `${OBSERVED_LO_B}-${OBSERVED_HI_B}`, 'POSITION  | parity, uix').p;
+    ok('corpus: POSITION under the wide band is p < 1e-9', wideP < 1e-9);
+    ok('corpus: POSITION under the bead band is p = 0.225', Math.abs(narrowP - 0.225) < 5e-3);
+    ok('corpus: the two bands DISAGREE about position', wideP < 0.001 && narrowP > 0.05);
+    ok('corpus: MODE under the bead band is p < 1e-8',
+      cmp('signed-furthest', `${OBSERVED_LO_B}-${OBSERVED_HI_B}`, 'MODE      | uix at pos1').p < 1e-8);
+    ok('corpus: SUBSTRATE is not NECESSARY — parity reagent carries 2 in the bead band',
+      cmp('signed-furthest', `${OBSERVED_LO_B}-${OBSERVED_HI_B}`, 'SUBSTRATE | parity pooled').b.k === 2);
+  } else {
+    ok('corpus: data directory present', false);
+  }
+
+  return checks;
+}
+
+// --- entry ------------------------------------------------------------------
+
+const DATA = path.join(__dirname, 'data');
+
+function corpus() {
+  const out = [];
+  for (const dir of fs.readdirSync(DATA)) {
+    const full = path.join(DATA, dir);
+    if (!fs.statSync(full).isDirectory()) continue;
+    for (const f of fs.readdirSync(full)) {
+      if (f.endsWith('.json')) out.push(path.join(full, f));
+    }
+  }
+  return out;
+}
+
+function load(p) {
+  const data = JSON.parse(fs.readFileSync(p, 'utf8'));
+  return { id: path.relative(DATA, p).replace(/\\/g, '/').replace(/\.json$/, ''), data };
+}
+
+const isFloorAlloc = (d) => {
+  const row = d.data.alloc;
+  return !!row && row.plan && row.plan.name === 'floor' && Array.isArray(row.perRound);
+};
+
+if (require.main === module) {
+  const argv = process.argv.slice(2);
+  if (argv.includes('--self-test')) {
+    const checks = selfTest();
+    for (const [pass, name] of checks) console.log(`${pass ? 'ok  ' : 'FAIL'} ${name}`);
+    const bad = checks.filter(([p]) => !p).length;
+    console.log(`alloc_cluster_carrier self-test: ${checks.length - bad}/${checks.length} passed`);
+    process.exit(bad ? 1 : 0);
+  }
+  const files = argv.includes('--corpus') ? corpus() : argv;
+  if (!files.length) {
+    console.error('usage: alloc_cluster_carrier.cjs <dataset.json>... | --corpus | --self-test');
+    process.exit(2);
+  }
+  const datasets = files.map(load).filter(isFloorAlloc);
+  if (!datasets.length) {
+    console.error('no plan=floor allocation record among the files given');
+    process.exit(2);
+  }
+  for (const line of report(analyse(datasets))) console.log(line);
+}
+
+module.exports = {
+  analyse,
+  report,
+  selfTest,
+  fisherExactTwoSided,
+  largestPositiveB,
+  BAND_LO_B,
+  BAND_HI_B,
+  OBSERVED_LO_B,
+  OBSERVED_HI_B,
+};

--- a/implementation/hicasso/test/re_frame/bench/hicasso/alloc_mode_rate_session.cjs
+++ b/implementation/hicasso/test/re_frame/bench/hicasso/alloc_mode_rate_session.cjs
@@ -1,0 +1,369 @@
+'use strict';
+// THE FLOOR ARM'S SECOND-MODE **RATE**, AGAINST ELAPSED TIME WITHIN A SESSION —
+// rf2-6kxub, read off committed datasets and nothing else.
+//
+//     node hicasso/test/re_frame/bench/hicasso/alloc_mode_rate_session.cjs
+//     node hicasso/test/re_frame/bench/hicasso/alloc_mode_rate_session.cjs --self-test
+//
+// ## THE QUESTION
+//
+// Three windows at ONE revision, on ONE instrument, with the SAME plan and the
+// SAME estimator produced three incompatible rates for the elevated floor mode:
+// 0 of 6, 2 of 20, and 37 of 69. `rf2-6kxub` filed that as a live risk to the
+// METHOD rather than an oddity, because every window on this arm SIZES ITS RUN
+// COUNT against a prior rate and a pre-declared count cannot be revised after
+// the fact.
+//
+// The bead's own first-named candidate is a within-window ordering effect, and
+// it is the one candidate that needs NOTHING new recorded: `generatedAt` is on
+// every dataset already. This reader tests it.
+//
+// ## THE CLASSIFIER, WHICH IS NOT THIS READER'S TO CHOOSE
+//
+// A run is HIGH when either segment's estimator reads at or above 21,000
+// B/write. That is `rf2-77gz8`'s criterion, carried unchanged through
+// `does-arming-the-census-move-the-high-level.md`, and it is quoted here rather
+// than invented: this reader must not be free to move the bar it counts
+// against. The estimator is the MEDIAN of `legMedian` over the run's CERTIFIED
+// floor windows, per segment.
+//
+// **THE BAR IS NOT A GATE.** Nothing passes or fails on it, no run is refused
+// by it, and it is not tau and is not calibrated against tau in either
+// direction. It is a label applied to an already-measured bimodal population.
+//
+// ## THE BOUNDARY SENSITIVITY, WHICH IS WHY THIS READER PRINTS A SWEEP
+//
+// The headline figure an earlier read quoted — a one-tail hypergeometric
+// P(<= 5 high among the first 19 of 69) = 0.0054 — turns on where the first
+// "quarter" is cut, and the cut is a choice rather than a measurement. Over
+// k = 17, 18, 19, 20 the same statistic reads 0.0210, 0.0109, 0.0054, 0.0025:
+// an eightfold move across a two-run choice.
+//
+// So this reader prints the sweep, and prints a BOUNDARY-FREE test beside it —
+// the Mann-Whitney rank-sum of each run's position in its session against
+// whether it read high. That statistic has no cut point to choose, and it is
+// the one a record should quote.
+//
+// ## WHAT THIS IS NOT
+//
+// It is not a gate and it launches nothing. It is a reader over records that
+// already exist, exactly as `alloc_heap_trajectory.cjs` is.
+
+const fs = require('node:fs');
+const path = require('node:path');
+
+const DATA = path.join(__dirname, 'data');
+
+// `rf2-77gz8`'s criterion, unchanged. See the header: quoted, not chosen.
+const HIGH_MODE_B = 21000;
+
+// The three sessions the bead names, in the order it names them.
+const SESSIONS = ['workcount-n1b9h', 'alloc-77gz8', 'alloc-c4hhk'];
+
+// The corpus that BOUNDS the result rather than supporting it.
+const BOUNDING_SESSION = 'alloc-9jrhi';
+
+const median = (xs) => {
+  if (!xs.length) return null;
+  const s = [...xs].sort((a, b) => a - b);
+  const m = s.length >> 1;
+  return s.length % 2 ? s[m] : (s[m - 1] + s[m]) / 2;
+};
+
+// --- combinatorics ----------------------------------------------------------
+
+const LOG_FACTORIAL = [0];
+function logFactorial(n) {
+  for (let i = LOG_FACTORIAL.length; i <= n; i++) LOG_FACTORIAL[i] = LOG_FACTORIAL[i - 1] + Math.log(i);
+  return LOG_FACTORIAL[n];
+}
+const logChoose = (n, k) => (k < 0 || k > n ? -Infinity : logFactorial(n) - logFactorial(k) - logFactorial(n - k));
+
+// P(exactly k successes) drawing n from N with K successes in it.
+const hypergeometric = (k, K, n, N) => Math.exp(logChoose(K, k) + logChoose(N - K, n - k) - logChoose(N, n));
+
+// ONE-TAILED, lower: P(at most `k` high among the first `n` of `N`), under the
+// null that the K high runs are arranged at random. This is the null the
+// question needs — "were the early runs unusually LOW" — and it is one-tailed
+// on purpose, which the report says beside every figure it prints.
+function hypergeometricAtMost(k, K, n, N) {
+  let p = 0;
+  for (let x = 0; x <= k; x++) p += hypergeometric(x, K, n, N);
+  return Math.min(1, p);
+}
+
+const binomial = (k, n, p) => Math.exp(logChoose(n, k) + k * Math.log(p) + (n - k) * Math.log(1 - p));
+function binomialAtMost(k, n, p) {
+  let s = 0;
+  for (let x = 0; x <= k; x++) s += binomial(x, n, p);
+  return Math.min(1, s);
+}
+
+// Abramowitz & Stegun 7.1.26. Accurate to ~1.5e-7, which is far finer than any
+// figure quoted from it here.
+function erf(x) {
+  const sign = x < 0 ? -1 : 1;
+  const z = Math.abs(x);
+  const t = 1 / (1 + 0.3275911 * z);
+  const y = 1 - ((((1.061405429 * t - 1.453152027) * t + 1.421413741) * t - 0.284496736) * t + 0.254829592) * t * Math.exp(-z * z);
+  return sign * y;
+}
+const normalUpperTail = (z) => 0.5 * (1 - erf(z / Math.SQRT2));
+
+// MANN-WHITNEY U on the run's ordinal position in its session, high against
+// low. No cut point, so no boundary to choose. The normal approximation is used
+// for the tail because n is 37 against 32 — far past where it bites — and the
+// exact U is printed beside it so the approximation can be checked.
+function mannWhitney(highRanks, lowRanks) {
+  let U = 0;
+  for (const a of highRanks) for (const b of lowRanks) if (a > b) U += 1;
+  const n1 = highRanks.length;
+  const n2 = lowRanks.length;
+  if (!n1 || !n2) return null;
+  const mu = (n1 * n2) / 2;
+  const sd = Math.sqrt((n1 * n2 * (n1 + n2 + 1)) / 12);
+  const z = (U - mu) / sd;
+  return { U, mu, sd, z, pOneTail: normalUpperTail(z) };
+}
+
+// --- the records ------------------------------------------------------------
+
+function runsOf(dir) {
+  const full = path.join(DATA, dir);
+  const out = [];
+  const skipped = [];
+  for (const f of fs.readdirSync(full).filter((x) => x.endsWith('.json')).sort()) {
+    const raw = JSON.parse(fs.readFileSync(path.join(full, f), 'utf8'));
+    const a = raw.alloc;
+    // A dataset with no `alloc` block carries no reading at all. It is counted
+    // as INADMISSIBLE and named, never silently dropped and never counted low —
+    // counting it low would move every rate on this page.
+    if (!a || !Array.isArray(a.perRound)) {
+      skipped.push({ file: f, why: 'no alloc block' });
+      continue;
+    }
+    const perSegment = {};
+    for (const round of a.perRound) {
+      for (const w of Object.values(round.arms || {})) {
+        if (!w.certified) continue;
+        (perSegment[w.segment] = perSegment[w.segment] || []).push(w.legMedian);
+      }
+    }
+    const levels = {};
+    for (const [seg, xs] of Object.entries(perSegment)) levels[seg] = median(xs);
+    out.push({
+      file: f.replace(/\.json$/, ''),
+      at: Date.parse(raw.generatedAt),
+      levels,
+      high: Object.values(levels).some((v) => v !== null && v >= HIGH_MODE_B),
+    });
+  }
+  out.sort((x, y) => x.at - y.at);
+  return { runs: out, skipped };
+}
+
+function sessionOf(dir) {
+  const { runs, skipped } = runsOf(dir);
+  const N = runs.length;
+  const K = runs.filter((r) => r.high).length;
+  const t0 = runs.length ? runs[0].at : null;
+  const t1 = runs.length ? runs[runs.length - 1].at : null;
+  const ranked = runs.map((r, i) => ({ ...r, rank: i + 1 }));
+  return {
+    dir,
+    N,
+    K,
+    rate: N ? K / N : null,
+    skipped,
+    openedAt: t0,
+    minutes: N > 1 ? (t1 - t0) / 60000 : 0,
+    runs: ranked,
+    // THE SWEEP. See the header: the published figure moves eightfold across a
+    // two-run choice of where the first quarter ends, so the choice is printed
+    // rather than made.
+    prefixSweep: [17, 18, 19, 20, Math.floor(N / 2)]
+      .filter((k) => k > 0 && k < N)
+      .sort((a, b) => a - b)
+      .map((k) => {
+        const h = ranked.slice(0, k).filter((r) => r.high).length;
+        return { k, high: h, pAtMost: hypergeometricAtMost(h, K, k, N) };
+      }),
+    rankTest: mannWhitney(ranked.filter((r) => r.high).map((r) => r.rank), ranked.filter((r) => !r.high).map((r) => r.rank)),
+  };
+}
+
+function analyse() {
+  const sessions = SESSIONS.map(sessionOf);
+  const bounding = sessionOf(BOUNDING_SESSION);
+  const long = sessions[sessions.length - 1];
+
+  // The other two sessions read against two reference rates: the long session's
+  // OWN EARLY rate, and its pooled rate. The contrast between those two columns
+  // is the whole of the "the three rates stop being incompatible" claim.
+  const early = long.prefixSweep.find((s) => s.k === 19) || long.prefixSweep[0];
+  const earlyRate = early.high / early.k;
+  const references = [
+    { label: `early prefix ${early.high}/${early.k}`, p: earlyRate },
+    { label: `pooled ${long.K}/${long.N}`, p: long.rate },
+  ];
+  const conditioned = references.map((ref) => ({
+    ...ref,
+    others: sessions.slice(0, -1).map((s) => ({
+      dir: s.dir,
+      observed: `${s.K}/${s.N}`,
+      pAtMost: binomialAtMost(s.K, s.N, ref.p),
+    })),
+  }));
+
+  return { sessions, bounding, conditioned };
+}
+
+// --- printing ---------------------------------------------------------------
+
+const pStr = (p) => (p >= 0.001 ? p.toFixed(4) : p.toExponential(2));
+
+function report(a) {
+  const L = [];
+  L.push("THE FLOOR ARM'S SECOND-MODE RATE AGAINST SESSION ELAPSED TIME (rf2-6kxub)");
+  L.push(`high-mode criterion: either segment's median certified legMedian at or above ${HIGH_MODE_B} B/write`);
+  L.push('');
+  L.push(`  ${'session'.padEnd(20)}${'runs'.padStart(6)}${'high'.padStart(6)}${'rate'.padStart(8)}${'minutes'.padStart(10)}   inadmissible`);
+  for (const s of [...a.sessions, a.bounding]) {
+    L.push(`  ${s.dir.padEnd(20)}${String(s.N).padStart(6)}${String(s.K).padStart(6)}${`${(100 * s.rate).toFixed(1)}%`.padStart(8)}${s.minutes.toFixed(1).padStart(10)}   ${s.skipped.map((x) => x.file).join(', ') || '—'}`);
+  }
+  L.push('');
+
+  const long = a.sessions[a.sessions.length - 1];
+  L.push(`WITHIN ${long.dir} — the one comparison that holds revision, box and date fixed:`);
+  L.push('');
+  L.push('  PREFIX SWEEP (one-tailed hypergeometric, P(at most this many high in the first k)):');
+  for (const s of long.prefixSweep) {
+    L.push(`    first ${String(s.k).padStart(2)} runs: ${String(s.high).padStart(2)} high   p = ${pStr(s.pAtMost)}`);
+  }
+  L.push('    ^ the figure MOVES with the cut. The cut is a choice; the test below is not.');
+  L.push('');
+  const rt = long.rankTest;
+  L.push(`  MANN-WHITNEY on position-in-session, high against low — NO cut point:`);
+  L.push(`    U = ${rt.U} against a null mean of ${rt.mu}, z = ${rt.z.toFixed(3)}, one-tail p = ${pStr(rt.pOneTail)}`);
+  L.push('');
+
+  L.push('THE OTHER TWO SESSIONS, read against two reference rates (one-tailed binomial):');
+  for (const ref of a.conditioned) {
+    L.push(`  against the ${ref.label} = ${(100 * ref.p).toFixed(1)}%:`);
+    for (const o of ref.others) L.push(`    ${o.dir.padEnd(20)} observed ${o.observed.padEnd(7)} P(at most that many) = ${pStr(o.pAtMost)}`);
+  }
+  L.push('');
+
+  L.push(`THE BOUND — ${a.bounding.dir}, ordered by generatedAt:`);
+  const b0 = a.bounding.runs[0].at;
+  for (const r of a.bounding.runs) {
+    const lv = Object.entries(r.levels).map(([k, v]) => `${k} ${v}`).join('  ');
+    L.push(`  +${((r.at - b0) / 60000).toFixed(1).padStart(5)} min  ${r.file.padEnd(34)}${r.high ? 'HIGH' : 'low '}   ${lv}`);
+  }
+  const hi = a.bounding.runs.findIndex((r) => r.high);
+  L.push(`  session ${a.bounding.minutes.toFixed(1)} min; its single high run is number ${hi + 1} of ${a.bounding.runs.length}, at ` +
+    `+${((a.bounding.runs[hi].at - b0) / 60000).toFixed(1)} min — EARLY, which is where the gradient says a high run is LEAST likely.`);
+  L.push('  So the elapsed-time account does NOT explain this run, and does not discharge rf2-9jrhi.');
+  return L;
+}
+
+// --- the self-test ----------------------------------------------------------
+
+function selfTest() {
+  const checks = [];
+  const ok = (name, pass) => checks.push([pass, name]);
+
+  // --- the combinatorics, against values computable by hand ---------------
+  ok('hypergeometric: P(0 of 1 drawn from 2 with 1 high) = 1/2', Math.abs(hypergeometric(0, 1, 1, 2) - 0.5) < 1e-12);
+  ok('hypergeometric: the full draw is certain', Math.abs(hypergeometricAtMost(3, 3, 5, 5) - 1) < 1e-12);
+  ok('binomial: P(0 of 6 | p = 1/2) = 1/64', Math.abs(binomial(0, 6, 0.5) - 1 / 64) < 1e-12);
+  ok('binomial: the whole distribution sums to 1', Math.abs(binomialAtMost(20, 20, 0.3) - 1) < 1e-9);
+  ok('erf: the normal upper tail at 0 is 1/2', Math.abs(normalUpperTail(0) - 0.5) < 1e-9);
+  ok('erf: the normal upper tail at 1.96 is 0.025', Math.abs(normalUpperTail(1.96) - 0.025) < 1e-3);
+  // Mann-Whitney against a case whose U is countable by eye: highs at ranks
+  // 3 and 4, lows at 1 and 2, so every one of the four pairs favours high.
+  const mw = mannWhitney([3, 4], [1, 2]);
+  ok('mann-whitney: a perfectly separated pair gives U = n1*n2', mw.U === 4);
+
+  // --- the classifier ------------------------------------------------------
+  // Pinned as literals so a change to the criterion reds here rather than
+  // moving every rate on the record silently.
+  ok('classifier: the bar is rf2-77gz8 21,000 B/write, unchanged', HIGH_MODE_B === 21000);
+
+  // --- the committed corpus, pinned ---------------------------------------
+  let a = null;
+  try {
+    a = analyse();
+  } catch (e) {
+    ok(`corpus: readable (${e.message})`, false);
+    return checks;
+  }
+  const byDir = Object.fromEntries([...a.sessions, a.bounding].map((s) => [s.dir, s]));
+  ok('corpus: workcount-n1b9h reads 0 of 6', byDir['workcount-n1b9h'].K === 0 && byDir['workcount-n1b9h'].N === 6);
+  ok('corpus: alloc-77gz8 reads 2 of 20', byDir['alloc-77gz8'].K === 2 && byDir['alloc-77gz8'].N === 20);
+  ok('corpus: alloc-c4hhk reads 37 of 69', byDir['alloc-c4hhk'].K === 37 && byDir['alloc-c4hhk'].N === 69);
+  ok('corpus: alloc-c4hhk names armed-25 as the one inadmissible run',
+    byDir['alloc-c4hhk'].skipped.length === 1 && /armed-25/.test(byDir['alloc-c4hhk'].skipped[0].file));
+  ok('corpus: the three session durations are 8.2 / 19.7 / 88.3 min',
+    Math.abs(byDir['workcount-n1b9h'].minutes - 8.2) < 0.05 &&
+    Math.abs(byDir['alloc-77gz8'].minutes - 19.7) < 0.05 &&
+    Math.abs(byDir['alloc-c4hhk'].minutes - 88.3) < 0.05);
+
+  const sweep = Object.fromEntries(byDir['alloc-c4hhk'].prefixSweep.map((s) => [s.k, s]));
+  ok('corpus: the first 19 runs carry 5 high, p = 0.0054', sweep[19].high === 5 && Math.abs(sweep[19].pAtMost - 0.0054) < 5e-5);
+  // AND THE SWEEP DISCRIMINATES: this is the whole reason it is printed.
+  ok('corpus: the same statistic reads 0.0210 at k = 17 and 0.0025 at k = 20',
+    Math.abs(sweep[17].pAtMost - 0.0210) < 5e-4 && Math.abs(sweep[20].pAtMost - 0.0025) < 5e-4);
+  ok('corpus: the cut choice moves the figure at least fourfold', sweep[17].pAtMost / sweep[20].pAtMost > 4);
+  ok('corpus: the boundary-free rank test is weaker than the best cut',
+    byDir['alloc-c4hhk'].rankTest.pOneTail > sweep[19].pAtMost);
+  ok('corpus: the boundary-free rank test reads one-tail p = 0.020',
+    Math.abs(byDir['alloc-c4hhk'].rankTest.pOneTail - 0.0198) < 1e-3);
+
+  const early = a.conditioned[0];
+  const pooled = a.conditioned[1];
+  ok('corpus: against the early rate, n1b9h reads 0.16 and 77gz8 reads 0.072',
+    Math.abs(early.others[0].pAtMost - 0.160) < 5e-3 && Math.abs(early.others[1].pAtMost - 0.072) < 5e-3);
+  ok('corpus: against the pooled rate, 77gz8 reads 5.9e-05',
+    Math.abs(pooled.others[1].pAtMost - 5.89e-5) < 1e-6);
+
+  // --- THE BOUND, pinned hardest of all -----------------------------------
+  // This is the half a write-up is most likely to lose, so it is the half the
+  // fixtures hold most tightly.
+  const b = byDir['alloc-9jrhi'];
+  ok('bound: the bisect carries exactly one high run', b.K === 1 && b.N === 8);
+  const idx = b.runs.findIndex((r) => r.high);
+  ok('bound: its high run is SECOND of eight, not third', idx === 1);
+  ok('bound: its high run sits at +3.6 min in a 14.9 min session',
+    Math.abs((b.runs[idx].at - b.runs[0].at) / 60000 - 3.6) < 0.05 && Math.abs(b.minutes - 14.9) < 0.05);
+  ok('bound: it is in the EARLY half, where the gradient predicts fewest highs', idx < b.N / 2);
+
+  return checks;
+}
+
+// --- entry ------------------------------------------------------------------
+
+if (require.main === module) {
+  const argv = process.argv.slice(2);
+  if (argv.includes('--self-test')) {
+    const checks = selfTest();
+    for (const [pass, name] of checks) console.log(`${pass ? 'ok  ' : 'FAIL'} ${name}`);
+    const bad = checks.filter(([p]) => !p).length;
+    console.log(`alloc_mode_rate_session self-test: ${checks.length - bad}/${checks.length} passed`);
+    process.exit(bad ? 1 : 0);
+  }
+  for (const line of report(analyse())) console.log(line);
+}
+
+module.exports = {
+  analyse,
+  report,
+  selfTest,
+  runsOf,
+  sessionOf,
+  hypergeometric,
+  hypergeometricAtMost,
+  binomialAtMost,
+  mannWhitney,
+  HIGH_MODE_B,
+};


### PR DESCRIPTION
Three measurement-lane beads, analysis and prose only. **No window was taken, no
browser or benchmark was started, no rig file was edited, and `p0_run.cjs` was
not touched.** Everything is re-derived from datasets already committed under
`implementation/hicasso/test/re_frame/bench/hicasso/data/`.

**No reading, threshold, band or budget status moved. τ untouched, in either
direction.** The 21,000 B/write high-mode criterion and the 700–800 / 1,000–1,300
/ 1,050–1,224 B bands are all quoted from existing records as labels on
already-measured populations, not adjudicated against.

---

## `rf2-0gjqi` — the control census correction (documentation only)

**The premise holds and reproduces exactly.** Parsing all eight `alloc-9jrhi`
datasets directly, `bisect-5-a-4a1537cb71-replicate` is the **only** one with
`controlVerdict.ok = false` — `perDouble` 12.303, `differential` 15.039 against a
predicted 8 B/double. The page said every one carried a passing control.

Corrected: the census (seven of eight), the quoted control values — which are
**not** uniform across the seven that pass either (`perDouble` 8.081 ×6 and 8.083
×1; `differential` 8.001 ×5, 7.913 ×1, 8.004 ×1) — and the `4a1537cb71` row,
which now marks the refused run and states the spread over the two admissible
runs.

**The finding is not weakened and no figure moved.** The refused run's medians
are the **middle** entry of each row, so the two admissible runs were already the
endpoints the 3,852 / 3,912 B/write spread was taken between. The page now says
so explicitly, and records the failing control as a fact about the instrument's
between-run behaviour rather than deleting the run.

The estimator is now named, because it had to be: the page's published figures
are `median(perWrite)` = `rise/W` with **W = 6 non-prime writes**, which
reproduces 22,984 / 19,236 / 19,132 and 23,468 / 19,736 / 19,556 to the digit.
Taking `legMedian` over the same certified rounds instead gives **3,792 / 3,792
B/write** — `rf2-77gz8`'s figure to the byte, and the same number on both
segments. Added as a cross-check.

## `rf2-csca8` — the confound is NOT already broken, and the rig change IS still needed

**This overturns the triage the dispatch rested on.** Re-derived on the full
committed floor corpus — **118 runs, 3,308 collection-free windows, 3,140 in the
position tables** — instead of the three paired runs the triage used.

Statistic: worst leg per window over its own leg median, `falls === 0`,
`controlSlot = first`. Test: **Fisher's exact, two-sided** (not the neighbouring
record's two-proportion `z`, which is undefined at the several zero- and
one-success cells here).

| triage claim | verdict | measured |
|---|---|---|
| Parity already supplies uix at position 0 (20 windows) | **CONFIRMED** | and 747 windows corpus-wide |
| POSITION refuted, 1/20 vs 1/23, `p` = 1.0 | **CONFIRMED, on 34× the evidence** | 8/747 vs 3/724, `p` = 0.2254 |
| SUBSTRATE confirmed, uix 11/81 vs reagent 0/89, `p` = 2.0e-04 | **ASSOCIATED, but NOT NECESSARY** | reagent carries it 2 of 1,588; uix 11/1,471 vs reagent 2/1,588, `p` = 0.0102 |
| MODE associated, 9/38 vs 2/43, `p` = 0.0204 | **REPRODUCED, and it pools positions** | strictly matched same-session it is 8/38 vs 1/23, **`p` = 0.1344** |
| "The bead's count is wrong: 9, not 8" | **REFUTED — an estimator difference, not an error** | see below |
| "Seen only under fixed" is FALSE | **CONFIRMED** | 11 parity windows in band, not zero |

All three triage `p`-values reproduce **exactly** under the *largest-positive*
reading of "worst leg" (1.0 / 1.96e-04 / 0.0204); under the bead's own
*signed-furthest* reading they are 1.0 / 4.43e-04 / 0.0399.

**The 8-vs-9 is an estimator difference and neither count is an error.**
`fixed-2` round 4 `uix-subs` has excesses `0, −12, 0, −4324, +1056, 0`.
Signed-furthest takes −4,324 B (out of band); largest-positive takes +1,056 B (in
band). `alloc_position_confound.cjs` has pinned **both** readings since it was
written. My reader prints both columns so the choice cannot be silent.

**Methodological finding: the bead's two bands do not answer the same question.**
The wider 1,000–1,300 B band admits a *second, different* term — at parity
position 0 its in-band legs sit at the **last** leg ordinal 43 times in 48, where
the fixed cluster never lands there (0 of 11). Under the wide band the position
verdict inverts to `p` = 8.82e-11, and that inversion is about the last-leg term,
not the cluster. Both bands are reported; the bead's own 1,050–1,224 is primary.

**IS THE RIG CHANGE STILL NEEDED? YES.** The triage's reason for saying no does
not survive. Parity supplies the position arm *under parity*, but the one arm
that survived is the **mode**, and inside `fixed` uix is always position 1 — so
substrate and position remain perfectly confounded there, in all 81 `fixed`
windows. A reversed-`fixed` run is the only arrangement that puts uix at position
0 while holding the mode constant.

**Sized, not made** (`p0_run.cjs` is off limits and one-toucher with `rf2-fk6pj`
/ `rf2-onozm`): **three lines** — one name in `ALLOC_SEG_ORDERS` (`:1717`), one
branch in `allocSegmentOrder` (`:1821`–`:1824`), and **nothing** in the preflight
(`:2582`–`:2585`), which already interpolates the roster. No reader, schema or
record change: both readers group on the recorded `segOrder` rather than
recomputing a parity rule.

Also recorded, not acted on: that −4,324 B leg is a leg something *removed* bytes
from, and the window carries `falls === 0`. A bound on the falls gate. **No gate
was widened or narrowed.**

## `rf2-6kxub` — the mode rate, and the bound is the point

**Every rate reproduces exactly**: 0/6, 2/20, **37/69 = 53.6%**; armed 18/34
(52.9%) against unarmed 19/35 (54.3%), so not an arming effect. Durations 8.2 /
19.7 / 88.3 min order the three rates. `armed-25` is the one inadmissible run
(no `alloc` block) and is **never counted low**.

**Two corrections.**

1. **The quartile `p` is boundary-sensitive.** P(at most 5 high in the first `k`
   given 37 of 69) reads **0.0210 at k=17, 0.0109 at 18, 0.0054 at 19, 0.0025 at
   20** — eightfold across a two-run choice — and a half/half split gives 0.093.
   The page therefore leads with a test that has **no cut point**: Mann-Whitney
   on position-in-session, **U = 763, z = 2.058, one-tail `p` = 0.0198**. The
   gradient is real at about `p` = 0.02, not `p` = 0.005.
2. **The bisect's high run is the SECOND of eight, not the third.** The triage's
   own ordered list shows it; its prose said third.

Conditioned on the long session's early rate the other two sessions are
unremarkable (**0.160** and **0.072**); against its pooled rate `alloc-77gz8` is
**5.89e-05**. Stated as conditional consistency, not as a test — the reference
rate comes from the same data the gradient was found in.

**THE HONEST BOUND, stated in the page's own summary, in its body at length, and
pinned by four fixtures.** The bisect's single high run sits at **+3.6 min,
second of eight, in a 14.9-minute session** — early, where the gradient says a
high is *least* likely. **Elapsed time does NOT explain it**, and this does
**NOT** discharge `rf2-9jrhi`'s revision-dependence question. The two stay
separate. A nuance worth having: the bisect's *rate* (12.5% at 14.9 min) fits the
duration ordering fine; it is its *internal ordering* that does not.

---

## Studio README index rows (I am fenced off `README.md` — please route these)

Two new rows, in the register the neighbouring measurement rows use:

- **the cluster follows the mode, and the third arm is still missing**
  (`the-cluster-follows-the-mode-and-the-third-arm-is-still-missing.md`) —
  `rf2-csca8`. The ~1,050–1,224 B cluster, on **118 runs / 3,140 windows**.
  POSITION **REFUTED** *(8/747 vs 3/724, `p` = 0.2254)*; SUBSTRATE **ASSOCIATED
  BUT NOT NECESSARY** *(11/1,471 vs 2/1,588, `p` = 0.0102)*; MODE **CONFIRMED**
  *(8/38 vs 3/724, `p` = 2.67e-9)*. **The reversed-`fixed` rig arm is STILL
  REQUIRED** and is sized at three lines. No window taken; τ untouched.
- **the mode rate tracks elapsed session time**
  (`the-mode-rate-tracks-elapsed-session-time.md`) — `rf2-6kxub`. Rates 0/6,
  2/20, 37/69 against 8.2 / 19.7 / 88.3 min. Gradient **`p` = 0.0198**
  boundary-free, where a quartile cut gives 0.0054 and moves eightfold with the
  cut. **BOUND: does NOT explain the bisect's high run (+3.6 min, second of
  eight) and does NOT discharge `rf2-9jrhi`.** No window taken; τ untouched.

One existing row may need a touch if it repeats the `alloc-9jrhi` control census
for `the-eight-signs-are-one-block.md`: that census is now **seven of eight**,
one control refused, no figure moved.

## Also for the mayor to route

`implementation/package.json`'s `test:script-helpers` line — I did **not** touch
it (shared, and `worker/levelwit-a233t` is adjacent). Both new readers self-test
and would slot in beside the existing `alloc_position_confound.cjs --self-test`:

```
node hicasso/test/re_frame/bench/hicasso/alloc_cluster_carrier.cjs --self-test
node hicasso/test/re_frame/bench/hicasso/alloc_mode_rate_session.cjs --self-test
```

## Fences observed

Derived at start-up and again before the first edit with `gh pr list --json
files`, `git worktree list`, three-dot `git diff` per worker branch and
`git status --porcelain` in each worktree with no open PR. Confirmed **not**
touched: `docs/design/hicasso/studio/README.md`,
`the-bisect-is-flat-and-the-floor-has-a-second-mode.md`,
`the-second-mode-is-per-write-and-the-controls-never-move.md` (all #8590),
`implementation/core/test/re_frame/bench/p0_run.cjs`,
`implementation/package.json`, `data/alloc-0gjqi/`, anything under `.beads/` or
`ai/`. My five files are listed in the diff and nothing else is.

I read the three-dot diff `origin/main...HEAD` before pushing: the only deletions
anywhere are the nine lines of the eight-signs page I deliberately replaced.
Nothing a sibling landed is reverted.

## Quality gates

| gate | command | exit code I captured |
|---|---|---|
| doc slugs | `python scripts/check_doc_slugs.py` | **0** |
| provenance pins | `python scripts/check_provenance_pins.py --changed-since origin/main` | **0** — *3 pages inspected, 12 cited pins, 12 landed, 0 findings* |
| new reader | `node …/alloc_cluster_carrier.cjs --self-test` | **0** — 30/30 |
| new reader | `node …/alloc_mode_rate_session.cjs --self-test` | **0** — 24/24 |
| pre-existing reader I import from | `node …/alloc_position_confound.cjs --self-test` | **0** — 33/33 |

**All five re-run on the FINAL base after rebasing past 11 landings** (including
#8589 and #8590), and all five green there. Exit codes are the ones I captured
myself with an explicit `echo $?` on the same command line as the redirect —
never piped, never taken from the harness.

**Both doc gates proved to reach my worktree by a planted fault, restored and
hash-verified.**

- `check_doc_slugs.py`: planted a broken link target in the eight-signs page →
  **exit 1**, naming `the-eight-signs-are-one-block.md:214 -> this-page-does-not-exist-modeconf-plant.md`.
  Restored to the identical **blob** hash `aa5213c68584450479e95563e05ba52295bcb784`, gate back to **0**.
- `check_provenance_pins.py`: the first plant returned **exit 0** — correctly, because
  the absorption rule let the stranded token share a paragraph with a landed pin.
  **I did not proceed on that green.** Re-planted in an isolated scope → **exit
  1**, naming `the-mode-rate-tracks-elapsed-session-time.md:43 … [UNRESOLVABLE]`.
  Restored to the identical **blob** hash `ffa796d2eea74b2e4bee878aa20372e92a772597`.

One run of `check_provenance_pins.py` *without* `--changed-since` (whole-tree) was
killed by the harness runtime cap and **wrote no exit file**. I treated that as
**no verdict**, not a pass, and re-ran the documented `--changed-since` form.

**Not run, and stated plainly: the fast-PR spine did not run.**
`python scripts/check_fast_pr_gap.py --list` (exit 0) reports **94 required
checks the spine does not run** — a fact about the SPINE, not a census of what I
ran. The targeted gates I ran directly are the five in the table.
`mkdocs build --strict` is **not** nominated: `exclude_docs` keeps
`docs/design/**` out of the site.

**Nothing validates the prose, the tables' sense or the statistics, so by hand:**
I verified **every markdown table** on the three pages programmatically for column
consistency — 5 tables on the eight-signs page, 8 on the cluster page, 5 on the
mode-rate page, **0 mismatches** (pipes inside code spans and escaped pipes
handled). Every figure quoted in the prose is an output of one of the three
readers above, and each reader carries a control on itself:
`alloc_cluster_carrier.cjs` re-derives the previously published **387 windows /
182 / 205 / 101 + 11 rider legs** exactly, and finds **0 of 37,680** control legs
in band.
