### PR TITLE
docs(hicasso): qualify the retired index write where it still reads as current (rf2-07rnj, PARTIAL)

### DIFF
--- a/docs/design/hicasso/studio/the-cold-read-mount-term.md
+++ b/docs/design/hicasso/studio/the-cold-read-mount-term.md
@@ -581,7 +581,16 @@ sub-cache peek 18; the sub-key mint 53.
    escrow the state machine forbids. The index write is 8.7% (~0.5 µs/key)
    and the cell-map insert 4.3%; batching either buys tens of microseconds
    on a 141-key mount and was declined as complexity the profile does not
-   license.
+   license. **The index write half of that reading is HISTORICAL, and does
+   not describe this tree:** `rf2-dabt3` (`383ba2d645`) retired the
+   sub-index it prices — `front/sub_index.cljs` is deleted — so 8.7% prices
+   a structure the runtime no longer has, and there is no index write left
+   to batch. What that commit put in its place is not resolved by any window
+   this page publishes, so nothing is offered in the figure's stead and no
+   share in this list has been re-taken. The cell-map insert clause is
+   untouched by the retirement and stands. (The commit-half table at the top
+   of this section carries the same mark on its `index write` row, and the
+   window notes under it set the retirement out in full.)
 
 ## 2. The cheapening — the cold read becomes the port's probe
 

--- a/docs/design/hicasso/studio/the-in-page-mount-term-decomposed.md
+++ b/docs/design/hicasso/studio/the-in-page-mount-term-decomposed.md
@@ -280,6 +280,21 @@ cell — this run closed at 05:28 and `rf2-6c237`'s at 21:43 the night before.
 The comparison is therefore still like for like, but 0.827 and 0.7625 are
 both upper bounds on today's seam (rf2-gttif).*
 
+*A **second** change has landed under those two figures since, and it does
+not read the same way. `rf2-dabt3` (`383ba2d645`, 2026-08-03 20:51) retired
+the sub-index into the cell table: `front/sub_index.cljs` is deleted, and
+the shipping commit half no longer performs an `index/mount!` plus a
+whole-set `record-reads!` but pushes one reader slot per key. **That is a
+fusion, not a removal** — work leaves and different work arrives — so unlike
+the mint it licenses no direction at all, and the cost of what replaced the
+index write is not resolved by the widened-window re-take recorded in
+[the cold-read mount term](the-cold-read-mount-term.md), which declines to
+publish that term at all. **0.827 and 0.7625
+therefore price a commit half whose structure this tree no longer has.** The
+like-for-like comparison between the two stands, because both predate the
+retirement; neither is a figure for today's seam, no direction is claimed
+for the difference, and no re-take is offered here (`rf2-07rnj`).*
+
 **(c) By counterfactual, on our own arm.** The decisive arm. `coarse` is the
 candidate's page reading **the twin's five coarse subscriptions** at five
 fixed sites, cards rendered from the collections — byte-identical DOM, five
@@ -387,6 +402,13 @@ asymmetry.**
    insert) and declined: escrowing it is a render-phase ref-count mutation
    the state machine forbids (`rf2-2rtt6.25`), and batching the index write
    and the cell-map insert buys tens of microseconds on a 141-key mount.
+   **The index write is no longer one of those candidates.** `rf2-dabt3`
+   (`383ba2d645`) retired the sub-index after this run — see §6(b) — so
+   there is nothing left to batch under that name, and the sub-term the
+   clause prices describes a structure the tree no longer has. The cell-map
+   insert survives the retirement, and the item's conclusion is unaffected
+   in either direction: what left was a batching candidate that had already
+   been declined. Nothing here has been re-measured (`rf2-07rnj`).
 3. **30% is the interpreter against a compiler**, and the fence forbids the
    remedy. UIx's `$` is compile-time; ours is a runtime walk over a hiccup
    tree we must also *build* (0.291 ms of it). Closing that gap means


### PR DESCRIPTION
## PARTIAL discharge of `rf2-07rnj` — the bead STAYS OPEN

This PR takes the separable half `rf2-07rnj`'s own triage identified: *"marking a
row as pricing a retired structure needs no measurement."*

**Neither the held ruling nor the quiet-box window is touched.** The question of
whether the bead's scope changes to accept reader membership as below instrument
resolution, or whether the instrument must gain resolution first, is the
operator's and is not answered, pre-empted or leaned on anywhere in this diff.
**No measurement, benchmark or window was run** — not one. Every marker here
reads the same whichever way that ruling goes. §4 of `the-cold-read-mount-term.md`
and the window notes are untouched.

