### PR TITLE
fix(bench): the slice broad clock's two arms were not comparable (rf2-9wmqd)

### DIFF
--- a/implementation/hicasso/test/re_frame/bench/hicasso/slice_broad_clock_app.cljs
+++ b/implementation/hicasso/test/re_frame/bench/hicasso/slice_broad_clock_app.cljs
@@ -166,6 +166,23 @@
   the pages are not the same page. `run.cjs` builds this lane in
   `release` mode, where the emit is DCE'd on both sides.
 
+  ## AND WHAT THE GATE CANNOT SEE IS WHAT [[pre-state]] IS FOR
+
+  The gate runs ONCE, on the seeded page, before the first window. Every
+  arm moves its own page afterwards, and the arms are not symmetric across
+  the two frames — so two arms that started on the same page can spend the
+  run on different ones, and nothing in the paragraph above would notice.
+
+  PR #8599's audit measured exactly that on this file's first cut: at
+  `{:warmup 8 :samples 12}`, `:theme` ran in the non-seed locale on 4 of
+  its 12 measured visits per round and `:donor-theme` on 8 of 12, because
+  two arms move the Hicasso frame's locale and only one moves the donor's.
+  The comparative theme figure was therefore a ratio between two
+  populations. [[pre-state]] closes it by making each arm's page state a
+  pure function of its own visit index, and
+  `slice-broad-window-dom-cljs-test` asserts the closure over a replay of
+  the schedule rather than trusting this paragraph.
+
   ## THE ECHO IS READ OFF SOMETHING THE INTERACTION CANNOT HAVE WRITTEN
 
   The first driver's rule, applied to two different operations. A
@@ -287,7 +304,14 @@
 
   **A tail quantile over 12 is mostly interpolation** (`lane/quantile`
   prices it), so the run that reads this instrument will want more, and
-  raising these two is how it gets them."
+  raising these two is how it gets them.
+
+  RAISING THEM IS SAFE HERE, and that is a property of [[pre-state]]
+  rather than of these numbers. Each arm's page state is a function of its
+  own visit index, so two paired arms see the same state mix at every
+  `:samples` — where an instrument that let the arms inherit each other's
+  state has mixes that depend on how `slot-order`'s rotation lands on the
+  count, and equalises at 12 while diverging at 13."
   {:warmup 8 :samples 12})
 
 (def rounds
@@ -352,6 +376,7 @@
          :donor-root        nil
          :echo-tally        nil
          :first-refusal     nil
+         :visits            {}
          :aux               {}}))
 
 (defn verification
@@ -360,6 +385,17 @@
   more the more of them there are."
   []
   (lane/tally-value (:echo-tally @!state)))
