### PR TITLE
feat(bench): a second slice clock driver, and the donor arm C3 and C4 are stated against (rf2-9wmqd)

### DIFF
--- a/implementation/hicasso/test/re_frame/bench/hicasso/slice_broad_clock_app.cljs
+++ b/implementation/hicasso/test/re_frame/bench/hicasso/slice_broad_clock_app.cljs
@@ -1,0 +1,1067 @@
+(ns re-frame.bench.hicasso.slice-broad-clock-app
+  "THE SLICE'S BROAD-UPDATE CLOCK, WITH A DONOR ARM BESIDE IT — one broad
+  application operation, through to the paint that follows it, taken on
+  the Hicasso page and on the UIx page that renders the same feed
+  (rf2-9wmqd).
+
+      HICASSO_INIT_FN=re-frame.bench.hicasso.slice-broad-clock-app/-main \\
+      HICASSO_OUT_DIR=out/hicasso-slice-broad \\
+      HICASSO_PORT=8139 \\
+        node implementation/hicasso/test/re_frame/bench/hicasso/run.cjs
+
+  NO NEW BUILD ID. `run.cjs` takes its entry from `HICASSO_INIT_FN` and
+  rides `:hicasso-bench`, the id the whole lane already shares, so this
+  arm costs `implementation/shadow-cljs.edn` — an HD-017 hot-zone file —
+  nothing.
+
+  ## WHY THERE IS A SECOND DRIVER AT ALL
+
+  [[re-frame.bench.hicasso.slice-echo-clock-app]] is the first, and its
+  own docstring states what it does not serve: **`U3` and `U4` are not in
+  its row set, and it carries no donor arm at all**, so `C3` and `C4`
+  have nothing to compare against. This driver takes the first of those
+  three — `U3`, *operation latency* for a broad application operation —
+  and supplies the donor arm `C3` and `C4` are stated on.
+
+  It does NOT take `U4`. §THE ROW SET below says why, at source, and the
+  reason is about the slice rather than about this mechanism.
+
+  ## IT IS THE SAME WINDOW, NOT A COPY OF IT
+
+  `window!` and `after-paint` are [[re-frame.bench.hicasso.slice-echo-clock-app]]'s,
+  REQUIRED rather than transcribed, and so are its `measured-mask` and
+  `structure-over-measured`. This lane pays for local copies deliberately
+  where the copy is of SHIPPING code (the rf2-2rtt6.32 call-convention
+  discipline), and that reason does not reach a sibling arm: two copies
+  of one bench mechanism is two things that can drift with nothing
+  holding them in step, which is the shape `lane/visit-plan`'s own
+  docstring is written against. So the two drivers cannot disagree about
+  what a window is, and a repair to the window reaches both.
+
+  Every reading is therefore `t0` → real DOM event → `requestAnimationFrame`
+  → `setTimeout 0` → `t-paint`, decomposed into `:commit`, `:to-raf` and
+  `:raf-to-paint`, exactly as over there.
+
+  ## THE ROW SET, AND WHY IT IS THE ONE IT IS
+
+      :idle-frame     no interaction at all — the frame and nothing else,
+                      on the Hicasso page. The FLOOR every other row pays.
+
+      :locale         a real `change` on the published `<select>`, which
+                      moves ONE key in `app-db` and re-renders every
+                      boundary on the page that read a string. `U3`'s
+                      estimand — operation latency for a broad
+                      application operation.
+
+      :theme          a real click on the published theme button, which
+                      moves one key and re-renders every boundary that
+                      read a token. `U3`'s estimand on a second event
+                      path, and a NARROWER broad update — which is the
+                      point of having both.
+
+      :donor-locale   `:locale`, on the UIx page.
+      :donor-theme    `:theme`, on the UIx page.
+
+      :ctl-blocked    `:locale` plus a busy-wait of [[blocked-ms]] on the
+                      window's post-commit seam. The positive control.
+
+  ### `U3`'S THREE NAMED OPERATIONS, AND WHY ONLY ONE CLASS OF THEM IS HERE
+
+  The first driver names *a route change, a reset, a save reply* as the
+  broad operations `U3` wants. **Two of those three cannot be bracketed
+  by this window at all, and the reason is mechanical rather than a
+  matter of taste.**
+
+  `re-frame.hicasso.examples.slice.flow-dom-cljs-test`'s namespace
+  docstring, §*TWO CLICKS, TWO SETTLING RULES*, records the split as a
+  finding of the slice's own authoring report:
+
+  - A **Hicasso intent** — the `:on-change` and `:on-click` vectors this
+    driver's two measured operations fire — dispatches through the
+    runtime's **synchronous** frame-locked door, so the handler has run,
+    `app-db` has moved and React has committed before the DOM event
+    returns. That is exactly the operation `window!` is shaped for.
+  - A **route-link** click ends at `re-frame.routing/activate-link!`,
+    which ends at `router/dispatch!` — **the ASYNC door**. The click
+    returns with the navigation merely ENQUEUED, and the router drains it
+    on `interop/next-tick`, a next-turn TASK. A window that stops at the
+    first paint after the click stops BEFORE THE OPERATION HAS BEGUN.
+  - **Every async mutation reply in any re-frame2 application arrives
+    through a router drain**, in that docstring's words, so a save reply
+    is the same case and so is the digest's reload.
+
+  A row over either would not be a slower reading of `U3`, it would be a
+  reading of the click that requested the operation — the same class of
+  error as a `p95` of a mount published against a line about a paint,
+  which is the error the first driver exists to have stopped making. So
+  the async-door operations are OUT, and what they need is a different
+  window — one bounded by the drain AND the paint that follows it — which
+  is not this mechanism and is not built here.
+
+  The third of the three, a **reset**, is synchronous and is reachable.
+  It is not here because it lives on the ARTICLE route, behind a draft
+  that has to be dirtied outside the window, and this page is the feed —
+  see §THE PAGE below. It is named so it is not rediscovered.
+
+  ### `U4` IS NOT SERVED BY THIS DRIVER EITHER, AND NOT FOR THE SAME REASON
+
+  `U4` is registered over *dragging/animation stay inside frame budget*,
+  estimand *per-frame latency*. **The slice application has no drag and no
+  animation**: every interaction it publishes is discrete — a keystroke, a
+  click, a select. A per-frame estimator driven by repeating one of those
+  once a frame would be measuring a scripted repetition of a discrete
+  interaction and publishing it against a line written about a continuous
+  one, and this programme has refused that shape before.
+
+  Adding a drag to the slice is not the repair either: it would move the
+  population, and `U1`–`U4` are governed on the application's own
+  interactions rather than on interactions added to reach a row.
+
+  **The repair exists and it is another witness application.**
+  `re-frame.hicasso.examples.ledger` publishes a virtualized 10,000-row
+  list over a real scroll viewport — its `virtualized-dom-cljs-test`
+  drives `scrollTop` and a real `scroll` event, and the vendor artefact's
+  own note names *host-local animation/drag state* — which is a genuinely
+  CONTINUOUS interaction and the population `U4` is stated over. A
+  per-frame driver belongs there, on this same `window!` mechanism but
+  with an estimator over FRAME INTERVALS rather than over window lengths.
+  It is a third driver on a third page, and it is not this one.
+
+  ## THE PAGE, AND WHY THE DONOR RENDERS EXACTLY IT
+
+  Both arms open on the slice's FEED route, at the shipped seed: seven
+  articles at a page size of three, so three pages, a pager with both
+  ends reachable, and the editor's digest with its five blocks — one of
+  them of a kind this build has no renderer for. Eleven boundaries.
+
+  The first driver sits on the ARTICLE route because its estimands are
+  the editor's controlled fields. This one takes the other route for the
+  reason that driver gives: *the route the editor rows type into is the
+  route a navigation row would leave*. Two drivers, two pages, no
+  preparation crossing between them.
+
+  [[re-frame.bench.hicasso.slice-donor-views]] renders the same feed page
+  in UIx, reading the same subscriptions and dispatching the same events.
+  Its own docstring carries the donor's argument — why UIx and not
+  Reagent, what makes it a denominator rather than a strawman, and the
+  three places the two arms are NOT the same.
+
+  ## THE FAIRNESS GATE RUNS BEFORE ANY CLOCK, AND IT HAS A NEGATIVE CONTROL
+
+  `lane/canonical` is this lane's one answer to *are these two arms
+  building the same page* — attribute names sorted, so the comparison is
+  of the DOM and not of two serialisers. [[assert-parity!]] takes it over
+  both containers on the seeded page and REFUSES the run when they
+  differ.
+
+  A gate nobody has seen refuse is a gate nobody should trust, so
+  [[parity-discrimination!]] moves the DONOR frame's locale to French,
+  outside every window, and requires the same comparison to DISAGREE —
+  then puts it back and requires it to agree again. Two settles, no
+  clock, and the run stops if the gate cannot tell two pages apart.
+
+  **A dev-mode compile is expected to REFUSE that gate, and correctly.**
+  `data-rf2-source-coord` carries each boundary's own source position, so
+  under `goog.DEBUG` the two arms' attributes differ by construction and
+  the pages are not the same page. `run.cjs` builds this lane in
+  `release` mode, where the emit is DCE'd on both sides.
+
+  ## THE ECHO IS READ OFF SOMETHING THE INTERACTION CANNOT HAVE WRITTEN
+
+  The first driver's rule, applied to two different operations. A
+  scripted interaction sets its control up by mutating it, so the
+  control's own state is the one thing the echo may not be read over.
+
+  - **`:locale`** writes the `<select>`'s value through the pristine
+    `HTMLSelectElement.prototype` setter and then checks the **`<h1>`'s
+    text** — the application's title, in the target language. Nothing but
+    a React commit puts `Chronique` on that heading, and the target is
+    always the locale the page is NOT in, so a stale page cannot pass by
+    carrying the previous sample's answer.
+  - **`:theme`** clicks a real button and then checks the **root
+    element's inline `background-color`** against the target theme's
+    `:surface` token. A button's activation behaviour writes no style.
+
+  Both checks are adjudicated per sample, banked into `lane/tally`, and
+  `lane/assert-verified!` refuses the run at `N unverified of M`.
+
+  ## THE NEGATIVE CONTROLS ON THE ECHOES, TAKEN ONCE AT BOOT
+
+  [[echo-discrimination!]] runs four windows before anything is measured
+  and requires all four to REFUSE:
+
+  - the two `:locale` arms' **setup mutation alone** — the native value
+    write with no `change` event, and therefore no handler, no dispatch,
+    no state write and no commit;
+  - the two `:theme` arms with **no interaction at all**, asked for the
+    other theme's token.
+
+  The theme arms get the weaker of the two shapes and that is stated
+  rather than smoothed: a click IS the whole interaction there, so there
+  is no setup mutation to keep while the event is suppressed. What their
+  control establishes is that the check distinguishes *a commit happened*
+  from *nothing happened*, which is the conjunct a broken arm would fail.
+
+  ## THE POSITIVE CONTROL ADJUDICATES THE WINDOW, NOT THE SENSITIVITY
+
+  `:ctl-blocked` is `:locale` plus [[blocked-ms]] of blocked main thread
+  spent AFTER React's commit has returned and BEFORE the browser can
+  produce a frame. Its prediction is additive and needs no model of the
+  application: the window must lengthen by [[blocked-ms]], to within the
+  one rendering interval the frame grid rounds it to ([[control-slack]]).
+  A commit-bounded window would not see one millisecond of it, so the
+  control catches a rig that had quietly stopped measuring a paint.
+
+  ONE control, on the Hicasso side only, and that is enough because there
+  is one window: both arms run the same `window!` over the same
+  mechanism. What a donor-side fault would look like is not a blind
+  window but an interaction that never reached the donor application, and
+  the donor's own per-sample echo and its boot negative control are what
+  adjudicate that.
+
+  ## WHAT THIS FILE PUBLISHES, AND WHAT IT REFUSES TO
+
+  Per arm: `{:n :min :max :p50 :p95 :p99}`, the `:commit` / `:to-raf` /
+  `:raf-to-paint` decomposition over the measured visits, the guard's
+  verdict, the control's verdict and the runtime label. Then two
+  comparative figures — `:locale / :donor-locale` and
+  `:theme / :donor-theme`, per round and as a range, through
+  `lane/ratio-between` — and every arm's range against the floor through
+  `lane/across-rounds`.
+
+  **No line is applied to any of them.** `U3`'s 100 ms `p95`, `C3`'s
+  `1.25x` and `C4`'s `1.5x` appear nowhere in this file and none of them
+  should: `budgets.md` §7 routes every distributional row to pinned
+  evidence runs on P-DEV-1 and forbids converting one into a pull-request
+  threshold, §9.1 says such a row may never name the first lane, and
+  `check_budget_ledger.py` enforces both. The only pass/fail this file
+  makes are the INSTRUMENT-INTEGRITY verdicts above — the parity gate,
+  the four echo controls, the echo tally, the arm-order guard and the
+  positive control — and §2's rule holds for every one of them: they are
+  structural, not distributional.
+
+  ## THE ONE THING A READER MUST CHECK BEFORE QUOTING ANY RATIO HERE
+
+  **A paint-bounded window is dominated by the wait for the browser's
+  next rendering opportunity, and that wait is in every arm.** Two arms
+  that each wait one interval read `1.00x` whatever their substrates
+  cost, so a `C3` ratio taken over `:summary` on a small page can be
+  `1.00x` for a reason that has nothing to do with either substrate.
+
+  That is why `:over-floor` is published beside the comparative figures.
+  It is `lane/across-rounds` over each arm's ratio to `:idle-frame`, and
+  its `:straddles-1?` flag is the resolution test: an arm whose range
+  against an EMPTY FRAME includes 1.0 was not separated from the floor by
+  this window, and no ratio between two such arms is a reading about
+  anything. The `:structure` block's `:commit` leg is the other half —
+  the application's own work, outside the frame grid entirely.
+
+  **If the shipped seed cannot separate the measured arms from the floor,
+  the honest conclusion is that `C3` needs a broader population than the
+  slice's feed page** — which is a finding about the row, and never a
+  licence to widen a band or to quote an unresolved ratio.
+
+  Owner: rf2-9wmqd."
+  (:require [re-frame.adapter.uix :as uix-adapter]
+            [re-frame.bench.hicasso.lane :as lane]
+            [re-frame.bench.hicasso.slice-donor-views :as donor]
+            [re-frame.bench.hicasso.slice-echo-clock-app :as echo]
+            [re-frame.core :as rf]
+            [re-frame.hicasso :as h]
+            [re-frame.hicasso.examples.slice.db :as slice-db]
+            [re-frame.hicasso.examples.slice.events :as slice-events]
+            [re-frame.hicasso.examples.slice.i18n :as slice-i18n]
+            [re-frame.hicasso.examples.slice.routes :as slice-routes]
+            [re-frame.hicasso.examples.slice.views :as slice-views]
+            [uix.dom :as uix-dom]))
+
+;; ---------------------------------------------------------------------------
+;; The knobs — every one of them a SCHEDULE knob, never a line
+;; ---------------------------------------------------------------------------
+
+(def sampling
+  "Per-round warm-up and measured counts. `rf2-h904p`'s values, carried
+  rather than chosen, and the sibling driver's — a comparative figure
+  taken on a different schedule from the row it sits beside is a
+  comparison a reader has to reconcile before they can read it.
+
+  **A tail quantile over 12 is mostly interpolation** (`lane/quantile`
+  prices it), so the run that reads this instrument will want more, and
+  raising these two is how it gets them."
+  {:warmup 8 :samples 12})
+
+(def rounds
+  "Rounds per run. Five is the lane's standard and what `across-rounds`
+  and `control-verdict-strict` are shaped for."
+  5)
+
+(def blocked-ms
+  "How long `:ctl-blocked` blocks the main thread after the commit and
+  before the frame.
+
+  Chosen against the FRAME INTERVAL rather than by taste, and the
+  sibling's reasoning is the whole of it: a paint-bounded window is
+  quantised by the display's rendering opportunities — roughly 16.7 ms at
+  60 Hz — so an injected cost much smaller than one frame can be absorbed
+  by the quantisation entirely. 50 ms is three frames."
+  50.0)
+
+(def control-slack
+  "The half-width of `:ctl-blocked`'s band, as a fraction of
+  [[blocked-ms]]. Derived from the frame grid, not tuned to a
+  measurement: every window ends at the first rendering opportunity at or
+  after its own work, so the injected duration reaches the difference
+  ROUNDED to the grid. `0.5` of 50 ms is ±25 ms, which covers one
+  interval with room for a grid that is not exactly 60 Hz.
+
+  It is [[re-frame.bench.hicasso.slice-echo-clock-app/control-slack]]'s
+  value and its argument. Stated here rather than aliased because a band
+  is a claim about THIS instrument's control, and an instrument whose
+  band moves when a sibling's moves is an instrument nobody can
+  re-adjudicate."
+  0.5)
+
+(def hicasso-frame
+  "The Hicasso arm's frame. Its own, because frames are isolated
+  contexts: the two arms hold two copies of the same seeded `app-db` and
+  neither can see the other's."
+  ::hicasso-frame)
+
+(def donor-frame
+  "The UIx arm's frame."
+  ::donor-frame)
+
+(def initial-events
+  "What both arms are seeded with, in order.
+
+  ONE definition for both, because the two arms differing in their seed
+  is the failure the canonical-DOM gate would report as a page difference
+  and a reader would spend an afternoon on. It is the slice's own pair
+  from `app.cljs`, opened on the feed rather than on an article."
+  [[::slice-events/seed]
+   [:rf.route/navigate {:to slice-routes/feed}]])
+
+;; ---------------------------------------------------------------------------
+;; State
+;; ---------------------------------------------------------------------------
+
+(defonce ^:private !state
+  (atom {:hicasso-container nil
+         :hicasso-handle    nil
+         :donor-container   nil
+         :donor-root        nil
+         :echo-tally        nil
+         :first-refusal     nil
+         :aux               {}}))
+
+(defn verification
+  "`{:writes M :unverified N}` over every window taken since the last
+  [[boot!]] — warm-up visits included, because a verification is worth
+  more the more of them there are."
+  []
+  (lane/tally-value (:echo-tally @!state)))
+
+(def populations
+  "Which visits each published figure is taken over.
+
+  `:summary`, `:structure`, `:comparative` and `:over-floor` are all
+  taken over the MEASURED visits, because the last two are built out of
+  the first two and a ratio whose numerator and denominator are drawn
+  from different populations is not a ratio. `:echo` is the verification
+  tally and covers every window, warm-up included: it is a count of
+  refusals rather than a distribution, so it decomposes nothing."
+  {:summary     :measured-visits
+   :structure   :measured-visits
+   :comparative :measured-visits
+   :over-floor  :measured-visits
+   :echo        :all-visits})
+
+;; ---------------------------------------------------------------------------
+;; The glass
+;; ---------------------------------------------------------------------------
+
+(def ^:private pristine-select-value-setter
+  "`HTMLSelectElement.prototype`'s own `value` setter, captured lazily.
+
+  The sibling's `HTMLInputElement` capture, one element type over — but
+  **NOT for the sibling's reason, and the difference is measured rather
+  than assumed.** Over there the prototype write is load-bearing: React
+  tracks a controlled text input's value on an instance-level descriptor,
+  so assigning through the instance leaves the following `input` looking
+  like a no-op change and the handler never runs. A `<select>` is not on
+  that path. `react-dom` 19.2's change plugin sends a `select`'s native
+  `change` to `getTargetInstForChangeEvent`, which is `if (\"change\" ===
+  domEventName) return targetInst;` and consults no tracker at all — the
+  tracker is read on the TEXT-INPUT branch beside it. A plain
+  `(set! (.-value node) v)` would produce a real change here.
+
+  So this is DEFENSIVE and it is kept anyway, because the alternative is
+  two doors: the two drivers would write a control's value from outside
+  React in two different ways, one of them correct for a reason the other
+  does not share, and the next arm would copy whichever it read first.
+
+  A `delay` and not a `def` of the setter itself: this namespace's top
+  level runs wherever it is loaded, and `js/HTMLSelectElement` does not
+  exist on the node lane."
+  (delay (.-set (js/Object.getOwnPropertyDescriptor
+                  js/HTMLSelectElement.prototype "value"))))
+
+(defn- set-native-select-value! [node v]
+  (.call @pristine-select-value-setter node v))
+
+(defn- container-for [side]
+  (case side
+    :hicasso (:hicasso-container @!state)
+    :donor   (:donor-container @!state)))
+
+(defn- node-at [side sel]
+  (some-> (container-for side) (.querySelector sel)))
+
+(defn- locale-select [side] (node-at side "#slice-locale"))
+(defn- title-heading [side] (node-at side "h1.slice-title"))
+(defn- page-root     [side] (node-at side "main.slice"))
+(defn- theme-buttons [side]
+  (some-> (container-for side) (.querySelectorAll "button.theme-choice") array-seq))
+
+;; ---------------------------------------------------------------------------
+;; The two echoes
+;; ---------------------------------------------------------------------------
+
+(def locales
+  "The two locales the row alternates between, in `i18n/locales`' order.
+  A vector rather than a set so *the other one* is arithmetic."
+  (vec slice-i18n/locales))
+
+(defn- other-locale [now]
+  (first (remove #(= % now) locales)))
+
+(defn locale-echo-check
+  "The observation the `:locale` arms take: is the application's own
+  `<h1>` showing the target locale's title?
+
+  `:rendered` is the discriminating half — only a React commit writes the
+  heading's text. `:glass` is the `<select>`'s own value, carried beside
+  it because the control keeping the value this file wrote is a real
+  fact whose opposite is a real regression, and a reader of a refusal
+  needs to see which of the two went."
+  [side want]
+  {:expect   (slice-i18n/t want :app/title)
+   :rendered (some-> (title-heading side) .-textContent)
+   :glass    (some-> (locale-select side) .-value)
+   :want     (name want)})
+
+(defn- locale-echo-verified? [{:keys [expect rendered glass want]}]
+  (and (= expect rendered) (= want glass)))
+
+(defn theme-echo-check
+  "The observation the `:theme` arms take: has the page root's inline
+  background moved to the target theme's `:surface` token?
+
+  The root's `style` attribute is written by React and by nothing else on
+  this page — a button's activation behaviour writes no style — so the
+  check needs no second place to read from and no sentinel to scribble.
+  The token values are already CSSOM's own serialisation
+  (`\"rgb(255, 255, 255)\"`), so this is an equality and not a parse."
+  [side want]
+  {:expect   (slice-i18n/token want :surface)
+   :rendered (some-> (page-root side) .-style .-backgroundColor)
+   :want     (name want)})
+
+(defn- theme-echo-verified? [{:keys [expect rendered]}]
+  (and (some? expect) (= expect rendered)))
+
+(defn- note-refusal!
+  "Keep the FIRST refusal's detail, so a run that dies on `N unverified of
+  M` says which arm, which conjunct and against what. `lane/tally` counts
+  and does not describe."
+  [arm-id echo]
+  (swap! !state update :first-refusal
+         (fn [prev] (or prev (assoc echo :arm arm-id))))
+  nil)
+
+;; ---------------------------------------------------------------------------
+;; The arms
+;; ---------------------------------------------------------------------------
+
+(defn- idle-plan
+  "The floor. No interaction at all — what one settle costs when the
+  application does nothing. `:echo` is `:n/a` and banks as verified,
+  because there is no echo to be late.
+
+  Taken on the Hicasso container, and one floor rather than two: the wait
+  for a rendering opportunity is the browser's and belongs to neither
+  arm. A second floor on the donor page would measure the same grid and
+  invite a reader to divide one by the other."
+  [_]
+  {:interact!        (fn [] nil)
+   :observe-at-frame (fn [] {:verified? true :echo :n/a})})
+
+(defn locale-plan
+  "Switch one arm's display language: write the OTHER locale onto the
+  `<select>` through the prototype's setter, then fire a real `change`.
+
+  ALTERNATING and not fixed. The target is always the locale the page is
+  not in, so a window that closed too early cannot pass the echo check by
+  carrying the previous sample's answer — the sibling's rotor property,
+  over a roster of two. Over a run each arm takes both directions in
+  equal numbers, so neither arm's distribution is a distribution of one
+  direction's work."
+  [side]
+  (fn [_]
+    (let [select (locale-select side)
+          now    (keyword (.-value select))
+          want   (other-locale now)]
+      {:interact!        (fn []
+                           (set-native-select-value! select (name want))
+                           (.dispatchEvent select (js/Event. "change" #js {:bubbles true})))
+       :observe-at-frame (fn []
+                           (let [seen (locale-echo-check side want)]
+                             {:verified? (locale-echo-verified? seen) :echo seen}))})))
+
+(def themes
+  "The themes the application's own table names, as a sequence.
+
+  Derived from `i18n/themes` rather than written out, so a theme added
+  there cannot leave this file quietly timing a two-theme page. ORDER IS
+  NOT RELIED ON and could not be — a map has none. The only question
+  asked of this roster is *which member is the page not wearing*, which
+  is answered by the token values and not by position."
+  (vec (keys slice-i18n/themes)))
+
+(defn theme-state
+  "`{:target <button> :want <theme>}` for one arm: the button to click,
+  and the theme the page will be in once the click has committed.
+
+  ## NEITHER FACT IS READ OFF A LABEL OR OFF AN INDEX
+
+  A theme button carries no id and no data attribute — its markup is a
+  class, a type, an intent and a TRANSLATED label — so the label cannot
+  name the theme (it is `Dark` in one locale and `Sombre` in another, and
+  the `:locale` arm moves the page between them). Position could name it,
+  because the view places `[:light :dark]` in that order, but that is a
+  literal inside a body this file does not own and a reordering there
+  would silently swap this arm's target.
+
+  So both facts come off the page instead: the BUTTON is the one the
+  application did not mark `current`, and the WANTED THEME is the one
+  whose `:surface` token is not the colour the root is wearing. Two
+  independent reads of the same fact, which is what makes the pair worth
+  asserting against each other.
+
+  REFUSES rather than guessing when the page is not in a state either
+  read can answer — a roster that is not two buttons, a `current` mark on
+  none or both, or a root wearing a colour no theme in the table names.
+  Each of those is a page this arm has no business timing, and a plan
+  that quietly picked `:light` would time it anyway."
+  [side]
+  (let [buttons (vec (theme-buttons side))
+        current? (fn [^js b] (.contains (.-classList b) "current"))
+        marked  (filterv current? buttons)
+        now-bg  (some-> (page-root side) .-style .-backgroundColor)
+        want    (first (remove (fn [th] (= (slice-i18n/token th :surface) now-bg)) themes))]
+    (when-not (= 2 (count themes))
+      (throw (ex-info (str "the application's theme table names " (count themes) " themes, and "
+                           "this arm's whole rule for choosing a target is *the one the page "
+                           "is not wearing*, which answers nothing at any other roster size")
+                      {:rf.error/id ::theme-table-unexpected
+                       :themes      themes})))
+    (when-not (= 2 (count buttons))
+      (throw (ex-info (str "the " (name side) " arm's theme switch is not two buttons — it has "
+                           (count buttons) ", so there is no `the other one` to click")
+                      {:rf.error/id ::theme-roster-unexpected
+                       :side        side
+                       :buttons     (count buttons)})))
+    (when-not (= 1 (count marked))
+      (throw (ex-info (str "the " (name side) " arm marks " (count marked) " theme buttons "
+                           "`current`, and exactly one of them is the page saying which "
+                           "theme it is in")
+                      {:rf.error/id ::theme-current-unexpected
+                       :side        side
+                       :marked      (count marked)})))
+    (when-not (some (fn [th] (= (slice-i18n/token th :surface) now-bg)) themes)
+      (throw (ex-info (str "the " (name side) " arm's root is wearing " (pr-str now-bg)
+                           ", which is neither theme's :surface token, so the theme echo "
+                           "has no target it could be checked against")
+                      {:rf.error/id ::theme-surface-unknown
+                       :side        side
+                       :observed    now-bg
+                       :tokens      (mapv #(slice-i18n/token % :surface) themes)})))
+    {:target (first (remove current? buttons))
+     :want   want}))
+
+(defn theme-plan
+  "Switch one arm's theme: a real click on whichever of the two theme
+  buttons is not the current one.
+
+  `HTMLElement.click()` and not a synthesised event: the user agent's
+  activation behaviour is what a user's click runs, and there is no
+  tracked value to leave stale — a button is not a controlled input.
+
+  ALTERNATING, like the locale arm and for the same reason: the target is
+  always the theme the page is not in, so a window that closed too early
+  cannot pass by carrying the previous sample's answer."
+  [side]
+  (fn [_]
+    (let [{:keys [target want]} (theme-state side)]
+      {:interact!        (fn [] (.click target))
+       :observe-at-frame (fn []
+                           (let [seen (theme-echo-check side want)]
+                             {:verified? (theme-echo-verified? seen) :echo seen}))})))
+
+(defn- busy-wait!
+  "Block the main thread for `ms`. A spin and not a `setTimeout`, because
+  the control has to occupy the interval the window is measuring rather
+  than yield it."
+  [ms]
+  (let [end (+ (lane/now-ms) ms)]
+    (loop [] (when (< (lane/now-ms) end) (recur)))))
+
+(defn- blocked-plan
+  "`:locale` on the Hicasso arm, plus [[blocked-ms]] of blocked main
+  thread on `window!`'s `after-commit!` seam.
+
+  WHERE THE COST SITS IS THE CONTROL. Injecting it inside `interact!`
+  would put it before `t-commit`, where a `flushSync` window would see
+  every millisecond of it and the control would prove only that the
+  instrument can measure a busy loop. On the seam it lands strictly
+  between the commit and the frame — invisible to the window this one
+  replaces, and fully inside this one.
+
+  It rides the LOCALE arm rather than the theme arm because
+  [[control-per-round]] subtracts the two, and a control paired with the
+  broader of the two operations is the pair whose difference is dominated
+  by the injected duration rather than by the operations' own spread."
+  [state]
+  (assoc ((locale-plan :hicasso) state)
+         :after-commit! (fn [] (busy-wait! blocked-ms))))
+
+;; ---------------------------------------------------------------------------
+;; Sampling
+;; ---------------------------------------------------------------------------
+
+(defn- bank-aux!
+  "Record one sample's structural parts, and adjudicate its echo.
+
+  Warm-up visits bank here and are narrowed out again before publication:
+  this is called from inside [[measure-one!]], which the lane calls for
+  warm-up and measured visits alike and which is handed an ARM rather
+  than a visit, so it cannot tell them apart and does not try.
+  `echo/structure-over-measured` narrows the parts to the measured
+  population using the mask `lane/visit-plan` produces.
+
+  The two consumers want different populations, which is why the
+  narrowing is at publication rather than here. The TALLY wants every
+  window; the DISTRIBUTIONS want the measured visits only."
+  [arm-id {:keys [commit-ms to-raf-ms raf-to-paint-ms echo]}]
+  (let [t (:echo-tally @!state)]
+    (when-not (:verified? echo) (note-refusal! arm-id (:echo echo)))
+    (swap! t (fn [{:keys [of bad]}]
+               {:of  (inc of)
+                :bad (if (:verified? echo) bad (inc bad))})))
+  (swap! !state update-in [:aux arm-id]
+         (fn [a] (-> (or a {:commit [] :to-raf [] :raf-to-paint []})
+                     (update :commit conj commit-ms)
+                     (update :to-raf conj to-raf-ms)
+                     (update :raf-to-paint conj raf-to-paint-ms))))
+  nil)
+
+(defn measure-one!
+  "One sample of `arm`, as a promise of its `:ms`.
+
+  The plan is built OUTSIDE the window — reading the node, deciding what
+  the echo must be — so nothing but the interaction and the frame is
+  inside it. `after-paint` runs first, also outside, so every window
+  starts in the first task after a paint: a paint-bounded window is
+  PREDECESSOR-DEPENDENT by construction, and aligning the phase makes it
+  a constant of the instrument rather than a property of whatever ran
+  before. The sibling's `measure-one!` carries the incident that
+  established this, and what the alignment costs the estimand."
+  [arm]
+  (.then (echo/after-paint)
+         (fn [_]
+           (.then (echo/window! ((:plan arm) !state))
+                  (fn [r] (bank-aux! (:id arm) r) (:ms r))))))
+
+;; ---------------------------------------------------------------------------
+;; Boot
+;; ---------------------------------------------------------------------------
+
+(defn- settle!
+  "Two frames, outside every window. React's commit and the initial
+  events' drain are not the same tick."
+  []
+  (.then (echo/after-paint) (fn [_] (echo/after-paint))))
+
+(defn boot!
+  "Mount both arms into their own containers on their own frames, and
+  answer a promise that resolves once both pages are on the screen.
+
+  The Hicasso arm goes through `h/mount!`, the application's own root
+  door, with the application's own views and `initial-events`. The donor
+  arm makes its frame with `rf/make-frame` — core's own door, carrying
+  the SAME `:initial-events` — and renders through `uix.dom`, which is
+  how a UIx application mounts.
+
+  `:identifier-prefix` on both, distinct: `useId` numbers every root from
+  the same start, and a page with two roots either names them apart or
+  watches their generated ids collide. Neither page renders a `useId`
+  value today; if one ever did, distinct prefixes would put the
+  difference in front of the canonical-DOM gate rather than under it.
+
+  INSTALLING THE ADAPTER AND LEAVING REACT'S `act` ENVIRONMENT ARE NOT
+  DONE HERE. Both are process-wide and belong to [[-main]], which owns
+  the bench page."
+  []
+  (let [hic-container (lane/fresh-container!)
+        don-container (lane/fresh-container!)
+        handle        (h/mount! hic-container
+                                {:frame             hicasso-frame
+                                 :identifier-prefix "hic"
+                                 :initial-events    initial-events}
+                                [slice-views/app {}])
+        _             (rf/make-frame {:id             donor-frame
+                                      :initial-events initial-events})
+        don-root      (uix-dom/create-root don-container {:identifier-prefix "don"})]
+    (uix-dom/render-root (donor/root donor-frame) don-root)
+    (swap! !state assoc
+           :hicasso-container hic-container
+           :hicasso-handle    handle
+           :donor-container   don-container
+           :donor-root        don-root
+           :first-refusal     nil
+           :aux               {}
+           :echo-tally        (lane/tally))
+    (.then (settle!)
+           (fn [_]
+             (doseq [side [:hicasso :donor]]
+               (when (nil? (locale-select side))
+                 (throw (ex-info (str "the " (name side) " arm mounted but its feed did not: "
+                                      "#slice-locale is not on its page, so there is no "
+                                      "published control to switch")
+                                 {:rf.error/id ::feed-absent
+                                  :side        side})))
+               (when (nil? (page-root side))
+                 (throw (ex-info (str "the " (name side) " arm rendered no main.slice root, "
+                                      "so the theme echo has nothing to read")
+                                 {:rf.error/id ::root-absent
+                                  :side        side}))))
+             nil))))
+
+(defn teardown!
+  "Take both roots down and drop both containers. Exposed for a caller
+  that mounts and unmounts around each of its rows."
+  []
+  (let [{:keys [hicasso-container hicasso-handle donor-container donor-root]} @!state]
+    (when hicasso-handle (h/unmount! hicasso-handle))
+    (when donor-root (uix-dom/unmount-root donor-root))
+    (doseq [c [hicasso-container donor-container]]
+      (when (and c (.-parentNode c)) (.removeChild (.-parentNode c) c)))
+    (swap! !state assoc
+           :hicasso-container nil :hicasso-handle nil
+           :donor-container nil :donor-root nil)
+    nil))
+
+;; ---------------------------------------------------------------------------
+;; The fairness gate, and the control that proves it discriminates
+;; ---------------------------------------------------------------------------
+
+(defn pages
+  "Both arms' canonical DOM, as `{:hicasso s :donor s}`."
+  []
+  {:hicasso (lane/canonical (container-for :hicasso))
+   :donor   (lane/canonical (container-for :donor))})
+
+(defn- first-difference
+  "The index of the first character at which `a` and `b` differ, and the
+  60 characters from it in each, or nil when they are equal. A refusal
+  that prints two 4 KB pages is a refusal nobody reads."
+  [a b]
+  (let [n (min (count a) (count b))
+        i (loop [i 0] (cond (= i n)                    (when (not= (count a) (count b)) i)
+                            (not= (nth a i) (nth b i)) i
+                            :else                      (recur (inc i))))]
+    (when (some? i)
+      {:at      i
+       :hicasso (subs a i (min (count a) (+ i 60)))
+       :donor   (subs b i (min (count b) (+ i 60)))})))
+
+(defn assert-parity!
+  "REFUSE unless both arms are building the same page.
+
+  This is the entire fairness guarantee of a cross-arm ratio, in
+  `lane/canonical`'s own words: without it two arms can be timed against
+  each other while building different pages. It runs on the seeded page,
+  before any window, because that is the only moment both arms are known
+  to be in the same state — every measured arm alternates its own page
+  independently afterwards, so a comparison taken later would be
+  comparing two different locales and would refuse for the wrong reason."
+  [why]
+  (let [{:keys [hicasso donor]} (pages)]
+    (when (not= hicasso donor)
+      (throw (ex-info (str "the two arms are not building the same page (" why "), so no "
+                           "ratio between them would be a ratio about a substrate. "
+                           "Under a dev compile this is expected and correct: "
+                           "data-rf2-source-coord carries each boundary's own source "
+                           "position, and the lane is built in release mode where the "
+                           "emit is DCE'd on both sides.")
+                      {:rf.error/id ::pages-differ
+                       :why         why
+                       :difference  (first-difference hicasso donor)
+                       :sizes       {:hicasso (count hicasso) :donor (count donor)}})))
+    nil))
+
+(defn parity-discrimination!
+  "THE SABOTAGE, BUILT IN, on the fairness gate rather than on an echo.
+
+  Move the DONOR frame's locale to the other one — outside every window,
+  through the application's own event, on the frame that arm renders from
+  — and require [[assert-parity!]] to REFUSE. Then put it back and
+  require it to pass again.
+
+  Answers a promise. A gate that cannot tell two pages apart would let
+  every later refusal read as a clean pass, and the run would publish a
+  ratio taken across two applications."
+  []
+  (let [;; Read off the donor's own `<select>` rather than assuming the
+        ;; seed's `:en`. The assumption would be true today and would stop
+        ;; being true the moment anything ran before this — which is
+        ;; exactly the class of thing a control is supposed to survive.
+        now         (keyword (.-value (locale-select :donor)))
+        other       (other-locale now)
+        to-locale!  (fn [l] (rf/with-frame donor-frame
+                              (rf/dispatch-sync [::slice-events/set-locale (name l)])))
+        restore     (fn [] (to-locale! now))
+        break       (fn [] (to-locale! other))]
+    (break)
+    (-> (settle!)
+        (.then (fn [_]
+                 (let [{:keys [hicasso donor]} (pages)]
+                   (when (= hicasso donor)
+                     (throw (ex-info (str "the canonical-DOM gate does not discriminate: the "
+                                          "donor arm was moved to a different locale and its "
+                                          "page still serialised identically to the Hicasso "
+                                          "arm's. Every parity check this run could take "
+                                          "would pass whatever the two arms rendered, so "
+                                          "nothing may be measured")
+                                      {:rf.error/id ::parity-not-discriminating
+                                       :size        (count hicasso)})))
+                   (restore))))
+        (.then (fn [_] (settle!)))
+        (.then (fn [_] (assert-parity! "after the gate's own negative control restored it")
+                 nil)))))
+
+;; ---------------------------------------------------------------------------
+;; The negative controls on the ECHOES
+;; ---------------------------------------------------------------------------
+
+(defn- refuse-window!
+  "Take one window over `plan` and require its observation to REFUSE.
+  Answers a promise of the refused observation and REJECTS if it passed."
+  [label plan]
+  (.then (echo/window! plan)
+         (fn [{:keys [echo]}]
+           (when (:verified? echo)
+             (throw (ex-info (str label " does not discriminate: a window whose interaction "
+                                  "could not have moved the application still verified. Every "
+                                  "reading this arm could take would be timing something "
+                                  "other than a slice-application echo, so nothing may be "
+                                  "measured")
+                             {:rf.error/id ::echo-not-discriminating
+                              :control     label
+                              :observed    (:echo echo)})))
+           (:echo echo))))
+
+(defn echo-discrimination!
+  "Four windows, before the first warm-up visit, all four required to
+  refuse. Answers a promise.
+
+  ## The locale halves: the SETUP MUTATION ALONE
+
+  Write the other locale onto the `<select>` through the same pristine
+  setter the arm uses — and fire NO event, so no handler, no dispatch, no
+  state write and no commit — then ask the arm's own check for the
+  target's title. It must refuse, because the heading is written by a
+  React commit and by nothing else. The control leaves the page as it
+  found it: the restoring write is through the same setter and is not a
+  model change, so it needs no dispatch to unwind.
+
+  ## The theme halves: NO INTERACTION AT ALL
+
+  Weaker, and stated rather than smoothed. A click IS the whole
+  interaction on a theme button, so there is no setup mutation to keep
+  while the event is suppressed — suppressing the click leaves nothing.
+  What this half establishes is that the check distinguishes *a commit
+  happened* from *nothing happened*, asked against the theme the page is
+  NOT in.
+
+  ## Why here rather than only in a suite
+
+  The sibling's argument, unchanged: a suite row is the right place to
+  prove a repair and the wrong place to keep a driver honest, because the
+  driver is what a quiet-box window runs and the suite is not. So the run
+  itself asks, once, at a cost of four frames."
+  []
+  (let [locale-control
+        (fn [side]
+          (let [select (locale-select side)
+                now    (keyword (.-value select))
+                want   (other-locale now)]
+            (.then (refuse-window!
+                     (str (name side) " locale echo")
+                     {:interact!        (fn [] (set-native-select-value! select (name want)))
+                      :observe-at-frame (fn []
+                                          (let [seen (locale-echo-check side want)]
+                                            {:verified? (locale-echo-verified? seen)
+                                             :echo      seen}))})
+                   (fn [seen]
+                     (set-native-select-value! select (name now))
+                     seen))))
+        theme-control
+        (fn [side]
+          ;; `theme-state`'s own `:want` — the arm's target, taken through
+          ;; the arm's own reader rather than through a second copy of the
+          ;; rule, so this control adjudicates the code the readings use.
+          (let [{:keys [want]} (theme-state side)]
+            (refuse-window!
+              (str (name side) " theme echo")
+              {:interact!        (fn [] nil)
+               :observe-at-frame (fn []
+                                   (let [seen (theme-echo-check side want)]
+                                     {:verified? (theme-echo-verified? seen)
+                                      :echo      seen}))})))]
+    (-> (locale-control :hicasso)
+        (.then (fn [_] (locale-control :donor)))
+        (.then (fn [_] (theme-control :hicasso)))
+        (.then (fn [_] (theme-control :donor))))))
+
+;; ---------------------------------------------------------------------------
+;; The run
+;; ---------------------------------------------------------------------------
+
+(def arms
+  "The measured arms, floor first so it leads the schedule."
+  [{:id :idle-frame   :plan idle-plan}
+   {:id :locale       :plan (locale-plan :hicasso)}
+   {:id :donor-locale :plan (locale-plan :donor)}
+   {:id :theme        :plan (theme-plan :hicasso)}
+   {:id :donor-theme  :plan (theme-plan :donor)}
+   {:id :ctl-blocked  :plan blocked-plan :control? true}])
+
+(defn- readings-by-arm [readings]
+  (reduce (fn [m round]
+            (reduce-kv (fn [m id xs] (update m id (fnil into []) xs)) m round))
+          {}
+          readings))
+
+(defn round-ratios
+  "Each round's arm-to-floor ratio map, which is what both comparative
+  figures are built from.
+
+  Every ratio is against the floor measured in THAT round — `lane/normalise`'s
+  rule, and the reason this box's drift across rounds is not a term in
+  any published figure. `lane/ratio-between` then divides two of them,
+  and the floor cancels: what is left is the per-round ratio of two
+  within-round medians."
+  [readings]
+  (mapv (fn [round] (:ratio (lane/normalise round :idle-frame))) readings))
+
+(defn control-per-round
+  "One adjudicated figure per round: `:ctl-blocked`'s median less
+  `:locale`'s, in milliseconds.
+
+  A DIFFERENCE and not a ratio, because the prediction is additive — the
+  control injects a duration, not a multiple — and pairing each round
+  with its own denominator is what `control-verdict-strict` asks for."
+  [readings]
+  (mapv (fn [round]
+          (lane/round4 (- (:p50 (lane/summarise (get round :ctl-blocked)))
+                          (:p50 (lane/summarise (get round :locale))))))
+        readings))
+
+(defn take-plan!
+  "Take the plan, publish the record, and adjudicate the
+  instrument-integrity verdicts. Answers a promise.
+
+  Order matters and is the lane's: the record is published BEFORE
+  `assert-verified!` can throw, so an operator reading a failed run has
+  the evidence on the console rather than only the refusal."
+  []
+  (.then
+    (lane/rounds-async! arms sampling rounds measure-one!)
+    (fn [{:keys [readings samples]}]
+      (let [by-arm  (readings-by-arm readings)
+            ratios  (round-ratios readings)
+            control (lane/control-verdict-strict blocked-ms
+                                                 (control-per-round readings)
+                                                 control-slack)
+            verdict (lane/guard! samples "slice broad update")]
+        (lane/record! :slice-broad
+                      {:window      :interaction-to-paint
+                       :population  {:hicasso {:app   're-frame.hicasso.examples.slice
+                                               :views 're-frame.hicasso.examples.slice.views
+                                               :route :feed}
+                                     :donor   {:app   're-frame.hicasso.examples.slice
+                                               :views 're-frame.bench.hicasso.slice-donor-views
+                                               :route :feed
+                                               :spine :uix/use-subscribe}
+                                     ;; DERIVED from the application's own seed,
+                                     ;; never transcribed: a population pin that
+                                     ;; restated three integers would be a second
+                                     ;; source for them, and the first thing to go
+                                     ;; stale when the seed grows an article.
+                                     :seed    {:articles  (count (:order slice-db/seed))
+                                               :page-size slice-db/page-size
+                                               :pages     (slice-db/page-count
+                                                            (slice-db/listed slice-db/seed))}}
+                       :schedule    (assoc sampling
+                                           :rounds           rounds
+                                           :visits-per-arm   (* (+ (:warmup sampling)
+                                                                   (:samples sampling))
+                                                                rounds)
+                                           :measured-per-arm (* (:samples sampling) rounds))
+                       :populations populations
+                       :summary     (into {} (map (fn [[id xs]] [id (lane/summarise xs)])) by-arm)
+                       :structure   (echo/structure-over-measured arms sampling rounds
+                                                                  (:aux @!state))
+                       :comparative {:locale (lane/ratio-between ratios :locale :donor-locale)
+                                     :theme  (lane/ratio-between ratios :theme :donor-theme)}
+                       :over-floor  (lane/across-rounds ratios)
+                       :control     control
+                       :guard       (select-keys verdict [:refuse? :contaminated?
+                                                          :unchecked? :tolerance])
+                       :echo        (cond-> (lane/tally-value (:echo-tally @!state))
+                                      (:first-refusal @!state)
+                                      (assoc :first-refusal (:first-refusal @!state)))
+                       :runtime     (lane/runtime-label)
+                       :note        (str "No line is applied to any figure above. U3's 100 ms "
+                                         "p95, C3's 1.25x and C4's 1.5x are read against this "
+                                         "instrument in their own quiet-box window, not here. "
+                                         "Read :over-floor's :straddles-1? on a measured arm "
+                                         "before quoting any :comparative range: an arm this "
+                                         "window did not separate from an empty frame carries "
+                                         "no ratio about a substrate.")})
+        (set! (.-HICASSO_GUARD_REFUSED js/window) (boolean (:refuse? verdict)))
+        (set! (.-HICASSO_CONTROL_FAILED js/window) (not (:ok? control)))
+        (lane/assert-verified! (:echo-tally @!state) "slice broad update")
+        nil))))
+
+(defn ^:export -main []
+  (rf/init! uix-adapter/adapter)
+  (lane/leave-act-environment!)
+  (if-not (lane/self-test!)
+    (lane/fail! (str "the arm-order self-test failed — the copy of the schedule "
+                     "rule this app is about to rely on no longer behaves like "
+                     "the one the .cjs drivers use, so nothing may be measured"))
+    (-> (boot!)
+        ;; The fairness gate first, then its own negative control, then
+        ;; the four echo controls — all of them before the first warm-up
+        ;; visit, and all of them travelling the same `.catch`, so a run
+        ;; whose instrument cannot discriminate dies here rather than
+        ;; publishing a record nobody should read.
+        (.then (fn [_] (assert-parity! "on the seeded page, before any window")))
+        (.then (fn [_] (parity-discrimination!)))
+        (.then (fn [_] (echo-discrimination!)))
+        (.then (fn [_] (take-plan!)))
+        (.catch (fn [e] (lane/fail! (lane/describe-throw "slice-broad-clock-app" e))))
+        (.then (fn [_] (lane/done!)))))
+  nil)

--- a/implementation/hicasso/test/re_frame/bench/hicasso/slice_donor_views.cljs
+++ b/implementation/hicasso/test/re_frame/bench/hicasso/slice_donor_views.cljs
@@ -1,0 +1,508 @@
+(ns re-frame.bench.hicasso.slice-donor-views
+  "THE SLICE'S FEED PAGE, TRANSCRIBED INTO UIx — the DONOR ARM `C3` and
+  `C4` are stated against (rf2-9wmqd).
+
+  `docs/design/hicasso/product/budgets.md` §4 registers `C3` as *broad
+  updates ≤ 1.25x the best relevant adapter after topology tuning* and
+  `C4` as *sustained > 1.5x*, and §9.4 states both **on the same readings
+  as `U1`–`U4`** — which is to say on the slice application's own
+  interactions, through a window that ends at a paint. A comparative row
+  needs two arms and
+  [[re-frame.bench.hicasso.slice-echo-clock-app]] has one, so this
+  namespace is the other: the same page, the same subscriptions, the same
+  events, read and written the way a UIx application reads and writes
+  them.
+
+  It renders nothing on its own. [[re-frame.bench.hicasso.slice-broad-clock-app]]
+  mounts it beside the Hicasso arm, gates the two pages equal, and times
+  the same operation on each.
+
+  ## WHY UIx IS THE DONOR, AND WHAT THAT CHOICE IS NOT
+
+  Two candidates exist on this lane — Reagent reading re-frame2
+  subscriptions ([[re-frame.bench.hicasso.p0-reagent-views]]) and UIx
+  reading them through the published `use-subscribe` spine
+  ([[re-frame.bench.hicasso.p0-uix-views]]) — and this arm is the second,
+  for two reasons that are not taste.
+
+  1. **The process already carries the UIx adapter.** `rf/init!` installs
+     ONE adapter for the process, the slice's own `app.cljs` installs
+     UIx, and the Hicasso arm's driver does the same. A Reagent donor on
+     this page would need a second adapter phase — the shape
+     `p0-reagent-views` records the predecessor programme paying for, and
+     the reason its own four arms are *Reagent or nothing*. One page, one
+     adapter.
+  2. **It is the harder denominator, which is the honest direction to
+     err.** `docs/design/hicasso/studio/hd8-composed-donor-arm.md`'s
+     re-taken rows read *on this clock, direct UIx is now the faster
+     donor*, and §4's `C2` states its own line against *direct UIx*. A
+     `≤ 1.25x` claim measured against the faster of the two donors is a
+     claim that survives the other.
+
+  **This does not decide `C3`'s *best relevant adapter*, and no file in a
+  bench tree could.** *Best* is a fact about a measurement, and the only
+  thing an instrument may do about it is carry an arm and say which one.
+  What a run reading this instrument may conclude is `Hicasso / UIx` on
+  the slice's broad updates; concluding `≤ 1.25x the best relevant
+  adapter` additionally needs the Reagent arm, and that arm needs a
+  second page because it needs a second adapter.
+
+  ## WHAT MAKES THIS A DENOMINATOR RATHER THAN A STRAWMAN
+
+  `p0-reagent-views` states the rule this arm is written under: *a
+  strawman denominator would make the whole comparison worthless*. So
+  every read below is a real subscription read against the same
+  registration the Hicasso arm reads, one per boundary, and every write
+  is the same event vector the Hicasso arm's intent lowers to.
+
+  - **The sub graph is `slice.subs`, untouched.** `[::subs/t k]`,
+    `[::subs/token k]`, `[::subs/feed]`, `[::subs/current-page]`,
+    `[::subs/page-count]`, `[::subs/tags-open? slug]`,
+    `[::subs/digest-blocks]` and `[::subs/digest-loading?]` — the same
+    layer-1 and layer-2 registrations, resolved against this arm's own
+    frame. Nothing is threaded as a prop that the Hicasso arm subscribes
+    to: a row that took its label as a prop would be a different sub
+    graph wearing the same name.
+  - **The event vectors are `slice.events`', verbatim.**
+    `[::events/set-locale s]` and `[::events/set-theme {:theme t}]` are
+    what Hicasso's `::h/value` marker and its intent vector lower to, and
+    they are what this arm dispatches. The MARKER is Hicasso's
+    ergonomics; the EVENT is the application's.
+  - **`dispatch-sync`, because the thing being compared is a discrete
+    interaction.** A Hicasso intent goes through the runtime's own
+    synchronous frame-locked door — `slice.flow-dom-cljs-test` §*TWO
+    CLICKS, TWO SETTLING RULES* states it — so the handler has run and
+    React has committed before the DOM event returns. A donor
+    dispatching asynchronously would not be a slower spelling of the same
+    operation, it would be a different operation, and the window would
+    close before it began. [[re-frame.bench.hicasso.jsfb-uix-app]]'s
+    `go!` reaches for `dispatch-sync` inside the click turn for exactly
+    this reason.
+  - **No `set-hiccup-emitter!`, no `use-memo` around subscription args.**
+    `p0-uix-views`' reasons, unchanged: routing this arm through a hiccup
+    interpreter would price a hiccup interpreter, which is the
+    candidate's product delta and not UIx's.
+
+  ## WHERE THE TWO ARMS ARE NOT THE SAME, STATED RATHER THAN LEFT TO BE FOUND
+
+  The claim this arm can carry is *the same page, built by the idiomatic
+  spelling of each substrate*. It is NOT *hook for hook, allocation for
+  allocation*, and three differences are real:
+
+  - **`use-frame` is a hook this arm pays and the Hicasso arm does not
+    pay in the same place.** Three boundaries here call it —
+    [[chrome]], [[article-row]] and [[digest]] — because a UIx body
+    reaches its frame's `dispatch-sync` in hook position. Hicasso's
+    intent vector is lowered inside the boundary's own hooks instead.
+    Both are the idiomatic spelling; neither is a handicap added for the
+    bench.
+  - **A runtime-chosen TAG is a branch here and a value there.**
+    [[callout-block]] picks `<strong>` or `<em>` from the block's tone,
+    and the Hicasso body writes `[(if warning? :strong :em) …]` because a
+    keyword in head position is a keyword in head position however it got
+    there. UIx's `$` compiles a non-literal head as a COMPONENT, so this
+    arm spells the same choice as a branch over two literal elements. The
+    DOM is identical — the gate below proves it — and the difference is
+    an authoring one.
+  - **The error regions are not feature-equal.** `h/error-boundary`
+    clears a caught failure when its `:reset-key` changes;
+    [[error-region]] has no reset key. That is a difference in FAILURE
+    behaviour and not in the measured path — nothing in the row set
+    throws, the seeded digest arrives whole — and it cannot reach a
+    reading silently, because a region that had caught would render its
+    fallback and the driver's canonical-DOM gate refuses two pages that
+    differ before any clock is read.
+
+  ## THE IDS ARE DUPLICATED ON PURPOSE
+
+  `#slice-locale` is this page's id and it is also the Hicasso page's,
+  because the two pages have to be the same page. Two roots on one
+  document therefore carry duplicate ids by construction. Nothing in the
+  driver reads through `document.getElementById`: every node is found by
+  `container.querySelector` on the arm's own container, which is
+  unambiguous. A `<label for>` pointing at an ambiguous id is a real
+  defect of this bench page and of no application; no arm activates a
+  label.
+
+  Owner: rf2-9wmqd."
+  (:require [re-frame.adapter.uix :as uixa]
+            [re-frame.hicasso.examples.slice.events :as events]
+            [re-frame.hicasso.examples.slice.i18n :as i18n]
+            [re-frame.hicasso.examples.slice.routes :as routes]
+            [re-frame.hicasso.examples.slice.subs :as subs]
+            [re-frame.routing :as routing]
+            [uix.core :as uix :refer [$ defui]]))
+
+;; ---------------------------------------------------------------------------
+;; The link — routing's URL, and routing's own async activation
+;; ---------------------------------------------------------------------------
+
+(defn href-for
+  "The URL for one address, from routing's own inverse of `match-url`.
+
+  `re-frame.hicasso.impl.route-link` takes its href from routing's
+  `:routing/link-model` late-bind seam; this arm takes it from
+  `routing/route-url`, the public door onto the same registrations. The
+  two are not asserted equal here and they do not need to be: the
+  driver's canonical-DOM gate compares the rendered anchors, so a
+  disagreement between the two doors REFUSES the run rather than
+  publishing a ratio taken over two different pages."
+  [address]
+  (routing/route-url address))
+
+(defn- link-click
+  "The click a plain UIx application writes on an in-application link:
+  claim the primary unmodified click, let every other one reach the
+  browser, and ask routing to navigate.
+
+  `dispatch` and NOT `dispatch-sync`, and that is fidelity rather than a
+  concession. `re-frame.routing/activate-link!` ends at the router's
+  async door — `slice.flow-dom-cljs-test`'s namespace docstring records
+  that the navigation is merely ENQUEUED when a `route-link` click
+  returns — so a synchronous donor link would be a faster mechanism than
+  the one it is standing in for. No arm in the driver clicks a link (see
+  its §THE ROW SET), so nothing measured turns on this; it is here
+  because a page with links that do not navigate is not the page."
+  [dispatch address]
+  (fn [^js e]
+    (when (and (zero? (.-button e))
+               (not (.-metaKey e))
+               (not (.-ctrlKey e))
+               (not (.-shiftKey e))
+               (not (.-altKey e)))
+      (.preventDefault e)
+      (dispatch [:rf.route/navigate address]))))
+
+;; ---------------------------------------------------------------------------
+;; The error region
+;; ---------------------------------------------------------------------------
+
+(def error-region
+  "A React error boundary in UIx's own spelling, standing where the
+  Hicasso page puts `h/error-boundary`.
+
+  It exists for the COMPONENT COUNT as much as for the behaviour: the
+  Hicasso arm nests two of them — one around the routed pane, one around
+  the digest — and a donor that rendered the same DOM through two fewer
+  components would be a donor doing less work. See the namespace
+  docstring for the one thing it deliberately does not carry."
+  (uix/create-error-boundary
+    {:display-name       "slice-donor-error-region"
+     :derive-error-state (fn [error] error)}
+    (fn [[error _set-error] {:keys [fallback children]}]
+      (if (some? error) fallback children))))
+
+;; ---------------------------------------------------------------------------
+;; The chrome
+;; ---------------------------------------------------------------------------
+
+(defui chrome
+  "The header: the application's name, the locale `<select>` and the two
+  theme buttons.
+
+  This is the boundary both measured operations start at. The `<select>`
+  is controlled on `[::subs/locale]` and its `change` dispatches
+  `[::events/set-locale <string>]` — the string a `<select>`'s `.value`
+  always is, keyworded by the handler and not by this body, exactly as
+  the Hicasso spelling leaves it.
+
+  ## THE TWO THEME LABELS ARE READ BEFORE THE LOOP, NOT INSIDE IT
+
+  The Hicasso body reads `(h/sub [::subs/t label-key])` inside the `for`
+  that places the two buttons, and it may: `h/sub` is an ambient
+  collector rather than a React hook. `use-subscribe` IS one, and a hook
+  reached from inside a `for` is reached from inside a LAZY SEQ — a seq
+  React realises while rendering the parent element, after this body has
+  already returned. The read would then happen outside the render it
+  belongs to, which is not a slower spelling of the same thing but a
+  broken one.
+
+  Reading both labels up front is the ordinary UIx repair and it costs
+  the arm nothing it was not already paying: the roster is two literal
+  pairs, so both strings are read on every render of the Hicasso body
+  too."
+  [_]
+  (let [locale-now              (uixa/use-subscribe [::subs/locale])
+        theme-now               (uixa/use-subscribe [::subs/theme])
+        title                   (uixa/use-subscribe [::subs/t :app/title])
+        locale-label            (uixa/use-subscribe [::subs/t :app/locale])
+        theme-label             (uixa/use-subscribe [::subs/t :app/theme])
+        light-label             (uixa/use-subscribe [::subs/t :theme/light])
+        dark-label              (uixa/use-subscribe [::subs/t :theme/dark])
+        {:keys [dispatch-sync]} (uixa/use-frame)]
+    ($ :header.slice-chrome
+       ($ :h1.slice-title title)
+
+       ($ :label.locale-label {:for "slice-locale"} locale-label)
+       ($ :select#slice-locale.locale
+          {:value     (name locale-now)
+           :on-change (fn [^js e]
+                        (dispatch-sync [::events/set-locale (.. e -target -value)]))}
+          (for [locale i18n/locales]
+            ($ :option {:key (name locale) :value (name locale)} (name locale))))
+
+       ($ :div.theme-switch
+          ($ :span.theme-label theme-label)
+          (for [[theme label] [[:light light-label] [:dark dark-label]]]
+            ($ :button.theme-choice
+               {:key      (name theme)
+                :type     "button"
+                :class    (when (= theme theme-now) "current")
+                :on-click (fn [_] (dispatch-sync [::events/set-theme {:theme theme}]))}
+               label))))))
+
+;; ---------------------------------------------------------------------------
+;; The feed's row
+;; ---------------------------------------------------------------------------
+
+(defui article-row
+  "One row of the feed.
+
+  The Hicasso body reads its two values through `h/use-subs`, the grouped
+  control, because both reads are unconditional. UIx has one door and it
+  is `use-subscribe`, so the two reads are two calls — the same two
+  edges, on the same two registrations."
+  [{:keys [slug title published? tags]}]
+  (let [open?      (uixa/use-subscribe [::subs/tags-open? slug])
+        tags-label (uixa/use-subscribe [::subs/t :feed/tags])
+        {:keys [dispatch dispatch-sync]} (uixa/use-frame)
+        address    {:to routes/article :params {:slug slug}}]
+    ($ :li.article-row
+       ($ :a {:class    "article-link"
+              :href     (href-for address)
+              :on-click (link-click dispatch address)}
+          title)
+       (when-not published?
+         ($ :span.draft-badge "draft"))
+       (when (seq tags)
+         ($ :div.tags
+            ($ :button.tags-toggle
+               {:type          "button"
+                :aria-expanded (str (boolean open?))
+                :on-click      (fn [_] (dispatch-sync [::subs/tags-open? slug (not open?)]))}
+               tags-label)
+            (when open?
+              ($ :ul.tag-list
+                 (for [tag tags]
+                   ($ :li.tag {:key tag} tag)))))))))
+
+;; ---------------------------------------------------------------------------
+;; The pager
+;; ---------------------------------------------------------------------------
+
+(defui pager
+  "The feed's pager. Every control is a link carrying `{:page n}` at
+  `:query`, because the page is a URL in this application and not a key
+  in `app-db`; the ends are `<span>`s rather than disabled links, for the
+  reason the Hicasso body states.
+
+  Both labels are read OUTSIDE the branches that place them, so the page
+  a reader is on does not change which strings this body reads — the
+  same read-set property the Hicasso body is written for, and one a
+  transcription can lose without the DOM changing at all.
+
+  It goes one step further than the Hicasso body and has to: the three
+  strings and the two pagination reads sit above the `when` that decides
+  whether a pager exists at all, because a hook cannot be conditional.
+  The Hicasso body reads them INSIDE that `when`, so a single-page feed
+  reads five fewer values there than here. It is not a difference the
+  shipped seed can express — seven articles over a page size of three is
+  three pages, so both arms take the branch on every render — and the
+  driver's population pin names the seed for exactly this class of
+  reason."
+  [_]
+  (let [page                  (uixa/use-subscribe [::subs/current-page])
+        pages                 (uixa/use-subscribe [::subs/page-count])
+        {:keys [dispatch]}    (uixa/use-frame)
+        pagination            (uixa/use-subscribe [::subs/t :feed/pagination])
+        previous              (uixa/use-subscribe [::subs/t :feed/previous])
+        next-label            (uixa/use-subscribe [::subs/t :feed/next])
+        page-address          (fn [n] {:to routes/feed :query {:page n}})]
+    (when (< 1 pages)
+      ($ :nav.pager {:aria-label pagination}
+         (if (= 1 page)
+           ($ :span.pager-prev {:aria-disabled "true"} previous)
+           (let [address (page-address (dec page))]
+             ($ :a {:class    "pager-prev"
+                    :href     (href-for address)
+                    :on-click (link-click dispatch address)}
+                previous)))
+         ($ :ol.pager-pages
+            (for [n (range 1 (inc pages))]
+              ($ :li.pager-page {:key n}
+                 (if (= n page)
+                   ($ :span.pager-current {:aria-current "page"} (str n))
+                   (let [address (page-address n)]
+                     ($ :a {:class    "pager-link"
+                            :href     (href-for address)
+                            :on-click (link-click dispatch address)}
+                        (str n)))))))
+         (if (= page pages)
+           ($ :span.pager-next {:aria-disabled "true"} next-label)
+           (let [address (page-address (inc page))]
+             ($ :a {:class    "pager-next"
+                    :href     (href-for address)
+                    :on-click (link-click dispatch address)}
+                next-label)))))))
+
+;; ---------------------------------------------------------------------------
+;; The digest — runtime-selected content
+;; ---------------------------------------------------------------------------
+
+(defui prose-block
+  "A paragraph."
+  [{:keys [block]}]
+  ($ :p.block-prose (:block/text block)))
+
+(defui list-block
+  "A bulleted list, and the one renderer here that REFUSES its input — the
+  Hicasso body's contract, kept: a list block with no `:block/items` is a
+  payload that arrived broken, and rendering an empty list for it would
+  put a silent hole on the page.
+
+  It never throws in any measured arm: the seeded digest arrives whole.
+  It is transcribed because a donor that could not fail where the
+  original fails is a donor rendering a different application."
+  [{:keys [block]}]
+  (let [items (:block/items block)]
+    (when (nil? items)
+      (throw (ex-info "a list block arrived without its items"
+                      {:block/id (:block/id block)})))
+    ($ :ul.block-list
+       (for [item items]
+         ($ :li.block-item {:key item} item)))))
+
+(defui callout-block
+  "An aside whose emphasis TAG and colour are both chosen from the block's
+  tone at render time.
+
+  The branch over two literal elements is UIx's spelling of the Hicasso
+  body's computed head; see the namespace docstring, §WHERE THE TWO ARMS
+  ARE NOT THE SAME."
+  [{:keys [block]}]
+  (let [warning? (= :warning (:block/tone block))
+        colour   (uixa/use-subscribe [::subs/token (if warning? :danger :accent)])]
+    ($ :aside.block-callout {:style {:color colour}}
+       (if warning?
+         ($ :strong {:class "block-emphasis"} (:block/text block))
+         ($ :em {:class "block-emphasis"} (:block/text block))))))
+
+(defui unsupported-block
+  "A block of a kind this build has no renderer for — the EXPECTED
+  failure, which stays data."
+  [{:keys [block]}]
+  (let [label (uixa/use-subscribe [::subs/t :digest/unsupported])]
+    ($ :p.block-unsupported
+       label
+       " "
+       ($ :code.block-kind (str (:block/kind block))))))
+
+(def block-views
+  "Block kind to the view that renders it — the same plain map of heads
+  the Hicasso page holds, with UIx components in it."
+  {:block/prose   prose-block
+   :block/list    list-block
+   :block/callout callout-block})
+
+(defui digest-body
+  "The blocks, each rendered by whichever view its own kind names.
+
+  A runtime component in head position is the one place UIx's `$` and
+  Hicasso's hiccup agree exactly: `$` compiles a non-keyword head as a
+  COMPONENT and takes the value at runtime, so this is the same
+  expression the Hicasso body writes."
+  [_]
+  (let [blocks (uixa/use-subscribe [::subs/digest-blocks])]
+    ($ :div.digest-body
+       (for [{:block/keys [id kind] :as block} blocks]
+         ($ (get block-views kind unsupported-block) {:key id :block block})))))
+
+(defui digest
+  "The digest region, and this page's nested error region."
+  [_]
+  (let [;; READ AND NOT PLACED, deliberately. The Hicasso body reads the
+        ;; blocks for its region's `:reset-key`; nothing in this arm's
+        ;; markup needs them. Dropping the read would give this boundary a
+        ;; SMALLER read set than the one it stands in for — one fewer edge
+        ;; into `[::subs/digest-blocks]`, so one fewer re-render when the
+        ;; digest moves — which is the quiet way a donor becomes a
+        ;; strawman.
+        _blocks                 (uixa/use-subscribe [::subs/digest-blocks])
+        loading?                (uixa/use-subscribe [::subs/digest-loading?])
+        heading                 (uixa/use-subscribe [::subs/t :digest/heading])
+        problem                 (uixa/use-subscribe [::subs/t :digest/problem])
+        retry                   (uixa/use-subscribe [::subs/t (if loading? :digest/loading :digest/retry)])
+        {:keys [dispatch-sync]} (uixa/use-frame)]
+    ($ :section.digest
+       ($ :h3.digest-heading heading)
+       ($ error-region
+          {:fallback ($ :div.digest-error {:role "alert"}
+                        ($ :p.digest-problem problem)
+                        ($ :button.digest-retry
+                           {:type     "button"
+                            :disabled loading?
+                            :on-click (fn [_] (dispatch-sync [::events/reload-digest]))}
+                           retry))}
+          ($ digest-body {})))))
+
+;; ---------------------------------------------------------------------------
+;; The feed page and the shell
+;; ---------------------------------------------------------------------------
+
+(defui feed-page
+  "The list, keyed by slug. The digest and the pager are CHILD boundaries
+  rather than markup written here, which is what keeps this body's read
+  set to the rows and its heading."
+  [_]
+  (let [rows        (uixa/use-subscribe [::subs/feed])
+        heading     (uixa/use-subscribe [::subs/t :feed/heading])
+        empty-label (uixa/use-subscribe [::subs/t :feed/empty])]
+    ($ :section.feed
+       ($ :h2 heading)
+       ($ digest {})
+       (if (seq rows)
+         ($ :ul.article-list
+            (for [{:keys [slug] :as row} rows]
+              ($ article-row {:key         slug
+                              :slug        slug
+                              :title       (:title row)
+                              :published?  (:published? row)
+                              :tags        (:tags row)})))
+         ($ :p.feed-empty empty-label))
+       ($ pager {}))))
+
+(defui app
+  "The whole page: the chrome, then the feed pane under one error region.
+
+  **The route is not branched on here, and that is the one structural
+  difference between this shell and the Hicasso one.** The Hicasso `app`
+  chooses its pane from `[:rf.route/id]`; this arm renders the feed
+  unconditionally, because the driver's row set contains no navigation
+  (a route-link click ends at routing's ASYNC door and cannot be
+  bracketed by a one-interaction-to-one-paint window — the driver's
+  §THE ROW SET states it in full) and a pane this page can never reach
+  is code that would be transcribed to be dead.
+
+  What it costs is one `[:rf.route/id]` read on one boundary out of
+  eleven, and it costs it in the DENOMINATOR'S favour — the arm doing
+  LESS is the one C3's ratio divides by, so the omission cannot flatter
+  the numerator."
+  [_]
+  (let [surface (uixa/use-subscribe [::subs/token :surface])
+        ink     (uixa/use-subscribe [::subs/token :ink])
+        pane    (uixa/use-subscribe [::subs/t :app/pane-error])]
+    ($ :main.slice {:style {:background surface :color ink}}
+       ($ chrome {})
+       ($ error-region
+          {:fallback ($ :p.pane-error {:role "alert"} pane)}
+          ($ feed-page {})))))
+
+(defn root
+  "The element a root renders: the page, scoped to `frame-id`.
+
+  `frame-provider` SCOPES an already-created frame and renders no DOM of
+  its own, so it cannot move the canonical-DOM gate. The frame is made by
+  the driver, outside every window."
+  [frame-id]
+  ($ uixa/frame-provider {:frame frame-id}
+     ($ app {})))


### PR DESCRIPTION
Two new files under `implementation/hicasso/test/re_frame/bench/hicasso/`. Both are pure additions; nothing existing is edited.

## What was verified at the tip before building

The bead's premises are claims, and both held.

- `slice_echo_clock_app.cljs:161` still reads **"`U3` AND `U4` ARE NOT SERVED BY THIS ROW SET"** verbatim.
- Its arms are still a floor, two Hicasso interactions and `:ctl-blocked` — **no donor arm**, so `C3` and `C4` still have nothing to compare against.
- PR #8595 merged while this was in flight, and `budgets.md` at this branch's base now carries the same finding from the ledger's side: *"this driver carries no donor arm at all — its four rows are a floor, two Hicasso interactions and a positive control."*

## What landed

**`slice_broad_clock_app.cljs`** — the second driver, on the slice's **feed** route (the first driver takes the article route, so the two share no preparation). It times two broad application operations through the **same `window!`** the first driver publishes — required, not transcribed, so the two drivers cannot drift into two definitions of a window:

| arm | what it is |
|---|---|
| `:idle-frame` | the floor — a frame and no application work |
| `:locale` | a real `change` on the published `<select>`; one key in `app-db`, every string boundary re-renders. `U3`'s estimand |
| `:theme` | a real click on the published theme button — `U3` on a second event path, and a narrower broad update |
| `:donor-locale` / `:donor-theme` | the same two operations on the UIx page |
| `:ctl-blocked` | `:locale` plus 50 ms of blocked main thread on the post-commit seam — the positive control |

**`slice_donor_views.cljs`** — the donor arm: the slice's feed page in UIx, reading the **same subscriptions from the same registrations** and dispatching the **same event vectors**, so the ratio is a substrate ratio and not a serialiser one. UIx rather than Reagent because the process carries one adapter and because this lane's own re-taken HD-008 rows make direct UIx the faster donor — the conservative direction to err. The file states plainly that carrying **one** donor does not settle `C3`'s *best relevant adapter*.

## Three refusals, each taken at source rather than by taste

1. **No navigation row.** Two of the three broad operations the first driver names — a route change and a save reply — **cannot be bracketed by this window at all**. `re-frame.routing/activate-link!` ends at `router/dispatch!`, the **async door**: the click returns with the operation merely *enqueued* and the router drains it on a next-turn task. A window that stops at the first paint after the click stops **before the operation has begun**. The slice's own `flow_dom_cljs_test.cljs` states the split (section *TWO CLICKS, TWO SETTLING RULES*), and notes that every async mutation reply in any re-frame2 application arrives the same way. Those operations need a different window — one bounded by the drain *and* its paint — and it is not built here.
2. **`U4` is not reachable on the slice.** It is registered over *dragging/animation*, and the slice publishes neither — every interaction it has is discrete. Repeating a discrete interaction once a frame and publishing the result against a line about a continuous one is the same class of error the first driver exists to have stopped making, and adding a drag to the slice would move the population. The repair is another witness: `examples/ledger` publishes a virtualized 10,000-row list over a real scroll viewport, which is genuinely continuous. That is a third driver on a third page.
3. **The donor's structural asymmetries are disclosed, not smoothed.** Three of them: `use-frame` is a hook the donor pays in three boundaries; a runtime-chosen *tag* is a branch in UIx and a value in Hicasso; and the donor's error region carries no `:reset-key`. Each is stated in the donor file with what it does and does not reach, and none can silently reach a reading — the parity gate refuses two pages that differ before any clock is read.

## No threshold, no band, no gate

`U3`'s 100 ms `p95`, `C3`'s `1.25x` and `C4`'s `1.5x` appear **nowhere** in either file. Section 7 routes every distributional row to pinned evidence runs on P-DEV-1 and forbids converting one into a PR threshold; section 9.1 forbids such a row naming the first lane; `check_budget_ledger.py` enforces both. The only pass/fail here are **instrument-integrity** verdicts, and every one is structural:

- a **canonical-DOM parity gate** (`lane/canonical`) — with its **own negative control**, which moves the donor frame's locale, requires the gate to refuse, restores, and requires it to pass again;
- **four echo negative controls** at boot — the two locale arms' *setup mutation alone* (native write, no event, so no handler, no dispatch, no commit) and the two theme arms with *no interaction at all*, all four required to refuse;
- the per-sample echo tally under `lane/assert-verified!`;
- the arm-order guard;
- the additive positive control, whose band is derived from the frame grid rather than tuned to a measurement.

**No ledger cell moves.** The ledger stands where it stood: 49 rows / 31 MET / 5 BREACH / 3 UNRESOLVED / 10 UNPINNED. `U3`, `U4`, `C3` and `C4` all keep `UNPINNED`; this is an instrument, and a verdict needs a window.

## The one thing a reader must check before quoting any ratio from this

A paint-bounded window is dominated by the wait for the next rendering opportunity, and that wait is in every arm — so two arms that each wait one interval read `1.00x` whatever their substrates cost. The record therefore publishes `:over-floor`, each arm's range against an **empty frame**, through `lane/across-rounds`; its `:straddles-1?` flag is the resolution test. **If the shipped seed cannot separate the measured arms from the floor, the honest conclusion is that `C3` needs a broader population than the slice's feed page** — a finding about the row, never a licence to widen a band.

## Quality gates

**NO WINDOW AND NO BENCH RUN WAS TAKEN.** The box was carrying other workers' lanes, and a reading taken beside one measures the fleet. This change builds an instrument; a later dispatch takes the window.

**The gate that covers this surface is heavyweight and was NOT run locally: `npm run test:hicasso-compile`.** It is one `shadow-cljs compile` of every namespace in the lane with warnings treated as failures, it **auto-covers new files by walking this directory** (its entry list is derived, never rostered), and **it runs on every PR** in `test.yml`'s `cljs_node_test` job. So the compile of both new files is gated in CI on this PR — it simply was not run on this machine. Neither was `npm run test:cljs`, for the same reason. `scripts/check_fast_pr_gap.py --list` names `hicasso-compile` among the spine's entries; **the fast-PR spine was not run at all**, and neither was any other suite.

What **was** run, locally and cheaply, on this worktree — each with a planted-fault discrimination proof and a hashed restore:

| check | result | discrimination |
|---|---|---|
| Clojure-aware delimiter balance, both new files | exit 0 | removed one `]` at a line I was editing, giving exit 1 naming that line; restored to the identical blob hash `f606bda55b9d5437692ba9444e4778a144a98508` |
| qualified-reference resolution (every `alias/sym` against the aliased namespace's own source) — 45 references in the driver, 8 in the donor views, all resolve | exit 0 | planted `routing/route-url-not-a-thing`, giving exit 1 naming it; restored to the identical blob hash `039f884521914f591ecc1179c832b4a21045f215` |

Both checks additionally ran against **known-good controls** — `slice_echo_clock_app.cljs`, `lane.cljs`, `p0_uix_views.cljs`, `jsfb_uix_app.cljs` — and the control run is what caught a false positive in the reference checker's own extractor (it did not understand namespaced `def` macros such as `h/defview`, and reported `slice-views/app` as undefined in the *merged* driver). Fixed, then re-run. The checker's index was probed for non-emptiness before any result was believed: 1,551 namespaces, with `re-frame.core` and the lane both found — an earlier run returned all-SKIP, which is a zero that proves nothing.

Neither check is a compile. They prove the reader reaches the end of each file and that every qualified name is defined somewhere in its namespace; they say nothing about arity, hook order, or React behaviour.

Two things verified by hand, because no gate reaches them:

- **`react-dom` 19.2's change plugin was read at source** rather than assumed. For a `<select>` it routes a native `change` through `getTargetInstForChangeEvent` — `if ("change" === domEventName) return targetInst;` — consulting **no value tracker**, which is the text-input branch beside it. So the prototype-descriptor write the sibling driver *needs* is **defensive here, not load-bearing**, and the docstring says so instead of repeating the sibling's reason.
- **`uix.core` 1.4.4's `$` compiles a non-literal head as a COMPONENT**, so `($ (if warning? :strong :em) ...)` would be wrong; the donor spells that choice as a branch over two literal elements, and a runtime *component* in head position (`digest-body`) is the one case where the two substrates' spellings agree exactly.

No files under `docs/` were touched, so neither `check_doc_slugs.py` nor `check_provenance_pins.py` is the gate for this change.

The branch was rebased onto `origin/main` after PR #8595 merged, and both checks were re-run on that final base. The merge-base diff (`origin/main...HEAD`) is 1,575 insertions and 0 deletions across two new files, so nothing a sibling landed is reverted.

## Tracker

`rf2-9wmqd` stays **OPEN**. `U3`, `C3` and `C4` now have an instrument; `U4` does not, and what it needs is a driver on the ledger witness rather than another arm here.