`rf2-07rnj` is **not** closed by this PR. A partial-discharge note goes on the
bead recording exactly what was discharged and what was left.

## The obligation, and what happened to each of its three items

The obligation is the block quote at the end of the widened-window note in
`the-cold-read-mount-term.md`:

> The `index write` row still prices the structure `rf2-dabt3` deleted; 0.8625 is
> still not the `c-local` measured above; and the conclusions built on both —
> §1's "Reading it" 4, and `the-in-page-mount-term-decomposed.md`'s §6(b)
> comparison and §9.2 "batching the index write" — still read as current.

**1. §1's commit-half table row for `index write` — ALREADY DISCHARGED, left
alone.** Checked at source. The row already carries
`— **arm and structure both retired since; see the window note below**`, and the
window note below it carries the `rf2-dabt3` bullet in full. Re-qualifying an
already-qualified row is the minutiae the project stance says to close rather
than action, so it is untouched.

**2. §1's "Reading it" 4 — QUALIFIED.** It stated the 8.7% index-write share and
the "batching either" decision in the present tense, restating as current fact
the very figure the table row above it already flags. Marked HISTORICAL, with the
cell-map insert clause explicitly left standing (that term survives the
retirement) and no replacement figure offered.

**3. `the-in-page-mount-term-decomposed.md` §6(b) and §9.2 — QUALIFIED.**

- §6(b) gains a second caveat beside the existing `rf2-aqgr2` one. The important
  asymmetry is stated rather than glossed: `rf2-dabt3` is a **fusion, not a
  removal**, so unlike the keyword mint it licenses **no direction at all**, and
  the existing paragraph's "upper bounds on today's seam" reading does not carry
  across to it. `0.827` and `0.7625` are marked as pricing a commit half whose
  structure the tree no longer has; the like-for-like comparison between the two
  still stands because both predate the retirement.
- §9.2's "batching the index write and the cell-map insert" is marked: the index
  write is no longer one of those candidates. The cell-map insert survives, and
  the item's conclusion is unaffected in either direction — what left was a
  candidate that had already been declined.

**Explicitly NOT touched: the second obligation in that same block quote,
`0.8625 is still not the c-local measured above`.** It is entangled with the held
measurement question in a way these three qualifications are not, and none of the
three needed it settled.

## Qualification only

No figure is deleted, restated, recomputed or re-measured. Every historical
number stays on the page beside a marker saying what it prices and that the
structure is retired — the same form the commit-half table's row already uses, so
a reader sees both the historical figure and the fact that it no longer describes
the shipped tree. The diff is **+32 / −1**, and the single deleted line is one
sentence being extended.

## Premises verified at source

Every claim carried into the pages was checked against the tree, not taken from
the bead:

- `front/sub_index.cljs` is absent from `git ls-files` (positive control: the
  sibling `hicasso/front/` files list normally).
- `383ba2d645` is `refactor(hicasso): the sub-index fuses into the cell table
  (rf2-dabt3)`, dated 2026-08-03 20:51, and its diffstat shows `sub_index.cljs`
  deleted (318 lines) along with its laws test.
- `(.push (.-readers cell) reg)` is present in the shipping
  `implementation/hicasso/src/re_frame/hicasso/impl/collector.cljs:959`.
- `index/mount!` and `record-reads!` survive only in prose and in
  `read_profile_app.cljs`'s docstring, both describing the retirement in the past
  tense. No live call site.
- Every commit SHA written into either page is an ancestor of `origin/main`.

## Quality gates

Run from `worker/coldqual-07rnj` **after** the rebase onto the current
`origin/main`, so these are verdicts on the final base and not on a tree that no
longer exists. Each exit code below was captured from the runner's own shell with
the redirect and the `echo $?` on one command line — never piped, and never taken
from a harness report.

| gate | covers this diff? | run | captured exit |
|---|---|---|---|
| `python scripts/check_doc_slugs.py` | **yes** — validates link targets and heading anchors under `docs/` | ran, post-rebase | **0** |
| `python scripts/check_provenance_pins.py --changed-since origin/main` | **yes** — its `DEFAULT_ROOT` is `docs/design/hicasso` | ran, post-rebase | **0** |
| `mkdocs build --strict` | **NO** | not run — see below | — |
| `python scripts/check_readme_links.py --ci` | **NO** | not run — see below | — |
| `scripts/test-fast-pr.sh` and every JVM/browser/shadow-cljs suite | **NO** | not run — see below | — |

The provenance gate reported `2 pages inspected, 45 cited pins — 28 landed, 17
stranded, 0 unresolvable, 0 foreign; 17 accompanied in scope; 0 findings`.

