### PR TITLE
docs(hicasso): eight conversion VARIANTS from two families, not eight independent conversions (rf2-nkeba)

### DIFF
--- a/docs/design/hicasso/allocation-instrument-rework.md
+++ b/docs/design/hicasso/allocation-instrument-rework.md
@@ -293,7 +293,8 @@ segments. Each page measured under `:p0/write-all` and under `:p0/write-page`.
 > have made it decide anything.
 >
 > Placed on that ladder, the 2026-08-08 row lands on the **top rung** to within
-> **2 – 373 B** (0.01 – 1.60%) across eight conversions. **Neither reading is
+> **2 – 373 B** (0.01 – 1.60%) across eight conversion variants per segment, drawn
+> from two partially independent families. **Neither reading is
 > withdrawn and neither is wrong**: 24,108 / 24,730 is a correct reading of the
 > arm's top rung and 19,349 – 20,696 are correct readings of its low rung. The
 > arm does not have a single value for the clause to test against.

--- a/docs/design/hicasso/studio/the-2026-08-08-row-is-the-arms-top-level.md
+++ b/docs/design/hicasso/studio/the-2026-08-08-row-is-the-arms-top-level.md
@@ -34,7 +34,9 @@ node implementation/hicasso/test/re_frame/bench/hicasso/alloc_ladder_placement.c
   revision, on one instrument, in one afternoon. **It cannot, and no amount of care in
   running it will change that.**
 - **Placed on the ladder, the 2026-08-08 row lands on the top rung to within
