### PR TITLE
docs(hicasso): B <= 3 is a projection, not a necessity; and the collection-bound guard now bites (rf2-2k3vo, rf2-onozm)

### DIFF
--- a/docs/design/hicasso/studio/the-fixed-cost-binds-on-one-rung.md
+++ b/docs/design/hicasso/studio/the-fixed-cost-binds-on-one-rung.md
@@ -31,24 +31,33 @@ node hicasso/test/re_frame/bench/hicasso/alloc_window_ceiling.cjs
 uncertifiability argument in the 300,000 B masking bound, and **that bound was
 RETIRED AND DELETED on 2026-08-08** (`rf2-2rtt6.141`, on this bead's own
 criterion 4), so every `max B` figure in [section 2](#2-the-ladder-arithmetic-re-run)
-is a **RECONSTRUCTION of the bead's case, not a live constraint**. Restating the
-question in the quantity the instrument actually exhibits —
-[section 4](#4-the-same-question-in-live-terms) — **reverses the answer**: against
-`rf2-onozm`'s observed **884,280 B** ceiling the full 1/3/7/20 ladder admits
-**B ≤ 3**, not B = 0. The bead's *"there is no page of one boundary or more"* was
-carried by the deleted constant's tightness, a 300,000 B window bracket against a
-ceiling **2.95× looser**.
+is a **RECONSTRUCTION of the bead's case, not a live constraint**. **The
+impossibility falls with the constant it divides by, and nothing live replaces
+it.** Re-running the identical arithmetic against `rf2-onozm`'s observed
+**884,280 B** ceiling — [section 4](#4-the-same-question-in-live-terms) — projects
+**B ≤ 3** rather than B = 0.
 
-**What survives is a one-rung constraint, and it is not an impossibility result.**
-R = 20 is where the ladder binds on the live ceiling exactly as it did on the
-retired bound; at the B = 4 this corpus runs it binds hard — **0/72 in six of the
-eight arm families, 24/24 in the other two** — and the largest full-ladder page
-the ceiling admits is one boundary *under* the page already being run. **That
-ceiling is NECESSARY and not SUFFICIENT**, so B ≤ 3 is a condition the ladder can
-meet rather than a page that certifies: 36 windows sit at or below the ceiling
-and refuse anyway, 20 of them with no collection at all, and **no committed
-dataset holds a window at any page size but B = 4**, so whether B = 3 certifies
-is **unmeasured**.
+**THAT B ≤ 3 IS A MODEL-CONDITIONED PROJECTION, NOT A NECESSARY CONDITION**, and
+the condition is *treat the corpus's largest observed success as a cap*.
+Corrected 2026-08-21 on the merged-PR audit of PR #8602, which found this page
+presenting it as a necessity. **884,280 B is the highest would-be total any
+window in this corpus certified at, and the largest observed success bounds a
+real maximum from BELOW, not from above.** Zero certified windows above it, in a
+finite corpus sampled only at B = 4, cannot exclude a certifying window higher
+up; the record puts the whole 884,280 – 1,028,670 B interval **unsampled**
+([the window total is the ceiling](the-window-total-is-the-ceiling.md#3-the-ceiling-which-is-what-the-sixteen-cells-were-measuring)),
+and `t(R)` is a one-point linear fit. So read the projection as *"if the observed
+ceiling caps the ladder, the ladder admits B ≤ 3"* — never as *"the ladder cannot
+exceed B = 3"*. **A real page-size necessity would need evidence at another B,
+and no committed dataset holds a window at any page but B = 4.**
+
+**What survives on the evidence alone is a one-rung EMPIRICAL result, and it is
+not an impossibility result.** At the B = 4 this corpus runs, R = 20 binds hard —
+**0/72 in six of the eight arm families, 24/24 in the other two** — where every
+rung beneath it certifies 88 – 95%. That is measured, and it owes the projection
+nothing. **Nor is the ceiling SUFFICIENT**: 36 windows sit at or below it and
+refuse anyway, 20 of them with no collection at all, so whether B = 3 certifies
+is **unmeasured** in the other direction too.
 
 - **F today is 19,280 B per write** — the floor arm's median `perWrite` over 48
   windows. Against the 42,857 B the *retired* bound allowed at W = 6 that is
@@ -72,11 +81,12 @@ is **unmeasured**.
   surviving arm family and nothing else. **That is a sharply lower rate in the
   sampled configuration; it is not, and is no longer offered as, a demonstration
   that no page size certifies.**
-- **The same arithmetic on the LIVE ceiling** — [section 4](#4-the-same-question-in-live-terms),
+- **The same arithmetic on the OBSERVED ceiling** — [section 4](#4-the-same-question-in-live-terms),
   fitted per arm family because at R = 20 the pooled rung median falls in a gap no
-  family occupies: R = 1 admits **B ≤ 31**, R = 3 **B ≤ 16**, R = 7 **B ≤ 8**,
-  R = 20 **B ≤ 3**, taking the binding family at each rung. **Stop the ladder at
-  R = 7 and the ceiling admits B ≤ 8** — where the reconstruction allowed B = 1.
+  family occupies. **Under the cap assumption and nowhere outside it**: R = 1
+  projects **B ≤ 31**, R = 3 **B ≤ 16**, R = 7 **B ≤ 8**, R = 20 **B ≤ 3**, taking
+  the binding family at each rung. **Stop the ladder at R = 7 and the same
+  projection gives B ≤ 8** — where the reconstruction allowed B = 1.
 - **This bead and `rf2-onozm` are ONE CONSTRAINT UNDER TWO NAMES.** R = 20 is the
   binding rung here and the whole subject there. Resolving R = 20 **discharges**
   this bead rather than re-measuring it.
@@ -166,7 +176,8 @@ below withdraws it.** `survives today's F unchanged` is true of the
 *reconstruction* and of nothing else: the conclusion is an artefact of the
 allowance it divides by, and the allowance is deleted.
 [Section 4](#4-the-same-question-in-live-terms) re-runs the identical arithmetic
-against the observed ceiling and gets **B ≤ 3 on the full ladder**.
+against the observed ceiling and **projects B ≤ 3 on the full ladder, under the
+cap assumption that section states**.
 
 **What the `certified` column beside it does and does not establish.** It is
 measured and owes the bound nothing, and it locates the binding rung: R = 20
@@ -175,13 +186,15 @@ not do is carry the bead's conclusion** — a sharply lower certification rate i
 the sampled configuration is not a demonstration that no page size certifies, and
 **24 R = 20 windows certify at B = 4 already**. `rf2-onozm` reaches the same rung
 on the observed 884,280 B ceiling, again without the bound, and that ceiling is
-**one-sided**: 36 windows below it refuse. **So the RUNG does not depend on the
-retired constant. The IMPOSSIBILITY did, and it does not survive.**
+**one-sided in both directions**: 36 windows below it refuse, so it is not
+sufficient; and it is the largest observed success, so it caps nothing except by
+assumption. **So the RUNG does not depend on the retired constant. The
+IMPOSSIBILITY did, and it does not survive.**
 
-**Stop at R = 7 and the reconstruction allows B = 1; the live ceiling allows
-B ≤ 8.** Either way it is not a widening — it is the ladder the four remaining
-rungs already support, and it is the same disposition `rf2-onozm` prices from the
-other side.
+**Stop at R = 7 and the reconstruction allows B = 1; the same projection on the
+observed ceiling gives B ≤ 8.** Either way it is not a widening — it is the
+ladder the four remaining rungs already support, and it is the same disposition
+`rf2-onozm` prices from the other side.
 
 **One honest note on how well the model does.** The `certified` column is not
 predicted by the max-B column and is not offered as agreeing with it — the two
@@ -267,13 +280,21 @@ no longer exists. **No window was taken for this section either** — it is the 
 528 committed windows read a second way, on base `551d7acb9a`.
 
 The instrument enforces the leg witness and the falls gate, and what those two
-exhibit at the window level is the **would-be total**, `6 × legMedian`, ceilinged
-at the **884,280 B** the corpus's highest certifying window actually reached. So
-run the bead's own arithmetic against that instead of against the retired
-allowance:
+exhibit at the window level is the **would-be total**, `6 × legMedian`, whose
+highest certifying observation in this corpus is **884,280 B**. So run the bead's
+own arithmetic against that instead of against the retired allowance:
+
+> **THE MODEL CONDITION, stated before the arithmetic that assumes it.**
+> Everything in this section holds **only if** the corpus's largest observed
+> success is treated as a cap on what can certify. It is not one on the evidence:
+> 884,280 B is a **lower** bound on any real maximum certifiable total, the
+> 168,036 B directly above it is unsampled, and `t(R)` is a single-point linear
+> fit at the only page size the corpus holds. **Every `max B` below is therefore
+> a PROJECTION under that assumption, not a necessary condition on the ladder.**
 
 ```
-total(R, B) ≈ T0 + B · t(R)        max B = floor((884,280 − T0) / t(R))
+total(R, B) ≈ T0 + B · t(R)        projected max B = floor((884,280 − T0) / t(R))
+                                   ^ conditioned on 884,280 B being a cap
 ```
 
 where `T0` is the family's **own** floor-arm would-be total and `t(R)` is fitted
@@ -282,7 +303,7 @@ because at R = 20 the pooled rung median is representative of nothing: six
 families sit at 1.03 – 1.05 MB and two at 0.85 – 0.86 MB, and the pooled 1,035,036 B
 falls in a gap no family occupies.
 
-| family | `T0` (B) | max B, R = 1 | R = 3 | R = 7 | R = 20 |
+| family | `T0` (B) | projected max B, R = 1 | R = 3 | R = 7 | R = 20 |
 |---|---|---|---|---|---|
 | `reagent-subs \| lad/reagent @page` | 105,816 | 32 | 17 | 8 | **3** |
 | `reagent-subs \| lad/hicasso @page` | 105,816 | 36 | 19 | 9 | **3** |
@@ -294,16 +315,21 @@ falls in a gap no family occupies.
 | `uix-subs \| lad/hicasso @all` | 118,392 | 36 | 19 | 9 | **3** |
 
 A ladder holds **one B across all rungs and all families**, so the binding cell
-decides:
+decides — **under the cap assumption above, and only there**:
 
-- **full 1/3/7/20 ladder — B ≤ 3**, binding at R = 20;
-- **reduced 1/3/7 ladder — B ≤ 8**, binding at R = 7.
+- **full 1/3/7/20 ladder — projected B ≤ 3**, binding at R = 20;
+- **reduced 1/3/7 ladder — projected B ≤ 8**, binding at R = 7.
 
-**The bead's conclusion does not survive.** *"At six writes there is no page of
-one boundary or more that certifies the 1/3/7/20 ladder"* is carried entirely by
-the retired bound's tightness — a 300,000 B window bracket against an observed
-884,280 B ceiling, **2.95× looser**. On the live ceiling the full ladder admits
-**B ≤ 3**: one boundary *under* the page this corpus already runs, not zero.
+**The bead's conclusion does not survive**, and it does not survive because the
+constant carrying it was deleted rather than because this projection replaces it.
+*"At six writes there is no page of one boundary or more that certifies the
+1/3/7/20 ladder"* is carried entirely by the retired bound's tightness — a
+300,000 B window bracket against an observed 884,280 B ceiling, **2.95×
+looser**. **Take the observed ceiling as a cap and the same arithmetic projects
+B ≤ 3**: one boundary *under* the page this corpus already runs, not zero. **Do
+not read that as the page-size necessity the bead claimed** — it is the same
+shape of claim, with an observation in place of the constant, and an observed
+maximum is not a cap.
 
 ### What the empirical column can and cannot check
 
@@ -316,24 +342,34 @@ at B = 4, so at B = 4 the test `max B ≥ 4` reduces *algebraically* to
 restated per family. It confirms the ceiling. It says nothing about the linear
 extrapolation to any other page.
 
-### And the ceiling is necessary, not sufficient
+### And the ceiling is neither necessary nor sufficient
 
 This is the qualification that keeps the restatement from becoming a second
-reconstruction. **36 windows sit at or below 884,280 B and refuse anyway, 20 of
-them carrying no collection at all.** So:
+reconstruction, and it has **two halves**. An earlier version of this section
+carried only the second, calling B ≤ 3 a *necessary* condition — struck
+2026-08-21 on the merged-PR audit of PR #8602.
 
-- **B ≤ 3 is a NECESSARY condition the full ladder can meet — it is NOT a
-  certifying page**, and nothing here says the ladder certifies at B = 3.
+- **NOT NECESSARY.** 884,280 B is the corpus's largest observed success, so it
+  bounds a real maximum certifiable total **from below**. **Zero of 72 windows
+  above it certified**, but a finite corpus sampled at one page size cannot
+  exclude a certifying window higher up, and the 168,036 B directly above it was
+  never sampled. **So B ≤ 3 is what the arithmetic yields when the observation is
+  ASSUMED to be a cap, and nothing follows from it about a ladder that exceeds
+  B = 3.** Deciding that needs evidence at another B.
+- **NOT SUFFICIENT.** **36 windows sit at or below 884,280 B and refuse anyway,
+  20 of them carrying no collection at all.** So B ≤ 3 is **not a certifying
+  page**, and nothing here says the ladder certifies at B = 3.
 - **No committed dataset holds a window at any page size but B = 4.** Whether
   B = 3 certifies is **unmeasured**, and measuring it needs a window. None was
   taken here, and this page does not propose one.
 
 **What survives, at the strength the evidence carries**: R = 20 is where the
-ladder binds, on the live ceiling as on the retired bound; at B = 4 it binds hard,
-0/72 in six of eight families; and the largest full-ladder page the ceiling admits
-is B = 3. **That is a one-rung constraint, not an impossibility result** — which
-is a materially weaker claim than the one this page carried before, and it is
-weaker because the evidence never supported the stronger one.
+ladder binds, on the observed ceiling as on the retired bound; at B = 4 it binds
+hard, 0/72 in six of eight families, against 88 – 95% on every rung beneath it.
+**That is a measured one-rung result, not an impossibility result**, and it is
+weaker than the claim this page carried before because the evidence never
+supported the stronger one. **The B ≤ 3 projection travels beside it as a
+conditional, not as a result.**
 
 Every figure above is printed by section 7 of the reader; run it and diff.
 
@@ -346,8 +382,8 @@ for that reason.
 
 | | `rf2-onozm` | `rf2-2rtt6.140` |
 |---|---|---|
-| what it observes | R = 20 certifies 24/96, all on one family | R = 20 is the binding rung: **B ≤ 3** live, B = 0 on the retired reconstruction |
-| the quantity | window would-be total, ceiling at **884,280 B** — observed | the same ceiling in [section 4](#4-the-same-question-in-live-terms); `perWrite` against the **retired** 42,857 B allowance in [section 2](#2-the-ladder-arithmetic-re-run) |
+| what it observes | R = 20 certifies 24/96, all on one family | R = 20 is the binding rung: **projected B ≤ 3** on the observed ceiling, B = 0 on the retired reconstruction |
+| the quantity | window would-be total, ceiling at **884,280 B** — observed | the same ceiling in [section 4](#4-the-same-question-in-live-terms), taken there as a cap **by assumption**; `perWrite` against the **retired** 42,857 B allowance in [section 2](#2-the-ladder-arithmetic-re-run) |
 | what binds | R = 20's total, 1,035,036 B median | R = 20's `s`, 31,533 B/bnd/write |
 | what discharges it | fewer writes at the top rung, or stop below it | the same |
 
@@ -367,15 +403,24 @@ this page.
 - **The bead is NOT discharged, and what remains of it is smaller than this page
   once said.** Its *rung* survives; its *conclusion* does not. The scope is one
   rung rather than the whole ladder, the route runs through `rf2-onozm`, and the
-  warrant is now the observed ceiling rather than a deleted constant. **What the
-  live restatement removes is the impossibility**: on the ceiling the full ladder
-  admits B ≤ 3, so the open question is no longer *"is any page certifiable?"* but
-  *"does B = 3 certify?"* — and that is **unmeasured**, because the corpus holds
-  no window at any page but B = 4. **Answering it needs a window.**
-- **B ≤ 3 IS NOT A CERTIFYING PAGE and must not be read as one.** The ceiling is
-  necessary and not sufficient — 36 windows below it refuse, 20 with no collection
-  at all. Reading `max B` as a page that certifies would repeat, one level down,
-  exactly the defect `rf2-2k3vo` was filed to fix.
+  warrant is the measured B = 4 certification column rather than a deleted
+  constant. **What the live restatement removes is the impossibility**, and it
+  puts **no replacement necessity in its place**: the open question is no longer
+  *"is any page certifiable?"* but *"does B = 3 certify, and does anything above
+  it?"* — both **unmeasured**, because the corpus holds no window at any page but
+  B = 4. **Answering either needs a window.**
+- **B ≤ 3 IS A MODEL-CONDITIONED PROJECTION, NOT A NECESSARY CONDITION.**
+  Corrected 2026-08-21 on the merged-PR audit of PR #8602, which found this page
+  and its reader using the observed 884,280 B ceiling as an upper cap. **The
+  largest observed success bounds a real maximum from BELOW**; 0 of 72 above it
+  in a corpus sampled at one page size excludes nothing, and the 168,036 B
+  directly above it is unsampled. The projection is kept, and its condition —
+  *treat the corpus's largest observed success as a cap* — is now stated
+  wherever it appears ([section 4](#4-the-same-question-in-live-terms)).
+- **B ≤ 3 IS NOT A CERTIFYING PAGE either, and must not be read as one.** 36
+  windows below the ceiling refuse, 20 with no collection at all. Reading
+  `max B` as a page that certifies would repeat, one level down, exactly the
+  defect `rf2-2k3vo` was filed to fix.
 - **No slope was fitted and none is published.** Both runs failed the falls gate.
 - **The masking bound was retired ELSEWHERE and EARLIER, and nothing here retires
   it.** No gate, constant or threshold is added, moved, widened, recalibrated or

--- a/docs/design/hicasso/studio/the-window-total-is-the-ceiling.md
+++ b/docs/design/hicasso/studio/the-window-total-is-the-ceiling.md
@@ -48,9 +48,14 @@ reason is arithmetic rather than luck.**
 - **At WINDOW granularity the separator is ONE-SIDED, and that is the finding
   rather than a caveat.** The highest would-be total any certified window in the
   corpus carries is **884,280 B**. **Zero of the 72 windows above it certify;
-  420 of the 456 at or below it do (92.1%).** So the total is a **NECESSARY**
-  condition for certification, **not a sufficient one** — 36 refusals sit below
-  the ceiling, 16 of them with a collection inside the window and 20 without.
+  420 of the 456 at or below it do (92.1%).** **What that observation bounds, it
+  bounds from BELOW.** 884,280 B is the largest observed success, so a real
+  maximum certifiable total is at least that — a finite corpus sampled at one
+  page size cannot exclude a certifying window above it. And it is plainly **not
+  sufficient** either: 36 refusals sit below it, 16 of them with a collection
+  inside the window and 20 without. **It is an observed ceiling, not a necessary
+  cap**, and [section 3](#3-the-ceiling-which-is-what-the-sixteen-cells-were-measuring)
+  says what may and may not be built on it.
 - **The refusal signature is AT LEAST ONE collection, whose dominant leg is of
   near-constant size.** All 72 R = 20 refusals carry a negative leg — but **76
   negative legs fall across those 72 windows**, three of them carrying more than
@@ -183,6 +188,16 @@ is an intra-leg one, because `P0_ALLOC_BY_SITE` was unset and
 certified window (884,280 B) and the lowest refusing R = 20 cell median
 (1,028,670 B) lies **168,036 B of territory this corpus never sampled**. The
 ceiling is bounded from below by an observation and from above by nothing.
+
+**So it may be used as a CAP only under an explicit condition, never as a
+necessity.** *"The largest total ever seen to certify"* and *"the largest total
+that can certify"* are different quantities, and this corpus fixes only the
+first. Any arithmetic that divides by 884,280 B — including the ladder
+projection in
+[the fixed cost binds on one rung](the-fixed-cost-binds-on-one-rung.md#4-the-same-question-in-live-terms) —
+is conditioned on *treat the corpus's largest observed success as a cap*, and
+carries whatever that assumption is worth and no more. **Deciding it needs a
+window above the ceiling, and this corpus holds none.**
 
 ## 4. The refusal signature
 
@@ -333,6 +348,14 @@ take one.
   highest certified observation in one corpus. **No gate, constant, threshold or
   rung parameter is added, moved or proposed on this page**, and none should be
   added for it.
+- **The ceiling is NOT an upper cap on what can certify.** It is the largest
+  observed success, which bounds any real maximum from **below**. Zero
+  certifications above it, from a corpus sampled at one page size with
+  168,036 B unsampled directly above, cannot exclude a certifying window higher
+  up. Anything that treats 884,280 B as a cap is **conditioned on that
+  assumption** and is labelled as such wherever it appears — corrected
+  2026-08-21 on the merged-PR audit of PR #8602
+  ([section 3](#3-the-ceiling-which-is-what-the-sixteen-cells-were-measuring)).
 - **The window total is NOT sufficient for certification.** Thirty-six windows
   below the ceiling refused, twenty of them without any collection inside. A
   reader who inverts the ceiling into "under 884,280 B certifies" has the

--- a/implementation/hicasso/test/re_frame/bench/hicasso/alloc_window_ceiling.cjs
+++ b/implementation/hicasso/test/re_frame/bench/hicasso/alloc_window_ceiling.cjs
@@ -128,6 +128,26 @@ const pos = (x) => (x > 0 ? x : 0);
 // a leg or across a leg boundary, and the count below bounds the number of
 // collections in NEITHER direction -- see the census in section 4.
 const negLegs = (c) => c.legs.filter((l) => l < 0);
+
+// THE COLLECTION-COUNT LOWER BOUND, DERIVED RATHER THAN ASSERTED (rf2-onozm).
+//
+// This is the reader's ONLY expression of the bound: the report prints what this
+// returns, and the self-test pins both this function and that printed line, so
+// the two cannot drift apart. Added on the merged-PR audit of #8602, which found
+// the previous guard checking `Math.min(negLegs(w).length, 1) === 1` -- 1 by
+// construction for any window with a negative leg, calling no production
+// function and consuming no report result, so the reported bound could be
+// changed with every check still green.
+//
+// ONE delta is sampled per leg, so a negative leg witnesses that SOMETHING
+// collected inside the window and nothing finer. A window with three negative
+// legs and a window with one therefore support the SAME bound -- one collection
+// -- because one collection spanning a leg boundary can mark several legs, and
+// one leg can hide several collections. THE BOUND IS DELIBERATELY NOT A FUNCTION
+// OF THE LEG COUNT; a change that makes it one is the regression this exists to
+// catch.
+const collectionLowerBound = (w) => (negLegs(w).length > 0 ? 1 : 0);
+
 const n0 = (v) => Math.round(v).toLocaleString('en-US');
 const pc = (v) => v.toFixed(1) + '%';
 
@@ -449,11 +469,16 @@ function report() {
   });
   const negObs = r20neg.flatMap((c) => negLegs(c));
   const multi = r20neg.filter((c) => negLegs(c).length > 1);
+  const bounds = r20neg.map(collectionLowerBound);
+  const boundPerWindow = bounds.length ? Math.min(...bounds) : 0;
+  const boundTotal = bounds.reduce((a, b) => a + b, 0);
   say(`      negative legs per window: ` +
       Object.keys(perWin).sort((a, b) => a - b).map((k) => `${k} x ${perWin[k]}`).join(', ') +
       `  ->  ${negObs.length} NEGATIVE-LEG OBSERVATIONS over ${r20neg.length} windows`);
-  say(`      All ${r20neg.length} refusing windows carry at least one, so each is`);
-  say(`      collection-affected and the lower bound is ONE COLLECTION PER WINDOW.`);
+  say(`      All ${r20neg.length} refusing windows carry at least one, so each is collection-affected.`);
+  say(`      THE LOWER BOUND IS ${boundPerWindow} COLLECTION PER WINDOW, ${boundTotal} IN ALL. That figure is`);
+  say(`      derived from the windows themselves and is deliberately NOT a function of the`);
+  say(`      leg count -- see collectionLowerBound(), which is what this line prints.`);
   say(`      ${negObs.length} IS A COUNT OF LEG OBSERVATIONS, NOT OF COLLECTIONS, and does not`);
   say(`      raise that bound: one collection spanning a leg boundary can make several`);
   say(`      legs negative, and one leg can hide several collections. The number of`);
@@ -711,12 +736,20 @@ function selfTest() {
   ck('deepest-magnitude cannot separate 3 negative legs from 1',
     Math.min(...synth.legs) === Math.min(...single.legs), true);
   ck('negLegs CAN separate them', negLegs(synth).length !== negLegs(single).length, true);
-  // And the claim the census may NOT make, pinned so it cannot creep back: the
-  // collection-count lower bound is one PER WINDOW, and the leg count does not
-  // raise it. Both synthetic windows are one collection-affected window each,
-  // whatever their leg counts.
-  ck('a 3-negative-leg window still bounds collections at >= 1, not >= 3',
-    Math.min(negLegs(synth).length, 1), 1);
+  // And the claim the census may NOT make: the collection-count lower bound is
+  // one PER WINDOW, and the leg count does not raise it. PINNED THROUGH THE
+  // PRODUCTION DERIVATION THE REPORT USES. The previous version of this check read
+  // `Math.min(negLegs(synth).length, 1) === 1`, which is 1 by construction for any
+  // window with a negative leg -- a synthetic answer carrying itself, exactly the
+  // shape struck from the set-relation guard below, and the merged-PR audit of
+  // #8602 caught it here. The three checks below go red if `collectionLowerBound`
+  // ever becomes a function of the leg count.
+  ck('a 3-negative-leg window and a 1-negative-leg window support the SAME bound',
+    collectionLowerBound(synth), collectionLowerBound(single));
+  ck('and that bound is ONE collection, not one per negative leg',
+    collectionLowerBound(synth), 1);
+  ck('a window with no negative leg supports no collection at all',
+    collectionLowerBound({ legs: [100, 100, 100, 100, 100, 100] }), 0);
 
   // THE SET-RELATIONSHIP GUARD, added when the merged-PR audit of #8591 caught
   // this page asserting that the retired bound "refuses nothing the certificate
@@ -774,6 +807,18 @@ function selfTest() {
   ck('and nothing above it was ever sampled at another page size',
     new Set(cws.map((c) => c.boundaries)).size, 1);
 
+  // AND THE REPORTED BOUND ITSELF, so a figure stated in the output cannot drift
+  // from the derivation behind it. BOTH halves are needed and neither substitutes
+  // for the other: the three checks above fail if `collectionLowerBound` becomes a
+  // function of the leg count, and this one fails if the sentence stops printing
+  // what that function returns -- an output line rewritten to "three collections",
+  // or a total re-derived from `negObs.length` (76 rather than 72), reds here.
+  const rep = report();
+  ck('the report states the derived collection bound and no other',
+    /THE LOWER BOUND IS 1 COLLECTION PER WINDOW, 72 IN ALL\./.test(rep), true);
+  ck('and it still names the 76 as leg observations rather than as collections',
+    /76 IS A COUNT OF LEG OBSERVATIONS, NOT OF COLLECTIONS/.test(rep), true);
+
   // An empty certified set must be NO CEILING rather than -Infinity, which would
   // place every window above the ceiling and read as a unanimous finding.
   let threw = false;
@@ -798,5 +843,5 @@ if (require.main === module) {
 
 module.exports = {
   windows, identities, cells, rungTable, ceiling, liveLadder, ladderMaxB,
-  report, selfTest, med, pos, MASKING_BOUND_B, W,
+  negLegs, collectionLowerBound, report, selfTest, med, pos, MASKING_BOUND_B, W,
 };

--- a/implementation/hicasso/test/re_frame/bench/hicasso/alloc_window_ceiling.cjs
+++ b/implementation/hicasso/test/re_frame/bench/hicasso/alloc_window_ceiling.cjs
@@ -59,15 +59,24 @@
 // the instrument actually exhibits — the observed would-be-total ceiling from
 // section 3 — and gets a DIFFERENT answer. The bead's `R20 forces B = 0` is an
 // artefact of the deleted constant's tightness: a 300,000 B window bracket
-// against a 884,280 B observed ceiling. Restated live, the full ladder admits
+// against a 884,280 B observed ceiling. Restated live, the full ladder PROJECTS
 // B <= 3.
 //
-// THAT IS A NECESSARY CONDITION AND NOT A SUFFICIENT ONE, and section 7 prints
-// its own limits rather than leaving them to the page: the ceiling admits 36
-// windows the certificate refuses, the model is fitted at the single page size
-// the corpus holds, and at that page size it reduces ALGEBRAICALLY to the
-// ceiling test, so the agreement it reports there is not independent evidence
-// for the extrapolation.
+// THAT B <= 3 IS A MODEL-CONDITIONED PROJECTION, NOT A NECESSARY CONDITION, and
+// the condition is: TREAT THE CORPUS'S LARGEST OBSERVED SUCCESS AS A CAP.
+// Corrected on the merged-PR audit of #8602, which found section 7 using
+// 884,280 B as an upper cap and calling B <= 3 necessary. It is not one. The
+// largest observed success bounds a real maximum certifiable total FROM BELOW:
+// zero certified windows above it, in a finite corpus sampled only at B = 4,
+// cannot exclude a certifying window higher up, and the 168,036 B directly above
+// it was never sampled. The projection is kept because a stated conditional is
+// useful; what was missing was the condition.
+//
+// NOR IS THE CEILING SUFFICIENT, and section 7 prints both limits rather than
+// leaving them to the page: 36 windows at or below the ceiling refuse anyway,
+// the model is fitted at the single page size the corpus holds, and at that page
+// size it reduces ALGEBRAICALLY to the ceiling test, so the agreement it reports
+// there is not independent evidence for the extrapolation.
 //
 // ## ADMISSIBILITY — A FAILED POSITIVE CONTROL IS NOT AN OBSERVATION
 //
@@ -240,11 +249,17 @@ function ceiling(ws) {
   return Math.max(...certified.map((c) => c.total));
 }
 
-// SECTION 7's model, and it is a MODEL. The would-be total is taken as
-// `total(R, B) ~= T0 + B * t(R)`, where T0 is the floor arm's own would-be total
-// -- the six writes with no subscription under them -- and `t(R)` is fitted from
-// the single page size the corpus holds, B = 4. The largest page a rung admits
-// under the OBSERVED ceiling is then `floor((CEIL - T0) / t(R))`.
+// SECTION 7's model, and it is a MODEL ON TOP OF AN ASSUMPTION. The would-be
+// total is taken as `total(R, B) ~= T0 + B * t(R)`, where T0 is the floor arm's
+// own would-be total -- the six writes with no subscription under them -- and
+// `t(R)` is fitted from the single page size the corpus holds, B = 4. The page a
+// rung PROJECTS is then `floor((CEIL - T0) / t(R))`.
+//
+// `maxB` HERE IS A PROJECTION, NOT A CEILING ON THE LADDER. It is conditioned on
+// treating CEIL -- the corpus's largest observed success -- as a cap on what can
+// certify, which is not what an observed maximum is: it bounds a real maximum
+// from BELOW. Nothing that consumes this number may restate it as a necessary
+// condition (rf2-2k3vo, merged-PR audit of #8602).
 //
 // Fitted PER FAMILY rather than per rung, because at R = 20 the pooled rung
 // median is not representative of any family: six families sit at 1.03 - 1.05 MB
@@ -284,8 +299,9 @@ function liveLadder(ws) {
   return { B, CEIL, fams };
 }
 
-// The largest page every rung in `set` admits, across every family -- the
-// binding rung of the binding family, since one ladder holds ONE B.
+// The largest page every rung in `set` PROJECTS, across every family -- the
+// binding rung of the binding family, since one ladder holds ONE B. Conditioned
+// on the observed ceiling being a cap; see `liveLadder` above.
 const ladderMaxB = (fams, set) => {
   const all = fams.flatMap((f) => set.map((g) => f.rungs.get(g)).filter(Boolean).map((r) => r.maxB));
   return all.includes(null) ? null : Math.min(...all);
@@ -378,7 +394,11 @@ function report() {
   say(`    windows AT OR BELOW: ${below.length}, certified ${below.filter((c) => c.certified).length}` +
       ` (${pc((100 * below.filter((c) => c.certified).length) / below.length)})`);
   say('');
-  say(`    So the total is NECESSARY, not SUFFICIENT. The ${below.length - below.filter((c) => c.certified).length}` +
+  say(`    THE CEILING IS AN OBSERVED MAXIMUM, SO IT BOUNDS FROM BELOW. It is the largest`);
+  say(`    would-be total ever seen to certify here -- NOT the largest that CAN certify. A`);
+  say(`    corpus sampled at one page size cannot exclude a certifying window above it, and`);
+  say(`    the interval directly above it is unsampled. It is not NECESSARY.`);
+  say(`    It is not SUFFICIENT either. The ${below.length - below.filter((c) => c.certified).length}` +
       ` refusals below the ceiling, by rung:`);
   const lowRef = below.filter((c) => !c.certified);
   const byRung = {};
@@ -555,11 +575,17 @@ function report() {
   say(`    Section 6 divides by a DELETED constant. This section asks the bead's question of`);
   say(`    the quantity the instrument exhibits: the observed ceiling from section 3.`);
   say('');
+  say(`    THE MODEL CONDITION, STATED BEFORE THE ARITHMETIC THAT ASSUMES IT: everything`);
+  say(`    below holds ONLY IF the corpus's largest observed success is treated as a CAP on`);
+  say(`    what can certify. It is not one on the evidence -- an observed maximum bounds a`);
+  say(`    real maximum FROM BELOW -- so every max B below is a PROJECTION under that`);
+  say(`    assumption and NOT a necessary condition on the ladder.`);
+  say('');
   say(`    total(R,B) ~= T0 + B x t(R), t fitted at the corpus's only page B = ${L.B};`);
   say(`    T0 = the family's own floor-arm would-be total; ceiling = ${n0(L.CEIL)} B (observed).`);
-  say(`    max B = floor((${n0(L.CEIL)} - T0) / t(R)).`);
+  say(`    projected max B = floor((${n0(L.CEIL)} - T0) / t(R)), conditioned on that cap.`);
   say('');
-  say('    family                            T0        R1    R3    R7   R20   <- max B under the ceiling');
+  say('    family                            T0        R1    R3    R7   R20   <- PROJECTED max B');
   for (const f of L.fams) {
     const cells = ['R1', 'R3', 'R7', 'R20'].map((g) => {
       const r = f.rungs.get(g);
@@ -572,15 +598,20 @@ function report() {
   const bFull = ladderMaxB(L.fams, FULL);
   const bShort = ladderMaxB(L.fams, SHORT);
   say('');
-  say(`    ONE B ACROSS ALL RUNGS AND ALL FAMILIES, so the binding cell decides:`);
-  say(`      full 1/3/7/20 ladder : B <= ${bFull}      (binding rung R20)`);
-  say(`      reduced 1/3/7 ladder : B <= ${bShort}      (binding rung R7)`);
+  say(`    ONE B ACROSS ALL RUNGS AND ALL FAMILIES, so the binding cell decides -- under the`);
+  say(`    cap assumption above, and only there:`);
+  say(`      full 1/3/7/20 ladder : projected B <= ${bFull}      (binding rung R20)`);
+  say(`      reduced 1/3/7 ladder : projected B <= ${bShort}      (binding rung R7)`);
   say('');
-  say(`    THE BEAD'S CONCLUSION DOES NOT SURVIVE THE RESTATEMENT. "At six writes there is no`);
-  say(`    page of one boundary or more that certifies the 1/3/7/20 ladder" is carried by the`);
-  say(`    RETIRED bound's tightness -- a ${n0(MASKING_BOUND_B)} B window bracket against an observed`);
-  say(`    ${n0(L.CEIL)} B ceiling, ${(L.CEIL / MASKING_BOUND_B).toFixed(2)}x looser. On the live ceiling the full ladder admits`);
-  say(`    B <= ${bFull}, which is one boundary UNDER the page this corpus runs, not zero.`);
+  say(`    THE BEAD'S CONCLUSION DOES NOT SURVIVE THE RESTATEMENT, and it falls with the`);
+  say(`    constant that carried it rather than because this projection replaces it. "At six`);
+  say(`    writes there is no page of one boundary or more that certifies the 1/3/7/20 ladder"`);
+  say(`    rests on the RETIRED bound's tightness -- a ${n0(MASKING_BOUND_B)} B window bracket against an`);
+  say(`    observed ${n0(L.CEIL)} B ceiling, ${(L.CEIL / MASKING_BOUND_B).toFixed(2)}x looser. Take the observed ceiling as a cap and`);
+  say(`    the same arithmetic projects B <= ${bFull}, one boundary UNDER the page this corpus runs.`);
+  say(`    DO NOT READ THAT AS THE PAGE-SIZE NECESSITY THE BEAD CLAIMED: it is the same shape`);
+  say(`    of claim with an observation in place of the constant, and an observed maximum is`);
+  say(`    not a cap.`);
   say('');
   say(`    WHAT THE EMPIRICAL COLUMN CAN AND CANNOT CHECK. At B = ${L.B} the prediction is exact:`);
   const admits = L.fams.filter((f) => f.rungs.get('R20').maxB >= L.B);
@@ -596,18 +627,26 @@ function report() {
   say(`    "total <= ceiling", which is section 3's test restated per family. It confirms the`);
   say(`    ceiling, not the linear extrapolation to any other page.`);
   say('');
-  say(`    AND THE CEILING IS NECESSARY, NOT SUFFICIENT -- section 3's own result. ` +
-      `${ws.filter((c) => c.total <= L.CEIL && !c.certified).length} windows`);
-  say(`    sit at or below it and refuse anyway, ` +
-      `${ws.filter((c) => c.total <= L.CEIL && !c.certified && !c.legs.some((l) => l < 0)).length} of them carrying no collection at all. So`);
-  say(`      B <= ${bFull} is a NECESSARY condition the full ladder can meet, NOT a certifying page.`);
+  say(`    AND THE CEILING IS NEITHER NECESSARY NOR SUFFICIENT -- section 3's own result, in`);
+  say(`    both halves.`);
+  say(`      NOT NECESSARY: ${n0(L.CEIL)} B is the corpus's largest OBSERVED success, so it bounds a`);
+  say(`      real maximum certifiable total from BELOW. ${ws.filter((c) => c.total > L.CEIL).length} windows sit above it and`);
+  say(`      ${ws.filter((c) => c.total > L.CEIL && c.certified).length} certified -- but one page size and a finite corpus exclude nothing above`);
+  say(`      it. So B <= ${bFull} is what the arithmetic yields when that observation is ASSUMED`);
+  say(`      to be a cap, and nothing follows from it about a ladder that exceeds B = ${bFull}.`);
+  say(`      NOT SUFFICIENT: ` +
+      `${ws.filter((c) => c.total <= L.CEIL && !c.certified).length} windows sit at or below it and refuse anyway, ` +
+      `${ws.filter((c) => c.total <= L.CEIL && !c.certified && !c.legs.some((l) => l < 0)).length} of them`);
+  say(`      carrying no collection at all, so B <= ${bFull} is NOT a certifying page.`);
   say(`      No committed dataset holds a window at any page size but B = ${L.B}, so whether B = ${bFull}`);
-  say(`      certifies is UNMEASURED. Answering it needs a window, and none was taken here.`);
+  say(`      certifies -- and whether anything above it does -- is UNMEASURED in both`);
+  say(`      directions. Answering either needs a window, and none was taken here.`);
   say('');
   say(`    WHAT SURVIVES, STATED AT THE STRENGTH THE EVIDENCE CARRIES: R = 20 is where the`);
-  say(`    ladder binds, on the live ceiling as on the retired bound; at B = ${L.B} it binds hard,`);
-  say(`    ${sum(excl)}/${cnt(excl)} in ${excl.length} of ${L.fams.length} families; and the largest full-ladder page the ceiling`);
-  say(`    admits is B = ${bFull}. That is a one-rung constraint. It is NOT an impossibility result.`);
+  say(`    ladder binds, on the observed ceiling as on the retired bound; at B = ${L.B} it binds`);
+  say(`    hard, ${sum(excl)}/${cnt(excl)} in ${excl.length} of ${L.fams.length} families. That is a MEASURED one-rung result and it is`);
+  say(`    NOT an impossibility result. The B <= ${bFull} projection travels beside it as a`);
+  say(`    conditional, not as a result.`);
 
   return out.join('\n');
 }
@@ -710,19 +749,30 @@ function selfTest() {
 
   // SECTION 7's ANSWER, pinned against the corpus for the same reason. The bead's
   // conclusion is that no page of one boundary or more certifies the full ladder;
-  // the live ceiling admits B <= 3, so the guard that matters is the one that
-  // fires if that ever silently returns 0 -- the reconstruction's answer arriving
-  // in the live section would be exactly the defect rf2-2k3vo exists to fix.
+  // the projection on the observed ceiling gives B <= 3, so the guard that matters
+  // is the one that fires if that ever silently returns 0 -- the reconstruction's
+  // answer arriving in the live section would be exactly the defect rf2-2k3vo
+  // exists to fix.
+  //
+  // NOTE THE UNITS, corrected on the merged-PR audit of #8602. These are
+  // PROJECTIONS under an assumed cap, not necessary conditions, and the check
+  // names say so: an observed maximum bounds a real maximum from BELOW, so 0 of
+  // 72 above it excludes nothing.
   const L = liveLadder(cws);
   ck('the observed ceiling is the corpus maximum certified would-be total', L.CEIL, 884280);
-  ck('the full 1/3/7/20 ladder admits a page of one boundary or more',
+  ck('the full 1/3/7/20 ladder PROJECTS a page of one boundary or more',
     ladderMaxB(L.fams, ['R1', 'R3', 'R7', 'R20']) >= 1, true);
-  ck('and that page is B <= 3', ladderMaxB(L.fams, ['R1', 'R3', 'R7', 'R20']), 3);
-  ck('the reduced 1/3/7 ladder admits B <= 8', ladderMaxB(L.fams, ['R1', 'R3', 'R7']), 8);
-  // The ceiling is NECESSARY and not SUFFICIENT, so a guard that only checked the
-  // admitting side would license reading max B as a certifying page.
+  ck('and that projection is B <= 3', ladderMaxB(L.fams, ['R1', 'R3', 'R7', 'R20']), 3);
+  ck('the reduced 1/3/7 ladder projects B <= 8', ladderMaxB(L.fams, ['R1', 'R3', 'R7']), 8);
+  // Neither necessary nor sufficient, and the guard checks BOTH sides. Checking
+  // only the refusals below would license reading max B as a certifying page;
+  // checking only that nothing certified above would license reading the observed
+  // maximum as a cap. The corpus is unsampled above the ceiling, and 72 windows
+  // over it is what "unsampled" looks like here -- all six refusing families.
   ck('the ceiling still admits windows the certificate refuses',
     cws.filter((c) => c.total <= L.CEIL && !c.certified).length, 36);
+  ck('and nothing above it was ever sampled at another page size',
+    new Set(cws.map((c) => c.boundaries)).size, 1);
 
   // An empty certified set must be NO CEILING rather than -Infinity, which would
   // place every window above the ceiling and read as a unanimous finding.


### PR DESCRIPTION
Two audit reopens on one surface, both from the merged-PR audit of #8602. Neither
reopen rejects the work that landed: #8602's semantic repairs were correct and
stay. Each carried one unsupported inference, and each is discharged the cheapest
correct way.

**I checked both premises at source before acting. Both hold.**

## rf2-2k3vo — `B ≤ 3` was presented as necessary; it is a model-conditioned projection

The contradiction was real and lived across two pages that disagreed with each
other:

- `the-window-total-is-the-ceiling.md` carried the correct evidential status —
  884,280 B is the *highest certified observation*, 168,036 B above it is
  unsampled, the ceiling is "bounded from below by an observation and from above
  by nothing".
- `the-fixed-cost-binds-on-one-rung.md` §4 and `alloc_window_ceiling.cjs` §7 then
  used the same figure as an **upper cap**: `max B = floor((884,280 − T0) / t(R))`,
  and "the ceiling is NECESSARY and not SUFFICIENT".

That does not follow. The largest observed success is a **lower** bound on any
real maximum certifiable total, not an upper one. Zero certified windows above an
observed maximum, in a finite corpus sampled only at B = 4, cannot exclude a
certifying window above it — and `t` is a one-point linear fit through an
interval the corpus never sampled. The 36 refusals below the figure prove it is
not *sufficient*; they do not make it *necessary*.

**The projection is kept, not deleted** — a stated conditional is useful, and the
condition is what was missing. `B ≤ 3` is now restated as a projection under the
explicit condition *"treat the corpus's largest observed success as a cap"*,
everywhere it appears:

| where | what changed |
|---|---|
| `the-fixed-cost-binds-on-one-rung.md` answer-first | new paragraph naming the condition and why an observed maximum is not a cap |
| §4 intro | a blockquote stating the model condition **before** the arithmetic that assumes it; formula annotated; table header now "projected max B" |
| §4 sub-heading | "And the ceiling is necessary, not sufficient" → "neither necessary nor sufficient", with both halves argued |
| §5 comparison table, *What was NOT concluded* | restated; a new bullet naming the audit and the direction of the bound |
| `the-window-total-is-the-ceiling.md` answer-first + §3 | says the observation bounds **from below**, and that the figure may be used as a cap only under an explicit condition |
| `alloc_window_ceiling.cjs` header, `liveLadder`, `ladderMaxB` | comments restated; `maxB` documented as a projection |
| reader §3 and §7 output | prints the model condition, and both halves of "neither necessary nor sufficient" |
| self-test | check names now say PROJECTS / projection; one check added |

**What is untouched**: the empirical B = 4 result. R = 20 binds hard — 0/72 in six
arm families, 24/24 in the other two, against 88 – 95% on every rung beneath it.
That is measured and it owes the projection nothing.

**No measurement was taken and none is proposed.** The page already says the
window that would decide a real page-size necessity is unmeasured.

## rf2-onozm — the regression guard was a tautology

The guard read `ck(..., Math.min(negLegs(synth).length, 1), 1)`. `Math.min(x, 1)`
is 1 for any `x >= 1`, so it held by construction, called no production function,
consumed no report result, and was disconnected from the `say()` lines stating
the bound.

**Measured, not assumed.** At the merge base, changing the reported bound to
"THREE COLLECTIONS PER WINDOW" leaves **all 24 checks green, exit 0** — the
audit's claim reproduces exactly.

The discharge gives the value one production derivation the report actually uses:

    const collectionLowerBound = (w) => (negLegs(w).length > 0 ? 1 : 0);

deliberately *not* a function of the leg count. The report prints what it returns
— per window and in total — and the self-test asserts from both ends: a
three-negative-leg window and a one-negative-leg window yield the **same** bound
of one (and a window with no negative leg yields zero); and the report states
that derived figure and no other. The two halves close the hole from both sides:
the helper checks catch a derivation changed to the leg count, the report pin
catches an output line rewritten past the derivation.

No collector model, no new framework. This is the shape #8602 correctly applied
to the set-relation guard a few lines below.

## Quality gates

Exit codes below are the ones **I captured myself** in the same shell as the run,
redirected to a log and echoed — not numbers reported about the run. All were
re-run on the **final rebased base** `2f86ebaa7a`.

| gate | command | exit |
|---|---|---|
| reader self-test (primary) | `node hicasso/test/re_frame/bench/hicasso/alloc_window_ceiling.cjs --self-test` from `implementation/` | **0** |
| reader over the corpus | same script, no flag (there is no `--corpus` flag; the bare invocation *is* the corpus report) | **0** |
| doc slugs | `python scripts/check_doc_slugs.py` | **0** |
| provenance pins | `python scripts/check_provenance_pins.py --changed-since origin/main` | **0** |

Self-test check count: **24 → 29**. 24 at the merge base, 25 after rf2-2k3vo
(commit 1, verified in isolation before commit 2 was applied), 29 after
rf2-onozm.

`scripts/check_fast_pr_gap.py --list` reports **94 required checks the fast spine
does not run** (exit 0). That is a fact about the spine, not a census of what I
ran: **I did not run the fast spine at all**. A bench worker was taking an
allocation measurement window on this box, and two heavyweight runs on one box
wedge rather than fail, so I ran only the four cheap targeted gates above — node
and Python invocations. No shadow-cljs, no browser, no npm build, no JVM gate.

`mkdocs build --strict` is **not** nominated: `mkdocs.yml`'s `exclude_docs` lists
`design/hicasso/`, so it does not cover either page.

Note on the doc-slug gate's fence carve-out: it normally strips fenced code
blocks, but `docs/design/hicasso` is one of exactly two named exceptions where a
doc link inside a fence **is** reported. It did not skip my fences.

### Planted-fault evidence — three plants, each run red, each restored

Restores verified by hashing the bytes against the committed object, never by
reading a diff.

**Plant A — derive the bound from the leg count.** `collectionLowerBound` changed
to `negLegs(w).length`. Self-test **exit 1**, naming three checks:

    SELF-TEST FAILED:
      a 3-negative-leg window and a 1-negative-leg window support the SAME bound: got 3, want 1
      and that bound is ONE collection, not one per negative leg: got 3, want 1
      the report states the derived collection bound and no other: got false, want true

**Plant B — rewrite the reported bound.** The printed sentence changed to
`THE LOWER BOUND IS THREE COLLECTIONS PER WINDOW, 216 IN ALL.` Self-test
**exit 1**: `the report states the derived collection bound and no other: got
false, want true`. This is precisely the change the audit said left all 24 checks
green before.

**Counterfactual, run rather than asserted.** The merge-base reader, with the
equivalent change to its output line, self-tests **exit 0, 24 checks green**. The
defect reproduces at the base and does not reproduce here.

**Plant C — prove the doc gate reaches this worktree.** A cross-page anchor in
`the-fixed-cost-binds-on-one-rung.md` pointed at a heading that does not exist.
`check_doc_slugs.py` went **exit 1** naming the planted target at line 48 of that
file — the discrimination is the red itself, since the fault existed only in this
tree. Restored to **exit 0**.

**The first plant attempt silently no-opped** and the hash caught it: a `perl`
substitution anchored with an end-of-line anchor matched nothing, because the
file has CRLF line endings and the carriage return sits between the text and the
line end. Match count 0, blob hash unchanged, and the self-test came back green —
a false "the guard does not bite". Re-anchored without the end anchor, it
applied.

Restore evidence — the identical blob hash `a9d560aea68665498c7a6cfdf123b85ba7230945`
for `alloc_window_ceiling.cjs` before plant A and after every restore, and the
identical blob hash `0a4ad738da3f7d59fc64124a737530bf1ee3b68f` for
`the-fixed-cost-binds-on-one-rung.md` before and after plant C.

### By-hand checks — nothing validates prose, tables, rendering or nav

Both pages are dense with numeric tables, and no gate reads a table. Checked by
hand, counting escaped pipes inside cells as content rather than as separators:

- `the-fixed-cost-binds-on-one-rung.md` — **4 tables**, all internally consistent:
  7 rows x 2 cols, 8 x 7, **10 x 6** (the §4 family table, whose header I edited),
  6 x 3 (the two-bead comparison, two rows edited).
- `the-window-total-is-the-ceiling.md` — **7 tables**, all consistent: 4 x 4,
  10 x 5, 18 x 5, 4 x 3, 13 x 3, 5 x 4, 6 x 2. None edited; listed because the
  page was edited.
- **0 mismatched tables of 11.**

Anchors, resolved by hand against the two pages' own headings:

- `the-fixed-cost-binds-on-one-rung.md` — 10 headings, **14 anchor links**, 13
  in-scope all resolving, 1 cross-page to a third studio page (covered by the
  slug gate).
- `the-window-total-is-the-ceiling.md` — 9 headings, **8 anchor links**, 7
  in-scope all resolving, 1 cross-page.
- **0 broken in-scope anchors of 22.**

The renamed heading "And the ceiling is neither necessary nor sufficient" changed
its anchor. `git grep` over the tracked tree (excluding `.beads`, which is a
full-database export) found **no inbound link** to the old slug, and the slug
gate agrees.

## Held file — README row not edited, reported instead

`docs/design/hicasso/studio/README.md` is fenced to another worker, so this PR
does not touch it. **Two spans in it now contradict these pages** and need a
follow-up edit by whoever holds it:

1. The `the-window-total-is-the-ceiling.md` row: *"…above which 0 of 72 certify
   and at or below which 420 of 456 (92.1%) do — a **NECESSARY** condition, **not
   a sufficient** one…"*. The `NECESSARY` half is the inference this PR strikes;
   it should read that the observation bounds a real maximum **from below** and
   is a cap only by assumption.
2. The `the-fixed-cost-binds-on-one-rung.md` row: *"…the **full 1/3/7/20 ladder
   admits B ≤ 3, not B = 0**…"* and *"**B ≤ 3 IS NECESSARY, NOT SUFFICIENT**"*.
   Both need the model-conditioned-projection framing — "projects B ≤ 3 under the
   condition *treat the corpus's largest observed success as a cap*", and
   "neither necessary nor sufficient".

## Scope

No threshold, band, budget status or τ moved. No gate widened. No measurement,
benchmark, window or browser run. `ALLOC_LEG_TOLERANCE`, `ALLOC_FALL_THRESHOLD_B`
and `ALLOC_MIN_WRITES` are untouched, R = 20 stays on the ladder, and the retired
300,000 B masking bound stays retired. `implementation/package.json` untouched.
Both discharges are computed from committed datasets and text.

Closes rf2-2k3vo. Closes rf2-onozm.