**Not run, and why.** `mkdocs build --strict` **does not cover these files** —
`mkdocs.yml`'s `exclude_docs` block lists `design/hicasso/` explicitly (read at
line 37, not taken on trust), so nominating it would return a green that
inspected nothing changed here. `check_readme_links.py --ci` owns repo-root
markdown and markdown beside source code; neither file is on its surface. The
fast-PR spine and every heavy suite were deliberately not run: a prose edit under
`docs/design/` reaches none of them, and a bench measurement window was live on
this box, where two heavyweight runs wedge rather than fail. **This is a
statement about what I ran, not about the spine** — for the spine-versus-CI gap
itself, `python scripts/check_fast_pr_gap.py --list` derives 94 required checks
the spine does not decide.

### Discriminating evidence that each gate read this worktree

Neither gate prints a root banner, so both were proved by other means rather than
assumed:

- **`check_provenance_pins.py`** names what it read. On the clean tree it reported
  `0 pages inspected — no page under docs/design/hicasso changed since
  origin/main, so NOTHING was checked and this exit 0 is not a verdict`. After the
  edits it reported `2 pages inspected`. The count is derived from this tree's
  diff, so the green is a verdict on these two pages.
- **`check_doc_slugs.py` is silent on success, so it was proved by a planted
  fault.** The link target added in §6(b) was changed to a non-existent page —
  match count read as exactly 1 before the patch was applied, so the plant could
  not silently no-op — and the gate came back **exit 1**, naming
  `BROKEN TARGET: ...the-in-page-mount-term-decomposed.md:291 -> the-cold-read-mount-term-PLANTED-FAULT.md`.
  The fault existed only in this worktree, so a run that had wandered into a
  sibling checkout would have come back green. The plant was then restored and
  the gate re-run green.
- **The restore was verified by hashing the bytes, not by reading a diff**: the
  identical **blob** hash `818746340db7984aa5b23c95a15d9f725288dc34` before the
  plant and after the restore, taken against the committed object rather than as
  a plain byte digest of the working file. A grep for the planted token returns
  zero matches.

### By-hand checks — nothing validates this markdown's prose, tables or rendering

Link targets and anchors are the whole of what the two gates check, and these are
pages dense with numeric tables, so the rest was checked by hand:

- **Table column counts.** Every table in both files was counted, header against
  each row, across block-quoted tables as well as top-level ones: **14 tables in
  `the-cold-read-mount-term.md` and 10 in `the-in-page-mount-term-decomposed.md`,
  0 mismatched rows.** The counter itself was run against a deliberately
  malformed 3-cell row under a 2-cell header and reported the mismatch, so a zero
  here is a check that passed rather than a pattern that missed.
- **The diff adds and removes no table rows at all** — a grep of the added lines
  for a leading pipe returns 0. Every table on both pages is byte-identical to
  `origin/main`.
- **Anchors.** One markdown link is introduced,
  `[the cold-read mount term](the-cold-read-mount-term.md)` — same directory, no
  anchor fragment, and its target is the sibling page. Proven live by the sabotage
  run above. The other cross-references added are prose section references
  (`§6(b)`, "the commit-half table at the top of this section"), not markdown
  links, and each was checked against the actual headings: §6 is "The read term,
  measured three ways" and its (b) is "By micro, on the page's own roster"; the
  commit-half table is in §1, the same section as "Reading it" 4.
- **Fences.** All three edits sit in **prose, not inside a fenced block** —
  verified by walking the fence state to each edited line. Worth stating
  precisely, because `docs/design/hicasso` is one of exactly two trees in
  `FENCED_DOC_LINK_TREES` (`scripts/check_doc_slugs.py:1708`) where a doc link
  inside a fence **is** reported rather than skipped. So the usual "the gate
  skipped my fence" caveat is doubly inapplicable here: this tree has no such
  skip, and nothing in this diff is fenced anyway.

### Rebase and revert check

Rebased onto the current `origin/main` and both gates re-run on that final base.
The branch was diffed against its **merge base** in the three-dot form and read
for what it would revert: **+32 / −1** across the two files, the single deletion
being one sentence extended in place. Nothing a sibling landed is undone.

### File ownership

Re-derived at start-up and again before the first edit, from three-dot branch
diffs plus per-worktree status rather than from branch names. Many live branches
hold pages under `docs/design/hicasso/studio/` (the positive control for the
scan), but **none holds either of these two files**. `studio/README.md` is held
by peers and is deliberately untouched — no index row is added for this change.