-  `2 – 373 B`** — 0.01% to 1.60%, across eight independent conversions. The row is
+  `2 – 373 B`** — 0.01% to 1.60%, across ~~eight independent conversions~~
+  **eight conversion variants per segment, drawn from two partially independent
+  families** (corrected — [§6](#6-the-row-against-the-top-rung)). The row is
   reproduced, not contradicted. What looked like a 16 – 20% across-time failure is a
   16 – 20% *level* difference between two single runs, each honest.
 - **The 2026-08-08 run cannot be adjudicated by the level witness, and not by accident.**
@@ -181,6 +183,32 @@ None of which is an inference. `alloc-9jrhi/pilot-rounds6-head-88411ed803.json` 
 committed six-round run of this arm, and the estimator returns **no value** for it on
 either segment, for exactly this reason.
 
+**ADDED 2026-08-21 (`rf2-nkeba`) — the witness was run on the 2026-08-08 dataset itself,
+and the refusal is over-determined.** The paragraphs above reason from a *2026-08-08-shaped*
+run and a six-round proxy. Pointing the landed witness at `alloc-2rtt6-138/run1.json`
+directly returns **exit 1**, `REFUSED [level-window]` on both segments, `n = 0` in **both**
+halves:
+
+| | `reagent-subs` | `uix-subs` |
+|---|---|---|
+| certified windows, rounds 1 – 5 (`BEFORE`) | 0 | 0 |
+| certified windows, rounds ≥ 6 (`AFTER`) | 0 | 0 |
+
+The round count is therefore **not the binding ground**, and the clause that actually
+fires is the earlier one — `BEFORE`, not `AFTER`. `inWindow` requires
+`r.certified && typeof r.legMedian === 'number'`, and **the 2026-08-08 arm records carry
+neither field**. Over all **132 arm records** in the dataset — 22 arms × 6 rounds — the
+union of keys is `arm`, `boundaries`, `cdpBracket`, `endpoints`, `fall`, `falls`,
+`headroom`, `maskable`, `maxStep`, `perBoundaryPerWrite`, `perWrite`, `reads`, `rise`,
+`rung`, `segment`, `text`: run-level scalars only, with no `legMedian`, no `certified`,
+no `legs` and no `samples`. The window predates the per-window certificate, which is what
+PR #8434 established from the other side. So a
+2026-08-08 run extended to eighteen rounds would still be refused, unchanged. This
+strengthens the section's conclusion rather than qualifying it: the run is out of the
+witness's reach by the *shape of its record*, which no re-analysis can repair, and not
+merely by stopping one round early. That is why the lesson under [Limits](#limits) is
+`rf2-erre5`'s — *retain the per-window samples* — and not *run more rounds*.
+
 ## 5. Placement inside the envelope
 
 Every certified per-round `legMedian` from the 69 admissible runs, against the six
@@ -198,7 +226,26 @@ shortfall of 4,034 – 5,018 B, it is an order of magnitude smaller.
 
 ## 6. The row against the top rung
 
-Eight conversions, all against `armed-13`'s estimator at the same substrate revision:
+~~Eight conversions~~ **Eight conversion variants per segment**, all against `armed-13`'s
+estimator at the same substrate revision:
+
+> **CORRECTED 2026-08-21 (merged-PR audit of PR #8540).** As landed, the answer-first
+> bullet called these *"eight independent conversions"* and the close record said they
+> shared *"no term but `rise`"*. **They are not eight independent conversions.** The
+> sixteen rows are **eight variants per segment from two families**: four reuse
+> `(rise − maxStep) / 5` and four reuse `(rise − E) / 6`, each family under the same two
+> toggles — the round subset (rounds 1 – 5 or all rounds) and a fixed 192 B `gaps out`
+> adjustment, divided by that family's own divisor. Within a family the variants share
+> their whole estimator; every variant additionally shares the one six-round source record
+> and the one top-rung comparator. **It is the two families, and only they, that share no
+> term but `rise`** — exactly as [Limits](#limits) says, and as §2 says above.
+>
+> **No derived value changes and no disposition changes.** The `2 – 373 B` spread, the
+> consistent sign, the retirement of the across-time clause and the NOT-COMPARABLE
+> markings all stand. What is withdrawn is the *degree of corroboration* the word
+> "independent" claimed for them: eight agreeing variants of two estimators is weaker
+> evidence than eight agreeing estimators would have been, and the placement rests on the
+> two families rather than on the sixteen cells.
 
 | segment | conversion | 2026-08-08 | top rung | delta | delta % |
 |---|---|---|---|---|---|

--- a/docs/design/hicasso/studio/the-floor-certifies-and-the-control-does-not.md
+++ b/docs/design/hicasso/studio/the-floor-certifies-and-the-control-does-not.md
@@ -207,7 +207,8 @@ the certified readings are still ≈ 3.1 – 3.6 KB below that.
 > care in running it could have made it decide.
 >
 > Placed on that ladder the 2026-08-08 target lands on the **top rung** to within
-> **2 – 373 B** (0.01 – 1.60%) across eight conversions, so the two readings in
+> **2 – 373 B** (0.01 – 1.60%) across eight conversion variants per segment drawn from
+> two partially independent families, so the two readings in
 > this table are **both correct** — one of the arm's top rung, one of its low
 > rung. **Every reading this window took stands exactly as taken**, and so does
 > the sentence below: the across-time half is not discharged and rows measured


### PR DESCRIPTION
Closes the merged-PR audit item that reopened `rf2-nkeba`, and records a source-located
**refusal** of the measurement window the dispatch proposed.

## The dispatch's premise did not hold, and it was checked rather than assumed

The brief asked me to use the now-armed within-run **level witness** to attack "which of
the two readings moved". **The witness cannot reach the 2026-08-08 reading**, and this is
measured rather than argued. Pointing the landed witness at the dataset itself:

```
node hicasso/test/re_frame/bench/hicasso/alloc_level_witness.cjs \
     hicasso/test/re_frame/bench/hicasso/data/alloc-2rtt6-138/run1.json
```

returns **exit 1**, `REFUSED [level-window]` on **both** segments, `n = 0` in **both**
halves. Two independent grounds, either sufficient:

- `alloc_level_witness.cjs:252-253` — `inWindow` requires `r.certified && typeof
  r.legMedian === 'number'`. Over all **132 arm records** in that dataset the union of
  keys is `arm, boundaries, cdpBracket, endpoints, fall, falls, headroom, maskable,
  maxStep, perBoundaryPerWrite, perWrite, reads, rise, rung, segment, text` — **no
  `legMedian`, no `certified`, no `legs`, no `samples`.**
- `AFTER_ROUND_MIN = 6`, and the run holds rounds 0 – 5.

The first ground is the one that actually fires, and it is the stronger: a 2026-08-08 run
extended to eighteen rounds would still be refused. **No bench window was taken, no
browser launched, no rig file touched, and no new allocation figure is published.**

## What the bead's obligation actually is

`bd show` read in tracker-timestamp order, plus the tracker export's own history, place it
precisely. The bead was **closed 2026-08-20 21:12 AUSEST** by PR #8540 with the
disposition it was held open for, then **reopened at 23:05** — in commit
`8b45177859f3d8d97a2dc93453aa82550bb3ae1d`, a `chore(beads): checkpoint`. That is not the
known JSONL-revert artefact: exactly one bead regressed in that commit and it carries a
written reason, a **merged-PR audit of PR #8540**:

> REOPENED for overstating evidentiary independence, not for changing the arithmetic or
> disposition. […] **ACCEPTANCE:** relabel the headline/table discussion as eight
> conversion variants across two partially independent families (or equivalent precise
> wording), and ensure the eventual close record makes the same distinction.

The audit's claim verifies at source, to the byte. The sixteen rows are **eight variants
per segment from two families**: four reuse `(rise − maxStep) / 5`, four reuse
`(rise − E) / 6`, each under the same two toggles — round subset, and a fixed 192 B
`gaps out` adjustment divided by that family's own divisor (`192/5 = 38.4` in the
`maxStep` family, `192/6 = 32.0` in the `E` family, which is exactly the delta between
each paired row). Every variant additionally shares the one six-round source record and
the one top-rung comparator.

## What changed

- **`the-2026-08-08-row-is-the-arms-top-level.md`** — the answer-first bullet's "eight
  independent conversions" struck and corrected; a dated `CORRECTED` block under §6 in the
  corpus's existing form; §4 strengthened with the measured refusal above.
- **`allocation-instrument-rework.md`**, **`the-floor-certifies-and-the-control-does-not.md`**
  — the same phrase in their pointer blocks brought into line.

**No derived value moves and no disposition moves.** The `2 – 373 B` spread, the consistent
sign, the retirement of the across-time clause and every NOT-COMPARABLE marking stand
exactly as landed. What is withdrawn is the *degree of corroboration* the word
"independent" claimed. **Nothing is widened** — no threshold, tolerance or budget moves.

## One item deliberately left for the mayor

`docs/design/hicasso/studio/README.md:126` carries the same **"across eight conversions
sharing no term but `rise`"** in its ledger row for this page. It is **not touched here**:
`worker/ladder-onozm` holds that file on open PR #8591. It needs the same one-phrase
relabel once #8591 lands.

## Quality gates

Captured with `cmd > log; echo $? > exit` on one command line — every number below is the
one I captured, never a harness-reported one. Artefacts named per worktree and per attempt.

| gate | captured exit |
|---|---|
| `scripts/check_doc_slugs.py` | **0** |
| `scripts/check_doc_slugs.py` — **SABOTAGE** | **1**, naming the planted anchor |
| `scripts/check_provenance_pins.py --changed-since origin/main` | **0** (3 pages, 13 pins, 13 landed, 0 findings) |
| `scripts/check_provenance_pins.py --self-test` | **0** |
| `scripts/check_allocation_non_claim.py` | **0** |
| `scripts/check_readme_links.py --ci` | **0** |
| `alloc_level_witness.cjs --self-test` | **0** (36/36 fixtures) |
| `alloc_ladder_placement.cjs` | **0** — every figure on the record page re-derives at the tip |

**Which tree the gate read**, by the planted-fault route: a broken anchor planted at a line
this PR edits took `check_doc_slugs.py` to exit 1 naming
`#6-the-row-against-the-top-rung-SABOTAGE`. The fault existed only in this worktree, so a
run that had wandered into a sibling's would have come back green. Restore verified by the
identical **blob** hash `0c746b9e27be0fb232f07e2079b74178bb1703c9`, before the plant and
after it.

**Hand checks**, because no gate covers prose, tables or rendering: **24 tables** across the
3 changed files, **0 column mismatches** (counted with escaped `\|` honoured — a naive
counter reports two false positives on pre-existing tables in the-floor-certifies page).
Both anchors introduced (`#6-the-row-against-the-top-rung`, `#limits`) resolve, confirmed by
the gate and by the sabotage run.

Re-run on the final base after rebasing past `origin/main` `da99b9e10b`. Merge-base
(three-dot) diff read before pushing: 53 insertions, 4 deletions, three files, **nothing
reverted** — every deletion is a phrase struck in place with `~~…~~` beside its correction.
