### PR TITLE
docs(method): an exclusion may carry its own carve-outs, so read those too (rf2-butkd)

### DIFF
--- a/docs/the-mayor-method/dispatch-prompt-template.md
+++ b/docs/the-mayor-method/dispatch-prompt-template.md
@@ -620,9 +620,12 @@ merge criterion, and this is not among them.
 - **Never nominate a gate that does not cover the surface being edited.** Site builds, linters and test
   runners all carry exclusion lists, and a gate run over an excluded path exits green having verified
   nothing — the same fail-open defect worth hunting anywhere else, except it is now the brief telling the
-  worker to trust it. **Read the exclusion config before naming the gate.** Where a surface genuinely has no
-  automated coverage, the honest brief says *no automated gate covers this surface; the worker verifies it by
-  hand and says so in the change body* — and the change body then reports what was checked and the counts.
+  worker to trust it. **Read the exclusion config before naming the gate.** Read the exclusion's own carve-outs
+  too, because an exclusion may itself name exceptions — a construct the gate skips everywhere but reports in
+  named trees — and **understating coverage misreports as surely as overstating it**, sending a worker to
+  hand-check what the gate already proved and to record a gap that is not there. Where a surface genuinely has
+  no automated coverage, the honest brief says *no automated gate covers this surface; the worker verifies it
+  by hand and says so in the change body* — and the change body then reports what was checked and the counts.
 
 A skipped gate needs a one-line reason in the change body. A silent skip fails review.
 


### PR DESCRIPTION
## What and why

The gate-nomination bullet under *Quality gates — which gate* covered one direction
only: a gate covering **less** than it appears, where nominating it returns a green
that inspected nothing. Its remedy — read the exclusion config before naming the gate
— is right as far as it goes, but it does not tell a reader to read the exclusion's
own **exceptions**.

An exclusion can carry a carve-out: a construct a gate skips everywhere but reports in
named trees. Stating only the blind spot then **understates** coverage, and that
direction is not the harmless one. A worker told a gate does not cover its edit will
hand-check — which costs little — and then **report that gap in the change body**, a
false statement, the same both-directions misreporting the fast-spine-gap rule already
warns about. Worse, it can read a green as having inspected nothing and go hunting a
problem the gate already proved absent.

This adds **one abstract sentence** to the existing bullet and nothing else.

## Scope discipline

The method tree is the generic document other projects read, so the added sentence
carries the **class** and no roster: no repository names, script names, constant names,
file paths, tracker ids or change numbers. The concrete, repo-specific half of this
defect landed separately and is deliberately neither named nor cited here, and that
file is untouched by this branch. Mechanically verified against the added lines — all
zero, each with a positive control run against text that does contain the pattern.

Diff is 1 file, +6/-3: one new sentence plus the rewrap it forces.

## Quality gates

Both gates below were run **in the foreground**, output redirected to a log with the
runner's own exit code echoed on the **same command line**, never piped through a
filter. The numbers quoted are the ones captured that way.

| Gate | Exit | Notes |
| --- | --- | --- |
| `python scripts/check_doc_slugs.py` | **0** | Validates link targets and heading anchors under the docs roots; this file sits under one of them. |
| `python -m mkdocs build --strict` | **0** | Site build. Ran as `python -m mkdocs` — the bare `mkdocs` name is not on PATH in this shell and returned exit 127, which is *command not found*, not a verdict. |

**Both gates were proved to read this worktree by a planted fault**, not by a printed
root banner. A broken relative link target was planted at a line this change already
edits; the anchor matched exactly once (checked **before** running, so a no-op plant
could not masquerade as a pass); and both gates went **red naming the plant**:

- `check_doc_slugs.py` → captured exit **1**, `BROKEN TARGET: ...dispatch-prompt-template.md:624`, the edited line.
- `mkdocs build --strict` → captured exit **1**, `WARNING - ... contains a link './...', but the target ... is not found`.

The fault existed only in this worktree, so a run that had wandered into a sibling
checkout would have come back green — the red **is** the discrimination. Restored via
version control and verified by hashing the bytes, not by reading a diff: the identical
**blob** hash `fceda05e06786030401a837f1444efa96b9b96f5` against the committed object
before the plant and after the restore, both times, with a clean working tree.

**Gates re-run on the final base after rebasing** onto the current trunk tip; the
numbers above are from those final runs, not from a pre-rebase tree.

### Not run, and why

`scripts/test-fast-pr.sh` and every heavyweight suite — shadow-cljs, browser/Playwright,
npm builds, JVM artefacts — were **not** run. None covers a prose edit confined to the
method tree, so there is nothing to lose, and a measurement window was live on this box
where two heavyweight runs wedge rather than fail. `scripts/check_readme_links.py --ci`
was **not** run: its surface is repo-root markdown, READMEs beside source and the command
files, none of which this change touches.

So that a reader can compute real coverage rather than infer it: the spine was **not**
run at all, the two targeted gates above were run directly, and the required checks the
spine does not run are derived by `python scripts/check_fast_pr_gap.py --list` (exit 0)
rather than restated here, since that set moves.

### By-hand checks — nothing validates this markdown's prose, tables, rendering or nav

Link targets and anchors are the whole of what the gates check, so the rest was checked
by hand and is reported here:

- **Anchors** — the added text contains no markdown link and no heading, so it introduces
  no anchor and invalidates none. Confirmed mechanically (0 matches), with the same pattern
  controlled against a sibling page where it returns 7.
- **Tables** — the edit touches no table; the added lines contain zero pipe characters, so
  there are no column counts to reconcile.
- **Rendering** — the new sentence sits inside the existing list item on continuation lines
  with the same two-space indent as the surrounding lines, so it renders as part of that
  bullet rather than breaking the list.
- **Nav** — unchanged; no file added, removed or renamed.
- **Wrapping** — added lines are 105–111 characters, within this file's existing convention
  (max 134, with 93 lines already over 110).
- **Register** — the added sentence does not open with bold, because a fixed-string search
  showed the file never places one bolded sentence immediately after another across its 173
  bold-bearing lines. The emphasis is placed mid-sentence instead, which the file does use.

One note for the reader, and it is the joke this change is about: the anchor-and-link gate
normally strips fenced code blocks before reading a link, but this tree is one of its named
carve-outs, so links inside its fences **are** reported. That is exactly the class of
exception the new sentence tells briefs to look for.
