### PR TITLE
docs(hicasso): gate 1's population half has closed for U1 and U2 (rf2-85og2)

### DIFF
--- a/docs/design/hicasso/product/budgets.md
+++ b/docs/design/hicasso/product/budgets.md
@@ -817,6 +817,37 @@ window**. `U1`–`U4` and `C3`/`C4` stay `UNPINNED`, and
 [§9.4](#94-what-rf2-hic-071-has-taken-so-far-and-what-it-still-cannot-take)
 carries the full record of both gaps and which of them closed.
 
+**[Amended 2026-08-21, `rf2-85og2`. No row moves, no reading was taken, and
+nothing here is a figure.]** The population gap has closed for two of those six
+rows and stands for the other four. `rf2-xa8wo`'s second deliverable landed as
+PR #8589:
+`implementation/hicasso/test/re_frame/bench/hicasso/slice_echo_clock_app.cljs`,
+whose `window!` starts at a real DOM event on a node the application rendered
+and stops in the first task after the frame carrying the echo has been through
+its rendering steps — a `requestAnimationFrame` callback with a `setTimeout 0`
+inside it — with no `flushSync` anywhere in its code. It mounts the slice
+through `re-frame.hicasso`'s own `h/mount!`, with the application's own views
+and its own initial events, so it is pointed at the package on the test
+[§9.4](#94-what-rf2-hic-071-has-taken-so-far-and-what-it-still-cannot-take)
+spells out, and its population is a witness application under
+`implementation/hicasso/test/re_frame/hicasso/examples/` rather than a synthetic
+bench page. **So the paragraph above is a true record of the two drivers it
+names and is no longer a true statement about this lane.**
+
+**What that leaves is a smaller set than the six, and the driver states it
+rather than leaving it to be discovered.** Its `:keystroke` arm is `U1`'s
+estimand — *latency to visible echo* on a controlled update — and an instance
+of `U2`'s; its `:toggle` arm is `U2`'s on a second event path. So `U1` and `U2`
+have an instrument on their governed population and want only their own quiet
+window. `U3` and `U4` do not: `U3` is a **broad** operation needing preparation
+outside the window, because the route the editor rows type into is the route a
+navigation row would leave, and `U4` is a run of consecutive frames whose
+estimator is a distribution over frame intervals rather than over window
+lengths. Both want another driver on the same mechanism. `C3` and `C4` are
+comparative against the best relevant adapter and this driver carries no donor
+arm at all — its four rows are a floor, two Hicasso interactions and a positive
+control. **All six rows keep `UNPINNED`, and nothing here decides one.**
+
 ### The §6 user-visible budgets
 
 Transcribed with their estimands. All are P-DEV-1-only and all inherit §1's
@@ -1616,6 +1647,15 @@ or `C5` changes with it.
   and a `p95` over the wrong population is worse than none, being quotable.
   [§4 states the corrected condition in full](#the-package-resident-clock-instrument-and-what-it-is-still-missing);
   the run itself is still a quiet window rather than an edit.
+  **[Amended 2026-08-21, `rf2-85og2`. All six rows still keep the status they
+  had.]** That driver has landed — PR #8589's slice interaction-to-paint clock
+  — so the condition this bullet states is met for `U1` and `U2`, which now
+  want only their own quiet window. It is **not** met for `U3`, `U4`, `C3` or
+  `C4`, and what blocks those four is no longer the window's shape but the
+  arms: the landed driver takes one discrete interaction through to one paint
+  and carries no donor arm.
+  [§4 carries the corrected condition](#the-package-resident-clock-instrument-and-what-it-is-still-missing)
+  rather than a second copy of it here.
 - **The 5% rule has no same-instrument anchor.** `C1` compares a reading
   against the pinned ordinary-Hicasso benchmark, and §6 records that the
   registered instrument's eleven pinned blobs are superseded rather than
@@ -2202,3 +2242,85 @@ positive control in both directions, because a search that returns zero and a
 search that looks nowhere print the same thing. **Neither refusal is about box
 quietness and no quiet-box time was spent on either**; the cheap source checks
 were taken before the first invocation.
+
+**[Re-tested at source 2026-08-21, `rf2-85og2`. NO window and NO bench run was
+taken — the machine was carrying another worker's heavyweight lane, and a
+reading taken beside one measures the fleet rather than the library. No status
+moves, no count moves, no threshold is guessed and no band is widened.]** One of
+the two standing refusals has expired in part, and the part that expired is not
+the part the row titles would suggest.
+
+**Gate 1 splits, and `U1`/`U2` now part company with `U3`/`U4` and `C3`/`C4`.**
+The population half — the half the 2026-08-19 entry above calls the one that
+governs — has closed for the first two.
+[§4's amendment](#the-package-resident-clock-instrument-and-what-it-is-still-missing)
+carries the corrected condition and the source for it; in one line, PR #8589
+landed a driver in the bench tree that requires the slice application's own
+`events`, `routes` and `views`, mounts it through `h/mount!`, and brackets a
+real DOM event through to the first task after the carrying frame's rendering
+steps. So both sentences the entry above rests on are now false at the tip: a
+driver under `implementation/hicasso/test/re_frame/bench/` **does** require
+something under `re-frame.hicasso.examples`, and that driver's window is **not**
+a `flushSync` commit. `U3`, `U4`, `C3` and `C4` are untouched by it, for the
+reason §4 records — the arms, not the window.
+
+**But there is no gate here to build, and that is a finding rather than a
+shortfall.** The obvious next move on a cleared ground is to write the check
+that enforces the row, and for `U1` and `U2` that move is forbidden by this
+page's own routing: [§7](#7-where-each-row-is-enforced) sends every
+distributional row to *pinned interleaved evidence runs on P-DEV-1* and says in
+terms that they are **never converted into flaky PR thresholds**;
+[§9.1](#91-how-to-read-a-row) says a distributional row may never name the first
+lane at all; and the ledger gate enforces exactly that, refusing a distributional
+row quietly routed into a pull-request threshold. So the whole edit-shaped half
+of gate 1 for `U1` and `U2` **was** the instrument, and `rf2-xa8wo` built it.
+What remains is one quiet-box window and nothing else. A worker who "built the
+`U1`/`U2` gate" would have had to breach §7 to do it.
+
+**Gate 2 needs nothing further from this bead's edit-shaped half.** The
+2026-08-19 entry above took its three runs and the operator's ruling of the same
+date settled the status cell. `C1`'s blocker has changed in kind rather than
+lifted, from *"the same instrument" names nothing* to a second reading not yet
+taken across a change, and no edit produces that reading.
+
+**Gate 3 is refused again, on a census re-run at this tip.** Shipping view code
+under `implementation/hicasso/test/re_frame/hicasso/examples/` still carries
+exactly one `h/as-element` call — `ledger/views.cljs`'s `:render-row`, the
+vendor-virtualizer boundary
+[§4's `C8` row](#the-comparative-and-regression-rules) places outside the
+population — and no `re-frame.hicasso.native` island anywhere under `examples/`.
+Both halves were controlled: `as-element` resolves in nine files under
+`implementation/hicasso/src/` and `native.cljc` exists there, so each name
+resolves and each absence is in the population rather than in the pattern.
+
+**One sentence in the 2026-08-19 `C8` entry above is wrong and is corrected
+here rather than over there, because that entry is dated.** It reads *Nothing
+under `examples/` mounts Hicasso either*. Six of the witness applications mount
+it from their own `app.cljs` — `editor`, `grid`, `ledger`, `slice`, `todo` and
+`typeahead` — and have since `2026-08-15`, so the sentence was already false
+when it was written. **`C8`'s conclusion is untouched by the correction**: the
+rule's population is escape sites taken for a benefit, not mounts, and that
+population is still empty.
+
+**A trigger the operator's 2026-08-19 ruling named has now fired, and it is a
+ruling rather than a worker's edit.** That ruling declined to mint a fifth
+ledger status for `C1`'s *anchored, instrument exists, awaiting a second
+reading*, ratified carrying the state in the row's annotation instead, and set
+an explicit condition: *if a second row ever reaches this state, reconsider —
+one instance is a note, a recurring class is a value*. `U1` and `U2` now sit in
+the same gap from the other side. `UNPINNED` is defined at
+[§9.1](#91-how-to-read-a-row) as *no instrument for it exists on the governed
+population*, and for these two an instrument on the governed population now
+does exist, while `MET` would record a verdict no reading has reached. **Their
+cells are deliberately not moved** — that is what the ruling instructs by
+default, and disclosure here tells a reader strictly more than a new one-word
+status would. The ledger is unchanged at 49 rows, 31 `MET`, 5 `BREACH`, 3
+`UNRESOLVED` and 10 `UNPINNED`.
+
+**What this bead still owes, after this pass.** One quiet-box window on the
+slice clock for `U1` and `U2`, which is now the only measurement standing
+between those two rows and a verdict. A second driver, on the same mechanism
+and not yet written, before `U3` and `U4` can be reached at all, and a donor
+arm beside it before `C3` and `C4` can. One comparison window across a change
+for `C1`. And for `C8`, a landed site, which no amount of machine time
+supplies.


### PR DESCRIPTION
Re-tested `rf2-85og2`'s three standing refusals at source. **No measurement window and no bench run was taken**, and that is deliberate: another worker's heavyweight lane held this box, two heavyweight runs on one machine wedge rather than fail, and a reading taken beside one measures the fleet rather than the library. This is phase 1 of two — re-test the grounds, build any gate whose ground has cleared. A later dispatch takes the window.

**No status moved, no ledger count moved, no threshold was guessed and no band was widened.** The ledger stands at 49 rows, 31 `MET`, 5 `BREACH`, 3 `UNRESOLVED`, 10 `UNPINNED`. The diff is 122 insertions and 0 deletions.

## What each of the three grounds did

**Ground 1 — CLEARED IN PART, and the split is the finding.** PR #8589 landed `slice_echo_clock_app.cljs`, which requires the slice application's own `events`, `routes` and `views`, mounts it through `re-frame.hicasso`'s `h/mount!`, and brackets a real DOM event through to the first task after the carrying frame's rendering steps (`requestAnimationFrame` with a `setTimeout 0` inside it; no `flushSync` in its code — all five occurrences of that name are prose contrasts). So both sentences the 2026-08-19 entry rested on are false at the tip. `U1` and `U2` now have an instrument on their governed population. `U3`, `U4`, `C3` and `C4` do not, and what blocks those four is the **arms** rather than the window: the driver's own docstring states `U3` and `U4` are not served, and its four rows are a floor, two Hicasso interactions and a positive control — no donor arm for a comparative rule.

**"Package-resident" was checked against the corpus rather than assumed.** §9.4 defines it as what the instrument is *pointed at*, never where its code ships. The driver sits in the bench tree and is pointed at the package, which is the same axis §4's *package figure* column already sorts on.

**No gate was built for `U1`/`U2`, because building one would breach §7.** This is the substantive result. §7 routes every distributional row to *pinned interleaved evidence runs on P-DEV-1* and forbids converting one into a PR threshold; §9.1 says such a row may never name the first lane; `check_budget_ledger.py` enforces exactly that. The entire edit-shaped half of gate 1 **was** the instrument, and `rf2-xa8wo` built it. What remains is one quiet-box window and nothing else.

**Ground 2 — CLEARED, and already discharged by an earlier window** (PR #8516, 2026-08-19), with the operator's ruling of the same date settling the status cell. `C1`'s blocker changed in kind rather than lifting: from *"the same instrument" names nothing* to a second reading not yet taken across a change. No edit produces that reading. Nothing here for this pass.

**Ground 3 — STILL REFUSED**, re-derived at this tip. Exactly one `h/as-element` in shipping example view code (`ledger/views.cljs`'s `:render-row`, the vendor-virtualizer boundary the rule itself places outside the population) and no `re-frame.hicasso.native` island under `examples/`. Controlled in both directions: `as-element` resolves in nine files under `implementation/hicasso/src/` and `native.cljc` exists there, so each name resolves and each absence is in the population rather than in the pattern.

## Two things surfaced that need a reader rather than a worker

**A factual error corrected.** The dated 2026-08-19 `C8` entry says *Nothing under `examples/` mounts Hicasso either*. Six witness applications mount it from their own `app.cljs` — `editor`, `grid`, `ledger`, `slice`, `todo`, `typeahead` — and have since 2026-08-15, so the sentence was already false when written. Corrected beside the dated record rather than over it. **`C8`'s conclusion is untouched**: its population is escape sites taken for a benefit, not mounts, and that population is still empty.

**The operator's 2026-08-19 reconsider trigger has fired.** That ruling declined to mint a fifth ledger status for `C1` and set a condition: *if a second row ever reaches this state, reconsider*. `U1` and `U2` now sit in the same gap — `UNPINNED` means *no instrument exists on the governed population* and one now does, while `MET` would record a verdict no reading reached. **Their cells are deliberately not moved**, which is what the ruling instructs by default. Minting a fifth value is a ruling, not a worker's edit.

## Quality gates

**No window, no bench run, no browser run, no fast-PR spine.** Targeted gates were run directly, each redirected to its own log with the runner's exit code echoed on the same command line and quoted below.

| Gate | Captured exit |
|---|---:|
| `scripts/check_doc_slugs.py` | `0` |
| `scripts/check_provenance_pins.py --changed-since origin/main` | `0` |
| `implementation/hicasso/scripts/check_budget_ledger.py` | `0` |
| `implementation/hicasso/scripts/check_budget_ledger.py --self-test` | `0` (49 rows: 31 MET, 5 BREACH, 3 UNRESOLVED, 10 UNPINNED) |

**Both prose gates were proved to reach this worktree by a planted fault, not by their banner.**

- `check_doc_slugs.py`: a broken anchor planted on a line this branch adds → **exit 1**, naming `#91-how-to-read-a-row-PLANTED-FAULT`. Restored; the identical blob hash `048ed71bd430917eba05f5b40485e0ed21253511` before the plant and after the restore, against the committed object.
- `check_provenance_pins.py`: a fabricated 40-hex commit token planted in commit-flavoured prose → **exit 1**, `[UNRESOLVABLE]`. Restored to the identical blob hash `048ed71bd430917eba05f5b40485e0ed21253511`. Its `--changed-since origin/main` run reports *1 page inspected*, which is this branch's only changed page.

Match counts were read before each plant (`1` each), so neither was a silent no-op.

**Hand checks, because nothing validates prose, tables or rendering.** The diff adds **zero** table rows and **zero** fenced blocks, so there are no column counts to verify and — importantly — the edit is entirely prose, which is the one condition under which both link gates actually see it (they strip fences before reading). All five anchors the diff introduces resolve to headings in this file, confirmed by the slug gate and by hand for the one fresh target, `#7-where-each-row-is-enforced` (heading at line 1203).

`mkdocs build --strict` is **not** nominated: `exclude_docs` keeps `docs/design/**` out of the site.

For the spine-versus-CI gap, `scripts/check_fast_pr_gap.py --list` reports **94** required checks the fast-PR spine does not decide. That is a fact about the spine, not a census of what ran here: **the spine was not run at all**, and the four gates above were invoked directly.

## Bead

`rf2-85og2` stays **OPEN**. It still owes: one quiet-box window on the slice clock for `U1`/`U2`; a second driver plus a donor arm before `U3`, `U4`, `C3` and `C4` can be reached; one comparison window across a change for `C1`; and for `C8` a landed site, which no machine time supplies.
