### PR TITLE
feat(bench): three allocation-rig arms in one change — a parity-free pass order, a reversed fixed arm, and box provenance (rf2-fk6pj, rf2-csca8, rf2-24o2z)

### DIFF
--- a/implementation/core/test/re_frame/bench/p0_ladder_structural.test.cjs
+++ b/implementation/core/test/re_frame/bench/p0_ladder_structural.test.cjs
@@ -39,6 +39,7 @@
 const assert = require('node:assert');
 const { spawnSync } = require('node:child_process');
 const fs = require('node:fs');
+const os = require('node:os');
 const path = require('node:path');
 
 const DRIVER = path.join(__dirname, 'p0_run.cjs');
@@ -68,6 +69,21 @@ const {
   // The confound-breaking segment order (rf2-rs8q6), pure and driven below.
   allocSegmentOrder,
   ALLOC_SEG_ORDERS,
+  // The write-leg order (rf2-fk6pj), pure and driven below for the reason the
+  // two either side of it are: what it changes is a property of a SEQUENCE of
+  // rounds, and the property that matters most — that a `seeded` schedule is
+  // not a function of round parity — is not readable off a ternary.
+  allocSeedHash,
+  allocSeedRandom,
+  allocPassFlips,
+  allocPassOrder,
+  ALLOC_PASS_ORDERS,
+  // The box provenance riders (rf2-24o2z), pure of the run and driven below.
+  boxSnapshot,
+  boxBusyFraction,
+  boxSessionOpen,
+  boxSessionClose,
+  boxRecord,
   // And the control slot (rf2-rs8q6), pure and driven below for the same
   // reason: what it moves is a property of a SEQUENCE of rounds.
   allocControlIndex,
@@ -2359,7 +2375,7 @@ test('THE SEGMENT ORDER — `parity` is the default and `fixed` breaks the confo
       allocSegmentOrder(plan, r, mode).map((s) => s.segment)
     );
 
-  assert.deepStrictEqual(ALLOC_SEG_ORDERS, ['parity', 'fixed']);
+  assert.deepStrictEqual(ALLOC_SEG_ORDERS, ['parity', 'fixed', 'fixed-reversed']);
   assert.strictEqual(constUnderEnv('ALLOC_SEG_ORDER', { P0_ALLOC_SEG_ORDER: '' }), 'parity');
   assert.strictEqual(
     constUnderEnv('ALLOC_SEG_ORDER', { P0_ALLOC_SEG_ORDER: 'fixed' }),
@@ -2403,6 +2419,358 @@ test('THE SEGMENT ORDER — `parity` is the default and `fixed` breaks the confo
     repeats('fixed').every((x) => x.repeat === false),
     'and under `fixed` no window repeats its predecessor, at either position'
   );
+});
+
+// --- AND THE ARM `fixed` ALONE CANNOT SUPPLY (rf2-csca8) -------------------
+//
+// Inside a `fixed` run the substrate and the within-round position are
+// perfectly confounded: with the plan as shipped, `uix-subs` is position 1 in
+// every `fixed` window there has ever been, so the 8-of-38 cluster is equally
+// consistent with "uix under `fixed`" and with "the SECOND-driven arm under
+// `fixed`". PR #8593 refuted POSITION on 3,140 windows and found SUBSTRATE
+// associated but not necessary, which leaves the MODE — and no committed run
+// puts uix at position 0 while HOLDING THE MODE CONSTANT.
+//
+// `fixed-reversed` is that arrangement and nothing else, so the pin drives the
+// sequence and reads the three properties that make it the discriminator: it
+// is `fixed`'s orientation reversed, it is constant across rounds like `fixed`
+// rather than alternating like `parity`, and it puts the other substrate at
+// position 0 at EVERY round rather than at half of them.
+test('THE REVERSED FIXED ARM — `fixed`, held constant, in the other orientation', () => {
+  const plan = [{ segment: 'reagent-subs' }, { segment: 'uix-subs' }];
+  const seqOf = (mode, rounds) =>
+    Array.from({ length: rounds }, (_, r) =>
+      allocSegmentOrder(plan, r, mode).map((s) => s.segment)
+    );
+
+  assert.strictEqual(
+    constUnderEnv('ALLOC_SEG_ORDER', { P0_ALLOC_SEG_ORDER: 'fixed-reversed' }),
+    'fixed-reversed',
+    'the third arm is reachable by naming it'
+  );
+  has(
+    /drives the segments in one of \$\{ALLOC_SEG_ORDERS\.join\(' \| '\)\} order/,
+    'and the preflight names the roster rather than a hard-coded pair, so the ' +
+      'new arm is refused-by-name-or-accepted with no second edit'
+  );
+
+  // The same order EVERY round — the property that makes it `fixed`'s
+  // counterpart and not a second `parity`.
+  assert.deepStrictEqual(seqOf('fixed-reversed', 4), [
+    ['uix-subs', 'reagent-subs'],
+    ['uix-subs', 'reagent-subs'],
+    ['uix-subs', 'reagent-subs'],
+    ['uix-subs', 'reagent-subs'],
+  ]);
+
+  // And it is EXACTLY `fixed` reversed, driven rather than restated.
+  for (let r = 0; r < 6; r++) {
+    assert.deepStrictEqual(
+      allocSegmentOrder(plan, r, 'fixed-reversed').map((s) => s.segment),
+      allocSegmentOrder(plan, r, 'fixed')
+        .map((s) => s.segment)
+        .reverse()
+    );
+  }
+
+  // IT MAY NOT REORDER THE CALLER'S PLAN. `fixed` returns the shipped array
+  // itself; the reversed arm must return a copy, or the ladder plan every
+  // later round is handed would come back already reversed — a fault that
+  // would look exactly like a working mode for one round and then invert.
+  const before = plan.map((s) => s.segment);
+  allocSegmentOrder(plan, 0, 'fixed-reversed');
+  allocSegmentOrder(plan, 1, 'fixed-reversed');
+  assert.deepStrictEqual(plan.map((s) => s.segment), before, 'the plan is not reversed in place');
+
+  // THE PROPERTY THE ARM IS FOR: uix sits at position 0 in EVERY round under
+  // the reversed arm, at NO round under `fixed`, and at half of them under
+  // `parity` — which is the state of the corpus that made the mode unreadable.
+  const uixAtZero = (mode) => seqOf(mode, 8).filter((r) => r[0] === 'uix-subs').length;
+  assert.strictEqual(uixAtZero('fixed'), 0, 'the confound `fixed` builds in');
+  assert.strictEqual(uixAtZero('fixed-reversed'), 8, 'and the arm that breaks it');
+  assert.strictEqual(uixAtZero('parity'), 4, 'while parity supplies it under the OTHER mode');
+});
+
+// --- THE WRITE-LEG ORDER, AND THE PARITY TIE IT BREAKS (rf2-fk6pj) ---------
+//
+// rf2-0gjqi's paired window measured the SECOND pass of a round reading lower
+// than the first in 10 of 12 blocks, whichever write occupied it. The rig
+// cannot say why, because the leg order was `round % 2` — every page-first
+// round was an even round, so the pass-position term and every other
+// even/odd property of a round are one column. `seeded` draws the order from
+// a seed instead.
+//
+// EVERY PROPERTY BELOW IS A CLAIM ABOUT A WHOLE RUN'S SCHEDULE and none is
+// readable off the source, so the pin DRIVES the draw:
+//
+//   - `parity` is the pre-bead expression, round for round, so no committed
+//     corpus is reinterpreted;
+//   - a `seeded` schedule is BALANCED, because an unbalanced one would trade
+//     the parity tie for the write/position confound the alternation exists
+//     to remove;
+//   - a `seeded` schedule is NOT a function of round parity, which is the
+//     entire deliverable;
+//   - the same seed gives the same schedule, which is what makes a `seeded`
+//     window re-readable rather than a one-shot.
+const LEGS = [{ selector: 'page' }, { selector: 'all' }];
+const legSeqOf = (mode, rounds, schedule) =>
+  Array.from({ length: rounds }, (_, r) =>
+    allocPassOrder(LEGS, r, mode, schedule).map((l) => l.selector).join('>')
+  );
+
+test('THE LEG ORDER — `parity` is the default and is the pre-bead rule, round for round', () => {
+  assert.deepStrictEqual(ALLOC_PASS_ORDERS, ['parity', 'seeded']);
+  assert.strictEqual(constUnderEnv('ALLOC_PASS_ORDER', { P0_ALLOC_PASS_ORDER: '' }), 'parity');
+  assert.strictEqual(
+    constUnderEnv('ALLOC_PASS_ORDER', { P0_ALLOC_PASS_ORDER: 'seeded' }),
+    'seeded',
+    'the parity-breaker is reachable by naming it'
+  );
+  assert.strictEqual(constUnderEnv('ALLOC_PASS_ORDER', { P0_ALLOC_PASS_ORDER: 'praity' }), 'praity');
+  has(/unknown P0_ALLOC_PASS_ORDER/, 'and the preflight refuses a mistyped order BY NAME');
+
+  // THE DEFAULTS-UNCHANGED PROOF, and it is the load-bearing assertion of this
+  // whole change: the shipped function under the default mode must produce the
+  // expression that stood in the round loop before it, ROUND FOR ROUND, over a
+  // range wider than any run takes. Anything else silently reinterprets every
+  // committed corpus.
+  const preBead = (round) => (round % 2 === 0 ? LEGS : [...LEGS].reverse());
+  for (let r = 0; r < 64; r++) {
+    assert.deepStrictEqual(
+      allocPassOrder(LEGS, r, 'parity', allocPassFlips(6, 'ignored-under-parity')).map(
+        (l) => l.selector
+      ),
+      preBead(r).map((l) => l.selector),
+      `round ${r}: \`parity\` must be the expression that stood in the loop`
+    );
+  }
+  // Even rounds hand back the CALLER'S array, not a copy — the pre-bead
+  // expression did, and the pass loop below it takes the legs by identity.
+  assert.strictEqual(allocPassOrder(LEGS, 0, 'parity', null), LEGS);
+  assert.strictEqual(allocPassOrder(LEGS, 2, 'parity', null), LEGS);
+
+  // A ONE-LEG RUN IS INERT UNDER BOTH MODES, which is what makes `page` and
+  // `all` — the selections every floor corpus is taken under — untouched by
+  // this change whatever the operator sets.
+  const one = [{ selector: 'page' }];
+  for (const mode of ALLOC_PASS_ORDERS) {
+    for (let r = 0; r < 8; r++) {
+      assert.deepStrictEqual(
+        allocPassOrder(one, r, mode, allocPassFlips(8, 'seed')).map((l) => l.selector),
+        ['page'],
+        'off `paired` there is one leg and no order to flip'
+      );
+    }
+  }
+});
+
+test('THE LEG ORDER — a `seeded` schedule is balanced, parity-free and reproducible', () => {
+  // BALANCED, at every round count a window might take. `parity` leads each
+  // leg exactly `floor(rounds / 2)` times; the draw must match it, or the
+  // write is confounded with the pass position — a worse column than the one
+  // being removed.
+  for (const rounds of [4, 5, 6, 8, 12, 20]) {
+    for (const seed of ['a', 'b', 'window-1', '12345', 'rf2-fk6pj']) {
+      const s = allocPassFlips(rounds, seed);
+      assert.strictEqual(s.flips.length, rounds);
+      assert.strictEqual(
+        s.flips.filter(Boolean).length,
+        Math.floor(rounds / 2),
+        `rounds=${rounds} seed=${seed}: the draw must be balanced exactly as parity is`
+      );
+      assert.strictEqual(s.parityTied, false, `rounds=${rounds} seed=${seed}`);
+    }
+  }
+
+  // NOT A FUNCTION OF ROUND PARITY — the deliverable. Both parity schedules
+  // are rejected: the alternating one AND its complement. A draw that returned
+  // either would separate nothing while costing a full allocation window.
+  for (const rounds of [4, 6, 8, 12]) {
+    for (let i = 0; i < 40; i++) {
+      const { flips } = allocPassFlips(rounds, `probe-${rounds}-${i}`);
+      assert.ok(
+        !flips.every((f, r) => f === (r % 2 === 1)) && !flips.every((f, r) => f === (r % 2 === 0)),
+        `rounds=${rounds} probe ${i}: a parity schedule is exactly what this mode may not return`
+      );
+    }
+  }
+
+  // AND THE DRAW IS ACTUALLY VARYING, not one schedule wearing many seeds. A
+  // generator that returned a constant would pass every assertion above.
+  const drawn = new Set(
+    Array.from({ length: 40 }, (_, i) => allocPassFlips(6, `vary-${i}`).flips.join(''))
+  );
+  assert.ok(drawn.size > 3, `the draw must vary with the seed — saw ${drawn.size} distinct`);
+
+  // REPRODUCIBLE FROM THE RECORDED SEED. This is what `legSeed` in the record
+  // is for: the schedule is recoverable from nothing else.
+  for (const seed of ['rf2-fk6pj', '1755000000000', 'zz']) {
+    assert.deepStrictEqual(allocPassFlips(6, seed), allocPassFlips(6, seed));
+    assert.deepStrictEqual(allocPassFlips(6, seed), allocPassFlips(6, String(seed)));
+  }
+  // The seed is TEXT, so an operator may use a memorable one; the two
+  // primitives underneath it are deterministic and total.
+  assert.strictEqual(allocSeedHash('abc'), allocSeedHash('abc'));
+  assert.notStrictEqual(allocSeedHash('abc'), allocSeedHash('abd'));
+  const rand = allocSeedRandom(allocSeedHash('abc'));
+  const draws = Array.from({ length: 8 }, () => rand());
+  assert.ok(draws.every((x) => x >= 0 && x < 1), 'the generator stays inside [0, 1)');
+  assert.deepStrictEqual(
+    Array.from({ length: 8 }, allocSeedRandom(allocSeedHash('abc'))),
+    draws,
+    'and the same seed replays the same stream'
+  );
+
+  // THE SCHEDULE IS WHAT THE ROUND LOOP DRIVES, read off the leg sequence
+  // rather than the flips array — the two could drift and only this catches it.
+  const s = allocPassFlips(6, 'rf2-fk6pj');
+  assert.deepStrictEqual(
+    legSeqOf('seeded', 6, s),
+    s.flips.map((f) => (f ? 'all>page' : 'page>all'))
+  );
+  // And under `seeded` the sequence is NOT the parity sequence, at this seed
+  // or any other — the same claim as above, now at the call site.
+  assert.notDeepStrictEqual(legSeqOf('seeded', 6, s), legSeqOf('parity', 6, s));
+
+  // AT TWO ROUNDS OR FEWER THERE IS NO UNTIED SCHEDULE, and the draw says so
+  // rather than looping forever or returning a parity schedule under a name
+  // that says it is not one. The preflight turns that into a refusal.
+  //
+  // THE BOUNDARY IS DRIVEN, NOT ASSERTED FROM THE PROSE. It falls at three and
+  // not at four: the three-round balanced set is the three single-flip
+  // schedules and only one of them alternates, where at two rounds BOTH
+  // balanced schedules are parity schedules. This test read four on its first
+  // pass and the draw contradicted it.
+  for (const rounds of [0, 1, 2]) {
+    assert.strictEqual(
+      allocPassFlips(rounds, 'any').parityTied,
+      true,
+      `rounds=${rounds}: every balanced schedule this short IS a parity schedule`
+    );
+  }
+  for (const seed of ['a', 'b', 'c', 'd', 'e']) {
+    const s3 = allocPassFlips(3, seed);
+    assert.strictEqual(s3.parityTied, false, 'three rounds is the first count that can separate');
+    assert.strictEqual(s3.flips.filter(Boolean).length, 1, 'and it is balanced as parity is');
+  }
+  has(
+    /P0_ALLOC_PASS_ORDER=seeded over \$\{ALLOC_ROUNDS\} round\(s\) has no schedule/,
+    'and the preflight refuses a `seeded` run that cannot separate anything'
+  );
+
+  // A SCHEDULE SHORTER THAN THE RUN FALLS BACK TO PARITY rather than driving
+  // `undefined` — total, for the reason every other pure function here is.
+  const short = allocPassFlips(4, 'short');
+  assert.deepStrictEqual(legSeqOf('seeded', 6, short).slice(4), legSeqOf('parity', 6, short).slice(4));
+});
+
+// --- WHAT THE BOX WAS DOING, WHICH NO DATASET EVER SAID (rf2-24o2z) --------
+//
+// Three riders on the record, each free: the Chromium build string, the box's
+// load at window open, and the elapsed time since the previous run in the same
+// session. Nothing here measures anything inside a window, and the pin drives
+// all three without a build, a server or a Chromium.
+test('THE BOX RIDERS — a snapshot, a busy fraction and a session gap', () => {
+  const snap = boxSnapshot();
+  for (const k of ['at', 'loadavg', 'cpus', 'cpuIdleMs', 'cpuBusyMs', 'freeMemB', 'totalMemB']) {
+    assert.ok(k in snap, `the snapshot states ${k}`);
+  }
+  assert.ok(Date.parse(snap.at) > 0, 'and it is stamped');
+  assert.ok(snap.cpus > 0 && snap.totalMemB > 0, 'and it read a real machine');
+  // `loadavg` IS `[0, 0, 0]` ON WINDOWS, which is where these windows are
+  // taken, so the record states whether the number means anything. A rider a
+  // reader cannot tell apart from a genuinely idle box is not a rider.
+  assert.strictEqual(snap.loadavgSupported, process.platform !== 'win32');
+
+  // The busy fraction is a DIFFERENCE of two snapshots — the load the run
+  // saw — and is `null`, never a fabricated zero, where it cannot be taken.
+  assert.strictEqual(boxBusyFraction(null, snap), null);
+  assert.strictEqual(boxBusyFraction(snap, null), null);
+  assert.strictEqual(boxBusyFraction(snap, snap), null, 'a zero interval is not a zero load');
+  const busy = boxBusyFraction(
+    { cpuBusyMs: 1000, cpuIdleMs: 9000 },
+    { cpuBusyMs: 1300, cpuIdleMs: 9700 }
+  );
+  assert.strictEqual(busy, 0.3);
+
+  // THE SESSION, DRIVEN OVER A MARKER OF THE PIN'S OWN — never the shipped
+  // path, which carries the real state of whatever run last used this box.
+  const marker = path.join(
+    fs.mkdtempSync(path.join(os.tmpdir(), 'p0-box-pin-')),
+    'session.json'
+  );
+  // A first run has no marker and says so rather than inventing a gap.
+  const t0 = Date.parse('2026-08-21T00:00:00.000Z');
+  const first = boxSessionOpen(t0, marker);
+  assert.strictEqual(first.previousRun, null, 'no marker, no previous run');
+  assert.strictEqual(first.runsInSession, 1);
+  assert.strictEqual(first.sessionStartedAt, first.startedAt);
+  assert.strictEqual(boxSessionClose(first, '2026-08-21T00:30:00.000Z', marker), null);
+
+  // A second run 10 minutes later CONTINUES the session, and the two gaps are
+  // different quantities: since the previous run STARTED, and since it ENDED.
+  // The idle gap is the one rf2-6kxub's confirming move is defined on.
+  const t1 = Date.parse('2026-08-21T00:40:00.000Z');
+  const second = boxSessionOpen(t1, marker);
+  assert.strictEqual(second.runsInSession, 2);
+  assert.strictEqual(second.sessionStartedAt, first.startedAt, 'the session is the same one');
+  assert.strictEqual(second.previousRun.sameSession, true);
+  assert.strictEqual(second.previousRun.sinceStartMs, 40 * 60 * 1000);
+  assert.strictEqual(second.previousRun.sinceEndMs, 10 * 60 * 1000);
+  assert.strictEqual(boxSessionClose(second, '2026-08-21T01:00:00.000Z', marker), null);
+
+  // A run after a gap wider than the recorded threshold OPENS A NEW SESSION,
+  // and still states the gap — the previous run is not erased, only re-placed.
+  const t2 = Date.parse('2026-08-21T05:00:00.000Z');
+  const third = boxSessionOpen(t2, marker);
+  assert.strictEqual(third.runsInSession, 1, 'four hours is a new session at the 60-min default');
+  assert.strictEqual(third.sessionStartedAt, third.startedAt);
+  assert.strictEqual(third.previousRun.sameSession, false);
+  assert.strictEqual(third.previousRun.sinceEndMs, 4 * 60 * 60 * 1000);
+  // The threshold travels in the record, so an analysis may redraw the
+  // boundary from the raw timestamps instead of inheriting this one.
+  assert.strictEqual(third.sessionGapMs, 60 * 60 * 1000);
+
+  // A MALFORMED MARKER IS A MISSING ONE. A provenance rider may not refuse a
+  // window, and an unwritable path is reported rather than thrown.
+  fs.writeFileSync(marker, 'not json at all');
+  assert.strictEqual(boxSessionOpen(t2, marker).previousRun, null);
+  assert.ok(
+    typeof boxSessionClose(first, '2026-08-21T00:30:00.000Z', path.join(marker, 'nope', 'x.json')) ===
+      'string',
+    'an unwritable marker comes back as a message, not an exception'
+  );
+  fs.rmSync(path.dirname(marker), { recursive: true, force: true });
+
+  // AND THE RIDER AS IT APPEARS IN THE RECORD. A run that launched no browser
+  // says `null` for the two riders a launch supplies — which a reader must be
+  // able to tell apart from a launched run that found the box idle.
+  const empty = boxRecord({ session: first, chromium: null, open: null, close: null });
+  assert.strictEqual(empty.chromium, null);
+  assert.strictEqual(empty.load.open, null);
+  assert.strictEqual(empty.load.busyFraction, null);
+  assert.strictEqual(empty.session.runsInSession, 1);
+  const full = boxRecord({
+    session: second,
+    chromium: 'chromium/140.0.7339.16',
+    open: { cpuBusyMs: 1000, cpuIdleMs: 9000 },
+    close: { cpuBusyMs: 1300, cpuIdleMs: 9700 },
+  });
+  assert.strictEqual(full.chromium, 'chromium/140.0.7339.16');
+  assert.strictEqual(full.load.busyFraction, 0.3);
+  assert.match(full.platform, /\//, 'and the platform is stated too');
+
+  // THE MARKER PATH IS NOT IN THE RECORD. A dataset is committed and the
+  // shipped marker lives under a home directory; the gaps travel, the path
+  // does not.
+  assert.ok(!JSON.stringify(full).includes(os.tmpdir()), 'no machine path rides into a dataset');
+
+  // AND THE DRIVER FILLS IT WHERE THE EVIDENCE SURVIVES A REFUSAL, beside the
+  // raw write rather than inside the try that a failed gate leaves early.
+  has(/out\.box = boxRecord\(\);/, 'the record carries the rider');
+  has(/if \(BOX\.open === null\) BOX\.open = boxSnapshot\(\);/, 'and the load is read at the launch');
+  has(/BOX\.chromium = `\$\{browser\.browserType\(\)\.name\(\)\}\/\$\{browser\.version\(\)\}`;/,
+    'and the build string comes off the launched browser');
 });
 
 // --- THE CONTROL SLOT, AND WHICH SLOT ACTUALLY SEPARATES (rf2-rs8q6) -------
@@ -2912,9 +3280,17 @@ test('the DRIVER honours both switches — the write, the plan, and the record',
   // `:cells` at `cells-n` and a page leg following it on an unseeded frame
   // would rebuild 300 cells and BE the bulk write, reading back correctly and
   // saying nothing.
+  // AND THE RULE IT ALTERNATES UNDER IS A MODE NOW (rf2-fk6pj), so the pin
+  // reads the CALL rather than the ternary that stood here. `parity` is still
+  // the default and `allocPassOrder` is still the same expression under it —
+  // both driven, not matched, in the leg-order test below.
   has(
-    /const legs = round % 2 === 0 \? ALLOC_WRITE_LEGS : \[\.\.\.ALLOC_WRITE_LEGS\]\.reverse\(\);/,
-    'the leg order alternates on round parity'
+    /const legs = allocPassOrder\(ALLOC_WRITE_LEGS, round, ALLOC_PASS_ORDER, ALLOC_PASS_SCHEDULE\);/,
+    'the leg order comes from the shipped rule, whichever mode this run drives'
+  );
+  lacks(
+    /const legs = round % 2 === 0 \?/,
+    'and no parity ternary survives beside it, which would pin the loop to one mode'
   );
   has(
     /const passes = segs\.flatMap\(\(\{ segment, arms \}\) =>\s*legs\.map\(\(leg\) => \(\{ segment, arms, leg \}\)\)\s*\);/,

--- a/implementation/core/test/re_frame/bench/p0_run.cjs
+++ b/implementation/core/test/re_frame/bench/p0_run.cjs
@@ -153,6 +153,7 @@
 const { spawnSync } = require('node:child_process');
 const fs = require('node:fs');
 const http = require('node:http');
+const os = require('node:os');
 const path = require('node:path');
 
 // One build id, N programs, so nothing may cache between them (rf2-2rtt6.20).
@@ -191,6 +192,201 @@ const ONLY = (() => {
   const i = process.argv.indexOf('--only');
   return i === -1 ? null : process.argv[i + 1];
 })();
+
+// ---------------------------------------------------------------------------
+// WHAT THE BOX WAS DOING, WHICH NO DATASET HAS EVER SAID (rf2-24o2z)
+// ---------------------------------------------------------------------------
+//
+// rf2-6kxub measured the floor arm's high-mode RATE tracking ELAPSED TIME
+// WITHIN A SESSION — 0/6 at 8.2 min, 1/8 at 14.9, 2/20 at 19.7, 37/69 at 88.3,
+// with a within-session gradient at one-tail p = 0.0198 on a boundary-free
+// Mann-Whitney. That locates the rate on elapsed-time-within-session and NAMES
+// NO MECHANISM: thermal state, V8 tier accumulation and heap fragmentation
+// over a long session all survive it equally, and across sessions the duration
+// is confounded with the date and the clock time.
+//
+// IT WAS ANSWERABLE AT ALL ONLY BECAUSE `generatedAt` HAPPENED TO BE IN THE
+// RECORD. Nothing else about the machine is. Three more riders of exactly that
+// kind cost the runner nothing and convert the NEXT window into evidence about
+// the rate rather than another instance of it:
+//
+//   - the CHROMIUM BUILD STRING, which playwright pins and no dataset states.
+//     Two windows taken weeks apart may be two different V8s, and the tier-up
+//     account is a claim about V8;
+//   - the BOX'S LOAD at window open, and again at close, which is the only one
+//     of the three that can be read against thermal or contention accounts;
+//   - the ELAPSED TIME SINCE THE PREVIOUS RUN in the same session, which is
+//     the axis the gradient was measured on and which a single record cannot
+//     currently place itself on at all.
+//
+// THIS IS THE CHEAP MOVE AND DELIBERATELY NOT THE OTHER ONE. rf2-6kxub's own
+// note holds that the same-plan cold / hot / after-an-idle-gap variation is
+// the CONFIRMING second move and must not be taken first. Nothing here varies
+// anything: it records.
+//
+// AND IT MEASURES NOTHING INSIDE A WINDOW. Every reading below is taken from
+// `node:os` outside any measured window — at the first browser launch and once
+// more when the record is written — so it cannot perturb a byte of what the
+// row publishes.
+//
+// `loadavg` IS NOT ENOUGH ON ITS OWN, and the reason is the box this
+// instrument runs on. Node's `os.loadavg()` is `[0, 0, 0]` on Windows, which
+// is where these windows are taken, so a record carrying only that would carry
+// nothing. The portable reading is the CPU time accumulated across all cores:
+// a snapshot at window open gives the busy fraction since boot, and the
+// difference between the open and close snapshots gives the busy fraction
+// ACROSS THE RUN — which is the quantity a contention account actually wants
+// and which costs no sleep to obtain.
+const BOX_SESSION_GAP_MS = Number(process.env.P0_BOX_SESSION_GAP_MIN || 60) * 60 * 1000;
+
+// Where one run leaves a note for the next. It lives in the OS temp directory
+// and NOT in the repository: a session marker is machine state, a dataset is
+// committed, and a path under a home directory has no business travelling into
+// either. The resolved path is deliberately NOT recorded for that same reason.
+const BOX_MARKER = process.env.P0_BOX_MARKER || path.join(os.tmpdir(), 'p0-run-session.json');
+
+// One snapshot. Pure of the run: it reads the machine and nothing this process
+// owns, so the pin can call it without a build, a server or a Chromium.
+function boxSnapshot() {
+  const cpus = os.cpus() || [];
+  let idle = 0;
+  let busy = 0;
+  for (const c of cpus) {
+    idle += c.times.idle;
+    busy += c.times.user + c.times.nice + c.times.sys + c.times.irq;
+  }
+  return {
+    at: new Date().toISOString(),
+    // `[0, 0, 0]` on Windows, and the record says so rather than leaving a
+    // reader to wonder whether the box was genuinely idle.
+    loadavg: os.loadavg(),
+    loadavgSupported: os.platform() !== 'win32',
+    cpus: cpus.length,
+    cpuIdleMs: idle,
+    cpuBusyMs: busy,
+    freeMemB: os.freemem(),
+    totalMemB: os.totalmem(),
+    // A box that rebooted between two runs is not the same box under the
+    // thermal account, and this is the one number that says so.
+    uptimeS: os.uptime(),
+  };
+}
+
+// The busy fraction BETWEEN two snapshots — the load the run actually saw,
+// rather than the average since boot. `null` where the two snapshots cannot
+// support the arithmetic, which a reader must be able to tell from a zero.
+function boxBusyFraction(open, close) {
+  if (!open || !close) return null;
+  const busy = close.cpuBusyMs - open.cpuBusyMs;
+  const total = busy + (close.cpuIdleMs - open.cpuIdleMs);
+  return total > 0 ? busy / total : null;
+}
+
+// WHAT THE PREVIOUS RUN LEFT, AND WHAT THIS ONE LEAVES. Read once at require,
+// so `sinceMs` is measured from the previous run rather than from wherever in
+// this one the record happens to be assembled.
+//
+// THE SESSION IS DEFINED BY A RECORDED THRESHOLD, not by a hunch. A run that
+// starts within `P0_BOX_SESSION_GAP_MIN` of the previous run's END continues
+// that session; otherwise it opens a new one. The threshold travels in the
+// record, so an analysis that wants a different boundary can redraw it from
+// the raw timestamps rather than inherit this one.
+//
+// AND IT NEVER FAILS A RUN. A missing, unreadable or malformed marker yields
+// `null` — the honest answer for the first run on a box, or one whose temp
+// directory was cleared — and a marker that cannot be written is recorded and
+// otherwise ignored. A provenance rider may not be able to refuse a window.
+//
+// THE MARKER PATH IS A PARAMETER, not a read of the constant, and that is what
+// makes the pin possible at all: a self-test that drove the shipped path would
+// read — and then OVERWRITE — the marker of whatever real run last used this
+// box, which is the one piece of state here that cannot be reconstructed.
+function boxSessionRead(marker = BOX_MARKER) {
+  try {
+    const prev = JSON.parse(fs.readFileSync(marker, 'utf8'));
+    if (!prev || typeof prev.startedAt !== 'string') return null;
+    return prev;
+  } catch {
+    return null;
+  }
+}
+
+function boxSessionOpen(now = Date.now(), marker = BOX_MARKER) {
+  const prev = boxSessionRead(marker);
+  const prevEnd = prev && prev.endedAt ? Date.parse(prev.endedAt) : null;
+  const prevStart = prev ? Date.parse(prev.startedAt) : null;
+  const sinceEndMs = Number.isFinite(prevEnd) ? now - prevEnd : null;
+  const continues = prev !== null && sinceEndMs !== null && sinceEndMs <= BOX_SESSION_GAP_MS;
+  return {
+    startedAt: new Date(now).toISOString(),
+    sessionStartedAt: continues ? prev.sessionStartedAt : new Date(now).toISOString(),
+    runsInSession: continues ? (prev.runsInSession || 1) + 1 : 1,
+    sessionGapMs: BOX_SESSION_GAP_MS,
+    previousRun:
+      prev === null
+        ? null
+        : {
+            startedAt: prev.startedAt,
+            endedAt: prev.endedAt || null,
+            sinceStartMs: Number.isFinite(prevStart) ? now - prevStart : null,
+            sinceEndMs,
+            sameSession: continues,
+          },
+  };
+}
+
+function boxSessionClose(session, endedAt = new Date().toISOString(), marker = BOX_MARKER) {
+  try {
+    fs.writeFileSync(
+      marker,
+      JSON.stringify({
+        startedAt: session.startedAt,
+        endedAt,
+        sessionStartedAt: session.sessionStartedAt,
+        runsInSession: session.runsInSession,
+      })
+    );
+    return null;
+  } catch (e) {
+    return String((e && e.message) || e);
+  }
+}
+
+// The one place the three riders accumulate. `chromium` is filled by the first
+// browser launch — see `newPage` — because the build string is a property of a
+// launched browser and there is nowhere earlier to read it from.
+const BOX = {
+  session: boxSessionOpen(),
+  chromium: null,
+  open: null,
+  close: null,
+};
+
+// The rider as it appears in the record, beside `generatedAt` and for the same
+// reason. Pure of the module's own state — it takes the accumulator — so the
+// pin can DRIVE a box with a launch and one without and read both shapes out.
+//
+// A RUN THAT LAUNCHED NOTHING SAYS SO. `chromium` and `load.open` are `null`
+// on a run that never reached a browser, which a reader must be able to tell
+// apart from a run that launched one and found the box idle. Nothing here
+// substitutes a plausible value for a missing one.
+function boxRecord(box = BOX) {
+  return {
+    bead: 'rf2-24o2z',
+    chromium: box.chromium,
+    node: process.version,
+    platform: `${os.platform()}/${os.arch()}/${os.release()}`,
+    load: {
+      open: box.open,
+      close: box.close,
+      // The busy fraction the RUN saw, which is the reading a contention or
+      // thermal account is actually about — the open snapshot alone can only
+      // give the average since boot.
+      busyFraction: boxBusyFraction(box.open, box.close),
+    },
+    session: box.session,
+  };
+}
 
 // The heap families, and which segment each arm needs. `null` is the
 // floor, which needs whichever adapter the segment it is being read in
@@ -491,6 +687,23 @@ async function newPage(chromium, query, jsFlags = '--expose-gc') {
   const browser = await chromium.launch({
     args: ['--enable-precise-memory-info', `--js-flags=${jsFlags}`],
   });
+  // THE TWO RIDERS THAT ONLY A LAUNCH CAN SUPPLY (rf2-24o2z). The build string
+  // is a property of a launched browser and there is nowhere earlier to read
+  // it from; the load snapshot is taken here rather than at require because
+  // "at window open" is what the mechanism question asks for, and the first
+  // launch is the closest thing this driver has to one — `--only alloc` runs
+  // NOTHING else, so under the selection every allocation window is taken with
+  // this IS the alloc page. FIRST LAUNCH ONLY: the clock row takes one page
+  // per round, and a snapshot per page would record the last round rather than
+  // the open. Neither read touches a measured window.
+  if (BOX.chromium === null) {
+    try {
+      BOX.chromium = `${browser.browserType().name()}/${browser.version()}`;
+    } catch (e) {
+      BOX.chromium = `unavailable: ${String((e && e.message) || e)}`;
+    }
+  }
+  if (BOX.open === null) BOX.open = boxSnapshot();
   const page = await browser.newPage();
   // Every `;; P0` record, and EVERY warning or error the page emits. The
   // second half is not debug scaffolding: a React warning about a root
@@ -1710,11 +1923,49 @@ const ALLOC_PLAN_SHAPE = ALLOC_PLAN_SHAPES[ALLOC_PLAN];
 // (`segments`), on criterion 6's rule that a reader of any row can tell FROM
 // THE ROW how it was taken.
 //
-// THE WRITE-LEG ORDER IS NOT TOUCHED. It flips on the same parity and carries
-// its own within-round position confound, which is a different question with
-// a different discriminator; under `P0_ALLOC_WRITE=all` — the selection every
-// floor corpus is taken under — there is ONE leg and the flip is inert.
-const ALLOC_SEG_ORDERS = ['parity', 'fixed'];
+// THE WRITE-LEG ORDER IS NOT TOUCHED HERE. It has its own mode below
+// (`ALLOC_PASS_ORDERS`, rf2-fk6pj) because it carries its own within-round
+// position confound, which is a different question with a different
+// discriminator; under `P0_ALLOC_WRITE=all` — the selection every floor
+// corpus is taken under — there is ONE leg and any flip is inert.
+//
+// AND `fixed-reversed`, THE ARM `fixed` ALONE CANNOT SUPPLY (rf2-csca8).
+// `fixed` drives ONE orientation, so inside a `fixed` run the substrate and
+// the within-round position are perfectly confounded again — with the plan as
+// shipped, `uix-subs` is position 1 in every `fixed` window there has ever
+// been. The 1,050-1,224 B cluster that bead names sits at 8 of 38 such
+// windows, and 8 of 38 is equally consistent with "uix under `fixed`" and
+// with "the SECOND-driven arm under `fixed`". No committed run separates
+// them: the analysis on PR #8593 re-derived POSITION as refuted (parity uix
+// 8/747 at position 0 against 3/724 at position 1, Fisher two-sided
+// p = 0.2254) and SUBSTRATE as associated but NOT necessary (reagent carries
+// the term twice in 1,588), which leaves the MODE as the only surviving arm
+// — and the mode cannot be read against itself from one orientation.
+//
+// `fixed-reversed` drives the plan REVERSED every round, so it puts the
+// second substrate at position 0 while HOLDING THE MODE CONSTANT. That is
+// the one arrangement the corpus lacks. Parity already supplies uix at
+// position 0 for 747 windows, but it supplies it UNDER PARITY, which is the
+// term the contrast is trying to hold still.
+//
+// WHAT EACH OUTCOME SETTLES, pre-registered here rather than chosen after the
+// run, on the same rule as the three above:
+//
+//   - the cluster FOLLOWS uix to position 0  -> the carrier is the SUBSTRATE
+//     under `fixed`, and the position reading of 8/38 is a coincidence of
+//     the shipped plan's order;
+//   - the cluster STAYS at position 1        -> the carrier is the
+//     SECOND-DRIVEN slot under `fixed`, whichever substrate occupies it;
+//   - the cluster appears at BOTH or NEITHER -> neither property is the
+//     carrier as stated, and the segment order has said all it can say.
+//
+// IT IS A DIAGNOSTIC ROW ON `fixed`'s OWN TERMS. Everything the paragraph
+// above says about a `fixed` row — that it gives up the between-substrate
+// comparison and may not be quoted for one — holds here unchanged, and the
+// row states which of the three orders it was taken under (`segOrder`) for
+// exactly that reason. No gate, band, threshold or budget constant moves in
+// any of the three, and τ is untouched in either direction.
+const ALLOC_SEG_ORDERS = ['parity', 'fixed', 'fixed-reversed'];
 const ALLOC_SEG_ORDER = process.env.P0_ALLOC_SEG_ORDER || 'parity';
 
 // THE CONTROL SLOT — THE LAST CONFOUND THE SCHEDULE BUILDS IN (rf2-rs8q6).
@@ -1820,8 +2071,166 @@ function allocRoundWindowKinds(passCount, slot) {
 // sequence out, rather than read the source and hope.
 function allocSegmentOrder(plan, round, order) {
   if (order === 'fixed') return plan;
+  // AND ITS REVERSED COUNTERPART (rf2-csca8), which is `fixed` in the other
+  // orientation and nothing else: the same plan every round, so the mode is
+  // held constant, with the substrate that `fixed` pins to position 1 now at
+  // position 0. A fresh array per round rather than a cached one, for the
+  // reason `parity`'s odd branch takes one — the plan the caller handed in is
+  // the shipped ladder plan and this function may not reorder it in place.
+  if (order === 'fixed-reversed') return [...plan].reverse();
   return round % 2 === 0 ? plan : [...plan].slice().reverse();
 }
+
+// ---------------------------------------------------------------------------
+// THE WRITE-LEG ORDER, AND WHY IT MAY NOT KEEP RIDING ON ROUND PARITY
+// (rf2-fk6pj)
+// ---------------------------------------------------------------------------
+//
+// Under `P0_ALLOC_WRITE=paired` the two write legs of every arm run as two
+// passes inside ONE round, and the round loop below alternates which leads.
+// rf2-0gjqi's paired window measured that THE PASS THAT RAN SECOND READS
+// LOWER — 10 of 12 round blocks, 6 of 6 in run 1 and 4 of 6 in run 2, median
+// second-minus-first −0.59%, WHICHEVER WRITE OCCUPIED IT. Decomposed under an
+// additive position model the pass-order half-difference reads +0.68% and
+// +0.21%, the same sign on both runs, while the order-free write half-sum
+// reads −0.33% and +0.24%, opposite signs. It is the class of term that
+// manufactured this instrument's last inferential finding, and it is still in
+// the instrument.
+//
+// AND THE INSTRUMENT CANNOT CURRENTLY ANSWER WHY, because the alternation is
+// `round % 2`: EVERY page-first round is an even round. Any other even/odd
+// property of a round that acts differently on a first and a second pass —
+// and a round is a long-lived, stateful thing — reads EXACTLY the same way.
+// The pass-position term and every other parity-indexed term are one column
+// in the design matrix, and no estimator over a parity-driven corpus can
+// split them. The other committed corpora do not break the tie either:
+// `segorder-rs8q6` varies the SEGMENT order and `ctrlslot-rs8q6` varies the
+// control SLOT, and neither reaches the write-leg order.
+//
+// `seeded` DRAWS THE LEG ORDER FROM A SEED AND THE ROUND INDEX INSTEAD, which
+// separates the two in one window: the leg order still varies round to round,
+// but it is no longer a function of round parity, so a term that tracks the
+// pass position and a term that tracks the parity now load on different
+// columns. `parity` is the pre-bead expression verbatim and stays the
+// default, so every committed corpus is read under the rule it was taken
+// under and no published row is reinterpreted.
+//
+// THE DRAW IS BALANCED, AND THAT IS NOT A REFINEMENT. `parity` guarantees
+// each leg leads exactly half the rounds, and that balance is what keeps the
+// WRITE from being confounded with the pass position — the defect the
+// alternation was landed for. An unbalanced Bernoulli draw would break the
+// parity tie by reintroducing the write/position confound, which is trading
+// one column for a worse one. So the schedule is a seeded permutation of a
+// BALANCED multiset: `floor(rounds / 2)` flipped rounds, exactly as parity
+// gives.
+//
+// AND A DRAW THAT REPRODUCES PARITY IS REDRAWN. Of the twenty balanced
+// six-round schedules, two ARE the parity schedules — the alternating one and
+// its complement — and a window that drew one of those would separate
+// nothing while costing a full allocation window. They are rejected and the
+// draw repeated. This needs a third balanced schedule to exist at all, which
+// it does from THREE rounds up: at three the balanced set is the three
+// single-flip schedules and only one of them alternates, while at two rounds
+// BOTH balanced schedules are parity schedules and the mode can separate
+// nothing. `parityTied` reports that, the preflight refuses on it, and the
+// pin drives both sides of the boundary rather than taking this paragraph's
+// word for where it falls.
+//
+// THE SEED IS RECORDED (`passSeed`), and that is what makes a `seeded` window
+// re-readable at all: the schedule is not recoverable from the mode name, so
+// a record that stated only `seeded` would be a record whose own schedule was
+// unknown. Re-passing the recorded seed reproduces the schedule exactly. The
+// round record also states the order it ACTUALLY drove, in `writeLegs`, for
+// the reason it always did — an estimator must never recompute the rule.
+//
+// IT IS `PASS` AND NOT `LEG`, AND THAT IS DELIBERATE. The obvious env name
+// for a mode over the write legs would put it under the same `P0_ALLOC_`
+// prefix that `ALLOC_LEG_TOLERANCE` would take if it ever acquired an env
+// route — and that prefix is BANNED, in a pin that refuses any occurrence of
+// it ANYWHERE in this file, comments included. τ decides whether a window may
+// be PUBLISHED, and this file's standing rule is that a gate with a dial on it
+// is a gate that gets dialled off; a switch sharing the prefix is one
+// careless grep away from looking like exactly that dial. `pass` is also the
+// more accurate word for what is ordered: the round loop drives `passes`, and
+// the measured term is a PASS-POSITION term. (The ban is the reason this
+// paragraph names no token — writing the forbidden one to explain the ban
+// trips it, which is how it was found.)
+const ALLOC_PASS_ORDERS = ['parity', 'seeded'];
+const ALLOC_PASS_ORDER = process.env.P0_ALLOC_PASS_ORDER || 'parity';
+// Drawn when it is not given, and recorded either way. It is INERT under
+// `parity` — the default, and the mode every published row was taken under —
+// and the record states the mode beside it so no reader can take a seed for
+// evidence that a seeded schedule ran.
+const ALLOC_PASS_SEED = process.env.P0_ALLOC_PASS_SEED || String(Date.now());
+
+// FNV-1a over the seed text, so the seed may be any string an operator finds
+// memorable rather than a number they have to invent. Pure and total.
+function allocSeedHash(text) {
+  let h = 0x811c9dc5;
+  for (let i = 0; i < text.length; i++) {
+    h ^= text.charCodeAt(i);
+    h = Math.imul(h, 0x01000193);
+  }
+  return h >>> 0;
+}
+
+// mulberry32 — a small, fully specified, deterministic 32-bit generator. The
+// requirement here is REPRODUCIBILITY from a recorded seed and nothing more:
+// no statistical quality claim is made or needed, because the schedule it
+// draws is checked for the one property the mode exists for.
+function allocSeedRandom(state) {
+  let s = state >>> 0;
+  return () => {
+    s = (s + 0x6d2b79f5) >>> 0;
+    let t = s;
+    t = Math.imul(t ^ (t >>> 15), t | 1);
+    t ^= t + Math.imul(t ^ (t >>> 7), t | 61);
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+// TRUE where the round drives its legs REVERSED. Pure, for `allocSegmentOrder`'s
+// reason: it needs neither a release build nor a Chromium, so the pin can DRIVE
+// the schedule over a seed and a round count and read its properties out —
+// balance, and independence from parity — rather than read the source and hope.
+function allocPassFlips(rounds, seed) {
+  const flipped = Math.floor(rounds / 2);
+  const base = Array.from({ length: rounds }, (_, i) => i < flipped);
+  // Parity is what this mode exists to escape, so a schedule that is a
+  // function of round parity is not a schedule this mode may return — the
+  // alternating one and its complement alike. An untied one exists from THREE
+  // rounds up; at two or fewer `parityTied` is the honest answer and the
+  // caller's window separates nothing.
+  const tiedToParity = (flips) =>
+    flips.every((f, r) => f === (r % 2 === 1)) || flips.every((f, r) => f === (r % 2 === 0));
+  const rand = allocSeedRandom(allocSeedHash(String(seed)));
+  // Bounded, because an unbounded redraw on a round count that admits no
+  // untied schedule would hang the run rather than tell the operator.
+  for (let attempt = 0; attempt < 64; attempt++) {
+    const flips = base.slice();
+    for (let i = flips.length - 1; i > 0; i--) {
+      const j = Math.floor(rand() * (i + 1));
+      const t = flips[i];
+      flips[i] = flips[j];
+      flips[j] = t;
+    }
+    if (!tiedToParity(flips)) return { flips, attempts: attempt + 1, parityTied: false };
+  }
+  return { flips: base.slice(), attempts: 64, parityTied: true };
+}
+
+// The legs ONE ROUND drives, in drive order. `parity` is the pre-bead
+// expression verbatim, to the character; `seeded` indexes the drawn schedule.
+// Pure for the reason above, and total on a schedule shorter than the round
+// index — a run that drove more rounds than it drew for falls back to parity
+// for that round rather than driving `undefined`.
+function allocPassOrder(legs, round, order, schedule) {
+  const seeded = order === 'seeded' && schedule && round < schedule.flips.length;
+  const flip = seeded ? schedule.flips[round] : round % 2 !== 0;
+  return flip ? [...legs].reverse() : legs;
+}
+
+const ALLOC_PASS_SCHEDULE = allocPassFlips(ALLOC_ROUNDS, ALLOC_PASS_SEED);
 
 // The plan a shape admits, as a PURE FUNCTION of the full plan and the shape
 // — the same reason `allocArmSizing` and `allocSteps` are pure: it needs
@@ -2599,6 +3008,34 @@ async function allocRow(chromium) {
         '`first` is the default every published row is taken under'
     );
   }
+  // AND THE FIFTH, ON THE SAME RULE (rf2-fk6pj). A mistyped leg order is
+  // undetectable after the fact for the segment order's reason exactly: a
+  // `seeded` run that quietly ran on `parity` produces a record carrying a
+  // seed, a mode name and a set of rounds whose leg order IS parity-derived —
+  // and the whole point of the window is that those two are distinguishable,
+  // so the run would arrive pre-refuted under a name that says it separates
+  // them.
+  if (!ALLOC_PASS_ORDERS.includes(ALLOC_PASS_ORDER)) {
+    throw new Error(
+      `unknown P0_ALLOC_PASS_ORDER ${JSON.stringify(ALLOC_PASS_ORDER)} — the allocation row ` +
+        `alternates its write legs under one of ${ALLOC_PASS_ORDERS.join(' | ')}, and \`parity\` ` +
+        'is the default every published row is taken under'
+    );
+  }
+  // AND A `seeded` RUN THAT CANNOT ESCAPE PARITY IS REFUSED RATHER THAN
+  // TAKEN (rf2-fk6pj). At two rounds or fewer every balanced schedule IS a
+  // parity schedule, so the draw has nothing to return and `allocPassFlips`
+  // says so. The window would cost the same and separate nothing, and a record
+  // stating `seeded` over a parity-derived schedule is the one artefact this
+  // mode may not produce.
+  if (ALLOC_PASS_ORDER === 'seeded' && ALLOC_PASS_SCHEDULE.parityTied) {
+    throw new Error(
+      `P0_ALLOC_PASS_ORDER=seeded over ${ALLOC_ROUNDS} round(s) has no schedule that is not a ` +
+        'function of round parity — at two rounds or fewer every balanced schedule alternates. ' +
+        'The mode exists to separate the pass-position term from round parity and cannot do it ' +
+        'here: RAISE P0_ALLOC_ROUNDS to at least 3, or take the window under `parity`'
+    );
+  }
   const { browser, page, watch } = await newPage(chromium, '?mode=heap');
   await watch.race('window.P0_READY === true || window.P0_ERROR', {
     timeoutMs: 180000,
@@ -2812,7 +3249,15 @@ async function allocRow(chromium) {
     // defect this switch exists to remove, and a drift within a run would be
     // read as a difference between the writes. Over the six default rounds
     // each leg leads three times.
-    const legs = round % 2 === 0 ? ALLOC_WRITE_LEGS : [...ALLOC_WRITE_LEGS].reverse();
+    //
+    // AND UNDER WHICH RULE IT ALTERNATES IS ITSELF A MODE NOW (rf2-fk6pj).
+    // `parity` is the expression that stood here — `round % 2 === 0`, and
+    // `allocPassOrder` is that expression verbatim under it, so every
+    // committed corpus is read under the rule it was taken under. `seeded`
+    // draws a balanced schedule from `passSeed` instead, which is the only way
+    // to separate the measured pass-position term from every other even/odd
+    // property of a round. See `allocPassFlips` for what the draw guarantees.
+    const legs = allocPassOrder(ALLOC_WRITE_LEGS, round, ALLOC_PASS_ORDER, ALLOC_PASS_SCHEDULE);
     const passes = segs.flatMap(({ segment, arms }) =>
       legs.map((leg) => ({ segment, arms, leg }))
     );
@@ -3171,6 +3616,27 @@ async function allocRow(chromium) {
     // flip was landed for, so a reader has to be able to tell from the row
     // whether the row is entitled to make one. `parity` on every published row.
     segOrder: ALLOC_SEG_ORDER,
+    // AND UNDER WHICH PASS-ORDER RULE ITS WRITE LEGS ALTERNATED (rf2-fk6pj),
+    // on that same criterion-6 rule and with one thing on top of it that the
+    // three modes above do not need. `parity` names a schedule a reader can reconstruct from the round
+    // index; `seeded` names one that NOTHING recovers except the seed, so the
+    // seed travels in the row. Re-passing it as `P0_ALLOC_PASS_SEED` reproduces
+    // the schedule exactly, which is what makes a `seeded` window re-readable
+    // rather than a one-shot.
+    //
+    // THE SEED IS RECORDED UNDER `parity` TOO, AND IS INERT THERE. It is
+    // resolved once at require whichever mode runs, so a row states the seed
+    // it HELD rather than the seed it USED; `passOrder` beside it is what says
+    // whether anything was drawn from it. `parity` on every published row.
+    passOrder: ALLOC_PASS_ORDER,
+    passSeed: ALLOC_PASS_SEED,
+    // AND WHAT THE DRAW ACTUALLY RETURNED, for the reason `windowOrder` and
+    // `segments` are recorded per round: an estimator must be able to read the
+    // schedule off the record rather than re-run the generator. `flips[r]` is
+    // TRUE where round r drove its legs reversed. Under `parity` this is the
+    // schedule that was drawn and NOT driven — `writeLegs` on each round is
+    // always the order that ran.
+    passSchedule: ALLOC_PASS_SCHEDULE,
     // AND WHICH CONTROL SLOT (rf2-rs8q6), on that same criterion-6 rule. The
     // controls are this row's null arm and every studio page reads them against
     // the arms window for window; a row whose controls were taken at another
@@ -4460,6 +4926,29 @@ module.exports = {
   allocSegmentOrder,
   ALLOC_SEG_ORDERS,
   ALLOC_SEG_ORDER,
+  // The write-leg order's three pure functions (rf2-fk6pj), exported on the
+  // rule above and with one more reason than the segment order has: the
+  // properties that matter — that `parity` is the pre-bead expression to the
+  // character, that a `seeded` schedule is BALANCED, and that it is not a
+  // function of round parity — are claims about a whole run's schedule, and
+  // none of the three is readable off a ternary in the source.
+  allocSeedHash,
+  allocSeedRandom,
+  allocPassFlips,
+  allocPassOrder,
+  ALLOC_PASS_ORDERS,
+  ALLOC_PASS_ORDER,
+  ALLOC_PASS_SEED,
+  ALLOC_PASS_SCHEDULE,
+  // The box riders (rf2-24o2z), pure of the run for the same reason: the pin
+  // can DRIVE a session over a marker it wrote itself and read the gap and the
+  // session arithmetic out, with no build, no server and no Chromium.
+  boxSnapshot,
+  boxBusyFraction,
+  boxSessionRead,
+  boxSessionOpen,
+  boxSessionClose,
+  boxRecord,
   // The control slot's two pure functions, so the pin can DRIVE the multi-round
   // window sequence and read the two properties this mode separates off it,
   // rather than match the source for a ternary (rf2-rs8q6).
@@ -4696,6 +5185,18 @@ if (require.main === module) (async () => {
   // 2026-08-16 and 2026-08-17 windows published records and no dataset, so the
   // same question is not askable of them at all. The convention has paid for
   // itself once; the three windows that skipped it cannot be made to pay later.
+  // AND WHAT THE BOX WAS DOING WHILE IT RAN (rf2-24o2z), closed here rather
+  // than in the try above so a REFUSED run carries it too — the evidence
+  // surviving the refusal is this file's own rule, and a window that refused
+  // is exactly the kind whose machine conditions a later reader will want.
+  BOX.close = boxSnapshot();
+  out.box = boxRecord();
+  // AND THE NOTE THIS RUN LEAVES FOR THE NEXT ONE. It is the only write here
+  // that is not into the record, and it is what makes `session.previousRun`
+  // answerable at all. A failure to write it is recorded and never thrown:
+  // this rider may not refuse a window.
+  const markerErr = boxSessionClose(BOX.session);
+  if (markerErr) out.box.session.markerError = markerErr;
   const raw = process.env.P0_RAW_OUT;
   if (raw) {
     fs.mkdirSync(path.dirname(raw), { recursive: true });


### PR DESCRIPTION
Three allocation-rig arms in ONE change to `implementation/core/test/re_frame/bench/p0_run.cjs`, because that file is 4,733 lines and strictly one-toucher and three separate PRs against it conflict every time. Beads: **rf2-fk6pj** (owner), **rf2-csca8**, **rf2-24o2z**.

## NO WINDOW, BENCHMARK, BROWSER OR BUILD WAS RUN

**Nothing here is a measured result.** This is phase 1 of two — the instrument lands, and a separate dispatch takes the single allocation window against it once the box is free. That shape is the beads' own: rf2-fk6pj says its rig change "must not be made inside a measurement window", and rf2-24o2z says its half is "HERMETIC, AND NEEDS NO WINDOW" with the payoff falling to the next window. A concurrent worker was also holding an allocation window on this box throughout, and two heavyweight runs on one machine wedge silently rather than fail.

Every number quoted below is re-cited from the beads and from the merged analyses on PR #8593 and PR #8591. None of it was re-measured here.

## 1 — a pass order independent of round parity (rf2-fk6pj)

Under `P0_ALLOC_WRITE=paired` the round loop alternated its two write legs on `round % 2`. Every page-first round was therefore an **even** round, so the measured pass-position term — the second pass reads lower in 10 of 12 blocks, median -0.59%, whichever write occupied it — sits in the same design column as every other even/odd property of a round. No estimator over a parity-driven corpus can split them, and the other committed corpora do not break the tie: `segorder-rs8q6` varies the segment order, `ctrlslot-rs8q6` varies the control slot, and neither reaches the write-leg order.

`P0_ALLOC_PASS_ORDER=seeded` draws the order from `P0_ALLOC_PASS_SEED` instead. Three properties, each driven by the pin rather than asserted:

- **Balanced.** `parity` leads each leg exactly `floor(rounds / 2)` times, and that balance is what keeps the *write* from being confounded with the pass position. An unbalanced Bernoulli draw would break the parity tie by reintroducing the confound the alternation exists to remove — a worse column for a better one. The schedule is a seeded permutation of a balanced multiset.
- **Not a function of round parity.** Two of the twenty balanced six-round schedules *are* the parity schedules — the alternating one and its complement — and drawing one would separate nothing at the full cost of a window. They are rejected and the draw repeated. An untied schedule exists from **three** rounds up; at two or fewer both balanced schedules alternate, and the preflight refuses rather than taking a window that cannot separate anything. (The boundary falls at three, not four: the test read four on its first pass and the draw contradicted it.)
- **Reproducible.** The seed is recorded as `passSeed`, because nothing else recovers the schedule; re-passing it reproduces the draw exactly. Each round already records the order it actually drove in `writeLegs`, so no estimator has to recompute a rule.

`parity` remains the default and is the pre-bead expression verbatim.

**The env prefix is `PASS` and not `LEG`, and that is not cosmetic.** The obvious name shares a prefix with `ALLOC_LEG_TOLERANCE` — the tolerance that decides whether a window may be published — and this file bans that prefix outright on the standing rule that a gate with a dial on it is a gate that gets dialled off. The pin refuses any occurrence anywhere in the file, comments included, which is how the collision was found and why the source paragraph explaining the ban names no token.

## 2 — the reversed `fixed` arm (rf2-csca8)

Inside `fixed`, uix is always position 1, so substrate and position stay perfectly confounded in all 81 committed fixed windows: 8/38 is equally consistent with "uix under `fixed`" and with "the second-driven arm under `fixed`". PR #8593 re-derived the three-way question on 118 runs and 3,140 positional windows and **refuted POSITION** (parity uix 8/747 pos0 against 3/724 pos1, Fisher two-sided p = 0.2254) while finding **SUBSTRATE associated but not necessary** (reagent carries the term 2 of 1,588) — leaving **MODE** as the only surviving arm, and the mode cannot be read against itself from one orientation.

`P0_ALLOC_SEG_ORDER=fixed-reversed` drives the plan reversed every round: the mode held constant, the other substrate at position 0. That is the one arrangement no committed run supplies — parity does put uix at position 0 for 747 windows, but it does so *under parity*, which is the term the contrast is trying to hold still.

**The three-line sizing from PR #8593 holds at the tip, and I re-derived it**: one name in `ALLOC_SEG_ORDERS`, one branch in `allocSegmentOrder`, and **nothing in the preflight** — it already interpolates the roster, and the pin now asserts that it does, so a fourth arm would need no second edit either. The prose above the roster is longer than three lines because the mode's pre-registered outcomes belong beside it, as they do for the three modes already there.

## 3 — what the box was doing (rf2-24o2z)

The floor arm's high-mode rate tracks elapsed time within a session — 0/6 at 8.2 min, 1/8 at 14.9, 2/20 at 19.7, 37/69 at 88.3, gradient at one-tail p = 0.0198 — and names no mechanism, because thermal state, V8 tier accumulation and heap fragmentation all survive it equally. It was answerable at all only because `generatedAt` happened to be in the record. Three riders of the same kind now travel beside it, in `out.box`:

- **the Chromium build string**, read off the launched browser, which playwright pins and no dataset has ever stated;
- **the box's load** at window open and again at close. `os.loadavg()` is `[0, 0, 0]` on Windows, which is where these windows are taken, so a record carrying only that would carry nothing — the portable reading is the CPU time across all cores, whose open-to-close difference gives the busy fraction the run actually saw at no sleep cost. The record states `loadavgSupported` so a reader can tell a dead field from an idle box;
- **the elapsed time since the previous run**, both since it started and since it *ended*, plus the session position. The session boundary comes from a recorded threshold (`P0_BOX_SESSION_GAP_MIN`, default 60 min) so an analysis can redraw it from the raw timestamps rather than inherit this one.

The marker one run leaves for the next lives in the OS temp directory, never the repository, and its **path is deliberately not recorded** — a dataset is committed and a home-directory path has no business travelling into one. A missing, malformed or unwritable marker yields `null` and is reported; a provenance rider may not refuse a window. Every reading is taken outside any measured window.

**The deliberate cold / hot / after-an-idle-gap variation is NOT taken.** rf2-6kxub's own note holds that as the confirming second move, and that stands.

## What did not move

`ALLOC_MIN_WRITES` 6, `ALLOC_FALL_THRESHOLD_B` 600000, `ALLOC_LEG_TOLERANCE` 0.25 and R = 20 are byte-identical to `origin/main`, checked line by line. The tolerance is untouched in either direction. No reading, threshold, band, budget status or tolerance moves. **Every new mode is off by default**, so a run taken without the new switches drives the identical schedule it always drove — which is proved rather than asserted, below.

The per-rung write count is **not** in this change. rf2-fk6pj's 04:15 mayor note listed rf2-onozm's arm in the bundle, but rf2-onozm has since closed with "FIVE WRITES IS SIZED, NOT SAFE — only a window can tell the difference", and the dispatch brief fences `ALLOC_MIN_WRITES` explicitly. Taking it would be a judgement the tracker has not made.

## Quality gates

**No window, benchmark, browser, shadow-cljs build or JVM gate was run, deliberately.** The gate that covers this surface is a node-level pin, and it is the one CI runs.

| Gate | Invocation | Captured exit |
|---|---|---|
| The structural pin — the registered `test:script-helpers` entry for this file, verbatim | `node core/test/re_frame/bench/p0_ladder_structural.test.cjs` from `implementation/` | **0** — `100 passed` (96 on `origin/main`; four new tests) |
| The neighbouring reader, unaffected | `node hicasso/test/re_frame/bench/hicasso/alloc_position_confound.cjs --self-test` | **0** — `33/33 passed` |

Both numbers are the ones the invoking shell captured, with the redirect and the `echo` on one command line — not any number reported about the run. The pin was re-run on the **final rebased base** and came back `0` again.

**Which tree the gate read, proved by planted faults.** The pin prints no root banner, so the discrimination is the red itself — the fault existed only in this worktree, so a run that had wandered into a sibling's would have come back green. Three plants, each at a line this change edits, each red on exactly the intended new test:

| Plant | Result |
|---|---|
| `fixed-reversed` returns `plan` unreversed | exit 1 — `FAIL THE REVERSED FIXED ARM`, the two substrates transposed in all four rounds |
| the `parity` branch inverted to `round % 2 === 0` | exit 1 — `FAIL THE LEG ORDER - parity is the default`, at round 0 |
| `boxBusyFraction`'s numerator off by one | exit 1 — `FAIL THE BOX RIDERS`, `a zero interval is not a zero load` |

Each restore was verified against the identical **blob** hash `ddc4f137bc2b5ee5ac7952dcb4f2cded7fcd0ca0` — git's own content hash of the working file, not a byte digest, since this checkout translates line endings.

**The defaults-unchanged property is proved by construction, not asserted.** The pin drives the shipped `allocPassOrder` under the default mode over 64 rounds and compares it round for round against the expression that stood in the round loop before this change, and separately asserts that even rounds hand back the *caller's* array rather than a copy — which the pre-bead expression did and the pass loop relies on. A one-leg run (`page`, `all` — the selections every floor corpus is taken under) is asserted inert under both modes.

Also verified by hand, since no gate covers it: **no committed reader recomputes the write-leg order from parity**, so a `seeded` run reinterprets nothing. `git grep writeLegs` over `implementation/hicasso` outside the data directories returns zero hits, and the only parity recomputation in that tree is `alloc_position_confound.cjs`'s `synth()` *fixture builder*, which is its own self-test's input rather than a reader of real records — real records are grouped on the recorded `segOrder` field. That fixture cannot yet synthesise `fixed-reversed`; the file is fenced to another worker this dispatch, so it is noted on rf2-csca8 rather than edited here.

`npm run test:script-policy` was also run to completion; it covers `implementation/scripts/**`, which this change does not touch. Its verdict is reported in a comment below rather than inferred.

## Records

**No studio page.** `docs/design/hicasso/studio/` records measurements, and this change measures nothing; a page describing an instrument would sit in that corpus looking like a result. The operator invocations phase 2 needs are on the beads instead, and the modes' pre-registered outcomes are in the source beside the switches that drive them. No index row is added, and `studio/README.md` is untouched.

## Beads

- **rf2-24o2z — CLOSED.** Its deliverable is the recording and it needs no window.
- **rf2-fk6pj and rf2-csca8 — OPEN.** Their questions are answered by the window phase 2 runs against this rig, not by the rig. What each still owes is written on the bead.