+
+(defn visits
+  "`{arm-id n}` — how many windows each arm has taken since the last
+  [[boot!]], warm-up visits included.
+
+  Exposed because it is the INDEX [[pre-state]] is a function of, so a
+  suite that wants to check the pre-state the driver actually established
+  against the one the schedule predicts needs to see the counter as well
+  as the rule."
+  []
+  (:visits @!state))
 
 (def populations
   "Which visits each published figure is taken over.
@@ -503,9 +539,14 @@
   ALTERNATING and not fixed. The target is always the locale the page is
   not in, so a window that closed too early cannot pass the echo check by
   carrying the previous sample's answer — the sibling's rotor property,
-  over a roster of two. Over a run each arm takes both directions in
-  equal numbers, so neither arm's distribution is a distribution of one
-  direction's work."
+  over a roster of two.
+
+  WHAT ALTERNATES IS THE PRE-STATE, and this body reads the result rather
+  than deciding it: [[pre-state]] puts the frame in the seed locale on
+  even visits and the other one on odd ones, so `now` alternates and the
+  target with it. Each arm therefore takes both directions in equal
+  numbers over any even block of visits, which used to be a consequence of
+  the plan and is now a statement about the arm."
   [side]
   (fn [_]
     (let [select (locale-select side)
@@ -599,7 +640,8 @@
 
   ALTERNATING, like the locale arm and for the same reason: the target is
   always the theme the page is not in, so a window that closed too early
-  cannot pass by carrying the previous sample's answer."
+  cannot pass by carrying the previous sample's answer. [[pre-state]] is
+  what alternates, and [[theme-state]] reads the page it left."
   [side]
   (fn [_]
     (let [{:keys [target want]} (theme-state side)]
@@ -630,10 +672,143 @@
   It rides the LOCALE arm rather than the theme arm because
   [[control-per-round]] subtracts the two, and a control paired with the
   broader of the two operations is the pair whose difference is dominated
-  by the injected duration rather than by the operations' own spread."
+  by the injected duration rather than by the operations' own spread.
+
+  A SUBTRACTION IS A COMPARATIVE, so this arm is bound by the same
+  requirement the two published ones are: it declares `:locale` at
+  [[pre-state]] exactly as `:locale` does, and the two therefore run over
+  one population. Before that rule existed they did not — the audit's
+  replay puts this arm in the non-seed THEME on 8 of 12 measured visits
+  per round against `:locale`'s 4 of 12, the same divergence as the
+  published theme pair with the dimensions swapped."
   [state]
   (assoc ((locale-plan :hicasso) state)
          :after-commit! (fn [] (busy-wait! blocked-ms))))
+
+;; ---------------------------------------------------------------------------
+;; The pre-state — what each arm's page is in BEFORE its window opens
+;; ---------------------------------------------------------------------------
+
+(defn- settle!
+  "Two frames, outside every window. React's commit and the initial
+  events' drain are not the same tick."
+  []
+  (.then (echo/after-paint) (fn [_] (echo/after-paint))))
+
+(def seed-locale
+  "The locale both frames open in, taken from the application's own seed
+  rather than written out. A literal `:en` here would be a second
+  authority for a fact `db/seed` already states, and the first thing to go
+  stale when the slice ships a third locale and changes its default."
+  (:locale slice-db/seed))
+
+(def seed-theme
+  "The theme both frames open in, from the same seed and for the same
+  reason."
+  (:theme slice-db/seed))
+
+(defn- other-theme
+  "The theme the application's table names that is not `now`. The same
+  rule [[theme-state]] applies to the RENDERED page, applied to a value —
+  *the one it is not* — so neither depends on the map's order."
+  [now]
+  (first (remove #(= % now) themes)))
+
+(defn pre-state
+  "`{:locale l :theme t}` — the state `arm`'s own frame is put into before
+  its `visit`th window, counting from zero.
+
+  ## WHY AN ARM ESTABLISHES ITS PRE-STATE INSTEAD OF INHERITING IT
+
+  Every measured arm moves ONE dimension of its page and reads the other.
+  Left to inherit, what it reads is whatever the arms scheduled before it
+  happened to leave — and the arms are not symmetric across the two
+  frames, so the two halves of a comparative are not drawn from the same
+  population.
+
+  PR #8599's audit measured it on this file's own roster. `:locale` and
+  `:ctl-blocked` both move the HICASSO frame's locale while only
+  `:donor-locale` moves the donor's, so replaying `lane/visit-plan` at
+  `{:warmup 8 :samples 12}` puts `:theme` in the non-seed locale on 4 of
+  its 12 measured visits per round and `:donor-theme` on 8 of 12. The same
+  arithmetic in the other dimension splits the CONTROL from the arm it is
+  subtracted from: `:ctl-blocked` runs in the non-seed theme on 8 of 12
+  where `:locale` runs there on 4 of 12. Neither is visible to the
+  canonical-DOM gate, which runs on the seeded page before sampling
+  begins and is silent by design about everything after it.
+
+  ## WHAT THIS RULE GIVES, AND WHY IT IS THE RULE RATHER THAN THE OTHER ONE
+
+  The pre-state is a pure function of `(arm, visit)`. No arm's page state
+  depends on any other arm's, so two paired arms see IDENTICAL state
+  mixes at every schedule, by construction — which is the property
+  `slice-broad-window-dom-cljs-test` asserts over a replay of the plan.
+
+  The audit named a second candidate, ISOLATING THE CONTROL — restoring
+  the locale the control moved, or giving the control its own root — and
+  it is rejected on a replay rather than on taste. Both variants happen to
+  equalise `:theme` against `:donor-theme` at `{:warmup 8 :samples 12}`,
+  and both stop doing so at `{:warmup 8 :samples 13}` and at `{:warmup 8
+  :samples 20}`: the equality is an accident of how `slot-order`'s
+  rotation lands on twelve indices, not a property of the schedule. Since
+  [[sampling]]'s own docstring says a run reading this instrument will
+  RAISE those counts, a repair that holds at 12 and breaks at 13 is a
+  repair that breaks exactly when it is first relied on. The isolating
+  variant also leaves the control's own theme mix wrong — a control on its
+  own root never has its theme moved at all — so it does not close the
+  second divergence in any case.
+
+  ## THE ARM'S OWN DIMENSION STILL ALTERNATES, AND NOW IT IS GUARANTEED
+
+  `:alternates` names the dimension the arm MOVES; that one is put into
+  the seed value on even visits and the other value on odd ones, so the
+  arm's target — always *the one the page is not in* — alternates too.
+  The rotor property [[locale-plan]] and [[theme-plan]] are written for is
+  therefore no longer inherited from whatever ran before: it is stated
+  here, and each arm takes both directions in equal numbers over any even
+  block of visits rather than as a happy consequence of the plan.
+
+  The dimension the arm does NOT move is pinned to the seed's value. That
+  NARROWS each measured arm's population — `:theme` now always switches
+  theme on a page in the seeded locale — and the narrowing is the point: a
+  comparative is a statement about two arms, and two arms narrowed to the
+  same stated population are comparable where two arms drifting
+  independently are not."
+  [{:keys [alternates]} visit]
+  (let [flip? (odd? visit)]
+    {:locale (if (and flip? (= :locale alternates)) (other-locale seed-locale) seed-locale)
+     :theme  (if (and flip? (= :theme  alternates)) (other-theme  seed-theme)  seed-theme)}))
+
+(defn- frame-for [side]
+  (case side
+    :hicasso hicasso-frame
+    :donor   donor-frame))
+
+(defn- claim-visit!
+  "Take this arm's next visit index, counting from zero. Called once per
+  [[measure-one!]] and by nothing else, so the index an arm's `n`th window
+  runs under is `n`."
+  [arm-id]
+  (-> (swap! !state update-in [:visits arm-id] (fnil inc -1))
+      (get-in [:visits arm-id])))
+
+(defn establish-pre-state!
+  "Put `arm`'s own frame into [[pre-state]] for `visit`, and answer a
+  promise that resolves once the page shows it.
+
+  Through the APPLICATION'S OWN EVENTS, on the arm's own frame, and
+  strictly outside every window — the same door and the same settle
+  [[parity-discrimination!]] uses to move a frame between two states
+  without touching a clock. A locale or theme already at its wanted value
+  writes the same value back, `app-db` does not move, and nothing
+  re-renders; the cost is a dispatch and two frames either way, and both
+  are outside the reading."
+  [arm visit]
+  (let [{:keys [locale theme]} (pre-state arm visit)]
+    (rf/with-frame (frame-for (:side arm))
+      (rf/dispatch-sync [::slice-events/set-locale (name locale)])
+      (rf/dispatch-sync [::slice-events/set-theme {:theme theme}]))
+    (settle!)))
 
 ;; ---------------------------------------------------------------------------
 ;; Sampling
@@ -668,29 +843,38 @@
 (defn measure-one!
   "One sample of `arm`, as a promise of its `:ms`.
 
-  The plan is built OUTSIDE the window — reading the node, deciding what
-  the echo must be — so nothing but the interaction and the frame is
-  inside it. `after-paint` runs first, also outside, so every window
-  starts in the first task after a paint: a paint-bounded window is
-  PREDECESSOR-DEPENDENT by construction, and aligning the phase makes it
-  a constant of the instrument rather than a property of whatever ran
-  before. The sibling's `measure-one!` carries the incident that
-  established this, and what the alignment costs the estimand."
+  Three things happen before the window and all of them are outside it.
+
+  [[establish-pre-state!]] runs FIRST, putting this arm's frame into the
+  state its own visit index names, so what the window measures does not
+  depend on which arms the schedule happened to run before it. Its
+  docstring carries the divergence that made this necessary and the
+  alternative that was rejected.
+
+  `after-paint` runs next, so every window starts in the first task after
+  a paint: a paint-bounded window is PREDECESSOR-DEPENDENT by
+  construction, and aligning the phase makes it a constant of the
+  instrument rather than a property of whatever ran before. The sibling's
+  `measure-one!` carries the incident that established this, and what the
+  alignment costs the estimand.
+
+  The plan is built last and still outside — reading the node, deciding
+  what the echo must be — so nothing but the interaction and the frame is
+  inside the window. It reads the page rather than the pre-state it was
+  just given, which is deliberate: the target stays *whichever value the
+  page is not showing*, so the echo is adjudicated against the rendered
+  page and a pre-state that failed to land cannot quietly become the
+  answer the arm expects."
   [arm]
-  (.then (echo/after-paint)
-         (fn [_]
-           (.then (echo/window! ((:plan arm) !state))
-                  (fn [r] (bank-aux! (:id arm) r) (:ms r))))))
+  (let [visit (claim-visit! (:id arm))]
+    (-> (establish-pre-state! arm visit)
+        (.then (fn [_] (echo/after-paint)))
+        (.then (fn [_] (echo/window! ((:plan arm) !state))))
+        (.then (fn [r] (bank-aux! (:id arm) r) (:ms r))))))
 
 ;; ---------------------------------------------------------------------------
 ;; Boot
 ;; ---------------------------------------------------------------------------
-
-(defn- settle!
-  "Two frames, outside every window. React's commit and the initial
-  events' drain are not the same tick."
-  []
-  (.then (echo/after-paint) (fn [_] (echo/after-paint))))
 
 (defn boot!
   "Mount both arms into their own containers on their own frames, and
@@ -729,6 +913,7 @@
            :donor-container   don-container
            :donor-root        don-root
            :first-refusal     nil
+           :visits            {}
            :aux               {}
            :echo-tally        (lane/tally))
     (.then (settle!)
@@ -939,13 +1124,27 @@
 ;; ---------------------------------------------------------------------------
 
 (def arms
-  "The measured arms, floor first so it leads the schedule."
-  [{:id :idle-frame   :plan idle-plan}
-   {:id :locale       :plan (locale-plan :hicasso)}
-   {:id :donor-locale :plan (locale-plan :donor)}
-   {:id :theme        :plan (theme-plan :hicasso)}
-   {:id :donor-theme  :plan (theme-plan :donor)}
-   {:id :ctl-blocked  :plan blocked-plan :control? true}])
+  "The measured arms, floor first so it leads the schedule.
+
+  `:side` is the frame the arm interacts with and reads, and
+  `:alternates` is the dimension of that frame's state it MOVES.
+  [[pre-state]] is a function of exactly those two and the arm's own visit
+  index, which is what makes two paired arms comparable: `:locale` and
+  `:donor-locale` declare the same `:alternates` on different sides, so
+  they see the same state mix on two frames, and so do `:theme` and
+  `:donor-theme`. `:ctl-blocked` declares `:locale` because it IS the
+  locale operation plus a blocked seam, which is what keeps
+  [[control-per-round]]'s subtraction over one population rather than two.
+
+  `:idle-frame` alternates NOTHING — it is the floor and it interacts with
+  nothing — so it holds the seeded state on every visit."
+  [{:id :idle-frame   :plan idle-plan              :side :hicasso :alternates nil}
+   {:id :locale       :plan (locale-plan :hicasso) :side :hicasso :alternates :locale}
+   {:id :donor-locale :plan (locale-plan :donor)   :side :donor   :alternates :locale}
+   {:id :theme        :plan (theme-plan :hicasso)  :side :hicasso :alternates :theme}
+   {:id :donor-theme  :plan (theme-plan :donor)    :side :donor   :alternates :theme}
+   {:id :ctl-blocked  :plan blocked-plan           :side :hicasso :alternates :locale
+    :control? true}])
 
 (defn- readings-by-arm [readings]
   (reduce (fn [m round]

--- a/implementation/hicasso/test/re_frame/bench/hicasso/slice_broad_clock_app.cljs
+++ b/implementation/hicasso/test/re_frame/bench/hicasso/slice_broad_clock_app.cljs
@@ -346,13 +346,19 @@
   0.5)
 
 (def hicasso-frame
-  "The Hicasso arm's frame. Its own, because frames are isolated
-  contexts: the two arms hold two copies of the same seeded `app-db` and
-  neither can see the other's."
+  "The Hicasso arm's DEFAULT frame id. Its own, because frames are
+  isolated contexts: the two arms hold two copies of the same seeded
+  `app-db` and neither can see the other's.
+
+  A DEFAULT rather than a constant, because [[boot!]] takes a pair of ids
+  and a caller that mounts REPEATEDLY IN ONE PROCESS must hand it fresh
+  ones — see [[boot!]]'s §MOUNTING TWICE. The bench page mounts once and
+  takes these."
   ::hicasso-frame)
 
 (def donor-frame
-  "The UIx arm's frame."
+  "The UIx arm's default frame id. [[hicasso-frame]] carries why it is a
+  default."
   ::donor-frame)
 
 (def initial-events
@@ -376,6 +382,7 @@
          :donor-root        nil
          :echo-tally        nil
          :first-refusal     nil
+         :frames            nil
          :visits            {}
          :aux               {}}))
 
@@ -390,12 +397,27 @@
   "`{arm-id n}` — how many windows each arm has taken since the last
   [[boot!]], warm-up visits included.
 
-  Exposed because it is the INDEX [[pre-state]] is a function of, so a
-  suite that wants to check the pre-state the driver actually established
-  against the one the schedule predicts needs to see the counter as well
-  as the rule."
+  A COUNT, not the last index. [[pre-state]] is a function of the INDEX,
+  which is one less, and [[claim-visit!]] is the one place that conversion
+  happens. The distinction is worth a line because the first cut of this
+  reader published the index under this docstring's words, and the suite
+  row that compares it against `lane/visit-plan`'s per-arm visit count is
+  what found the disagreement.
+
+  Exposed because a suite that wants to check the pre-state the driver
+  actually established against the one the schedule predicts needs to see
+  the counter as well as the rule."
   []
   (:visits @!state))
+
+(defn frames
+  "`{:hicasso id :donor id}` — the frame ids THIS boot mounted on.
+
+  Read this rather than [[hicasso-frame]] / [[donor-frame]]: those are
+  defaults, and a caller that mounts repeatedly hands [[boot!]] fresh ones
+  for the reason its §MOUNTING TWICE gives."
+  []
+  (:frames @!state))
 
 (def populations
   "Which visits each published figure is taken over.
@@ -779,18 +801,26 @@
     {:locale (if (and flip? (= :locale alternates)) (other-locale seed-locale) seed-locale)
      :theme  (if (and flip? (= :theme  alternates)) (other-theme  seed-theme)  seed-theme)}))
 
-(defn- frame-for [side]
-  (case side
-    :hicasso hicasso-frame
-    :donor   donor-frame))
+(defn- frame-for
+  "The frame id THIS boot gave `side` — read from the live pair rather
+  than from [[hicasso-frame]] / [[donor-frame]], which are only its
+  defaults. A caller that mounts twice on fresh ids and then dispatched
+  into the default would be writing to a frame nothing renders from."
+  [side]
+  (get (frames) side))
 
 (defn- claim-visit!
-  "Take this arm's next visit index, counting from zero. Called once per
-  [[measure-one!]] and by nothing else, so the index an arm's `n`th window
-  runs under is `n`."
+  "Bank this arm's visit and answer its INDEX, counting from zero. Called
+  once per [[measure-one!]] and by nothing else, so the index an arm's
+  `n`th window runs under is `n - 1`.
+
+  The stored value is the COUNT and the answer is the index. Storing the
+  index instead would make [[visits]] read one short of the plan's own
+  per-arm visit count, which is exactly the disagreement the suite's
+  schedule row is written to catch."
   [arm-id]
-  (-> (swap! !state update-in [:visits arm-id] (fnil inc -1))
-      (get-in [:visits arm-id])))
+  (dec (get-in (swap! !state update-in [:visits arm-id] (fnil inc 0))
+               [:visits arm-id])))
 
 (defn establish-pre-state!
   "Put `arm`'s own frame into [[pre-state]] for `visit`, and answer a
@@ -894,47 +924,88 @@
 
   INSTALLING THE ADAPTER AND LEAVING REACT'S `act` ENVIRONMENT ARE NOT
   DONE HERE. Both are process-wide and belong to [[-main]], which owns
-  the bench page."
-  []
-  (let [hic-container (lane/fresh-container!)
-        don-container (lane/fresh-container!)
-        handle        (h/mount! hic-container
-                                {:frame             hicasso-frame
-                                 :identifier-prefix "hic"
-                                 :initial-events    initial-events}
-                                [slice-views/app {}])
-        _             (rf/make-frame {:id             donor-frame
-                                      :initial-events initial-events})
-        don-root      (uix-dom/create-root don-container {:identifier-prefix "don"})]
-    (uix-dom/render-root (donor/root donor-frame) don-root)
-    (swap! !state assoc
-           :hicasso-container hic-container
-           :hicasso-handle    handle
-           :donor-container   don-container
-           :donor-root        don-root
-           :first-refusal     nil
-           :visits            {}
-           :aux               {}
-           :echo-tally        (lane/tally))
-    (.then (settle!)
-           (fn [_]
-             (doseq [side [:hicasso :donor]]
-               (when (nil? (locale-select side))
-                 (throw (ex-info (str "the " (name side) " arm mounted but its feed did not: "
-                                      "#slice-locale is not on its page, so there is no "
-                                      "published control to switch")
-                                 {:rf.error/id ::feed-absent
-                                  :side        side})))
-               (when (nil? (page-root side))
-                 (throw (ex-info (str "the " (name side) " arm rendered no main.slice root, "
-                                      "so the theme echo has nothing to read")
-                                 {:rf.error/id ::root-absent
-                                  :side        side}))))
-             nil))))
+  the bench page.
+
+  ## MOUNTING TWICE: THE FRAME IDS ARE AN ARGUMENT, AND FRESH ONES ARE
+  ## MANDATORY FOR A CALLER THAT MOUNTS REPEATEDLY
+
+  The bench page boots once and the no-arg arity is for it. A SUITE boots
+  once per row, and handing this the same pair of ids each time does not
+  merely inherit the previous row's `app-db` — **it leaves the Hicasso arm
+  RENDERED BUT DEAF**, and that is measured rather than feared.
+
+  `re-frame.hicasso.impl.collector`'s `!cells` is a process-global table
+  keyed by `(frame, query)`, and its own comment states that isolation
+  between roots is a property of THAT KEYING rather than anything React
+  provides. A cell holds its reaction for the life of every boundary that
+  reads the key, and `invalidate-cell!` is the repair for a reaction that
+  has been retired — including, in its own words, *across a same-id
+  reincarnation*. But that repair rides the reaction's DISPOSAL hook, and
+  a test fixture that resets `re-frame.frame/frames` to `{}` retires the
+  frame without disposing through it. The second mount on the same id then
+  finds a live cell holding a dead reaction: `subs/subscribe` is never
+  called again, so the new frame's sub-cache stays EMPTY, and no watch is
+  installed, so nothing on the page ever re-renders.
+
+  The symptom is silent in the worst way — the first render is perfect.
+  PR #8606's first cut booted every row on these two defaults and CI read
+  it exactly so: the mount row passed, the Hicasso arm's captured read
+  roster came back `#{}` against the donor's 34, every locale and theme
+  pre-state failed to reach the page, and all nine Hicasso-side windows
+  went unverified while all six donor-side ones verified.
+
+  So a repeat caller passes fresh ids, which is the discipline
+  `slice-echo-window-dom-cljs-test` already keeps against a milder form of
+  the same hazard. [[frames]] answers the pair this boot actually used;
+  read that rather than the defaults."
+  ([] (boot! {:hicasso hicasso-frame :donor donor-frame}))
+  ([{hic-frame :hicasso don-frame :donor}]
+   (let [hic-container (lane/fresh-container!)
+         don-container (lane/fresh-container!)
+         handle        (h/mount! hic-container
+                                 {:frame             hic-frame
+                                  :identifier-prefix "hic"
+                                  :initial-events    initial-events}
+                                 [slice-views/app {}])
+         _             (rf/make-frame {:id             don-frame
+                                       :initial-events initial-events})
+         don-root      (uix-dom/create-root don-container {:identifier-prefix "don"})]
+     (uix-dom/render-root (donor/root don-frame) don-root)
+     (swap! !state assoc
+            :hicasso-container hic-container
+            :hicasso-handle    handle
+            :donor-container   don-container
+            :donor-root        don-root
+            :first-refusal     nil
+            :frames            {:hicasso hic-frame :donor don-frame}
+            :visits            {}
+            :aux               {}
+            :echo-tally        (lane/tally))
+     (.then (settle!)
+            (fn [_]
+              (doseq [side [:hicasso :donor]]
+                (when (nil? (locale-select side))
+                  (throw (ex-info (str "the " (name side) " arm mounted but its feed did not: "
+                                       "#slice-locale is not on its page, so there is no "
+                                       "published control to switch")
+                                  {:rf.error/id ::feed-absent
+                                   :side        side})))
+                (when (nil? (page-root side))
+                  (throw (ex-info (str "the " (name side) " arm rendered no main.slice root, "
+                                       "so the theme echo has nothing to read")
+                                  {:rf.error/id ::root-absent
+                                   :side        side}))))
+              nil)))))
 
 (defn teardown!
   "Take both roots down and drop both containers. Exposed for a caller
-  that mounts and unmounts around each of its rows."
+  that mounts and unmounts around each of its rows.
+
+  It does NOT make a re-mount on the same frame ids safe, and could not:
+  the table that goes stale is `collector/!cells`, which is
+  process-global, keyed by `(frame, query)` and reached through a disposal
+  hook this cannot reach. [[boot!]]'s §MOUNTING TWICE carries the
+  measurement and the remedy."
   []
   (let [{:keys [hicasso-container hicasso-handle donor-container donor-root]} @!state]
     (when hicasso-handle (h/unmount! hicasso-handle))
@@ -1013,7 +1084,7 @@
         ;; exactly the class of thing a control is supposed to survive.
         now         (keyword (.-value (locale-select :donor)))
         other       (other-locale now)
-        to-locale!  (fn [l] (rf/with-frame donor-frame
+        to-locale!  (fn [l] (rf/with-frame (frame-for :donor)
                               (rf/dispatch-sync [::slice-events/set-locale (name l)])))
         restore     (fn [] (to-locale! now))
         break       (fn [] (to-locale! other))]

--- a/implementation/hicasso/test/re_frame/bench/hicasso/slice_broad_window_dom_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/bench/hicasso/slice_broad_window_dom_cljs_test.cljs
@@ -1,0 +1,620 @@
+(ns re-frame.bench.hicasso.slice-broad-window-dom-cljs-test
+  "THE BROAD-UPDATE CLOCK'S OWN SELF-TEST (rf2-9wmqd, item (b)).
+
+  [[re-frame.bench.hicasso.slice-broad-clock-app]] times one broad
+  application operation on the slice's feed page, on the Hicasso arm and
+  on the UIx donor arm beside it, and divides the two. This file asks
+  whether the two arms are COMPARABLE — and it is a correctness test of
+  the instrument rather than a benchmark: **no assertion here is a line on
+  a latency**, no figure is published, and nothing is compared to `U3`,
+  `C3` or `C4`.
+
+  It is the browser-suite row PR #8599 left owed. That driver already
+  carries six instrument-integrity controls that run IN it — a
+  canonical-DOM parity gate with its own negative control, four echo
+  negative controls, the tally, the arm-order guard and the additive
+  positive control — and in-driver is the stronger place for them, by the
+  sibling `slice-echo-window-dom-cljs-test`'s own argument: the driver is
+  what a quiet-box window runs and a suite is not. What a suite is for is
+  proving a REPAIR, and this file proves two.
+
+  ## THE TWO CLAIMS, AND WHY CANONICAL DOM CANNOT CARRY EITHER
+
+  A cross-arm ratio needs two arms doing the same work on the same page.
+  The driver's parity gate answers *the same PAGE* and answers it well.
+  Neither claim below is about the page.
+
+  **Do the two arms make the same READS?** Two pages can serialise
+  identically while one of them subscribes to a value the other reads only
+  in a branch it never takes. PR #8599's donor did exactly that with
+  `[::subs/t :feed/empty]`, on a seed that is never empty, so the donor
+  carried a subscription and a hook the Hicasso arm did not — work in the
+  DENOMINATOR, moving `Hicasso / UIx` in the numerator's favour.
+  [[the-donor-reads-nothing-the-hicasso-arm-does-not]] compares the two
+  frames' subscription caches, and
+  [[the-roster-gate-catches-an-unconditional-branch-local-read]] replants
+  the removed read and requires the comparison to catch it.
+
+  **Do PAIRED ARMS see the same page STATE?** The parity gate runs once,
+  on the seeded page, before the first window; every arm moves its own
+  page afterwards. The audit's replay of `lane/visit-plan` found `:theme`
+  running in the non-seed locale on 4 of its 12 measured visits per round
+  against `:donor-theme`'s 8 of 12, so the comparative theme figure was a
+  ratio between two populations.
+  [[paired-arms-see-the-same-governed-state-mix]] asserts the repair over
+  the schedule itself, and
+  [[the-mix-gate-catches-a-rig-whose-arms-inherit-each-others-state]] is
+  its negative control: it models the rig PR #8599 shipped and requires
+  the same comparison to report the same 4-against-8.
+
+  ## WHAT THIS FILE DELIBERATELY DOES NOT RE-ADJUDICATE
+
+  **The canonical-DOM parity gate.** `clock/assert-parity!` is a RELEASE
+  gate by construction: under `goog.DEBUG` each Hicasso boundary emits its
+  own `data-rf2-source-coord`, the UIx arm emits none, and the two pages
+  are correctly not the same page. This suite compiles in dev, so a row
+  asserting that equality here would either fail honestly or have to strip
+  attributes until it passed — and a gate re-stated with an exemption is a
+  weaker gate wearing a stronger one's name. The driver owns it, `run.cjs`
+  builds `release`, and the mount row below asks only what a dev compile
+  can honestly answer.
+
+  **The control's own verdict**, for the sibling's reason:
+  `control-verdict-strict` adjudicates a difference of per-round medians,
+  and adjudicating it on a shared runner would be a latency threshold in a
+  PR gate by another name.
+
+  ## Runtime
+
+  The DOM rows need a real browser and the `-dom-cljs-test` suffix puts
+  them on `:browser-test`; each degrades to a stated skip under
+  `:node-test`, which is the posture every other `*-dom` suite in this
+  tree keeps. The schedule rows are pure arithmetic over
+  `lane/visit-plan` and run on both."
+  (:require [cljs.test :refer-macros [async deftest is testing use-fixtures]]
+            [clojure.set :as set]
+            [re-frame.adapter.uix :as uixa]
+            [re-frame.bench.hicasso.lane :as lane]
+            [re-frame.bench.hicasso.slice-broad-clock-app :as clock]
+            [re-frame.bench.hicasso.slice-echo-clock-app :as echo]
+            [re-frame.hicasso.examples.slice.routes :as slice-routes]
+            [re-frame.hicasso.examples.slice.subs :as subs]
+            [re-frame.subs.tooling :as subs-tooling]
+            [re-frame.test-support :as test-support]
+            [uix.core :as uix :refer [$ defui]]
+            [uix.dom :as uix-dom]))
+
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture
+    {:adapter       uixa/adapter
+     :ambient-frame nil
+     ;; The MAP shape, because every DOM row is `async`: `cljs.test` refuses
+     ;; an async test under a fn-form fixture and ABORTS THE WHOLE NAMESPACE
+     ;; — silently as far as the row is concerned, and taking every suite
+     ;; scheduled after it in the same bundle with it. The sibling suite and
+     ;; `examples.slice.flow-dom-cljs-test` carry the same three keys.
+     :async?        true
+     :init-fn       (fn []
+                      ;; React's `act` queue is not the browser's scheduler,
+                      ;; and every reading this instrument takes is taken
+                      ;; outside it — `lane/leave-act-environment!`'s own
+                      ;; argument, applied to the suite that drives it.
+                      (set! (.-IS_REACT_ACT_ENVIRONMENT js/globalThis) false)
+                      ;; The reset restores the registrar to a baseline
+                      ;; captured when THIS FORM was evaluated, which is
+                      ;; before `slice.routes` finished loading — so the
+                      ;; route both arms navigate to would not exist.
+                      (slice-routes/register!))}))
+
+(def ^:private off-browser
+  "no DOM on this runtime — the rows below mount two real roots, take real
+  subscription caches off two real frames and fire real DOM events, and
+  :browser-test is where they are asked")
+
+(defn- browser? []
+  (and (exists? js/document) (some? js/document) (some? (.-body js/document))))
+
+(defn- skip! [why]
+  (is true (str "two mounted React roots need a real DOM — " why)))
+
+(defn- fail-async [done]
+  (fn [e]
+    (is false (str "the instrument threw rather than answering: " e))
+    (done)))
+
+;; ---------------------------------------------------------------------------
+;; Both arms mounted, both torn down again
+;; ---------------------------------------------------------------------------
+
+(defn- with-both-arms
+  "Mount both arms through the instrument's own [[clock/boot!]], run `f` —
+  which answers a promise — and tear both roots down afterwards whatever
+  happened.
+
+  `boot!` names its own frames and makes its own containers, so there is
+  nothing to hand it. The `:each` fixture resets `frame/frames` between
+  rows, which is what lets two rows boot the same two frame ids without
+  the second inheriting the first's `app-db`."
+  [f]
+  (-> (clock/boot!)
+      (.then (fn [_] (f)))
+      (.then (fn [v] (clock/teardown!) v)
+             (fn [e] (clock/teardown!) (throw e)))))
+
+(defn- arm-of [id]
+  (first (filter #(= id (:id %)) clock/arms)))
+
+;; ---------------------------------------------------------------------------
+;; The read roster — what each frame has actually subscribed to
+;; ---------------------------------------------------------------------------
+
+(defn- roster
+  "The set of query vectors live in `frame-id`'s subscription cache.
+
+  `subs-tooling/sub-cache-snapshot` is the tool-facing read of the same
+  per-frame cache BOTH substrates go through — Hicasso's collector calls
+  `subs/subscribe` for every `h/sub` edge, and the UIx adapter's
+  `use-subscribe` calls it for every hook — so the two rosters are
+  comparable without either arm being asked to report on itself."
+  [frame-id]
+  (set (keys (subs-tooling/sub-cache-snapshot frame-id))))
+
+(defn- donor-only
+  "What the donor arm reads that the Hicasso arm does not. THE ONE THAT
+  MATTERS: an entry here is work in the denominator of `C3`."
+  []
+  (set/difference (roster clock/donor-frame) (roster clock/hicasso-frame)))
+
+(defui empty-label-probe
+  "One UNCONDITIONAL read of `[::subs/t :feed/empty]` on the donor frame.
+
+  This is exactly the shape `slice-donor-views/feed-page` carried before
+  rf2-9wmqd's repair — a hook cannot be conditional, so a branch-local
+  string read beside the rows and the heading became a read the arm makes
+  on every render of a feed that is never empty. It is replanted here, in
+  the suite rather than in the arm, so
+  [[the-roster-gate-catches-an-unconditional-branch-local-read]] has a
+  fault to catch."
+  [_]
+  ($ :span.empty-label-probe (uixa/use-subscribe [::subs/t :feed/empty])))
+
+(defn- with-probe-mounted
+  "Render [[empty-label-probe]] into its own root on the DONOR frame, run
+  `f` — which answers a promise — and take the root down again.
+
+  Its own container, so it cannot move either arm's page and cannot reach
+  the driver's canonical-DOM gate; what it moves is the donor frame's
+  subscription cache, which is the thing under test."
+  [f]
+  (let [c    (lane/fresh-container!)
+        root (uix-dom/create-root c {:identifier-prefix "probe"})
+        drop! (fn []
+                (uix-dom/unmount-root root)
+                (when (.-parentNode c) (.removeChild (.-parentNode c) c)))]
+    (uix-dom/render-root ($ uixa/frame-provider {:frame clock/donor-frame}
+                            ($ empty-label-probe {}))
+                         root)
+    (-> (echo/after-paint)
+        (.then (fn [_] (echo/after-paint)))
+        (.then (fn [_] (f)))
+        (.then (fn [v] (drop!) v)
+               (fn [e] (drop!) (throw e))))))
+
+;; ---------------------------------------------------------------------------
+;; Replaying the schedule — where the state mix can be settled without a
+;; browser at all
+;; ---------------------------------------------------------------------------
+
+(defn- established-runs
+  "`{arm-id [pre-state …]}` over the MEASURED visits of one whole run,
+  taking each arm's pre-state from the driver's own [[clock/pre-state]]
+  and from the arm's own visit index.
+
+  The index is counted the way [[clock/claim-visit!]] counts it — every
+  visit the plan makes, warm-up included — because the driver's counter is
+  advanced once per `measure-one!` and `measure-one!` is called for both."
+  [arms sampling rounds]
+  (let [!n (atom {})]
+    (reduce (fn [acc {:keys [arm measured?]}]
+              (let [i (get (swap! !n update (:id arm) (fnil inc -1)) (:id arm))]
+                (if measured?
+                  (update acc (:id arm) (fnil conj []) (clock/pre-state arm i))
+                  acc)))
+            {}
+            (lane/visit-plan arms sampling rounds))))
+
+(defn- other-of [roster* now]
+  (first (remove #(= % now) roster*)))
+
+(defn- inherited-runs
+  "The same replay under a model of the rig PR #8599 SHIPPED: no arm
+  establishes anything, so what an arm reads is whatever the arms
+  scheduled before it left on ITS OWN FRAME.
+
+  The asymmetry the model carries is the driver's own roster, not an
+  invention: `:locale` and `:ctl-blocked` both move the Hicasso frame's
+  locale while only `:donor-locale` moves the donor's, and `:theme` /
+  `:donor-theme` move one theme each."
+  [arms sampling rounds]
+  (let [!st (atom {:hicasso {:locale clock/seed-locale :theme clock/seed-theme}
+                   :donor   {:locale clock/seed-locale :theme clock/seed-theme}})]
+    (reduce (fn [acc {:keys [arm measured?]}]
+              (let [{:keys [id side alternates]} arm
+                    before (get @!st side)
+                    acc'   (if measured? (update acc id (fnil conj []) before) acc)]
+                (when alternates
+                  (swap! !st update-in [side alternates]
+                         (fn [v] (other-of (if (= :locale alternates)
+                                             clock/locales
+                                             clock/themes)
+                                           v))))
+                acc'))
+            {}
+            (lane/visit-plan arms sampling rounds))))
+
+(def ^:private compared-pairs
+  "The three pairs whose two halves are subtracted or divided by each
+  other, and which therefore have to be drawn from one population.
+
+  The first two are the driver's published `:comparative` figures. The
+  third is the POSITIVE CONTROL and its denominator: `control-per-round`
+  subtracts `:locale`'s per-round median from `:ctl-blocked`'s, and a
+  subtraction over two populations is as unreadable as a ratio over two."
+  [[:locale :donor-locale]
+   [:theme :donor-theme]
+   [:ctl-blocked :locale]])
+
+(defn- mix [runs id]
+  (frequencies (get runs id)))
+
+(defn- non-seed-locales [runs id]
+  (count (remove #(= clock/seed-locale (:locale %)) (get runs id))))
+
+(defn- non-seed-themes [runs id]
+  (count (remove #(= clock/seed-theme (:theme %)) (get runs id))))
+
+;; The audit's own schedule, written out rather than read off the module,
+;; so the numbers below stay the numbers the audit measured however the
+;; module's knobs move afterwards.
+(def ^:private audit-sampling {:warmup 8 :samples 12})
+(def ^:private audit-rounds 5)
+
+;; ---------------------------------------------------------------------------
+;; The state mix
+;; ---------------------------------------------------------------------------
+
+(deftest paired-arms-see-the-same-governed-state-mix
+  (testing "Each arm's page state is a pure function of its own visit
+           index, so two arms that are divided or subtracted by each other
+           see the SAME multiset of pre-states — the same locales in the
+           same numbers, and the same themes.
+
+           Asserted over several schedules, and the last two are the
+           point: `clock/sampling`'s own docstring says a run reading this
+           instrument will raise `:samples`, so a repair that held at 12
+           and failed at 13 would fail exactly when it was first relied
+           on."
+    (doseq [[sampling rounds] [[audit-sampling audit-rounds]
+                               [clock/sampling clock/rounds]
+                               [{:warmup 3 :samples 6} 5]
+                               [{:warmup 8 :samples 13} 5]
+                               [{:warmup 8 :samples 20} 5]]]
+      (let [runs (established-runs clock/arms sampling rounds)]
+        (doseq [{:keys [id]} clock/arms]
+          (is (= (* rounds (:samples sampling)) (count (get runs id)))
+              (str id " has one measured pre-state per measured visit at "
+                   (pr-str sampling))))
+        (doseq [[a b] compared-pairs]
+          (is (= (mix runs a) (mix runs b))
+              (str a " and " b " are drawn from one population at "
+                   (pr-str sampling) " over " rounds " rounds")))))))
+
+(deftest the-mix-gate-catches-a-rig-whose-arms-inherit-each-others-state
+  (testing "ANTI-VACUITY for the row above, and the audit's finding
+           reproduced. Replay the identical schedule under a model of the
+           rig PR #8599 shipped — every arm reading whatever the arms
+           before it left on its own frame — and the same comparison has
+           to REFUSE, with the numbers the audit measured.
+
+           A green here would mean the row above passes whatever the arms
+           see, and every state-mix claim this instrument could make would
+           be worthless."
+    (let [runs (inherited-runs clock/arms audit-sampling audit-rounds)]
+      (is (not= (mix runs :theme) (mix runs :donor-theme))
+          "the published theme comparative's two halves are NOT one population")
+      (is (= (* audit-rounds 4) (non-seed-locales runs :theme))
+          ":theme runs in the non-seed locale on 4 of its 12 measured visits per round")
+      (is (= (* audit-rounds 8) (non-seed-locales runs :donor-theme))
+          "and :donor-theme on 8 of 12 — twice as often, on the other frame")
+      (is (not= (mix runs :ctl-blocked) (mix runs :locale))
+          "and the positive control is not drawn from its own denominator's
+           population either")
+      (is (= (* audit-rounds 8) (non-seed-themes runs :ctl-blocked))
+          ":ctl-blocked runs in the non-seed THEME on 8 of 12 per round")
+      (is (= (* audit-rounds 4) (non-seed-themes runs :locale))
+          "against :locale's 4 of 12 — the same divergence with the
+           dimensions swapped, which the audit did not name and the replay
+           finds"))
+    (testing "and the repair closes both at the same schedule, so the
+             refusals above are about the rig and not about the replay"
+      (let [runs (established-runs clock/arms audit-sampling audit-rounds)]
+        (is (= (mix runs :theme) (mix runs :donor-theme)))
+        (is (= (mix runs :ctl-blocked) (mix runs :locale)))))))
+
+(deftest every-arm-takes-both-directions-in-equal-numbers
+  (testing "`locale-plan` and `theme-plan` are written for a rotor — the
+           target is always the value the page is NOT showing — and each
+           claims its arm takes both directions in equal numbers. Under
+           [[clock/pre-state]] that is a property of the arm rather than a
+           consequence of the plan, so it can be asserted.
+
+           The floor alternates nothing and holds the seed on every
+           visit, which is what makes it a floor."
+    (let [runs (established-runs clock/arms clock/sampling clock/rounds)
+          n    (* clock/rounds (:samples clock/sampling))]
+      (doseq [{:keys [id alternates]} clock/arms]
+        (case alternates
+          :locale (do (is (= (/ n 2) (non-seed-locales runs id))
+                          (str id " opens half its measured windows in each locale"))
+                      (is (zero? (non-seed-themes runs id))
+                          (str id " never moves the theme, so it holds the seed's")))
+          :theme  (do (is (= (/ n 2) (non-seed-themes runs id))
+                          (str id " opens half its measured windows in each theme"))
+                      (is (zero? (non-seed-locales runs id))
+                          (str id " never moves the locale, so it holds the seed's")))
+          (do (is (zero? (non-seed-locales runs id))
+                  (str id " alternates nothing and holds the seeded locale"))
+              (is (zero? (non-seed-themes runs id))
+                  (str id " alternates nothing and holds the seeded theme"))))))))
+
+;; ---------------------------------------------------------------------------
+;; The roster, on the arms themselves
+;; ---------------------------------------------------------------------------
+
+(deftest both-arms-mount-their-feed-page-and-render-it
+  (testing "The population is the slice application on its FEED route, one
+           copy through `h/mount!` and one through `uix.dom`, each on its
+           own frame. If either page is not there, every row below is
+           meaningless.
+
+           What is asked is what a DEV compile can honestly answer: both
+           pages exist, both carry the application's title in the seeded
+           locale and both wear the seeded theme's surface. The canonical
+           equality of the two is the driver's own release-mode gate — see
+           the namespace docstring."
+    (if-not (browser?)
+      (skip! off-browser)
+      (async done
+        (-> (with-both-arms
+              (fn []
+                (let [{:keys [hicasso donor]} (clock/pages)]
+                  (is (pos? (count hicasso)) "the Hicasso arm rendered a page")
+                  (is (pos? (count donor)) "and so did the donor arm"))
+                (doseq [side [:hicasso :donor]]
+                  (let [loc (clock/locale-echo-check side clock/seed-locale)
+                        thm (clock/theme-echo-check side clock/seed-theme)]
+                    (is (= (:expect loc) (:rendered loc))
+                        (str "the " (name side) " arm's <h1> carries the seeded"
+                             " locale's title"))
+                    (is (= (:expect thm) (:rendered thm))
+                        (str "and its root wears the seeded theme's surface"))))
+                (js/Promise.resolve nil)))
+            (.then (fn [_] (done)) (fail-async done)))))))
+
+(deftest the-donor-reads-nothing-the-hicasso-arm-does-not
+  (testing "THE READ-ROSTER ROW. `C3` divides the Hicasso arm by the donor
+           arm, so a read the donor makes and the Hicasso arm does not is
+           work in the denominator and moves the ratio in the numerator's
+           favour. On the seeded page there must be none.
+
+           The one asymmetry that remains runs the other way and is
+           documented at `slice-donor-views/app`: this arm renders no route
+           branch, so it does not read `[:rf.route/id]`. An arm doing LESS
+           is the arm the ratio divides BY, so the omission cannot flatter
+           the numerator."
+    (if-not (browser?)
+      (skip! off-browser)
+      (async done
+        (-> (with-both-arms
+              (fn []
+                (let [hic (roster clock/hicasso-frame)
+                      don (roster clock/donor-frame)]
+                  ;; ANTI-VACUITY FIRST. An empty roster would make every
+                  ;; difference below empty and every claim vacuous, and a
+                  ;; production compile elides the snapshot's body entirely.
+                  (is (< 10 (count hic))
+                      "the Hicasso arm's cache holds a real page's worth of reads")
+                  (is (< 10 (count don))
+                      "and so does the donor arm's")
+                  (is (contains? hic [::subs/feed])
+                      "both arms read the feed off the same registration")
+                  (is (contains? don [::subs/feed]))
+                  (is (contains? hic [::subs/t :app/title])
+                      "and both read the title string")
+                  (is (contains? don [::subs/t :app/title]))
+
+                  (is (empty? (set/difference don hic))
+                      (str "the donor reads NOTHING the Hicasso arm does not — "
+                           (pr-str (set/difference don hic))))
+
+                  (is (not (contains? don [::subs/t :feed/empty]))
+                      "in particular the empty-state string, which the Hicasso
+                       body reads only in its empty branch and the seed is never
+                       empty (rf2-9wmqd's repair)")
+                  (is (not (contains? hic [::subs/t :feed/empty]))
+                      "and the Hicasso arm does not read it either — so the two
+                       agree by BOTH not reading it, rather than by the donor
+                       having been matched to a read that was never taken")
+
+                  (is (contains? hic [:rf.route/id])
+                      "the shell's route read is on the Hicasso arm")
+                  (is (not (contains? don [:rf.route/id]))
+                      "and not on the donor's — the documented asymmetry, and it
+                       runs in the denominator's favour"))
+                (js/Promise.resolve nil)))
+            (.then (fn [_] (done)) (fail-async done)))))))
+
+(deftest the-roster-gate-catches-an-unconditional-branch-local-read
+  (testing "THE SABOTAGE on the row above, and it is the audit's finding
+           replanted rather than an invented fault: one UIx boundary on the
+           donor frame reading `[::subs/t :feed/empty]` unconditionally,
+           which is what `slice-donor-views/feed-page` did before the
+           repair.
+
+           The comparison must go from EMPTY to naming exactly that read.
+           A green here — no difference detected with the read plainly
+           added — would mean the row above passes whatever the two arms
+           subscribe to."
+    (if-not (browser?)
+      (skip! off-browser)
+      (async done
+        (-> (with-both-arms
+              (fn []
+                (is (empty? (donor-only))
+                    "before the plant, the donor reads nothing extra")
+                (with-probe-mounted
+                  (fn []
+                    (is (= #{[::subs/t :feed/empty]} (donor-only))
+                        "and with one unconditional branch-local read added on
+                         the donor frame, the comparison names it and nothing
+                         else")
+                    (js/Promise.resolve nil)))))
+            (.then (fn [_] (done)) (fail-async done)))))))
+
+;; ---------------------------------------------------------------------------
+;; The pre-state, on the arms themselves
+;; ---------------------------------------------------------------------------
+
+(deftest establishing-a-pre-state-puts-the-arms-page-in-it
+  (testing "The bridge between the replay rows and the instrument. Those
+           rows assert a property of [[clock/pre-state]], which is
+           arithmetic; this one asserts that
+           [[clock/establish-pre-state!]] actually lands that arithmetic on
+           the arm's own page, read back through the driver's own echo
+           checks rather than through a second reader written here.
+
+           Both parities of the visit index, on both frames, in both
+           dimensions."
+    (if-not (browser?)
+      (skip! off-browser)
+      (async done
+        (-> (with-both-arms
+              (fn []
+                (lane/chain
+                  nil
+                  (for [id    [:locale :donor-locale :theme :donor-theme :ctl-blocked]
+                        visit [0 1]]
+                    [(arm-of id) visit])
+                  (fn [_ [arm visit]]
+                    (.then (clock/establish-pre-state! arm visit)
+                           (fn [_]
+                             (let [{:keys [locale theme]} (clock/pre-state arm visit)
+                                   side (:side arm)
+                                   loc  (clock/locale-echo-check side locale)
+                                   thm  (clock/theme-echo-check side theme)]
+                               (is (= (:expect loc) (:rendered loc))
+                                   (str (:id arm) " visit " visit ": the page's <h1> is in "
+                                        locale))
+                               (is (= (:want loc) (:glass loc))
+                                   (str (:id arm) " visit " visit ": and its <select> agrees"))
+                               (is (= (:expect thm) (:rendered thm))
+                                   (str (:id arm) " visit " visit ": the root wears "
+                                        theme "'s surface"))
+                               nil)))))))
+            (.then (fn [_] (done)) (fail-async done)))))))
+
+(deftest the-whole-schedule-runs-and-every-window-advances-its-own-counter
+  (testing "`lane/rounds-async!` drives all six arms over the two real
+           applications, every echo verifies, and — the half this file
+           needs — each arm's visit counter has advanced exactly once per
+           visit the plan made for it. That counter is the index
+           [[clock/pre-state]] is a function of, so a counter that
+           advanced twice, or not at all, would leave the replay rows
+           asserting a property of a schedule the driver does not run.
+
+           The schedule is TINY here and the module's own is not: this row
+           asks whether the instrument runs, and a run that reads it wants
+           `clock/sampling` and `clock/rounds`."
+    (if-not (browser?)
+      (skip! off-browser)
+      (async done
+        (let [sampling {:warmup 1 :samples 2}
+              rounds   1
+              per-arm  (* rounds (+ (:warmup sampling) (:samples sampling)))]
+          (-> (with-both-arms
+                (fn []
+                  (.then (lane/rounds-async! clock/arms sampling rounds clock/measure-one!)
+                         (fn [{:keys [readings samples]}]
+                           (is (= (* rounds (:samples sampling) (count clock/arms))
+                                  (count samples))
+                               "every measured visit was banked for the guard")
+                           (is (= rounds (count readings)))
+                           (is (every? (fn [round] (= (count clock/arms) (count round)))
+                                       readings)
+                               "and every arm has a reading in every round")
+                           (is (= {:writes (* per-arm (count clock/arms)) :unverified 0}
+                                  (clock/verification))
+                               "0 unverified of M — every window, warm-up included,
+                                reached a frame that carried its own echo")
+                           (is (= (into {} (map (fn [{:keys [id]}] [id per-arm])) clock/arms)
+                                  (clock/visits))
+                               "and every arm's visit counter advanced exactly once
+                                per visit — warm-up visits included, because the
+                                pre-state is established for those too")))))
+              (.then (fn [_] (done)) (fail-async done))))))))
+
+;; ---------------------------------------------------------------------------
+;; The roster the file documents, where it can be pinned without a browser
+;; ---------------------------------------------------------------------------
+
+(deftest the-arm-roster-is-the-six-rows-the-file-documents
+  (testing "The namespace docstring names six rows and says which estimands
+           they can and cannot serve, and each row now also declares the
+           SIDE it runs on and the state dimension it MOVES. A seventh
+           added silently, or an arm whose declaration drifted from what
+           its plan does, would leave that prose describing an instrument
+           that no longer exists — the drift class this lane keeps paying
+           for."
+    (is (= [:idle-frame :locale :donor-locale :theme :donor-theme :ctl-blocked]
+           (mapv :id clock/arms))
+        "floor first, so it leads the schedule")
+    (is (= [:ctl-blocked] (mapv :id (filter :control? clock/arms)))
+        "and exactly one of them is a control")
+    (is (= {:idle-frame   [:hicasso nil]
+            :locale       [:hicasso :locale]
+            :donor-locale [:donor   :locale]
+            :theme        [:hicasso :theme]
+            :donor-theme  [:donor   :theme]
+            :ctl-blocked  [:hicasso :locale]}
+           (into {} (map (juxt :id (juxt :side :alternates))) clock/arms))
+        "every arm declares its side and the dimension it moves")
+    (doseq [[a b] compared-pairs]
+      (is (= (:alternates (arm-of a)) (:alternates (arm-of b)))
+          (str a " and " b " move the same dimension — otherwise there is
+               nothing for a comparative to hold constant")))
+    (is (= 2 (count clock/locales)) "the rotor's roster is two locales")
+    (is (= 2 (count clock/themes)) "and two themes")
+    (is (contains? (set clock/locales) clock/seed-locale))
+    (is (contains? (set clock/themes) clock/seed-theme))
+    (is (pos? (:warmup clock/sampling)))
+    (is (pos? (:samples clock/sampling)))
+    (is (even? (:samples clock/sampling))
+        "an ODD `:samples` would leave each arm's measured block one visit
+         short of a whole number of rotor turns, so the two directions
+         would not be taken in equal numbers")
+    (is (pos? clock/rounds))))
+
+(deftest the-record-labels-which-population-each-figure-is-taken-over
+  (testing "`:summary`, `:structure`, `:comparative` and `:over-floor` are
+           all taken over the measured visits, because the last two are
+           built out of the first two and a ratio whose numerator and
+           denominator are drawn from different populations is not a ratio.
+           `:echo` deliberately is not: it is a count of refusals rather
+           than a distribution, and a verification is worth more the more
+           windows it covers."
+    (is (= {:summary     :measured-visits
+            :structure   :measured-visits
+            :comparative :measured-visits
+            :over-floor  :measured-visits
+            :echo        :all-visits}
+           clock/populations))))

--- a/implementation/hicasso/test/re_frame/bench/hicasso/slice_broad_window_dom_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/bench/hicasso/slice_broad_window_dom_cljs_test.cljs
@@ -64,6 +64,23 @@
   and adjudicating it on a shared runner would be a latency threshold in a
   PR gate by another name.
 
+  ## THE HARNESS HALF, WHICH COST A CI CYCLE TO FIND
+
+  Every DOM row here boots on FRESH frame ids. That is not hygiene: a
+  second mount on a used id leaves the Hicasso arm rendered and DEAF,
+  because the collector's cell table is process-global and keyed by
+  `(frame, query)` while the fixture retires a frame without going through
+  the disposal hook that repairs those cells. [[with-both-arms]] and
+  `clock/boot!`'s §MOUNTING TWICE carry the mechanism and the measurement.
+
+  Two of the rows below are what found it, and they were written for
+  something else — which is the argument for having them. The read-roster
+  row reported the Hicasso arm's cache as `#{}` against the donor's 34,
+  and the schedule row reported `9 unverified of 18`, exactly the nine
+  Hicasso-side windows. The same schedule row also caught a real
+  disagreement in the driver's own contract: `clock/visits` published the
+  last visit INDEX under a docstring promising a COUNT.
+
   ## Runtime
 
   The DOM rows need a real browser and the `-dom-cljs-test` suffix puts
@@ -126,17 +143,36 @@
 ;; Both arms mounted, both torn down again
 ;; ---------------------------------------------------------------------------
 
+(defonce ^:private !frame-n (atom 0))
+
+(defn- fresh-frame-ids
+  "A pair of frame ids no earlier row in this process has used."
+  []
+  (let [n (swap! !frame-n inc)]
+    {:hicasso (keyword "re-frame.bench.hicasso.slice-broad-window-dom-cljs-test"
+                       (str "hicasso-" n))
+     :donor   (keyword "re-frame.bench.hicasso.slice-broad-window-dom-cljs-test"
+                       (str "donor-" n))}))
+
 (defn- with-both-arms
   "Mount both arms through the instrument's own [[clock/boot!]], run `f` —
   which answers a promise — and tear both roots down afterwards whatever
   happened.
 
-  `boot!` names its own frames and makes its own containers, so there is
-  nothing to hand it. The `:each` fixture resets `frame/frames` between
-  rows, which is what lets two rows boot the same two frame ids without
-  the second inheriting the first's `app-db`."
+  FRESH FRAME IDS PER MOUNT, and this is load-bearing rather than tidy.
+  `clock/boot!`'s §MOUNTING TWICE carries the measurement: the Hicasso
+  collector's `!cells` table is process-global and keyed by
+  `(frame, query)`, the repair for a retired reaction rides a disposal
+  hook, and the `:each` fixture retires a frame by resetting
+  `re-frame.frame/frames` rather than through that hook. A second mount on
+  a used id therefore renders once and is then DEAF — empty sub-cache, no
+  watches, no re-render — while looking perfectly healthy on the glass.
+
+  This suite's first cut booted on `clock/`'s two default ids and CI read
+  exactly that: the mount row green, and every row after it red. It is the
+  discipline `slice-echo-window-dom-cljs-test` already keeps."
   [f]
-  (-> (clock/boot!)
+  (-> (clock/boot! (fresh-frame-ids))
       (.then (fn [_] (f)))
       (.then (fn [v] (clock/teardown!) v)
              (fn [e] (clock/teardown!) (throw e)))))
@@ -155,15 +191,27 @@
   per-frame cache BOTH substrates go through — Hicasso's collector calls
   `subs/subscribe` for every `h/sub` edge, and the UIx adapter's
   `use-subscribe` calls it for every hook — so the two rosters are
-  comparable without either arm being asked to report on itself."
+  comparable without either arm being asked to report on itself.
+
+  IT IS THE REALISED SUBGRAPH, NOT THE BOUNDARY READ SET, and the
+  difference is worth stating because it makes this comparison STRONGER
+  rather than looser. A cache entry exists for every reaction that was
+  materialised, so a `:<-` sub's inputs are in here beside the values a
+  body asked for: reading `[::subs/current-page]` puts `[::subs/listed]`,
+  `[::subs/page]`, `[:rf.route/query]` and `[:rf/route]` in the roster
+  too. A donor whose extra read were hidden one layer down — a different
+  input chain reaching the same value — would still show up."
   [frame-id]
   (set (keys (subs-tooling/sub-cache-snapshot frame-id))))
+
+(defn- hicasso-roster [] (roster (:hicasso (clock/frames))))
+(defn- donor-roster [] (roster (:donor (clock/frames))))
 
 (defn- donor-only
   "What the donor arm reads that the Hicasso arm does not. THE ONE THAT
   MATTERS: an entry here is work in the denominator of `C3`."
   []
-  (set/difference (roster clock/donor-frame) (roster clock/hicasso-frame)))
+  (set/difference (donor-roster) (hicasso-roster)))
 
 (defui empty-label-probe
   "One UNCONDITIONAL read of `[::subs/t :feed/empty]` on the donor frame.
@@ -191,7 +239,7 @@
         drop! (fn []
                 (uix-dom/unmount-root root)
                 (when (.-parentNode c) (.removeChild (.-parentNode c) c)))]
-    (uix-dom/render-root ($ uixa/frame-provider {:frame clock/donor-frame}
+    (uix-dom/render-root ($ uixa/frame-provider {:frame (:donor (clock/frames))}
                             ($ empty-label-probe {}))
                          root)
     (-> (echo/after-paint)
@@ -417,8 +465,8 @@
       (async done
         (-> (with-both-arms
               (fn []
-                (let [hic (roster clock/hicasso-frame)
-                      don (roster clock/donor-frame)]
+                (let [hic (hicasso-roster)
+                      don (donor-roster)]
                   ;; ANTI-VACUITY FIRST. An empty roster would make every
                   ;; difference below empty and every claim vacuous, and a
                   ;; production compile elides the snapshot's body entirely.
@@ -432,6 +480,11 @@
                   (is (contains? hic [::subs/t :app/title])
                       "and both read the title string")
                   (is (contains? don [::subs/t :app/title]))
+                  (is (contains? don [:rf.route/query])
+                      "and the roster reaches INPUTS, not just the values a body
+                       asked for: neither page reads the route's query directly,
+                       and it is here because `[::subs/page]` is `:<-` it — so a
+                       read hidden one layer down would still show up")
 
                   (is (empty? (set/difference don hic))
                       (str "the donor reads NOTHING the Hicasso arm does not — "

--- a/implementation/hicasso/test/re_frame/bench/hicasso/slice_donor_views.cljs
+++ b/implementation/hicasso/test/re_frame/bench/hicasso/slice_donor_views.cljs
@@ -113,6 +113,38 @@
     fallback and the driver's canonical-DOM gate refuses two pages that
     differ before any clock is read.
 
+  ## THE READ ROSTER, COMPARED READ FOR READ (rf2-9wmqd, PR #8599's audit)
+
+  The three differences above are AUTHORING ones. A fourth was a
+  MEASUREMENT one, and it is repaired: this arm's `feed-page` read
+  `[::subs/t :feed/empty]` unconditionally where the Hicasso body reads it
+  only in its empty branch, so on a seed that is never empty the donor
+  carried a subscription and a hook the Hicasso arm did not. See
+  [[feed-empty]].
+
+  The rest of the page was then compared boundary by boundary, and what
+  the comparison found is stated here rather than left to be re-derived:
+
+  - **[[chrome]] 7, [[article-row]] 2, [[digest]] 5, [[digest-body]] 1,
+    [[callout-block]] 1, [[unsupported-block]] 1** — read for read with
+    their Hicasso counterparts, on the same registrations. `h/use-subs`
+    and two `use-subscribe` calls are one door and two doors onto the same
+    two edges, not two read sets.
+  - **[[pager]] 5 against 5 at the pinned seed**, from a body that reads
+    them unconditionally against one that reads three of them inside its
+    branch. INERT rather than hidden, and [[pager]] carries why the
+    [[feed-empty]] repair would make it worse rather than better.
+  - **[[app]] 3 against the Hicasso shell's 4** — this arm does not read
+    `[:rf.route/id]`, because it renders no route branch. The one
+    remaining asymmetry, it runs in the DENOMINATOR'S favour, and [[app]]
+    states it.
+
+  So the donor reads NOTHING the Hicasso arm does not, and the Hicasso arm
+  reads one thing the donor does not. That is an assertion rather than a
+  claim: `slice-broad-window-dom-cljs-test` takes both frames'
+  subscription caches on the seeded page and compares them, with a
+  negative control that re-plants exactly the read this repair removed.
+
   ## THE IDS ARE DUPLICATED ON PURPOSE
 
   `#slice-locale` is this page's id and it is also the Hicasso page's,
@@ -309,7 +341,23 @@
   shipped seed can express — seven articles over a page size of three is
   three pages, so both arms take the branch on every render — and the
   driver's population pin names the seed for exactly this class of
-  reason."
+  reason.
+
+  ## AND THAT IS WHY [[feed-empty]]'S REPAIR IS NOT APPLIED HERE
+
+  The two conditional reads look like one defect and are not. Splitting
+  this body the way [[feed-empty]] splits the empty state would put a
+  child boundary on the MEASURED page — the seed always renders a pager —
+  so this arm would render one component more than the Hicasso arm on
+  every visit, which is the same class of error in the same direction as
+  the one that repair removes, only larger and always on. The empty
+  state's boundary is free precisely because the branch that places it
+  never runs at the pinned seed.
+
+  What is left here is a difference that the seed makes INERT rather than
+  one it hides: at three pages both arms read the same five values, and a
+  seed that ever made the feed single-page would move the population
+  before it moved this."
   [_]
   (let [page                  (uixa/use-subscribe [::subs/current-page])
         pages                 (uixa/use-subscribe [::subs/page-count])
@@ -449,14 +497,38 @@
 ;; The feed page and the shell
 ;; ---------------------------------------------------------------------------
 
-(defui feed-page
-  "The list, keyed by slug. The digest and the pager are CHILD boundaries
-  rather than markup written here, which is what keeps this body's read
-  set to the rows and its heading."
+(defui feed-empty
+  "The empty state, and the one read on this page that belongs to a BRANCH
+  rather than to a body.
+
+  The Hicasso `feed-page` writes `[:p.feed-empty (h/sub [::subs/t
+  :feed/empty])]` inside its empty branch, so a feed with rows in it never
+  records an edge on that string. `use-subscribe` is a React hook and a
+  hook cannot be conditional, so the transcription that read it beside the
+  rows and the heading gave this arm ONE SUBSCRIPTION AND ONE HOOK THE
+  HICASSO ARM DOES NOT HAVE — on the shipped seed, which is seven
+  articles and never empty. That is work in the DENOMINATOR, and it moves
+  a `Hicasso / UIx` ratio in the numerator's favour.
+
+  A child boundary is the ordinary UIx repair and it costs the measured
+  population nothing: the branch that would place it never renders at the
+  pinned seed, so the arm pays neither the boundary nor the read. The DOM
+  is `<p class=\"feed-empty\">…` either way, so the driver's canonical-DOM
+  gate reads the same page in both states."
   [_]
-  (let [rows        (uixa/use-subscribe [::subs/feed])
-        heading     (uixa/use-subscribe [::subs/t :feed/heading])
-        empty-label (uixa/use-subscribe [::subs/t :feed/empty])]
+  ($ :p.feed-empty (uixa/use-subscribe [::subs/t :feed/empty])))
+
+(defui feed-page
+  "The list, keyed by slug. The digest, the pager and the empty state are
+  CHILD boundaries rather than markup written here, which is what keeps
+  this body's read set to the rows and its heading — the same two reads
+  the Hicasso body makes unconditionally, and no third.
+
+  [[feed-empty]] carries the reason the empty state is a boundary here and
+  is markup there."
+  [_]
+  (let [rows    (uixa/use-subscribe [::subs/feed])
+        heading (uixa/use-subscribe [::subs/t :feed/heading])]
     ($ :section.feed
        ($ :h2 heading)
        ($ digest {})
@@ -468,7 +540,7 @@
                               :title       (:title row)
                               :published?  (:published? row)
                               :tags        (:tags row)})))
-         ($ :p.feed-empty empty-label))
+         ($ feed-empty {}))
        ($ pager {}))))
 
 (defui app


### PR DESCRIPTION
Takes two measurement-fidelity repairs from the audit of PR #8599, and the suite-level self-test the bead owes for them (rf2-9wmqd items 1, 2 and (b)).

**No window was run, no reading taken, no ledger cell moved, no threshold, band or gate created.** Item (c) — the quiet-box window for U3/C3/C4 — is untouched and the bead stays open on it.

## Both premises were re-checked at source, and both hold

**Repair 1's premise held, verbatim.** `slice_donor_views.cljs`'s `feed-page` bound `empty-label (uixa/use-subscribe [::subs/t :feed/empty])` unconditionally inside its `let`, while `slice/views.cljs`'s `feed-page` reads the same value only inside `(if (empty? rows) [:p.feed-empty (h/sub [::subs/t :feed/empty])] …)`. The seed is seven articles at a page size of three, so the empty branch never renders and the donor carried one subscription and one hook the Hicasso arm did not.

**Repair 2's counts reproduced exactly, in every round.** I replayed the six-arm `lane/visit-plan` — `order_guard/slot-order`'s rotate-then-reflect at `k = 6`, indexed by the sample index and not by the round — at `{:warmup 8 :samples 12}` over five rounds, tracking each frame's locale and theme. At the measured slots `s = 8..19`, `:theme` runs in the non-seed locale on **4 of 12** visits per round and `:donor-theme` on **8 of 12**, identically in all five rounds. The audit's numbers, unchanged.

**The replay also found a divergence the audit did not name**, in the other dimension and on the *positive control's* pairing: `:ctl-blocked` runs in the non-seed **theme** on 8 of 12 measured visits per round against `:locale`'s 4 of 12. `control-per-round` subtracts those two medians, so the additive control was adjudicated across two page-state populations. Same mechanism (the Hicasso theme is moved by `:theme`, which sits at a different slot distance from `:locale` than from `:ctl-blocked`), same class of error. Both are closed by this PR.

## Repair 1 — the donor's read set

Fixed on the **donor** side only. `slice/views.cljs` is a shipped slice example consumed by `a11y_cljs_test`, `l0_cljs_test` and `l2_cljs_test`; equalising the arms there would change the population all three are written over.

A hook cannot be conditional, so the repair is the audit's own suggestion — an empty-state child boundary, `feed-empty`. It costs the measured population nothing: the branch that places it never renders at the pinned seed, so the arm pays neither the boundary nor the read, and the DOM is `<p class="feed-empty">…` in both arms when the feed *is* empty.

### The sibling sweep, read for read

I compared the donor page's full read roster against the Hicasso page's, boundary by boundary. The result is now recorded in the donor namespace's docstring rather than left to be re-derived. **Two other differences exist and neither is the same defect:**

| boundary | Hicasso | donor | verdict |
|---|---|---|---|
| `chrome` | 7 | 7 | equal |
| `article-row` | 2 | 2 | equal (`h/use-subs` is one door onto the same two edges) |
| `pager` | 5 at the seed (3 inside the branch) | 5 unconditional | **inert at the seed**, see below |
| `digest` | 5 | 5 | equal (both fallbacks are built eagerly) |
| `digest-body` / `callout-block` / `unsupported-block` | 1 / 1 / 1 | 1 / 1 / 1 | equal |
| `feed-page` | 2 (+1 in the empty branch) | **3** → now 2 | **the defect, repaired** |
| `app` (shell) | 4 | 3 | asymmetric the *other* way |

- **The pager is a REFUSAL, source-located.** Seven articles over a page size of three is three pages, so both arms take the branch on every render and both read the same five values — the difference is inert at the pinned seed rather than hidden by it. Applying `feed-empty`'s repair here would put a child boundary on the **measured** page, since the seed always renders a pager, so the donor would render one component more than the Hicasso arm on every visit. That is the same class of error in the same direction as the one being removed, only larger and always on.
- **The shell's missing `[:rf.route/id]` read** was already documented and runs in the denominator's favour: the arm doing less is the one C3 divides *by*.

## Repair 2 — the pre-state, established rather than inherited

Each arm now declares the `:side` it runs on and the state dimension it `:alternates`. `pre-state` is a pure function of the arm and its own visit index; `establish-pre-state!` puts the arm's frame into it through the application's own events, on the same door and the same settle `parity-discrimination!` already uses, strictly outside every window. `measure-one!` runs it first, then the existing phase-alignment `after-paint`, then the plan build, then the window.

Because no arm's page state depends on any other arm's, paired arms see identical mixes **at every schedule, by construction** — not as an arithmetic coincidence.

### Why the audit's other candidate was rejected

I replayed both variants of "isolate the control's state/root" rather than choosing on taste:

| schedule (5 rounds) | current rig | control restores its locale | control on its own root | pre-state established |
|---|---|---|---|---|
| `{8, 12}` | 4/12 vs 8/12 ✗ | equal | equal | equal |
| `{3, 6}` | ✗ | equal | equal | equal |
| `{8, 13}` | ✗ | **✗** | **✗** | equal |
| `{8, 20}` | ✗ | **✗** | **✗** | equal |

Both isolating variants happen to equalise the theme pair at twelve samples and stop doing so at thirteen and at twenty — the equality is an accident of how `slot-order`'s rotation lands on twelve indices. `sampling`'s own docstring says a tail quantile over 12 is mostly interpolation and that the run reading this instrument will raise those counts, so a repair that holds at 12 and breaks at 13 breaks exactly where it is first relied on. The own-root variant also leaves the control's theme mix wrong (0 of 12 against `:locale`'s 4 of 12 — a control on its own root never has its theme moved at all), so it does not close the second divergence in any case.

### What the repair does and does not cost the estimand

The dimension an arm moves still alternates — now off its own visit counter, so `locale-plan`'s "both directions in equal numbers" is guaranteed rather than inherited. The dimension it does *not* move is pinned to the seed's value, which **narrows** each measured arm's population (`:theme` now always switches theme on a page in the seeded locale). That narrowing is the point: two arms narrowed to the same stated population are comparable where two arms drifting independently are not.

## The self-test — item (b)

New file: `implementation/hicasso/test/re_frame/bench/hicasso/slice_broad_window_dom_cljs_test.cljs`, beside `slice_broad_clock_app.cljs`.

**Which driver it belongs beside, and why.** There are two clock drivers in that directory. `slice_echo_clock_app.cljs` already has `slice_echo_window_dom_cljs_test.cljs`; both of the audit's repairs live in `slice_broad_clock_app.cljs` and its donor views, which is the driver PR #8599 landed and the one with no suite. The name follows the sibling's convention (`…_window_dom_cljs_test`, after the window rather than after the clock). `-dom-cljs-test$` puts it on `:browser-test` by ns-regexp with nothing to register; its pure rows also run under `:node-test`, and its DOM rows degrade to a stated skip there, which is the posture the sibling keeps.

Ten rows, each named as a claim, following `the-measured-mask-is-the-lanes-own-schedule` and `the-arm-roster-is-the-four-rows-the-file-documents`:

**The read roster is a first-class assertion, with its own negative control.**
- `the-donor-reads-nothing-the-hicasso-arm-does-not` takes both frames' subscription caches through `subs.tooling/sub-cache-snapshot` — the same per-frame cache *both* substrates go through, since Hicasso's collector calls `subs/subscribe` for every `h/sub` edge and the UIx adapter calls it for every hook — and asserts the donor's roster minus the Hicasso arm's is **empty**, that `[::subs/t :feed/empty]` is in *neither*, and that `[:rf.route/id]` is on the Hicasso side only. It carries its own anti-vacuity first: an empty roster would make every difference trivially empty.
- `the-roster-gate-catches-an-unconditional-branch-local-read` re-plants exactly the removed read — one UIx boundary on the donor frame calling `use-subscribe` for `[::subs/t :feed/empty]` unconditionally, in its own root so it cannot touch either arm's page — and requires the same comparison to go from empty to naming exactly that read.

**The governed state mix is a first-class assertion, with its own negative control.**
- `paired-arms-see-the-same-governed-state-mix` replays `lane/visit-plan` through the driver's own `pre-state` and asserts the three compared pairs are drawn from one population, at five schedules including `{8, 13}` and `{8, 20}`.
- `the-mix-gate-catches-a-rig-whose-arms-inherit-each-others-state` models the rig PR #8599 shipped and requires the same comparison to refuse — reproducing 4-against-8 on the locale dimension and 8-against-4 on the control's theme dimension inside the suite. It closes with the repaired model passing at the same schedule, so the refusals are about the rig and not about the replay.

**And a bridge from the arithmetic to the instrument**, because a pure replay proves a model rather than a driver: `establishing-a-pre-state-puts-the-arms-page-in-it` calls `establish-pre-state!` for both parities on both frames and reads the result back through the driver's own echo checks, and `the-whole-schedule-runs-and-every-window-advances-its-own-counter` runs a tiny schedule end to end and asserts each arm's visit counter — the index `pre-state` is a function of — advanced exactly once per visit the plan made for it.

**What the suite deliberately does not re-adjudicate**, stated in the file: the canonical-DOM parity gate is a *release* gate by construction (`data-rf2-source-coord` makes the two arms' attributes differ under `goog.DEBUG`), so a dev-compiled suite row asserting that equality would either fail honestly or have to strip attributes until it passed. The driver owns it and `run.cjs` builds release. And the control's own verdict, for the sibling's reason.

**No seventh in-driver control was added.** The driver already runs six, and in-driver is the stronger place by the sibling's own argument. What was missing was the browser-suite row.

## Quality gates

**`npm run test:hicasso-compile` is the gate covering this surface, and CI runs it on this PR.** It walks the lane directory to derive its entry list, so all three files — including the new one — are covered by construction with no roster to edit. I did **not** run it locally: a peer worker is holding a live allocation measurement window on this box, two heavyweight runs on one machine wedge rather than fail, and a wedged window returns a plausible number that is worthless. That is a machine constraint, not a judgement about this change.

For the same reason I ran **no** `scripts/test-fast-pr.sh`, no shadow-cljs, no browser or Playwright run, no npm build and no JVM gate. `python scripts/check_fast_pr_gap.py --list` reports **94** required checks the fast spine does not decide — a fact about the spine, and here also a description of what I ran, which is none of it.

What I ran locally, both cheap and both plantable:

| check | files | result | exit code (captured) |
|---|---|---|---|
| Clojure-aware delimiter balance | all 3 | balanced | `0` |
| qualified-reference resolution | all 3 | **98** distinct in-repo refs (45 driver / 20 donor views / 33 suite), 0 unresolved; 8 further refs are external (`clojure.set`, the UIx jar) and are reported as out of reach rather than counted as resolved | `0` |

The checker blanks strings, character literals and `;` comments before it counts a delimiter or matches a symbol, and resolves each `alias/name` against the ns index it builds by walking `implementation/`.

### Planted-fault discrimination, and the restores verified by blob hash

Three plants, each at a line this PR already edits, each run red naming what was planted, each restored and each restore verified against the committed object:

| file | plant | the check's output | restore |
|---|---|---|---|
| `slice_broad_clock_app.cljs` | one extra `)` on `establish-pre-state!`'s last line | `DELIMITER FAIL line 811: closing ) with nothing open` | the identical blob hash `e75c74b8fe6a86ca28ddfe5d3438bea9fed5dd51` |
| `slice_donor_views.cljs` | `use-subscribe` → `use-subscribe-typo` in the new `feed-empty` boundary | `UNRESOLVED line 519: uixa/use-subscribe-typo -> re-frame.adapter.uix/use-subscribe-typo (no top-level def)` | the identical blob hash `baa614e3c9f503033117fbdd9f430f4c047cf691` |
| `slice_broad_window_dom_cljs_test.cljs` | both classes at once — an extra `(` in `roster`, and `clock/establish-pre-state!` → `…-typo!` | `DELIMITER FAIL line 151: unclosed (` and `UNRESOLVED line 509: …` | the identical blob hash `9116b75e0b32d6ca91a8cb198a32b197713004f7` |

`git status` is clean after all three. Two mechanical notes worth recording: an end-anchored `perl -pi` pattern matched **nothing** on these CRLF-checked-out files, caught by reading the substitution count before running the check rather than by the hash afterwards; and a `s/…/…/` whose pattern contained a `/` aborted perl before it wrote anything, so that attempt is not in the table.

### Not verified locally, and stated rather than left to be found

- **The compile.** CI's `test:hicasso-compile` decides it. The two static checks close the two regression classes a dev compile catches first — unbalanced forms and a renamed or missing var — and neither is a substitute for the compiler.
- **The browser rows.** They need a real DOM and a browser run, which is exactly what the machine constraint forbids this tick. `:browser-test` in `test.yml` is where they are decided.
- **`implementation/package.json` was not touched.** The new suite needs no script-helper registration: `-dom-cljs-test$` is discovered by ns-regexp and the compile gate discovers the file by walking its directory.

### Re-run on the final base

The trunk moved while this was in flight (`b03376ce7e` → `059b1bbd52`, twelve landings, none of them touching these three files). The branch was rebased onto that tip and **both static checks were re-run there**, same output and the same captured exit code `0`. The three-dot diff against the new merge base was read before pushing: the only deletions in it are lines this PR itself rewrites, so nothing a sibling landed is reverted.

---

## Second cycle: CI read the first cut as 14 failures, and they were one cause

The browser lane went red on the first push. The fix is in the harness, and **no assertion was weakened to get it green** — one was added.

### The cause, and the hypothesis that was tested and rejected

`collector/!cells` is a **process-global table keyed by `(frame, query)`**, and its own comment states that isolation between roots is a property of that keying rather than anything React provides. `invalidate-cell!` is the repair for a cell whose reaction has been retired — including, in its own words, *across a same-id reincarnation* — but that repair rides the reaction's **disposal hook**, and `make-reset-runtime-fixture` retires a frame by resetting `frame/frames` to `{}` rather than through it. A second mount on the same id then finds a live cell holding a dead reaction: `subs/subscribe` is never called again, so the new frame's sub-cache stays empty, and no watch is installed, so nothing on the page ever re-renders.

The symptom is silent in the worst way — **the first render is perfect**. The evidence lines up on exactly that shape:

| row | mount | result |
|---|---|---|
| `both-arms-mount-their-feed-page-and-render-it` | 1st | **passed** |
| `the-donor-reads-nothing-the-hicasso-arm-does-not` | 2nd | `hic` = `#{}` against `don` = 34 |
| `the-roster-gate-catches-…` | 3rd | difference = the donor's whole roster |
| `establishing-a-pre-state-…` | 4th | every Hicasso-side pre-state stayed English/light |
| `the-whole-schedule-runs-…` | 5th | `9 unverified of 18` — precisely the nine Hicasso-side windows, with all six donor-side ones verified |

The act-environment hypothesis was **tested and rejected rather than assumed**: every `not wrapped in act(...)` line in that log is timestamped `+12.32s` / `+14.36s`, and this namespace ran at `+28.58s`. They are a neighbouring suite's noise.

### The fix

The discipline `slice-echo-window-dom-cljs-test` already keeps. `boot!` takes the frame ids as an argument (`hicasso-frame` / `donor-frame` become documented **defaults** for the bench page's single mount), the live pair is published by a new `frames` reader, and `frame-for` and `parity-discrimination!` resolve through it — a caller that dispatched into the default while the page rendered from a fresh id would be writing to a frame nothing reads. The suite mints a fresh pair per row. The mechanism and the measurement are recorded at source in `boot!`'s §MOUNTING TWICE and in `teardown!`, which explicitly cannot fix it.

### A real contract bug the suite also caught

`visits` published the last visit **index** under a docstring promising a **count**, so it read one short of the plan's own per-arm count (`{… :locale 2 …}` against an expected 3). `claim-visit!` now banks the count and answers the index. The bridge row earned its place on its first run.

### And the first direct measurement of the donor's read roster

The empty-Hicasso failure printed the donor's cache in full: **34 query vectors**, and every one is read by the Hicasso arm too — the fifteen `::subs/t` strings match one for one against the sweep in the table above. `[::subs/t :feed/empty]` is **absent**, which is repair 1 confirmed on the shipped population rather than argued.

It also showed the roster reaches a `:<-` sub's **inputs**, not only the values a body asks for: `[:rf.route/query]` and `[:rf/route]` are there as `[::subs/page]`'s input chain, though neither page reads the route's query directly. That makes the comparison stronger than claimed — a donor read hidden one layer down would still show up — so the docstring now says so and **a new assertion pins it**.

## Quality gates — final

**The browser lane is now a gate that RAN, not a gate that was cited.** `CLJS (shadow-cljs :browser-test, headless Chromium)`: red at 14 failures, then **green** after the fix, then **green again on the rebased base**. `CLJS (shadow-cljs :node-test)` green as well — the `-dom-cljs-test$` suffix also matches `cljs-test$`, and this suite is the first thing to pull the driver (and `uix.dom`) into that bundle, so its green is a real result too. All PR checks are green with nothing pending.

The green is not vacuous: the red and green runs both report **1044 tests**, and assertions go **5937 → 5938** — exactly the one assertion added. Had the DOM rows collapsed to their off-browser skips, the count would have dropped by roughly forty-five.

Local checks re-run on the final base after the second rebase: delimiter balance and qualified-reference resolution over all three files, **97** distinct in-repo refs, 0 unresolved, captured exit `0`. Two further planted faults on this round's own edited lines — an extra `)` on `boot!`'s new no-arg arity line, and `clock/frames` → `clock/frames-typo` in the suite — each red naming what was planted (`DELIMITER FAIL line 998`, `UNRESOLVED line 207`), each restored to the identical blob hashes `bc3863e9c6946fd84b9f2965b9fd5ad8d38bbac7` and `5d4751cf3882495c4ff77564f247147f85190ef3`.

Still not run locally, and still for the machine-contention reason: `npm run test:hicasso-compile`, the fast-PR spine, shadow-cljs, and any browser run. CI decided every one of them.
